### PR TITLE
Generalized the parsing machineries to work over any 'uni' and 'fun'

### DIFF
--- a/plutus-core/generators/Language/PlutusCore/Generators/AST.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/AST.hs
@@ -54,6 +54,9 @@ genVersion = Version () <$> int' <*> int' <*> int' where
 
 -- | Generate a fixed set of names which we will use, of only up to a short size to make it
 -- likely that we get reuse.
+-- We do not attempt not to generate reserved words such as @all@ or @abs@ as the classic syntax
+-- parsers (both PLC and PIR ones) can handle names of variables clashing with reserved words.
+-- In the readable syntax that would be troubling, though, but we don't have a parser for that anyway.
 genNames :: MonadGen m => m [Name]
 genNames = do
     let genUniq = Unique <$> Gen.int (Range.linear 0 100)

--- a/plutus-core/plutus-ir-test/OptimizerSpec.hs
+++ b/plutus-core/plutus-ir-test/OptimizerSpec.hs
@@ -9,6 +9,8 @@ import           Language.PlutusIR.Optimizer.DeadCode
 import           Language.PlutusIR.Parser
 import           Language.PlutusIR.Transform.Rename   ()
 
+import qualified Language.PlutusCore                  as PLC
+
 optimizer :: TestNested
 optimizer = testNested "optimizer" [
     deadCode
@@ -17,7 +19,7 @@ optimizer = testNested "optimizer" [
 deadCode :: TestNested
 deadCode =
     testNested "deadCode"
-    $ map (goldenPir removeDeadBindings term)
+    $ map (goldenPir removeDeadBindings $ term @PLC.DefaultUni @PLC.DefaultFun)
     [ "typeLet"
     , "termLet"
     , "strictLet"

--- a/plutus-core/plutus-ir-test/ParserSpec.hs
+++ b/plutus-core/plutus-ir-test/ParserSpec.hs
@@ -76,8 +76,10 @@ propRoundTrip = property $ do
 propIgnores :: Gen String -> Property
 propIgnores splice = property $ do
     (original, scrambled) <- forAll (genScrambledWith splice)
-    let parse1 = display @String <$> (parse program "test" $ T.pack original)
-        parse2 = display <$> (parse program "test" $ T.pack scrambled)
+    let displayProgram :: Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos -> String
+        displayProgram = display
+        parse1 = displayProgram <$> (parse program "test" $ T.pack original)
+        parse2 = displayProgram <$> (parse program "test" $ T.pack scrambled)
     parse1 === parse2
 
 parsing :: TestNested

--- a/plutus-core/plutus-ir-test/Spec.hs
+++ b/plutus-core/plutus-ir-test/Spec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -45,7 +46,7 @@ tests = testGroup "plutus-ir" <$> sequence
 
 prettyprinting :: TestNested
 prettyprinting = testNested "prettyprinting"
-    $ map (goldenPir id term)
+    $ map (goldenPir id $ term @PLC.DefaultUni @PLC.DefaultFun)
     [ "basic"
     , "maybe"
     ]

--- a/plutus-core/plutus-ir-test/TransformSpec.hs
+++ b/plutus-core/plutus-ir-test/TransformSpec.hs
@@ -29,21 +29,21 @@ transform = testNested "transform" [
 
 thunkRecursions :: TestNested
 thunkRecursions = testNested "thunkRecursions"
-    $ map (goldenPir ThunkRec.thunkRecursions term)
+    $ map (goldenPir ThunkRec.thunkRecursions $ term @PLC.DefaultUni @PLC.DefaultFun)
     [ "listFold"
     , "monoMap"
     ]
 
 nonStrict :: TestNested
 nonStrict = testNested "nonStrict"
-    $ map (goldenPir (runQuote . NonStrict.compileNonStrictBindings) term)
+    $ map (goldenPir (runQuote . NonStrict.compileNonStrictBindings) $ term @PLC.DefaultUni @PLC.DefaultFun)
     [ "nonStrict1"
     ]
 
 letFloat :: TestNested
 letFloat =
     testNested "letFloat"
-    $ map (goldenPir (LetFloat.floatTerm . runQuote . PLC.rename) term)
+    $ map (goldenPir (LetFloat.floatTerm . runQuote . PLC.rename) $ term @PLC.DefaultUni @PLC.DefaultFun)
   [ "letInLet"
   ,"listMatch"
   ,"maybe"
@@ -82,7 +82,7 @@ instance Monoid SourcePos where
 inline :: TestNested
 inline =
     testNested "inline"
-    $ map (goldenPir (Inline.inline . runQuote . PLC.rename) term)
+    $ map (goldenPir (Inline.inline . runQuote . PLC.rename) $ term @PLC.DefaultUni @PLC.DefaultFun)
     [ "var"
     , "builtin"
     , "constant"

--- a/plutus-core/src/Language/PlutusCore/Parsable.hs
+++ b/plutus-core/src/Language/PlutusCore/Parsable.hs
@@ -23,14 +23,14 @@ import           Data.Char       (ord)
 import qualified Data.Text       as T
 import           Text.Read       (readMaybe)
 
-
-class Parsable a
-  where
-  parseConstant :: T.Text -> Maybe a
-  -- ^ Return Nothing if the string is invalid, otherwise the corresponding value of type a.
-  default parseConstant :: Read a => T.Text -> Maybe a
-  parseConstant = readMaybe . T.unpack
-  -- ^ The default implmentation is 'read'
+-- | A class for things that are parsable. Those include tags for built-in types and constants of
+-- such types.
+class Parsable a where
+    parse :: T.Text -> Maybe a
+    -- ^ Return Nothing if the string is invalid, otherwise the corresponding value of type a.
+    default parse :: Read a => T.Text -> Maybe a
+    parse = readMaybe . T.unpack
+    -- ^ The default implementation is in terms of 'Read'.
 
 instance Parsable Bool
 instance Parsable Char
@@ -39,7 +39,7 @@ instance Parsable String
 instance Parsable ()
 
 instance Parsable ByteString
-  where parseConstant = parseByteStringConstant
+  where parse = parseByteStringConstant
 
 
 --- Parsing bytestrings ---
@@ -76,4 +76,3 @@ asBSLiteral s =
     mapM hexDigitToWord8 s >>= pairs      -- convert s into a list of pairs of Word8 values in [0..0xF]
     <&> map (\(a,b) -> shiftL a 4 .|. b)  -- convert pairs of values in [0..0xF] to values in [0..xFF]
     <&> BS.pack
-

--- a/plutus-core/src/Language/PlutusCore/Parser.y
+++ b/plutus-core/src/Language/PlutusCore/Parser.y
@@ -155,6 +155,9 @@ mapParseRun run = do
     liftQuote $ markNonFreshBelow u
     pure p
 
+-- Generalizing this and functions below to work over any @uni@ and @fun@ makes @happy@ unhappy and
+-- it starts throwing ambiguous type errors that I've no idea how to fix.
+-- See https://github.com/input-output-hk/plutus/pull/2458#issuecomment-725706274
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseProgram :: (AsParseError e AlexPosn, MonadError e m, MonadQuote m) => ByteString -> m (Program TyName Name DefaultUni DefaultFun AlexPosn)

--- a/plutus-core/src/Language/PlutusCore/Universe/Default.hs
+++ b/plutus-core/src/Language/PlutusCore/Universe/Default.hs
@@ -3,8 +3,10 @@
 {-# OPTIONS_GHC -fno-warn-orphans        #-}  -- The @Pretty ByteString@ instance.
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}  -- Appears in generated instances.
 
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -13,6 +15,7 @@ module Language.PlutusCore.Universe.Default
     ( DefaultUni (..)
     ) where
 
+import           Language.PlutusCore.Parsable
 import           Language.PlutusCore.Universe.Core
 
 import qualified Data.ByteString                   as BS
@@ -79,8 +82,17 @@ instance Show (DefaultUni a) where
     show DefaultUniUnit       = "unit"
     show DefaultUniBool       = "bool"
 
+instance Parsable (Some DefaultUni) where
+    parse "bool"       = Just $ Some DefaultUniBool
+    parse "bytestring" = Just $ Some DefaultUniByteString
+    parse "char"       = Just $ Some DefaultUniChar
+    parse "integer"    = Just $ Some DefaultUniInteger
+    parse "string"     = Just $ Some DefaultUniString
+    parse "unit"       = Just $ Some DefaultUniUnit
+    parse _            = Nothing
+
 instance DefaultUni `Includes` Integer         where knownUni = DefaultUniInteger
-instance DefaultUni `Includes` BS.ByteString  where knownUni = DefaultUniByteString
+instance DefaultUni `Includes` BS.ByteString   where knownUni = DefaultUniByteString
 instance a ~ Char => DefaultUni `Includes` [a] where knownUni = DefaultUniString
 instance DefaultUni `Includes` Char            where knownUni = DefaultUniChar
 instance DefaultUni `Includes` ()              where knownUni = DefaultUniUnit

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Parser.y
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Parser.y
@@ -121,6 +121,9 @@ mapParseRun run = do
     liftQuote $ markNonFreshBelow u
     pure p
 
+-- Generalizing this and functions below to work over any @uni@ and @fun@ makes @happy@ unhappy and
+-- it starts throwing ambiguous type errors that I've no idea how to fix.
+-- See https://github.com/input-output-hk/plutus/pull/2458#issuecomment-725706274
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseProgram :: (AsParseError e AlexPosn, MonadError e m, MonadQuote m) => ByteString -> m (Program Name DefaultUni DefaultFun AlexPosn)


### PR DESCRIPTION
The PLC parser is not updated fully due to me not getting along with `happy`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
