### PR TITLE
[Refac] 'CompiledCode' -> 'CompiledCodeIn'

### DIFF
--- a/doc/tutorials/BasicPolicies.hs
+++ b/doc/tutorials/BasicPolicies.hs
@@ -36,7 +36,7 @@ oneAtATimePolicy ctx =
 -- We can use 'compile' to turn a forging policy into a compiled Plutus Core program,
 -- just as for validator scripts. We also provide a 'wrapMonetaryPolicy' function
 -- to handle the boilerplate.
-oneAtATimeCompiled :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Data -> ())
+oneAtATimeCompiled :: CompiledCode (Data -> ())
 oneAtATimeCompiled = $$(compile [|| wrapMonetaryPolicy oneAtATimePolicy ||])
 -- BLOCK2
 singleSignerPolicy :: PolicyCtx -> Bool

--- a/doc/tutorials/BasicValidators.hs
+++ b/doc/tutorials/BasicValidators.hs
@@ -40,7 +40,7 @@ alwaysFails _ _ _ = error ()
 
 -- We can use 'compile' to turn a validator function into a compiled Plutus Core program.
 -- Here's a reminder of how to do it.
-alwaysSucceedsCompiled :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Data -> Data -> Data -> ())
+alwaysSucceedsCompiled :: CompiledCode (Data -> Data -> Data -> ())
 alwaysSucceedsCompiled = $$(compile [|| alwaysSucceeds ||])
 -- BLOCK3
 -- | Checks if a date is before the given end date.

--- a/doc/tutorials/PlutusTx.hs
+++ b/doc/tutorials/PlutusTx.hs
@@ -27,9 +27,9 @@ import           Language.PlutusTx.Prelude
 -- >>> import Data.Text.Prettyprint.Doc
 
 -- BLOCK2
