### PR TITLE
Fix purty pre-commit

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -115,10 +115,10 @@
         "homepage": "",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d3c52b5fe6873f4cd8b0c518fc704bfaded5bf10",
-        "sha256": "0ysnc8pyhxxjxgfn2kcnn7zf3q233g0sia1ama1n4xf3d0ljjjya",
+        "rev": "431227b41d0aaa83fabdee6611e145b7d9bd150b",
+        "sha256": "0ff24n8i3mfw0jw5r5lsgvbahmh88zhi3qsk9yxrb8x82jprgzsy",
         "type": "tarball",
-        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/d3c52b5fe6873f4cd8b0c518fc704bfaded5bf10.tar.gz",
+        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/431227b41d0aaa83fabdee6611e145b7d9bd150b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "sphinxcontrib-haddock": {


### PR DESCRIPTION
This PR fixes **purty pre-commit invocation**: This switches to a fork of pre-commit-hooks.nix where purty works
correctly even when multiple files have been altered.

@krisajenkins had noticed that purty actually fails when multiple files are being specified. Unfortunately purty simply can't handle taking more than one file on the command line and the pre-commit-hooks machinery doesn't work around that by default. 



----
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
- [ ] Added link to upstream issue/PR to commit message
