### PR TITLE
Add a nixos vm test for webghc

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,9 +75,8 @@ rec {
     inherit set-git-rev haskell webCommon;
   };
 
-  tests = import ./nix/tests/default.nix {
-    inherit pkgs iohkNix;
-    inherit (plutus) stylish-haskell purty;
+  tests = import ./nix/tests {
+    inherit pkgs iohkNix haskell plutus;
     src = ./.;
   };
 

--- a/nix/tests/vm-tests/web-ghc/default.nix
+++ b/nix/tests/vm-tests/web-ghc/default.nix
@@ -1,0 +1,31 @@
+{ pkgs, web-ghc }:
+
+let
+  webghcPort = 8080;
+  webghcHealthEndpoint = "http://localhost:${toString webghcPort}/health";
+  webghcCompileEndpoint = "http://localhost:${toString webghcPort}/runghc";
+  webghcVersionEndpoint = "http://localhost:${toString webghcPort}/version";
+in
+
+pkgs.nixosTest {
+
+  machine = { pkgs, ... }: {
+    nixpkgs.overlays = [ (self: super: { inherit web-ghc; }) ];
+    imports = [ ./module.nix ];
+    services.web-ghc = {
+      enable = true;
+      port = webghcPort;
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    # fmt: off
+    machine.start()
+    machine.wait_for_unit("web-ghc.service")
+    machine.wait_for_open_port(${toString webghcPort})
+    machine.wait_until_succeeds("curl -q ${webghcHealthEndpoint}")
+    machine.wait_until_succeeds("curl -q ${webghcVersionEndpoint}")
+    machine.wait_until_succeeds("curl -q --header \"Content-Type: application/json\" --data '{\"code\": \"main = return ()\", \"implicitPrelude\": true}' ${webghcCompileEndpoint} | grep 'Right'")
+    machine.wait_until_succeeds("curl -q --header \"Content-Type: application/json\" --data '{\"code\": \"Kartoffelsalat\", \"implicitPrelude\": true}' ${webghcCompileEndpoint} | grep 'Left'")
+  '';
+}

--- a/nix/tests/vm-tests/web-ghc/module.nix
+++ b/nix/tests/vm-tests/web-ghc/module.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, config, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types mkIf;
+  cfg = config.services.web-ghc;
+in
+{
+  options.services.web-ghc = {
+    enable = mkEnableOption "web-ghc";
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = ''
+        Port web-ghc should bind to.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.web-ghc = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.web-ghc}/bin/web-ghc-server webserver -p ${toString cfg.port}";
+      };
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -27,9 +27,11 @@ lib.fix (jobsets: ciJobsets // {
     name = "plutus-required-checks";
 
     constituents =
-      # Misc tests
-      (allJobs [ "linux" "tests" ] jobsets)
-        ++ (allJobs [ "darwin" "tests" ] jobsets)
+      # Linting and VM Tests
+      (allJobs [ "linux" "tests" "lintingTests" ] jobsets)
+        ++ (allJobs [ "linux" "tests" "vmTests" ] jobsets)
+        ++ (allJobs [ "darwin" "tests" "lintingTests" ] jobsets)
+        ++ (allJobs [ "darwin" "tests" "vmTests" ] jobsets)
         # Haskell tests
         ++ (allJobs [ "linux" "haskell" ] jobsets)
         ++ (allJobs [ "darwin" "haskell" ] jobsets)


### PR DESCRIPTION
This adds a nixos vm test for web-ghc in nix/tests/vm-tests/web-ghc

- group tests into `lintingTests` and `vmTests`
- pass `plutus` to tests/default.nix to get access to web-ghc
- Tests that the configured port is open, tests version, health and
  compile endpoint of web-ghc

**Note 1**: Maybe web-ghc isn't the most essential piece of software but i wanted to pick something with a small scope to start with and showcase how tests are written. For now you can have a look at https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests for more info
**Note 2**: I should probably add some notes on running and debugging this test, maybe a README in the vm-tests folder or so
**Note 3**: @shmish111 i added you since you wrote web-ghc, let me know if you can think of something that i should add as a test


----

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