-integerOne :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+integerOne :: CompiledCode Integer
 {- 'compile' turns the 'TExpQ Integer' into a
-  'TExpQ (CompiledCode PLC.DefaultUni PLC.DefaultFun Integer)' and the splice
+  'TExpQ (CompiledCode Integer)' and the splice
   inserts it into the program. -}
 integerOne = $$(compile
     {- The quote has type 'TExpQ Integer'.
@@ -44,7 +44,7 @@ integerOne = $$(compile
 )
 -}
 -- BLOCK3
-integerIdentity :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+integerIdentity :: CompiledCode (Integer -> Integer)
 integerIdentity = $$(compile [|| \(x:: Integer) -> x ||])
 
 {- |
@@ -78,7 +78,7 @@ myProgram =
         externalTwo = plusOne 1
     in localTwo `addInteger` externalTwo
 
-functions :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+functions :: CompiledCode Integer
 functions = $$(compile [|| myProgram ||])
 
 {- We’ve used the CK evaluator for Plutus Core to evaluate the program
@@ -88,7 +88,7 @@ functions = $$(compile [|| myProgram ||])
 (con 4)
 -}
 -- BLOCK5
-matchMaybe :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Maybe Integer -> Integer)
+matchMaybe :: CompiledCode (Maybe Integer -> Integer)
 matchMaybe = $$(compile [|| \(x:: Maybe Integer) -> case x of
     Just n  -> n
     Nothing -> 0
@@ -98,29 +98,29 @@ matchMaybe = $$(compile [|| \(x:: Maybe Integer) -> case x of
 data EndDate = Fixed Integer | Never
 
 -- | Check whether a given time is past the end date.
-pastEnd :: CompiledCode PLC.DefaultUni PLC.DefaultFun (EndDate -> Integer -> Bool)
+pastEnd :: CompiledCode (EndDate -> Integer -> Bool)
 pastEnd = $$(compile [|| \(end::EndDate) (current::Integer) -> case end of
     Fixed n -> n `lessThanEqInteger` current
     Never   -> False
   ||])
 -- BLOCK7
 -- | Check whether a given time is past the end date.
-pastEnd' :: CompiledCode PLC.DefaultUni PLC.DefaultFun (EndDate -> Integer -> Bool)
+pastEnd' :: CompiledCode (EndDate -> Integer -> Bool)
 pastEnd' = $$(compile [|| \(end::EndDate) (current::Integer) -> case end of
     Fixed n -> n < current
     Never   -> False
   ||])
 -- BLOCK8
-addOne :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+addOne :: CompiledCode (Integer -> Integer)
 addOne = $$(compile [|| \(x:: Integer) -> x `addInteger` 1 ||])
 -- BLOCK9
-addOneToN :: Integer -> CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+addOneToN :: Integer -> CompiledCode Integer
 addOneToN n =
     addOne
     -- 'applyCode' applies one 'CompiledCode' to another.
     `applyCode`
     -- 'liftCode' lifts the argument 'n' into a
-    -- 'CompiledCode PLC.DefaultUni PLC.DefaultFun Integer'.
+    -- 'CompiledCode Integer'.
     liftCode n
 
 {- |
@@ -165,7 +165,7 @@ addOneToN n =
 -- 'makeLift' generates instances of 'Lift' automatically.
 makeLift ''EndDate
 
-pastEndAt :: EndDate -> Integer -> CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+pastEndAt :: EndDate -> Integer -> CompiledCode Bool
 pastEndAt end current =
     pastEnd
     `applyCode`

--- a/doc/tutorials/plutus-tx.rst
+++ b/doc/tutorials/plutus-tx.rst
@@ -60,12 +60,12 @@ The Plutus Tx compiler compiles Haskell *expressions* (not values!), so
 naturally it takes a quote (representing an expression) as an argument.
 The result is a new quote, this time for a Haskell program that
 represents the *compiled* program. In Haskell, the type of :hsobj:`Language.PlutusTx.TH.compile`
-is ``TExpQ a → TExpQ (CompiledCode PLC.DefaultUni PLC.DefaultFun a)``. This is just
+is ``TExpQ a → TExpQ (CompiledCode a)``. This is just
 what we already said:
 
 -  ``TExpQ a`` is a quoted representing a program of type ``a``.
 
--  ``TExprQ (CompiledCode PLC.DefaultUni PLC.DefaultFun a)`` is quote representing a
+-  ``TExprQ (CompiledCode a)`` is quote representing a
    compiled Plutus Core program.
 
 .. note::
@@ -103,7 +103,7 @@ This simple program just evaluates to the integer ``1``.
    :end-before: BLOCK3
 
 We can see how the metaprogramming works: the Haskell program ``1``
-was turned into a ``CompiledCode PLC.DefaultUni PLC.DefaultFun Integer`` at compile
+was turned into a ``CompiledCode Integer`` at compile
 time, which we spliced into our Haskell program. We can inspect at runtime
 to see the generated Plutus Core (or to put it on the blockchain).
 

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -28,8 +28,6 @@ import qualified Language.Marlowe.Semantics            as Marlowe
 import           Language.Plutus.Contract
 import           Language.Plutus.Contract.StateMachine (AsSMContractError, StateMachine (..), Void)
 import qualified Language.Plutus.Contract.StateMachine as SM
-import qualified Language.PlutusCore.Builtins          as PLC
-import qualified Language.PlutusCore.Universe          as PLC
 import qualified Language.PlutusTx                     as PlutusTx
 import           Language.PlutusTx.AssocMap            (Map)
 import qualified Language.PlutusTx.AssocMap            as Map
@@ -254,7 +252,7 @@ mkValidator p = SM.mkValidator $ SM.mkStateMachine (mkMarloweStateMachineTransit
 
 mkMarloweValidatorCode
     :: MarloweParams
-    -> PlutusTx.CompiledCode PLC.DefaultUni PLC.DefaultFun (Scripts.ValidatorType MarloweStateMachine)
+    -> PlutusTx.CompiledCode (Scripts.ValidatorType MarloweStateMachine)
 mkMarloweValidatorCode params =
     $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode params
 

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -133,7 +133,7 @@ scriptSize (Script s) = UPLC.programSize s
 
 -- See Note [Normalized types in Scripts]
 -- | Turn a 'CompiledCode' (usually produced by 'compile') into a 'Script' for use with this package.
-fromCompiledCode :: CompiledCode PLC.DefaultUni PLC.DefaultFun a -> Script
+fromCompiledCode :: CompiledCode a -> Script
 fromCompiledCode = fromPlc . getPlc
 
 fromPlc :: UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun () -> Script
@@ -185,13 +185,13 @@ instance ToJSON Data where
 instance FromJSON Data where
     parseJSON = JSON.decodeSerialise
 
-mkValidatorScript :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Data -> Data -> Data -> ()) -> Validator
+mkValidatorScript :: CompiledCode (Data -> Data -> Data -> ()) -> Validator
 mkValidatorScript = Validator . fromCompiledCode
 
 unValidatorScript :: Validator -> Script
 unValidatorScript = getValidator
 
-mkMonetaryPolicyScript :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Data -> ()) -> MonetaryPolicy
+mkMonetaryPolicyScript :: CompiledCode (Data -> ()) -> MonetaryPolicy
 mkMonetaryPolicyScript = MonetaryPolicy . fromCompiledCode
 
 unMonetaryPolicyScript :: MonetaryPolicy -> Script

--- a/plutus-ledger/src/Ledger/Typed/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts.hs
@@ -27,8 +27,6 @@ module Ledger.Typed.Scripts(
     , Any
     ) where
 
-import qualified Language.PlutusCore             as PLC
-
 import           Language.PlutusTx
 
 import qualified Ledger.Address                  as Addr
@@ -54,9 +52,9 @@ data ScriptInstance (a :: Type) =
 
 -- | The 'ScriptInstance' of a validator script and its wrapper.
 validator ::
-    CompiledCode PLC.DefaultUni PLC.DefaultFun (ValidatorType a)
+    CompiledCode (ValidatorType a)
     -- ^ Validator script (compiled)
-    -> CompiledCode PLC.DefaultUni PLC.DefaultFun (ValidatorType a -> WrappedValidatorType)
+    -> CompiledCode (ValidatorType a -> WrappedValidatorType)
     -- ^ A wrapper for the compiled validator
     -> ScriptInstance a
 validator vc wrapper =

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -208,7 +208,7 @@ pubkeyHashOnChainAndOffChain :: Property
 pubkeyHashOnChainAndOffChain = property $ do
     pk <- forAll $ PubKey . LedgerBytes <$> Gen.genSizedByteString 32 -- this won't generate a valid public key but that doesn't matter for the purposes of pubKeyHash
     let offChainHash = Crypto.pubKeyHash pk
-        onchainProg :: CompiledCode PLC.DefaultUni PLC.DefaultFun (PubKey -> PubKeyHash -> ())
+        onchainProg :: CompiledCode (PubKey -> PubKeyHash -> ())
         onchainProg = $$(PlutusTx.compile [|| \pk expected -> if (expected PlutusTx.== Validation.pubKeyHash pk) then PlutusTx.trace "correct" () else PlutusTx.traceError "not correct" ||])
         script = Scripts.fromCompiledCode $ onchainProg `applyCode` (liftCode pk) `applyCode` (liftCode offChainHash)
         result = runExcept $ evaluateScript script

--- a/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
@@ -123,7 +123,7 @@ pluginPass opts guts = do
 Working out what to process and where to put it is tricky. We are going to turn the result in
 to a 'CompiledCode', not the Haskell expression we started with!
 
-Currently we look for calls to the 'plc :: a -> CompiledCode' function, and we replace the whole application with the
+Currently we look for calls to the @plc :: a -> CompiledCode a@ function, and we replace the whole application with the
 generated code object, which will still be well-typed.
 -}
 
@@ -247,7 +247,7 @@ compileMarkedExprs opts markerName =
       e@(GHC.Type _) -> pure e
 
 -- Helper to avoid doing too much construction of Core ourselves
-mkCompiledCode :: forall a . BS.ByteString -> BS.ByteString -> CompiledCode PLC.DefaultUni PLC.DefaultFun a
+mkCompiledCode :: forall a . BS.ByteString -> BS.ByteString -> CompiledCode a
 mkCompiledCode plcBS pirBS = SerializedCode plcBS (Just pirBS)
 
 -- | Actually invokes the Core to PLC compiler to compile an expression into a PLC literal.
@@ -275,12 +275,9 @@ compileCoreExpr (opts, famEnvs) locStr codeTy origE = do
             in if poDeferErrors opts
             -- this will blow up at runtime
             then do
-                defUni <- GHC.lookupTyCon =<< thNameToGhcNameOrFail ''PLC.DefaultUni
-                defFun <- GHC.lookupTyCon =<< thNameToGhcNameOrFail ''()
                 tcName <- thNameToGhcNameOrFail ''CompiledCode
                 tc <- GHC.lookupTyCon tcName
-                let args = [GHC.mkTyConTy defUni, GHC.mkTyConTy defFun, codeTy]
-                pure $ GHC.mkRuntimeErrorApp GHC.rUNTIME_ERROR_ID (GHC.mkTyConApp tc args) shown
+                pure $ GHC.mkRuntimeErrorApp GHC.rUNTIME_ERROR_ID (GHC.mkTyConApp tc [codeTy]) shown
             -- this will actually terminate compilation
             else failCompilation shown
         Right (pirP, uplcP) -> do

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -27,10 +27,10 @@ import           Codec.Serialise              (Serialise)
 import           Data.Text.Prettyprint.Doc
 
 instance (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun) =>
-            ToUPlc (CompiledCode uni fun a) uni fun where
+            ToUPlc (CompiledCodeIn uni fun a) uni fun where
     toUPlc = catchAll . getPlc
 
 goldenPir
     :: (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Serialise, Pretty fun, Serialise fun)
-    => String -> CompiledCode uni fun a -> TestNested
+    => String -> CompiledCodeIn uni fun a -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ pretty $ getPir value

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -33,15 +33,15 @@ basic = testNested "Basic" [
   , goldenUEval "ifOptEval" [ifOpt]
   ]
 
-monoId :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+monoId :: CompiledCode (Integer -> Integer)
 monoId = plc (Proxy @"monoId") (\(x :: Integer) -> x)
 
-monoK :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Integer)
+monoK :: CompiledCode (Integer -> Integer -> Integer)
 monoK = plc (Proxy @"monoK") (\(i :: Integer) -> \(j :: Integer) -> i)
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let
-letFun :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Bool)
+letFun :: CompiledCode (Integer -> Integer -> Bool)
 letFun = plc (Proxy @"letFun") (\(x::Integer) (y::Integer) -> let f z = Builtins.equalsInteger x z in f y)
 
