### PR TITLE
use hashes to sync s3 files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -219,7 +219,7 @@ rec {
   plutus-playground-lambda = pkgsMusl.callPackage ./plutus-playground-server/lambda.nix { haskellPackages = haskell.muslPackages; };
 
   deployment = pkgs.callPackage ./deployment {
-    inherit marlowe-playground plutus-playground marlowe-symbolic-lambda marlowe-playground-lambda plutus-playground-lambda;
+    inherit pkgsLocal marlowe-playground plutus-playground marlowe-symbolic-lambda marlowe-playground-lambda plutus-playground-lambda;
   };
 
   inherit (haskell.packages.plutus-scb.components.exes)

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -95,7 +95,6 @@ let
     pkgs.callPackage ./thorp {
       thorpSrc = sources.thorp;
       inherit mvn2nix;
-      inherit (pkgs) stdenv jdk11_headless maven makeWrapper graphviz;
     };
 
   # not available in 20.03 and we depend on several recent changes

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -10,9 +10,6 @@
 let
 
   iohkNix =
-    let
-      sources = import ../sources.nix;
-    in
     import sources.iohk-nix {
       inherit system config;
       # Make iohk-nix use our nixpkgs
@@ -93,10 +90,13 @@ let
 
   # Thorp is an S3 sync tool used for deployments
   thorp =
-    let
-      sources = import ../sources.nix;
+    let mvn2nix = import sources.mvn2nix { };
     in
-    import ./thorp { inherit sources pkgs; };
+    pkgs.callPackage ./thorp {
+      thorpSrc = sources.thorp;
+      inherit mvn2nix;
+      inherit (pkgs) stdenv jdk11_headless maven makeWrapper graphviz;
+    };
 
   # not available in 20.03 and we depend on several recent changes
   # including stylish-haskell support

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -91,6 +91,12 @@ let
     inherit git-rev;
   };
 
+  # Thorp is an S3 sync tool used for deployments
+  thorp =
+    let
+      sources = import ../sources.nix;
+    in
+    import ./thorp { inherit sources pkgs; };
 
   # not available in 20.03 and we depend on several recent changes
   # including stylish-haskell support
@@ -119,6 +125,6 @@ in
   inherit nix-pre-commit-hooks nodejs-headers;
   inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios purty;
   inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps;
-  inherit iohkNix set-git-rev;
+  inherit iohkNix set-git-rev thorp;
   inherit easyPS;
 }

--- a/nix/pkgs/thorp/default.nix
+++ b/nix/pkgs/thorp/default.nix
@@ -1,18 +1,17 @@
-{ pkgs, sources }:
+{ thorpSrc, mvn2nix, stdenv, jdk11_headless, maven, makeWrapper, graphviz }:
 let
-  mvn2nix = import sources.mvn2nix { };
+
   # This file was generated from mvn2nix pom.xml > mvn2nix-lock.json however one of the hashes was incorrect
   # and so was changed manually, see https://github.com/fzakaria/mvn2nix/issues/29
   # also the format in the json file is base32 but the error is reported in base64 so you need to convert
   # nix-hash --type sha256 --to-base16 $expectedHash
-  file = ./mvn2nix-lock.json;
-  mavenRepository = mvn2nix.buildMavenRepositoryFromLockFile { inherit file; };
+  mavenRepository = mvn2nix.buildMavenRepositoryFromLockFile { file = ./mvn2nix-lock.json; };
 in
-with pkgs; stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "thorp";
   version = "2.0.1";
   name = "${pname}-${version}";
-  src = sources.thorp;
+  src = thorpSrc;
   buildInputs = [ jdk11_headless maven makeWrapper graphviz ];
   buildPhase = ''
     echo "Building with maven repository ${mavenRepository}"
@@ -36,4 +35,9 @@ with pkgs; stdenv.mkDerivation rec {
     makeWrapper ${jdk11_headless}/bin/java $out/bin/${pname} \
           --add-flags "-jar $out/${name}.jar"
   '';
+  meta = {
+    description = "Synchronisation of files with S3 using the hash of the file contents.";
+    homepage = "https://github.com/kemitix/thorp";
+    license = stdenv.lib.licenses.mit;
+  };
 }

--- a/nix/pkgs/thorp/default.nix
+++ b/nix/pkgs/thorp/default.nix
@@ -1,0 +1,39 @@
+{ pkgs, sources }:
+let
+  mvn2nix = import sources.mvn2nix { };
+  # This file was generated from mvn2nix pom.xml > mvn2nix-lock.json however one of the hashes was incorrect
+  # and so was changed manually, see https://github.com/fzakaria/mvn2nix/issues/29
+  # also the format in the json file is base32 but the error is reported in base64 so you need to convert
+  # nix-hash --type sha256 --to-base16 $expectedHash
+  file = ./mvn2nix-lock.json;
+  mavenRepository = mvn2nix.buildMavenRepositoryFromLockFile { inherit file; };
+in
+with pkgs; stdenv.mkDerivation rec {
+  pname = "thorp";
+  version = "2.0.1";
+  name = "${pname}-${version}";
+  src = sources.thorp;
+  buildInputs = [ jdk11_headless maven makeWrapper graphviz ];
+  buildPhase = ''
+    echo "Building with maven repository ${mavenRepository}"
+    mvn package --offline -Dmaven.repo.local=${mavenRepository}
+  '';
+
+  installPhase = ''
+    # create the bin directory
+    mkdir -p $out/bin
+
+    # create a symbolic link for the lib directory
+    ln -s ${mavenRepository} $out/lib
+
+    # copy out the JAR
+    # Maven already setup the classpath to use m2 repository layout
+    # with the prefix of lib/
+    cp app/target/${name}-jar-with-dependencies.jar $out/${name}.jar
+
+    # create a wrapper that will automatically set the classpath
+    # this should be the paths from the dependency derivation
+    makeWrapper ${jdk11_headless}/bin/java $out/bin/${pname} \
+          --add-flags "-jar $out/${name}.jar"
+  '';
+}

--- a/nix/pkgs/thorp/mvn2nix-lock.json
+++ b/nix/pkgs/thorp/mvn2nix-lock.json
@@ -1,0 +1,6149 @@
+{
+  "dependencies": {
+    "org.codehaus.plexus:plexus-utils:pom:3.0.10": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.pom",
+      "sha256": "1f4ed909a012a1ae3eec7b649ae84c0425a05cbb05c48b6a644d122fb6f6bc4b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.pom"
+    },
+    "org.kathrynhuxtable.maven.wagon:wagon-gitsite:jar:0.3.1": {
+      "layout": "org/kathrynhuxtable/maven/wagon/wagon-gitsite/0.3.1/wagon-gitsite-0.3.1.jar",
+      "sha256": "636047154b24670c92fbe89f846cd7130e25795961604f175a6e8dfc6157843e",
+      "url": "https://repo.maven.apache.org/maven2/org/kathrynhuxtable/maven/wagon/wagon-gitsite/0.3.1/wagon-gitsite-0.3.1.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.17": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.17/plexus-utils-3.0.17.pom",
+      "sha256": "e5f820f02dc5513b3f9518f6403fbcbcb0f1654cb965c759eb1e31ddd80f57fb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.17/plexus-utils-3.0.17.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.15/plexus-utils-3.0.15.pom",
+      "sha256": "b4fe0bed469e2e973c661b4b7647db374afee7bda513560e96cd780132308f0b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.15/plexus-utils-3.0.15.pom"
+    },
+    "org.apache.maven:maven-core:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
+      "sha256": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
+    },
+    "org.codehaus.plexus:plexus-velocity:jar:1.1.2": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.1.2/plexus-velocity-1.1.2.jar",
+      "sha256": "767909fbe35e179e28e48ea6c81705ac233cfadff7a884a5302d9b4a5176372a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.1.2/plexus-velocity-1.1.2.jar"
+    },
+    "org.codehaus.plexus:plexus-velocity:jar:1.1.7": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.jar",
+      "sha256": "1c9c994fbcd31526d451797072d7afb19f9b1962e710f3088f54fd1267b45fae",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.jar"
+    },
+    "org.sonatype.sisu:sisu-inject-bean:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom",
+      "sha256": "06d75dd6f2a0dc9ea6bf73a67491ba4790f92251c654bf4925511e5e4f48f1df",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom"
+    },
+    "com.fasterxml.jackson.dataformat:jackson-dataformats-binary:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/dataformat/jackson-dataformats-binary/2.11.3/jackson-dataformats-binary-2.11.3.pom",
+      "sha256": "02f701edf7215a75521ee49548a330426e339273fb857dab74221ba7be0a8730",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformats-binary/2.11.3/jackson-dataformats-binary-2.11.3.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.20": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.pom",
+      "sha256": "8ded3e5d2d85f09b4b3bb1ae52b125bf28e02bab1a935787c548d97cb555912a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.20/plexus-utils-3.0.20.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-core:pom:4.3.2": {
+      "layout": "org/apache/httpcomponents/httpcomponents-core/4.3.2/httpcomponents-core-4.3.2.pom",
+      "sha256": "aa3ec31c7dd2161cfe3a3975645ea8703db0a6d6adb7d5b1766b32764c5c1806",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-core/4.3.2/httpcomponents-core-4.3.2.pom"
+    },
+    "org.junit.platform:junit-platform-launcher:jar:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1.jar",
+      "sha256": "6f698076c33cf27d2b80de11506031b625733aab7f18e2d4c5d15803f27231dd",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.24": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.pom",
+      "sha256": "11067f6a75fded12bcdc8daf7a66ddd942ce289c3daf88a3fe0f8b12858a2ee6",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-project/2.0.2/maven-project-2.0.2.pom",
+      "sha256": "10600e2d9469d7e10d09c4ed6031dabfe333634b9786d5a3867458dce4e84d67",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.2/maven-project-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.22": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom",
+      "sha256": "f20db219a9c2ebbfea479a1c58a252d795689b8627d43442748d8a21e0052f57",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom"
+    },
+    "org.codehaus.plexus:plexus-io:jar:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar",
+      "sha256": "e2f88c8813463aabfb1b689f0be551c24c58e8e5508fd5a44f8d20a327b1517f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar"
+    },
+    "org.sonatype.buildsupport:public-parent:pom:6": {
+      "layout": "org/sonatype/buildsupport/public-parent/6/public-parent-6.pom",
+      "sha256": "46894ca74541a0e8ef27e2c738361affad4565acc8ce1a7fcf94c0ce52da2a4a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/6/public-parent-6.pom"
+    },
+    "org.eclipse.aether:aether-api:pom:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.pom",
+      "sha256": "1c4b2e76a2af82a7ddfc1539c0eeb5e79ed2c6b3d412b31a5c617744f4535827",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.pom"
+    },
+    "com.sun.jersey:jersey-core:jar:1.17.1": {
+      "layout": "com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.jar",
+      "sha256": "bed577a78f1ca9e580d1e7e3df1f36e84377672c13f7a73f871577c35e6b1139",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.jar"
+    },
+    "org.sonatype.sisu.siesta:siesta-common:pom:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-common/1.7/siesta-common-1.7.pom",
+      "sha256": "ad81da8ebbaa78cfc26a71e6e1a98e3628f1f367ce5e69eefc34f11f9173b6d0",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-common/1.7/siesta-common-1.7.pom"
+    },
+    "org.iq80.snappy:snappy:jar:0.4": {
+      "layout": "org/iq80/snappy/snappy/0.4/snappy-0.4.jar",
+      "sha256": "46a0c87d504ce9d6063e1ff6e4d20738feb49d8abf85b5071a7d18df4f11bac9",
+      "url": "https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.jar"
+    },
+    "org.apache.maven:maven-project:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom",
+      "sha256": "7dd6468c154d99c39a94c7a8c734aa96366864334b6b2ea10778459860cbe3e5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom",
+      "sha256": "fa8043afdbe232e7541b965386dc582be336783ac220aadc9bde401b02295a90",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom"
+    },
+    "org.apache.maven:maven-model:pom:3.1.0": {
+      "layout": "org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.pom",
+      "sha256": "f99770a493eb79eadd4fb0629425035a8496d02f377d89949b75274698c67dfb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.pom"
+    },
+    "org.slf4j:jul-to-slf4j:pom:1.7.25": {
+      "layout": "org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.pom",
+      "sha256": "b30fcd17b18557a188dfa1148afb56dec3f4386dbdad6c7fbf15667e22f665df",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-project/2.0.8/maven-project-2.0.8.pom",
+      "sha256": "7b0afd8e494832df5736bd3994eae90ed2306bfbcbcea79ae2ec377a68a67dbc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.8/maven-project-2.0.8.pom"
+    },
+    "logkit:logkit:pom:1.0.1": {
+      "layout": "logkit/logkit/1.0.1/logkit-1.0.1.pom",
+      "sha256": "3de328dfa1b563ba6dfc5829774cf2f8dab0dc9528ed2731c35251ab7fd6c4c6",
+      "url": "https://repo.maven.apache.org/maven2/logkit/logkit/1.0.1/logkit-1.0.1.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom",
+      "sha256": "0ef1a886c795b5ca48d08245b13d1128ecbc6fd0f05e6556749547df9978680b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom",
+      "sha256": "5566a0bb51dc994c0350206608c7b4cdcc9b66881497bab56a32c42edca53e79",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom"
+    },
+    "com.amazonaws:aws-java-sdk-core:jar:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-core/1.11.893/aws-java-sdk-core-1.11.893.jar",
+      "sha256": "1699aa86f65c2d7f42655bb381a38ef4e82da7a8794b7f9fd18e24f8f38c1a1c",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.893/aws-java-sdk-core-1.11.893.jar"
+    },
+    "xpp3:xpp3_min:pom:1.1.4c": {
+      "layout": "xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.pom",
+      "sha256": "b5b46ac0c09da41b04dbc753456b48912856a7ffbb1490676910b510c471d13f",
+      "url": "https://repo.maven.apache.org/maven2/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.pom"
+    },
+    "net.kemitix.tiles:enforcer:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/enforcer/2.7.0/enforcer-2.7.0.pom",
+      "sha256": "1ee8a69d88c68c71ce14ee7ab3464793cad53ec7ac817b3adb23463641b02bd5",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/enforcer/2.7.0/enforcer-2.7.0.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:pom:1.4": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom",
+      "sha256": "a63a2e23988cca7fac6c93886d6f0506fd26d88d7e8cc0cb89b9c6e0d6c994ad",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom"
+    },
+    "org.sonatype.nexus.plugins:nexus-plugins:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/plugins/nexus-plugins/2.9.1-02/nexus-plugins-2.9.1-02.pom",
+      "sha256": "907c6950a01b62328a93830c71343748f9228c56f9fd6e40e789989d174a7a11",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins/2.9.1-02/nexus-plugins-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom",
+      "sha256": "12a3c9a32b82fdc95223cab1f9d344e14ef3e396da14c4d0013451646f3280e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom"
+    },
+    "backport-util-concurrent:backport-util-concurrent:pom:3.1": {
+      "layout": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom",
+      "sha256": "770471090ca40a17b9e436ee2ec00819be42042da6f4085ece1d37916dc08ff9",
+      "url": "https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-core:pom:4.4.13": {
+      "layout": "org/apache/httpcomponents/httpcomponents-core/4.4.13/httpcomponents-core-4.4.13.pom",
+      "sha256": "c554e7008e4517c7ef54e005cc8b74f4c87a54a0ea2c6f57be5d0569df51936b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-core/4.4.13/httpcomponents-core-4.4.13.pom"
+    },
+    "javax.validation:validation-api:jar:1.1.0.Final": {
+      "layout": "javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar",
+      "sha256": "f39d7ba7253e35f5ac48081ec1bc28c5df9b32ac4b7db20853e5a8e76bf7b0ed",
+      "url": "https://repo.maven.apache.org/maven2/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar"
+    },
+    "net.kemitix.tiles:parent:pom:2.4.1": {
+      "layout": "net/kemitix/tiles/parent/2.4.1/parent-2.4.1.pom",
+      "sha256": "dadc6fb354effabb9f7e4c99085527d49bcdb452612dae3204b4e6561ea58cbc",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/parent/2.4.1/parent-2.4.1.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:pom:1.7": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom",
+      "sha256": "82d7be6e6f96bb38ea05412a8a8732ab3977afbd15041d9e0dbb786414ca53d2",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.pom"
+    },
+    "commons-collections:commons-collections:pom:3.1": {
+      "layout": "commons-collections/commons-collections/3.1/commons-collections-3.1.pom",
+      "sha256": "59c9e5fc75e5790e56976c166a89f2cbdad99f76c49b92f74a1749689af726a2",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.1/commons-collections-3.1.pom"
+    },
+    "org.ow2.asm:asm:jar:7.3.1": {
+      "layout": "org/ow2/asm/asm/7.3.1/asm-7.3.1.jar",
+      "sha256": "2f67e11ceec819ebd88ddee5300aba699b1cbab2e20c22e97cf027d3be93959b",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.3.1/asm-7.3.1.jar"
+    },
+    "commons-collections:commons-collections:pom:3.2": {
+      "layout": "commons-collections/commons-collections/3.2/commons-collections-3.2.pom",
+      "sha256": "6da6d5e61be60d77a7eea6c7d0b8ac3cc35ca73cef3cbff97d5982006553786d",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2/commons-collections-3.2.pom"
+    },
+    "org.junit.jupiter:junit-jupiter-params:pom:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.pom",
+      "sha256": "23873e305a9751109839ad08b6b37dfadd1036f43b359b3b1b7bd2601fc73260",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:4.2.0": {
+      "layout": "org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.pom",
+      "sha256": "aa6ce1f10002697df86634c5b6645e9d003a73a50b97a4a5eadd91cd9de1ad10",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.pom"
+    },
+    "org.apache.geronimo.genesis:genesis-java5-flava:pom:2.0": {
+      "layout": "org/apache/geronimo/genesis/genesis-java5-flava/2.0/genesis-java5-flava-2.0.pom",
+      "sha256": "e7c5358bbbbc27daa5b327f63bc12650a75ddc9f9ac6d4bfa12789be1f2c29db",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-java5-flava/2.0/genesis-java5-flava-2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-i18n:pom:1.0-beta-7": {
+      "layout": "org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.pom",
+      "sha256": "9a4c894f2601f403396363f31b22ff55f665de9393c0ec941df38a05d5ab4d66",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.pom"
+    },
+    "org.apache.maven.doxia:doxia-skin-model:pom:1.7.4": {
+      "layout": "org/apache/maven/doxia/doxia-skin-model/1.7.4/doxia-skin-model-1.7.4.pom",
+      "sha256": "ded04d7acabcf950b8fd226fbccac8db2f49c0a8aa45f17d3cfa5d4e9aa522ee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/1.7.4/doxia-skin-model-1.7.4.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-api:pom:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom",
+      "sha256": "822b617cf487e06f520c28e14ade592563b30638a26b40acb4d5402efdf8cd26",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom"
+    },
+    "org.codehaus.plexus:plexus-i18n:pom:1.0-beta-6": {
+      "layout": "org/codehaus/plexus/plexus-i18n/1.0-beta-6/plexus-i18n-1.0-beta-6.pom",
+      "sha256": "2b10aa54fc08ef9612acb72b2f9be9fac65fb3f8e5b4a05a4a04a448efd676fe",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-6/plexus-i18n-1.0-beta-6.pom"
+    },
+    "org.junit.jupiter:junit-jupiter:jar:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter/5.7.0/junit-jupiter-5.7.0.jar",
+      "sha256": "f15ebc08c85be1f46cd2aff06d6125e5083da0f527cd434f8b5431b5b0a1abd0",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.7.0/junit-jupiter-5.7.0.jar"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:jar:3.1.0": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.jar",
+      "sha256": "c3cf1359555b42467a72b3d07b11e2c2698c1e47ffeb05166d6af1a4c32d39e6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.jar"
+    },
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.3.1/jackson-jaxrs-base-2.3.1.pom",
+      "sha256": "d0ceb3dda6ab3bf254833a7ebfeda2ce9510f1b60216a6ce32418be0eb12b0c0",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.3.1/jackson-jaxrs-base-2.3.1.pom"
+    },
+    "org.apache.maven.surefire:surefire-booter:jar:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.jar",
+      "sha256": "bf20823458740de95899a75ef0276fad9a7eff5c76c036d177be79073b571b4f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.jar"
+    },
+    "org.apache.commons:commons-compress:pom:1.9": {
+      "layout": "org/apache/commons/commons-compress/1.9/commons-compress-1.9.pom",
+      "sha256": "7ad155ed7d6c44976eaeae2a3acbe145b09ceccc39aa4f094cf08e70df8825cc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.9/commons-compress-1.9.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:4.2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/4.2.1/plexus-archiver-4.2.1.pom",
+      "sha256": "2b1aa2adef45630f4668144c7c22f829bf6d1f7d96aaeae178096c9dfcd05204",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.2.1/plexus-archiver-4.2.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.8/doxia-core-1.8.pom",
+      "sha256": "eb9029d58040b2b6427b69812849439c84e144e383121764b32c3664825c0ce8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.8/doxia-core-1.8.pom"
+    },
+    "org.apache.maven:maven-toolchain:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.pom",
+      "sha256": "2537524657d2e4dc51eb84e587ab67c8153f8da19389c24c2006954b2a4b36fb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.pom",
+      "sha256": "0d0882a3f6f55bc987cb42a9309e9254b1eb9255619a2e73c18dc7373d7c8374",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.0/doxia-core-1.0.pom",
+      "sha256": "d0a6f46bff1940ddd32e580db24fe441ef3045fb9308d98fe3c066dcde6c8247",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.0/doxia-core-1.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.jar",
+      "sha256": "e1a1b4f93bfd8c02b72ebd52ffbdfc10034cbc5e5cb2cb246efbdaf9206e7507",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.jar"
+    },
+    "org.sonatype.buildsupport:public-parent:pom:5": {
+      "layout": "org/sonatype/buildsupport/public-parent/5/public-parent-5.pom",
+      "sha256": "a9197ae62144fa302b1f33184741ad29a7da7f7e30e1b51e025df173af2e5a4d",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/public-parent/5/public-parent-5.pom"
+    },
+    "org.apache.maven:maven-parent:pom:8": {
+      "layout": "org/apache/maven/maven-parent/8/maven-parent-8.pom",
+      "sha256": "3cb6712f827c80dc6b0b0b967776dba451c023a92b7741bba45d23ab7a83281a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/8/maven-parent-8.pom"
+    },
+    "org.apache.maven:maven-parent:pom:6": {
+      "layout": "org/apache/maven/maven-parent/6/maven-parent-6.pom",
+      "sha256": "df8f5fc5e956249833fe9e9bd6df891ca7224ceff1cb729dd84848376545afda",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/6/maven-parent-6.pom"
+    },
+    "ch.qos.logback:logback-classic:pom:1.1.2": {
+      "layout": "ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.pom",
+      "sha256": "8fe8c84f238e235336993624fc698def0f257ec84f47711564041a9010c8c68e",
+      "url": "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.pom"
+    },
+    "org.apache.maven:maven-parent:pom:5": {
+      "layout": "org/apache/maven/maven-parent/5/maven-parent-5.pom",
+      "sha256": "5d7c2a229173155823c45380332f221bf0d27e52c9db76e9217940306765bd50",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/5/maven-parent-5.pom"
+    },
+    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.3.1/jackson-module-jaxb-annotations-2.3.1.pom",
+      "sha256": "aae6d734a5ed7ee812e690625cbe3c27f945b3eca3f5ccf02cfa045bdc3b9c2a",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.3.1/jackson-module-jaxb-annotations-2.3.1.pom"
+    },
+    "commons-codec:commons-codec:jar:1.3": {
+      "layout": "commons-codec/commons-codec/1.3/commons-codec-1.3.jar",
+      "sha256": "1bafd2ece2e88db4cdf835a7f8f0de65fab5b1147977a5dcc59b7c1b8c6f5080",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.3/commons-codec-1.3.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.5.4": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.4/plexus-component-annotations-1.5.4.pom",
+      "sha256": "0124227bc47efc9a00b9aa4fc3ef7f70823d322213c26489e5369a914339c84a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.4/plexus-component-annotations-1.5.4.pom"
+    },
+    "org.apache.maven.shared:maven-artifact-transfer:jar:0.11.0": {
+      "layout": "org/apache/maven/shared/maven-artifact-transfer/0.11.0/maven-artifact-transfer-0.11.0.jar",
+      "sha256": "1f474df0b9dd55e5bb755a131ec64b307c557293328711adb579d21c010dffde",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.11.0/maven-artifact-transfer-0.11.0.jar"
+    },
+    "net.kemitix.tiles:testing:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/testing/2.7.0/testing-2.7.0.xml",
+      "sha256": "350cee6ec015a2b77a8efbf1ab9538f51d36357f819b9deac5b92a0cab558566",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/testing/2.7.0/testing-2.7.0.xml"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.0/doxia-decoration-model-1.0.jar",
+      "sha256": "ec95e400c9b272b87254327ec408ef50f0252a5a8edf331f00902371c733fc00",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.0/doxia-decoration-model-1.0.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom",
+      "sha256": "815f3ec316b8c5fa701385fdf4009bfb51e07d780e8f6a6e2afe720c52d7e292",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom"
+    },
+    "commons-codec:commons-codec:jar:1.6": {
+      "layout": "commons-codec/commons-codec/1.6/commons-codec-1.6.jar",
+      "sha256": "54b34e941b8e1414bd3e40d736efd3481772dc26db3296f6aa45cec9f6203d86",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.6/commons-codec-1.6.jar"
+    },
+    "org.easymock:easymock:jar:3.4": {
+      "layout": "org/easymock/easymock/3.4/easymock-3.4.jar",
+      "sha256": "ce2885cabe0d2c44d99d405796f9b1e248b76a6106863ad6a236bd4bcc311e19",
+      "url": "https://repo.maven.apache.org/maven2/org/easymock/easymock/3.4/easymock-3.4.jar"
+    },
+    "org.apache.maven:maven-plugin-descriptor:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.0/maven-plugin-descriptor-2.2.0.jar",
+      "sha256": "b0996900e2d9f7191ae3258779863a508eb60e9b51b5bc7196fd0e16c1539858",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.0/maven-plugin-descriptor-2.2.0.jar"
+    },
+    "org.objenesis:objenesis-parent:pom:3.1": {
+      "layout": "org/objenesis/objenesis-parent/3.1/objenesis-parent-3.1.pom",
+      "sha256": "1493584824e110e22d6047584978ca2fc9907987102369bdb1e3773d54963ada",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.1/objenesis-parent-3.1.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.jar",
+      "sha256": "ea41346759cb042027a4f6f98996427ba0ecf72602b1c3ee925461ddd00266b4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.jar"
+    },
+    "xmlpull:xmlpull:jar:1.1.3.1": {
+      "layout": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar",
+      "sha256": "34e08ee62116071cbb69c0ed70d15a7a5b208d62798c59f2120bb8929324cb63",
+      "url": "https://repo.maven.apache.org/maven2/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar"
+    },
+    "org.apache.velocity:velocity:pom:1.5": {
+      "layout": "org/apache/velocity/velocity/1.5/velocity-1.5.pom",
+      "sha256": "de893ceb40c4659cbcd3f5507edb9474c825f72c5c0b61892cc87ace7197f6fe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.5/velocity-1.5.pom"
+    },
+    "commons-collections:commons-collections:pom:3.2.1": {
+      "layout": "commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.pom",
+      "sha256": "1f9626cbaa584ed5d86021866e4e367e26fe5efc248382652be68beeb43e7416",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:5": {
+      "layout": "org/sonatype/forge/forge-parent/5/forge-parent-5.pom",
+      "sha256": "e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:4": {
+      "layout": "org/sonatype/forge/forge-parent/4/forge-parent-4.pom",
+      "sha256": "1838d132479005b4b7459b798e9d9915515090c288082fdcd86db0b10983a24c",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom"
+    },
+    "org.eclipse.sisu:sisu-inject:pom:0.3.2": {
+      "layout": "org/eclipse/sisu/sisu-inject/0.3.2/sisu-inject-0.3.2.pom",
+      "sha256": "fe1379bb832bf832ad5644dc159b6f89a732c75d27b6dc3bbb2b4876ddc0ab56",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-inject/0.3.2/sisu-inject-0.3.2.pom"
+    },
+    "org.apache.maven.plugin-tools:maven-plugin-tools:pom:3.5.2": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-tools/3.5.2/maven-plugin-tools-3.5.2.pom",
+      "sha256": "441ffde95bfa0b6fa235797b00341c3c622be8fb568e2c2490ed35cd5b34cf8f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-tools/3.5.2/maven-plugin-tools-3.5.2.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:6": {
+      "layout": "org/sonatype/forge/forge-parent/6/forge-parent-6.pom",
+      "sha256": "9c5f7cd5226ac8c3798cb1f800c031f7dedc1606dc50dc29567877c8224459a7",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom"
+    },
+    "org.apache.felix:maven-bundle-plugin:pom:3.5.1": {
+      "layout": "org/apache/felix/maven-bundle-plugin/3.5.1/maven-bundle-plugin-3.5.1.pom",
+      "sha256": "6eb2c0e09a1ee52fea479285ddb30ce31c1b760898a42e493634b57ea85af27e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.5.1/maven-bundle-plugin-3.5.1.pom"
+    },
+    "org.apache.httpcomponents:httpclient:pom:4.0.2": {
+      "layout": "org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.pom",
+      "sha256": "1c0a5ab5ce9980cd49e4e37c8089d28611f852e2b33e9c3d0f8ae40f0eea75b8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom",
+      "sha256": "f658a628efd6e0efe416b977638ba144af660fe6413f3637a4d03feb6a1ce806",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-artifact/2.2.0/maven-artifact-2.2.0.pom",
+      "sha256": "8a9bf07184f8a654b9974b509d10ca6f582570ffdfc3ddc7158ad0ddcb5c0096",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.0/maven-artifact-2.2.0.pom"
+    },
+    "org.apache.velocity:velocity:pom:1.7": {
+      "layout": "org/apache/velocity/velocity/1.7/velocity-1.7.pom",
+      "sha256": "a3f97ceab5f073ed93ef8fe6304e35252d83ecf2442c83fe0492b8b73da3b40b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.7/velocity-1.7.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:jar:3.5.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/3.5.0/biz.aQute.bndlib-3.5.0.jar",
+      "sha256": "884322bca122810402776527496ac6faa7eca5463b4f806587fe708cb6ca862c",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/3.5.0/biz.aQute.bndlib-3.5.0.jar"
+    },
+    "org.apache.maven:maven-compat:pom:3.0": {
+      "layout": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.pom",
+      "sha256": "612a1751377f324c1a6167c6d70a26800cbe3f1b2a37d03a9377ef4f80e7b526",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0/maven-compat-3.0.pom"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:jar:1.2": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
+      "sha256": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom",
+      "sha256": "3b0fa210dcbf0c92545ac31740fc2dd8af61dc72fd452cfca3d68aeabb642003",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom"
+    },
+    "org.apache.struts:struts-master:pom:4": {
+      "layout": "org/apache/struts/struts-master/4/struts-master-4.pom",
+      "sha256": "7a9ee24480959cfbef9ccc8ca9b55da3a2bf9cbed81518de340a21289d12cec6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-master/4/struts-master-4.pom"
+    },
+    "com.fasterxml.jackson.core:jackson-annotations:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-annotations/2.3.1/jackson-annotations-2.3.1.pom",
+      "sha256": "1ceb884ca051130a06383df7df2a95ef998df4b6d7eced7bf4843e4be2a7338a",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.3.1/jackson-annotations-2.3.1.pom"
+    },
+    "org.osgi:org.osgi.compendium:pom:4.2.0": {
+      "layout": "org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.pom",
+      "sha256": "16ba26c9913f454f9db166bd38b2c3341b4dfc884ae5256b4f1b3c9d307228c7",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.pom"
+    },
+    "com.fasterxml.jackson.core:jackson-annotations:pom:2.3.0": {
+      "layout": "com/fasterxml/jackson/core/jackson-annotations/2.3.0/jackson-annotations-2.3.0.pom",
+      "sha256": "4a51ac0c3696f8974d8dde4e6d464e8d03d5a919eb6d365ca6b410e1f6a7cf6c",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.3.0/jackson-annotations-2.3.0.pom"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:pom:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom",
+      "sha256": "a98f60925af4a1729529a1e9c5aba78ffdd024c67a8f825ed974a0ab006d315a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom"
+    },
+    "org.apiguardian:apiguardian-api:jar:1.1.0": {
+      "layout": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar",
+      "sha256": "a9aae9ff8ae3e17a2a18f79175e82b16267c246fbbd3ca9dfbbb290b08dcfdd4",
+      "url": "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+    },
+    "org.tukaani:xz:jar:1.8": {
+      "layout": "org/tukaani/xz/1.8/xz-1.8.jar",
+      "sha256": "8c7964b36fe3f0cbe644b04fcbff84e491ce81917db2f5bfa0cba8e9548aff5d",
+      "url": "https://repo.maven.apache.org/maven2/org/tukaani/xz/1.8/xz-1.8.jar"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:jar:5.1.1": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/5.1.1/biz.aQute.bndlib-5.1.1.jar",
+      "sha256": "335471dfbc7a9c593b2ea21f8f450c9af0f8e5821579774ca4e93a97a841af22",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/5.1.1/biz.aQute.bndlib-5.1.1.jar"
+    },
+    "net.sourceforge.pmd:pmd-jsp:jar:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-jsp/6.23.0/pmd-jsp-6.23.0.jar",
+      "sha256": "cf7fea7d37361e05e64f9955f41360c2735d26525262b77b0f11478d2fb834b0",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-jsp/6.23.0/pmd-jsp-6.23.0.jar"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.inject:pom:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.pom",
+      "sha256": "77df04bd50d231861e65945c4edd889456f093fe6b316f6ee906bd75c45108c4",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.pom"
+    },
+    "org.apache.maven:maven-settings:jar:3.1.0": {
+      "layout": "org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.jar",
+      "sha256": "a44bb2a6c8571269a06ab8efba046fd319af34c4985deda66512dc1e648f301a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-annotations:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-annotations/2.11.3/jackson-annotations-2.11.3.pom",
+      "sha256": "f86e56b9e5f606e7d30f6831d9da550704772a869862ede001ad324b37974c9d",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.11.3/jackson-annotations-2.11.3.pom"
+    },
+    "org.apache.maven:maven-model:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.pom",
+      "sha256": "9ba289da159f25f24f732489d4af6be4f2e6d7222f273968af4bc0e4ebb7412f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.pom"
+    },
+    "javax.inject:javax.inject:jar:1": {
+      "layout": "javax/inject/javax.inject/1/javax.inject-1.jar",
+      "sha256": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+      "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    "org.mockito:mockito-core:pom:3.6.0": {
+      "layout": "org/mockito/mockito-core/3.6.0/mockito-core-3.6.0.pom",
+      "sha256": "1a1c59304f942b6f127d6c885f8b237f3c62c1e1c75994e4f19e6359514dc209",
+      "url": "https://repo.maven.apache.org/maven2/org/mockito/mockito-core/3.6.0/mockito-core-3.6.0.pom"
+    },
+    "org.beanshell:bsh:pom:2.0b4": {
+      "layout": "org/beanshell/bsh/2.0b4/bsh-2.0b4.pom",
+      "sha256": "9c048fddf29663d9380a68f414d089717ae3e30b915e6c96015bf4a64a82f18f",
+      "url": "https://repo.maven.apache.org/maven2/org/beanshell/bsh/2.0b4/bsh-2.0b4.pom"
+    },
+    "org.sonatype.aether:aether-util:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar",
+      "sha256": "ff690ffc550b7ada3a4b79ef4ca89bf002b24f43a13a35d10195c3bba63d7654",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar"
+    },
+    "org.sonatype.nexus.maven:nexus-staging:pom:1.6.6": {
+      "layout": "org/sonatype/nexus/maven/nexus-staging/1.6.6/nexus-staging-1.6.6.pom",
+      "sha256": "024f50e77bf4811b1d677d07b55338de7021096b8058baf492593c6bc89e0061",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-staging/1.6.6/nexus-staging-1.6.6.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom",
+      "sha256": "77ca407ccc76079a2b60f4d3e652c19552890303fa00748623e372eac09039a1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom"
+    },
+    "org.osgi:org.osgi.core:jar:6.0.0": {
+      "layout": "org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar",
+      "sha256": "1c1bb435eb34cbf1f743653da38f604d45d53fbc95979053768cd3fc293cb931",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar"
+    },
+    "org.apache.maven.shared:file-management:pom:3.0.0": {
+      "layout": "org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.pom",
+      "sha256": "0ad8749b05438dd80b6f421dcad95688c46670f47ff8ef75496d503576640f08",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.pom"
+    },
+    "com.google.guava:guava:pom:14.0.1": {
+      "layout": "com/google/guava/guava/14.0.1/guava-14.0.1.pom",
+      "sha256": "3dd4a992d53eb524a1c6546a24b853b332b26520755e26b25d38100131424b7b",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.pom"
+    },
+    "com.google.guava:guava-parent:pom:16.0.1": {
+      "layout": "com/google/guava/guava-parent/16.0.1/guava-parent-16.0.1.pom",
+      "sha256": "2c98892cbf7c606b91b4f0f0d1d91da26746bbf5f8595626f5b4d6a5a1914824",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/16.0.1/guava-parent-16.0.1.pom"
+    },
+    "org.sonatype.sisu.inject:guice-bean:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom",
+      "sha256": "d2ee7efbcdc82206c69559548aef86a99add95378f03cc58b4d9696b3969c8bb",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom"
+    },
+    "org.apache.maven.resolver:maven-resolver:pom:1.4.1": {
+      "layout": "org/apache/maven/resolver/maven-resolver/1.4.1/maven-resolver-1.4.1.pom",
+      "sha256": "831c3849751101226495acfe9119582feb734a4539b070e0fbd9e85b03b501ce",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver/1.4.1/maven-resolver-1.4.1.pom"
+    },
+    "org.sonatype.plexus:plexus-build-api:jar:0.0.7": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar",
+      "sha256": "934171640fbd3d2495c50b79b0d9adb11e2c83e65bad157df8fe34bcac0ff798",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar"
+    },
+    "org.codehaus.plexus:plexus-java:jar:0.9.10": {
+      "layout": "org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar",
+      "sha256": "9f4c82ea85ccad3c8bb6ae8101ed760aabf5b33b529586a8bd5d1e3d3ab67f1b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar"
+    },
+    "ch.qos.logback:logback-core:pom:1.1.2": {
+      "layout": "ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.pom",
+      "sha256": "3cad40ee01d5d4a5b92c74b6562c8b8ecdaad254273bfea97f35f8e18b024ee1",
+      "url": "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.pom"
+    },
+    "org.apache.maven:maven-model:jar:3.0": {
+      "layout": "org/apache/maven/maven-model/3.0/maven-model-3.0.jar",
+      "sha256": "27e426d73f8662b47f60df0e43439b3dec2909c42b89175a6e4431dfed3edafd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar"
+    },
+    "org.apache.maven.scm:maven-scm-provider-git-commons:jar:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-git-commons/1.9.1/maven-scm-provider-git-commons-1.9.1.jar",
+      "sha256": "d4842409c491c8cd27d8fac3c3e75649e692b59aef7d728d790fc0e1eb5a8443",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-git-commons/1.9.1/maven-scm-provider-git-commons-1.9.1.jar"
+    },
+    "commons-validator:commons-validator:pom:1.1.4": {
+      "layout": "commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.pom",
+      "sha256": "ccaaa3dee350fd5683f2caecc4b316e5803fa304d23fb78ab69efee22cb445d1",
+      "url": "https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.2/maven-plugin-api-2.0.2.pom",
+      "sha256": "722197546d5d4157e0a529aa449fe4979b7f5ab04ae25ff56aea953279e95dd1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.2/maven-plugin-api-2.0.2.pom"
+    },
+    "org.apache.maven.surefire:surefire-logger-api:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.pom",
+      "sha256": "8b33826369e8a056dd48a837d7f607406b32d33aae3d80ed8370eebc5ed6cd5b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom",
+      "sha256": "e5886cbf7478ed0a89d4502cb4b6b4d25095a53b74e07439ec0ab3f793405822",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom"
+    },
+    "org.apache.maven.scm:maven-scm-api:jar:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-api/1.9.1/maven-scm-api-1.9.1.jar",
+      "sha256": "925e5d8aaf3a4308ddaa41d7c48c302d009fd1b85377fb03737118dc38aab050",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-api/1.9.1/maven-scm-api-1.9.1.jar"
+    },
+    "net.sourceforge.saxon:saxon:jar:9.1.0.8": {
+      "layout": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.jar",
+      "sha256": "f3dcde81066c75db4ffca341d543555dbbbba7fff7ba6d1c2e7de1101dea394a",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-30": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.jar",
+      "sha256": "ef5fa49aeb90df9cac923435577dc9c2701a18ba29191b6e407e7870795eea35",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.jar"
+    },
+    "net.kemitix.tiles:parent:pom:0.8.1": {
+      "layout": "net/kemitix/tiles/parent/0.8.1/parent-0.8.1.pom",
+      "sha256": "2579b4c2fcd80a3957b2bdc0649242b86651a0e276bd62dd68c4d8e0a094c7bd",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/parent/0.8.1/parent-0.8.1.pom"
+    },
+    "javax.inject:javax.inject:pom:1": {
+      "layout": "javax/inject/javax.inject/1/javax.inject-1.pom",
+      "sha256": "943e12b100627804638fa285805a0ab788a680266531e650921ebfe4621a8bfa",
+      "url": "https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:3.0.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.jar",
+      "sha256": "0796ca76de719a8f8178f090de4b9b03158ba65268f58cc8fc9bbe71a9f58f9e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.jar"
+    },
+    "com.fasterxml.jackson:jackson-parent:pom:2.11": {
+      "layout": "com/fasterxml/jackson/jackson-parent/2.11/jackson-parent-2.11.pom",
+      "sha256": "c1b0a13d8cfe63b40b0fae8458b99463169ed0c60f7fc963ef3f05257150cbe8",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.11/jackson-parent-2.11.pom"
+    },
+    "org.objenesis:objenesis:jar:2.2": {
+      "layout": "org/objenesis/objenesis/2.2/objenesis-2.2.jar",
+      "sha256": "2ee6c7e5a871d3f007b5a0c08c89b3b50772f345d45376c8ddc564647eb9aabe",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis/2.2/objenesis-2.2.jar"
+    },
+    "org.sonatype.plugins:nexus-staging-maven-plugin:jar:1.6.6": {
+      "layout": "org/sonatype/plugins/nexus-staging-maven-plugin/1.6.6/nexus-staging-maven-plugin-1.6.6.jar",
+      "sha256": "030aaefc7a3a2dcbad09798c24ff559954ffc699f2db08bfc6a23fbf4f61c0c6",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.6/nexus-staging-maven-plugin-1.6.6.jar"
+    },
+    "org.apache.maven.shared:maven-filtering:jar:3.2.0": {
+      "layout": "org/apache/maven/shared/maven-filtering/3.2.0/maven-filtering-3.2.0.jar",
+      "sha256": "f3d247b564ff1ec2fb7662529e72156f250935dc0f91d0a718e2df1f8bc7a6bb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.2.0/maven-filtering-3.2.0.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-testing:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.9.1-02/nexus-buildsupport-testing-2.9.1-02.pom",
+      "sha256": "3e496a3b9b4a1c08c56ddff00b8467e7ec0a21b86dd3a40a32e305829bf4fc69",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-testing/2.9.1-02/nexus-buildsupport-testing-2.9.1-02.pom"
+    },
+    "plexus:plexus-utils:pom:1.0.2": {
+      "layout": "plexus/plexus-utils/1.0.2/plexus-utils-1.0.2.pom",
+      "sha256": "55e55cf810205c43996609a89ae14e0979ec9ccd0fad21cee7dcd6112bf139b3",
+      "url": "https://repo.maven.apache.org/maven2/plexus/plexus-utils/1.0.2/plexus-utils-1.0.2.pom"
+    },
+    "net.kemitix.tiles:huntbugs:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/huntbugs/2.7.0/huntbugs-2.7.0.pom",
+      "sha256": "cd7151b3075857ed6b09ea574df836845d0b826816bf8336e6c43ff98646511c",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/huntbugs/2.7.0/huntbugs-2.7.0.pom"
+    },
+    "org.apache.xbean:xbean-reflect:pom:3.4": {
+      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom",
+      "sha256": "01c97d4286dd3b5e5441faac3abb589f1fe123cea138bb4ae0995ffae14938df",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom",
+      "sha256": "ab803be997ac806ee7f2e179ad3cda640345ed8fc911082b1f80202c7fc463a4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:pom:2.10": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.pom",
+      "sha256": "7296cc651bf159a9b83daa7dfd1ce08625c03d432b3967b4bfd899acb247dbe8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.pom"
+    },
+    "commons-lang:commons-lang:jar:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.jar",
+      "sha256": "2ded7343dc8e57decd5e6302337139be020fdd885a2935925e8d575975e480b9",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:pom:3.1.0": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.pom",
+      "sha256": "034e12a9d1d5f5618a9e0dda23aadda4ed659ec55240876b6e954cc2172be456",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom",
+      "sha256": "a909a0cbe292e54122b6b785f6924ab2f09b1630b7889c800e099e2627f91a78",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom"
+    },
+    "classworlds:classworlds:pom:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom",
+      "sha256": "0cc647963b74ad1d7a37c9868e9e5a8f474e49297e1863582253a08a4c719cb1",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0.2": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0.2/maven-reporting-2.0.2.pom",
+      "sha256": "b32e715794005398792c61fc4b2c071360bf8c441be9fbfb797d7c24f1c4986b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.2/maven-reporting-2.0.2.pom"
+    },
+    "org.apache.xbean:xbean-reflect:pom:3.7": {
+      "layout": "org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.pom",
+      "sha256": "9795c15322c5d19af336eebd9e164fa7d5897c4b004a7d66e21635a173e748a9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.pom"
+    },
+    "commons-lang:commons-lang:jar:2.4": {
+      "layout": "commons-lang/commons-lang/2.4/commons-lang-2.4.jar",
+      "sha256": "2c73b940c91250bc98346926270f13a6a10bb6e29d2c9316a70d134e382c873e",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.4/commons-lang-2.4.jar"
+    },
+    "commons-lang:commons-lang:jar:2.6": {
+      "layout": "commons-lang/commons-lang/2.6/commons-lang-2.6.jar",
+      "sha256": "50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar"
+    },
+    "org.mozilla:rhino:jar:1.7.7.2": {
+      "layout": "org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.jar",
+      "sha256": "5c6dae050ceb71774a5fc82ce6e3f0392daf0ffa9ec3596f70d4d07ee50b8970",
+      "url": "https://repo.maven.apache.org/maven2/org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.jar"
+    },
+    "org.apache.maven.surefire:surefire-api:jar:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.jar",
+      "sha256": "1db98cfa84a3ea3b6c978304a66520fae93a2c84b029799a608c6d7c32479834",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.jar"
+    },
+    "org.codehaus.plexus:plexus-velocity:pom:1.2": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.pom",
+      "sha256": "508a1682a95da8220e9bd582e2a9e1629d016cfe67c4769ee0b1755279ff5fd6",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.pom"
+    },
+    "org.apache.maven:maven-archiver:jar:3.5.0": {
+      "layout": "org/apache/maven/maven-archiver/3.5.0/maven-archiver-3.5.0.jar",
+      "sha256": "44da564ea37b05aba884f89da2525fbaaadcd3348547e2c679db0f5f40e43246",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.5.0/maven-archiver-3.5.0.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar",
+      "sha256": "5e6cc5d0501c8d9b9abf9605283e95733b9428c9033a079502cd4d97cd0c490e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-databind:jar:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-databind/2.11.3/jackson-databind-2.11.3.jar",
+      "sha256": "5eb2fa8403a077a15391b80f43784fe09f8787863f5c6f53cc9edd710fd3c1ae",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.11.3/jackson-databind-2.11.3.jar"
+    },
+    "org.sonatype.spice:spice-parent:pom:15": {
+      "layout": "org/sonatype/spice/spice-parent/15/spice-parent-15.pom",
+      "sha256": "13d15ddfe9946b8427bb7b4b081ab63962285eed0bf6fa5142aea25a46e15814",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/15/spice-parent-15.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:16": {
+      "layout": "org/sonatype/spice/spice-parent/16/spice-parent-16.pom",
+      "sha256": "258f43b5e805687302a5bb400856b972a573ec42a44f949641354a84b9243758",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/16/spice-parent-16.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:17": {
+      "layout": "org/sonatype/spice/spice-parent/17/spice-parent-17.pom",
+      "sha256": "9151f9a5b33ec36ee8778842fc56144fb0242d39cbcc42061b053b8909969bdf",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/17/spice-parent-17.pom"
+    },
+    "org.apache.maven.scm:maven-scm-manager-plexus:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-manager-plexus/1.3/maven-scm-manager-plexus-1.3.pom",
+      "sha256": "205b2640fa52402ff0a7238e724ff26fd9deb107dd82b3a6f528b65aa65a183a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-manager-plexus/1.3/maven-scm-manager-plexus-1.3.pom"
+    },
+    "org.fusesource.hawtbuf:hawtbuf-proto:jar:1.9": {
+      "layout": "org/fusesource/hawtbuf/hawtbuf-proto/1.9/hawtbuf-proto-1.9.jar",
+      "sha256": "7b31c14c48b54e8741fd0978b1799a9acb5a24bc585fe3e1b2488cdefa4ca0bc",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/hawtbuf/hawtbuf-proto/1.9/hawtbuf-proto-1.9.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar",
+      "sha256": "98d6f3fbd17a67736d65e9c4ee484c5d6bc54589042e7cd3db65f87d91070f2a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar"
+    },
+    "com.google.code.gson:gson:jar:2.8.5": {
+      "layout": "com/google/code/gson/gson/2.8.5/gson-2.8.5.jar",
+      "sha256": "233a0149fc365c9f6edbd683cfe266b19bdc773be98eabdaf6b3c924b48e7d81",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar"
+    },
+    "commons-codec:commons-codec:pom:1.11": {
+      "layout": "commons-codec/commons-codec/1.11/commons-codec-1.11.pom",
+      "sha256": "c1e7140d1dea8fdf3528bc1e3c5444ac0b541297311f45f9806c213ec3ee9a10",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.pom"
+    },
+    "org.sonatype.nexus:nexus-oss:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/nexus-oss/2.9.1-02/nexus-oss-2.9.1-02.pom",
+      "sha256": "95a9fb7d281c4849bc7d2ea139281a2918928b7390b1e57d8b2f7b9f84510774",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-oss/2.9.1-02/nexus-oss-2.9.1-02.pom"
+    },
+    "org.slf4j:slf4j-api:pom:1.7.25": {
+      "layout": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.pom",
+      "sha256": "7cd9d7a0b5d93dfd461a148891b43509cf403a9c7f9fb49060d3554df1c81e1e",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.pom"
+    },
+    "commons-codec:commons-codec:pom:1.15": {
+      "layout": "commons-codec/commons-codec/1.15/commons-codec-1.15.pom",
+      "sha256": "c86ee198a35a3715487860f419cbf642e7e4d9e8714777947dbe6a4e3a20ab58",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15.pom"
+    },
+    "org.apache.httpcomponents:httpcore:jar:4.4.13": {
+      "layout": "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar",
+      "sha256": "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:jar:3.0": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/3.0/maven-dependency-tree-3.0.jar",
+      "sha256": "53150e9b638a45958a8d0c6821502f4b932dfe305ce49732affc808d5c5ab2f0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/3.0/maven-dependency-tree-3.0.jar"
+    },
+    "commons-codec:commons-codec:pom:1.12": {
+      "layout": "commons-codec/commons-codec/1.12/commons-codec-1.12.pom",
+      "sha256": "bcf0d52508a85d306acfd9668b489d38527fe3f4ff27aa6f621b6a1dc47e2368",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:12": {
+      "layout": "org/sonatype/spice/spice-parent/12/spice-parent-12.pom",
+      "sha256": "21a19b26dbe5c38ddb5114cf4eadbf5ccb411bc6b128fdd5949b1ccb12f3683e",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom"
+    },
+    "com.sun.jersey:jersey-client:pom:1.17.1": {
+      "layout": "com/sun/jersey/jersey-client/1.17.1/jersey-client-1.17.1.pom",
+      "sha256": "fbb0582f24dcfad8255b8d79704617c81ac705cc128b3e3bb01a9157b6366788",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-client/1.17.1/jersey-client-1.17.1.pom"
+    },
+    "org.sonatype.oss:oss-parent:pom:7": {
+      "layout": "org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+      "sha256": "b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.pom",
+      "sha256": "846018aaff0b19f555a33d5d63fb5a1815cda60d180f5e74caaf64f75fa550e7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.pom"
+    },
+    "org.apache.maven.scm:maven-scm-api:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-api/1.3/maven-scm-api-1.3.pom",
+      "sha256": "c2a9c35b3187bba3d997ea3a9b59062e5b893c84c2eecdfe2805e0270b2918bf",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-api/1.3/maven-scm-api-1.3.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-jetty:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.9.1-02/nexus-buildsupport-jetty-2.9.1-02.pom",
+      "sha256": "02ebce040f7bac7c7069bb259231c0fed90f1f88d05b325091d1fb182bcbe6b8",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-jetty/2.9.1-02/nexus-buildsupport-jetty-2.9.1-02.pom"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.pom",
+      "sha256": "456851e2f3b1ae877c8bf69849db19f93e5cfbf86ae13e22ffcc423334beac2e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-artifact/2.2.0/maven-artifact-2.2.0.jar",
+      "sha256": "e8c875ba960481d651090ded2e95e52d202e273b67fa9961c72a802d8f321f0a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.0/maven-artifact-2.2.0.jar"
+    },
+    "org.apache.maven.shared:maven-shared-incremental:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar",
+      "sha256": "61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar"
+    },
+    "org.apache.maven:maven-artifact:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.jar",
+      "sha256": "d53062ffe8677a4f5e1ad3a1d1fa37ed600fab39166d39be7ed204635c5f839b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:pom:1.1": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.pom",
+      "sha256": "2ae3c442073d5b65b623c2464aa4d8c46717d300a20baa932b74031b59710a62",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.pom"
+    },
+    "org.eclipse.aether:aether-spi:pom:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.pom",
+      "sha256": "2ddb14eccb4e80b79b547fe809d77c9460499f076411a0d92122c11a4bc14f7e",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.pom"
+    },
+    "org.apache.maven.shared:maven-shared-io:pom:3.0.0": {
+      "layout": "org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.pom",
+      "sha256": "028d029948d0c83ca090173d1e31537f481beada8b1f138b71aed454978db89c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.jar",
+      "sha256": "5fe283f47b0e7f7d95a4252af3fa7a0db4d8f080cd9df308608c0472b8f168a1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.0/maven-repository-metadata-2.2.0.jar",
+      "sha256": "4e06dbe4f248069a9c0c6be0515e80a604406630b607785e0941f4e422b7a85b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.0/maven-repository-metadata-2.2.0.jar"
+    },
+    "software.amazon.ion:ion-java:pom:1.0.2": {
+      "layout": "software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.pom",
+      "sha256": "20a643c46de6bc30cc81fa3b9e3bb1697afa37168cc183745497b704969bbb92",
+      "url": "https://repo.maven.apache.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.pom"
+    },
+    "org.apache.maven:maven-project:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.jar",
+      "sha256": "f32c1b2b26d02606682c27b7f6f8ac1a364d1c950c3fd980bce93602fbec3ff3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.jar"
+    },
+    "classworlds:classworlds:jar:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.jar",
+      "sha256": "4e3e0ad158ec60917e0de544c550f31cd65d5a97c3af1c1968bf427e4a9df2e4",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.jar"
+    },
+    "org.apache.maven:maven-project:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.jar",
+      "sha256": "24ddb65b7a6c3befb6267ce5f739f237c84eba99389265c30df67c3dd8396a40",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.jar"
+    },
+    "net.kemitix.aws:kemitix-aws-java-sdk-s3-wrapper:jar:1.11.893": {
+      "layout": "net/kemitix/aws/kemitix-aws-java-sdk-s3-wrapper/1.11.893/kemitix-aws-java-sdk-s3-wrapper-1.11.893.jar",
+      "sha256": "9351a13b71c5a98efbe71a6f166b77604cfa6c84ac11659addd13ea2ad5c0384",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/aws/kemitix-aws-java-sdk-s3-wrapper/1.11.893/kemitix-aws-java-sdk-s3-wrapper-1.11.893.jar"
+    },
+    "org.apache.struts:struts-tiles:jar:1.3.8": {
+      "layout": "org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.jar",
+      "sha256": "3d66e61734b2ddad6e4b34aaa2382480ad6061e59e5e178e346cc275c0429e57",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.jar"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.1": {
+      "layout": "org/apache/maven/doxia/doxia/1.1/doxia-1.1.pom",
+      "sha256": "922e221bd72502f90730df5600a965e8a68adbc2c41c7db272de7d690596fb96",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.1/doxia-1.1.pom"
+    },
+    "commons-io:commons-io:pom:2.5": {
+      "layout": "commons-io/commons-io/2.5/commons-io-2.5.pom",
+      "sha256": "28ebb2998bc7d7acb25078526971640892000f3413586ff42d611f1043bfec30",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia/1.0/doxia-1.0.pom",
+      "sha256": "38246291439393fd08f54c6d7fedde2db0fd5c94d0910f17b99e8d59a2858e98",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0/doxia-1.0.pom"
+    },
+    "commons-io:commons-io:pom:2.4": {
+      "layout": "commons-io/commons-io/2.4/commons-io-2.4.pom",
+      "sha256": "b2b5dd46cf998fa626eb6f8a1c114f6167c8d392694164e62533e5898e9b31f2",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.pom"
+    },
+    "org.apache.felix:maven-bundle-plugin:jar:5.1.1": {
+      "layout": "org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.jar",
+      "sha256": "a4cbf4dbe34b2a4d02879988ace6cb251cc0e6162c85ee2a2bba51d73b21efff",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.jar"
+    },
+    "commons-io:commons-io:pom:2.6": {
+      "layout": "commons-io/commons-io/2.6/commons-io-2.6.pom",
+      "sha256": "0c23863893a2291f5a7afdbd8d15923b3948afd87e563fa341cdcf6eae338a60",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.pom"
+    },
+    "net.java.dev.javacc:javacc:pom:5.0": {
+      "layout": "net/java/dev/javacc/javacc/5.0/javacc-5.0.pom",
+      "sha256": "941660d47822f9c0d80d40ea06d4981fcdc2b87cc625381b545efd7e6b449cef",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/javacc/javacc/5.0/javacc-5.0.pom"
+    },
+    "commons-io:commons-io:pom:2.2": {
+      "layout": "commons-io/commons-io/2.2/commons-io-2.2.pom",
+      "sha256": "6c221dc2dca94331a92a9cb19b3943631f7cb7c0302255fb5cd0450654e812c7",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.2/commons-io-2.2.pom"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia/1.8/doxia-1.8.pom",
+      "sha256": "adc1b44670f867365aeeaf5f9ec46a09347e61e2f29ba980bed111502eb32f85",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.8/doxia-1.8.pom"
+    },
+    "joda-time:joda-time:jar:2.2": {
+      "layout": "joda-time/joda-time/2.2/joda-time-2.2.jar",
+      "sha256": "e5183ca131f7195bde5b27e4cd18deeb6d14f8bc5c483b1431421132927240af",
+      "url": "https://repo.maven.apache.org/maven2/joda-time/joda-time/2.2/joda-time-2.2.jar"
+    },
+    "org.codehaus.plexus:plexus-languages:pom:0.9.8": {
+      "layout": "org/codehaus/plexus/plexus-languages/0.9.8/plexus-languages-0.9.8.pom",
+      "sha256": "14ec5d7ea581a8881ac1c2d54f95ae686f1909298d350fa9c15ba826c6d443be",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.8/plexus-languages-0.9.8.pom"
+    },
+    "org.apache.httpcomponents:httpclient:pom:4.5.13": {
+      "layout": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.pom",
+      "sha256": "78eb9ada74929fcd63d07adc4f49236841a45cc29d5f817bf45801f513fd7e6c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.pom"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia/1.7/doxia-1.7.pom",
+      "sha256": "bf4d8dc55ade524f7f37cab634ffb3898af0e84c74f512406baa080fc44cd5d7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.7/doxia-1.7.pom"
+    },
+    "org.codehaus.groovy:groovy:jar:3.0.4": {
+      "layout": "org/codehaus/groovy/groovy/3.0.4/groovy-3.0.4.jar",
+      "sha256": "bd875faf7b6d6555d20367425695d36d639962dc70e196072cd52285c976111f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy/3.0.4/groovy-3.0.4.jar"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.0/maven-plugin-api-2.2.0.jar",
+      "sha256": "90975aff5c1f61ad12c864830e55d48e2951d5c83b206577f723e5f0d49884f6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.0/maven-plugin-api-2.2.0.jar"
+    },
+    "org.codehaus.groovy:groovy:jar:3.0.6": {
+      "layout": "org/codehaus/groovy/groovy/3.0.6/groovy-3.0.6.jar",
+      "sha256": "5c972a7ddb70a151ca46aa8d2f6062f051935584c0d20a9bd57b228267921c6e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy/3.0.6/groovy-3.0.6.jar"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.jar",
+      "sha256": "72a47a963563009c5e8b851491ced3f63e2d276b862bde1f9d10d53abac5b22f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.jar"
+    },
+    "net.java.dev.javacc:javacc:jar:5.0": {
+      "layout": "net/java/dev/javacc/javacc/5.0/javacc-5.0.jar",
+      "sha256": "71113161bc8cf6641515541c2818028b87c78ec2e8ffaa75317686ee08967b89",
+      "url": "https://repo.maven.apache.org/maven2/net/java/dev/javacc/javacc/5.0/javacc-5.0.jar"
+    },
+    "org.apache.maven:maven-aether-provider:pom:3.0": {
+      "layout": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom",
+      "sha256": "755c07a1ae47cff80f633265b224341d6d8cc26f02d37eb407bc45ff5db9a71d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom"
+    },
+    "org.mozilla:rhino:pom:1.7.7.2": {
+      "layout": "org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.pom",
+      "sha256": "0769068987c18953e51d419e062f40956f1e82f3a2a140fea884d7c5e6fa947f",
+      "url": "https://repo.maven.apache.org/maven2/org/mozilla/rhino/1.7.7.2/rhino-1.7.7.2.pom"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:pom:1.2": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.pom",
+      "sha256": "5629a9061aa0c7b056408c4db75dc5bd51322bbdd6591978529c6ba61bd67731",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.pom"
+    },
+    "ch.qos.logback:logback-core:jar:1.1.2": {
+      "layout": "ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.jar",
+      "sha256": "90f1dfca25cd776f28a589f58b181d0e6787668a1b1fa8510bead402f86edcb1",
+      "url": "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-core/1.1.2/logback-core-1.1.2.jar"
+    },
+    "net.sourceforge.pmd:pmd-javascript:pom:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-javascript/6.23.0/pmd-javascript-6.23.0.pom",
+      "sha256": "807eee40e069aa7f5feab1988247888aae7be7b83bf6be969e36b6a26de60e56",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-javascript/6.23.0/pmd-javascript-6.23.0.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.0/maven-plugin-api-2.2.0.pom",
+      "sha256": "0b9164cb7c1a9ec55d8a94d63d6c4f245dc658f8e21d24b65e4bc19f6462506d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.0/maven-plugin-api-2.2.0.pom"
+    },
+    "com.google:google:pom:5": {
+      "layout": "com/google/google/5/google-5.pom",
+      "sha256": "e09d345e73ca3fbca7f3e05f30deb74e9d39dd6b79a93fee8c511f23417b6828",
+      "url": "https://repo.maven.apache.org/maven2/com/google/google/5/google-5.pom"
+    },
+    "org.apache.maven:maven-plugin-api:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom",
+      "sha256": "c10d0460c2d5c5076304598965991d6257d1bf31bdef921a17ce3d059bce654e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom"
+    },
+    "org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7": {
+      "layout": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar",
+      "sha256": "240113a2f22fd1f0b182b32baecf0e7876b3a8e41f3c4da3335eeb9ffb24b9f4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar"
+    },
+    "net.kemitix:kemitix-pmd-ruleset:jar:1.1.0": {
+      "layout": "net/kemitix/kemitix-pmd-ruleset/1.1.0/kemitix-pmd-ruleset-1.1.0.jar",
+      "sha256": "0a069c724d35d6ef8a8d3c47a90fc40bb82b3ce7b5061f31bd667f0d14fb6cd4",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/kemitix-pmd-ruleset/1.1.0/kemitix-pmd-ruleset-1.1.0.jar"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.2.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom",
+      "sha256": "6aad43eb7fee989d50f1ecaf4a8030c708f9c9ea3eb72ee023d76746ff89570a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.2.3": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom",
+      "sha256": "a2d14b6752e30a100a6cb03c040d0160b71b61928daf8ea97cabfb4a3335b213",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom"
+    },
+    "com.google:google:pom:1": {
+      "layout": "com/google/google/1/google-1.pom",
+      "sha256": "cd6db17a11a31ede794ccbd1df0e4d9750f640234731f21cff885a9997277e81",
+      "url": "https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom"
+    },
+    "org.apache.felix:org.apache.felix.bundlerepository:jar:1.6.6": {
+      "layout": "org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.jar",
+      "sha256": "6759ca9b14032623096706be4cf8a85cc1345be4c3c08d95b745b9ad672c7599",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.jar"
+    },
+    "org.junit.platform:junit-platform-engine:jar:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1.jar",
+      "sha256": "303d0546c3e950cc3beaca00dfcbf2632d4eca530e4e446391bf193cbc2a71a3",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-20": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-20/plexus-container-default-1.0-alpha-20.pom",
+      "sha256": "5fe611b07793d5ff3378ca3ae2c75e38bae08e73c3ae0acdf116ae5d6978d19f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-20/plexus-container-default-1.0-alpha-20.pom"
+    },
+    "ch.qos.logback:logback-parent:pom:1.1.2": {
+      "layout": "ch/qos/logback/logback-parent/1.1.2/logback-parent-1.1.2.pom",
+      "sha256": "07ef142cabe0e1fd41002d01ce6a5758f26200731859cc15eb81aa80ebfc4e8c",
+      "url": "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-parent/1.1.2/logback-parent-1.1.2.pom"
+    },
+    "net.kemitix.tiles:compiler-jdk-8:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/compiler-jdk-8/2.7.0/compiler-jdk-8-2.7.0.xml",
+      "sha256": "5fc263231bda5fbe5056985f6e0d5500079617cba05c93f4aa8c792c1dc16e05",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/compiler-jdk-8/2.7.0/compiler-jdk-8-2.7.0.xml"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.0/maven-plugin-parameter-documenter-2.2.0.pom",
+      "sha256": "973598f11bb0b30ac23971822ccb3d48e3933b512640d144bf57072fafeae6c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.0/maven-plugin-parameter-documenter-2.2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-compilers:pom:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom",
+      "sha256": "82a8175c836ce32d32077191111ebc256e2cbb7d907909edbb6b9b66e88521a6",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom"
+    },
+    "org.apache.maven.scm:maven-scm-provider-git-commons:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-git-commons/1.9.1/maven-scm-provider-git-commons-1.9.1.pom",
+      "sha256": "e8d8b785193f0457863098fe27dec857625ab090cf070bd76b1050e115c8f3f6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-git-commons/1.9.1/maven-scm-provider-git-commons-1.9.1.pom"
+    },
+    "org.ow2.asm:asm:jar:6.1.1": {
+      "layout": "org/ow2/asm/asm/6.1.1/asm-6.1.1.jar",
+      "sha256": "dd3b546415dd4bade2ebe3b47c7828ab0623ee2336604068e2d81023f9f8d833",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.1.1/asm-6.1.1.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom",
+      "sha256": "902b0160f7b81ec76452468f8ae087fc1cfefc08367c84d9197512dfb01d845d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom"
+    },
+    "com.google.guava:guava-parent:pom:14.0.1": {
+      "layout": "com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom",
+      "sha256": "e5a525ed3b5d7fff2a8da9641e0cb985c7fdb847e3081e2a373daf2e70039b63",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/14.0.1/guava-parent-14.0.1.pom"
+    },
+    "org.eclipse.sisu:sisu-plexus:pom:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/sisu-plexus/0.0.0.M2a/sisu-plexus-0.0.0.M2a.pom",
+      "sha256": "83769dbe7b5728f6b22061acb243aac887a3cdcd070e140a3fc9e59818b17645",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-plexus/0.0.0.M2a/sisu-plexus-0.0.0.M2a.pom"
+    },
+    "org.apache.xbean:xbean:pom:3.4": {
+      "layout": "org/apache/xbean/xbean/3.4/xbean-3.4.pom",
+      "sha256": "56ab9c6c2d022a9b7079006ba500a996cd2c21411d53cac524933af20c5a4b99",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.4/xbean-3.4.pom"
+    },
+    "org.apache.felix:org.apache.felix.utils:jar:1.6.0": {
+      "layout": "org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.jar",
+      "sha256": "03dc4ee75332284f4ba4b187c8c946c07f0c822b09e02f8821d85c8d8f46ccfa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.jar"
+    },
+    "org.apache.maven.shared:file-management:jar:3.0.0": {
+      "layout": "org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.jar",
+      "sha256": "a37db9f4108b019a96b4fee8c6becaea64a3e755d5d21a904a8549501c7fc065",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/3.0.0/file-management-3.0.0.jar"
+    },
+    "org.apache.xbean:xbean:pom:3.7": {
+      "layout": "org/apache/xbean/xbean/3.7/xbean-3.7.pom",
+      "sha256": "ea717132de8404b62fc9097a1f3215c705d525d457be9a5f12653adc68c33ab7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.7/xbean-3.7.pom"
+    },
+    "commons-io:commons-io:jar:2.5": {
+      "layout": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+      "sha256": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar"
+    },
+    "commons-io:commons-io:jar:2.6": {
+      "layout": "commons-io/commons-io/2.6/commons-io-2.6.jar",
+      "sha256": "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.jar"
+    },
+    "org.apache.maven:maven:pom:3.1.0": {
+      "layout": "org/apache/maven/maven/3.1.0/maven-3.1.0.pom",
+      "sha256": "08b93530e36adea529c882f8d362402dce74250fdc010256029455655f795607",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.1.0/maven-3.1.0.pom"
+    },
+    "commons-io:commons-io:jar:2.4": {
+      "layout": "commons-io/commons-io/2.4/commons-io-2.4.jar",
+      "sha256": "cc6a41dc3eaacc9e440a6bd0d2890b20d36b4ee408fe2d67122f328bb6e01581",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar"
+    },
+    "com.google.inject:guice:jar:no_aop:4.0": {
+      "layout": "com/google/inject/guice/4.0/guice-4.0-no_aop.jar",
+      "sha256": "19393891be59b6feaf7e308bd8a3843b4e552c10cdb687ebffd7695634a250a8",
+      "url": "https://repo.maven.apache.org/maven2/com/google/inject/guice/4.0/guice-4.0-no_aop.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.pom",
+      "sha256": "79c9792073fdee3cdbebd61a76ba8c2dd11624a9f85d128bae56bda19e20475c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.pom"
+    },
+    "net.kemitix.tiles:all:pom:2.4.1": {
+      "layout": "net/kemitix/tiles/all/2.4.1/all-2.4.1.pom",
+      "sha256": "45ca520b348289a6157ac55cd58e3c8873eb79bbd01482e71a649a8b32e46fd8",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/all/2.4.1/all-2.4.1.pom"
+    },
+    "net.kemitix.checkstyle:tile:pom:5.0.0": {
+      "layout": "net/kemitix/checkstyle/tile/5.0.0/tile-5.0.0.pom",
+      "sha256": "f8bec2ad9d3d1f14f3aa7641146d65a618aa6c5c113a7e246b7811b966c7961a",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/checkstyle/tile/5.0.0/tile-5.0.0.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.plexus:pom:0.3.2": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.pom",
+      "sha256": "63f209d8d6a3aa5f7929ad2ac5eefec64499f0799429f0627ad6195b79de4d4a",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.3": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom",
+      "sha256": "29fd54ef49c7b404b091e87bb8726de50447d728b46c592fab0806ac9f6b113b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.3/plexus-utils-1.3.pom"
+    },
+    "org.slf4j:slf4j-parent:pom:1.7.7": {
+      "layout": "org/slf4j/slf4j-parent/1.7.7/slf4j-parent-1.7.7.pom",
+      "sha256": "1dffae3ce768d0547e261c96898cf5d9d194bffd5600f597c9751cc6a73d33d4",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.7/slf4j-parent-1.7.7.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.pom",
+      "sha256": "9967f48cf38bd1d7e94d9f9ccc9876296cd6e8d5d9d04b8b9c1cce16770dded4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.pom"
+    },
+    "commons-io:commons-io:jar:2.2": {
+      "layout": "commons-io/commons-io/2.2/commons-io-2.2.jar",
+      "sha256": "675f60bd11a82d481736591fe4054c66471fa5463d45616652fd71585792ba87",
+      "url": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.2/commons-io-2.2.jar"
+    },
+    "org.sonatype.oss:oss-parent:pom:9": {
+      "layout": "org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+      "sha256": "fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom",
+      "sha256": "e1772a8a6be92088ae069a3dd4f7c9dcbc0888434341028735da0f22481bcd47",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.pom"
+    },
+    "org.slf4j:slf4j-parent:pom:1.7.5": {
+      "layout": "org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom",
+      "sha256": "c43bc5a022dbfd9de82be232dffe46208cbc7de12c14385b5da824e331e535bb",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.11": {
+      "layout": "org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom",
+      "sha256": "5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.10": {
+      "layout": "org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom",
+      "sha256": "09b999a969e73525a6cc3ad2868ea744766e1d93b25c6c656d61a5ff9c881da9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.10/plexus-1.0.10.pom"
+    },
+    "asm:asm-parent:pom:3.3.1": {
+      "layout": "asm/asm-parent/3.3.1/asm-parent-3.3.1.pom",
+      "sha256": "2c62f613e86db57b58fe3d5f443dccf0a51f09d1c9c2cb39776afde06d0f7ff0",
+      "url": "https://repo.maven.apache.org/maven2/asm/asm-parent/3.3.1/asm-parent-3.3.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-apt:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-apt/1.0/doxia-module-apt-1.0.jar",
+      "sha256": "8180ea21cc240abac7a0422f394ec01860306f7964b8148614cceea0dd3302f2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-apt/1.0/doxia-module-apt-1.0.jar"
+    },
+    "plexus:plexus-utils:jar:1.0.2": {
+      "layout": "plexus/plexus-utils/1.0.2/plexus-utils-1.0.2.jar",
+      "sha256": "56ffe79b4426ce24ea35f1ab5af3dfd324a749b0d5812a6f6fec913c3b5e7a0d",
+      "url": "https://repo.maven.apache.org/maven2/plexus/plexus-utils/1.0.2/plexus-utils-1.0.2.jar"
+    },
+    "javax.enterprise:cdi-api:jar:1.0": {
+      "layout": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+      "sha256": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+      "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    "org.apache.maven:maven-archiver:pom:3.5.0": {
+      "layout": "org/apache/maven/maven-archiver/3.5.0/maven-archiver-3.5.0.pom",
+      "sha256": "3013b3b9e7bf1b47fe42b579db2bc7740949688cac18d48c53158a049dbc8c57",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.5.0/maven-archiver-3.5.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.7": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.7/plexus-utils-1.5.7.pom",
+      "sha256": "33fac5d689f8aed46324072d72cf6a4552c3ca9ac899a41b4019482a9d406c3a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.7/plexus-utils-1.5.7.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:3.3.3": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.3.3/maven-shared-utils-3.3.3.pom",
+      "sha256": "34564d462b074de2650b855be723de8f5593e590cb9132bae34d9db1dffb5be7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.3/maven-shared-utils-3.3.3.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom",
+      "sha256": "1ff4fb95c218af4a46f71d625212c70f377ccf97ad2e26cb8d4c10709265bf62",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom"
+    },
+    "commons-digester:commons-digester:pom:1.8": {
+      "layout": "commons-digester/commons-digester/1.8/commons-digester-1.8.pom",
+      "sha256": "c10144f223d7ab697ccea7da0e753b75603ea7fbc4e35570068e6c477068e9b5",
+      "url": "https://repo.maven.apache.org/maven2/commons-digester/commons-digester/1.8/commons-digester-1.8.pom"
+    },
+    "org.eclipse.sisu:sisu-plexus:pom:0.3.2": {
+      "layout": "org/eclipse/sisu/sisu-plexus/0.3.2/sisu-plexus-0.3.2.pom",
+      "sha256": "2478bc7addbf9317b507cc1df975f5c68ea1839ea5b1680747d2d909f5bcfa14",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-plexus/0.3.2/sisu-plexus-0.3.2.pom"
+    },
+    "com.google.guava:guava:jar:18.0": {
+      "layout": "com/google/guava/guava/18.0/guava-18.0.jar",
+      "sha256": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/18.0/guava-18.0.jar"
+    },
+    "commons-digester:commons-digester:pom:1.6": {
+      "layout": "commons-digester/commons-digester/1.6/commons-digester-1.6.pom",
+      "sha256": "9ef0db04ffe98d03eb9a921337364be7d123d58d66dcaff3eac763f0b0c63d48",
+      "url": "https://repo.maven.apache.org/maven2/commons-digester/commons-digester/1.6/commons-digester-1.6.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom",
+      "sha256": "e237bba8d1c65c171b5fe8774a2ff817525df6315b929a2085cf70cff15b1b58",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom"
+    },
+    "xmlpull:xmlpull:pom:1.1.3.1": {
+      "layout": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.pom",
+      "sha256": "8f10ffd8df0d3e9819c8cc8402709c6b248bc53a954ef6e45470d9ae3a5735fb",
+      "url": "https://repo.maven.apache.org/maven2/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom",
+      "sha256": "f860675cad10e561bfa175d5717e2d8617d40c62321086ca4a85c006a0fa30d1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-xdoc:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-xdoc/1.0/doxia-module-xdoc-1.0.jar",
+      "sha256": "a29daf6fc6a29db301b2df5b0c8715c86ff5c08fe00bbef2a14e3bdbb15d31f8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xdoc/1.0/doxia-module-xdoc-1.0.jar"
+    },
+    "io.repaint.maven:tiles-maven-plugin:jar:2.18": {
+      "layout": "io/repaint/maven/tiles-maven-plugin/2.18/tiles-maven-plugin-2.18.jar",
+      "sha256": "eca168bc8774e1e2b3fd6eab58dce08396ea13f4b0bee0eca17d1d97531925a3",
+      "url": "https://repo.maven.apache.org/maven2/io/repaint/maven/tiles-maven-plugin/2.18/tiles-maven-plugin-2.18.jar"
+    },
+    "io.repaint.maven:tiles-maven-plugin:jar:2.17": {
+      "layout": "io/repaint/maven/tiles-maven-plugin/2.17/tiles-maven-plugin-2.17.jar",
+      "sha256": "919a71419436d520e5f413f5c2f26de95f408590e2f60189ae358347f39a1b3b",
+      "url": "https://repo.maven.apache.org/maven2/io/repaint/maven/tiles-maven-plugin/2.17/tiles-maven-plugin-2.17.jar"
+    },
+    "net.sourceforge.saxon:saxon:pom:9.1.0.8": {
+      "layout": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.pom",
+      "sha256": "9b0779fa96df29a833bce3218e8db9cc01863605b2f73ade3d308ce1f7f79179",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8.pom"
+    },
+    "org.apache.maven.resolver:maven-resolver-api:pom:1.4.1": {
+      "layout": "org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.pom",
+      "sha256": "335513ce1dd2cf4c7d1dbfa1b8aa14656d9be5f9f3f0d0875ac528893c9f0f06",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.pom"
+    },
+    "org.codehaus.plexus:plexus-languages:pom:0.9.10": {
+      "layout": "org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom",
+      "sha256": "863adcfb4eaec8286de72e606c9cb39d65b0473309c41a2e7d37983291a10ba3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom"
+    },
+    "org.apache.velocity:velocity:pom:1.6.2": {
+      "layout": "org/apache/velocity/velocity/1.6.2/velocity-1.6.2.pom",
+      "sha256": "f663422e0b92069dcb30d58a2652660b727252ae94e40e8616e710723c64cdec",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.6.2/velocity-1.6.2.pom"
+    },
+    "org.sonatype.nexus.maven:nexus-maven-plugins:pom:1.6.6": {
+      "layout": "org/sonatype/nexus/maven/nexus-maven-plugins/1.6.6/nexus-maven-plugins-1.6.6.pom",
+      "sha256": "9cce12fb1a8cca26ca28712c90b4caf17cd993d96263fb2d389247c82e9ddf5a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-maven-plugins/1.6.6/nexus-maven-plugins-1.6.6.pom"
+    },
+    "org.apache.maven.wagon:wagon:pom:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon/1.0-beta-6/wagon-1.0-beta-6.pom",
+      "sha256": "025caec7c56a0cb4d86c45bc18ac3e23dba291e22ebceb76302a9a9b9b7183cc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/1.0-beta-6/wagon-1.0-beta-6.pom"
+    },
+    "com.google.code.findbugs:jsr305:pom:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom",
+      "sha256": "02c12c3c2ae12dd475219ff691c82a4d9ea21f44bc594a181295bf6d43dcfbb0",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom"
+    },
+    "org.opentest4j:opentest4j:jar:1.2.0": {
+      "layout": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
+      "sha256": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
+      "url": "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar",
+      "sha256": "dce817d7c4229d5e666247c05853ef8ad7ac1b72d27953501c4a1ea739f67b25",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:3.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar",
+      "sha256": "c938e4d8cdf0674496749a87e6d3b29aa41b1b35a39898a1ade2bc9eae214c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar"
+    },
+    "regexp:regexp:pom:1.3": {
+      "layout": "regexp/regexp/1.3/regexp-1.3.pom",
+      "sha256": "501fee6ed79e9d42d7d1e0b94207f19eddc33b890df1de2444b6eeda97252fdc",
+      "url": "https://repo.maven.apache.org/maven2/regexp/regexp/1.3/regexp-1.3.pom"
+    },
+    "org.apache.commons:commons-lang3:jar:3.4": {
+      "layout": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
+      "sha256": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
+    },
+    "org.apache.commons:commons-lang3:jar:3.5": {
+      "layout": "org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar",
+      "sha256": "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"
+    },
+    "asm:asm:pom:3.3.1": {
+      "layout": "asm/asm/3.3.1/asm-3.3.1.pom",
+      "sha256": "6e9dcc0313935ff11e7bea368811e48066ae3177a72ed69bceb3792096f7c2bb",
+      "url": "https://repo.maven.apache.org/maven2/asm/asm/3.3.1/asm-3.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-30": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.pom",
+      "sha256": "8858248de2cab772fa26741b8972137058a6f4457b0a2b3e7cd8771d03d9373b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-30/plexus-container-default-1.0-alpha-30.pom"
+    },
+    "org.apache.maven.enforcer:enforcer:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/enforcer/enforcer/3.0.0-M3/enforcer-3.0.0-M3.pom",
+      "sha256": "19dc813dc367122f6a45a3a361cf809e90724137d4235da87f71a12778060092",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/enforcer/enforcer/3.0.0-M3/enforcer-3.0.0-M3.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.5.4": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.5.4/plexus-containers-1.5.4.pom",
+      "sha256": "18b4a1b0a65c0d6b7cf9cd48ee9f3467b6deb8ace4c1309522c184f94c4cfa2e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.4/plexus-containers-1.5.4.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom",
+      "sha256": "1bc264824ec876b0ca6f4f5838175c541c638cbc43326a268b9aee7d4778b5ef",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom"
+    },
+    "com.google.guava:guava:jar:14.0.1": {
+      "layout": "com/google/guava/guava/14.0.1/guava-14.0.1.jar",
+      "sha256": "d69df3331840605ef0e5fe4add60f2d28e870e3820937ea29f713d2035d9ab97",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.jar"
+    },
+    "javax.enterprise:cdi-api:pom:1.0": {
+      "layout": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.pom",
+      "sha256": "43125840dd928065fa83fb76c89873be4fc34e28c8b6fb62fd66be9be965100d",
+      "url": "https://repo.maven.apache.org/maven2/javax/enterprise/cdi-api/1.0/cdi-api-1.0.pom"
+    },
+    "org.apache.httpcomponents:httpcore:jar:4.3.2": {
+      "layout": "org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.jar",
+      "sha256": "abd02320e2356f89d054dae4cf02306bef20a9cf7865b3ac94ec7552b4f1528b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar",
+      "sha256": "2c302f060de887716be438e0eb0c3d89d7ece213631882446ee0b19880c00dbd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar"
+    },
+    "org.easymock:easymock:pom:3.4": {
+      "layout": "org/easymock/easymock/3.4/easymock-3.4.pom",
+      "sha256": "2f1abc16c3302f07c54b668976860fbf16bee3840d65546e714f4a5122b6d182",
+      "url": "https://repo.maven.apache.org/maven2/org/easymock/easymock/3.4/easymock-3.4.pom"
+    },
+    "org.apache.struts:struts-taglib:pom:1.3.8": {
+      "layout": "org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.pom",
+      "sha256": "93349fdf9c95458fad1b8105f20ce75155a37d2888fa7daeffbad1b30fa27ec0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.pom"
+    },
+    "org.apache.maven.scm:maven-scm-manager-plexus:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-manager-plexus/1.9.1/maven-scm-manager-plexus-1.9.1.pom",
+      "sha256": "53c06226ccea760605bb2da3d6559222775df98e0bcac0b6eb6e9b21dd2cea57",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-manager-plexus/1.9.1/maven-scm-manager-plexus-1.9.1.pom"
+    },
+    "commons-beanutils:commons-beanutils-core:jar:1.8.3": {
+      "layout": "commons-beanutils/commons-beanutils-core/1.8.3/commons-beanutils-core-1.8.3.jar",
+      "sha256": "cc5bd7d2dfb1bc7395034a558898f729871911e9af9a05146bd2ae8842b9f650",
+      "url": "https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils-core/1.8.3/commons-beanutils-core-1.8.3.jar"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:pom:3.0": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/3.0/maven-dependency-tree-3.0.pom",
+      "sha256": "fbfb7cb73ee048d37e592f8ca571b4c8cd78a61c8a937a2215298e4a7c278c55",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/3.0/maven-dependency-tree-3.0.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-plexus:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.9.1-02/nexus-buildsupport-plexus-2.9.1-02.pom",
+      "sha256": "0047ff967e805bfca49a99350d85d42f5687be5312b8e150d287734158bec9e4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-plexus/2.9.1-02/nexus-buildsupport-plexus-2.9.1-02.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar",
+      "sha256": "f1e4b0af3079cc0db361eab9429a3cda7b118cd032211c7e61b3805a62bfde1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar"
+    },
+    "org.apache.maven:maven-plugin-api:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar",
+      "sha256": "a1b54bbe38d25ccd3179c5563156b3b0c0ecd014647c3ebaeba8e92b2e2e5053",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar"
+    },
+    "org.apache.felix:maven-bundle-plugin:jar:3.5.1": {
+      "layout": "org/apache/felix/maven-bundle-plugin/3.5.1/maven-bundle-plugin-3.5.1.jar",
+      "sha256": "b30befd53e02ccf45c44b4e30b7d3f7e5a9ee48f2b2c1a624900dfb123ca2cd3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.5.1/maven-bundle-plugin-3.5.1.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom",
+      "sha256": "b5b53025b13fa0013ae2caede21f9af4215c25279db4ee0a1f943aaa8815c174",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar",
+      "sha256": "7c758612888782ccfe376823aee7cdcc7e0cdafb097f7ef50295a0b0c3a16edf",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar"
+    },
+    "org.apache.httpcomponents:httpclient:jar:4.0.2": {
+      "layout": "org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.jar",
+      "sha256": "377e963549427abe67e7c21b2c374cfa87c9218a9a947d71d7675a4cbdff20d0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.0.2/httpclient-4.0.2.jar"
+    },
+    "org.osgi:org.osgi.core:pom:6.0.0": {
+      "layout": "org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom",
+      "sha256": "42a22743fb32df6543536f78add4fcfd2557c8af5d0bf0aff5ba9d7491cde350",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom"
+    },
+    "org.apache.maven.scm:maven-scm-providers-git:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-providers-git/1.3/maven-scm-providers-git-1.3.pom",
+      "sha256": "57b1840a4e69f0089b371951fa77412b84bd4476c75d8e8842fe1f56894a67f5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-providers-git/1.3/maven-scm-providers-git-1.3.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:3.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom",
+      "sha256": "8d9ce34e4bc02c4df761578c5f48ac3da5af51f259f5e3e4ea9047ec345ed1b7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.7.1/plexus-container-default-1.7.1.pom",
+      "sha256": "8ae58b62c34d19c7588a67d9aa473be4a1cb3d34cdacab1001df13a137007a97",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.7.1/plexus-container-default-1.7.1.pom"
+    },
+    "org.apache.maven:maven-model:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
+      "sha256": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
+    },
+    "net.kemitix.tiles:digraph:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/digraph/2.7.0/digraph-2.7.0.xml",
+      "sha256": "d7fb6726a0b44c4de0d1fd849bdf6f7c4432cf2e24e732c310052e02021ed5ff",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/digraph/2.7.0/digraph-2.7.0.xml"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.1.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.pom",
+      "sha256": "1473d1eb9e2ffbed025819892b078985c5dd55c190b1d82fd1b5685505b2b819",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.pom"
+    },
+    "org.apache.felix:felix-parent:pom:2.1": {
+      "layout": "org/apache/felix/felix-parent/2.1/felix-parent-2.1.pom",
+      "sha256": "c552a5643ab467c31225e07cb55b1dc2ae5a811e567481a73a254a3898138736",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/2.1/felix-parent-2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.1.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.1.1/plexus-utils-3.1.1.pom",
+      "sha256": "6e9ef6a42b78c418176d07882762f53664bc39bac88135be8cb56337c050e6dd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.1/plexus-utils-3.1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:2.8.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.pom",
+      "sha256": "727460b027428940e180ec30263f86a8359dfa3a505f8046fa64d1929a857016",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.pom"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:jar:3.0.1": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar",
+      "sha256": "b291bd2d46ecd42ba26938a78ec053eedb240e5a3eef3ffc82c46ecafa95c306",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom",
+      "sha256": "ef71d45a49edfe76be0f520312a76bc2aae73ec0743a5ffffe10d30122c6e2b2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom",
+      "sha256": "f479d0dc224974b50cfefae14344a4cd8b692b8dbf58df2d8c5c2f13db01d642",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom"
+    },
+    "org.slf4j:slf4j-parent:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom",
+      "sha256": "b9d17d6f915b389c7dd77f170d6fcc77f1c7d6c7362fefb146043d8412defddd",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-xdoc:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-xdoc/1.0/doxia-module-xdoc-1.0.pom",
+      "sha256": "6047c86dae48672243662c26074731be6328edcc170a366807d56f57ce2a1965",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xdoc/1.0/doxia-module-xdoc-1.0.pom"
+    },
+    "regexp:regexp:jar:1.3": {
+      "layout": "regexp/regexp/1.3/regexp-1.3.jar",
+      "sha256": "27998732ecd5745924644f891f41adaf73736fe259a0a20843979452574f0385",
+      "url": "https://repo.maven.apache.org/maven2/regexp/regexp/1.3/regexp-1.3.jar"
+    },
+    "org.sonatype.sisu.siesta:siesta-common:jar:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-common/1.7/siesta-common-1.7.jar",
+      "sha256": "a65f17d55b6fedb8a3be019e87774fc7f0b185327080bf5f6c9fdf801c780347",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-common/1.7/siesta-common-1.7.jar"
+    },
+    "org.slf4j:slf4j-api:pom:1.7.5": {
+      "layout": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom",
+      "sha256": "afaf8e74019b230d3f56fdd7c93fb1070c0dca34f3d2d5ab5dea9fc616bd5ca4",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom"
+    },
+    "org.sonatype.sisu.siesta:siesta-jackson:pom:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-jackson/1.7/siesta-jackson-1.7.pom",
+      "sha256": "83fac04ff6b154ee5249f2a9344ec8d7923bef4804c6783e6abf7eaf66a8a545",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-jackson/1.7/siesta-jackson-1.7.pom"
+    },
+    "org.apache.maven:maven-model-builder:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
+      "sha256": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
+    },
+    "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.3.1/jackson-module-jaxb-annotations-2.3.1.jar",
+      "sha256": "aba89903ebbfb5af8d65cdd0b985b00b2f4b8e0c9c0b98b061045f276b58ac03",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.3.1/jackson-module-jaxb-annotations-2.3.1.jar"
+    },
+    "org.slf4j:slf4j-api:pom:1.7.7": {
+      "layout": "org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7.pom",
+      "sha256": "353904a7a6c28304d0dcac80fad30c48cd898f6db03b93f05ad6c90dd42d98ad",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7.pom"
+    },
+    "xalan:xalan:pom:2.7.0": {
+      "layout": "xalan/xalan/2.7.0/xalan-2.7.0.pom",
+      "sha256": "2fbabe793ffb3c434e3519bb44dfff52b9d4ed004f76ce6402b2cc35147b3c80",
+      "url": "https://repo.maven.apache.org/maven2/xalan/xalan/2.7.0/xalan-2.7.0.pom"
+    },
+    "org.apache.velocity:velocity:jar:1.7": {
+      "layout": "org/apache/velocity/velocity/1.7/velocity-1.7.jar",
+      "sha256": "ec92dae810034f4b46dbb16ef4364a4013b0efb24a8c5dd67435cae46a290d8e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.7/velocity-1.7.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-annotations:jar:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-annotations/2.11.3/jackson-annotations-2.11.3.jar",
+      "sha256": "6519b3811cb1c0afbbdab74fd841b0b34f3a489fccb43e9f981da1328d8ec23d",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.11.3/jackson-annotations-2.11.3.jar"
+    },
+    "org.apache.velocity:velocity:jar:1.5": {
+      "layout": "org/apache/velocity/velocity/1.5/velocity-1.5.jar",
+      "sha256": "e06403f9cd69033e523bec43195a2a1b6106e28c5d7d053b569ae771e9e49a62",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.5/velocity-1.5.jar"
+    },
+    "net.sourceforge.pmd:pmd-java:jar:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-java/6.23.0/pmd-java-6.23.0.jar",
+      "sha256": "2b8bbc5867c76eff84dd1bfca5cea05221d44abaef438d92b486cb9c45cd2f04",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-java/6.23.0/pmd-java-6.23.0.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.11": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom",
+      "sha256": "b84d281f59b9da528139e0752a0e1cab0bd98d52c58442b00e45c9748e1d9eee",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom"
+    },
+    "org.apache.commons:commons-parent:pom:5": {
+      "layout": "org/apache/commons/commons-parent/5/commons-parent-5.pom",
+      "sha256": "8bd632c00bdf80a7de36c22b60f12452c147d8eca2f00d79d66699ebe7daa02a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/5/commons-parent-5.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-fml:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-fml/1.0/doxia-module-fml-1.0.jar",
+      "sha256": "50fa72ddfdd176d02736e8f435e244882c7351d9397a27816b140f52a5d091ef",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-fml/1.0/doxia-module-fml-1.0.jar"
+    },
+    "plexus:plexus-root:pom:1.0.3": {
+      "layout": "plexus/plexus-root/1.0.3/plexus-root-1.0.3.pom",
+      "sha256": "45363cc49c9419edf74f9f927deca5d6b08668ed985544165984aea8984a32c5",
+      "url": "https://repo.maven.apache.org/maven2/plexus/plexus-root/1.0.3/plexus-root-1.0.3.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom",
+      "sha256": "4a9f28e95f82a80fbd0632e6305b3c676f4d5e946f93028226d5365f53492bc7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom"
+    },
+    "org.apache.commons:commons-compress:jar:1.9": {
+      "layout": "org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar",
+      "sha256": "b8e0a1700023359a2b4d9f04b9287d7b9aa200f4feac1079812337eef2dcb8e2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.14": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom",
+      "sha256": "d08155c497df37b2c3d9b5b0dfdb02ec0525b2070b5be3739fffde942fcac9af",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom",
+      "sha256": "cb80662bd8274131bb09e140a4075bff660bdab5be56bf0f926efee0389f3c4e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-fml:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.jar",
+      "sha256": "ceee66de87351654d8e759048ae63bc19ebb0c5da23dbca6006ca9df2d87bfcc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.jar"
+    },
+    "org.apache.maven:maven-jxr:pom:3.0.0": {
+      "layout": "org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.pom",
+      "sha256": "b4a683fd292049d9991d878e6b853a5b24274b01c750d9a031abd3a00f4f8ca7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.pom"
+    },
+    "org.apache.commons:commons-parent:pom:9": {
+      "layout": "org/apache/commons/commons-parent/9/commons-parent-9.pom",
+      "sha256": "5331b7d3e0aed59728c80f1118e4dbf78565d4109e81d16602c9cadbdb23a128",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/9/commons-parent-9.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.inject:pom:0.3.2": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.pom",
+      "sha256": "8951fd9333d1b213d094c080602148fac96bfa33fbf6ba0a18494672473bed3c",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.pom"
+    },
+    "org.slf4j:jcl-over-slf4j:jar:1.7.7": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.7.7/jcl-over-slf4j-1.7.7.jar",
+      "sha256": "c6472b5950e1c23202e567c6334e4832d1db46fad604b7a0d7af71d4a014bce2",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.7/jcl-over-slf4j-1.7.7.jar"
+    },
+    "com.google.inject:guice:pom:4.0": {
+      "layout": "com/google/inject/guice/4.0/guice-4.0.pom",
+      "sha256": "3c8f4302965a037a47385f3b0b5752d34661bad482733b88af8251975fc49016",
+      "url": "https://repo.maven.apache.org/maven2/com/google/inject/guice/4.0/guice-4.0.pom"
+    },
+    "com.google.code.findbugs:jsr305:jar:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar",
+      "sha256": "1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-engine:jar:5.6.2": {
+      "layout": "org/junit/jupiter/junit-jupiter-engine/5.6.2/junit-jupiter-engine-5.6.2.jar",
+      "sha256": "0eb1ab3fc8e4130943b54f4d86824b106ef1cd90d96789343f3944e48b3c501c",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.6.2/junit-jupiter-engine-5.6.2.jar"
+    },
+    "org.apache.maven:maven-plugin-api:pom:3.0": {
+      "layout": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom",
+      "sha256": "8a722af2564205ae996f9035cc04670d3e9e4ae592f5a643c58fb7b0f43e1501",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom"
+    },
+    "org.apache.maven.surefire:surefire-booter:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.pom",
+      "sha256": "16693c056b14b10af33c03990ae8eba4bb25d0ea30dc51b71824d4841108c977",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.22.2/surefire-booter-2.22.2.pom"
+    },
+    "org.apache.maven.plugins:maven-failsafe-plugin:pom:2.22.2": {
+      "layout": "org/apache/maven/plugins/maven-failsafe-plugin/2.22.2/maven-failsafe-plugin-2.22.2.pom",
+      "sha256": "1bae914e36b751ce0e31659c5502f1e67ae0cd3d6a9ac4b1cc5b9a60d4b47266",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-failsafe-plugin/2.22.2/maven-failsafe-plugin-2.22.2.pom"
+    },
+    "org.sonatype.plugins:nexus-staging-maven-plugin:pom:1.6.6": {
+      "layout": "org/sonatype/plugins/nexus-staging-maven-plugin/1.6.6/nexus-staging-maven-plugin-1.6.6.pom",
+      "sha256": "f3f866517bfd0d7882ebaabc91c725c1057ddc0fa530a975f2508f306e2e281e",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plugins/nexus-staging-maven-plugin/1.6.6/nexus-staging-maven-plugin-1.6.6.pom"
+    },
+    "org.codehaus.plexus:plexus-i18n:jar:1.0-beta-6": {
+      "layout": "org/codehaus/plexus/plexus-i18n/1.0-beta-6/plexus-i18n-1.0-beta-6.jar",
+      "sha256": "8d5c55f504184711cf155af434d0a501efe982e3cc6cba41aaf53c50968d1978",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-6/plexus-i18n-1.0-beta-6.jar"
+    },
+    "org.codehaus.plexus:plexus-i18n:jar:1.0-beta-7": {
+      "layout": "org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar",
+      "sha256": "fff07392dc6b29ef90c435ab004671a715f0aa36653e53b44c358eb842ce67d9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar"
+    },
+    "org.eclipse.aether:aether-util:jar:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+      "sha256": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
+    },
+    "xmlunit:xmlunit:jar:1.5": {
+      "layout": "xmlunit/xmlunit/1.5/xmlunit-1.5.jar",
+      "sha256": "b041399902889bef7fa489370d0e8f4d862812938beb14c88d93d250d464fb0d",
+      "url": "https://repo.maven.apache.org/maven2/xmlunit/xmlunit/1.5/xmlunit-1.5.jar"
+    },
+    "org.sonatype.aether:aether-spi:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom",
+      "sha256": "a5a8a19df914af051d29eeb4084189a118c8c301054df41472d9f180ddcc6747",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:3.0.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.pom",
+      "sha256": "948e8e116200325886eff501d39355b0bee1526d699f2bd6b227c18f5e35cdf4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.0.0/maven-shared-utils-3.0.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.jar",
+      "sha256": "1cd68e9b4cf427a2b6b9a943a9bef6da879d25702334ea5addb0d153bb8f8911",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.jar"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0-alpha-20": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0-alpha-20/plexus-containers-1.0-alpha-20.pom",
+      "sha256": "3e48e181d5efa33edb06aaa14b9af5ed2a7582e87963f87602cfdad8fa659bb4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-20/plexus-containers-1.0-alpha-20.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.jar",
+      "sha256": "e176691e5c03bc3046c6fbd3567c6217d3a0a17b3d92891a0bec2e60fa6caea3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.jar"
+    },
+    "org.sonatype.nexus.plugins:nexus-plugins-restlet1x:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.9.1-02/nexus-plugins-restlet1x-2.9.1-02.pom",
+      "sha256": "8f0388974c340a8515174961113915524fc0999e6a9b91bcee06d4a067492ddc",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-plugins-restlet1x/2.9.1-02/nexus-plugins-restlet1x-2.9.1-02.pom"
+    },
+    "org.apache.commons:commons-lang3:pom:3.8.1": {
+      "layout": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.pom",
+      "sha256": "ec8e09f75411685205bd0d9d7872cc3622e67c76df44a0a227b278bea04458d5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.pom"
+    },
+    "commons-logging:commons-logging:pom:1.0.3": {
+      "layout": "commons-logging/commons-logging/1.0.3/commons-logging-1.0.3.pom",
+      "sha256": "8c23c6e92f1df7f58b455cd2caa009dcc87a2fe64976e6ce461522e635aea41e",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.0.3/commons-logging-1.0.3.pom"
+    },
+    "commons-logging:commons-logging:pom:1.0.4": {
+      "layout": "commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.pom",
+      "sha256": "65d310509352b5425118225ee600a01f83ba72142d035014b5d164bc04b2d284",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.pom"
+    },
+    "com.fasterxml.jackson.core:jackson-core:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.pom",
+      "sha256": "60ac54fa6f12017cfabf2557bacf2f6614efd868f616b4cb646782cf8f8c4949",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom",
+      "sha256": "0447b3919bc7d0301b763852aca8dc0e87ccfbe34a4d5257f7f4fae8a4e87998",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.8/maven-repository-metadata-2.0.8.pom",
+      "sha256": "c23b83008edab0936fa4ff1130ccd321613f181d750bde667765904d3a54d235",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.8/maven-repository-metadata-2.0.8.pom"
+    },
+    "org.beanshell:beanshell:pom:2.0b4": {
+      "layout": "org/beanshell/beanshell/2.0b4/beanshell-2.0b4.pom",
+      "sha256": "0792e581f159243127661c65859d14f4f0b66fc774d478da2a874292bb47b874",
+      "url": "https://repo.maven.apache.org/maven2/org/beanshell/beanshell/2.0b4/beanshell-2.0b4.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom",
+      "sha256": "df10657745e39010954fd009276b65b75198bdc40d0adb9916f9697c71fcd986",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom"
+    },
+    "org.apache.maven.doxia:doxia-modules:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-modules/1.0/doxia-modules-1.0.pom",
+      "sha256": "dd5fc215db73fc436a70366aa38859517582bcc8f2805c7b95c0f159dd215cf7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-modules/1.0/doxia-modules-1.0.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar",
+      "sha256": "a65e27aefbe74102d73cd7e3c5c7637021d294a9e7f33132f3c782a76714d0a3",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:pom:4.2.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.pom",
+      "sha256": "50d4f366213b16b797712edb0e9e90a13cedd79b526ce1dc50f0822a6df59ae3",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.pom"
+    },
+    "org.objenesis:objenesis:pom:2.2": {
+      "layout": "org/objenesis/objenesis/2.2/objenesis-2.2.pom",
+      "sha256": "7ac5b03016abbe9fbd913d8f72bba02c6950ebb93e9b099bfce46e15d85f8156",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis/2.2/objenesis-2.2.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom",
+      "sha256": "4dd5ff83a2089613e828ee6c8bd6888d8732217392e2c442f6302df4a025e629",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.2/maven-repository-metadata-2.0.2.pom"
+    },
+    "org.apache.maven.doxia:doxia-modules:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-modules/1.7/doxia-modules-1.7.pom",
+      "sha256": "08a63724d2ce4af8f65628f783af912f1dc8b166596737b8734bdefe73ed4bf0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-modules/1.7/doxia-modules-1.7.pom"
+    },
+    "org.sonatype.sisu.siesta:siesta-client:pom:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-client/1.7/siesta-client-1.7.pom",
+      "sha256": "46a17cbe5fddb3b120d41bf83692b218073d0c92d86261de46611adbd6731145",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-client/1.7/siesta-client-1.7.pom"
+    },
+    "org.apache.maven.doxia:doxia-modules:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-modules/1.8/doxia-modules-1.8.pom",
+      "sha256": "7abb0e672d2a19bf5f984c44b6e987d8b4dc59d17deb24c41dede2e66e5d34c9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-modules/1.8/doxia-modules-1.8.pom"
+    },
+    "org.apache.maven:maven-model:jar:3.1.0": {
+      "layout": "org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.jar",
+      "sha256": "f9f7ad6301942d385fc79ed0615a7d5f06dbda60dee70b709e679624313e642a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.1.0/maven-model-3.1.0.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.22": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.pom",
+      "sha256": "d8b27f9b6c6c0f75de9861a7b3a4d2e4e6b0c20459eb13015d855ec4870e9f40",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.pom"
+    },
+    "com.amazonaws:aws-java-sdk-kms:pom:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-kms/1.11.893/aws-java-sdk-kms-1.11.893.pom",
+      "sha256": "c361b8a30f4cc58a482a6e3fe17516dd3494d0c44a3c14a02004914b38a00488",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-kms/1.11.893/aws-java-sdk-kms-1.11.893.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.21": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.pom",
+      "sha256": "e078ac8780c6f2da5c11c5d2164bf2c2262112a89a82884de9c9886333267f7d",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.26": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.pom",
+      "sha256": "e1c10b3a6335641eb74a668daa9ee86ae4ab06610174e59ba07c8c68042327f7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.3.1": {
+      "layout": "org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom",
+      "sha256": "8cbcb2aacd7f4a7759866ce91b2f910310fbe5a586b5fc7b9bdb76af9257e7c4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:1.2-alpha-7": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom",
+      "sha256": "2a0abfc63ed5c6216356255aa7c572723087938879934aca1ce11f17c24ce156",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-7/plexus-classworlds-1.2-alpha-7.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.24": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.pom",
+      "sha256": "b5d8bac2ef7fd1136298223e53489980ad7a077d1c9e54c06b2884670771819f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.pom"
+    },
+    "org.apache.maven.surefire:surefire-api:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.pom",
+      "sha256": "b1d803a626937e0469e7a4b2862189a2ac7ee0136aa10c37247a9ed8ed97e1ef",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.22.2/surefire-api-2.22.2.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.25": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.pom",
+      "sha256": "9eb551c0ca3ec1354f10bbc5a037a89809d4e32bac9f55a4431e4be0eb8f0d8f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:1.2-alpha-9": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/1.2-alpha-9/plexus-classworlds-1.2-alpha-9.pom",
+      "sha256": "224fe4d0c650f085c012f0a03c1995c598c7b5c506bc5350b727c75874330f00",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/1.2-alpha-9/plexus-classworlds-1.2-alpha-9.pom"
+    },
+    "org.easymock:easymock:pom:2.4": {
+      "layout": "org/easymock/easymock/2.4/easymock-2.4.pom",
+      "sha256": "fd42020cbe60910aedcb3fdd425da164eb8d9e889c30123481af84f4c9fa6a1d",
+      "url": "https://repo.maven.apache.org/maven2/org/easymock/easymock/2.4/easymock-2.4.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.5.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+      "sha256": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-api:jar:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.jar",
+      "sha256": "b03f78e0daeed2d77a0af9bcd662b4cdb9693f7ee72e01a539b508b84c63d182",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.jar"
+    },
+    "org.apache.maven:maven-core:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.pom",
+      "sha256": "17a49218e52955fa16fb4c0d18544e6308613b6d5d001c2434cb0e2c20e1a7ae",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.pom"
+    },
+    "org.eclipse.aether:aether-util:pom:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.pom",
+      "sha256": "c5583eada1381e9b22c870464468593c283fcc16f3d0c892366e531eaa1aada3",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.3.1": {
+      "layout": "org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom",
+      "sha256": "6ec96f889bc29250f90b167c14e547f1b05aa23565c63f9079595befbde816bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom"
+    },
+    "org.junit.platform:junit-platform-commons:pom:1.7.0": {
+      "layout": "org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.pom",
+      "sha256": "0cd7c4f9bee659912ac1dce46f123cd06f40bbb73ab316bd9411c792e3c680a2",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.pom"
+    },
+    "org.apache.maven.plugins:maven-jxr-plugin:pom:3.0.0": {
+      "layout": "org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.pom",
+      "sha256": "3626220dd8ad74097079cdaa7e8cc17ad0079a384d74bd5a050e949b7dc372e7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.pom"
+    },
+    "org.codehaus.plexus:plexus-velocity:jar:1.2": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.jar",
+      "sha256": "b4c4a0dbeacad54306a1ae230eff5ab45d58e3ab88c86ab7245d3a0772be57ab",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.2/plexus-velocity-1.2.jar"
+    },
+    "org.apache.maven:maven-model:pom:3.0": {
+      "layout": "org/apache/maven/maven-model/3.0/maven-model-3.0.pom",
+      "sha256": "3d6fdeb72b2967f1fa2784134fb832d08d8d6e879b7ace7712f2c7281994fc1e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom"
+    },
+    "org.apache.maven:maven-aether-provider:jar:3.0": {
+      "layout": "org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar",
+      "sha256": "1205a1f229999170dcadcfb885a278ad0bc2295540a251f4c438f887ead7bbd9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar"
+    },
+    "org.apache.maven.enforcer:enforcer-api:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom",
+      "sha256": "bc0590627148cc95b91597fc0b69b1b1a3fb37565a229befd4ffe6af347f5943",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom"
+    },
+    "org.apache.maven.doxia:doxia-sitetools:pom:1.7.4": {
+      "layout": "org/apache/maven/doxia/doxia-sitetools/1.7.4/doxia-sitetools-1.7.4.pom",
+      "sha256": "62e4b8dd8172265650f4ab17cb4d24b6426c5a3679768fbdd4ff624621069193",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sitetools/1.7.4/doxia-sitetools-1.7.4.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.3.2": {
+      "layout": "org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom",
+      "sha256": "2fd3853acd7d8b548ab59507f1a5a06897efdc0c4f05acb7c2a49bc78ad83eff",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom",
+      "sha256": "228367b7569fb1462a3eb1423bc2778e2fc7fbaee3d3767890c02b8924fa1889",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-maven:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.9.1-02/nexus-buildsupport-maven-2.9.1-02.pom",
+      "sha256": "67b3d176a78e8fc6f4d6b88e266fe26a100fbcb74a927cee80dd2fb49a89b202",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-maven/2.9.1-02/nexus-buildsupport-maven-2.9.1-02.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.2.0/maven-error-diagnostics-2.2.0.pom",
+      "sha256": "098c25447e27b932a5f4471e33881552b1d9d9b93bb08c9d94ced37e9f442928",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.0/maven-error-diagnostics-2.2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0-alpha-30": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0-alpha-30/plexus-containers-1.0-alpha-30.pom",
+      "sha256": "74b039c9d08454c6abcf2f2581e0cfddfabd01360480876039c8de5104878d3b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0-alpha-30/plexus-containers-1.0-alpha-30.pom"
+    },
+    "net.sourceforge.pmd:pmd-javascript:jar:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-javascript/6.23.0/pmd-javascript-6.23.0.jar",
+      "sha256": "4133fb7fb34a75724683e1ac5a367538b8c87cae45cee82938966d4dc56da8cf",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-javascript/6.23.0/pmd-javascript-6.23.0.jar"
+    },
+    "org.apache.struts:struts-parent:pom:1.3.8": {
+      "layout": "org/apache/struts/struts-parent/1.3.8/struts-parent-1.3.8.pom",
+      "sha256": "e6137fdb8a229c10d12b8aa4808c55ca4e07b4e759f2f352f3869dec1227c750",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-parent/1.3.8/struts-parent-1.3.8.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-db:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.9.1-02/nexus-buildsupport-db-2.9.1-02.pom",
+      "sha256": "d991632e8f485d33c290402f1c5da0d4a483240824bde6773504682bbc620056",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-db/2.9.1-02/nexus-buildsupport-db-2.9.1-02.pom"
+    },
+    "org.slf4j:jcl-over-slf4j:jar:1.5.6": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.jar",
+      "sha256": "03e1898e878806cace2028d9b42cda3377d70ceb2b06253c43f6a587a0f67067",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.jar"
+    },
+    "org.codehaus.plexus:plexus-io:pom:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom",
+      "sha256": "67a1ce072ad9ff4ce37985a1c32827eaeda4660cabe7f69eff2ca1ebff2d23bd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom"
+    },
+    "org.apache.maven:maven-settings-builder:jar:3.0": {
+      "layout": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar",
+      "sha256": "e17e706c6f03c453f6000599cab607c2af5f1cc6e3a3b1e6fce27e5ef4999eab",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar"
+    },
+    "xpp3:xpp3_min:jar:1.1.4c": {
+      "layout": "xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar",
+      "sha256": "bfc90e9e32d0eab1f397fb974b5f150a815188382ac41f372a7149d5bc178008",
+      "url": "https://repo.maven.apache.org/maven2/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar"
+    },
+    "org.codehaus.plexus:plexus-velocity:pom:1.1.2": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.1.2/plexus-velocity-1.1.2.pom",
+      "sha256": "f45fc03d76b3b1318f1fd0b9d8562cccb15f975396f38157a7cbb961678126ce",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.1.2/plexus-velocity-1.1.2.pom"
+    },
+    "org.apache.maven.surefire:surefire-logger-api:jar:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.jar",
+      "sha256": "e61f04bcc9349921239e7bd0f42dcd33ebd3bf80095961e3e93a834f1e478f87",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/2.22.2/surefire-logger-api-2.22.2.jar"
+    },
+    "javax.activation:javax.activation-api:pom:1.2.0": {
+      "layout": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.pom",
+      "sha256": "da2926f3c8be898643cc10acdec6de0b0351a57fb2735770fa0177b06ade71b9",
+      "url": "https://repo.maven.apache.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.2": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
+      "sha256": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar",
+      "sha256": "37e66f15f348df957538f81f7e10a3fdcf84e5fbd687b2001ee3d6ab4a25aafe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar"
+    },
+    "avalon-framework:avalon-framework:pom:4.1.3": {
+      "layout": "avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom",
+      "sha256": "c6c971b146ec8e596e660e64d5517aae02e34c3cce240de44bb92ccd98f046bf",
+      "url": "https://repo.maven.apache.org/maven2/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom"
+    },
+    "org.sonatype.nexus.plugins:nexus-restlet1x-model:jar:2.9.1-02": {
+      "layout": "org/sonatype/nexus/plugins/nexus-restlet1x-model/2.9.1-02/nexus-restlet1x-model-2.9.1-02.jar",
+      "sha256": "85231ac86b74ac795436379775dabf6cf7b2f20a9869141d0c6ab2dbeb297d0d",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.9.1-02/nexus-restlet1x-model-2.9.1-02.jar"
+    },
+    "org.apache.maven:maven-settings:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom",
+      "sha256": "0d25a88a1b1e44801f8912206a40ff249cb5702ee87cf3d243d5213f7bcf534f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-velocity:pom:1.1.7": {
+      "layout": "org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.pom",
+      "sha256": "f3812df661f0a82e501d6b1ee14df1b277df29ab58c6c8c785624d6b1149b76d",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-velocity/1.1.7/plexus-velocity-1.1.7.pom"
+    },
+    "org.apache.maven:maven-settings:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-settings/2.2.0/maven-settings-2.2.0.pom",
+      "sha256": "792da338d3614ca96763b7c1655fa3cce5c88076151666f80eda7357dcefa629",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.0/maven-settings-2.2.0.pom"
+    },
+    "oro:oro:jar:2.0.8": {
+      "layout": "oro/oro/2.0.8/oro-2.0.8.jar",
+      "sha256": "e00ccdad5df7eb43fdee44232ef64602bf63807c2d133a7be83ba09fd49af26e",
+      "url": "https://repo.maven.apache.org/maven2/oro/oro/2.0.8/oro-2.0.8.jar"
+    },
+    "oro:oro:jar:2.0.7": {
+      "layout": "oro/oro/2.0.7/oro-2.0.7.jar",
+      "sha256": "36ae6fff1e3ace81739ab168ebc2374513b55965c7c6f7c2ebaeadc2f193f68b",
+      "url": "https://repo.maven.apache.org/maven2/oro/oro/2.0.7/oro-2.0.7.jar"
+    },
+    "org.ow2.asm:asm:pom:6.2": {
+      "layout": "org/ow2/asm/asm/6.2/asm-6.2.pom",
+      "sha256": "92ec633f93f9c84dcb087a79df1395cfef07be574076ceaeb3159e096b4d4643",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom"
+    },
+    "org.apache.maven.scm:maven-scm-provider-gitexe:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-gitexe/1.9.1/maven-scm-provider-gitexe-1.9.1.pom",
+      "sha256": "67d07129aaff6459d024069935674e0ce5b1452f93a6b191ccc73d6d3170ea91",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/1.9.1/maven-scm-provider-gitexe-1.9.1.pom"
+    },
+    "commons-beanutils:commons-beanutils:pom:1.6": {
+      "layout": "commons-beanutils/commons-beanutils/1.6/commons-beanutils-1.6.pom",
+      "sha256": "f1309fdb6c64284485bc39188e55d0a30ddbb9311e4d4b6ee08bb038fa4b556d",
+      "url": "https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.6/commons-beanutils-1.6.pom"
+    },
+    "org.sonatype.sisu:sisu-inject-bean:jar:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar",
+      "sha256": "fb3160e1e3a7852b441016dbcc97a34e3cf4eeb8ceb9e82edf2729439858f080",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar"
+    },
+    "org.apache.maven.surefire:maven-surefire-common:jar:2.22.2": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.jar",
+      "sha256": "5b0a9e0d3e35b7c1a652c8e60fb9e6c87569e087429e2b9dee1d4747f7150e52",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:1.5.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.jar",
+      "sha256": "2ca121831e597b4d8f2cb22d17c5c041fc23a7777ceb6bfbdd4dfb34bbe7d997",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.jar"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.jar",
+      "sha256": "d825854caf7045253c07b5408cd25db36d108706dde3805b5ad5766e78f510f8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.7/doxia-logging-api-1.7.jar"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:jar:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar",
+      "sha256": "1f22f2e528daddbc5d06518c4dbe4d5f4fa6995c8441c702ee5d7d506bb4b4f3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar"
+    },
+    "org.apache.maven:maven-core:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar",
+      "sha256": "710d56c05add33beadea2f86254223955aca570c15a610f81be07c96c919d7b6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar"
+    },
+    "commons-beanutils:commons-beanutils:pom:1.7.0": {
+      "layout": "commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.pom",
+      "sha256": "b6aca6465a28b027686f025d57702f90ad0d128e14d1cfceca0bd871f0084ad9",
+      "url": "https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.pom"
+    },
+    "com.amazonaws:aws-java-sdk-kms:jar:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-kms/1.11.893/aws-java-sdk-kms-1.11.893.jar",
+      "sha256": "d19999ae6d5a5eca8089da4d807209ce5baf7afd8c0892bece1150de9e383a2a",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-kms/1.11.893/aws-java-sdk-kms-1.11.893.jar"
+    },
+    "org.sonatype.aether:aether:pom:1.13.1": {
+      "layout": "org/sonatype/aether/aether/1.13.1/aether-1.13.1.pom",
+      "sha256": "719fe091fd3fe4c6a7b8f69c8714935138b85a2b6145068a1ccfdb57d2e500d1",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether/1.13.1/aether-1.13.1.pom"
+    },
+    "org.junit.jupiter:junit-jupiter-api:pom:5.4.2": {
+      "layout": "org/junit/jupiter/junit-jupiter-api/5.4.2/junit-jupiter-api-5.4.2.pom",
+      "sha256": "1d8de34f706edc691a2bd1dbb25162ed2bb5ef35b2604140776030a0cb3357ed",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.4.2/junit-jupiter-api-5.4.2.pom"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:jar:1.1": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.jar",
+      "sha256": "80f1b67a2f698f0e8dd11e5cedfc28c5b8e6fb2986adf939bfa04d92d9367d66",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.1/doxia-logging-api-1.1.jar"
+    },
+    "org.ow2.asm:asm:pom:7.3.1": {
+      "layout": "org/ow2/asm/asm/7.3.1/asm-7.3.1.pom",
+      "sha256": "eacdcd500d6527e963888daeda31923e4bc241a25424dcc38acca2e601e7fde2",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.3.1/asm-7.3.1.pom"
+    },
+    "org.apache.maven.resolver:maven-resolver-util:pom:1.4.1": {
+      "layout": "org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.pom",
+      "sha256": "a58c932e967e85e7bcb8d4adaedd14a5221a1750a1d089c5086c4d73df505155",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.pom"
+    },
+    "org.sonatype.nexus.maven:nexus-common:pom:1.6.6": {
+      "layout": "org/sonatype/nexus/maven/nexus-common/1.6.6/nexus-common-1.6.6.pom",
+      "sha256": "3b9507dfafa4ba33ae172d879038ef45721a70774d99aa1c8f5260c440f8ad76",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.6/nexus-common-1.6.6.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:pom:3.2.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/3.2.0/biz.aQute.bndlib-3.2.0.pom",
+      "sha256": "7366d5a03ff318ed510545fa6803ae5863387bc7df8e39c0f2256129f949d53b",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/3.2.0/biz.aQute.bndlib-3.2.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-logging-api:jar:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.jar",
+      "sha256": "24d3085e7bbbc197a64328c9cca135cb3b746b15ce2a335fd417df84c96c6aff",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-logging-api/1.8/doxia-logging-api-1.8.jar"
+    },
+    "org.slf4j:slf4j-api:jar:1.7.25": {
+      "layout": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+      "sha256": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+    },
+    "org.junit.jupiter:junit-jupiter:pom:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter/5.7.0/junit-jupiter-5.7.0.pom",
+      "sha256": "23b69f77c0264f81eea5aa26eec3b35313336c629c4fa8ee0692107796e16d00",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.7.0/junit-jupiter-5.7.0.pom"
+    },
+    "org.apache.maven.scm:maven-scm-provider-git-commons:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-git-commons/1.3/maven-scm-provider-git-commons-1.3.pom",
+      "sha256": "48b9144e8421761d5a47c6cb9a881c9a32bba2d8646e871e049d169b7a370e07",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-git-commons/1.3/maven-scm-provider-git-commons-1.3.pom"
+    },
+    "com.amazonaws:jmespath-java:pom:1.11.893": {
+      "layout": "com/amazonaws/jmespath-java/1.11.893/jmespath-java-1.11.893.pom",
+      "sha256": "5cca7ef2b501ca3a344292031d7511e272fdb1c7164f32e161ff5d7e370973e2",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/jmespath-java/1.11.893/jmespath-java-1.11.893.pom"
+    },
+    "org.apache.maven:maven-settings-builder:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.pom",
+      "sha256": "74c4de94135d61fc11e18651380e6d9f33787e3c635daf8293ed1f9ff4e381e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.pom"
+    },
+    "org.fusesource.hawtbuf:hawtbuf-proto:pom:1.9": {
+      "layout": "org/fusesource/hawtbuf/hawtbuf-proto/1.9/hawtbuf-proto-1.9.pom",
+      "sha256": "58419761712b7f1fb53e28a2122bd20c6d88b7242bff0da90f9ace9cc1d508d7",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/hawtbuf/hawtbuf-proto/1.9/hawtbuf-proto-1.9.pom"
+    },
+    "org.apache.maven.plugins:maven-assembly-plugin:pom:3.3.0": {
+      "layout": "org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom",
+      "sha256": "159c19ac52c50ea25875625f64d354b4b29352a2fb9f0be3598946a341c07897",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.pom"
+    },
+    "org.antlr:antlr4-runtime:pom:4.7": {
+      "layout": "org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.pom",
+      "sha256": "666828d6b775cde482714d0a4b478ddfe99e9e9d8be67b76b643f0c3c394b10a",
+      "url": "https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.pom"
+    },
+    "org.projectlombok:lombok:pom:1.18.16": {
+      "layout": "org/projectlombok/lombok/1.18.16/lombok-1.18.16.pom",
+      "sha256": "34353bdceac715ac005aa8bcb89930cde3897ba9fc61280c1f1c0e7863de941c",
+      "url": "https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.16/lombok-1.18.16.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom",
+      "sha256": "9dad0f56523955b60a9903f4e8342891355d7a59c77f36a3b53cf6ff2e4df625",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.0/maven-repository-metadata-2.2.0.pom",
+      "sha256": "b12e86e205e4ea0a1f51fb562202e73083f627c9a690347519ad44edd9d80f71",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.0/maven-repository-metadata-2.2.0.pom"
+    },
+    "org.apache.maven.enforcer:enforcer-api:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar",
+      "sha256": "977fcc0b50cb6bb825299651d0c1e7499a09ae98e744ccf46ed9c32ee743ab33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar"
+    },
+    "org.apache.maven.enforcer:enforcer-rules:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.pom",
+      "sha256": "c924683b741ec244fcc69754a5178756d795276d641c38ab31dfce9ef684bb9c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.pom"
+    },
+    "org.sonatype.buildsupport:buildsupport:pom:5": {
+      "layout": "org/sonatype/buildsupport/buildsupport/5/buildsupport-5.pom",
+      "sha256": "a8cb0a45e21a4515a281125667d90c3bfa2a5ba0b9f2d644928291a7fe67899a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/5/buildsupport-5.pom"
+    },
+    "org.sonatype.buildsupport:buildsupport:pom:6": {
+      "layout": "org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom",
+      "sha256": "040894e4017fba7aad2e770f12f0379f0f84b2cec223c9fc5184792be9c1e0c6",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/buildsupport/buildsupport/6/buildsupport-6.pom"
+    },
+    "net.kemitix.tiles:testing:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/testing/2.7.0/testing-2.7.0.pom",
+      "sha256": "1d86cc60231c0271f5581a28c14c6c6d8944d4ae4d670fbc3e7174440c438ebb",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/testing/2.7.0/testing-2.7.0.pom"
+    },
+    "org.apache.maven:maven-monitor:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-monitor/2.2.0/maven-monitor-2.2.0.pom",
+      "sha256": "6751bddaa88643d751ae1cb012d6c3b08a6bc4dadbd3b72911088fd7802b08af",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.0/maven-monitor-2.2.0.pom"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:pom:3.1.0": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.pom",
+      "sha256": "3e81c8c4e842f89c45fd6908f7c4ec8e538b716e92d73423a27fe02cf3e31300",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.1.0/maven-resources-plugin-3.1.0.pom"
+    },
+    "org.apache.maven:maven-monitor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom",
+      "sha256": "bc962d48dcebb463c1071004015c4609516d616e884ce36eb7390f9a8095a65b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom"
+    },
+    "plexus:plexus-containers:pom:1.0.2": {
+      "layout": "plexus/plexus-containers/1.0.2/plexus-containers-1.0.2.pom",
+      "sha256": "131ed39a845f96761a46974a2d515235da6fa31eb78de8484466426a49504d16",
+      "url": "https://repo.maven.apache.org/maven2/plexus/plexus-containers/1.0.2/plexus-containers-1.0.2.pom"
+    },
+    "backport-util-concurrent:backport-util-concurrent:jar:3.1": {
+      "layout": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar",
+      "sha256": "f5759b7fcdfc83a525a036deedcbd32e5b536b625ebc282426f16ca137eb5902",
+      "url": "https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar"
+    },
+    "org.sonatype.aether:aether-util:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom",
+      "sha256": "0342bdcbd23208534dde58819ddf937aabbe3d61a47231ffb06632fb47dd2657",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom"
+    },
+    "sslext:sslext:pom:1.2-0": {
+      "layout": "sslext/sslext/1.2-0/sslext-1.2-0.pom",
+      "sha256": "75929e166762dcef294281f216b2bdcf866bbbc7835a59be1e68bf7032de016a",
+      "url": "https://repo.maven.apache.org/maven2/sslext/sslext/1.2-0/sslext-1.2-0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-io:jar:3.0.0": {
+      "layout": "org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.jar",
+      "sha256": "7f9d12b2d569ccde2cacd22a39e301b20f82567b80e21d625c5f4d93dc09c2c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/3.0.0/maven-shared-io-3.0.0.jar"
+    },
+    "ch.qos.logback:logback-classic:jar:1.1.2": {
+      "layout": "ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar",
+      "sha256": "30b792e2745752fad8e1f92ca750d5f2d480edd2c5e99bc098aaebe22eb48c22",
+      "url": "https://repo.maven.apache.org/maven2/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-7/doxia-decoration-model-1.0-alpha-7.jar",
+      "sha256": "a45e2a094468d7a8a1a63ae2712be2a30275f95dd5f90b66d7403fb6f864ab07",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-7/doxia-decoration-model-1.0-alpha-7.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom",
+      "sha256": "94348507ad85d221df9167e9db313dfdb474d59e715d2c0638d3eac341756222",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.2/maven-artifact-manager-2.0.2.pom"
+    },
+    "com.google.guava:guava-parent:pom:10.0.1": {
+      "layout": "com/google/guava/guava-parent/10.0.1/guava-parent-10.0.1.pom",
+      "sha256": "a3a4ec4c42839308905126340a882a7f37e7e124843ae8f5ea832e1aad9661ba",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/10.0.1/guava-parent-10.0.1.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom",
+      "sha256": "a80884dfac999ebdda57904f929a14f28ab08e5411d515bdb1fbdaacf0ed6d6f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-javac:pom:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom",
+      "sha256": "1b46ab52843b7446be98623a97f80db01c1ba4672fba1a41beb165436c0c0601",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.6": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.pom",
+      "sha256": "593a0ff086fb81700e17707c303f8552880bf2a50ce41d9dcb5918e8443710dd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.pom"
+    },
+    "org.apache.maven:maven-builder-support:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
+      "sha256": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom",
+      "sha256": "eececa44387deebbac73192967eabad80f2f43fe96f70b98f3e21951b1bfaea1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom"
+    },
+    "com.fasterxml.jackson:jackson-base:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/jackson-base/2.11.3/jackson-base-2.11.3.pom",
+      "sha256": "baef2a3066e9872190050c4ccf45341769c33bf452fc18c93052b12a2409619c",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.11.3/jackson-base-2.11.3.pom"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom",
+      "sha256": "672f22f9b697784518b8b84719324013a8f1bf0337f1d3059b83982d4ca480ca",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:1.5.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar",
+      "sha256": "b7554a41499282e3b2226a22aff3ebe984f7e159798c461d917c1b829b130cd1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar"
+    },
+    "org.apache.maven:maven-settings:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-settings/2.0.8/maven-settings-2.0.8.pom",
+      "sha256": "b6e05664e0a840e3b9e4a3c47e2fbbe4f74feb819f1a05a1da10f524cc8c8398",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.8/maven-settings-2.0.8.pom"
+    },
+    "org.junit.platform:junit-platform-engine:pom:1.6.2": {
+      "layout": "org/junit/platform/junit-platform-engine/1.6.2/junit-platform-engine-1.6.2.pom",
+      "sha256": "6572dcfd47e62fc04d8571cd6a21c0101c5f4f779f0b162824067efa4d9dc07a",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.6.2/junit-platform-engine-1.6.2.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar",
+      "sha256": "72582f8ba285601fa753ceeda73ff3cbd94c6e78f52ec611621eaa0186165452",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar"
+    },
+    "org.eclipse.aether:aether:pom:0.9.0.M2": {
+      "layout": "org/eclipse/aether/aether/0.9.0.M2/aether-0.9.0.M2.pom",
+      "sha256": "30bf8c64ccf77ebbf52b04ec576a0fa77b16b26eaf348519b1684263450d39ce",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether/0.9.0.M2/aether-0.9.0.M2.pom"
+    },
+    "velocity:velocity-dep:jar:1.4": {
+      "layout": "velocity/velocity-dep/1.4/velocity-dep-1.4.jar",
+      "sha256": "ab2aa30ec476779ae0a9a4cc299009ecb40468c175de296ab6a866bd1249597b",
+      "url": "https://repo.maven.apache.org/maven2/velocity/velocity-dep/1.4/velocity-dep-1.4.jar"
+    },
+    "org.codehaus.plexus:plexus-io:jar:3.2.0": {
+      "layout": "org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.jar",
+      "sha256": "15cf8cbd9e014b7156482bbb48e515613158bdd9b4b908d21e6b900f7876f6ff",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:3.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom",
+      "sha256": "efaa4fc4832aad9703df46b89cb02845dbf4db6f6ac88534b7824c4956a3a5fb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.pom"
+    },
+    "junit:junit:jar:4.8.2": {
+      "layout": "junit/junit/4.8.2/junit-4.8.2.jar",
+      "sha256": "a2aa2c3bb2b72da76c3e6a71531f1eefdc350494819baf2b1d80d7146e020f9e",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.8.2/junit-4.8.2.jar"
+    },
+    "org.opentest4j:opentest4j:pom:1.2.0": {
+      "layout": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.pom",
+      "sha256": "a96e671816c1ff8803bdec74c9241f025bdfb277da5d2b4ee02266405936f994",
+      "url": "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.8/maven-artifact-manager-2.0.8.pom",
+      "sha256": "830712322ed645c919f2bfbef7ed42a219339451e5bcb82bc8d9df38e70f1739",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.8/maven-artifact-manager-2.0.8.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom",
+      "sha256": "d573bbb1b78c76523c45aba2859d390883b932dfde67e3c2032fc443c0fa098d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom"
+    },
+    "net.kemitix.tiles:pmd:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/pmd/2.7.0/pmd-2.7.0.xml",
+      "sha256": "0a21741637240b236c7f2e8ef2623e8f18b0ce1646d6682e8a6bec86bba07673",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/pmd/2.7.0/pmd-2.7.0.xml"
+    },
+    "org.apache.struts:struts-taglib:jar:1.3.8": {
+      "layout": "org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.jar",
+      "sha256": "0b54adf308e50d8fdb82066b058bfa57ee244d1cdcf4bf7b6c12fb11d91f44a5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-taglib/1.3.8/struts-taglib-1.3.8.jar"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:0.7": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.jar",
+      "sha256": "728ab424aeebd468d8f3b974e7255e500cc80eaaac7cce2166e282596dead601",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.jar"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom",
+      "sha256": "d4ef608f90dc9599c0cc325ca2ccc2e1ceb439b3d2ff31ae22e30ac1a63a68f0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.0/maven-plugin-descriptor-2.2.0.pom",
+      "sha256": "b0f4d7b30878695cb76bdb4e242c07eaa423d0293cc6e5a3f44ec089dee8230e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.0/maven-plugin-descriptor-2.2.0.pom"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:pom:3.0.1": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.pom",
+      "sha256": "0adc76dbae4051be08ed8205bd0f6caea6f4c7c3cb836a03f6bd2fd734d149ad",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.0.1/maven-common-artifact-filters-3.0.1.pom"
+    },
+    "org.codehaus.plexus:plexus-java:jar:0.9.8": {
+      "layout": "org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.jar",
+      "sha256": "5e20038a9275daf63c588ef07bc287e14b3681c015ce16f155f74db52508d5b7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.jar"
+    },
+    "javax.validation:validation-api:pom:1.1.0.Final": {
+      "layout": "javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.pom",
+      "sha256": "b8634911e6cbe6c14b30bd06e3837d7e6928fc7e1c96278dec61708b6aaee21c",
+      "url": "https://repo.maven.apache.org/maven2/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.pom"
+    },
+    "com.fasterxml.jackson:jackson-bom:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/jackson-bom/2.11.3/jackson-bom-2.11.3.pom",
+      "sha256": "4b006a69f9ec9f70ff38b153efeaba3d7f5fd17e98490415f6cab45c17da720f",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.11.3/jackson-bom-2.11.3.pom"
+    },
+    "org.fusesource:fusesource-pom:pom:1.12": {
+      "layout": "org/fusesource/fusesource-pom/1.12/fusesource-pom-1.12.pom",
+      "sha256": "c40d960daadcef7b01c1b1c6657afbac4fffb5e53168f8fcb0b28b84e6fdcca1",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/fusesource-pom/1.12/fusesource-pom-1.12.pom"
+    },
+    "org.eclipse.aether:aether-util:pom:0.9.0.M2": {
+      "layout": "org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.pom",
+      "sha256": "8e1f27e5463f12e4e1d7b242562239c42065e9bcdbf01629399e265035606986",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-other:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.9.1-02/nexus-buildsupport-other-2.9.1-02.pom",
+      "sha256": "90037250502f75013d8105d0a2e5255870ab62b59d185b595b8665458e1b1043",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-other/2.9.1-02/nexus-buildsupport-other-2.9.1-02.pom"
+    },
+    "net.sourceforge.saxon:saxon:jar:dom:9.1.0.8": {
+      "layout": "net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8-dom.jar",
+      "sha256": "c6cf3ecc7f4b65ab8b613d00fd9e9c0648a5aa03264a941ba0fd2da5339f917a",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/saxon/saxon/9.1.0.8/saxon-9.1.0.8-dom.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+      "sha256": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
+    },
+    "commons-lang:commons-lang:pom:2.6": {
+      "layout": "commons-lang/commons-lang/2.6/commons-lang-2.6.pom",
+      "sha256": "ed76b8891c30b566289c743656f8a4d435986982438d40c567c626233247e711",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.pom"
+    },
+    "commons-lang:commons-lang:pom:2.4": {
+      "layout": "commons-lang/commons-lang/2.4/commons-lang-2.4.pom",
+      "sha256": "90306278d39ed5a50dafa468adee4d272b635d54c4f7295e293e42bbdb8ad666",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.4/commons-lang-2.4.pom"
+    },
+    "org.apache.maven.jxr:jxr:pom:3.0.0": {
+      "layout": "org/apache/maven/jxr/jxr/3.0.0/jxr-3.0.0.pom",
+      "sha256": "977e83e5267f672b63e546ff3dd2077ad8a5b1ca1d7bf83b1d086d80a1f774e5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/jxr/jxr/3.0.0/jxr-3.0.0.pom"
+    },
+    "commons-lang:commons-lang:pom:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.pom",
+      "sha256": "f1a709cd489f23498a0b6b3dfbfc0d21d4f15904791446dec7f8a58a7da5bd6a",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.pom"
+    },
+    "org.fusesource.hawtbuf:hawtbuf:jar:1.9": {
+      "layout": "org/fusesource/hawtbuf/hawtbuf/1.9/hawtbuf-1.9.jar",
+      "sha256": "a057c86610e9ebdd7eef79c4b277c71126507bc9a2b685d7b5848bf7e5360d86",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/hawtbuf/hawtbuf/1.9/hawtbuf-1.9.jar"
+    },
+    "org.apache.maven.surefire:surefire-junit-platform:jar:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-junit-platform/2.22.2/surefire-junit-platform-2.22.2.jar",
+      "sha256": "c33490024cd816e0c2c27331a68ba82e4c023d5255bdfa4ac71ba5998e13079d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/2.22.2/surefire-junit-platform-2.22.2.jar"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.0/doxia-module-xhtml-1.0.jar",
+      "sha256": "bbd4aecfdbb825c256c0a2901197f853cde368ca167681aff84675f85c677d8c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.0/doxia-module-xhtml-1.0.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-api:pom:5.6.2": {
+      "layout": "org/junit/jupiter/junit-jupiter-api/5.6.2/junit-jupiter-api-5.6.2.pom",
+      "sha256": "1d3b97e7a6fcd708fb42cada5a70131d08d5a505b15a51bce76aca6f4d67d23b",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.6.2/junit-jupiter-api-5.6.2.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.jar",
+      "sha256": "de41a9b940560ce070f07f9b894633e748eb2f74a3576dd799a37db79c9f3f41",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.jar"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:jar:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.jar",
+      "sha256": "7a8298c505baacb5d209bc0210e2706732bd7826cf90589a455d85617205bf9f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.jar"
+    },
+    "commons-beanutils:commons-beanutils-core:pom:1.8.3": {
+      "layout": "commons-beanutils/commons-beanutils-core/1.8.3/commons-beanutils-core-1.8.3.pom",
+      "sha256": "8959cbed8c9b2a7d168b9df726067638634bf3ec748762382215e8080d44dbc8",
+      "url": "https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils-core/1.8.3/commons-beanutils-core-1.8.3.pom"
+    },
+    "org.apache.maven:maven-settings:pom:3.0": {
+      "layout": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom",
+      "sha256": "2340855d40ce6125d9a23ab80d94848efa50b2957cf93531e2a7dcf631b4f22b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom"
+    },
+    "org.apache.maven:maven-core:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.jar",
+      "sha256": "cfdf0057b2d2a416d48b873afe5a2bf8d848aabbba07636149fcbb622c5952d7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.jar"
+    },
+    "com.thoughtworks.xstream:xstream:jar:1.4.7": {
+      "layout": "com/thoughtworks/xstream/xstream/1.4.7/xstream-1.4.7.jar",
+      "sha256": "7f8039c0ee7284f9c2a9554b5e2bc20bf26b74b37f690633a75ff1993136f364",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream/1.4.7/xstream-1.4.7.jar"
+    },
+    "org.apache.maven:maven-core:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-core/2.2.0/maven-core-2.2.0.jar",
+      "sha256": "7bad92349e534650328a8a18207159fa29a3cede904bb0619c321c24072e1f47",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.0/maven-core-2.2.0.jar"
+    },
+    "commons-validator:commons-validator:jar:1.3.1": {
+      "layout": "commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.jar",
+      "sha256": "d3680636c84e5cea6bfe43f338f8bab03d6a3e18cc663fc8b671684ef66c0c8d",
+      "url": "https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.2.1": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.pom",
+      "sha256": "fcb6b491372e3396b61362aa1d367e7ce0454db16abca22089be85afcf856922",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.2.1/maven-reporting-api-2.2.1.pom"
+    },
+    "net.kemitix.tiles:maven-plugins:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/maven-plugins/2.7.0/maven-plugins-2.7.0.xml",
+      "sha256": "6b622f2f4d03d39ff1add72a38b3201a0890a4b27ade87adae4864d62cd1eaf6",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/maven-plugins/2.7.0/maven-plugins-2.7.0.xml"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-osgi:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.9.1-02/nexus-buildsupport-osgi-2.9.1-02.pom",
+      "sha256": "9b56c687fdde322b5e0b1bfa64ac8f0e560c01f1bc6c64377e99237980fe61ed",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-osgi/2.9.1-02/nexus-buildsupport-osgi-2.9.1-02.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.2.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.2.0/maven-reporting-api-2.2.0.pom",
+      "sha256": "34e94a5a286007c92631add26b8247b85373ec4b425c77146a587d052a758908",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.2.0/maven-reporting-api-2.2.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:3.2.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.jar",
+      "sha256": "d62150f831761f11ad6947f0090f89f411c75179c4995ccccd774b5c2f8a90bd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.1.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+      "sha256": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
+    },
+    "org.sonatype.spice.zapper:spice-zapper:pom:1.3": {
+      "layout": "org/sonatype/spice/zapper/spice-zapper/1.3/spice-zapper-1.3.pom",
+      "sha256": "6f21bf623efd08021df8d3510dc8f4796152fc7e7dbc2f817e88fa9183798fca",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/zapper/spice-zapper/1.3/spice-zapper-1.3.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-core:pom:4.0.1": {
+      "layout": "org/apache/httpcomponents/httpcomponents-core/4.0.1/httpcomponents-core-4.0.1.pom",
+      "sha256": "70d3b2bb5d199da825681559ff68aa5bdee201206c50af177bf7ca4d94226752",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-core/4.0.1/httpcomponents-core-4.0.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.0-alpha-7/doxia-site-renderer-1.0-alpha-7.pom",
+      "sha256": "b3d22627ff432c40a01eead282a97e37264c0156173faf8c57e5fe21321801e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.0-alpha-7/doxia-site-renderer-1.0-alpha-7.pom"
+    },
+    "commons-chain:commons-chain:pom:1.1": {
+      "layout": "commons-chain/commons-chain/1.1/commons-chain-1.1.pom",
+      "sha256": "cf0c15c4e843507d95be11114039794494d6fc6259118581a90e03b2db5f5acb",
+      "url": "https://repo.maven.apache.org/maven2/commons-chain/commons-chain/1.1/commons-chain-1.1.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:3.2.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+      "sha256": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+    },
+    "org.apache.httpcomponents:httpcore:pom:4.4.6": {
+      "layout": "org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.pom",
+      "sha256": "398285cfef554fb55b81f20c94f54bf0e28b0462ba92fa3970e933945c08f655",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.pom"
+    },
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.3.1/jackson-jaxrs-json-provider-2.3.1.pom",
+      "sha256": "fb8151bd7f8714cfc2bf02ab8987132b5d3278a0dae6296f660ea7a3c376d6a1",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.3.1/jackson-jaxrs-json-provider-2.3.1.pom"
+    },
+    "org.jdom:jdom:pom:1.1": {
+      "layout": "org/jdom/jdom/1.1/jdom-1.1.pom",
+      "sha256": "ac41c3fb1766896bd257d92afbdaa8a5363cdbe6580383ffd3ec9c50b3a6c3b7",
+      "url": "https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1/jdom-1.1.pom"
+    },
+    "org.apache.maven.resolver:maven-resolver-api:jar:1.4.1": {
+      "layout": "org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.jar",
+      "sha256": "33dc67306cc95da14e5444e8b494d967924abf1d01bae1894676164cbd3f6112",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-api/1.4.1/maven-resolver-api-1.4.1.jar"
+    },
+    "org.apache.commons:commons-compress:jar:1.19": {
+      "layout": "org/apache/commons/commons-compress/1.19/commons-compress-1.19.jar",
+      "sha256": "ff2d59fad74e867630fbc7daab14c432654712ac624dbee468d220677b124dd5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.19/commons-compress-1.19.jar"
+    },
+    "org.apache.httpcomponents:httpcomponents-client:pom:4.5.3": {
+      "layout": "org/apache/httpcomponents/httpcomponents-client/4.5.3/httpcomponents-client-4.5.3.pom",
+      "sha256": "43c7d2975a1125bb00cf058a3877f549a1f1894f8b8ad47e2c3e46e3fc4623dc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-client/4.5.3/httpcomponents-client-4.5.3.pom"
+    },
+    "javax.xml.bind:jaxb-api:jar:2.3.1": {
+      "layout": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+      "sha256": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
+      "url": "https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
+    },
+    "antlr:antlr:pom:2.7.2": {
+      "layout": "antlr/antlr/2.7.2/antlr-2.7.2.pom",
+      "sha256": "5e9abd6c993c7d2859fb759bfb77355a6c8184aa5d200aa740e345da5f4c58fe",
+      "url": "https://repo.maven.apache.org/maven2/antlr/antlr/2.7.2/antlr-2.7.2.pom"
+    },
+    "javax.servlet:servlet-api:pom:2.3": {
+      "layout": "javax/servlet/servlet-api/2.3/servlet-api-2.3.pom",
+      "sha256": "abb294a8f064018ea226a5ad2176eaa9dbf1cde029a47815fd4a4049d1374160",
+      "url": "https://repo.maven.apache.org/maven2/javax/servlet/servlet-api/2.3/servlet-api-2.3.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom",
+      "sha256": "e88566fd64906e8e9a2315e5cb67efb7e0f4947a1c45a45cff399f64a235ac1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-model/2.0.8/maven-model-2.0.8.pom",
+      "sha256": "37b28072a2a3af9d40c56c397ed27767931aebba83e60834d332b2179c349b95",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.8/maven-model-2.0.8.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom",
+      "sha256": "2bfc8ce93b46c1bbe8e809197a2f970c5573d2b0d3412c84d7cdfa5961299087",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-model/2.0.2/maven-model-2.0.2.pom",
+      "sha256": "d21a7092ae8c21a1a383ebb0979ca2667ab429a2725a7fe15782c5267998b06d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.2/maven-model-2.0.2.pom"
+    },
+    "org.apache.maven:maven-monitor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom",
+      "sha256": "2cfd187d6465c5ad99552da8441d31ff0c1ced1808d2f624dbdb49223d3baa89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom"
+    },
+    "javax.annotation:jsr250-api:pom:1.0": {
+      "layout": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.pom",
+      "sha256": "548b0ef6f04356ef2283af5140d9404f38fd3891a509d468537abf2f9462944d",
+      "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.pom"
+    },
+    "org.apiguardian:apiguardian-api:pom:1.0.0": {
+      "layout": "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.pom",
+      "sha256": "2ecc15d2614124cb9630c7173efcae1776cf43588a8f3ab1b04684b8dbe02489",
+      "url": "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.0/maven-artifact-manager-2.2.0.pom",
+      "sha256": "2459b7366e49b88ee3b03821302b78028b26608c87ab593b9a1732af87394a88",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.0/maven-artifact-manager-2.2.0.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom",
+      "sha256": "ecf58351f8fe0c398b8b452216705bece5291b9b327d30202c16b28ac680450c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.jar",
+      "sha256": "7a75e19eac2c506108d49944a7f6cbf4789f78d3687bced6f651a53399101151",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.jar"
+    },
+    "junit:junit:jar:3.8.1": {
+      "layout": "junit/junit/3.8.1/junit-3.8.1.jar",
+      "sha256": "b58e459509e190bed737f3592bc1950485322846cf10e78ded1d065153012d70",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:jar:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.jar",
+      "sha256": "5d7f639583663b4e721dc2e0edcfed8a56509f973b0f8aa3bd92a7dcf092fd61",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.jar"
+    },
+    "com.intellij:annotations:jar:9.0.4": {
+      "layout": "com/intellij/annotations/9.0.4/annotations-9.0.4.jar",
+      "sha256": "4ea8157f9d4f06b229a306093c21eafbcc5df84d0eeac81c0dca6578fc7d05fe",
+      "url": "https://repo.maven.apache.org/maven2/com/intellij/annotations/9.0.4/annotations-9.0.4.jar"
+    },
+    "commons-logging:commons-logging:pom:1.2": {
+      "layout": "commons-logging/commons-logging/1.2/commons-logging-1.2.pom",
+      "sha256": "c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.pom"
+    },
+    "commons-logging:commons-logging:pom:1.1": {
+      "layout": "commons-logging/commons-logging/1.1/commons-logging-1.1.pom",
+      "sha256": "1f68425fce1007c3343343a27c27057f1427970682cb6d33e493c111721f7cb6",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1/commons-logging-1.1.pom"
+    },
+    "commons-logging:commons-logging:pom:1.0": {
+      "layout": "commons-logging/commons-logging/1.0/commons-logging-1.0.pom",
+      "sha256": "52b3caa59ca5e8f6279421ecb517a0b24571d666ea86bb145462076760026a6f",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.0/commons-logging-1.0.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:4.0": {
+      "layout": "org/codehaus/plexus/plexus/4.0/plexus-4.0.pom",
+      "sha256": "0a1b692d7fcc90d6a45dae2e50f4660d48f7a44504f174aa60ef34fbe1327f6a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.0/doxia-site-renderer-1.0.jar",
+      "sha256": "590288e8f5bd89ec0500a299879f004c200f9296b21cfaebb770c387429cabde",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.0/doxia-site-renderer-1.0.jar"
+    },
+    "org.apache.felix:org.apache.felix.utils:pom:1.6.0": {
+      "layout": "org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.pom",
+      "sha256": "a78f5532c0feb67129eb196e4cea39a4b851f03e5a967181a4b0fe9d23a3bddd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.utils/1.6.0/org.apache.felix.utils-1.6.0.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom",
+      "sha256": "34af0baedaef19375b7c1a7da967e9089d5e0754647fdbe9a302590392874b77",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.pom",
+      "sha256": "b6cbf4b13178e85fb42f6e5cf5f97a3d11166417d2680a873e47da8d946bd871",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.0/maven-project-2.2.0.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-groovy:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.9.1-02/nexus-buildsupport-groovy-2.9.1-02.pom",
+      "sha256": "990b81b45d532ac5a2c78ff0845febde84f609cf61d1054ac10c4d88f0347473",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-groovy/2.9.1-02/nexus-buildsupport-groovy-2.9.1-02.pom"
+    },
+    "software.amazon.ion:ion-java:jar:1.0.2": {
+      "layout": "software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar",
+      "sha256": "0d127b205a1fce0abc2a3757a041748651bc66c15cf4c059bac5833b27d471a5",
+      "url": "https://repo.maven.apache.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-engine:pom:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.pom",
+      "sha256": "b702e250875d331ee3c6b88f37299fbe951f43992f4b2e4a8f144e2e4cf2c7e8",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.pom"
+    },
+    "org.apache.velocity:velocity-tools:jar:2.0": {
+      "layout": "org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.jar",
+      "sha256": "b174eb36bc48c25dce10571c7d3d5dca4e4c1b3e2e31a92b9ed68fe9dea688d9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.jar"
+    },
+    "com.sun.jersey.contribs:jersey-contribs:pom:1.17.1": {
+      "layout": "com/sun/jersey/contribs/jersey-contribs/1.17.1/jersey-contribs-1.17.1.pom",
+      "sha256": "d7796b8d7f03c669da806a0ddc6f4edf647cda4662694528421de0e3f876433f",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/contribs/jersey-contribs/1.17.1/jersey-contribs-1.17.1.pom"
+    },
+    "org.apache.maven:maven-aether-provider:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
+      "sha256": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
+    },
+    "org.apache.felix:maven-bundle-plugin:pom:3.2.0": {
+      "layout": "org/apache/felix/maven-bundle-plugin/3.2.0/maven-bundle-plugin-3.2.0.pom",
+      "sha256": "cf9ada57a6415529b1788e940a3b722da9a1c6aadf3fd5ac11457ccff598a6e6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.2.0/maven-bundle-plugin-3.2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.7.1": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+      "sha256": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    "org.apache.httpcomponents:httpclient:jar:4.5.13": {
+      "layout": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar",
+      "sha256": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"
+    },
+    "org.apache.maven:maven-toolchain:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.jar",
+      "sha256": "809e55c88a15012e76d262ad9c9b762084128e3d81bffe045dd4e6318eef2890",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.2.1/maven-toolchain-2.2.1.jar"
+    },
+    "org.apache.maven.shared:maven-artifact-transfer:pom:0.10.0": {
+      "layout": "org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.pom",
+      "sha256": "b78766b1bcf69834ed931e20ad1ccbb92dbcd03d517b568b207108f9cd89bed8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.pom"
+    },
+    "org.eclipse.aether:aether:pom:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether/1.0.2.v20150114/aether-1.0.2.v20150114.pom",
+      "sha256": "5568154dd92fbe418eab0174d394b479d8b292688ffc965cf376d3a2d29c8243",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether/1.0.2.v20150114/aether-1.0.2.v20150114.pom"
+    },
+    "net.kemitix.tiles:maven-plugins:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/maven-plugins/2.7.0/maven-plugins-2.7.0.pom",
+      "sha256": "b7203608e9c464985f3ad97860f08b64336b9f2a958bec72adb50a0efc89c5bb",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/maven-plugins/2.7.0/maven-plugins-2.7.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0.24": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.jar",
+      "sha256": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.jar"
+    },
+    "org.jboss.weld:weld-parent:pom:6": {
+      "layout": "org/jboss/weld/weld-parent/6/weld-parent-6.pom",
+      "sha256": "74ab64d978a3415cab65c3639b7c5ba5a20599ca5578251b748dd81c882a6088",
+      "url": "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-parent/6/weld-parent-6.pom"
+    },
+    "org.codehaus.groovy:groovy:pom:3.0.4": {
+      "layout": "org/codehaus/groovy/groovy/3.0.4/groovy-3.0.4.pom",
+      "sha256": "39477e1daa352f8a8b5d975013cf06a952c603b5ab66b43aafa96b4fee39ddf0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy/3.0.4/groovy-3.0.4.pom"
+    },
+    "org.apache.maven:maven-core:pom:3.0": {
+      "layout": "org/apache/maven/maven-core/3.0/maven-core-3.0.pom",
+      "sha256": "f70e12ebea93f119f4f63766c2b8a3386c34bb48e588df710cb98c8e3822f7c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom"
+    },
+    "org.projectlombok:lombok:jar:1.18.16": {
+      "layout": "org/projectlombok/lombok/1.18.16/lombok-1.18.16.jar",
+      "sha256": "7206cbbfd6efd5e85bceff29545633645650be58d58910a23b0d4835fbd15ed7",
+      "url": "https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.16/lombok-1.18.16.jar"
+    },
+    "junit:junit:jar:4.11": {
+      "layout": "junit/junit/4.11/junit-4.11.jar",
+      "sha256": "90a8e1603eeca48e7e879f3afbc9560715322985f39a274f6f6070b43f9d06fe",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.11/junit-4.11.jar"
+    },
+    "org.apache.felix:org.apache.felix.bundlerepository:pom:1.6.6": {
+      "layout": "org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.pom",
+      "sha256": "c4a603649248eac9222f7be1a5950f4a3db41fe2d38647fddf6a8d3731b3af6e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/org.apache.felix.bundlerepository/1.6.6/org.apache.felix.bundlerepository-1.6.6.pom"
+    },
+    "junit:junit:jar:4.12": {
+      "layout": "junit/junit/4.12/junit-4.12.jar",
+      "sha256": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.jar"
+    },
+    "org.assertj:assertj-core:jar:3.18.0": {
+      "layout": "org/assertj/assertj-core/3.18.0/assertj-core-3.18.0.jar",
+      "sha256": "282a661e525fcd42ee471a7d6dc422d18092c7e580696f7de8867c165f54ed36",
+      "url": "https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.18.0/assertj-core-3.18.0.jar"
+    },
+    "com.sun.jersey:jersey-client:jar:1.17.1": {
+      "layout": "com/sun/jersey/jersey-client/1.17.1/jersey-client-1.17.1.jar",
+      "sha256": "f4b805760be9edfef9680f4affd39180316d7e93dee39ef5c1f240e38012ae61",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-client/1.17.1/jersey-client-1.17.1.jar"
+    },
+    "org.junit.platform:junit-platform-commons:jar:1.6.2": {
+      "layout": "org/junit/platform/junit-platform-commons/1.6.2/junit-platform-commons-1.6.2.jar",
+      "sha256": "341621f4d998fd7b539b38baa7e1a3da80b7cac00b983e6206b01c9290915fe9",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.6.2/junit-platform-commons-1.6.2.jar"
+    },
+    "commons-validator:commons-validator:jar:1.1.4": {
+      "layout": "commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.jar",
+      "sha256": "cbc59ea6ab683d232364ecb9b5d2576f39c782a219e93e3f0769d50345999ba9",
+      "url": "https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.2": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.2/maven-reporting-api-2.0.2.pom",
+      "sha256": "ca3cbf271609e3cec8d0ebd9293b2a9affd913e82f5f7f8835a6b66c81865a07",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.2/maven-reporting-api-2.0.2.pom"
+    },
+    "net.kemitix.tiles:pmd:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/pmd/2.7.0/pmd-2.7.0.pom",
+      "sha256": "40b0e29b7c726dead105dfa8333d524479c58ba17439325cc3d06fb3ed090035",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/pmd/2.7.0/pmd-2.7.0.pom"
+    },
+    "commons-logging:commons-logging-api:pom:1.0.4": {
+      "layout": "commons-logging/commons-logging-api/1.0.4/commons-logging-api-1.0.4.pom",
+      "sha256": "7f1c4c51afbd97e0d60efe3cdffc4bb73128748518a1f4263d211d2a4120f45f",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.0.4/commons-logging-api-1.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar",
+      "sha256": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar"
+    },
+    "org.codehaus.groovy:groovy:pom:3.0.6": {
+      "layout": "org/codehaus/groovy/groovy/3.0.6/groovy-3.0.6.pom",
+      "sha256": "87fe72befde10a04432b5f4fa9f815886be13795a8750920c53beef1da712437",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy/3.0.6/groovy-3.0.6.pom"
+    },
+    "aopalliance:aopalliance:jar:1.0": {
+      "layout": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+      "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+      "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
+    },
+    "org.apache.maven:maven-model-builder:pom:3.0": {
+      "layout": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom",
+      "sha256": "c1413ace47dafabe7917072f26e0b667f5b3a762156f82893544cd71e6a6c4ba",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom",
+      "sha256": "4ac659858bac5929ea8fc183d7ce4b588d7e69363a76277f6a26349393686657",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0.10": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.jar",
+      "sha256": "9fc0794062be85c3606000b326ea0339e8620d15949cb96a254b85a8f958e955",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.jar"
+    },
+    "org.sonatype.nexus:nexus-client-core:jar:2.9.1-02": {
+      "layout": "org/sonatype/nexus/nexus-client-core/2.9.1-02/nexus-client-core-2.9.1-02.jar",
+      "sha256": "ebfb2ac85e68abfd01b4d92df3c25519519779cb44d37be4e22644b6c3dc8c60",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.9.1-02/nexus-client-core-2.9.1-02.jar"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.0-alpha-7/doxia-site-renderer-1.0-alpha-7.jar",
+      "sha256": "1afcbfd704b5959f291112831a1c4f7d735ea9fb9e0c0fe25c82c1fa9cd32795",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.0-alpha-7/doxia-site-renderer-1.0-alpha-7.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-databind:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-databind/2.11.3/jackson-databind-2.11.3.pom",
+      "sha256": "743a7086a75bd0ec67bf788ce728fe752241f21619145a0b2da2ed242557216a",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.11.3/jackson-databind-2.11.3.pom"
+    },
+    "net.bytebuddy:byte-buddy-parent:pom:1.10.15": {
+      "layout": "net/bytebuddy/byte-buddy-parent/1.10.15/byte-buddy-parent-1.10.15.pom",
+      "sha256": "95f928ce833c13bbdfc166e411b408a510012920481a93aa2bf74bee5fd56db1",
+      "url": "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.10.15/byte-buddy-parent-1.10.15.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom",
+      "sha256": "77f614225a71c207a45f270be0190d34bac4dbc14684cda26015717710411aee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-client:pom:4.3.5": {
+      "layout": "org/apache/httpcomponents/httpcomponents-client/4.3.5/httpcomponents-client-4.3.5.pom",
+      "sha256": "1cd94af7cbac852c537104ec695361f97042506f6c3003e8c0dbc515f1082644",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-client/4.3.5/httpcomponents-client-4.3.5.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.pom",
+      "sha256": "eb7bf61f1215585e1d625781a803d9e7fe4ac21466b150674873ffa4819809c7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.8/maven-artifact-2.0.8.pom"
+    },
+    "net.sourceforge.pmd:pmd-java:pom:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-java/6.23.0/pmd-java-6.23.0.pom",
+      "sha256": "b7a62fc5de52e1ae769db808112df523a9f2fc809a7ec7697fd4086393378f1c",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-java/6.23.0/pmd-java-6.23.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.15/plexus-utils-3.0.15.jar",
+      "sha256": "d0be76c5ce910134a7e07fd2aa48d9b677800ab0e95873f314b445c6f177c973",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.15/plexus-utils-3.0.15.jar"
+    },
+    "org.apache.maven:maven-model:pom:3.0.4": {
+      "layout": "org/apache/maven/maven-model/3.0.4/maven-model-3.0.4.pom",
+      "sha256": "264be3f212d59f9103d3b997c9d0197ff89489d06b7d195d80ee56356b6c662e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0.4/maven-model-3.0.4.pom"
+    },
+    "org.beanshell:bsh:jar:2.0b4": {
+      "layout": "org/beanshell/bsh/2.0b4/bsh-2.0b4.jar",
+      "sha256": "91395c07885839a8c6986d5b7c577cd9bacf01bf129c89141f35e8ea858427b6",
+      "url": "https://repo.maven.apache.org/maven2/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar"
+    },
+    "joda-time:joda-time:jar:2.8.1": {
+      "layout": "joda-time/joda-time/2.8.1/joda-time-2.8.1.jar",
+      "sha256": "b4670b95f75957c974284c5f3ada966040be2578f643c5c6083d262162061fa2",
+      "url": "https://repo.maven.apache.org/maven2/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-databind:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-databind/2.3.1/jackson-databind-2.3.1.jar",
+      "sha256": "42560c44a7ef917040e3ee2e0b890756b88700e5cd046d16adbd01257c910afc",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.3.1/jackson-databind-2.3.1.jar"
+    },
+    "dom4j:dom4j:pom:1.1": {
+      "layout": "dom4j/dom4j/1.1/dom4j-1.1.pom",
+      "sha256": "03c18c93b1df85cbce3a21a17d9b27e399e27478c1421071f5348c58bd0ab61f",
+      "url": "https://repo.maven.apache.org/maven2/dom4j/dom4j/1.1/dom4j-1.1.pom"
+    },
+    "org.ow2.asm:asm:pom:6.1.1": {
+      "layout": "org/ow2/asm/asm/6.1.1/asm-6.1.1.pom",
+      "sha256": "3600b7c74d24512ee377eab08e01201fcf2179d540181824a5b591fa7b36770d",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.1.1/asm-6.1.1.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom",
+      "sha256": "7231047667b34a36cfed19d51ef38c9755e97e1acf11595a4b503c5ce7f0c595",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom"
+    },
+    "org.apache.maven:maven-model:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-model/2.2.0/maven-model-2.2.0.pom",
+      "sha256": "1fa532cbf3e6f8d6949dc612b6db60b28b7938eb2cf8ba7227c68fba69aa5325",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.0/maven-model-2.2.0.pom"
+    },
+    "com.google.guava:guava:jar:10.0.1": {
+      "layout": "com/google/guava/guava/10.0.1/guava-10.0.1.jar",
+      "sha256": "7d228a16b9cd0d78ac7cc1a45cd6b65c9423c32c5e26f99f9bd2577d37396baa",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/10.0.1/guava-10.0.1.jar"
+    },
+    "org.apache.maven:maven-model:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom",
+      "sha256": "62dd8e35a2c4432bb22f8250bbfe08639635599b4064d5d747bd24cf3c02fac5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom",
+      "sha256": "0123d59dd14fa00b8a50eb299bf59945dbd824b6deec43823e2612151ca38c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.2/maven-artifact-2.0.2.pom"
+    },
+    "com.amazonaws:aws-java-sdk-pom:pom:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-pom/1.11.893/aws-java-sdk-pom-1.11.893.pom",
+      "sha256": "84846ec570aa2e347a51c7b6d6081a7d679c5429a074b036c20f07e3622e17fc",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-pom/1.11.893/aws-java-sdk-pom-1.11.893.pom"
+    },
+    "net.bytebuddy:byte-buddy:jar:1.10.15": {
+      "layout": "net/bytebuddy/byte-buddy/1.10.15/byte-buddy-1.10.15.jar",
+      "sha256": "79be97529a296fca4a885c4652814a939ae37f1a86a6b13bd29d0725fa4e5711",
+      "url": "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.10.15/byte-buddy-1.10.15.jar"
+    },
+    "org.jboss.weld:weld-api-parent:pom:1.0": {
+      "layout": "org/jboss/weld/weld-api-parent/1.0/weld-api-parent-1.0.pom",
+      "sha256": "1fb0dbd26fba2b009a75355e87620256b0689cb46f124f4836bc66fc296942c1",
+      "url": "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-api-parent/1.0/weld-api-parent-1.0.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
+      "sha256": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.jar",
+      "sha256": "d1e247c4ed3952385fd704ac9db2a222247cfe7d20508b4f3c76b90f857952ed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.jar"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.0/maven-artifact-manager-2.2.0.jar",
+      "sha256": "69f1b54f7ed903524a4fdfa499184d0b468db089a61275127987fc8bd982948c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.0/maven-artifact-manager-2.2.0.jar"
+    },
+    "com.google.inject:guice-parent:pom:4.0": {
+      "layout": "com/google/inject/guice-parent/4.0/guice-parent-4.0.pom",
+      "sha256": "f65f11a7f2c06859d00b166f6ec57354c1be92599d6c1525674e5ff64f8feeab",
+      "url": "https://repo.maven.apache.org/maven2/com/google/inject/guice-parent/4.0/guice-parent-4.0.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.5.1": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.5.1/plexus-classworlds-2.5.1.pom",
+      "sha256": "bc1f058e3aa1596fd67a203b3359ea42cd88b8d7cd2e1008ebf46cec1f61a769",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.1/plexus-classworlds-2.5.1.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.5.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.pom",
+      "sha256": "89811897b815beefa094c39b4603e3f60c42276a2cd5d80b924ab19183629925",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.pom"
+    },
+    "org.apache.commons:commons-parent:pom:22": {
+      "layout": "org/apache/commons/commons-parent/22/commons-parent-22.pom",
+      "sha256": "fb8c5e55e30a7addb4ff210858a0e8d2494ed6757bbe19012da99d51586c3cbb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/22/commons-parent-22.pom"
+    },
+    "org.apache.commons:commons-parent:pom:25": {
+      "layout": "org/apache/commons/commons-parent/25/commons-parent-25.pom",
+      "sha256": "467ae650442e876867379094e7518dfdd67d22c5352ebd39808c84259e9790ba",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/25/commons-parent-25.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.19": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom",
+      "sha256": "d3e7f3adf5d002c01f362760ad1c2dce98e6354009a7c07c0a105c3eccb17159",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.18": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom",
+      "sha256": "ef5dbc7fa918b6dbba71d27e5b3d7a00df624bcfa2549a7297f36fe275f634d7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom"
+    },
+    "org.apache.commons:commons-parent:pom:24": {
+      "layout": "org/apache/commons/commons-parent/24/commons-parent-24.pom",
+      "sha256": "aa392820b5e956f57f8d8f5b0878fcb8920b3961ffba153cb69203e96a713ccd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/24/commons-parent-24.pom"
+    },
+    "org.apache.maven.plugins:maven-jxr-plugin:jar:3.0.0": {
+      "layout": "org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.jar",
+      "sha256": "c7cebcb2986e7db0ef210c6e61224fd7b2a4990c0a25b8e43b5aab47c58b8c99",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jxr-plugin/3.0.0/maven-jxr-plugin-3.0.0.jar"
+    },
+    "org.junit.platform:junit-platform-commons:jar:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1.jar",
+      "sha256": "457d8e1c0c80d1e320a792ec35e7c180694ba05182d7ecf7dabdb4e5a8a12fe2",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1.jar"
+    },
+    "org.apache.maven:maven-settings:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-settings/2.2.0/maven-settings-2.2.0.jar",
+      "sha256": "ee521e5d990da65ba2d4fc5ebd082323007c48d16dd67960dcbb84384bb3ac3f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.0/maven-settings-2.2.0.jar"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.12": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.12/plexus-components-1.1.12.pom",
+      "sha256": "a854365061c28821ddf1a520b8a197991613fd1d56f50f42c468b789b4714f20",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.12/plexus-components-1.1.12.pom"
+    },
+    "org.sonatype.sisu:sisu-guice:pom:2.1.7": {
+      "layout": "org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom",
+      "sha256": "2b3f02f2d0ec3e95884f9ab415596ce627492469c2d8fd75e3fb00fb69532c44",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.8/doxia-sink-api-1.8.pom",
+      "sha256": "5a02bec1c908687f9bb2c615299eb5ad129edab2a9d10c6a2218c57c8ad0bf14",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.8/doxia-sink-api-1.8.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.14": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom",
+      "sha256": "381d72c526be217b770f9f8c3f749a86d3b1548ac5c1fcb48d267530ec60d43f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.pom",
+      "sha256": "05f6a72ff10b12e0a7eafbe8d17e8da8c70942bfbc74227d8e200a307fef9a5b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.7/doxia-sink-api-1.7.pom"
+    },
+    "org.apache.maven:maven-settings:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.jar",
+      "sha256": "9a9f556713a404e770c9dbdaed7eb086078014c989291960c76fdde6db4192f7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-core:jar:2.11.3": {
+      "layout": "com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.jar",
+      "sha256": "78cd0a6b936232e06dd3e38da8a0345348a09cd1ff9c4d844c6ee72c75cfc402",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.11.3/jackson-core-2.11.3.jar"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.1": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.pom",
+      "sha256": "9d9f2299c52d9e5797647c3cbb0426b15cb266c4f847b88cb55ce05f2690e961",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.1/doxia-sink-api-1.1.pom"
+    },
+    "org.objenesis:objenesis:jar:3.1": {
+      "layout": "org/objenesis/objenesis/3.1/objenesis-3.1.jar",
+      "sha256": "cdb3d038c188de6f46ffd5cd930be2d5e5dba59c53b26437995d534e3db2fb80",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.1/objenesis-3.1.jar"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.jar",
+      "sha256": "03df90434ddf1851924dd9ba4d5f22aff7b134265fe9c7ecdb59d9b1dc3c1987",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.jar"
+    },
+    "org.osgi:org.osgi.core:jar:4.3.1": {
+      "layout": "org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1.jar",
+      "sha256": "10dad99322b2081015749e2d21538a4a9bc4cb3699d3b7b41ce452a544b09abe",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.pom",
+      "sha256": "50d699f86369802baf2cd16c31d936ad8f0c1a8976120cd1dc3dc70c8abed99a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.pom"
+    },
+    "xml-apis:xml-apis:pom:1.0.b2": {
+      "layout": "xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.pom",
+      "sha256": "7bc38e7a0f8ca20b0caed607e00cbb144dc8d006ebec4aa193f55dcf391bad50",
+      "url": "https://repo.maven.apache.org/maven2/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.pom"
+    },
+    "net.kemitix:kemitix-parent:pom:5.3.0": {
+      "layout": "net/kemitix/kemitix-parent/5.3.0/kemitix-parent-5.3.0.pom",
+      "sha256": "0038ef7b9d6530b2b5a2d5a71504d7e16834c5622e5a2498fd287dafb1cc3035",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/kemitix-parent/5.3.0/kemitix-parent-5.3.0.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-core:pom:4.4.6": {
+      "layout": "org/apache/httpcomponents/httpcomponents-core/4.4.6/httpcomponents-core-4.4.6.pom",
+      "sha256": "2a3cb532d0dd63f3f3f080307edd5ff84f4625253bf6b564eb72737753dd96be",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-core/4.4.6/httpcomponents-core-4.4.6.pom"
+    },
+    "org.sonatype.aether:aether-api:jar:1.13.1": {
+      "layout": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar",
+      "sha256": "ae8dc80232771f8913febfa410c5719e9ba8ded81fb99788e214fd676dbbe13f",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar"
+    },
+    "org.apache.felix:maven-bundle-plugin:pom:4.2.0": {
+      "layout": "org/apache/felix/maven-bundle-plugin/4.2.0/maven-bundle-plugin-4.2.0.pom",
+      "sha256": "759ff889a33d9c82ce6074a7c8fca390a5932e082d00cbea8dd4355d457aa93d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/4.2.0/maven-bundle-plugin-4.2.0.pom"
+    },
+    "org.apache.commons:commons-parent:pom:11": {
+      "layout": "org/apache/commons/commons-parent/11/commons-parent-11.pom",
+      "sha256": "b9e0306f393460105b8a3fa5105250c5291b1efaa99954ace0ec1c783109a02a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/11/commons-parent-11.pom"
+    },
+    "org.objenesis:objenesis-parent:pom:2.2": {
+      "layout": "org/objenesis/objenesis-parent/2.2/objenesis-parent-2.2.pom",
+      "sha256": "fe0a4d482cddaf2eeab57c834f2463e151788e3b762f67abd5faef73516bc932",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/2.2/objenesis-parent-2.2.pom"
+    },
+    "com.amazonaws:aws-java-sdk-core:pom:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-core/1.11.893/aws-java-sdk-core-1.11.893.pom",
+      "sha256": "59241f1076ebbafd36bd1eaab86d8f8988e076b76ffcaa362e55d19dd8043a51",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.893/aws-java-sdk-core-1.11.893.pom"
+    },
+    "org.apache.httpcomponents:httpcomponents-parent:pom:11": {
+      "layout": "org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom",
+      "sha256": "a901f87b115c55070c7ee43efff63e20e7b02d30af2443ae292bf1f4e532d3aa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.2": {
+      "layout": "org/apache/maven/maven/2.0.2/maven-2.0.2.pom",
+      "sha256": "1eb80693b5d9c6d8c0124766606cca4e8199f7a07724d09fdf4e9c000ee8c304",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.2/maven-2.0.2.pom"
+    },
+    "javax.ws.rs:jsr311-api:pom:1.1.1": {
+      "layout": "javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.pom",
+      "sha256": "737eb223b3b721ce9bb93a7ff24f919de1a766c38e63cfe5f2cafebe92c30099",
+      "url": "https://repo.maven.apache.org/maven2/javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom",
+      "sha256": "2896dbf57e8c82121481400e8be4df6110edd37e346a6c144b3156f24bf98f72",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.9": {
+      "layout": "org/apache/maven/maven/2.0.9/maven-2.0.9.pom",
+      "sha256": "6db25755b962d443bd7698b87654f336de43fd5319cbcc000e2e72c08c3619b4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.9/maven-2.0.9.pom"
+    },
+    "org.easymock:easymock:jar:2.4": {
+      "layout": "org/easymock/easymock/2.4/easymock-2.4.jar",
+      "sha256": "7c48d8ba6e070409f65a45afc4904824b7702598ab0bec273cdd0ce6f4c2c64f",
+      "url": "https://repo.maven.apache.org/maven2/org/easymock/easymock/2.4/easymock-2.4.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom",
+      "sha256": "35bc7d1213616236571072b2c56da18f7a57658de8b4a4100645b7054a2b273b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.8": {
+      "layout": "org/apache/maven/maven/2.0.8/maven-2.0.8.pom",
+      "sha256": "33f59eb5269d810f999ce018f974e23ce4e8a144daf72943bd50265b6b7f4f0d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.8/maven-2.0.8.pom"
+    },
+    "org.apache.commons:commons-parent:pom:17": {
+      "layout": "org/apache/commons/commons-parent/17/commons-parent-17.pom",
+      "sha256": "96e718baf534874ee62ce4d42de265f2ddacd88391a540e030d59d98fa7c4408",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/17/commons-parent-17.pom"
+    },
+    "org.apache.maven:maven:pom:2.0.6": {
+      "layout": "org/apache/maven/maven/2.0.6/maven-2.0.6.pom",
+      "sha256": "f5755c01058f048c61c3baf11e03c605b9c0ec1021ab40a3dcb76fb5bf51ff34",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.6/maven-2.0.6.pom"
+    },
+    "org.slf4j:slf4j-jdk14:jar:1.5.6": {
+      "layout": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.jar",
+      "sha256": "9b659d87e77ef601b0c564019b0d7fd1267c141f2d2dc55c9ba7613e63ca6786",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.jar"
+    },
+    "org.sonatype.nexus.maven:nexus-common:jar:1.6.6": {
+      "layout": "org/sonatype/nexus/maven/nexus-common/1.6.6/nexus-common-1.6.6.jar",
+      "sha256": "da11f7a50d9e7fbc4037c5b983f9389e3f2c19cac37aacadf8e0d97cdd8bc619",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/maven/nexus-common/1.6.6/nexus-common-1.6.6.jar"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.2": {
+      "layout": "org/apache/maven/maven-profile/2.0.2/maven-profile-2.0.2.pom",
+      "sha256": "0103ecc42af3252aa5b8873fa5c0ddb0565c9dc537187d1e68002e210a6d02a7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.2/maven-profile-2.0.2.pom"
+    },
+    "com.beust:jcommander:pom:1.72": {
+      "layout": "com/beust/jcommander/1.72/jcommander-1.72.pom",
+      "sha256": "c23f7e6b5b08bbf014bd16479e352ee040f4e9b73415f37e334df952797995eb",
+      "url": "https://repo.maven.apache.org/maven2/com/beust/jcommander/1.72/jcommander-1.72.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-profile/2.0.8/maven-profile-2.0.8.pom",
+      "sha256": "dfd16c9c5d30b8e0c5773cf17af5cee9aa6bf9d0ee8b9cba971676d83c84ab03",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.8/maven-profile-2.0.8.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom",
+      "sha256": "3be51b8a7e080ae0a765e870fa8c3acaab2a916ec24cbf0bb468d5d8abcbc104",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom",
+      "sha256": "09455abf6ab86671fab0ae5bba8293c17382c8a9c53fafc3befb3e0720f2b707",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom",
+      "sha256": "1ab7fdd1b82382690c081d3ea3f53bad2902e1d62a11a8096488711e7a5f607e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:jar:3.2.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/3.2.0/biz.aQute.bndlib-3.2.0.jar",
+      "sha256": "59c6c196fd71b277f86532892f91a989feaa166018ad9225db772cb43f440b4b",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/3.2.0/biz.aQute.bndlib-3.2.0.jar"
+    },
+    "org.apache.commons:commons-parent:pom:41": {
+      "layout": "org/apache/commons/commons-parent/41/commons-parent-41.pom",
+      "sha256": "b2877c8016f8b28924c8e90dd5ae40cd11f328d02a1de98d80de22574ab36ec7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/41/commons-parent-41.pom"
+    },
+    "org.apache.maven.plugins:maven-failsafe-plugin:jar:2.22.2": {
+      "layout": "org/apache/maven/plugins/maven-failsafe-plugin/2.22.2/maven-failsafe-plugin-2.22.2.jar",
+      "sha256": "7de02f9a21b80bead5639a3c0837c2aac9bd8cb9bb4b71afb4dd1dde23b267cc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-failsafe-plugin/2.22.2/maven-failsafe-plugin-2.22.2.jar"
+    },
+    "org.apache.maven.scm:maven-scm-provider-gitexe:jar:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-gitexe/1.3/maven-scm-provider-gitexe-1.3.jar",
+      "sha256": "96b6e4c8bb8332a6522d520445a6d26e66ab6947ded7135bebfe1924548fbb6b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/1.3/maven-scm-provider-gitexe-1.3.jar"
+    },
+    "net.sourceforge.pmd:pmd:pom:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd/6.23.0/pmd-6.23.0.pom",
+      "sha256": "f39e641241541614b2c99de725bf50c36230c7fe791c829252debf73e6d3d0ee",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/6.23.0/pmd-6.23.0.pom"
+    },
+    "org.apache.commons:commons-parent:pom:42": {
+      "layout": "org/apache/commons/commons-parent/42/commons-parent-42.pom",
+      "sha256": "cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/42/commons-parent-42.pom"
+    },
+    "org.apache.commons:commons-parent:pom:47": {
+      "layout": "org/apache/commons/commons-parent/47/commons-parent-47.pom",
+      "sha256": "8a8ecb570553bf9f1ffae211a8d4ca9ee630c17afe59293368fba7bd9b42fcb7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/47/commons-parent-47.pom"
+    },
+    "org.apache.commons:commons-parent:pom:48": {
+      "layout": "org/apache/commons/commons-parent/48/commons-parent-48.pom",
+      "sha256": "1e1f7de9370a7b7901f128f1dacd1422be74e3f47f9558b0f79e04c0637ca0b4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/48/commons-parent-48.pom"
+    },
+    "com.google.guava:guava:pom:18.0": {
+      "layout": "com/google/guava/guava/18.0/guava-18.0.pom",
+      "sha256": "e743d61d76f76b5dc060d6f7914fdd41c4418b3529062556920116a716719836",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/18.0/guava-18.0.pom"
+    },
+    "org.apache.struts:struts-core:jar:1.3.8": {
+      "layout": "org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.jar",
+      "sha256": "a7881710517dd6a50fa81c04d494e1493ad326bcc1adf2eb9493e5eb9ca9e077",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.jar"
+    },
+    "org.apache.httpcomponents:httpcore:pom:4.0.1": {
+      "layout": "org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.pom",
+      "sha256": "d1f666e38907c9471c64a3cdf87e0b1b0469d503e51cc14661860f7f6bd70c6e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-7/doxia-decoration-model-1.0-alpha-7.pom",
+      "sha256": "c1b6cffb8d63e166c736e931ef785f3da3a0d180fb434d0a67691dbe087fb3f7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-7/doxia-decoration-model-1.0-alpha-7.pom"
+    },
+    "org.apache.maven:maven-monitor:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-monitor/2.2.0/maven-monitor-2.2.0.jar",
+      "sha256": "45a36d3a347bb699e248d6fbb249268274e02ce866d92d1e1a9e4274e73c94d5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.0/maven-monitor-2.2.0.jar"
+    },
+    "org.apache.maven:maven-monitor:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.jar",
+      "sha256": "a5f0d9e3f9afaa0cdc982e4f4c82d96a8608fd67c26f64eacd0405d5ac0f97d2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:2.0.0": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.pom",
+      "sha256": "dcf193612b315713771e267b42de2d44de090be5945b2577345ed5ab8de2d271",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.pom"
+    },
+    "org.easymock:easymock-parent:pom:3.4": {
+      "layout": "org/easymock/easymock-parent/3.4/easymock-parent-3.4.pom",
+      "sha256": "c151988b3b67c4e0cca4fb9bb56f7952561f52bad765c4d97bf6b90c072de2bb",
+      "url": "https://repo.maven.apache.org/maven2/org/easymock/easymock-parent/3.4/easymock-parent-3.4.pom"
+    },
+    "org.fusesource.hawtbuf:hawtbuf-project:pom:1.9": {
+      "layout": "org/fusesource/hawtbuf/hawtbuf-project/1.9/hawtbuf-project-1.9.pom",
+      "sha256": "f0160ac76f39d37a693c3ec642a60eeeacc87002d5cf29cf2b6ef3337b514cfa",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/hawtbuf/hawtbuf-project/1.9/hawtbuf-project-1.9.pom"
+    },
+    "org.apache.commons:commons-parent:pom:32": {
+      "layout": "org/apache/commons/commons-parent/32/commons-parent-32.pom",
+      "sha256": "e4d258af8b2ff4032148d415379def7870789a6003e80576f1504b10f26b4be8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/32/commons-parent-32.pom"
+    },
+    "org.apache.maven:maven:pom:3.0": {
+      "layout": "org/apache/maven/maven/3.0/maven-3.0.pom",
+      "sha256": "28fc63720c4a5ff92bf0e358ed55a6f24626f35bccc13cc3e194231e158848f6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom"
+    },
+    "org.apache.commons:commons-parent:pom:37": {
+      "layout": "org/apache/commons/commons-parent/37/commons-parent-37.pom",
+      "sha256": "ee705a4dd68d8dcd9cc8d1249d5790861eb145ce7b0c6d6c0555ba94489d014b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/37/commons-parent-37.pom"
+    },
+    "org.apache.commons:commons-parent:pom:34": {
+      "layout": "org/apache/commons/commons-parent/34/commons-parent-34.pom",
+      "sha256": "3a2e69d06d641d1f3b293126dc9e2e4ea6563bf8c36c87e0ab6fa4292d04b79c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/34/commons-parent-34.pom"
+    },
+    "org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.5.2": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.jar",
+      "sha256": "5ec6466844f7fc5740ebe36cb4c57cc102a2d27bf363102df84b5ca7bbc6d69f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.jar"
+    },
+    "org.eclipse.aether:aether-api:jar:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+      "sha256": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
+    },
+    "org.apache.commons:commons-parent:pom:39": {
+      "layout": "org/apache/commons/commons-parent/39/commons-parent-39.pom",
+      "sha256": "87cd27e1a02a5c3eb6d85059ce98696bb1b44c2b8b650f0567c86df60fa61da7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/39/commons-parent-39.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
+      "sha256": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar",
+      "sha256": "59c637b910c0de53d28aeeb6444ee5fe1a8fa8f3da32dbbc4485250c166d3fee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar"
+    },
+    "org.apache:apache:pom:16": {
+      "layout": "org/apache/apache/16/apache-16.pom",
+      "sha256": "9f85ff2fd7d6cb3097aa47fb419ee7f0ebe869109f98aba9f4eca3f49e74a40e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/16/apache-16.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar",
+      "sha256": "2cc0e74f4f8fe9f9733cd207101809273026464c64d3f1fb2af06b9d2a3c323e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar"
+    },
+    "org.apache:apache:pom:15": {
+      "layout": "org/apache/apache/15/apache-15.pom",
+      "sha256": "36c2f2f979ac67b450c0cb480e4e9baf6b40f3a681f22ba9692287d1139ad494",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/15/apache-15.pom"
+    },
+    "commons-collections:commons-collections:pom:2.0": {
+      "layout": "commons-collections/commons-collections/2.0/commons-collections-2.0.pom",
+      "sha256": "dafa5cd143542dca7ec092ef4c670a3fd285dfc02b00e790cbe25687bef513cc",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/2.0/commons-collections-2.0.pom"
+    },
+    "org.jboss.weld:weld-api-bom:pom:1.0": {
+      "layout": "org/jboss/weld/weld-api-bom/1.0/weld-api-bom-1.0.pom",
+      "sha256": "8f74dc3a67c107376168b9f7b1b94e317e172768d398f826330931a02ff57b98",
+      "url": "https://repo.maven.apache.org/maven2/org/jboss/weld/weld-api-bom/1.0/weld-api-bom-1.0.pom"
+    },
+    "org.apache.maven:maven-artifact-manager:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar",
+      "sha256": "d913865e03e719ac5733260019e98090a12b50683134e65f78c36e8d67f11ff1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar"
+    },
+    "org.apache:apache:pom:14": {
+      "layout": "org/apache/apache/14/apache-14.pom",
+      "sha256": "4c3acb6a5f8467babe3e9e4486e35224e20eff822f4bedb520f3319a96dc9579",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/14/apache-14.pom"
+    },
+    "commons-collections:commons-collections:pom:2.1": {
+      "layout": "commons-collections/commons-collections/2.1/commons-collections-2.1.pom",
+      "sha256": "f8a93d50bfaf6fc0720eee8fde6e8fde20da33238ba296e9b1b7cba50ca6d772",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/2.1/commons-collections-2.1.pom"
+    },
+    "org.apache:apache:pom:13": {
+      "layout": "org/apache/apache/13/apache-13.pom",
+      "sha256": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom"
+    },
+    "org.apache:apache:pom:19": {
+      "layout": "org/apache/apache/19/apache-19.pom",
+      "sha256": "91f7a33096ea69bac2cbaf6d01feb934cac002c48d8c8cfa9c240b40f1ec21df",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/19/apache-19.pom"
+    },
+    "org.apache:apache:pom:18": {
+      "layout": "org/apache/apache/18/apache-18.pom",
+      "sha256": "7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom"
+    },
+    "org.apache:apache:pom:17": {
+      "layout": "org/apache/apache/17/apache-17.pom",
+      "sha256": "398044b74b5a719326be218ae08124e5e2f3318ab5d78fe199d504efc2e0d43f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/17/apache-17.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.2": {
+      "layout": "org/codehaus/plexus/plexus-components/1.2/plexus-components-1.2.pom",
+      "sha256": "e4c6c2df74c9225687c7d913e2d0a7ec3e852477ed2740383f8161e6a691c7fd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.2/plexus-components-1.2.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.3": {
+      "layout": "org/codehaus/plexus/plexus-components/1.3/plexus-components-1.3.pom",
+      "sha256": "ca34c8d86394449ce46017d360954b270443ddaa7e62568db0cfce872315c830",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3/plexus-components-1.3.pom"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:pom:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom",
+      "sha256": "42aada809ec125bbfe4d38f9d196bbeb59f298b389df96e610269e369b8eb2c9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom"
+    },
+    "org.apache.maven.scm:maven-scm-provider-git-commons:jar:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-git-commons/1.3/maven-scm-provider-git-commons-1.3.jar",
+      "sha256": "b39be3637156e717517efb0d170939f9e899ef9d07f42ff1271ee429621d46cd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-git-commons/1.3/maven-scm-provider-git-commons-1.3.jar"
+    },
+    "org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0": {
+      "layout": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0-no_aop.jar",
+      "sha256": "4b76079f35407e5682aac1ecbe67afd5f430ae619044a9d6a413666a45750c25",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0-no_aop.jar"
+    },
+    "org.apache:apache:pom:11": {
+      "layout": "org/apache/apache/11/apache-11.pom",
+      "sha256": "9a4fb5addb41d8116b6441e9e3c48764d9cc562243d5608652bea6db0509297b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom"
+    },
+    "org.apache.maven.doxia:doxia-skin-model:jar:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.jar",
+      "sha256": "2c90594e2b3eb9e034522b9a28ac2dce35e4b224ea4aa1d448179caa746c05a5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.jar"
+    },
+    "org.apache:apache:pom:10": {
+      "layout": "org/apache/apache/10/apache-10.pom",
+      "sha256": "802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom"
+    },
+    "org.apache.maven.doxia:doxia-skin-model:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.jar",
+      "sha256": "dd4f862c1d5219f7b645fed79e7d4ef2aaa53b38b6f6ee8ac4ad8277a6faa28c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.jar"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:3.1.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar",
+      "sha256": "88e5334c4c29a6e81c74a1d814c54a9a3b1e4fc6560a95da196fe16928095471",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.jar"
+    },
+    "org.apache.maven.shared:maven-filtering:jar:3.1.1": {
+      "layout": "org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar",
+      "sha256": "c18508178f300201c4cb5fd771ebb0449ad596da18ba2881037d4f74f202505f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar"
+    },
+    "xalan:xalan:jar:2.7.0": {
+      "layout": "xalan/xalan/2.7.0/xalan-2.7.0.jar",
+      "sha256": "bf1f065efd6e3d5cb964db4130815752015873338999d23dcafc2dbc89fc7d9b",
+      "url": "https://repo.maven.apache.org/maven2/xalan/xalan/2.7.0/xalan-2.7.0.jar"
+    },
+    "org.codehaus.plexus:plexus-resources:pom:1.0.1": {
+      "layout": "org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.pom",
+      "sha256": "1ad48f9a6cbc82bfd2ae188f67df67c5829ba295a1592cf554eb6ad40a1b34cd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.pom"
+    },
+    "net.kemitix.tiles:digraph:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/digraph/2.7.0/digraph-2.7.0.pom",
+      "sha256": "84888f8045eb2b5d7f8f5366096d51ddcddee7230aee336f0c24a4e80b514b66",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/digraph/2.7.0/digraph-2.7.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:33": {
+      "layout": "org/apache/maven/maven-parent/33/maven-parent-33.pom",
+      "sha256": "3856e3fcd169502d5f12fe2452604ebf6c7c025f15656bfa558ea99ed29d73ea",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom"
+    },
+    "org.apache.maven:maven-parent:pom:34": {
+      "layout": "org/apache/maven/maven-parent/34/maven-parent-34.pom",
+      "sha256": "1a8faf7a6a2b848acb26a959954ee115c0d79dbe75a6206fb3b8c7c2f45a237f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom"
+    },
+    "org.apache.maven:maven-parent:pom:31": {
+      "layout": "org/apache/maven/maven-parent/31/maven-parent-31.pom",
+      "sha256": "42fde763a6e6fe8480b1608adff2c35d02612e279ec9ce72fabb4fd8fb5c5753",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/31/maven-parent-31.pom"
+    },
+    "org.apache.maven:maven-parent:pom:30": {
+      "layout": "org/apache/maven/maven-parent/30/maven-parent-30.pom",
+      "sha256": "70709ad646f5aa57bb44e2a8b4f3de4993b108202ba095bd164e41cdc3181e70",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom"
+    },
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:pom:2.11.3": {
+      "layout": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.11.3/jackson-dataformat-cbor-2.11.3.pom",
+      "sha256": "a8b39f8c87f76ef223b898038b9ca58a4cd3567f4bf5921d8480cff8538cbd6d",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.11.3/jackson-dataformat-cbor-2.11.3.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-httpclient:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.9.1-02/nexus-buildsupport-httpclient-2.9.1-02.pom",
+      "sha256": "236493290a0160468a8cd5a0c04ad53f27c44cd23a158bbe9d5c0328689e6863",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-httpclient/2.9.1-02/nexus-buildsupport-httpclient-2.9.1-02.pom"
+    },
+    "org.apache:apache:pom:23": {
+      "layout": "org/apache/apache/23/apache-23.pom",
+      "sha256": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom"
+    },
+    "org.apache:apache:pom:21": {
+      "layout": "org/apache/apache/21/apache-21.pom",
+      "sha256": "af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.0-alpha-7/doxia-core-1.0-alpha-7.pom",
+      "sha256": "dbbc71789029ae65237565e5142f899bd6fa2250bf7cdfb667f548d52cd12f24",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.0-alpha-7/doxia-core-1.0-alpha-7.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom",
+      "sha256": "d2e14a5c6bed6ac4fc27d57f6ba227bb64a96742f71ee3fbafd2c019fa9d4449",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom"
+    },
+    "org.apache.maven.scm:maven-scm-managers:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-managers/1.9.1/maven-scm-managers-1.9.1.pom",
+      "sha256": "1bb56a80eb1aa1107dd35bfc2787eb1b5fd9ee5aa265754befdce2f45213c27f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-managers/1.9.1/maven-scm-managers-1.9.1.pom"
+    },
+    "velocity:velocity:jar:1.4": {
+      "layout": "velocity/velocity/1.4/velocity-1.4.jar",
+      "sha256": "ff9ea1a3ad582e58a40a7bf744661101aa1c1dcb9f4de6a64722ff5d09380853",
+      "url": "https://repo.maven.apache.org/maven2/velocity/velocity/1.4/velocity-1.4.jar"
+    },
+    "org.apache.httpcomponents:httpcomponents-client:pom:4.5.13": {
+      "layout": "org/apache/httpcomponents/httpcomponents-client/4.5.13/httpcomponents-client-4.5.13.pom",
+      "sha256": "9cba594c08db7271d0c20e9845d622bb39e69583910b45e7d5df82f6058d4dd9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-client/4.5.13/httpcomponents-client-4.5.13.pom"
+    },
+    "net.kemitix.tiles:compiler-jdk-8:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/compiler-jdk-8/2.7.0/compiler-jdk-8-2.7.0.pom",
+      "sha256": "6acca902b81545443a0208132d93af80d1071fe29386dfbf958dd58c6464edc6",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/compiler-jdk-8/2.7.0/compiler-jdk-8-2.7.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:22": {
+      "layout": "org/apache/maven/maven-parent/22/maven-parent-22.pom",
+      "sha256": "165a409718070698b4eb18fdfee4325bc3361cbb8e96a35f4669982cd2adb79a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom"
+    },
+    "org.apache.maven:maven-parent:pom:21": {
+      "layout": "org/apache/maven/maven-parent/21/maven-parent-21.pom",
+      "sha256": "fc45af8911ea307d1b57564eef1f78b69801e9c11a5619e7eb58d5d00ae9db8e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom"
+    },
+    "org.apache.maven:maven-parent:pom:24": {
+      "layout": "org/apache/maven/maven-parent/24/maven-parent-24.pom",
+      "sha256": "c7484a8a375ad6e3d14781c3675ff496d568b8c95e11b6a3784f6ef21419cdbf",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/24/maven-parent-24.pom"
+    },
+    "org.apache.maven:maven-parent:pom:23": {
+      "layout": "org/apache/maven/maven-parent/23/maven-parent-23.pom",
+      "sha256": "5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom"
+    },
+    "org.sonatype.aether:aether-impl:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar",
+      "sha256": "288149850d8d131763df4151f7e443fd2739e48510a6e4cfe49ca082c76130fa",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar"
+    },
+    "org.apache.maven:maven-profile:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-profile/2.2.0/maven-profile-2.2.0.pom",
+      "sha256": "0e495e6001f0f4dd0af968c23fc1fb4509d4f975b98f475a95dba48559520e3c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.0/maven-profile-2.2.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:20": {
+      "layout": "org/apache/maven/maven-parent/20/maven-parent-20.pom",
+      "sha256": "fc360ff4b09dafd2683faf1370864c35799802a00398e197be825f406fbf88e6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/20/maven-parent-20.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-fml:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.pom",
+      "sha256": "ffe8434fc1f1de3c6871711d97cb8a57e73ef13bce07ff9e23118548d8981a9b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-fml/1.7/doxia-module-fml-1.7.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom",
+      "sha256": "d125b3ade9f694ae60ef835f5ae000b6ba35fba8c34bafd8b40a1961375e63fa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.4": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.pom",
+      "sha256": "c0439c2b2d850488686143e2529f521b38f2abded6ac212add8f0c637eb912e9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:3.0": {
+      "layout": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom",
+      "sha256": "c56a0dbd90cea691f83e58fa9a6388fb3ac6bc3c14b8c04d2e112544651fa528",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom",
+      "sha256": "36623a9539061d87f078af61ca62c3eacf422eb374641cf8903cdeb759671eb3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom"
+    },
+    "org.apache.maven:maven-compat:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar",
+      "sha256": "2653f603b4aa7b521d8ad850c88a34dafd64aa79d7650399daa719de71cd1329",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar"
+    },
+    "org.apache.maven:maven-parent:pom:26": {
+      "layout": "org/apache/maven/maven-parent/26/maven-parent-26.pom",
+      "sha256": "ca10303316712e963b50f5a9c44eeacc7cf5e05b32b70336ba07440d2b0ce2d7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/26/maven-parent-26.pom"
+    },
+    "org.junit.platform:junit-platform-engine:pom:1.7.0": {
+      "layout": "org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.pom",
+      "sha256": "225b99c5032fd1cb8cecda2e8b5a7526d6a5f81fb98a29a57557f7f5ccda9d12",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:25": {
+      "layout": "org/apache/maven/maven-parent/25/maven-parent-25.pom",
+      "sha256": "3e66146707bc76e9d5b6cd8c98cf77d931c0894e7955a8e7f104f6790769abf1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/25/maven-parent-25.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-fml:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-fml/1.0/doxia-module-fml-1.0.pom",
+      "sha256": "63eb01028f78b813c965845932124e470be75f82fc73630eb252978c5df37ba6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-fml/1.0/doxia-module-fml-1.0.pom"
+    },
+    "org.apache.maven:maven-parent:pom:27": {
+      "layout": "org/apache/maven/maven-parent/27/maven-parent-27.pom",
+      "sha256": "56987ec424c449a9dc4dd427458ea1cb09b38e67ef4c219378a268a5e0d1b8a0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/27/maven-parent-27.pom"
+    },
+    "net.kemitix:mon:pom:2.2.0": {
+      "layout": "net/kemitix/mon/2.2.0/mon-2.2.0.pom",
+      "sha256": "dc0fc34507e67a8bfa57cad95625efca88b47a890ab36e3b7e713de1cd05e61d",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/mon/2.2.0/mon-2.2.0.pom"
+    },
+    "org.apache.maven.surefire:surefire:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire/2.22.2/surefire-2.22.2.pom",
+      "sha256": "aaf9e1b9c96399e67eb9961edb314e2027398f5ae9100f7a44bc1e9659bc8379",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.22.2/surefire-2.22.2.pom"
+    },
+    "com.sun.jersey:jersey-project:pom:1.17.1": {
+      "layout": "com/sun/jersey/jersey-project/1.17.1/jersey-project-1.17.1.pom",
+      "sha256": "a3d9324b02a7433907e9b2cf0fa4542307857eaeab393ebb694f0e65fdf13ea5",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-project/1.17.1/jersey-project-1.17.1.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-metrics:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.9.1-02/nexus-buildsupport-metrics-2.9.1-02.pom",
+      "sha256": "c466d6ce2e3574275eff50a5dcddc4b50a32557fba6d1630d92352909bf33870",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-metrics/2.9.1-02/nexus-buildsupport-metrics-2.9.1-02.pom"
+    },
+    "org.jdom:jdom:jar:1.1": {
+      "layout": "org/jdom/jdom/1.1/jdom-1.1.jar",
+      "sha256": "3c167654499436ee9c19674b519d04e7364085533f6facada1bf90b16ad34897",
+      "url": "https://repo.maven.apache.org/maven2/org/jdom/jdom/1.1/jdom-1.1.jar"
+    },
+    "org.slf4j:slf4j-api:jar:1.5.6": {
+      "layout": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.jar",
+      "sha256": "b96864a2ad8c005d62351a500d72d2545b3bcb3e30564a64b0c467c935de8303",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.jar"
+    },
+    "org.fusesource:fusesource-pom:pom:1.9": {
+      "layout": "org/fusesource/fusesource-pom/1.9/fusesource-pom-1.9.pom",
+      "sha256": "69022c7dd091ebb2b27f6b74709b19435e4c2e86cb6b5e698ce8f37258c60363",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/fusesource-pom/1.9/fusesource-pom-1.9.pom"
+    },
+    "org.antlr:antlr4-master:pom:4.7": {
+      "layout": "org/antlr/antlr4-master/4.7/antlr4-master-4.7.pom",
+      "sha256": "e9eb2598366effa8aec751286e06fdd8eb8f89b2baffef48365e503c2d8a3a99",
+      "url": "https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.7/antlr4-master-4.7.pom"
+    },
+    "org.apache.geronimo.genesis:genesis:pom:2.0": {
+      "layout": "org/apache/geronimo/genesis/genesis/2.0/genesis-2.0.pom",
+      "sha256": "b9ed2f9dd434631158d77308ee5648622c229ccece1722c5e377a4296923dae6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis/2.0/genesis-2.0.pom"
+    },
+    "org.apache.maven:maven-archiver:jar:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar",
+      "sha256": "9fd34ed18dc5a49011380e620be86314f9f734193b8fcf85fb11e7b3a3929d6e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar"
+    },
+    "org.apache.maven:maven-archiver:jar:2.6": {
+      "layout": "org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.jar",
+      "sha256": "2a89e25e7f659702ea0c7237cfe14e8bcd29ec1118d2bf1ae148ef8b292ca677",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.jar"
+    },
+    "org.apiguardian:apiguardian-api:jar:1.0.0": {
+      "layout": "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar",
+      "sha256": "1f58b77470d8d147a0538d515347dd322f49a83b9e884b8970051160464b65b3",
+      "url": "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar"
+    },
+    "org.apache.maven:maven-parent:pom:11": {
+      "layout": "org/apache/maven/maven-parent/11/maven-parent-11.pom",
+      "sha256": "7450c3330cf06c254db9f0dc5ef49eac15502311cf19e0208ba473076ee043d6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/11/maven-parent-11.pom"
+    },
+    "org.apache.maven:maven-parent:pom:10": {
+      "layout": "org/apache/maven/maven-parent/10/maven-parent-10.pom",
+      "sha256": "81fe14cb9779d36e0c610e1049e5b32a6b9974957f257921acf628b31c5486c8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/10/maven-parent-10.pom"
+    },
+    "com.thoughtworks.xstream:xstream-parent:pom:1.4.7": {
+      "layout": "com/thoughtworks/xstream/xstream-parent/1.4.7/xstream-parent-1.4.7.pom",
+      "sha256": "0f6140075720f87d0b86c4cbb83e27c1a400cb2d0dc44c274786e31ce6207f22",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream-parent/1.4.7/xstream-parent-1.4.7.pom"
+    },
+    "org.codehaus.plexus:plexus-io:jar:2.3.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.jar",
+      "sha256": "1400cf4a5c766d9be9721a03f647ce31c76080ed729b6296e2e5cfc163e5efa7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.jar"
+    },
+    "org.apache.maven:maven-artifact:jar:3.0": {
+      "layout": "org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar",
+      "sha256": "759079b9cf0cddae5ba06c96fd72347d82d0bc1d903c95d398c96522b139e470",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar"
+    },
+    "org.apache.httpcomponents:httpclient:jar:4.5.3": {
+      "layout": "org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar",
+      "sha256": "db3d1b6c2d6a5e5ad47577ad61854e2f0e0936199b8e05eb541ed52349263135",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar"
+    },
+    "org.apache.maven:maven-parent:pom:15": {
+      "layout": "org/apache/maven/maven-parent/15/maven-parent-15.pom",
+      "sha256": "e25770d5d46dcdfdbb9e38ca04f272c5bdf476d88392ab4044ba90678e616d54",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/15/maven-parent-15.pom"
+    },
+    "org.apache.maven:maven-parent:pom:16": {
+      "layout": "org/apache/maven/maven-parent/16/maven-parent-16.pom",
+      "sha256": "70cef83d246309a2aa355c38f2004edda3621ae0bc5c55a7a139eaeef4d1231a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/16/maven-parent-16.pom"
+    },
+    "org.apache.httpcomponents:project:pom:4.0": {
+      "layout": "org/apache/httpcomponents/project/4.0/project-4.0.pom",
+      "sha256": "a35e70c72865add3f9416194e02d6f9967dbf0c77d253933f80fbf46ad4d2169",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/project/4.0/project-4.0.pom"
+    },
+    "com.intellij:annotations:pom:9.0.4": {
+      "layout": "com/intellij/annotations/9.0.4/annotations-9.0.4.pom",
+      "sha256": "d61fa827bc837106acc0f10f263544262a09ea1249be419882a0af3a09612dad",
+      "url": "https://repo.maven.apache.org/maven2/com/intellij/annotations/9.0.4/annotations-9.0.4.pom"
+    },
+    "org.apache.httpcomponents:project:pom:4.1": {
+      "layout": "org/apache/httpcomponents/project/4.1/project-4.1.pom",
+      "sha256": "dcd740b63214f341a758b23f19940d0c5f6523077e2daa92c88512de5f012b05",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/project/4.1/project-4.1.pom"
+    },
+    "org.ow2.asm:asm:jar:6.2": {
+      "layout": "org/ow2/asm/asm/6.2/asm-6.2.jar",
+      "sha256": "917bda888bc543187325d5fbc1034207eed152574ef78df1734ca0aee40b7fc8",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.jar"
+    },
+    "org.mockito:mockito-junit-jupiter:pom:3.6.0": {
+      "layout": "org/mockito/mockito-junit-jupiter/3.6.0/mockito-junit-jupiter-3.6.0.pom",
+      "sha256": "e9cb31898f69d3bac16294cad67dc600692dd9102769b7a634cca56cacb72942",
+      "url": "https://repo.maven.apache.org/maven2/org/mockito/mockito-junit-jupiter/3.6.0/mockito-junit-jupiter-3.6.0.pom"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+      "sha256": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+      "sha256": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+    },
+    "org.hamcrest:hamcrest-core:pom:1.3": {
+      "layout": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom",
+      "sha256": "fde386a7905173a1b103de6ab820727584b50d0e32282e2797787c20a64ffa93",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:jar:4.2.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.jar",
+      "sha256": "65a76105ed55c53357dc80125d504f350c7abc4fd578ee352d62ae04ac7199f1",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.0/maven-plugin-registry-2.2.0.pom",
+      "sha256": "3575ae50e622b827c5188f7a19b653a86ae3554eb18340355860bef5918c258f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.0/maven-plugin-registry-2.2.0.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom",
+      "sha256": "3db15325cd620c0e54c3d88b6b7ec1bac43db376e18c9bf56bd0c05402ee6be8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom"
+    },
+    "com.sun.jersey.contribs:jersey-apache-client4:pom:1.17.1": {
+      "layout": "com/sun/jersey/contribs/jersey-apache-client4/1.17.1/jersey-apache-client4-1.17.1.pom",
+      "sha256": "f91026298d89334df66097729f204224354909195c210b5e61b936b5ab4f86ba",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/contribs/jersey-apache-client4/1.17.1/jersey-apache-client4-1.17.1.pom"
+    },
+    "org.apache:apache:pom:2": {
+      "layout": "org/apache/apache/2/apache-2.pom",
+      "sha256": "c0242e48994aad79edfa2e983959d840aa6ba0930317c64c2dff4c3134b5e0e1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/2/apache-2.pom"
+    },
+    "com.fasterxml:oss-parent:pom:12": {
+      "layout": "com/fasterxml/oss-parent/12/oss-parent-12.pom",
+      "sha256": "a67070d6da35edf7187aafa019cf51a011324df3962d0de8db23b7932f1181ee",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/12/oss-parent-12.pom"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:pom:2.1": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.pom",
+      "sha256": "71f09cac39ffb470144b3885a8aae65d35dc79f658d6c5e0b0900f87a79677c0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.pom"
+    },
+    "org.apache:apache:pom:3": {
+      "layout": "org/apache/apache/3/apache-3.pom",
+      "sha256": "393c50afb4b7aa6eb57e5377a55a1a0610b19f75b52ece01308db04a1187a20e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/3/apache-3.pom"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:pom:2.2": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.pom",
+      "sha256": "3fb4145aed54ac2a8139317627a26b75389c889c16aea26374790f4cd3525a4a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.pom"
+    },
+    "org.apache:apache:pom:4": {
+      "layout": "org/apache/apache/4/apache-4.pom",
+      "sha256": "9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom"
+    },
+    "org.apache:apache:pom:5": {
+      "layout": "org/apache/apache/5/apache-5.pom",
+      "sha256": "1933a6037439b389bda2feaccfc0113880fd8d88f7d240d2052b91108dd5ae89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/5/apache-5.pom"
+    },
+    "com.fasterxml:oss-parent:pom:11": {
+      "layout": "com/fasterxml/oss-parent/11/oss-parent-11.pom",
+      "sha256": "921764d5858a332a654bc0d54a188856a4ba83e6f2b0e823bfe46ac8cc573a6d",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/11/oss-parent-11.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:9": {
+      "layout": "org/apache/maven/shared/maven-shared-components/9/maven-shared-components-9.pom",
+      "sha256": "968f0769c245ab2e1e6c455efd77e1b990ea19e22156edf4ac7c56aa439f0d5e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/9/maven-shared-components-9.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:jar:2.10": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
+      "sha256": "930b2e409513be03864d7a66e22dfdf5c086725e22ba3cf57ad45ed8af02996d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar"
+    },
+    "org.mockito:mockito-junit-jupiter:jar:3.6.0": {
+      "layout": "org/mockito/mockito-junit-jupiter/3.6.0/mockito-junit-jupiter-3.6.0.jar",
+      "sha256": "9a9663f369b296e41459e1fd99ace7776275590f6b35c22bfc667449ce6766f2",
+      "url": "https://repo.maven.apache.org/maven2/org/mockito/mockito-junit-jupiter/3.6.0/mockito-junit-jupiter-3.6.0.jar"
+    },
+    "org.apache.maven.scm:maven-scm-provider-gitexe:jar:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-gitexe/1.9.1/maven-scm-provider-gitexe-1.9.1.jar",
+      "sha256": "e41759d97646c597ca6bacaebeae5ff32bc07b56c149605fd68f980fac316ba0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/1.9.1/maven-scm-provider-gitexe-1.9.1.jar"
+    },
+    "org.eclipse.aether:aether-util:jar:0.9.0.M2": {
+      "layout": "org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar",
+      "sha256": "7d62b0fdef90196ec4b2947f5973d750bfd3935785244e77cc06780131c404e9",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-util/0.9.0.M2/aether-util-0.9.0.M2.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-impl:pom:2.0.2": {
+      "layout": "org/apache/maven/reporting/maven-reporting-impl/2.0.2/maven-reporting-impl-2.0.2.pom",
+      "sha256": "d51567f4500c4b4b31b80ae4944df3b751c1a09865ff5264c6f26062f9063885",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/2.0.2/maven-reporting-impl-2.0.2.pom"
+    },
+    "javax.activation:javax.activation-api:jar:1.2.0": {
+      "layout": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar",
+      "sha256": "43fdef0b5b6ceb31b0424b208b930c74ab58fac2ceeb7b3f6fd3aeb8b5ca4393",
+      "url": "https://repo.maven.apache.org/maven2/javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:pom:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.pom",
+      "sha256": "85c3c8840bb21554faf159998146f7ca9ef1b951defb29ec4e8252ec463728fd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.pom"
+    },
+    "org.apache.httpcomponents:httpclient:pom:4.3.5": {
+      "layout": "org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.pom",
+      "sha256": "229fb915a60e6f8a688dfa6efb3de1d2b4124f76b43222681366abc1f1e7241a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.4": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar",
+      "sha256": "259d528a29722cab6349d7e7d432e3fd4877c087ffcb04985a6612e97023bba8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar"
+    },
+    "org.assertj:assertj-core:pom:3.18.0": {
+      "layout": "org/assertj/assertj-core/3.18.0/assertj-core-3.18.0.pom",
+      "sha256": "6cc60c3dcfc49b98b05e4538f633927d5cd0b9b4dca5294ff77cc761dc828957",
+      "url": "https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.18.0/assertj-core-3.18.0.pom"
+    },
+    "org.antlr:antlr4-runtime:jar:4.7": {
+      "layout": "org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.jar",
+      "sha256": "2a61943f803bbd1d0e02dffd19b92a418f83340c994346809e3b51e2231aa6c0",
+      "url": "https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.7/antlr4-runtime-4.7.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.1/plexus-utils-2.1.pom",
+      "sha256": "9f4ac6987113d09099bf43b846d2ec1d5e7a8091a6185f1f16d68e845f681243",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.1/plexus-utils-2.1.pom"
+    },
+    "org.sonatype.aether:aether-api:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar",
+      "sha256": "1c5c5ac5e8f29aefc8faa051ffa14eccd85b9e20f4bb35dc82fba7d5da50d326",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar"
+    },
+    "commons-collections:commons-collections:jar:2.0": {
+      "layout": "commons-collections/commons-collections/2.0/commons-collections-2.0.jar",
+      "sha256": "b5d8a9f671a4e6698d553d0ec98d33ba70358e9b2180c845c88fc7176ddfbb1e",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/2.0/commons-collections-2.0.jar"
+    },
+    "org.osgi:org.osgi.core:pom:4.1.0": {
+      "layout": "org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.pom",
+      "sha256": "9675906bddadebf6bc88b3c90b0bc80cc299a82942876ccfa67d909a75a903f5",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.1.0/org.osgi.core-4.1.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-apt:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-apt/1.0/doxia-module-apt-1.0.pom",
+      "sha256": "4e21576d0ca654101e048e54fc2dc5375ae9f4a433b5cee0a95110f6fbbcbb39",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-apt/1.0/doxia-module-apt-1.0.pom"
+    },
+    "net.kemitix.aws:kemitix-aws-java-sdk-s3-wrapper:pom:1.11.893": {
+      "layout": "net/kemitix/aws/kemitix-aws-java-sdk-s3-wrapper/1.11.893/kemitix-aws-java-sdk-s3-wrapper-1.11.893.pom",
+      "sha256": "f51ce6f46aa96343fe2b9413649875e66256f3283e43f6c88e53f5c75b341f9e",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/aws/kemitix-aws-java-sdk-s3-wrapper/1.11.893/kemitix-aws-java-sdk-s3-wrapper-1.11.893.pom"
+    },
+    "org.sonatype.sisu.siesta:siesta-jackson:jar:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-jackson/1.7/siesta-jackson-1.7.jar",
+      "sha256": "a7f5f50d25a6b996dabdcbda7c1e4b191c199556dc3a35e60c3ebed88616442b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-jackson/1.7/siesta-jackson-1.7.jar"
+    },
+    "org.apache.maven.scm:maven-scm-api:jar:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-api/1.3/maven-scm-api-1.3.jar",
+      "sha256": "9e6f4d54b48627010b9f0ff7a773cb0621fc74ddc5387e9db5d101eeefc97394",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-api/1.3/maven-scm-api-1.3.jar"
+    },
+    "org.ow2:ow2:pom:1.5": {
+      "layout": "org/ow2/ow2/1.5/ow2-1.5.pom",
+      "sha256": "0f8a1b116e760b8fe6389c51b84e4b07a70fc11082d4f936e453b583dd50b43b",
+      "url": "https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:jar:2.1": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.jar",
+      "sha256": "0203354f89bd242e76667e30bb71fbd93b01ebf70ad566aeff2fd55f8a32e0a3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/2.1/maven-dependency-tree-2.1.jar"
+    },
+    "org.apache.maven.shared:maven-dependency-tree:jar:2.2": {
+      "layout": "org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.jar",
+      "sha256": "1672dc69008e72e0785ebc7ba605bf854d20d56e8b6b62ce3c14b7b03cf377f1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-dependency-tree/2.2/maven-dependency-tree-2.2.jar"
+    },
+    "joda-time:joda-time:pom:2.8.1": {
+      "layout": "joda-time/joda-time/2.8.1/joda-time-2.8.1.pom",
+      "sha256": "18ba5cfdff96091e0019895361446079d91235ee566cb1d497639c1ace629d78",
+      "url": "https://repo.maven.apache.org/maven2/joda-time/joda-time/2.8.1/joda-time-2.8.1.pom"
+    },
+    "org.junit:junit-bom:pom:5.6.2": {
+      "layout": "org/junit/junit-bom/5.6.2/junit-bom-5.6.2.pom",
+      "sha256": "e8ad601b3181b23787a18e71d26ac86a49c56dc5f85606764bc3c51b5e45fe13",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.6.2/junit-bom-5.6.2.pom"
+    },
+    "org.apache.maven.resolver:maven-resolver-util:jar:1.4.1": {
+      "layout": "org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.jar",
+      "sha256": "6b2184872fa7cc2ef5a90481b56af9711c15b371e69ab52f0f31bf24e910dd82",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-util/1.4.1/maven-resolver-util-1.4.1.jar"
+    },
+    "net.kemitix.tiles:huntbugs:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/huntbugs/2.7.0/huntbugs-2.7.0.xml",
+      "sha256": "638b3aa98259d25196e06b61ccbf404917f0f52faa54e90d2ba64a57c4e8d04b",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/huntbugs/2.7.0/huntbugs-2.7.0.xml"
+    },
+    "org.apache.maven.scm:maven-scm-managers:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-managers/1.3/maven-scm-managers-1.3.pom",
+      "sha256": "601cb97c16c9c781a374dc06d8facc9d54024b918c67bcb5b3a037157e69f429",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-managers/1.3/maven-scm-managers-1.3.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-7": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-7/plexus-container-default-1.0-alpha-7.pom",
+      "sha256": "39b2035b94953ac38162d6b671be1aac22e383f2e38354cc011b1b1e9b104d23",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-7/plexus-container-default-1.0-alpha-7.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-8": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom",
+      "sha256": "b6617c2c7169b8d6c2440972e0d36e1265a80ed1d0def0263f1b400f4f3494a3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-8/plexus-container-default-1.0-alpha-8.pom"
+    },
+    "org.sonatype.nexus.plugins:nexus-restlet1x-model:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/plugins/nexus-restlet1x-model/2.9.1-02/nexus-restlet1x-model-2.9.1-02.pom",
+      "sha256": "0694b9a1174305e761bce7ac7794e7540e121d85ebbfc2f029ad61daa5ef6774",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/plugins/nexus-restlet1x-model/2.9.1-02/nexus-restlet1x-model-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom",
+      "sha256": "8864b08e353614d0c4111f455f8b3907179f8b0be6c0845bc7f31ef6daf206ec",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom"
+    },
+    "com.google.collections:google-collections:pom:1.0": {
+      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.pom",
+      "sha256": "893d56afcea1b22f83220fd7e49a6668c5b8901e39bd59dc57b42f55673721ce",
+      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom"
+    },
+    "org.apache.felix:maven-bundle-plugin:jar:4.2.0": {
+      "layout": "org/apache/felix/maven-bundle-plugin/4.2.0/maven-bundle-plugin-4.2.0.jar",
+      "sha256": "37b213c3858ea73df299f932a51b82b7552bd6cb9ffa8ed2cb5b22f418513e05",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/4.2.0/maven-bundle-plugin-4.2.0.jar"
+    },
+    "com.google.code.gson:gson-parent:pom:2.8.5": {
+      "layout": "com/google/code/gson/gson-parent/2.8.5/gson-parent-2.8.5.pom",
+      "sha256": "8f1fec72b91a71ea39ec39f5f778c4d1124b6b097c6d55b3a50b554a52237b27",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/gson/gson-parent/2.8.5/gson-parent-2.8.5.pom"
+    },
+    "org.apache.httpcomponents:httpclient:jar:4.3.5": {
+      "layout": "org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.jar",
+      "sha256": "b184521bce85de3f7f57a9d6afba133b323c8752857723031ec5468d4feef8c6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-core:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-core/2.3.1/jackson-core-2.3.1.jar",
+      "sha256": "c51123693c62d76771309f9b4ac49e6916da7d42872040334b0c272cc008ada4",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.3.1/jackson-core-2.3.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:pom:1.7.4": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.pom",
+      "sha256": "8e3bb25159776ab6e235a5200a721b7408567cb8a48cb618ba3fc7fead9679f3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.pom"
+    },
+    "net.bytebuddy:byte-buddy:pom:1.10.15": {
+      "layout": "net/bytebuddy/byte-buddy/1.10.15/byte-buddy-1.10.15.pom",
+      "sha256": "1cef6524cccce1b5a5fd6b884433cc455d2f20ea0e81340015fdfe58529c6d99",
+      "url": "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.10.15/byte-buddy-1.10.15.pom"
+    },
+    "velocity:velocity:pom:1.4": {
+      "layout": "velocity/velocity/1.4/velocity-1.4.pom",
+      "sha256": "ac4804914f9f061bbedce3a647d2892243e1501718bc5cd0e50f687b787f0f6b",
+      "url": "https://repo.maven.apache.org/maven2/velocity/velocity/1.4/velocity-1.4.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:2.0.0": {
+      "layout": "org/codehaus/plexus/plexus-containers/2.0.0/plexus-containers-2.0.0.pom",
+      "sha256": "be5e3f8e59edce852a0fdaef8caedb32f364bf13db654d15f98e17930e456487",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/2.0.0/plexus-containers-2.0.0.pom"
+    },
+    "info.picocli:picocli:pom:4.5.2": {
+      "layout": "info/picocli/picocli/4.5.2/picocli-4.5.2.pom",
+      "sha256": "2bfb96ae5a01400703a2f4a438eac20b04764ba53669e7bffeaa4026302c4ee2",
+      "url": "https://repo.maven.apache.org/maven2/info/picocli/picocli/4.5.2/picocli-4.5.2.pom"
+    },
+    "org.apache.httpcomponents:project:pom:7": {
+      "layout": "org/apache/httpcomponents/project/7/project-7.pom",
+      "sha256": "3d6eba428555a558de046b5d76eacc1f5a54b4f5f20b84d636ed7aff18aa48c3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/project/7/project-7.pom"
+    },
+    "org.apache.maven.scm:maven-scm:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm/1.3/maven-scm-1.3.pom",
+      "sha256": "08b9a7bf480ceb7210ff16912b3d9e7846828f771b31b98a5a7d55191ca2a205",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm/1.3/maven-scm-1.3.pom"
+    },
+    "org.apache.maven:maven-jxr:jar:3.0.0": {
+      "layout": "org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.jar",
+      "sha256": "f769d792cbe78fae9a12657e98f82fc1d60ef251c3d9a181a9d1b98b025714a3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-jxr/3.0.0/maven-jxr-3.0.0.jar"
+    },
+    "com.google.guava:guava:pom:10.0.1": {
+      "layout": "com/google/guava/guava/10.0.1/guava-10.0.1.pom",
+      "sha256": "66004371bf79dd1ee82716097e2d6a7245a95baf75f90cb80e0689412b26f921",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/10.0.1/guava-10.0.1.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar",
+      "sha256": "ba372ac9e52b481671bb3ea913063cd66747780de340d0c3b1f18c49ec998786",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar"
+    },
+    "org.hamcrest:hamcrest-parent:pom:1.3": {
+      "layout": "org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom",
+      "sha256": "6d535f94efb663bdb682c9f27a50335394688009642ba7a9677504bc1be4129b",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom"
+    },
+    "org.apache.maven:maven-builder-support:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.pom",
+      "sha256": "48ba80707e7a1c5576c8cc50c2608ae5b75dc29d07445f964f811fb0e9bf8691",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-impl:pom:3.0.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.pom",
+      "sha256": "b67e22d77fd823345b850f8544f87da5ffed4cb59ec4cdc538488149a0f692e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.pom"
+    },
+    "org.junit.platform:junit-platform-engine:jar:1.6.2": {
+      "layout": "org/junit/platform/junit-platform-engine/1.6.2/junit-platform-engine-1.6.2.jar",
+      "sha256": "23b41ac95e4673f7b31e8502424451be4154fe4db1d448448945e2215473c246",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.6.2/junit-platform-engine-1.6.2.jar"
+    },
+    "net.sourceforge.pmd:pmd-core:jar:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-core/6.23.0/pmd-core-6.23.0.jar",
+      "sha256": "c0767200e178afcf06bb2bb8c88d26ff93c116f46d0d79daa402aa97f90d9104",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-core/6.23.0/pmd-core-6.23.0.jar"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar",
+      "sha256": "1e5c98ebc4b9ae1f2c8d843c1dd9701a1c25b9afaff143c3e1fa4d90c22850fe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar",
+      "sha256": "bb7af11f28a37d21bf20e11705c78aa4adce3aaff1b9b981c031c6be1aa0ec97",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar"
+    },
+    "org.fusesource.mvnplugins:mvnplugins:pom:1.45": {
+      "layout": "org/fusesource/mvnplugins/mvnplugins/1.45/mvnplugins-1.45.pom",
+      "sha256": "4881265077cad8cdac1bf5af82f95cbec9425c7f3c91d0fc926d2121d3048188",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/mvnplugins/mvnplugins/1.45/mvnplugins-1.45.pom"
+    },
+    "commons-cli:commons-cli:jar:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.jar",
+      "sha256": "43f24850b7b7b7d79c5fa652418518fbdf427e602b1edabe6f11b85fb93eb013",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar"
+    },
+    "commons-cli:commons-cli:jar:1.2": {
+      "layout": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar",
+      "sha256": "e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar"
+    },
+    "org.apache.maven.shared:maven-shared-incremental:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom",
+      "sha256": "f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom"
+    },
+    "javax.ws.rs:jsr311-api:jar:1.1.1": {
+      "layout": "javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar",
+      "sha256": "ab1534b73b5fa055808e6598a5e73b599ccda28c3159c3c0908977809422ee4a",
+      "url": "https://repo.maven.apache.org/maven2/javax/ws/rs/jsr311-api/1.1.1/jsr311-api-1.1.1.jar"
+    },
+    "org.sonatype.nexus:nexus-client-core:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/nexus-client-core/2.9.1-02/nexus-client-core-2.9.1-02.pom",
+      "sha256": "f05abfb749afad9e9da5e17163bb7e0ce07f42c2e4d60ff5d634d83e60d729e2",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-client-core/2.9.1-02/nexus-client-core-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar",
+      "sha256": "4f60eb379f93d8b616bc3b4d299f466bc54fcced959f7ad082dae78b89d6a3f0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar"
+    },
+    "org.codehaus:codehaus-parent:pom:3": {
+      "layout": "org/codehaus/codehaus-parent/3/codehaus-parent-3.pom",
+      "sha256": "50eb253acd0b6ee048f432d9fc3a3b36264efb3da1ffa7fb07f6c4d4b7a8ca31",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/3/codehaus-parent-3.pom"
+    },
+    "net.kemitix.tiles:enforcer:xml:2.7.0": {
+      "layout": "net/kemitix/tiles/enforcer/2.7.0/enforcer-2.7.0.xml",
+      "sha256": "d5c9d1b0494b24c6a59f9dea4006a7a2140474f0956d37c69ed440f6a94b3b08",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/enforcer/2.7.0/enforcer-2.7.0.xml"
+    },
+    "org.apache.maven.surefire:maven-surefire-common:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.pom",
+      "sha256": "402347badce1d0ffeef7d1e9b70809273c9148e90f4d34ae082532f08ff3cac6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.22.2/maven-surefire-common-2.22.2.pom"
+    },
+    "org.apache.maven:maven:pom:3.0.4": {
+      "layout": "org/apache/maven/maven/3.0.4/maven-3.0.4.pom",
+      "sha256": "4d223e01a6569d6655c1f4fce84969d45142cdbabdb118ea08c5c8c33ec632f6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0.4/maven-3.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom",
+      "sha256": "0f0794dc7bdd60775d1b1e9bf70c55f2e4051bcd3d5e263a56c678080db3bbc1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom"
+    },
+    "org.apache.maven.doxia:doxia:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom",
+      "sha256": "172106a7ac51408883a074a1b847768e71c40fbbd969c8d645d2570026b811be",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom"
+    },
+    "org.apache.maven.shared:maven-artifact-transfer:jar:0.10.0": {
+      "layout": "org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar",
+      "sha256": "6f919f97c9272263fa910cfe7fa88595982a0451e7d7b121cca8ac85f6162882",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.10.0/maven-artifact-transfer-0.10.0.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:jar:3.1.0": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.jar",
+      "sha256": "82a584c58bd6a1b13861e2d4cc194b5afc09ca0adad9fda741f16337dcda2e96",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.1.0/maven-common-artifact-filters-3.1.0.jar"
+    },
+    "net.kemitix:kemitix-parent:pom:5.1.1": {
+      "layout": "net/kemitix/kemitix-parent/5.1.1/kemitix-parent-5.1.1.pom",
+      "sha256": "da481c0a43d4c0471536461682e9d68f105949a1c919e4168740c4b578748e7b",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/kemitix-parent/5.1.1/kemitix-parent-5.1.1.pom"
+    },
+    "org.apache.httpcomponents:httpclient:pom:4.5.3": {
+      "layout": "org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.pom",
+      "sha256": "cde5750309c07bbac140d0d981697243d3c58c2ee525c1319b9ba887d89f2c9c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.pom"
+    },
+    "net.kemitix:kemitix-parent:pom:5.1.0": {
+      "layout": "net/kemitix/kemitix-parent/5.1.0/kemitix-parent-5.1.0.pom",
+      "sha256": "ecd3200a0d76c647ef651dd9f556690273c692645a6f25573d59896c89f5a30e",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/kemitix-parent/5.1.0/kemitix-parent-5.1.0.pom"
+    },
+    "org.objenesis:objenesis:pom:3.1": {
+      "layout": "org/objenesis/objenesis/3.1/objenesis-3.1.pom",
+      "sha256": "d46072a46dff7707e06545777486b18d73e052231e3139cd3d9c3f347bc4e6e4",
+      "url": "https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.1/objenesis-3.1.pom"
+    },
+    "org.apache.maven.scm:maven-scm-manager-plexus:jar:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-manager-plexus/1.3/maven-scm-manager-plexus-1.3.jar",
+      "sha256": "e1c9b69cc64e6515211c66ddb8ef5102236bfcd96d2473791addb5d9a809aea5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-manager-plexus/1.3/maven-scm-manager-plexus-1.3.jar"
+    },
+    "org.apache.commons:commons-parent:pom:52": {
+      "layout": "org/apache/commons/commons-parent/52/commons-parent-52.pom",
+      "sha256": "75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/52/commons-parent-52.pom"
+    },
+    "org.codehaus.groovy:groovy-xml:jar:3.0.4": {
+      "layout": "org/codehaus/groovy/groovy-xml/3.0.4/groovy-xml-3.0.4.jar",
+      "sha256": "dd8151a1cb135e01b00204408dfdfa6384818756d81fdb141b7f4e70fb8b9c5a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.4/groovy-xml-3.0.4.jar"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:pom:1.0": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.pom",
+      "sha256": "0c64ed9aaf466bced1ef73654fd513528fad444dd147f3df2a2d895a72b6f1bd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.pom"
+    },
+    "org.apache.maven:maven:pom:2.2.0": {
+      "layout": "org/apache/maven/maven/2.2.0/maven-2.2.0.pom",
+      "sha256": "69fe8a241caa3bf5a73557e00fe410bdac3189d98461a98c9cf6ec57637ca4db",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.0/maven-2.2.0.pom"
+    },
+    "org.apache.maven:maven:pom:2.2.1": {
+      "layout": "org/apache/maven/maven/2.2.1/maven-2.2.1.pom",
+      "sha256": "d135cff96dcbbc8a5fab30180e557cae620373cf26941d4c738a88896a2d98ed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-manager:pom:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom",
+      "sha256": "4e9353e40fa16ba9384e8667490f0707267b30d75b77b6d588e4aaf8209936e9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom"
+    },
+    "org.codehaus.plexus:plexus-io:pom:3.2.0": {
+      "layout": "org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.pom",
+      "sha256": "726b07803e7aea9e03cc1da166b7c5d90d681b5b0c292f57a93cf5b07eaf7f80",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.2.0/plexus-io-3.2.0.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:34": {
+      "layout": "org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom",
+      "sha256": "83e11813318d17e4693f17f25935b3c1dd4d75025bed955ee80e7bba8c220441",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/34/maven-plugins-34.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:33": {
+      "layout": "org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom",
+      "sha256": "5db02c6f379712fa428b82f7742407bb712b98ad592c7779e2b66bd66ec8b1d2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom"
+    },
+    "org.apache.maven.shared:maven-filtering:pom:3.2.0": {
+      "layout": "org/apache/maven/shared/maven-filtering/3.2.0/maven-filtering-3.2.0.pom",
+      "sha256": "0ec91161657ca8ab6c41c3221b27ce7ccd7370e8e573b02cadcd3449c98890a7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.2.0/maven-filtering-3.2.0.pom"
+    },
+    "org.osgi:org.osgi.core:pom:4.3.1": {
+      "layout": "org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1.pom",
+      "sha256": "962ece2a5b9a5016534dcd5e59042d2e3ab5b3a8556952e70e2a7fc9cd431945",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.core/4.3.1/org.osgi.core-4.3.1.pom"
+    },
+    "org.codehaus.groovy:groovy-xml:jar:3.0.6": {
+      "layout": "org/codehaus/groovy/groovy-xml/3.0.6/groovy-xml-3.0.6.jar",
+      "sha256": "0abf5faae85ded150d9c122816b7cda7bcb642e8566230d6d3af68d79e6b1e2b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.6/groovy-xml-3.0.6.jar"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:31": {
+      "layout": "org/apache/maven/plugins/maven-plugins/31/maven-plugins-31.pom",
+      "sha256": "a9b41300fdeb4925fe92ef53fc15fad8db3b5bab65e40c2b2ef3c08a5d19cbfd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/31/maven-plugins-31.pom"
+    },
+    "org.sonatype.aether:aether-api:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom",
+      "sha256": "e855b04820e58822bda1ab448f7b29e2fccf363f1b2ca95c8c05f2d625b28928",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom"
+    },
+    "org.apache.maven.plugins:maven-compiler-plugin:jar:3.8.1": {
+      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.jar",
+      "sha256": "d14731947840eec6facef2c8f3ca050ae6dd2ff4d071700e1e62ccfd510856bd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.jar"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:3.2.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom",
+      "sha256": "ebfec96908fd4ff54d29df33e5b0d8ddd113272dc5c1c34402de8ea8a9f7bf66",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar",
+      "sha256": "e67fc0b78b5cbabe6748677ebec9844db5014ac397ab1537558bcd614b5c41e1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:3.2.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.pom",
+      "sha256": "06a9d67118fc1da7600de250b35449ca4b11de7f1d4c6ff0e1954359ed9bb700",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.0/maven-shared-utils-3.2.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-sitetools:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-sitetools/1.0/doxia-sitetools-1.0.pom",
+      "sha256": "f1c07cff218cb7f834ab5218671f996d188d07210bd425e1a31c6e57bb662399",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sitetools/1.0/doxia-sitetools-1.0.pom"
+    },
+    "com.fasterxml:oss-parent:pom:38": {
+      "layout": "com/fasterxml/oss-parent/38/oss-parent-38.pom",
+      "sha256": "c83f8f45dfdca8d0b6b3661c60b3f84780f671b12e06f91ad5d1c1a1d1f966e8",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/38/oss-parent-38.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom",
+      "sha256": "894261f5b21a2a18519537086181426450300385518e53d2555f5b4a6c1260e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.2": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom",
+      "sha256": "93d6675b2cf585c9c1148f1964156306c2573adfc1181c7219bd42a54a133771",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.2/plexus-utils-1.4.2.pom"
+    },
+    "commons-cli:commons-cli:pom:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.pom",
+      "sha256": "97ee40f4e80ca5ecc20162f4e97ee1adfeac1b45ba88b923d5a521e487c9c407",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom",
+      "sha256": "687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.2.0": {
+      "layout": "org/apache/maven/maven-core/2.2.0/maven-core-2.2.0.pom",
+      "sha256": "703a0c65822203c8725ae3ea519631bd54a969496702f949752790aa3d6bf5c8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.0/maven-core-2.2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.6": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom",
+      "sha256": "6c68126854b084eed9b25ebc7dd08e965a3b0e73d7538fc750b4a56e44e7b920",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.6/plexus-utils-1.4.6.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom",
+      "sha256": "5cc81603cab47bf20dbfd5e28e311da1fd26f2e3617b50547da5cd0b4f59edf3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom"
+    },
+    "commons-cli:commons-cli:pom:1.2": {
+      "layout": "commons-cli/commons-cli/1.2/commons-cli-1.2.pom",
+      "sha256": "18f3e92076e08c2fde48317025098e9f6baaa85f6912eb43f2d7e68d570e4561",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.pom"
+    },
+    "com.google.code.findbugs:jsr305:pom:1.3.9": {
+      "layout": "com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom",
+      "sha256": "feab9191311c3d7aeef2b66d6064afc80d3d1d52d980fb07ae43c78c987ba93a",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom"
+    },
+    "org.sonatype.sisu:sisu-inject:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom",
+      "sha256": "a5991ead85259ba9f8c985d194aace3b069e14bcd8cde68fce928223714d3968",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom"
+    },
+    "org.apache.maven:maven-settings:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.pom",
+      "sha256": "5c283013408f8589145bd9b566a9283b85b4b22759241f7bdab2cc30fcde576d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.pom"
+    },
+    "com.thoughtworks.qdox:qdox:pom:2.0-M7": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.pom",
+      "sha256": "9cadf9ea7765f8b581e6aeac6a30606b3c486dc242c77b41888abe0fb7cbbeca",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.pom"
+    },
+    "org.fusesource.mvnplugins:maven-graph-plugin:pom:1.45": {
+      "layout": "org/fusesource/mvnplugins/maven-graph-plugin/1.45/maven-graph-plugin-1.45.pom",
+      "sha256": "bb92521af06beffe9942b5d9da3bf9d41c594673616d773a93197bdc9d398f64",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/mvnplugins/maven-graph-plugin/1.45/maven-graph-plugin-1.45.pom"
+    },
+    "org.apache.maven:maven-monitor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar",
+      "sha256": "47289bc307849383d41eddbe3800f1945b2204ab319b0d38e391f6780c37b4e3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar"
+    },
+    "oro:oro:pom:2.0.7": {
+      "layout": "oro/oro/2.0.7/oro-2.0.7.pom",
+      "sha256": "f230a1141e0db8f150a253c4b29071ad3a0d4791adba1f2a58fd8416286960a5",
+      "url": "https://repo.maven.apache.org/maven2/oro/oro/2.0.7/oro-2.0.7.pom"
+    },
+    "oro:oro:pom:2.0.8": {
+      "layout": "oro/oro/2.0.8/oro-2.0.8.pom",
+      "sha256": "9aa9dfeb2e85e1d5e7932c87140697cecc2b0fadd933d679fd420a2e43831a82",
+      "url": "https://repo.maven.apache.org/maven2/oro/oro/2.0.8/oro-2.0.8.pom"
+    },
+    "org.apache.maven.scm:maven-scm:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm/1.9.1/maven-scm-1.9.1.pom",
+      "sha256": "76fc22881b0b34b6971f86cc23b561f1e1b621518bfdf5925ec65ada13468eb0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm/1.9.1/maven-scm-1.9.1.pom"
+    },
+    "commons-digester:commons-digester:jar:1.8": {
+      "layout": "commons-digester/commons-digester/1.8/commons-digester-1.8.jar",
+      "sha256": "05662373044f3dff112567b7bb5dfa1174e91e074c0c727b4412788013f49d56",
+      "url": "https://repo.maven.apache.org/maven2/commons-digester/commons-digester/1.8/commons-digester-1.8.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-shiro:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.9.1-02/nexus-buildsupport-shiro-2.9.1-02.pom",
+      "sha256": "e651cf4d1123bf436d05984f01810d16259f5db0de1bb9c819125ab6dcf60a3b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-shiro/2.9.1-02/nexus-buildsupport-shiro-2.9.1-02.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:22": {
+      "layout": "org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom",
+      "sha256": "34d303bbdd31d34f5a1570549b0e134b72afb18db53d8fcfdad222d51e941630",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom"
+    },
+    "org.apache.maven.doxia:doxia-sitetools:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-sitetools/1.8/doxia-sitetools-1.8.pom",
+      "sha256": "e6e016e530445f7dbf433d4514bdbb77b3951185031b5ed9afa54f81f5feaa1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sitetools/1.8/doxia-sitetools-1.8.pom"
+    },
+    "com.thoughtworks.qdox:qdox:pom:2.0-M9": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom",
+      "sha256": "8fb39a1e86ee1dca54680df79512ff2939eba17660f62e142b2b9df699b3b6a3",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom"
+    },
+    "org.apache.maven.doxia:doxia-sitetools:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-sitetools/1.7/doxia-sitetools-1.7.pom",
+      "sha256": "eb35d5346a08c58e4ac8537fab89359ffd35529dd554420929bf8aaba3a8e8ca",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sitetools/1.7/doxia-sitetools-1.7.pom"
+    },
+    "com.thoughtworks.qdox:qdox:pom:2.0-M8": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.pom",
+      "sha256": "43853966acfff3f0a34fed1d40e6ab89d17962daa4cc005c33fd1490a78bf8cf",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.pom"
+    },
+    "org.apache.maven.surefire:surefire-junit-platform:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-junit-platform/2.22.2/surefire-junit-platform-2.22.2.pom",
+      "sha256": "d8b651d8329231a9b8036cc2b5834f6523433df85b1093203acd9842cb756460",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/2.22.2/surefire-junit-platform-2.22.2.pom"
+    },
+    "org.opentest4j:opentest4j:jar:1.1.1": {
+      "layout": "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar",
+      "sha256": "f106351abd941110226745ed103c85863b3f04e9fa82ddea1084639ae0c5336c",
+      "url": "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar"
+    },
+    "com.sun.activation:all:pom:1.2.0": {
+      "layout": "com/sun/activation/all/1.2.0/all-1.2.0.pom",
+      "sha256": "1d8518e3ac7532a104e4f7be77def37c982e530723c6bdb3d67708cce2b0c2c4",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.0/all-1.2.0.pom"
+    },
+    "xmlunit:xmlunit:pom:1.5": {
+      "layout": "xmlunit/xmlunit/1.5/xmlunit-1.5.pom",
+      "sha256": "092e64f9d645761c83d9a11969f0233cb7ccf0fa7cf2804437595ec9ca113a1e",
+      "url": "https://repo.maven.apache.org/maven2/xmlunit/xmlunit/1.5/xmlunit-1.5.pom"
+    },
+    "org.apache.maven.plugins:maven-pmd-plugin:pom:3.13.0": {
+      "layout": "org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.pom",
+      "sha256": "0069b6eeafac8483775f3b945e31cc22860d6d5e0ecf6702319447fd938f8b35",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.pom"
+    },
+    "joda-time:joda-time:pom:2.2": {
+      "layout": "joda-time/joda-time/2.2/joda-time-2.2.pom",
+      "sha256": "7b45ef6680cc25e32fcbc7a1b11fc150686ad671091981f374ea3ae4e83e79b8",
+      "url": "https://repo.maven.apache.org/maven2/joda-time/joda-time/2.2/joda-time-2.2.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-bouncycastle:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.9.1-02/nexus-buildsupport-bouncycastle-2.9.1-02.pom",
+      "sha256": "eef5e6ae26dc3260a67c94e9b1d1e769b4fac35cc0d776f3db3100b43d30f003",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-bouncycastle/2.9.1-02/nexus-buildsupport-bouncycastle-2.9.1-02.pom"
+    },
+    "org.apache.commons:commons-lang3:jar:3.8.1": {
+      "layout": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+      "sha256": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    "javax.xml.bind:jaxb-api:pom:2.3.1": {
+      "layout": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.pom",
+      "sha256": "12b20cf922773445c3445c2883cbf671fa982111e9bf9f875020f9313b3814b1",
+      "url": "https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.4": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.4/plexus-components-1.1.4.pom",
+      "sha256": "3002aea8cc5ff29b0702e01b7fe853f6950d63722c1f1cb55be36fed801b7d67",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.4/plexus-components-1.1.4.pom"
+    },
+    "xml-apis:xml-apis:pom:2.0.2": {
+      "layout": "xml-apis/xml-apis/2.0.2/xml-apis-2.0.2.pom",
+      "sha256": "a902d962402c02f4c1a57c5a2303a608a8ac3aef5cd145e1980563447603d606",
+      "url": "https://repo.maven.apache.org/maven2/xml-apis/xml-apis/2.0.2/xml-apis-2.0.2.pom"
+    },
+    "org.junit.platform:junit-platform-commons:pom:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1.pom",
+      "sha256": "50c8567c1c1afb4204e8c96a54daecbb8c40b1054b9b9cbb2a8f30d8eb86449e",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.3.1/junit-platform-commons-1.3.1.pom"
+    },
+    "org.apache:apache:pom:6": {
+      "layout": "org/apache/apache/6/apache-6.pom",
+      "sha256": "12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom"
+    },
+    "org.apache.commons:commons-lang3:pom:3.5": {
+      "layout": "org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.pom",
+      "sha256": "45e7fbb2c231db903a5d5aadafc636a173a4d54560f78a11ff498028ef9e345e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.pom"
+    },
+    "org.apache:apache:pom:7": {
+      "layout": "org/apache/apache/7/apache-7.pom",
+      "sha256": "1397ce1db433adc9f223dbf07496d133681448751f4ae29e58f68e78fb4b6c25",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/7/apache-7.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:2.2.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.2.0/maven-reporting-api-2.2.0.jar",
+      "sha256": "c0302267b35041bb83e65a66815da40e1aea4320b3986e3719cb4078a1655606",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.2.0/maven-reporting-api-2.2.0.jar"
+    },
+    "org.apache.maven:maven-plugin-api:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.pom",
+      "sha256": "ab10d1fba9169558f2bc756faf6b350a92eaabc024545608ad7806621c75d3b9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.pom"
+    },
+    "org.apache:apache:pom:9": {
+      "layout": "org/apache/apache/9/apache-9.pom",
+      "sha256": "4946e60a547c8eda69f3bc23c5b6f0dadcf8469ea49b1d1da7de34aecfcf18dd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom"
+    },
+    "org.codehaus.plexus:plexus-resources:jar:1.0.1": {
+      "layout": "org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.jar",
+      "sha256": "04a6129486d318e0743b41a9536d6cc20d56f1ea320d58777c2f71b815502e35",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-resources/1.0.1/plexus-resources-1.0.1.jar"
+    },
+    "classworlds:classworlds:pom:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.pom",
+      "sha256": "25a1efc00bcd1f029fd20c44df843b8b12d1fa17485235470764f011d2f5cb29",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.pom"
+    },
+    "org.apache.commons:commons-lang3:pom:3.4": {
+      "layout": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.pom",
+      "sha256": "686e75b561a13c1031d43a7647a364e2ed3e456467050eac4527b94b06d73fd1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.pom"
+    },
+    "org.apache.httpcomponents:httpcore:jar:4.4.6": {
+      "layout": "org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar",
+      "sha256": "d7f853dee87680b07293d30855b39b9eb56c1297bd16ff1cd6f19ddb8fa745fb",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar"
+    },
+    "junit:junit:pom:3.8.1": {
+      "layout": "junit/junit/3.8.1/junit-3.8.1.pom",
+      "sha256": "e68f33343d832398f3c8aa78afcd808d56b7c1020de4d3ad8ce47909095ee904",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:3.1.0": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.pom",
+      "sha256": "68f9fdef85d2c89f53c63cbc559920e0115bd30eb6f7076c9854931d3829027b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.1.0/maven-shared-utils-3.1.0.pom"
+    },
+    "org.sonatype.forge:forge-parent:pom:10": {
+      "layout": "org/sonatype/forge/forge-parent/10/forge-parent-10.pom",
+      "sha256": "c14fb9c32b59cc03251f609416db7c0cff01f811edcccb4f6a865d6e7046bd0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/10/forge-parent-10.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:pom:3.5.0": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/3.5.0/biz.aQute.bndlib-3.5.0.pom",
+      "sha256": "545289489b39308151ed1e9f2d545ae133a5cc1a27d229faef65bbf98b48c201",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/3.5.0/biz.aQute.bndlib-3.5.0.pom"
+    },
+    "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.11.3": {
+      "layout": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.11.3/jackson-dataformat-cbor-2.11.3.jar",
+      "sha256": "057e0535c1132e73dc85a61cc3f7bf32460d8ab8ca49f917d306ee2f8d7c4c79",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.11.3/jackson-dataformat-cbor-2.11.3.jar"
+    },
+    "org.sonatype.aether:aether-impl:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom",
+      "sha256": "0cf0bc1966c54645ed9702538158cc4a363861905470991616f4dabd4030e851",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom"
+    },
+    "com.fasterxml.jackson.core:jackson-core:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-core/2.3.1/jackson-core-2.3.1.pom",
+      "sha256": "514703abf9831e6b7ca1f22eaabe2cffd5955d29426263553481d3701dbc1881",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.3.1/jackson-core-2.3.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:pom:1.7.4": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.7.4/doxia-site-renderer-1.7.4.pom",
+      "sha256": "a10e284048c67daae326d4b019b32d49e1dc366cb4593044fca64ad9b8f228f9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.7.4/doxia-site-renderer-1.7.4.pom"
+    },
+    "org.apache.felix:maven-bundle-plugin:jar:3.2.0": {
+      "layout": "org/apache/felix/maven-bundle-plugin/3.2.0/maven-bundle-plugin-3.2.0.jar",
+      "sha256": "83c23f6ebf13e27596fd5852608ce289ff8af0024fd275512e8df0ff62a0fb89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/3.2.0/maven-bundle-plugin-3.2.0.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-impl:jar:3.0.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.jar",
+      "sha256": "721ce27b1403dbbeaa6a0171d1183de603bb7ba56c61cccb381b0bc0ff00fe36",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/3.0.0/maven-reporting-impl-3.0.0.jar"
+    },
+    "org.apache.maven:maven-aether-provider:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.pom",
+      "sha256": "80002cef742269bdc30597fb556cb4a376437de1731650c9f5eb196994a171f2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.pom"
+    },
+    "com.fasterxml.jackson.core:jackson-databind:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-databind/2.3.1/jackson-databind-2.3.1.pom",
+      "sha256": "87d803a04aa9441b9e435532e6803b2751f3c42eb40349ae730df7fbdae8d9e5",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.3.1/jackson-databind-2.3.1.pom"
+    },
+    "org.fusesource.mvnplugins:maven-graph-plugin:jar:1.45": {
+      "layout": "org/fusesource/mvnplugins/maven-graph-plugin/1.45/maven-graph-plugin-1.45.jar",
+      "sha256": "2a419e7ce980e48c8e2d172b994fbd720fc6a2aee5960764bd40808ec8cee160",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/mvnplugins/maven-graph-plugin/1.45/maven-graph-plugin-1.45.jar"
+    },
+    "commons-collections:commons-collections:jar:3.2.1": {
+      "layout": "commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar",
+      "sha256": "87363a4c94eaabeefd8b930cb059f66b64c9f7d632862f23de3012da7660047b",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar"
+    },
+    "com.google.guava:guava-parent:pom:18.0": {
+      "layout": "com/google/guava/guava-parent/18.0/guava-parent-18.0.pom",
+      "sha256": "a4accc8895e757f6a33f087e4fd0b661c5638ffe5e0728f298efe7d80551b166",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/18.0/guava-parent-18.0.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.plexus:pom:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.pom",
+      "sha256": "215b1dd8b624097f9e4b519031011e8baf74dbb78444640d4a5e660a858c3e54",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.0.0.M2a/org.eclipse.sisu.plexus-0.0.0.M2a.pom"
+    },
+    "org.apache.maven:maven-model:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-model/2.2.0/maven-model-2.2.0.jar",
+      "sha256": "164c158f3e45d4ea2355482669c0adfddc24878e21671dfc6788622c6a71588d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.0/maven-model-2.2.0.jar"
+    },
+    "org.apache.maven.doxia:doxia-skin-model:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.pom",
+      "sha256": "2345559aa744589e8881f588aaacac3119c6ae06c1eaa65d75a54ff6f73b933a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/1.7/doxia-skin-model-1.7.pom"
+    },
+    "org.apache.maven:maven-model:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.jar",
+      "sha256": "153b32f474fd676ec36ad807c508885005139140fc92168bb76bf6be31f8efb8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-skin-model:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.pom",
+      "sha256": "046cc23603e802a4e84a0bec17857b713ce7ee965682007a00684d078082c13f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-skin-model/1.8/doxia-skin-model-1.8.pom"
+    },
+    "biz.aQute.bnd:biz.aQute.bndlib:pom:5.1.1": {
+      "layout": "biz/aQute/bnd/biz.aQute.bndlib/5.1.1/biz.aQute.bndlib-5.1.1.pom",
+      "sha256": "bd2353bf1bd950591c4b4692c664da55792da60f4a98416a694230c28b0dec93",
+      "url": "https://repo.maven.apache.org/maven2/biz/aQute/bnd/biz.aQute.bndlib/5.1.1/biz.aQute.bndlib-5.1.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.8/doxia-decoration-model-1.8.pom",
+      "sha256": "b8c50d2338559057f330e056258e0eb25466548a7948de2edf50012514ae9b2f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.8/doxia-decoration-model-1.8.pom"
+    },
+    "org.apache.maven:maven-model:jar:3.0.4": {
+      "layout": "org/apache/maven/maven-model/3.0.4/maven-model-3.0.4.jar",
+      "sha256": "26b6825ea73ac4d7b1a6f5e62ac1c11b0fc272504da6dde9ba8f894cd847e1c1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0.4/maven-model-3.0.4.jar"
+    },
+    "classworlds:classworlds:jar:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar",
+      "sha256": "2bf4e59f3acd106fea6145a9a88fe8956509f8b9c0fdd11eb96fee757269e3f3",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.pom",
+      "sha256": "c5931378737dfc5718089a6114dc25f8139c000cc7743f25958b615998c507e2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.7/doxia-decoration-model-1.7.pom"
+    },
+    "org.codehaus.plexus:plexus-java:pom:0.9.10": {
+      "layout": "org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom",
+      "sha256": "b0013096156cbb98dba97c2b0b07be194d33208b5bde7ee8866e69355e9ebd86",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.0/doxia-decoration-model-1.0.pom",
+      "sha256": "95661c2959cd9f40411d5a4e492d2adf0297d03ec78e0a23303d04eb1dd8af7c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.0/doxia-decoration-model-1.0.pom"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:pom:1.3": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom",
+      "sha256": "d5e650c50ef6958c028ed024b59af04cf3d38e1453a77d542b6b484bc0f4ca0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom"
+    },
+    "org.junit.platform:junit-platform-commons:pom:1.4.2": {
+      "layout": "org/junit/platform/junit-platform-commons/1.4.2/junit-platform-commons-1.4.2.pom",
+      "sha256": "c0b2a83d9a1925d14c42c3b34a82276a60db638a14cba26e5fd12a7c80a6ca7c",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.4.2/junit-platform-commons-1.4.2.pom"
+    },
+    "org.hamcrest:hamcrest-core:jar:1.3": {
+      "layout": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+      "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+      "url": "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+    },
+    "org.sonatype.plexus:plexus-sec-dispatcher:pom:1.4": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom",
+      "sha256": "b4d6f1e2b9172fb7510e18b14aea4ca5a0646fc8b3a2d70a2ebffa6fe48787dc",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.pom"
+    },
+    "org.apache.maven:maven-compat:jar:3.0": {
+      "layout": "org/apache/maven/maven-compat/3.0/maven-compat-3.0.jar",
+      "sha256": "3b8ad55703b8b60e6978b0efed24103a331c7ffd788374af85e2020f6c9b1f00",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.0/maven-compat-3.0.jar"
+    },
+    "org.apache.maven:maven-compat:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.pom",
+      "sha256": "39dc3bcdc82b43558c07819c850a527a4a0d5811deaecf3f8954dd7e2d8023ab",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.pom"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar",
+      "sha256": "89c07a73ea3b41e6c3c7e126871c898f1741fbfddd35633f9524fda09c25dc01",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar"
+    },
+    "org.iq80.snappy:snappy:pom:0.4": {
+      "layout": "org/iq80/snappy/snappy/0.4/snappy-0.4.pom",
+      "sha256": "a709ce17111e4149d9b79a5295644e0cd5a8355aec4b2ef4c0436aba7b25d08a",
+      "url": "https://repo.maven.apache.org/maven2/org/iq80/snappy/snappy/0.4/snappy-0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.14": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar",
+      "sha256": "7fc63378d3e84663619b9bedace9f9fe78b276c2be3c62ca2245449294c84176",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar",
+      "sha256": "7111a4eb5f137781b68127a5a02d0208c28f26d2626fbd7a81d1172cd56449a8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar"
+    },
+    "commons-logging:commons-logging-api:jar:1.0.4": {
+      "layout": "commons-logging/commons-logging-api/1.0.4/commons-logging-api-1.0.4.jar",
+      "sha256": "e168814e138fd3c00ba5e6dd4db0cf64896dfaa0f3a890d0d66652088fd01816",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.0.4/commons-logging-api-1.0.4.jar"
+    },
+    "org.apache.maven.scm:maven-scm-api:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-api/1.9.1/maven-scm-api-1.9.1.pom",
+      "sha256": "6a0660b4d5cadf372214b81d83976db94a168e044887fc180f65e6ab970ecd4e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-api/1.9.1/maven-scm-api-1.9.1.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.11": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.jar",
+      "sha256": "fd9507feb858fa620d1b4aa4b7039fdea1a77e09d3fd28cfbddfff468d9d8c28",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:3.0.1": {
+      "layout": "org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom",
+      "sha256": "1649f67caab553dd7e6b98002dcc670dab3f624c78f1259c8323e705b0c41e32",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom"
+    },
+    "org.junit.platform:junit-platform-commons:pom:1.6.2": {
+      "layout": "org/junit/platform/junit-platform-commons/1.6.2/junit-platform-commons-1.6.2.pom",
+      "sha256": "c5d762d66dfea70f38df383e70b7ca5cfd2f643f0cad188800994b7fb09fbc02",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.6.2/junit-platform-commons-1.6.2.pom"
+    },
+    "org.junit.platform:junit-platform-engine:jar:1.7.0": {
+      "layout": "org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.jar",
+      "sha256": "75f21a20dc594afdc875736725b408cec6d0344874d29f34b2dd3075500236f2",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.jar"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:4.2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/4.2.1/plexus-archiver-4.2.1.jar",
+      "sha256": "c5bb0a59716c337125e8c760f55ebea9a8f7cc30194c54df3d2ae7258a6f9e35",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.2.1/plexus-archiver-4.2.1.jar"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:4.2.0": {
+      "layout": "org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.jar",
+      "sha256": "2a8143caa8c0eb047b7c0f998aa5bbbd9eb8926a59ec11ca6bc86b37363b26b0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.2.0/plexus-archiver-4.2.0.jar"
+    },
+    "org.apache.maven.plugins:maven-enforcer-plugin:pom:3.0.0-M3": {
+      "layout": "org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.pom",
+      "sha256": "ef10db4a502b1f75118018c558bf301c04873cd2bc0d286ff83bb2892ed2cd66",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-commons:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.9.1-02/nexus-buildsupport-commons-2.9.1-02.pom",
+      "sha256": "15022aa4521a5dfc73ed88e40518dafb29f4c3a898a58a569192176ef93d16e5",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-commons/2.9.1-02/nexus-buildsupport-commons-2.9.1-02.pom"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar",
+      "sha256": "88fe952eaf4e28da0533ceef5d8e9b7fc9f09f7f825ab342130bf4b8c3805664",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar"
+    },
+    "com.google.code.findbugs:jsr305:jar:1.3.9": {
+      "layout": "com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
+      "sha256": "905721a0eea90a81534abb7ee6ef4ea2e5e645fa1def0a5cd88402df1b46c9ed",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-engine:jar:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.jar",
+      "sha256": "dfa26af94644ac2612dde6625852fcb550a0d21caa243257de54cba738ba87af",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.jar"
+    },
+    "io.repaint.maven:tiles-maven-plugin:pom:2.18": {
+      "layout": "io/repaint/maven/tiles-maven-plugin/2.18/tiles-maven-plugin-2.18.pom",
+      "sha256": "ed036dec8c4e32d4ae82ab80d071522b6b76ab42caeec2da9689c7bbbe8da591",
+      "url": "https://repo.maven.apache.org/maven2/io/repaint/maven/tiles-maven-plugin/2.18/tiles-maven-plugin-2.18.pom"
+    },
+    "io.repaint.maven:tiles-maven-plugin:pom:2.17": {
+      "layout": "io/repaint/maven/tiles-maven-plugin/2.17/tiles-maven-plugin-2.17.pom",
+      "sha256": "39ef471d253e8cbe04dfe111f58ff3191d543258b49809eebeff2e67dfaf663e",
+      "url": "https://repo.maven.apache.org/maven2/io/repaint/maven/tiles-maven-plugin/2.17/tiles-maven-plugin-2.17.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:5.1": {
+      "layout": "org/codehaus/plexus/plexus/5.1/plexus-5.1.pom",
+      "sha256": "a343e44ff5796aed0ea60be11454c935ce20ab1c5f164acc8da574482dcbc7e9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/5.1/plexus-5.1.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-api:jar:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar",
+      "sha256": "ea80e16c7b10200ad7fbc7d6ebb244b30243e299648c7f9d1329720aec6dd3fe",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:pom:2.22.2": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.pom",
+      "sha256": "a3c9f23e4e09de0d01f8e92181dae908c7121c19f5f7302d37c19f57b5c62abc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.pom"
+    },
+    "org.apache.maven.scm:maven-scm-providers:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-providers/1.9.1/maven-scm-providers-1.9.1.pom",
+      "sha256": "21f3f15f97e641eded7f2b6cef895412dc688c84f8d772872bd11c83c7aa2346",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-providers/1.9.1/maven-scm-providers-1.9.1.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.5.4": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.5.4/plexus-container-default-1.5.4.pom",
+      "sha256": "db69c840d775d9f8fd2190027ba60ad3948b910b89d3fe2e8403146832f0067c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.4/plexus-container-default-1.5.4.pom"
+    },
+    "org.apache.maven:maven-model-builder:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.pom",
+      "sha256": "878c40d7d74624fbaa28c614ccff3c82fa8cedfd33d4bc510627fdc7fe246310",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.pom"
+    },
+    "com.amazonaws:jmespath-java:jar:1.11.893": {
+      "layout": "com/amazonaws/jmespath-java/1.11.893/jmespath-java-1.11.893.jar",
+      "sha256": "ce6ec37b115439e1614a850805283ad01394fac21f8a08e4b58235cbc3b34ef9",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/jmespath-java/1.11.893/jmespath-java-1.11.893.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.25": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+      "sha256": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
+    },
+    "org.eclipse.aether:aether-impl:pom:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.pom",
+      "sha256": "fa3859cfc65441125ca5b96e3633976ab1d0ed3fd4c10cd303877fadd72bb685",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.26": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar",
+      "sha256": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar"
+    },
+    "net.kemitix:mon:jar:2.2.0": {
+      "layout": "net/kemitix/mon/2.2.0/mon-2.2.0.jar",
+      "sha256": "e97cf626f5abc259fda93223108c211a3bc5485165cf561b0a739e1bd4e9ab5f",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/mon/2.2.0/mon-2.2.0.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.21": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+      "sha256": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-goodies:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.9.1-02/nexus-buildsupport-goodies-2.9.1-02.pom",
+      "sha256": "1a824827c9164a5ac2c0fdc6e80f0bf45a07cd12edfcd1e88433afa42a52f67a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-goodies/2.9.1-02/nexus-buildsupport-goodies-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.22": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.jar",
+      "sha256": "6e9eff136fac5fd972ae792cb63524438ee7f76e89cbf22fdb3321b2e33a4624",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.jar"
+    },
+    "org.codehaus.plexus:plexus-io:pom:2.3.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.pom",
+      "sha256": "337ea90ba0cec24098aff52866c3a2dc8e5a59c1dd3f137ab0f94a6c5251fa12",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.3.2/plexus-io-2.3.2.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.24": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.jar",
+      "sha256": "8fe2be04b067a75d02fb8a1a9caf6c1c8615f0d5577cced02e90b520763d2f77",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.24/plexus-interpolation-1.24.jar"
+    },
+    "org.apache.maven:maven-settings:pom:3.1.0": {
+      "layout": "org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.pom",
+      "sha256": "eed800f7352a1b68225908045ee23171b469f681e8d008f340263a6f780263b7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.1.0/maven-settings-3.1.0.pom"
+    },
+    "org.assertj:assertj-parent-pom:pom:2.2.8": {
+      "layout": "org/assertj/assertj-parent-pom/2.2.8/assertj-parent-pom-2.2.8.pom",
+      "sha256": "50b0568b4ca35f0d1242f5d43e187f5325bcd59850af28a128d2e59c99923465",
+      "url": "https://repo.maven.apache.org/maven2/org/assertj/assertj-parent-pom/2.2.8/assertj-parent-pom-2.2.8.pom"
+    },
+    "org.sonatype.sisu.inject:guice-plexus:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom",
+      "sha256": "13a66ca6e6ad1a186076513eea822db2c3c0e460a983a0a31f4d937de336ad98",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:jar:1.7": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar",
+      "sha256": "114859861ff10f987b880d6f34e3215274af3cc92b3a73831c84d596e37c6511",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar"
+    },
+    "org.slf4j:slf4j-api:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom",
+      "sha256": "91b0a0d016b8c0cba1ddd8a5c59e5bf5c2a9b49b95577e8e38927a7fdff55ce8",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom"
+    },
+    "org.sonatype.plexus:plexus-cipher:jar:1.4": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+      "sha256": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar",
+      "sha256": "5a49a4c13e29da41c24bbb35b2f94b82bde259e25d4dd55ee3159e31d20677b8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar"
+    },
+    "org.apache.maven.plugins:maven-compiler-plugin:pom:3.8.1": {
+      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.pom",
+      "sha256": "9c50ff65fb7ee9045bcf94eea07d4451d13acee678387de82547cddc4d05aae9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.pom"
+    },
+    "org.apache.maven.shared:maven-filtering:pom:3.1.1": {
+      "layout": "org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.pom",
+      "sha256": "e3a57b487aeac4bb9411bb6d11ba3e655585c389cff0085372c973b418431c73",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.pom"
+    },
+    "com.amazonaws:aws-java-sdk-s3:jar:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-s3/1.11.893/aws-java-sdk-s3-1.11.893.jar",
+      "sha256": "e189097b5a69b27e78a4cf4da80fbfae0303f12603c1bc0c570722ac078b77bd",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.893/aws-java-sdk-s3-1.11.893.jar"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:jar:1.0": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.jar",
+      "sha256": "b28dd1302ac34433d8d1b45fb254e093cd7b47277441af2018c8a3a4d8c1a60d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0/wagon-provider-api-1.0.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom",
+      "sha256": "cf633e8cde33e65580776d845756d332d24f7c6d5bf9ae90fc6c43d73cb5fe23",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-impl:jar:2.0.2": {
+      "layout": "org/apache/maven/reporting/maven-reporting-impl/2.0.2/maven-reporting-impl-2.0.2.jar",
+      "sha256": "ebf1b6587e83295b9cfc2d96b7f80b6bcc984fd5aef1e7e28ac7c063fb52b1aa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-impl/2.0.2/maven-reporting-impl-2.0.2.jar"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.jar",
+      "sha256": "4ad0673155d7e0e5cf6d13689802d8d507f38e5ea00a6d2fb92aef206108213d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.jar"
+    },
+    "org.sonatype.aether:aether-api:pom:1.13.1": {
+      "layout": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.pom",
+      "sha256": "9a58a1ddbbbe5b635674a958ac9d95d4ffaba7a40b9f800cde2cdf4986c3ef2a",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0.8": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.8/maven-plugin-registry-2.0.8.pom",
+      "sha256": "d0c55c17026bb825f0172fb81df0a6ebba2545926a012f5fa67ac83deee6bbec",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.8/maven-plugin-registry-2.0.8.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom",
+      "sha256": "7de23d8212885031dc2e6fabc327957ff8324563a8fbeb10b0a85b498b826667",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom"
+    },
+    "org.sonatype.spice.zapper:spice-zapper:jar:1.3": {
+      "layout": "org/sonatype/spice/zapper/spice-zapper/1.3/spice-zapper-1.3.jar",
+      "sha256": "d38c784e925b022e428101efec43c1746d1ced9940c2268c7fc4d318d1f5b0c0",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/zapper/spice-zapper/1.3/spice-zapper-1.3.jar"
+    },
+    "org.apache.maven:maven-archiver:pom:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom",
+      "sha256": "86214750be31034691143c797a2656bc647f0defeb4988031aa5afaf39f16a31",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom"
+    },
+    "org.apache.maven:maven-archiver:pom:2.6": {
+      "layout": "org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.pom",
+      "sha256": "10a953395a2a2779dea476acba56bacd980af4af86aa433bc45ce9823ecec814",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.6/maven-archiver-2.6.pom"
+    },
+    "junit:junit:pom:4.11": {
+      "layout": "junit/junit/4.11/junit-4.11.pom",
+      "sha256": "18ad8b0ae9e65a9195d04e25427dfe8b58175abcdae875a5a406aee38bddfb26",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.11/junit-4.11.pom"
+    },
+    "junit:junit:pom:4.12": {
+      "layout": "junit/junit/4.12/junit-4.12.pom",
+      "sha256": "90f163f78e3ffb6f1c7ad97de9e7eba4eea25807141b85d6d12be67ca25449c4",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.pom"
+    },
+    "org.junit:junit-bom:pom:5.7.0": {
+      "layout": "org/junit/junit-bom/5.7.0/junit-bom-5.7.0.pom",
+      "sha256": "35fb15f8d0bee2b5900a22832762366552f9a349c56ced60ba123ce47738ff00",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.7.0/junit-bom-5.7.0.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar",
+      "sha256": "0b16842a33350f5478c4c717bf664251c27459ec5c0b8d0ca4d0050545aba48b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-javac:jar:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar",
+      "sha256": "a37a6d56a32bd0861d53d817c4c81088c87f9e4601caed01eaec4ede7fa4677a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.0/doxia-module-xhtml-1.0.pom",
+      "sha256": "6627123a5e0c5ea2bc977b732b3a3b7e3f1380bd7557456ccb65aeb62da0a44c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.0/doxia-module-xhtml-1.0.pom"
+    },
+    "org.apache.maven.enforcer:enforcer-rules:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar",
+      "sha256": "3db863d1e77c10178981451f7ba436bd7363dba28fc0a9ba60452ab36fb474a1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar"
+    },
+    "commons-logging:commons-logging:pom:1.1.1": {
+      "layout": "commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom",
+      "sha256": "d0f2e16d054e8bb97add9ca26525eb2346f692809fcd2a28787da8ceb3c35ee8",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.pom"
+    },
+    "org.apache.maven:maven-artifact:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar",
+      "sha256": "f45629a70af0dfec1c1b542e162a2aceb976bb492825b6ee192e6a14fff238b6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.6": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.6/plexus-containers-1.6.pom",
+      "sha256": "0829f2a50f20b098223d1f92c19badb0738267d953726ac56cac9f3c9c6fc9bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.6/plexus-containers-1.6.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.0/maven-plugin-registry-2.2.0.jar",
+      "sha256": "e60996bcde88cf4175311234a06f67089504b5d79b0a0055853b8fced1acd51f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.0/maven-plugin-registry-2.2.0.jar"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.pom",
+      "sha256": "2c6093b6ad7dd498c516b9b04d77810b0103788926dc81c9cb47340d1f3510aa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.8/doxia-module-xhtml-1.8.pom"
+    },
+    "org.apache.maven.doxia:doxia-module-xhtml:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.pom",
+      "sha256": "2f7c916db46b85b7015ee2c37bafbef0dc5e49278e757c9d83b247c7c51fa06f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-module-xhtml/1.7/doxia-module-xhtml-1.7.pom"
+    },
+    "javax.xml.bind:jaxb-api-parent:pom:2.3.1": {
+      "layout": "javax/xml/bind/jaxb-api-parent/2.3.1/jaxb-api-parent-2.3.1.pom",
+      "sha256": "cd1beaa4560dc4dfdb826b9d809e464db22526dfb54264bae78a6ff7efb08e1f",
+      "url": "https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api-parent/2.3.1/jaxb-api-parent-2.3.1.pom"
+    },
+    "org.apache.maven:maven-project:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar",
+      "sha256": "c82db125f53716f59008e3214063869717a976bf857879de6d4092c73cdc7e12",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar"
+    },
+    "info.picocli:picocli:jar:4.5.2": {
+      "layout": "info/picocli/picocli/4.5.2/picocli-4.5.2.jar",
+      "sha256": "b4395e9a67932616efd2245d984bf5fcd453c2c5049558c3ce959ac2af4d3fac",
+      "url": "https://repo.maven.apache.org/maven2/info/picocli/picocli/4.5.2/picocli-4.5.2.jar"
+    },
+    "net.kemitix.tiles:maven-plugins:pom:0.8.1": {
+      "layout": "net/kemitix/tiles/maven-plugins/0.8.1/maven-plugins-0.8.1.pom",
+      "sha256": "d9fe83a84d6a491c08f4312f8100530eeb9a7c3be4360d3501479614dc8e67b0",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/maven-plugins/0.8.1/maven-plugins-0.8.1.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:2.8.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.jar",
+      "sha256": "6b1ddd8d0eaaf93b4d7c05b7e48711990b7b13705dd4edc97980d738c685de70",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.8.1/plexus-archiver-2.8.1.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:2.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar",
+      "sha256": "6a17cfbfffe6bb87215ad38bcaac716383e552ec2ba7b204e2673ee66a2afaaa",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar"
+    },
+    "org.apache.maven:maven-model:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar",
+      "sha256": "b86dbf20852da19fb17301ae7e2a40d87930c7d76fe43f0f93ff86b8a64c6962",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar"
+    },
+    "org.apache.maven:maven-model:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar",
+      "sha256": "87083dd97721542f2745eede587fbb6cb1aef2b395f46c2bd578c6d9d7b63521",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar"
+    },
+    "org.apache.maven:maven-project:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar",
+      "sha256": "f091ef5587537947a4c6e43cf200c567e1bf44c101443e8f8cf51e2c126e0195",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar"
+    },
+    "org.apache.httpcomponents:httpcomponents-client:pom:4.0.2": {
+      "layout": "org/apache/httpcomponents/httpcomponents-client/4.0.2/httpcomponents-client-4.0.2.pom",
+      "sha256": "d6b6540bcc1a2fbd2a3733e657cd0c70eebd1fd0dac43031d5bfc975c2c755a7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcomponents-client/4.0.2/httpcomponents-client-4.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:2.0.0": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.jar",
+      "sha256": "405eef6fc9188241ec88579c3e473f5c8997455c69bcd62e142492aca15106bc",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.0.0/plexus-component-annotations-2.0.0.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.jar",
+      "sha256": "dccfc47a4245e2d648e3bdeadb7a4daf51efc70fbd8b7b456454377c9cc5584a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-params:jar:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.jar",
+      "sha256": "ca9f555c37b9bf79effd2e834af549e4feb52ad8ac9e348fe5b430d4d8a482b7",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.jar"
+    },
+    "commons-logging:commons-logging-api:pom:1.1": {
+      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom",
+      "sha256": "69b8be61aa746c7d02acb1b11eb3b57cb22b246780ed71d79764195cbbe3d99d",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom"
+    },
+    "org.sonatype.nexus:nexus-components:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/nexus-components/2.9.1-02/nexus-components-2.9.1-02.pom",
+      "sha256": "5af92940886a1755b9bd50502b623599083d63504d6a862e73b8439238cd671e",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/nexus-components/2.9.1-02/nexus-components-2.9.1-02.pom"
+    },
+    "net.bytebuddy:byte-buddy-agent:pom:1.10.15": {
+      "layout": "net/bytebuddy/byte-buddy-agent/1.10.15/byte-buddy-agent-1.10.15.pom",
+      "sha256": "00623295bd3b07abd8e6734950c5b3e4ba0c6545c7439ae1a101adbc40c0748d",
+      "url": "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.15/byte-buddy-agent-1.10.15.pom"
+    },
+    "asm:asm:jar:3.3.1": {
+      "layout": "asm/asm/3.3.1/asm-3.3.1.jar",
+      "sha256": "c2b39275f8e951bc74750080a1266cdabc39399bc5e13d642bf2d346449df7f3",
+      "url": "https://repo.maven.apache.org/maven2/asm/asm/3.3.1/asm-3.3.1.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler-manager:jar:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar",
+      "sha256": "ec139721f45f8986fbee1cc45f428cd036fe5ed434959048d5d10d3eb73b5731",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar"
+    },
+    "org.apache.maven:maven-artifact:pom:3.3.9": {
+      "layout": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.pom",
+      "sha256": "3ef229ccf722e1d32fcac5a30aba8824ba78a0af9b6ba052815e119374294415",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.pom"
+    },
+    "org.slf4j:slf4j-jdk14:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom",
+      "sha256": "85f97344eeeed2714eda6f800aa712c1aa7405b0d7f98e207499363f82f37eec",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom"
+    },
+    "org.apache.maven.plugin-tools:maven-plugin-annotations:pom:3.5.2": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.pom",
+      "sha256": "78fd2b4399e786aee919118f6b2f1993849f6dfb0f29e203b752cccff3b7efb3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.5.2/maven-plugin-annotations-3.5.2.pom"
+    },
+    "org.codehaus.groovy:groovy-xml:pom:3.0.6": {
+      "layout": "org/codehaus/groovy/groovy-xml/3.0.6/groovy-xml-3.0.6.pom",
+      "sha256": "5e37a3ba52cf7dfe1581dea9d8e60a542e2721c201255c887d248856d16bbb7b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.6/groovy-xml-3.0.6.pom"
+    },
+    "org.apache.maven:maven:pom:3.3.9": {
+      "layout": "org/apache/maven/maven/3.3.9/maven-3.3.9.pom",
+      "sha256": "2387d71a5c80f2b88c1d7fe963854db4612afdce135bde593ec1726f8f96dc13",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.3.9/maven-3.3.9.pom"
+    },
+    "commons-codec:commons-codec:pom:1.9": {
+      "layout": "commons-codec/commons-codec/1.9/commons-codec-1.9.pom",
+      "sha256": "e5efcf039cd909688c201dc5479b144fd6f01f0e40252b7fc5e7d2e1b5c07990",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.pom"
+    },
+    "org.codehaus.groovy:groovy-xml:pom:3.0.4": {
+      "layout": "org/codehaus/groovy/groovy-xml/3.0.4/groovy-xml-3.0.4.pom",
+      "sha256": "505f4972b7eb877323a946b1657290613e1e76b546f5e78e85845a571704bd5e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.4/groovy-xml-3.0.4.pom"
+    },
+    "commons-codec:commons-codec:pom:1.3": {
+      "layout": "commons-codec/commons-codec/1.3/commons-codec-1.3.pom",
+      "sha256": "d157e34244e884dd91fa01921ca84372e11f7bb08fedb5d456c0670c28054636",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.3/commons-codec-1.3.pom"
+    },
+    "org.apache.maven.scm:maven-scm-manager-plexus:jar:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-manager-plexus/1.9.1/maven-scm-manager-plexus-1.9.1.jar",
+      "sha256": "9600da565132b86fb2c5fc2e85aa87930395c3226ebd010cee162248f7660991",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-manager-plexus/1.9.1/maven-scm-manager-plexus-1.9.1.jar"
+    },
+    "commons-codec:commons-codec:pom:1.6": {
+      "layout": "commons-codec/commons-codec/1.6/commons-codec-1.6.pom",
+      "sha256": "a06e35d3fff3a6b813d94894ebf3e498f9540c864c5b39ae783907e3a6c72889",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.6/commons-codec-1.6.pom"
+    },
+    "net.java:jvnet-parent:pom:1": {
+      "layout": "net/java/jvnet-parent/1/jvnet-parent-1.pom",
+      "sha256": "281440811268e65d9e266b3cc898297e214e04f09740d0386ceeb4a8923d63bf",
+      "url": "https://repo.maven.apache.org/maven2/net/java/jvnet-parent/1/jvnet-parent-1.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:0.7": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.pom",
+      "sha256": "dc032929320f3b70e98f890c6430745b49ee911c867f7002977baffbb1ab7d52",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.7/maven-shared-utils-0.7.pom"
+    },
+    "org.apache.httpcomponents:httpcore:jar:4.0.1": {
+      "layout": "org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.jar",
+      "sha256": "3b6bf92affa85d4169a91547ce3c7093ed993b41ad2df80469fc768ad01e6b6b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.0.1/httpcore-4.0.1.jar"
+    },
+    "net.java:jvnet-parent:pom:5": {
+      "layout": "net/java/jvnet-parent/5/jvnet-parent-5.pom",
+      "sha256": "1af699f8d9ddab67f9a0d202fbd7915eb0362a5a6dfd5ffc54cafa3465c9cb0a",
+      "url": "https://repo.maven.apache.org/maven2/net/java/jvnet-parent/5/jvnet-parent-5.pom"
+    },
+    "org.fusesource.hawtbuf:hawtbuf:pom:1.9": {
+      "layout": "org/fusesource/hawtbuf/hawtbuf/1.9/hawtbuf-1.9.pom",
+      "sha256": "7d88ffd0a0dceddb6be2d561a50aad7be5953d2ae7eb6289bb8fe86273b1eabc",
+      "url": "https://repo.maven.apache.org/maven2/org/fusesource/hawtbuf/hawtbuf/1.9/hawtbuf-1.9.pom"
+    },
+    "org.tukaani:xz:pom:1.8": {
+      "layout": "org/tukaani/xz/1.8/xz-1.8.pom",
+      "sha256": "f29e75cb88eb4acbf7e5aa5c09ed55eac2cbae601d63a9f375231f45452c1013",
+      "url": "https://repo.maven.apache.org/maven2/org/tukaani/xz/1.8/xz-1.8.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar",
+      "sha256": "6c040032841fe6b23612c7a4b52347a4a115fdde748086c399a154b4b108e56b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar"
+    },
+    "net.kemitix:kemitix-pmd-ruleset:pom:1.1.0": {
+      "layout": "net/kemitix/kemitix-pmd-ruleset/1.1.0/kemitix-pmd-ruleset-1.1.0.pom",
+      "sha256": "38fcc683a45014eec0cfd8e1ab89e309b55cba7e1f006f64430c59b869a62b79",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/kemitix-pmd-ruleset/1.1.0/kemitix-pmd-ruleset-1.1.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:pom:0.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom",
+      "sha256": "9ecb36b0e0d7d1d0f0dabd8705368b710df58b943091e9fa9071a29ccdc15a33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
+      "sha256": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-all:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.9.1-02/nexus-buildsupport-all-2.9.1-02.pom",
+      "sha256": "1531d6f81f9bd104fc37db32ec9150ec1e48094ff012a1a2f7893dccf1ecaaaa",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-all/2.9.1-02/nexus-buildsupport-all-2.9.1-02.pom"
+    },
+    "org.apache.geronimo.genesis:genesis-default-flava:pom:2.0": {
+      "layout": "org/apache/geronimo/genesis/genesis-default-flava/2.0/genesis-default-flava-2.0.pom",
+      "sha256": "08e6e146f4e245266dff9dd800b12875dd2367d3f67a34ab660a126c811215f8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-default-flava/2.0/genesis-default-flava-2.0.pom"
+    },
+    "org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-6": {
+      "layout": "org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.jar",
+      "sha256": "e116f32edcb77067289a3148143f2c0c97b27cf9a1342f8108ee37dec4868861",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-beta-6/wagon-provider-api-1.0-beta-6.jar"
+    },
+    "commons-collections:commons-collections:jar:3.2": {
+      "layout": "commons-collections/commons-collections/3.2/commons-collections-3.2.jar",
+      "sha256": "093fea360752de55afcb80cf713403eb1a66cb7dc0d529955b6f4a96f975df5c",
+      "url": "https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2/commons-collections-3.2.jar"
+    },
+    "org.apache.maven.scm:maven-scm-providers:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-providers/1.3/maven-scm-providers-1.3.pom",
+      "sha256": "27f38b140b3c9bb35c7329603eb511f4f372ba01c33ec21bf77d24ae3e1e5f26",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-providers/1.3/maven-scm-providers-1.3.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0.3": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom",
+      "sha256": "7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom"
+    },
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.3.1/jackson-jaxrs-json-provider-2.3.1.jar",
+      "sha256": "69741b31cb0c81fa7f9da199d443f946396f2ee771073e9e30f15d23f6db4200",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.3.1/jackson-jaxrs-json-provider-2.3.1.jar"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.jar",
+      "sha256": "b3005544708f8583e455c22b09a4940596a057108bccdadb9db4d8e048091fed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-api:pom:5.7.0": {
+      "layout": "org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.pom",
+      "sha256": "a0f823d513c8d4692935f24c2fe6e77cc4a7b6147a9e8a518f722e50bbf86138",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.pom"
+    },
+    "org.apache.httpcomponents:httpcore:pom:4.3.2": {
+      "layout": "org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.pom",
+      "sha256": "dfe5335f45b9466af820368b95c543d7542fcfcbe5f5d379e91cf0432e2df489",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.pom"
+    },
+    "org.junit.platform:junit-platform-commons:jar:1.7.0": {
+      "layout": "org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.jar",
+      "sha256": "5330ee87cc7586e6e25175a34e9251624ff12ff525269d3415d0b4ca519b6fea",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-rest:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.9.1-02/nexus-buildsupport-rest-2.9.1-02.pom",
+      "sha256": "c4a4f9f9aa7f4d2e85da14427e0331a2c32ca9d533c85f48bd7a5d1e71c68538",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-rest/2.9.1-02/nexus-buildsupport-rest-2.9.1-02.pom"
+    },
+    "org.apache.maven.shared:maven-shared-utils:jar:3.3.3": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/3.3.3/maven-shared-utils-3.3.3.jar",
+      "sha256": "44a60c610f4e31524b03d81a698b1ecceba116320ea510babf859575b2ea7233",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.3/maven-shared-utils-3.3.3.jar"
+    },
+    "net.sourceforge.pmd:pmd-core:pom:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-core/6.23.0/pmd-core-6.23.0.pom",
+      "sha256": "9440a8310e3d8c64124c30d62c4b7b31b9b8fe6a5415935edff87fe3a26bb4b8",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-core/6.23.0/pmd-core-6.23.0.pom"
+    },
+    "org.sonatype.sisu.siesta:siesta:pom:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta/1.7/siesta-1.7.pom",
+      "sha256": "5110217456e45de20a07dc8c7e7edc367711bfe1954ebf8376343d41c06c8dbf",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta/1.7/siesta-1.7.pom"
+    },
+    "org.sonatype.plexus:plexus-build-api:pom:0.0.7": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom",
+      "sha256": "e067317a47ed9e84b2ba85a76d3cf72980e2b0dc873a90b9cbfe74fe80c37c17",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.6": {
+      "layout": "org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom",
+      "sha256": "bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.7": {
+      "layout": "org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom",
+      "sha256": "2b59062030ab0a15c5d0977ba22421706368926488739a65f25793e715cc8a74",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom"
+    },
+    "org.apache.maven:maven-settings:jar:3.0": {
+      "layout": "org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar",
+      "sha256": "3b1a46b4bc26a0176acaf99312ff2f3a631faf3224b0996af546aa48bd73c647",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar"
+    },
+    "antlr:antlr:jar:2.7.2": {
+      "layout": "antlr/antlr/2.7.2/antlr-2.7.2.jar",
+      "sha256": "2a53206963dfa78e33746b6f8367f7d9970fa36865a825d7bfbce1784dc0f4d4",
+      "url": "https://repo.maven.apache.org/maven2/antlr/antlr/2.7.2/antlr-2.7.2.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom",
+      "sha256": "e246e2a062b5d989fdefc521c9c56431ba5554ff8d2344edee9218a34a546a33",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.3": {
+      "layout": "org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom",
+      "sha256": "fcc5670db8864c50c16bd96972f0da876f6651a8edc99850e68b2d569c5a4776",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom"
+    },
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-providers:pom:2.3.1": {
+      "layout": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-providers/2.3.1/jackson-jaxrs-providers-2.3.1.pom",
+      "sha256": "519ddf31b8cd38b00baf4038a227a8935e0fadeb6aecdb96501e39894483bf9a",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-providers/2.3.1/jackson-jaxrs-providers-2.3.1.pom"
+    },
+    "org.osgi:org.osgi.compendium:jar:4.2.0": {
+      "layout": "org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.jar",
+      "sha256": "c1310c4186ccc17a0d7089d83f96dc940c4eccb98d5edfd58819393c29c31655",
+      "url": "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.compendium/4.2.0/org.osgi.compendium-4.2.0.jar"
+    },
+    "javax.annotation:jsr250-api:jar:1.0": {
+      "layout": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+      "sha256": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+      "url": "https://repo.maven.apache.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus/2.0.5/plexus-2.0.5.pom",
+      "sha256": "72b31dc11351a5bf4f5841221be5b1afc2b802ff96f23f2b77838f6d46cd3ad5",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.5/plexus-2.0.5.pom"
+    },
+    "org.apiguardian:apiguardian-api:pom:1.1.0": {
+      "layout": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.pom",
+      "sha256": "a945b9cb5cd9b77b2c711844e659c43ec070ef59d9f509fa9f4c1861b4862711",
+      "url": "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.pom"
+    },
+    "org.apache.maven:maven-settings:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
+      "sha256": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
+    },
+    "org.junit.jupiter:junit-jupiter-api:jar:5.6.2": {
+      "layout": "org/junit/jupiter/junit-jupiter-api/5.6.2/junit-jupiter-api-5.6.2.jar",
+      "sha256": "3f476de9b214f20ca69da51e801186d001f67328a686df81bc3de3ba11953870",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-api/5.6.2/junit-jupiter-api-5.6.2.jar"
+    },
+    "org.codehaus.plexus:plexus-compiler:pom:2.8.4": {
+      "layout": "org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom",
+      "sha256": "90de88821eb50c3238f576eab8b08f36635a1b5d6a66d1ed52b93b10d54730b0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:3.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.jar",
+      "sha256": "498949e5576b022559d1622e534c18e052f94dec883924b67e0a4e8676c07b17",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/3.0/maven-reporting-api-3.0.jar"
+    },
+    "org.apache.maven.wagon:wagon:pom:2.10": {
+      "layout": "org/apache/maven/wagon/wagon/2.10/wagon-2.10.pom",
+      "sha256": "82beff347a31987a602cb9595cea83fe8c7264f76fe3856fd8c539a1d412704b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/2.10/wagon-2.10.pom"
+    },
+    "commons-beanutils:commons-beanutils:jar:1.7.0": {
+      "layout": "commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar",
+      "sha256": "24bcaa20ccbdc7c856ce0c0aea144566943403e2e9f27bd9779cda1d76823ef4",
+      "url": "https://repo.maven.apache.org/maven2/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar"
+    },
+    "commons-codec:commons-codec:jar:1.15": {
+      "layout": "commons-codec/commons-codec/1.15/commons-codec-1.15.jar",
+      "sha256": "b3e9f6d63a790109bf0d056611fbed1cf69055826defeb9894a71369d246ed63",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
+    },
+    "commons-validator:commons-validator:pom:1.3.1": {
+      "layout": "commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.pom",
+      "sha256": "7ea241ea8821d6236125d8d6388e51d9d8e9a558cee8444f016dfdadb6044ccc",
+      "url": "https://repo.maven.apache.org/maven2/commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.pom"
+    },
+    "net.sourceforge.pmd:pmd-jsp:pom:6.23.0": {
+      "layout": "net/sourceforge/pmd/pmd-jsp/6.23.0/pmd-jsp-6.23.0.pom",
+      "sha256": "24dec593f86c3a6f92f6bb9c0103b9bfafca537eeee2f20f4c1b04b6c54ea476",
+      "url": "https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-jsp/6.23.0/pmd-jsp-6.23.0.pom"
+    },
+    "com.thoughtworks.xstream:xstream:pom:1.4.7": {
+      "layout": "com/thoughtworks/xstream/xstream/1.4.7/xstream-1.4.7.pom",
+      "sha256": "82c21bce2967242540110131376686e4e69b3aaa4ef558cc8ffac4c8b8784663",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/xstream/xstream/1.4.7/xstream-1.4.7.pom"
+    },
+    "commons-codec:commons-codec:jar:1.12": {
+      "layout": "commons-codec/commons-codec/1.12/commons-codec-1.12.jar",
+      "sha256": "23df58fae9c83d1bcd277b99f9429e9d8c134f0600b73e2e86b2385ed793c81e",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.12/commons-codec-1.12.jar"
+    },
+    "org.slf4j:slf4j-api:jar:1.7.5": {
+      "layout": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar",
+      "sha256": "fe30825245d2336c859dc38d60c0fc5f3668dbf29cd586828d2b5667ec355b91",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar"
+    },
+    "org.apache.maven:maven-model-builder:jar:3.0": {
+      "layout": "org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar",
+      "sha256": "1c98a4ec9eb0cb86ecf01710aa75c0346ee3f96edc6edeabcb21ed984120e154",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar"
+    },
+    "commons-codec:commons-codec:jar:1.11": {
+      "layout": "commons-codec/commons-codec/1.11/commons-codec-1.11.jar",
+      "sha256": "e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d",
+      "url": "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.11/commons-codec-1.11.jar"
+    },
+    "org.opentest4j:opentest4j:pom:1.1.1": {
+      "layout": "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.pom",
+      "sha256": "d9ddb3babfbfc0a7b5b3a76e7ebd0e8f35854af9f6db0e949919b6f85b7dfd68",
+      "url": "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.pom"
+    },
+    "velocity:velocity-dep:pom:1.4": {
+      "layout": "velocity/velocity-dep/1.4/velocity-dep-1.4.pom",
+      "sha256": "1aedc28ee9805a7182a30a881514cef848eb1e7e7f9d5157d59ef0fa0c052eb2",
+      "url": "https://repo.maven.apache.org/maven2/velocity/velocity-dep/1.4/velocity-dep-1.4.pom"
+    },
+    "com.thoughtworks.qdox:qdox:jar:2.0-M9": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar",
+      "sha256": "ee2f7fa60b6ef3151f1bb0a242e0bacb832ff29f3ee8fd3da61d26d8608bc1bc",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar"
+    },
+    "org.slf4j:slf4j-api:jar:1.7.7": {
+      "layout": "org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7.jar",
+      "sha256": "69980c038ca1b131926561591617d9c25fabfc7b29828af91597ca8570cf35fe",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7.jar"
+    },
+    "com.thoughtworks.qdox:qdox:jar:2.0-M7": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.jar",
+      "sha256": "d5d596e64c49e91c4463e45673b8fb7f379d6ae01221ac0b555ad2b53cd5411c",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M7/qdox-2.0-M7.jar"
+    },
+    "com.thoughtworks.qdox:qdox:jar:2.0-M8": {
+      "layout": "com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.jar",
+      "sha256": "5de01a9b2c8c3600f8dd4524693ca511cc0973e5cd40116e0391fe8abc617b55",
+      "url": "https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M8/qdox-2.0-M8.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.2.1": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.2.1/maven-reporting-2.2.1.pom",
+      "sha256": "e6ef1c7e8ff076a726c5e5895e360fb52ef6478d9d5412ef5bdff8aed1f55995",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.2.1/maven-reporting-2.2.1.pom"
+    },
+    "org.apache.maven.scm:maven-scm-provider-gitexe:pom:1.3": {
+      "layout": "org/apache/maven/scm/maven-scm-provider-gitexe/1.3/maven-scm-provider-gitexe-1.3.pom",
+      "sha256": "aa901230da7d695ed7e623a5508b10dc88b0140abc43a2123adfcd804dfac8ee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-provider-gitexe/1.3/maven-scm-provider-gitexe-1.3.pom"
+    },
+    "org.eclipse.aether:aether-spi:jar:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+      "sha256": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.2.0": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.2.0/maven-reporting-2.2.0.pom",
+      "sha256": "2443d86504a083bb29b676d10ee82926f1e792f0a2a4011c1a4b150dedb2bd01",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.2.0/maven-reporting-2.2.0.pom"
+    },
+    "org.codehaus.plexus:plexus-java:pom:0.9.8": {
+      "layout": "org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.pom",
+      "sha256": "5c6c8bb342308d213c22f94af779be83b2538fe7d80cd68832119c4751c5bac5",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.8/plexus-java-0.9.8.pom"
+    },
+    "com.beust:jcommander:jar:1.72": {
+      "layout": "com/beust/jcommander/1.72/jcommander-1.72.jar",
+      "sha256": "e0de160b129b2414087e01fe845609cd55caec6820cfd4d0c90fabcc7bdb8c1e",
+      "url": "https://repo.maven.apache.org/maven2/com/beust/jcommander/1.72/jcommander-1.72.jar"
+    },
+    "com.fasterxml.jackson.core:jackson-annotations:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/core/jackson-annotations/2.3.1/jackson-annotations-2.3.1.jar",
+      "sha256": "2862c90eb10d4d8fde2b5abb278aa4467879cf8995d0f5542bacfb1a909456be",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.3.1/jackson-annotations-2.3.1.jar"
+    },
+    "org.slf4j:jcl-over-slf4j:pom:1.5.6": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom",
+      "sha256": "d71d7748e68bb9cb7ad38b95d17c0466e31fc1f4d15bb1e635f3ebad34a38ff3",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom"
+    },
+    "com.sun.jersey.contribs:jersey-apache-client4:jar:1.17.1": {
+      "layout": "com/sun/jersey/contribs/jersey-apache-client4/1.17.1/jersey-apache-client4-1.17.1.jar",
+      "sha256": "e4cf47229aca581e8de36683434e184e5a1e986311b4adcd966446efb27d33c6",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/contribs/jersey-apache-client4/1.17.1/jersey-apache-client4-1.17.1.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport/2.9.1-02/nexus-buildsupport-2.9.1-02.pom",
+      "sha256": "cef291298068438d40b3fa63fcb74f12b6dc5ab9eb1bc71f8d888c1100dec755",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport/2.9.1-02/nexus-buildsupport-2.9.1-02.pom"
+    },
+    "org.eclipse.aether:aether-impl:jar:1.0.2.v20150114": {
+      "layout": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+      "sha256": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
+    },
+    "org.mockito:mockito-core:jar:3.6.0": {
+      "layout": "org/mockito/mockito-core/3.6.0/mockito-core-3.6.0.jar",
+      "sha256": "97ccee94ca841f79c3cdca7f16d54036509dec9068269c496c88f63a4f29bccd",
+      "url": "https://repo.maven.apache.org/maven2/org/mockito/mockito-core/3.6.0/mockito-core-3.6.0.jar"
+    },
+    "net.kemitix.tiles:parent:pom:2.7.0": {
+      "layout": "net/kemitix/tiles/parent/2.7.0/parent-2.7.0.pom",
+      "sha256": "8a2c1198a27fb039d5c93eb080d2b12409034869390d0737b448c64d36e9b572",
+      "url": "https://repo.maven.apache.org/maven2/net/kemitix/tiles/parent/2.7.0/parent-2.7.0.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.6": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+      "sha256": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
+    },
+    "junit:junit:pom:4.8.2": {
+      "layout": "junit/junit/4.8.2/junit-4.8.2.pom",
+      "sha256": "df39d34d1f5830b2d8a92790c66b5798358b0b3e01452dc85b3722a881ad923e",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/4.8.2/junit-4.8.2.pom"
+    },
+    "org.apache.maven.scm:maven-scm-providers-git:pom:1.9.1": {
+      "layout": "org/apache/maven/scm/maven-scm-providers-git/1.9.1/maven-scm-providers-git-1.9.1.pom",
+      "sha256": "28153069c762311c8d5f0428d8814d3a3ef96eadabcdd4baea197df58be00971",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/scm/maven-scm-providers-git/1.9.1/maven-scm-providers-git-1.9.1.pom"
+    },
+    "org.apache.maven:maven-settings-builder:pom:3.0": {
+      "layout": "org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom",
+      "sha256": "1e707086b2efabe7527e75539f87e5b4544ed20e8b5ae8aa35bcc24d7ba3a2b0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar",
+      "sha256": "b5f0dd177264a6e25ce0ed8724f8b6f3bca48b215b9ff4576e1bec7b0773f9e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar"
+    },
+    "org.apache.commons:commons-compress:pom:1.19": {
+      "layout": "org/apache/commons/commons-compress/1.19/commons-compress-1.19.pom",
+      "sha256": "9d5a690d1dea6a747e0dd8e74e64447167f395cb8f148010b8241334f58b525b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.19/commons-compress-1.19.pom"
+    },
+    "javax.servlet:servlet-api:jar:2.3": {
+      "layout": "javax/servlet/servlet-api/2.3/servlet-api-2.3.jar",
+      "sha256": "8478b902d0815ed066db860fb14cc5d404548d4b6348ab930b46270fcddeba68",
+      "url": "https://repo.maven.apache.org/maven2/javax/servlet/servlet-api/2.3/servlet-api-2.3.jar"
+    },
+    "org.apache.maven.plugins:maven-pmd-plugin:jar:3.13.0": {
+      "layout": "org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.jar",
+      "sha256": "371450ef2a8c9bb4d42e2163d25d2d3516e3933b29024a2458eeaf0b6d6bdcab",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-pmd-plugin/3.13.0/maven-pmd-plugin-3.13.0.jar"
+    },
+    "org.eclipse.sisu:sisu-inject:pom:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/sisu-inject/0.0.0.M2a/sisu-inject-0.0.0.M2a.pom",
+      "sha256": "6ea322bae1e866d7917baf572458ebdb07a620b83b0cb623f9297d7ec91c4718",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-inject/0.0.0.M2a/sisu-inject-0.0.0.M2a.pom"
+    },
+    "org.sonatype.sisu.siesta:siesta-client:jar:1.7": {
+      "layout": "org/sonatype/sisu/siesta/siesta-client/1.7/siesta-client-1.7.jar",
+      "sha256": "7977f05a0c08f91ad78101fa5488fdb8ca200784b70e760aee0ea8d4b2d7673c",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/siesta/siesta-client/1.7/siesta-client-1.7.jar"
+    },
+    "com.google.code.gson:gson:pom:2.8.5": {
+      "layout": "com/google/code/gson/gson/2.8.5/gson-2.8.5.pom",
+      "sha256": "b8308557a7fccc92d9fe7c8cd0599258b361285d2ecde7689eda98843255a092",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5.pom"
+    },
+    "commons-chain:commons-chain:jar:1.1": {
+      "layout": "commons-chain/commons-chain/1.1/commons-chain-1.1.jar",
+      "sha256": "e408f72da5ed4c5db6ae19e8c3b7ee36259c36c05f7a77f15509a014bfe7bcaa",
+      "url": "https://repo.maven.apache.org/maven2/commons-chain/commons-chain/1.1/commons-chain-1.1.jar"
+    },
+    "org.sonatype.aether:aether-spi:jar:1.7": {
+      "layout": "org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar",
+      "sha256": "f54a0a28ce3d62af0e1cfe41dde616f645c28e452e77f77b78bc36e74d5e1a69",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar"
+    },
+    "org.apache.maven.doxia:doxia-core:jar:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.jar",
+      "sha256": "33e4a3e5c5599c9eb06477fd2af7b642fd5b5937cb788bfe74eaf7c227259340",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.7/doxia-core-1.7.jar"
+    },
+    "org.slf4j:jcl-over-slf4j:pom:1.7.7": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.7.7/jcl-over-slf4j-1.7.7.pom",
+      "sha256": "3845c33fa17953724d077fe1d90178f634ff36a975bd85b423578ad5c21416e8",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.7.7/jcl-over-slf4j-1.7.7.pom"
+    },
+    "aopalliance:aopalliance:pom:1.0": {
+      "layout": "aopalliance/aopalliance/1.0/aopalliance-1.0.pom",
+      "sha256": "26e82330157d6b844b67a8064945e206581e772977183e3e31fec6058aa9a59b",
+      "url": "https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.pom"
+    },
+    "com.google.guava:guava:pom:16.0.1": {
+      "layout": "com/google/guava/guava/16.0.1/guava-16.0.1.pom",
+      "sha256": "c676575845fc8ad6dcfeca0827f405066a140f5fa5434715598179c8ba1c0817",
+      "url": "https://repo.maven.apache.org/maven2/com/google/guava/guava/16.0.1/guava-16.0.1.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:jar:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.0/doxia-core-1.0.jar",
+      "sha256": "26a90faef53a1346795d9e3a3ab24111e149b59e80408263747c9441ed966154",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.0/doxia-core-1.0.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:18": {
+      "layout": "org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom",
+      "sha256": "a1d54fb81b5a8f197f5b3d0a928f63da2278c79bc8dd06e0be93593403f05775",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom"
+    },
+    "org.apache.felix:maven-bundle-plugin:pom:5.1.1": {
+      "layout": "org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.pom",
+      "sha256": "276578bde46cc91685977f4276259d0720aa9fccf3861efe9c53ab6918764e67",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/maven-bundle-plugin/5.1.1/maven-bundle-plugin-5.1.1.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:17": {
+      "layout": "org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom",
+      "sha256": "4b96931a6d12491f858b44b2dbea50c1070c960232c041b966189dc905ac2631",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:19": {
+      "layout": "org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom",
+      "sha256": "d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom"
+    },
+    "org.apache.maven:maven-plugin-api:jar:3.0": {
+      "layout": "org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar",
+      "sha256": "f5ecc6eaa4a32ee0c115d31525f588f491b2cc75fdeb4ed3c0c662c12ac0c32f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar"
+    },
+    "org.sonatype.aether:aether-parent:pom:1.7": {
+      "layout": "org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom",
+      "sha256": "29004012161043936443d59574924e0406a2326f53943f02eca7944b33c169df",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom"
+    },
+    "sslext:sslext:jar:1.2-0": {
+      "layout": "sslext/sslext/1.2-0/sslext-1.2-0.jar",
+      "sha256": "4ec193f85bf3c5e84be4ef79fe1e8e71493b317858735cfe062c4c54f818c312",
+      "url": "https://repo.maven.apache.org/maven2/sslext/sslext/1.2-0/sslext-1.2-0.jar"
+    },
+    "org.sonatype.sisu:sisu-guice:pom:3.1.0": {
+      "layout": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.pom",
+      "sha256": "28a7c38bd751e9e2a9f8d13ddf876266f90f9d6e29c9178b524828afbc5e45f4",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.pom"
+    },
+    "org.apache.maven.wagon:wagon:pom:1.0": {
+      "layout": "org/apache/maven/wagon/wagon/1.0/wagon-1.0.pom",
+      "sha256": "7ed40507ea766a9ae9c433305f32bf02a1d7dba533b75b3926a28c469b475c54",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon/1.0/wagon-1.0.pom"
+    },
+    "org.apache.maven.doxia:doxia-core:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-core/1.0-alpha-7/doxia-core-1.0-alpha-7.jar",
+      "sha256": "0ca347aefddfb9d370b43e0531d4746eed9b762be41008236f7bd2e3c2749a89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-core/1.0-alpha-7/doxia-core-1.0-alpha-7.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:15": {
+      "layout": "org/apache/maven/shared/maven-shared-components/15/maven-shared-components-15.pom",
+      "sha256": "6a58eb24291600f75ce0fe369b73fe6700f575ace4b664724d3cd0a6b85b63ee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/15/maven-shared-components-15.pom"
+    },
+    "org.slf4j:slf4j-parent:pom:1.7.25": {
+      "layout": "org/slf4j/slf4j-parent/1.7.25/slf4j-parent-1.7.25.pom",
+      "sha256": "18f5c52120db036e88d6136f8839c832d074bdda95c756c6f429249d2db54ac6",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.25/slf4j-parent-1.7.25.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom",
+      "sha256": "2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom"
+    },
+    "dom4j:dom4j:jar:1.1": {
+      "layout": "dom4j/dom4j/1.1/dom4j-1.1.jar",
+      "sha256": "50bd5c21b5fbd27b8bbb5f8050544b53f49a4480fd347ce9c46d55c706015156",
+      "url": "https://repo.maven.apache.org/maven2/dom4j/dom4j/1.1/dom4j-1.1.jar"
+    },
+    "org.apache.maven.doxia:doxia-decoration-model:jar:1.7.4": {
+      "layout": "org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.jar",
+      "sha256": "2da5e88be0074a96ba3407313de0a483a6a666da78e8c1f388594a485d4e58b0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-decoration-model/1.7.4/doxia-decoration-model-1.7.4.jar"
+    },
+    "org.sonatype.sisu.inject:guice-parent:pom:3.1.0": {
+      "layout": "org/sonatype/sisu/inject/guice-parent/3.1.0/guice-parent-3.1.0.pom",
+      "sha256": "6c1be769d69337f1a8cc2d7e756f94b8bdc02a76c3087545aad1e374ac4bd0ce",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-parent/3.1.0/guice-parent-3.1.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:21": {
+      "layout": "org/apache/maven/shared/maven-shared-components/21/maven-shared-components-21.pom",
+      "sha256": "eedad42e177b4150b7fc8b84c6c2824bcbd3d6461bf7b87d2fb294efc4010a33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/21/maven-shared-components-21.pom"
+    },
+    "org.apache.maven.surefire:surefire-providers:pom:2.22.2": {
+      "layout": "org/apache/maven/surefire/surefire-providers/2.22.2/surefire-providers-2.22.2.pom",
+      "sha256": "eb6e3bcc4d5b7c353cf58402bb5b77f85dbcbe6a8b2bc653b75ea56e4131e408",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/2.22.2/surefire-providers-2.22.2.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:20": {
+      "layout": "org/apache/maven/shared/maven-shared-components/20/maven-shared-components-20.pom",
+      "sha256": "3dcc49b7261dc4c274b15a62f96961551f23fc0341622b068938ec3a66503748",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/20/maven-shared-components-20.pom"
+    },
+    "net.bytebuddy:byte-buddy-agent:jar:1.10.15": {
+      "layout": "net/bytebuddy/byte-buddy-agent/1.10.15/byte-buddy-agent-1.10.15.jar",
+      "sha256": "15cecd0ca128d0517d99b5bb8682b4f187c73a68eeff4a1797168322bc0ebc5c",
+      "url": "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.10.15/byte-buddy-agent-1.10.15.jar"
+    },
+    "org.apache.maven:maven-core:jar:3.0": {
+      "layout": "org/apache/maven/maven-core/3.0/maven-core-3.0.jar",
+      "sha256": "ba03294ee53e7ba31838e4950f280d033c7744c6c7b31253afc75aa351fbd989",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:22": {
+      "layout": "org/apache/maven/shared/maven-shared-components/22/maven-shared-components-22.pom",
+      "sha256": "754543cedb4af3f32708377e065e4a2cc37fc35569f0c073f946e7fc64865387",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/22/maven-shared-components-22.pom"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-guice:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.9.1-02/nexus-buildsupport-guice-2.9.1-02.pom",
+      "sha256": "0430e3d04e83c05a1a2e3554f77db5fc35fd4acf26687adf1ac732ef79399645",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-guice/2.9.1-02/nexus-buildsupport-guice-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.8": {
+      "layout": "org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom",
+      "sha256": "a89a2f99088e244b3e52e35f19f5f7d3aba03dbb3cfaea044e2a694119e88f79",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.8/plexus-1.0.8.pom"
+    },
+    "org.kathrynhuxtable.maven.wagon:wagon-gitsite:pom:0.3.1": {
+      "layout": "org/kathrynhuxtable/maven/wagon/wagon-gitsite/0.3.1/wagon-gitsite-0.3.1.pom",
+      "sha256": "8cb44adf479ed2fbd0601f4370e9507111b346905f0c86519666059e43683de0",
+      "url": "https://repo.maven.apache.org/maven2/org/kathrynhuxtable/maven/wagon/wagon-gitsite/0.3.1/wagon-gitsite-0.3.1.pom"
+    },
+    "org.junit.platform:junit-platform-launcher:pom:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1.pom",
+      "sha256": "81ccd9bb246741e52faafb2e6dedc589d2f264303bbb7282140de3aae6a98bfe",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.3.1/junit-platform-launcher-1.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.9": {
+      "layout": "org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom",
+      "sha256": "11a987607957fcac04d6ac182308abf5a7d3707f519863e55c8eb419953f5374",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.9/plexus-1.0.9.pom"
+    },
+    "org.apache.maven.plugins:maven-assembly-plugin:jar:3.3.0": {
+      "layout": "org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar",
+      "sha256": "2d51509b2a8c53a524ba2d97609a8b7be00751f22df1ff3019c174c8ed127536",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-assembly-plugin/3.3.0/maven-assembly-plugin-3.3.0.jar"
+    },
+    "org.sonatype.sisu:sisu-parent:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom",
+      "sha256": "abb04084d0885319fd0b372d77655f8feb8aa8bb091699fcd99b45798a9587d5",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom"
+    },
+    "org.apache.maven:maven-settings-builder:jar:3.3.9": {
+      "layout": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
+      "sha256": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
+    },
+    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.3.1": {
+      "layout": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.3.1/jackson-jaxrs-base-2.3.1.jar",
+      "sha256": "b328bdc38991004df7da611485afc696630af671c9000ddb6d53a0999b87b4ce",
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.3.1/jackson-jaxrs-base-2.3.1.jar"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.2.3": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar",
+      "sha256": "7d95ad21733b060bfda2142b62439a196bde7644f9f127c299ae86d92179b518",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar"
+    },
+    "com.sun.jersey:jersey-core:pom:1.17.1": {
+      "layout": "com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.pom",
+      "sha256": "db547b24bfd1c23f760f34e31e9c73c4b21c92121746505e7b37fa5e13d38d11",
+      "url": "https://repo.maven.apache.org/maven2/com/sun/jersey/jersey-core/1.17.1/jersey-core-1.17.1.pom"
+    },
+    "org.apache.maven:maven-profile:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.jar",
+      "sha256": "ecaffef655fea6b138f0855a12f7dbb59fc0d6bffb5c1bfd31803cccb49ea08c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.jar",
+      "sha256": "d87645908695bd18375b77b9149741a9309521f9e13a872d5aa6bcdf361d0226",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.0/maven-plugin-parameter-documenter-2.2.0.jar",
+      "sha256": "5be00bfc35fd07e629b18940a70c555b79174c0833e6329e094b9a0e070ccc92",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.0/maven-plugin-parameter-documenter-2.2.0.jar"
+    },
+    "org.apache.maven:maven-profile:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-profile/2.2.0/maven-profile-2.2.0.jar",
+      "sha256": "26a78300a7c844cd15d1405e5d18a7623b3f296ba9de1ecaa39475defa39611f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.0/maven-profile-2.2.0.jar"
+    },
+    "org.junit.platform:junit-platform-engine:pom:1.3.1": {
+      "layout": "org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1.pom",
+      "sha256": "3cbdbb4fefa6033dd14befe346b9ccd92d3d128201c210e794ee8514110954d6",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.3.1/junit-platform-engine-1.3.1.pom"
+    },
+    "xml-apis:xml-apis:jar:1.0.b2": {
+      "layout": "xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar",
+      "sha256": "8232f3482c346d843e5e3fb361055771c1acc105b6d8a189eb9018c55948cf9f",
+      "url": "https://repo.maven.apache.org/maven2/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar"
+    },
+    "org.sonatype.nexus.buildsupport:nexus-buildsupport-logging:pom:2.9.1-02": {
+      "layout": "org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.9.1-02/nexus-buildsupport-logging-2.9.1-02.pom",
+      "sha256": "32703657ab2f79427d6d3c80f6a4138c05ff8732d2303bb61bfc45521ab1a330",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/nexus/buildsupport/nexus-buildsupport-logging/2.9.1-02/nexus-buildsupport-logging-2.9.1-02.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:4.0": {
+      "layout": "org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom",
+      "sha256": "1a5c0f95f65ed3e98edcf4f3b27c21cbcb14567384d9e4cf07f83a49675347ed",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom"
+    },
+    "org.apache.struts:struts-core:pom:1.3.8": {
+      "layout": "org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.pom",
+      "sha256": "9751850b8c81e1c20091ab5cbfa309491c7a59f816a8566c475f901a8f554e1e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-core/1.3.8/struts-core-1.3.8.pom"
+    },
+    "commons-logging:commons-logging:jar:1.2": {
+      "layout": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+      "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+    },
+    "commons-logging:commons-logging:jar:1.1": {
+      "layout": "commons-logging/commons-logging/1.1/commons-logging-1.1.jar",
+      "sha256": "9e8d01f172301b966f1f404aa6fc0bdbec478ae9197256ad95bfcad1ef927601",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging/1.1/commons-logging-1.1.jar"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:31": {
+      "layout": "org/apache/maven/shared/maven-shared-components/31/maven-shared-components-31.pom",
+      "sha256": "d81a80d2cb54500a4f9f2a015e484393cba991e39d336425458ec6682d9a2dca",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/31/maven-shared-components-31.pom"
+    },
+    "org.slf4j:jul-to-slf4j:jar:1.7.25": {
+      "layout": "org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar",
+      "sha256": "416c5a0c145ad19526e108d44b6bf77b75412d47982cce6ce8d43abdbdbb0fac",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:pom:1.7": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.pom",
+      "sha256": "aedb973fa23215ac3a03ae4c52532dc4ef35766d77d2993380f4ec11c4180638",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.7/doxia-site-renderer-1.7.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:34": {
+      "layout": "org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom",
+      "sha256": "64d0edb5f21cfff600b1c3ab7d45f9754cd18ba5fbf83b3d1bb7c4849437d8e3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:33": {
+      "layout": "org/apache/maven/shared/maven-shared-components/33/maven-shared-components-33.pom",
+      "sha256": "f43ff6fee0b32533765b3406648d6a5532f85d5e488079480788cb36e79d0980",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/33/maven-shared-components-33.pom"
+    },
+    "org.apache.maven.plugins:maven-enforcer-plugin:jar:3.0.0-M3": {
+      "layout": "org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.jar",
+      "sha256": "b7220ba197a6ae585b8cce5f99efc7d12ba4b1e1ee79c571da836ec3344d691a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-enforcer-plugin/3.0.0-M3/maven-enforcer-plugin-3.0.0-M3.jar"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:jar:2.22.2": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.jar",
+      "sha256": "d8e3571a8c13e080a0a101016f16bd2c84d62440283143838388093e482f4675",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.jar"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:pom:1.0": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.0/doxia-site-renderer-1.0.pom",
+      "sha256": "fa4efbdc62b7e885a8ee35b23bd71a3b0c08f7fc7d2da878795042ede9f7dc48",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.0/doxia-site-renderer-1.0.pom"
+    },
+    "org.apache.maven.shared:maven-shared-components:pom:30": {
+      "layout": "org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom",
+      "sha256": "ad9df3b73df8bbc0309ad42818fa9779cd10528df0708788f4aceddc514bd031",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.3": {
+      "layout": "org/codehaus/plexus/plexus/3.3/plexus-3.3.pom",
+      "sha256": "3d2ad3a8bfd49d95952443afe2c14183136811019435bf16eed40796b2210ad2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3/plexus-3.3.pom"
+    },
+    "org.apache.maven.doxia:doxia-site-renderer:pom:1.8": {
+      "layout": "org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.pom",
+      "sha256": "ee88c9c133eeb15a56d08909db3ad2045fed7c8df019c3036cf3e26c5c7c8d56",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-site-renderer/1.8/doxia-site-renderer-1.8.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.2": {
+      "layout": "org/codehaus/plexus/plexus/3.2/plexus-3.2.pom",
+      "sha256": "1c7c732fdc37e7705af76835b1589fedd9db2abe1baa76b16bd061bd7291de4f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.2/plexus-3.2.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.0.0.M2a": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.jar",
+      "sha256": "3e745c61748a4780839cbc6c0b10854abae3be26f3cf283a00bc002d2ed98bd1",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.0.0.M2a/org.eclipse.sisu.inject-0.0.0.M2a.jar"
+    },
+    "org.sonatype.sisu:sisu-inject-plexus:pom:1.4.2": {
+      "layout": "org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom",
+      "sha256": "e302200cf462cf1af9f3e870738253cdf90d7abc8279b9d3b507a5d0d3b9f289",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom"
+    },
+    "org.junit.jupiter:junit-jupiter-engine:pom:5.6.2": {
+      "layout": "org/junit/jupiter/junit-jupiter-engine/5.6.2/junit-jupiter-engine-5.6.2.pom",
+      "sha256": "c6e6887988ca316556762b86ab60ecb644980474d9124a6f2b0edce7f34309d2",
+      "url": "https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.6.2/junit-jupiter-engine-5.6.2.pom"
+    },
+    "com.amazonaws:aws-java-sdk-s3:pom:1.11.893": {
+      "layout": "com/amazonaws/aws-java-sdk-s3/1.11.893/aws-java-sdk-s3-1.11.893.pom",
+      "sha256": "c17d4c3e8b0e9612fb2f787b153deffbdef2e6e2f050bd1956a128462fc29f2a",
+      "url": "https://repo.maven.apache.org/maven2/com/amazonaws/aws-java-sdk-s3/1.11.893/aws-java-sdk-s3-1.11.893.pom"
+    },
+    "org.apache.maven:maven-plugin-descriptor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar",
+      "sha256": "e6e99e03921e576358e24a797e3034d0587ad08dac8ebf78b3fcf3e1a96a37d9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar"
+    },
+    "org.apache.velocity:velocity-tools:pom:2.0": {
+      "layout": "org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.pom",
+      "sha256": "b12f13ab462281d48c573acabf124e067a9d49e65ec72b27597db9e91f721b95",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/velocity/velocity-tools/2.0/velocity-tools-2.0.pom"
+    },
+    "org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.2": {
+      "layout": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
+      "sha256": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
+      "url": "https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
+    },
+    "org.apache.struts:struts-tiles:pom:1.3.8": {
+      "layout": "org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.pom",
+      "sha256": "d678f338f62da055bafb93483ec8ddcbed7c2762649e31766ad8347f59ef1c6c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/struts/struts-tiles/1.3.8/struts-tiles-1.3.8.pom"
+    },
+    "org.apache.httpcomponents:httpcore:pom:4.4.13": {
+      "layout": "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.pom",
+      "sha256": "8f812d9fa7b72a3d4aa7f825278932a5df344b42a6d8398905879431a1bf9a97",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.pom"
+    },
+    "log4j:log4j:pom:1.2.12": {
+      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.pom",
+      "sha256": "cb54dedc5d8c4510148dfa792701cbac1a84c383a84f48f5a32e6d7e460bbb72",
+      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.pom"
+    },
+    "org.apache.felix:felix-parent:pom:6": {
+      "layout": "org/apache/felix/felix-parent/6/felix-parent-6.pom",
+      "sha256": "3608b6b200f6c8f488c77cc159847d515e6966e8333b85d8e04e394a093b5595",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/6/felix-parent-6.pom"
+    },
+    "org.apache.maven.shared:maven-artifact-transfer:pom:0.11.0": {
+      "layout": "org/apache/maven/shared/maven-artifact-transfer/0.11.0/maven-artifact-transfer-0.11.0.pom",
+      "sha256": "18cb9370815a5bd8002208fd8e51a53abee7eb056f3ae90fee9f276a4e4d909e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-artifact-transfer/0.11.0/maven-artifact-transfer-0.11.0.pom"
+    },
+    "org.apache.felix:felix-parent:pom:4": {
+      "layout": "org/apache/felix/felix-parent/4/felix-parent-4.pom",
+      "sha256": "5ccd30f2ce5ed53d3da191a23ecef59b15b0fd0e494a01aeeb4026441427e468",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/felix/felix-parent/4/felix-parent-4.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.2.0": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.2.0/maven-error-diagnostics-2.2.0.jar",
+      "sha256": "3b4b1e7037d2c5dd5be2d2300204317a8d9c26420ea3769bb80336514725bbd6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.0/maven-error-diagnostics-2.2.0.jar"
+    }
+  }
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,6 +48,18 @@
         "url": "https://github.com/input-output-hk/iohk-nix/archive/24ddc8f531f320c9e2394d205d0df39857222901.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "mvn2nix": {
+        "branch": "master",
+        "description": "Easily package your Maven Java application with the Nix package manager.",
+        "homepage": "",
+        "owner": "fzakaria",
+        "repo": "mvn2nix",
+        "rev": "a4c9ec1cd6118e22a6a5e5fc04c30c406d0d80ea",
+        "sha256": "1xf2i5cjpgsw42631mp9n20nj1rvw2swyhlqjxyrwydvk6vlf22p",
+        "type": "tarball",
+        "url": "https://github.com/fzakaria/mvn2nix/archive/a4c9ec1cd6118e22a6a5e5fc04c30c406d0d80ea.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "naersk": {
         "branch": "master",
         "builtin": false,
@@ -144,6 +156,18 @@
         "sha256": "18dpgyk5hrc6w3f9nwsb22k5ar9q5c8x40mszxzqmrdhkrymrykk",
         "type": "tarball",
         "url": "https://github.com/input-output-hk/stackage.nix/archive/e32c8b06d56954865725514ce0d98d5d1867e43a.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "thorp": {
+        "branch": "master",
+        "description": "Synchronisation of files with the cloud using the hash of the file contents",
+        "homepage": "https://github.com/kemitix/thorp",
+        "owner": "kemitix",
+        "repo": "thorp",
+        "rev": "42634f9c09664ff9d5981fbd1212fe3b9b419afc",
+        "sha256": "0bxh4b3kkpm5ls3v3329gd3zljzfph5315z8plvi2ac8y2y10bs6",
+        "type": "tarball",
+        "url": "https://github.com/kemitix/thorp/archive/42634f9c09664ff9d5981fbd1212fe3b9b419afc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR uses https://github.com/kemitix/thorp to sync the static content of the playgrounds with S3. This has two positive effects:
1. files were getting left in the buckets (david.marlowe had more than 1000 superfluous files)
2. it is _much_ faster to sync if not all files have changed. For example, a no-op sync of all files (including tutorials/haddock) took more than 10 mins with a decent internet connection, now it takes less than 20 seconds)
This may be the best value-for-money PR I have ever made 😄 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A dev.scripts.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