-ifOpt :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+ifOpt :: CompiledCode Integer
 ifOpt = plc (Proxy @"ifOpt") (if ((1 `Builtins.divideInteger` 0) `Builtins.equalsInteger` 0) then 1 else 1)

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -51,56 +51,56 @@ monoData = testNested "monomorphic" [
 
 data MyEnum = Enum1 | Enum2
 
-basicEnum :: CompiledCode PLC.DefaultUni PLC.DefaultFun MyEnum
+basicEnum :: CompiledCode MyEnum
 basicEnum = plc (Proxy @"basicEnum") Enum1
 
 data MyMonoData = Mono1 Integer Integer | Mono2 Integer | Mono3 Integer
     deriving (Show, Eq)
 
-monoDataType :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoData -> MyMonoData)
+monoDataType :: CompiledCode (MyMonoData -> MyMonoData)
 monoDataType = plc (Proxy @"monoDataType") (\(x :: MyMonoData) -> x)
 
-monoConstructor :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> MyMonoData)
+monoConstructor :: CompiledCode (Integer -> Integer -> MyMonoData)
 monoConstructor = plc (Proxy @"monConstructor") Mono1
 
-monoConstructed :: CompiledCode PLC.DefaultUni PLC.DefaultFun MyMonoData
+monoConstructed :: CompiledCode MyMonoData
 monoConstructed = plc (Proxy @"monoConstructed") (Mono2 1)
 
-monoCase :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoData -> Integer)
+monoCase :: CompiledCode (MyMonoData -> Integer)
 monoCase = plc (Proxy @"monoCase") (\(x :: MyMonoData) -> case x of { Mono1 _ b -> b;  Mono2 a -> a; Mono3 a -> a })
 
-defaultCase :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoData -> Integer)
+defaultCase :: CompiledCode (MyMonoData -> Integer)
 defaultCase = plc (Proxy @"defaultCase") (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
 
-irrefutableMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoData -> Integer)
+irrefutableMatch :: CompiledCode (MyMonoData -> Integer)
 irrefutableMatch = plc (Proxy @"irrefutableMatch") (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
 
-atPattern :: CompiledCode PLC.DefaultUni PLC.DefaultFun ((Integer, Integer) -> Integer)
+atPattern :: CompiledCode ((Integer, Integer) -> Integer)
 atPattern = plc (Proxy @"atPattern") (\t@(x::Integer, y::Integer) -> let fst (a, b) = a in Builtins.addInteger y (fst t))
 
 data MyMonoRecord = MyMonoRecord { mrA :: Integer , mrB :: Integer}
     deriving (Show, Eq)
 
-monoRecord :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoRecord -> MyMonoRecord)
+monoRecord :: CompiledCode (MyMonoRecord -> MyMonoRecord)
 monoRecord = plc (Proxy @"monoRecord") (\(x :: MyMonoRecord) -> x)
 
 data RecordNewtype = RecordNewtype { newtypeField :: MyNewtype }
 
-recordNewtype :: CompiledCode PLC.DefaultUni PLC.DefaultFun (RecordNewtype -> RecordNewtype)
+recordNewtype :: CompiledCode (RecordNewtype -> RecordNewtype)
 recordNewtype = plc (Proxy @"recordNewtype") (\(x :: RecordNewtype) -> x)
 
 -- must be compiled with a lazy case
-nonValueCase :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyEnum -> Integer)
+nonValueCase :: CompiledCode (MyEnum -> Integer)
 nonValueCase = plc (Proxy @"nonValueCase") (\(x :: MyEnum) -> case x of { Enum1 -> 1::Integer ; Enum2 -> Builtins.error (); })
 
 data StrictPattern a = StrictPattern !a !a
 
-strictPattern :: CompiledCode PLC.DefaultUni PLC.DefaultFun (StrictPattern Integer)
+strictPattern :: CompiledCode (StrictPattern Integer)
 strictPattern = plc (Proxy @"strictPattern") (StrictPattern 1 2)
 
 type Synonym = Integer
 
-synonym :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+synonym :: CompiledCode Integer
 synonym = plc (Proxy @"synonym") (1::Synonym)
 
 polyData :: TestNested
@@ -112,13 +112,13 @@ polyData = testNested "polymorphic" [
 
 data MyPolyData a b = Poly1 a b | Poly2 a
 
-polyDataType :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyPolyData Integer Integer -> MyPolyData Integer Integer)
+polyDataType :: CompiledCode (MyPolyData Integer Integer -> MyPolyData Integer Integer)
 polyDataType = plc (Proxy @"polyDataType") (\(x:: MyPolyData Integer Integer) -> x)
 
-polyConstructed :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyPolyData Integer Integer)
+polyConstructed :: CompiledCode (MyPolyData Integer Integer)
 polyConstructed = plc (Proxy @"polyConstructed") (Poly1 (1::Integer) (2::Integer))
 
-defaultCasePoly :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyPolyData Integer Integer -> Integer)
+defaultCasePoly :: CompiledCode (MyPolyData Integer Integer -> Integer)
 defaultCasePoly = plc (Proxy @"defaultCasePoly") (\(x :: MyPolyData Integer Integer) -> case x of { Poly1 a _ -> a ; _ -> 2; })
 
 newtypes :: TestNested
@@ -138,27 +138,27 @@ newtype MyNewtype = MyNewtype Integer
 
 newtype MyNewtype2 = MyNewtype2 MyNewtype
 
-basicNewtype :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyNewtype -> MyNewtype)
+basicNewtype :: CompiledCode (MyNewtype -> MyNewtype)
 basicNewtype = plc (Proxy @"basicNewtype") (\(x::MyNewtype) -> x)
 
-newtypeMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyNewtype -> Integer)
+newtypeMatch :: CompiledCode (MyNewtype -> Integer)
 newtypeMatch = plc (Proxy @"newtypeMatch") (\(MyNewtype x) -> x)
 
-newtypeCreate :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> MyNewtype)
+newtypeCreate :: CompiledCode (Integer -> MyNewtype)
 newtypeCreate = plc (Proxy @"newtypeCreate") (\(x::Integer) -> MyNewtype x)
 
-newtypeId :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyNewtype -> MyNewtype)
+newtypeId :: CompiledCode (MyNewtype -> MyNewtype)
 newtypeId = plc (Proxy @"newtypeId") (\(MyNewtype x) -> MyNewtype x)
 
-newtypeCreate2 :: CompiledCode PLC.DefaultUni PLC.DefaultFun MyNewtype
+newtypeCreate2 :: CompiledCode MyNewtype
 newtypeCreate2 = plc (Proxy @"newtypeCreate2") (MyNewtype 1)
 
-nestedNewtypeMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyNewtype2 -> Integer)
+nestedNewtypeMatch :: CompiledCode (MyNewtype2 -> Integer)
 nestedNewtypeMatch = plc (Proxy @"nestedNewtypeMatch") (\(MyNewtype2 (MyNewtype x)) -> x)
 
 newtype ParamNewtype a = ParamNewtype (Maybe a)
 
-paramNewtype :: CompiledCode PLC.DefaultUni PLC.DefaultFun (ParamNewtype Integer -> ParamNewtype Integer)
+paramNewtype :: CompiledCode (ParamNewtype Integer -> ParamNewtype Integer)
 paramNewtype = plc (Proxy @"paramNewtype") (\(x ::ParamNewtype Integer) -> x)
 
 recursiveTypes :: TestNested
@@ -178,32 +178,32 @@ recursiveTypes = testNested "recursive" [
     , goldenUPlc "sameEmptyRose" sameEmptyRose
   ]
 
-listConstruct :: CompiledCode PLC.DefaultUni PLC.DefaultFun [Integer]
+listConstruct :: CompiledCode [Integer]
 listConstruct = plc (Proxy @"listConstruct") ([]::[Integer])
 
 -- This will generate code using 'build' if we're on greater than -O0. That's not optimal for
 -- us, since we don't have any rewrite rules to fire, but it's fine and we can handle it.
-listConstruct2 :: CompiledCode PLC.DefaultUni PLC.DefaultFun [Integer]
+listConstruct2 :: CompiledCode [Integer]
 listConstruct2 = plc (Proxy @"listConstruct2") ([1]::[Integer])
 
 -- It is very difficult to get GHC to make a non-polymorphic redex if you use
 -- list literal syntax with integers. But this works.
-listConstruct3 :: CompiledCode PLC.DefaultUni PLC.DefaultFun [Integer]
+listConstruct3 :: CompiledCode [Integer]
 listConstruct3 = plc (Proxy @"listConstruct3") ((1::Integer):(2::Integer):(3::Integer):[])
 
-listMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun ([Integer] -> Integer)
+listMatch :: CompiledCode ([Integer] -> Integer)
 listMatch = plc (Proxy @"listMatch") (\(l::[Integer]) -> case l of { (x:_) -> x ; [] -> 0; })
 
 data B a = One a | Two (B (a, a))
 
-ptreeConstruct :: CompiledCode PLC.DefaultUni PLC.DefaultFun (B Integer)
+ptreeConstruct :: CompiledCode (B Integer)
 ptreeConstruct = plc (Proxy @"ptreeConstruct") (Two (Two (One ((1,2),(3,4)))) :: B Integer)
 
 -- TODO: replace this with 'first' when we have working recursive functions
-ptreeMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun (B Integer -> Integer)
+ptreeMatch :: CompiledCode (B Integer -> Integer)
 ptreeMatch = plc (Proxy @"ptreeMatch") (\(t::B Integer) -> case t of { One a -> a; Two _ -> 2; })
 
-polyRec :: CompiledCode PLC.DefaultUni PLC.DefaultFun (B Integer -> Integer)
+polyRec :: CompiledCode (B Integer -> Integer)
 polyRec = plc (Proxy @"polyRec") (
     let
         depth :: B a -> Integer
@@ -212,7 +212,7 @@ polyRec = plc (Proxy @"polyRec") (
             Two inner -> Builtins.addInteger 1 (depth inner)
     in \(t::B Integer) -> depth t)
 
-ptreeFirst :: CompiledCode PLC.DefaultUni PLC.DefaultFun (B Integer -> Integer)
+ptreeFirst :: CompiledCode (B Integer -> Integer)
 ptreeFirst = plc (Proxy @"ptreeFirst") (
     let go :: (a -> Integer) -> B a -> Integer
         go k (One x) = k x
@@ -221,10 +221,10 @@ ptreeFirst = plc (Proxy @"ptreeFirst") (
 
 data EmptyRose = EmptyRose [EmptyRose]
 
-emptyRoseConstruct :: CompiledCode PLC.DefaultUni PLC.DefaultFun EmptyRose
+emptyRoseConstruct :: CompiledCode EmptyRose
 emptyRoseConstruct = plc (Proxy @"emptyRoseConstruct") (EmptyRose [EmptyRose [], EmptyRose []])
 
-sameEmptyRose :: CompiledCode PLC.DefaultUni PLC.DefaultFun (EmptyRose -> EmptyRose)
+sameEmptyRose :: CompiledCode (EmptyRose -> EmptyRose)
 sameEmptyRose = plc (Proxy @"sameEmptyRose") (
     -- The type signatures are needed due to a bug (see 'emptyRoseNewId')
     let (.|) :: ([EmptyRose] -> [EmptyRose]) -> (EmptyRose -> [EmptyRose]) -> EmptyRose -> [EmptyRose]
@@ -251,13 +251,13 @@ typeFamilies = testNested "families" [
 type family BasicClosed a where
     BasicClosed Bool = Integer
 
-basicClosed :: CompiledCode PLC.DefaultUni PLC.DefaultFun (BasicClosed Bool -> BasicClosed Bool)
+basicClosed :: CompiledCode (BasicClosed Bool -> BasicClosed Bool)
 basicClosed = plc (Proxy @"basicClosed") (\(x :: BasicClosed Bool) -> x)
 
 type family BasicOpen a
 type instance BasicOpen Bool = Integer
 
-basicOpen :: CompiledCode PLC.DefaultUni PLC.DefaultFun (BasicOpen Bool -> BasicOpen Bool)
+basicOpen :: CompiledCode (BasicOpen Bool -> BasicOpen Bool)
 basicOpen = plc (Proxy @"basicOpen") (\(x :: BasicOpen Bool) -> x)
 
 class Associated a where
@@ -271,7 +271,7 @@ data Param a = Param a
 instance Associated (Param a) where
     type instance AType (Param a) = a
 
-associated :: CompiledCode PLC.DefaultUni PLC.DefaultFun (AType Bool -> AType Bool)
+associated :: CompiledCode (AType Bool -> AType Bool)
 associated = plc (Proxy @"associated") (\(x :: AType Bool) -> x)
 
 -- Despite the type family being applied to a parameterized type we can still reduce it
@@ -279,7 +279,7 @@ associated = plc (Proxy @"associated") (\(x :: AType Bool) -> x)
 paramId :: forall a . Param a -> AType (Param a) -> AType (Param a)
 paramId _ x = x
 
-associatedParam :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+associatedParam :: CompiledCode Integer
 associatedParam = plc (Proxy @"associatedParam") (paramId (Param 1) 1)
 
 -- Here we cannot reduce the type family
@@ -287,11 +287,11 @@ associatedParam = plc (Proxy @"associatedParam") (paramId (Param 1) 1)
 tfId :: forall a . a -> BasicClosed a -> BasicClosed a
 tfId _ x = x
 
-irreducible :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+irreducible :: CompiledCode Integer
 irreducible = plc (Proxy @"irreducible") (tfId True 1)
 
 data family BasicData a
 data instance BasicData Bool = Inst Integer
 
-basicData :: CompiledCode PLC.DefaultUni PLC.DefaultFun (BasicData Bool -> Integer)
+basicData :: CompiledCode (BasicData Bool -> Integer)
 basicData = plc (Proxy @"basicData") (\(x :: BasicData Bool) -> let Inst i = x in i)

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -43,18 +43,18 @@ errors = testNested "Errors" [
     , goldenUPlcCatch "literalCaseOther" literalCaseOther
   ]
 
-machInt :: CompiledCode PLC.DefaultUni PLC.DefaultFun Int
+machInt :: CompiledCode Int
 machInt = plc (Proxy @"machInt") (1::Int)
 
-negativeInt :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+negativeInt :: CompiledCode Integer
 negativeInt = plc (Proxy @"negativeInt") (-1 :: Integer)
 
-caseInt :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Bool)
+caseInt :: CompiledCode (Integer -> Bool)
 caseInt = plc (Proxy @"caseInt") (\(i::Integer) -> case i of { S# i -> True; _ -> False; } )
 
 newtype RecursiveNewtype = RecursiveNewtype [RecursiveNewtype]
 
-recursiveNewtype :: CompiledCode PLC.DefaultUni PLC.DefaultFun (RecursiveNewtype)
+recursiveNewtype :: CompiledCode (RecursiveNewtype)
 recursiveNewtype = plc (Proxy @"recursiveNewtype") (RecursiveNewtype [])
 
 {-# INLINABLE evenDirectLocal #-}
@@ -66,13 +66,13 @@ oddDirectLocal :: Integer -> Bool
 oddDirectLocal n = if Builtins.equalsInteger n 0 then False else evenDirectLocal (Builtins.subtractInteger n 1)
 
 -- FIXME: these seem to only get unfoldings when they're in a separate module, even with the simplifier pass
-mutualRecursionUnfoldingsLocal :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+mutualRecursionUnfoldingsLocal :: CompiledCode Bool
 mutualRecursionUnfoldingsLocal = plc (Proxy @"mutualRecursionUnfoldingsLocal") (evenDirectLocal 4)
 
-literalCaseInt :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+literalCaseInt :: CompiledCode (Integer -> Integer)
 literalCaseInt = plc (Proxy @"literalCaseInt") (\case { 1 -> 2; x -> x})
 
-literalCaseBs :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString)
+literalCaseBs :: CompiledCode (Builtins.ByteString -> Builtins.ByteString)
 literalCaseBs = plc (Proxy @"literalCaseBs") (\x -> case x of { "abc" -> ""; x -> x})
 
 data AType = AType
@@ -85,5 +85,5 @@ instance Eq AType where
 
 -- Unfortunately, this actually succeeds, since the match gets turned into an equality and we can actually inline it.
 -- I'm leaving it here since I'd really prefer it were an error for consistency, but I'm not sure how to do that nicely.
-literalCaseOther :: CompiledCode PLC.DefaultUni PLC.DefaultFun (AType -> AType)
+literalCaseOther :: CompiledCode (AType -> AType)
 literalCaseOther = plc (Proxy @"literalCaseOther") (\x -> case x of { "abc" -> ""; x -> x})

--- a/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
@@ -39,7 +39,7 @@ recursiveFunctions = testNested "recursive" [
     , goldenUEval "even4" [ toUPlc evenMutual, toUPlc $ plc (Proxy @"4") (4::Integer) ]
   ]
 
-fib :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+fib :: CompiledCode (Integer -> Integer)
 -- not using case to avoid literal cases
 fib = plc (Proxy @"fib") (
     let fib :: Integer -> Integer
@@ -50,14 +50,14 @@ fib = plc (Proxy @"fib") (
             else Builtins.addInteger (fib(Builtins.subtractInteger n 1)) (fib(Builtins.subtractInteger n 2))
     in fib)
 
-sumDirect :: CompiledCode PLC.DefaultUni PLC.DefaultFun ([Integer] -> Integer)
+sumDirect :: CompiledCode ([Integer] -> Integer)
 sumDirect = plc (Proxy @"sumDirect") (
     let sum :: [Integer] -> Integer
         sum []     = 0
         sum (x:xs) = Builtins.addInteger x (sum xs)
     in sum)
 
-evenMutual :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Bool)
+evenMutual :: CompiledCode (Integer -> Bool)
 evenMutual = plc (Proxy @"evenMutual") (
     let even :: Integer -> Bool
         even n = if Builtins.equalsInteger n 0 then True else odd (Builtins.subtractInteger n 1)
@@ -87,13 +87,13 @@ andDirect = \(a :: Bool) -> \(b::Bool) -> nandDirect (nandDirect a b) (nandDirec
 nandDirect :: Bool -> Bool -> Bool
 nandDirect = \(a :: Bool) -> \(b::Bool) -> if a then False else if b then False else True
 
-nandPlcDirect :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+nandPlcDirect :: CompiledCode Bool
 nandPlcDirect = plc (Proxy @"nandPlcDirect") (nandDirect True False)
 
-andPlcDirect :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+andPlcDirect :: CompiledCode Bool
 andPlcDirect = plc (Proxy @"andPlcDirect") (andDirect True False)
 
-andPlcExternal :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+andPlcExternal :: CompiledCode Bool
 andPlcExternal = plc (Proxy @"andPlcExternal") (andExternal True False)
 
 -- self-recursion
@@ -102,16 +102,16 @@ allDirect p l = case l of
     []  -> True
     h:t -> andDirect (p h) (allDirect p t)
 
-allPlcDirect :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+allPlcDirect :: CompiledCode Bool
 allPlcDirect = plc (Proxy @"andPlcDirect") (allDirect (\(x::Integer) -> Builtins.greaterThanInteger x 5) [7, 6])
 
-mutualRecursionUnfoldings :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+mutualRecursionUnfoldings :: CompiledCode Bool
 mutualRecursionUnfoldings = plc (Proxy @"mutualRecursionUnfoldings") (evenDirect 4)
 
-recordSelector :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyMonoRecord -> Integer)
+recordSelector :: CompiledCode (MyMonoRecord -> Integer)
 recordSelector = plc (Proxy @"recordSelector") (\(x :: MyMonoRecord) -> mrA x)
 
-recordSelectorExternal :: CompiledCode PLC.DefaultUni PLC.DefaultFun (MyExternalRecord -> Integer)
+recordSelectorExternal :: CompiledCode (MyExternalRecord -> Integer)
 recordSelectorExternal = plc (Proxy @"recordSelectorExternal") (\(x :: MyExternalRecord) -> myExternal x)
 
 mapDirect :: (a -> b) -> [a] -> [b]
@@ -119,11 +119,11 @@ mapDirect f l = case l of
     []   -> []
     x:xs -> f x : mapDirect f xs
 
-polyMap :: CompiledCode PLC.DefaultUni PLC.DefaultFun ([Integer])
+polyMap :: CompiledCode ([Integer])
 polyMap = plc (Proxy @"polyMap") (mapDirect (Builtins.addInteger 1) [0, 1])
 
 myDollar :: (a -> b) -> a -> b
 myDollar f a = f a
 
-applicationFunction :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer)
+applicationFunction :: CompiledCode (Integer)
 applicationFunction = plc (Proxy @"applicationFunction") ((\x -> Builtins.addInteger 1 x) `myDollar` 1)

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -27,7 +27,7 @@ laziness = testNested "Laziness" [
     , goldenPir "lazyDepUnit" lazyDepUnit
   ]
 
-joinErrorPir :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Bool -> Bool -> ())
+joinErrorPir :: CompiledCode (Bool -> Bool -> ())
 joinErrorPir = plc (Proxy @"joinError") joinError
 
 {-# NOINLINE monoId #-}
@@ -39,5 +39,5 @@ monoId x = x
 aByteString :: Builtins.ByteString
 aByteString = monoId Builtins.emptyByteString
 
-lazyDepUnit :: CompiledCode PLC.DefaultUni PLC.DefaultFun Builtins.ByteString
+lazyDepUnit :: CompiledCode Builtins.ByteString
 lazyDepUnit = plc (Proxy @"lazyDepUnit") aByteString

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -58,75 +58,75 @@ primitives = testNested "Primitives" [
   , goldenPir "stringConvert" stringConvert
   ]
 
-string :: CompiledCode PLC.DefaultUni PLC.DefaultFun String
+string :: CompiledCode String
 string = plc (Proxy @"string") "test"
 
-int :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+int :: CompiledCode Integer
 int = plc (Proxy @"int") (1::Integer)
 
-int2 :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+int2 :: CompiledCode Integer
 int2 = plc (Proxy @"int2") (2::Integer)
 
-emptyBS :: CompiledCode PLC.DefaultUni PLC.DefaultFun Builtins.ByteString
+emptyBS :: CompiledCode Builtins.ByteString
 emptyBS = plc (Proxy @"emptyBS") Builtins.emptyByteString
 
-bool :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+bool :: CompiledCode Bool
 bool = plc (Proxy @"bool") True
 
-andPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Bool -> Bool -> Bool)
+andPlc :: CompiledCode (Bool -> Bool -> Bool)
 andPlc = plc (Proxy @"andPlc") (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else False)
 
-tuple :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer, Integer)
+tuple :: CompiledCode (Integer, Integer)
 tuple = plc (Proxy @"tuple") (1::Integer, 2::Integer)
 
-tupleMatch :: CompiledCode PLC.DefaultUni PLC.DefaultFun ((Integer, Integer) -> Integer)
+tupleMatch :: CompiledCode ((Integer, Integer) -> Integer)
 tupleMatch = plc (Proxy @"tupleMatch") (\(x:: (Integer, Integer)) -> let (a, b) = x in a)
 
-intCompare :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Bool)
+intCompare :: CompiledCode (Integer -> Integer -> Bool)
 intCompare = plc (Proxy @"intCompare") (\(x::Integer) (y::Integer) -> Builtins.lessThanInteger x y)
 
-intEq :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Bool)
+intEq :: CompiledCode (Integer -> Integer -> Bool)
 intEq = plc (Proxy @"intEq") (\(x::Integer) (y::Integer) -> Builtins.equalsInteger x y)
 
 -- Has a Void in it
-void :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Bool)
+void :: CompiledCode (Integer -> Integer -> Bool)
 void = plc (Proxy @"void") (\(x::Integer) (y::Integer) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in Builtins.equalsInteger x y `a` Builtins.equalsInteger y x)
 
-intPlus :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Integer)
+intPlus :: CompiledCode (Integer -> Integer -> Integer)
 intPlus = plc (Proxy @"intPlus") (\(x::Integer) (y::Integer) -> Builtins.addInteger x y)
 
-intDiv :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Integer)
+intDiv :: CompiledCode (Integer -> Integer -> Integer)
 intDiv = plc (Proxy @"intDiv") (\(x::Integer) (y::Integer) -> Builtins.divideInteger x y)
 
-errorPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun (() -> Integer)
+errorPlc :: CompiledCode (() -> Integer)
 errorPlc = plc (Proxy @"errorPlc") (Builtins.error @Integer)
 
-ifThenElse :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Integer)
+ifThenElse :: CompiledCode (Integer -> Integer -> Integer)
 ifThenElse = plc (Proxy @"ifThenElse") (\(x::Integer) (y::Integer) -> if Builtins.equalsInteger x y then x else y)
 
-emptyByteString :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString)
+emptyByteString :: CompiledCode (Builtins.ByteString -> Builtins.ByteString)
 emptyByteString = plc (Proxy @"emptyByteString") (\(x :: Builtins.ByteString) -> x)
 
-bytestring :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString)
+bytestring :: CompiledCode (Builtins.ByteString -> Builtins.ByteString)
 bytestring = plc (Proxy @"bytestring") (\(x::Builtins.ByteString) -> x)
 
-sha2 :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString)
+sha2 :: CompiledCode (Builtins.ByteString -> Builtins.ByteString)
 sha2 = plc (Proxy @"sha2") (\(x :: Builtins.ByteString) -> Builtins.sha2_256 x)
 
-bsEquals :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString -> Bool)
+bsEquals :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Bool)
 bsEquals = plc (Proxy @"bs32Equals") (\(x :: Builtins.ByteString) (y :: Builtins.ByteString) -> Builtins.equalsByteString x y)
 
-bsLt :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString -> Bool)
+bsLt :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Bool)
 bsLt = plc (Proxy @"bsLt") (\(x :: Builtins.ByteString) (y :: Builtins.ByteString) -> Builtins.lessThanByteString x y)
 
-verify :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.ByteString -> Builtins.ByteString -> Builtins.ByteString -> Bool)
+verify :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Builtins.ByteString -> Bool)
 verify = plc (Proxy @"verify") (\(x::Builtins.ByteString) (y::Builtins.ByteString) (z::Builtins.ByteString) -> Builtins.verifySignature x y z)
 
-trace :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.String -> ())
+trace :: CompiledCode (Builtins.String -> ())
 trace = plc (Proxy @"trace") (\(x :: Builtins.String) -> Builtins.trace x)
 
-stringLiteral :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.String)
+stringLiteral :: CompiledCode (Builtins.String)
 stringLiteral = plc (Proxy @"stringLiteral") ("abc"::Builtins.String)
 
-stringConvert :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Builtins.String)
+stringConvert :: CompiledCode (Builtins.String)
 stringConvert = plc (Proxy @"stringConvert") ((noinline P.stringToBuiltinString) "abc")

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -45,10 +45,10 @@ instance (Sized a, Sized b) => Sized (a, b) where
     {-# INLINABLE size #-}
     size (a, b) = size a `Builtins.addInteger` size b
 
-sizedBasic :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+sizedBasic :: CompiledCode (Integer -> Integer)
 sizedBasic = plc (Proxy @"sizedBasic") (\(a::Integer) -> size a)
 
-sizedPair :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Integer)
+sizedPair :: CompiledCode (Integer -> Integer -> Integer)
 sizedPair = plc (Proxy @"sizedPair") (\(a::Integer) (b::Integer) -> size (a, b))
 
 -- This has multiple methods, so will have to be passed as a dictionary
@@ -72,7 +72,7 @@ instance PersonLike Alien where
     likesAnimal AlienJane Dog = True
     likesAnimal _ _           = False
 
-multiFunction :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Person -> Bool)
+multiFunction :: CompiledCode (Person -> Bool)
 multiFunction = plc (Proxy @"multiFunction") (
     let
         {-# NOINLINE predicate #-}
@@ -80,7 +80,7 @@ multiFunction = plc (Proxy @"multiFunction") (
         predicate p = likesAnimal p Cat P.&& (age p `Builtins.greaterThanInteger` 30)
     in \(p::Person) -> predicate p)
 
-defaultMethods :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+defaultMethods :: CompiledCode (Integer -> Integer)
 defaultMethods = plc (Proxy @"defaultMethods") (
     let
         {-# NOINLINE f #-}
@@ -88,10 +88,10 @@ defaultMethods = plc (Proxy @"defaultMethods") (
         f a = method2 a
     in \(a::Integer) -> f a)
 
-partialApplication :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer -> Ordering)
+partialApplication :: CompiledCode (Integer -> Integer -> Ordering)
 partialApplication = plc (Proxy @"partialApplication") (P.compare @Integer)
 
-sequenceTest :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Maybe [Integer])
+sequenceTest :: CompiledCode (Maybe [Integer])
 sequenceTest = plc (Proxy @"sequenceTests") (P.sequence [Just (1 :: Integer), Just (2 :: Integer)])
 
 opCompare :: P.Ord a => a -> a -> Ordering
@@ -100,5 +100,5 @@ opCompare a b = case P.compare a b of
     EQ -> EQ
     GT -> LT
 
-compareTest :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Ordering)
+compareTest :: CompiledCode (Ordering)
 compareTest = plc (Proxy @"compareTest") (opCompare (1::Integer) (2::Integer))

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -35,7 +35,7 @@ import qualified Language.PlutusCore.Universe as PLC
 
 import           Data.Proxy
 
-roundPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Ratio.Rational -> Integer)
+roundPlc :: CompiledCode (Ratio.Rational -> Integer)
 roundPlc = plc (Proxy @"roundPlc") Ratio.round
 
 tests :: TestNested
@@ -116,5 +116,5 @@ genData =
             , List <$> genList genData
             ]
 
-errorTrace :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer)
+errorTrace :: CompiledCode (Integer)
 errorTrace = plc (Proxy @"errorTrace") (PlutusTx.traceError "")

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -79,29 +79,29 @@ tests = testNested "TH" [
     , nestedGoldenVsDoc "someData" (pretty $ show someData)
   ]
 
-simple :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Bool -> Integer)
+simple :: CompiledCode (Bool -> Integer)
 simple = $$(compile [|| \(x::Bool) -> if x then (1::Integer) else (2::Integer) ||])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
-powerPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun (Integer -> Integer)
+powerPlc :: CompiledCode (Integer -> Integer)
 powerPlc = $$(compile [|| $$(power (4::Integer)) ||])
 
-andPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+andPlc :: CompiledCode Bool
 andPlc = $$(compile [|| $$(andTH) True False ||])
 
-allPlc :: CompiledCode PLC.DefaultUni PLC.DefaultFun Bool
+allPlc :: CompiledCode Bool
 allPlc = $$(compile [|| all (\(x::Integer) -> x > 5) [7, 6] ||])
 
-convertString :: CompiledCode PLC.DefaultUni PLC.DefaultFun Builtins.String
+convertString :: CompiledCode Builtins.String
 convertString = $$(compile [|| "test" ||])
 
-traceDirect :: CompiledCode PLC.DefaultUni PLC.DefaultFun ()
+traceDirect :: CompiledCode ()
 traceDirect = $$(compile [|| Builtins.trace "test" ||])
 
-tracePrelude :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+tracePrelude :: CompiledCode Integer
 tracePrelude = $$(compile [|| trace "test" (1::Integer) ||])
 
-traceRepeatedly :: CompiledCode PLC.DefaultUni PLC.DefaultFun Integer
+traceRepeatedly :: CompiledCode Integer
 traceRepeatedly = $$(compile
      [||
                let i1 = trace "Making my first int" (1::Integer)

--- a/plutus-tx/src/Language/PlutusTx.hs
+++ b/plutus-tx/src/Language/PlutusTx.hs
@@ -1,6 +1,7 @@
 module Language.PlutusTx (
     module Export,
     CompiledCode,
+    CompiledCodeIn,
     getPlc,
     getPir,
     applyCode,
@@ -14,7 +15,7 @@ module Language.PlutusTx (
     safeLiftCode,
     liftCode) where
 
-import           Language.PlutusTx.Code       (CompiledCode, applyCode, getPir, getPlc)
+import           Language.PlutusTx.Code       (CompiledCode, CompiledCodeIn, applyCode, getPir, getPlc)
 import           Language.PlutusTx.Data       (Data (..))
 import           Language.PlutusTx.IsData     (IsData (..), makeIsData, makeIsDataIndexed)
 import           Language.PlutusTx.Lift       (liftCode, makeLift, safeLiftCode)

--- a/plutus-tx/src/Language/PlutusTx/Code.hs
+++ b/plutus-tx/src/Language/PlutusTx/Code.hs
@@ -25,26 +25,29 @@ import qualified Data.ByteString.Lazy             as BSL
 -- NOTE: any changes to this type must be paralleled by changes
 -- in the plugin code that generates values of this type. That is
 -- done by code generation so it's not typechecked normally.
--- | A compiled Plutus Tx program. The type parameter indicates
+-- | A compiled Plutus Tx program. The last type parameter indicates
 -- the type of the Haskell expression that was compiled, and
 -- hence the type of the compiled code.
 --
 -- Note: the compiled PLC program does *not* have normalized types,
 -- if you want to put it on the chain you must normalize the types first.
-data CompiledCode uni fun a =
+data CompiledCodeIn uni fun a =
     -- | Serialized UPLC code and possibly serialized PIR code.
     SerializedCode BS.ByteString (Maybe BS.ByteString)
     -- | Deserialized UPLC program and possibly deserialized PIR program.
     | DeserializedCode (UPLC.Program PLC.Name uni fun ()) (Maybe (PIR.Program PLC.TyName PLC.Name uni fun ()))
 
+-- | 'CompiledCodeIn' instantiated with default built-in types and functions.
+type CompiledCode = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun
+
 -- | Apply a compiled function to a compiled argument.
 applyCode
     :: (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun)
-    => CompiledCode uni fun (a -> b) -> CompiledCode uni fun a -> CompiledCode uni fun b
+    => CompiledCodeIn uni fun (a -> b) -> CompiledCodeIn uni fun a -> CompiledCodeIn uni fun b
 applyCode fun arg = DeserializedCode (getPlc fun `UPLC.applyProgram` getPlc arg) Nothing
 
--- | The size of a 'CompiledCode', in AST nodes.
-sizePlc :: (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun) => CompiledCode uni fun a -> Integer
+-- | The size of a 'CompiledCodeIn', in AST nodes.
+sizePlc :: (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun) => CompiledCodeIn uni fun a -> Integer
 sizePlc = UPLC.programSize . getPlc
 
 {- Note [Deserializing the AST]
@@ -57,20 +60,20 @@ instance Show ImpossibleDeserialisationFailure where
     show (ImpossibleDeserialisationFailure e) = "Failed to deserialise our own program! This is a bug, please report it. Caused by: " ++ show e
 instance Exception ImpossibleDeserialisationFailure
 
--- | Get the actual Plutus Core program out of a 'CompiledCode'.
+-- | Get the actual Plutus Core program out of a 'CompiledCodeIn'.
 getPlc
     :: (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun)
-    => CompiledCode uni fun a -> UPLC.Program PLC.Name uni fun ()
+    => CompiledCodeIn uni fun a -> UPLC.Program PLC.Name uni fun ()
 getPlc wrapper = case wrapper of
     SerializedCode plc _ -> case deserialiseOrFail (BSL.fromStrict plc) of
         Left e  -> throw $ ImpossibleDeserialisationFailure e
         Right p -> p
     DeserializedCode plc _ -> plc
 
--- | Get the Plutus IR program, if there is one, out of a 'CompiledCode'.
+-- | Get the Plutus IR program, if there is one, out of a 'CompiledCodeIn'.
 getPir
     :: (PLC.Closed uni, uni `PLC.Everywhere` Serialise, Serialise fun)
-    => CompiledCode uni fun a -> Maybe (PIR.Program PIR.TyName PIR.Name uni fun ())
+    => CompiledCodeIn uni fun a -> Maybe (PIR.Program PIR.TyName PIR.Name uni fun ())
 getPir wrapper = case wrapper of
     SerializedCode _ pir -> case pir of
         Just bs -> case deserialiseOrFail (BSL.fromStrict bs) of

--- a/plutus-tx/src/Language/PlutusTx/Lift.hs
+++ b/plutus-tx/src/Language/PlutusTx/Lift.hs
@@ -85,7 +85,7 @@ safeLiftCode
        , AsError e uni fun (Provenance ()), MonadError e m, MonadQuote m
        , PLC.ToBuiltinMeaning uni fun
        )
-    => a -> m (CompiledCode uni fun a)
+    => a -> m (CompiledCodeIn uni fun a)
 safeLiftCode x = DeserializedCode <$> safeLiftProgram x <*> pure Nothing
 
 unsafely
@@ -115,10 +115,10 @@ liftProgramDef
     => a -> UPLC.Program Name PLC.DefaultUni PLC.DefaultFun ()
 liftProgramDef = liftProgram
 
--- | Get a Plutus Core program corresponding to the given value as a 'CompiledCode', throwing any errors that occur as exceptions and ignoring fresh names.
+-- | Get a Plutus Core program corresponding to the given value as a 'CompiledCodeIn', throwing any errors that occur as exceptions and ignoring fresh names.
 liftCode
     :: (Lift.Lift uni a, Throwable uni fun, PLC.ToBuiltinMeaning uni fun)
-    => a -> CompiledCode uni fun a
+    => a -> CompiledCodeIn uni fun a
 liftCode x = unsafely $ safeLiftCode x
 
 {- Note [Checking the type of a term with Typeable]
@@ -165,7 +165,7 @@ typeCheckAgainst p plcTerm = do
     let plcPrismatic = first (view (re PIR._PLCError)) plcConcrete
     liftEither plcPrismatic -- embed prismatic-either to a monaderror
 
--- | Try to interpret a PLC program as a 'CompiledCode' of the given type. Returns successfully iff the program has the right type.
+-- | Try to interpret a PLC program as a 'CompiledCodeIn' of the given type. Returns successfully iff the program has the right type.
 typeCode
     :: forall e a uni fun m .
        ( Lift.Typeable uni a
@@ -178,7 +178,7 @@ typeCode
        )
     => Proxy a
     -> PLC.Program PLC.TyName PLC.Name uni fun ()
-    -> m (CompiledCode uni fun a)
+    -> m (CompiledCodeIn uni fun a)
 typeCode p prog@(PLC.Program _ _ term) = do
     _ <- typeCheckAgainst p term
     pure $ DeserializedCode (UPLC.eraseProgram prog) Nothing

--- a/plutus-tx/src/Language/PlutusTx/Plugin/Utils.hs
+++ b/plutus-tx/src/Language/PlutusTx/Plugin/Utils.hs
@@ -11,9 +11,6 @@ import           GHC.TypeLits
 import           Language.PlutusTx.Code
 import           Language.PlutusTx.Utils
 
-import qualified Language.PlutusCore.Builtins as PLC
-import qualified Language.PlutusCore.Universe as PLC
-
 {- Note [plc and Proxy]
 It would be nice to use TypeApplications instead of passing a Proxy to plc.
 However, this means we need to create a type application in the TH-generated code which calls it.
@@ -28,6 +25,6 @@ a Proxy to avoid this.
 -- If we inline this then we won't be able to find it later!
 {-# NOINLINE plc #-}
 -- | Marks the given expression for compilation to PLC.
-plc :: forall (loc::Symbol) a . Proxy loc -> a -> CompiledCode PLC.DefaultUni PLC.DefaultFun a
+plc :: forall (loc::Symbol) a . Proxy loc -> a -> CompiledCode a
 -- this constructor is only really there to get rid of the unused warning
 plc _ _ = SerializedCode (mustBeReplaced "plc") (mustBeReplaced "pir")

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -9,15 +9,12 @@ import           Data.Proxy
 import           Language.PlutusTx.Code
 import           Language.PlutusTx.Plugin.Utils
 
-import qualified Language.PlutusCore.Builtins   as PLC
-import qualified Language.PlutusCore.Universe   as PLC
-
 import qualified Language.Haskell.TH            as TH
 import qualified Language.Haskell.TH.Syntax     as TH
 
 
 -- | Compile a quoted Haskell expression into a corresponding Plutus Core program.
-compile :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp (CompiledCode PLC.DefaultUni PLC.DefaultFun a))
+compile :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp (CompiledCode a))
 -- See note [Typed TH]
 compile e = TH.unsafeTExpCoerce $ compileUntyped $ TH.unType <$> e
 
@@ -26,11 +23,11 @@ It's nice to use typed TH! However, we sadly can't *quite* use it thoroughly, be
 want to make a type literal, and there's no way to do that properly with typed TH.
 
 Moreover, we really want to create an expression with the precise form that we want,
-so we can't isolate the badness much. So we pretty much just have to use unsafeTExpCoerce
+so we can't isolate the badness much. So we pretty much just have to use 'unsafeTExpCoerce'
 and assert that we know what we're doing.
 
 This isn't so bad, since our plc function accepts an argument of any type, so that's always
-going to typecheck, and the result is always a CompiledCode, so that's also fine.
+going to typecheck, and the result is always a 'CompiledCode', so that's also fine.
 -}
 
 -- | Compile a quoted Haskell expression into a corresponding Plutus Core program.

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -50,9 +50,6 @@ import qualified Language.Plutus.Contract.StateMachine as SM
 import qualified Language.PlutusTx                     as PlutusTx
 import           Language.PlutusTx.Prelude             hiding (Applicative (..))
 
-import qualified Language.PlutusCore.Builtins          as PLC
-import qualified Language.PlutusCore.Universe          as PLC
-
 --   $multisig
 --   The n-out-of-m multisig contract works like a joint account of
 --   m people, requiring the consent of n people for any payments.
@@ -233,7 +230,7 @@ transition params State{ stateData =s, stateValue=currentValue} i = case (s, i) 
 mkValidator :: Params -> Scripts.ValidatorType MultiSigSym
 mkValidator p = SM.mkValidator $ SM.mkStateMachine (transition p) (const False)
 
-validatorCode :: Params -> PlutusTx.CompiledCode PLC.DefaultUni PLC.DefaultFun (Scripts.ValidatorType MultiSigSym)
+validatorCode :: Params -> PlutusTx.CompiledCode (Scripts.ValidatorType MultiSigSym)
 validatorCode params = $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode params
 
 type MultiSigSym = StateMachine MSState Input

--- a/plutus-use-cases/test/Spec/Lib.hs
+++ b/plutus-use-cases/test/Spec/Lib.hs
@@ -6,7 +6,7 @@ module Spec.Lib
     , timesFeeAdjustV
     ) where
 
-import           Control.Monad.IO.Class       (MonadIO (liftIO))
+import           Control.Monad.IO.Class    (MonadIO (liftIO))
 import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
@@ -15,14 +15,12 @@ import           Data.Maybe
 import           Data.String
 import           Data.Text.Prettyprint.Doc
 
-import qualified Language.PlutusCore.Builtins as PLC
-import qualified Language.PlutusCore.Universe as PLC
 import           Language.PlutusTx
-import qualified Language.PlutusTx.Prelude    as P
-import           Ledger                       (Validator)
+import qualified Language.PlutusTx.Prelude as P
+import           Ledger                    (Validator)
 import qualified Ledger
-import qualified Ledger.Ada                   as Ada
-import           Ledger.Value                 (Value)
+import qualified Ledger.Ada                as Ada
+import           Ledger.Value              (Value)
 
 -- | Assert that the size of a 'Validator' is below
 --   the maximum.
@@ -34,7 +32,7 @@ reasonable (Ledger.unValidatorScript -> s) maxSize = do
     liftIO $ putStrLn ("Script size: " ++ show sz)
     assertBool msg (sz <= maxSize)
 
-goldenPir :: FilePath -> CompiledCode PLC.DefaultUni PLC.DefaultFun a -> TestTree
+goldenPir :: FilePath -> CompiledCode a -> TestTree
 goldenPir path code = goldenVsString "PIR" path (pure $ fromString $ show $ pretty $ fromJust $ getPir code)
 
 staticFee :: Integer


### PR DESCRIPTION
Now `CompiledCode` is named `CompiledCodeIn` and I added

```haskell
type CompiledCode = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun
```

as per discussion that we had in the extensible built-in functions PR.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
