### PR TITLE
Kwxm/fix flat erasure plc command

### DIFF
--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -23,17 +23,15 @@ import           Language.PlutusCore.Builtins
 import qualified Language.PlutusCore.Pretty   as PLC
 import           Language.PlutusCore.Universe
 import qualified Language.PlutusTx            as Tx
-import           Language.PlutusTx.Builtins   (divideInteger, remainderInteger)
+import           Language.PlutusTx.Builtins   (divideInteger, modInteger)
 import           Language.PlutusTx.Prelude    as Tx hiding (divMod, even)
+import           Language.PlutusTx.Ratio      (divMod)
 import           Language.UntypedPlutusCore
 
 ---------------- Extras ----------------
 
 even :: Integer -> Bool
-even n = (n `remainderInteger` 2) == 0
-
-divMod :: Integer -> Integer -> (Integer, Integer)
-divMod a b = (a `divideInteger` b, a `remainderInteger` b)
+even n = (n `modInteger` 2) == 0
 
 ---------------- IntLib ----------------
 
@@ -67,11 +65,11 @@ powerMod :: Integer -> Integer -> Integer -> Integer
 powerMod a b m =
     if b == 0 then 1
     else f a' (b-1) a'
-        where a' = a `remainderInteger` m
+        where a' = a `modInteger` m
               f a b c = if b == 0 then c
                         else g a b where
-                             g a b | even b = g ((a*a) `remainderInteger` m) (b `divideInteger` 2)
-                                   | otherwise = f a (b-1) ((a*c) `remainderInteger` m)
+                             g a b | even b = g ((a*a) `modInteger` m) (b `divideInteger` 2)
+                                   | otherwise = f a (b-1) ((a*c) `modInteger` m)
 
 {- The value $@y@=@cubeRoot x@$ is the integer cube root of @x@, {\it
    i.e.} $@y@ = \lfloor \sqrt[3]{@x@} \, \rfloor$. Given $@x@\geq 0$,
@@ -161,7 +159,7 @@ singleTestX n (k, q) x
          witness (t:ts) = if t == (n-1) then True
                           else if t == 1 then False
                                else witness ts
-         square x       = (x*x) `remainderInteger` n
+         square x       = (x*x) `modInteger` n
 
 -- The function @singleTest@ takes an odd, positive, @Integer@ @n@ and a
 -- pair of @Integer@'s derived from @n@ by the @findKQ@ function
@@ -218,10 +216,10 @@ boundedRandom n r = (makeNumber 65536 (uniform ns rs), r')
 -- in the range @0..ns@ from the random numbers @rs@.
 {-# INLINABLE uniform #-}
 uniform :: [Integer] -> [Integer] -> [Integer]
-uniform [n]    [r]    = [r `remainderInteger` n]
+uniform [n]    [r]    = [r `modInteger` n]
 uniform (n:ns) (r:rs) = if t == n then t: uniform ns rs
-                                  else t: map ((`remainderInteger` 65536). toInteger) rs
-                        where t  = toInteger r `remainderInteger` (n+1)
+                                  else t: map ((`modInteger` 65536). toInteger) rs
+                        where t  = toInteger r `modInteger` (n+1)
 
 
 ---------------- Main ----------------

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -19,7 +19,7 @@ import           GHC.Generics
 import qualified Prelude                      (Eq (..), String)
 
 import           Language.PlutusCore          (Name (..))
-import           Language.PlutusCore.Builtins
+import           Language.PlutusCore.Builtins (DefaultFun)
 import qualified Language.PlutusCore.Pretty   as PLC
 import           Language.PlutusCore.Universe
 import qualified Language.PlutusTx            as Tx

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -598,7 +598,7 @@ runErase (EraseOptions inp ifmt outp ofmt mode) = do
   case ofmt of
     Plc           -> writePlc outp mode untypedProg
     Cbor cborMode -> writeCBOR outp cborMode untypedProg
-    Flat flatMode -> writeCBOR outp flatMode untypedProg
+    Flat flatMode -> writeFlat outp flatMode untypedProg
 
 
 ---------------- Evaluation ----------------

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
@@ -183,6 +183,8 @@ builtinNames = [
     , 'Builtins.subtractInteger
     , 'Builtins.multiplyInteger
     , 'Builtins.divideInteger
+    , 'Builtins.modInteger
+    , 'Builtins.quotientInteger
     , 'Builtins.remainderInteger
     , 'Builtins.greaterThanInteger
     , 'Builtins.greaterThanEqInteger
@@ -288,6 +290,12 @@ defineBuiltinTerms = do
     do
         let term = mkBuiltin PLC.DivideInteger
         defineBuiltinTerm 'Builtins.divideInteger term [int]
+    do
+        let term = mkBuiltin PLC.ModInteger
+        defineBuiltinTerm 'Builtins.modInteger term [int]
+    do
+        let term = mkBuiltin PLC.QuotientInteger
+        defineBuiltinTerm 'Builtins.quotientInteger term [int]
     do
         let term = mkBuiltin PLC.RemainderInteger
         defineBuiltinTerm 'Builtins.remainderInteger term [int]

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -46,6 +46,7 @@ tests =
     , testRatioProperty "truncate" Ratio.truncate truncate
     , testRatioProperty "abs" (fmap Ratio.toGHC Ratio.abs) abs
     , pure $ testProperty "ord" testOrd
+    , pure $ testProperty "divMod" testDivMod
     , pure $ testProperty "quotRem" testQuotRem
     , pure $ testProperty "reduce" testReduce
     , pure $ testProperty "Eq @Data" eqData
@@ -57,6 +58,16 @@ testRatioProperty nm plutusFunc ghcFunc = pure $ testProperty nm $ Hedgehog.prop
     rat <- Hedgehog.forAll $ Gen.realFrac_ (Range.linearFrac (-10000) 100000)
     let ghcResult = ghcFunc rat
         plutusResult = plutusFunc $ Ratio.fromGHC rat
+    Hedgehog.annotateShow ghcResult
+    Hedgehog.annotateShow plutusResult
+    Hedgehog.assert (ghcResult == plutusResult)
+
+testDivMod :: Property
+testDivMod = Hedgehog.property $ do
+    let gen = Gen.integral (Range.linear (-10000) 100000)
+    (n1, n2) <- Hedgehog.forAll $ (,) <$> gen <*> gen
+    let ghcResult = divMod n1 n2
+        plutusResult = Ratio.divMod n1 n2
     Hedgehog.annotateShow ghcResult
     Hedgehog.annotateShow plutusResult
     Hedgehog.assert (ghcResult == plutusResult)

--- a/plutus-tx/src/Language/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/Language/PlutusTx/Builtins.hs
@@ -23,6 +23,8 @@ module Language.PlutusTx.Builtins (
                                 , subtractInteger
                                 , multiplyInteger
                                 , divideInteger
+                                , modInteger
+                                , quotientInteger
                                 , remainderInteger
                                 , greaterThanInteger
                                 , greaterThanEqInteger
@@ -129,6 +131,16 @@ multiplyInteger = (*)
 -- | Divide two integers.
 divideInteger :: Integer -> Integer -> Integer
 divideInteger = div
+
+{-# NOINLINE modInteger #-}
+-- | Integer modulo operation.
+modInteger :: Integer -> Integer -> Integer
+modInteger = mod
+
+{-# NOINLINE quotientInteger #-}
+-- | Quotient of two integers.
+quotientInteger :: Integer -> Integer -> Integer
+quotientInteger = quot
 
 {-# NOINLINE remainderInteger #-}
 -- | Take the remainder of dividing two 'Integer's.

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -29,6 +29,8 @@ module Language.PlutusTx.Prelude (
     module Bool,
     -- * Int operators
     divide,
+    modulo,
+    quotient,
     remainder,
     -- * Tuples
     fst,
@@ -133,19 +135,38 @@ traceIfTrue :: Builtins.String -> Bool -> Bool
 traceIfTrue str a = if a then trace str True else False
 
 {-# INLINABLE divide #-}
--- | Integer division
+-- | Integer division, rounding downwards
 --
---   >>> divide 3 2
---   1
+--   >>> divide (-41) 5
+--   -9
 --
 divide :: Integer -> Integer -> Integer
 divide = Builtins.divideInteger
 
-{-# INLINABLE remainder #-}
--- | Remainder (of integer division)
+{-# INLINABLE modulo #-}
+-- | Integer remainder, always positive for a positive divisor
 --
---   >>> remainder 3 2
---   1
+--   >>> modulo (-41) 5
+--   4
+--
+modulo :: Integer -> Integer -> Integer
+modulo = Builtins.modInteger
+
+{-# INLINABLE quotient #-}
+-- | Integer division, rouding towards zero
+--
+--   >>> quotient (-41) 5
+--   -8
+--
+
+quotient :: Integer -> Integer -> Integer
+quotient = Builtins.quotientInteger
+
+{-# INLINABLE remainder #-}
+-- | Integer remainder, same sign as dividend
+--
+--   >>> remainder (-41) 5
+--   -1
 --
 remainder :: Integer -> Integer -> Integer
 remainder = Builtins.remainderInteger

--- a/plutus-tx/src/Language/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/Language/PlutusTx/Ratio.hs
@@ -90,14 +90,13 @@ Plutus Core provides built-in functions 'divideInteger', 'modInteger',
 'quotientInteger' and 'remainderInteger' which are implemented as the Haskell
 functions 'div', 'mod', 'quot', and 'rem' respectively.
 
-
 The operations 'div' and 'mod' go together, as do 'quot' and 'rem': * DO NOT use
 'div' with 'rem' or 'quot' with 'mod' *.  For most purposes users shoud probably use
 'div' and 'mod': see below for details.
 
 For any integers a and b with b nonzero we have
 
-  a * (a  `div` b  + a `mod` b = a
+  a * (a  `div` b) + a `mod` b = a
   a * (a `quot` b) + a `rem` b = a
 
 (all operations give a "divide by zero" error if b = 0).
@@ -106,7 +105,8 @@ For positive divisors b, div truncates downwards and mod always returns a
 non-negative result (0 <= a `mod` b <= b-1), which is consistent with standard
 mathematical practice.  The `quot` operation truncates towards zero and `rem`
 will give a negative remainder if a<0 and b>0.  If a<0 and b<0 then `mod` willl
-also yield a negative result.
+also yield a negative result.  Results for different combinations of signs are
+shown below.
 
 -------------------------------
 |   n  d | div mod | quot rem |
@@ -135,9 +135,10 @@ We get a positive remainder in all cases (which is desirable), but note for
 instance that the pairs (41,5) and (-41,-5) give different results, which might
 be unexpected.
 
-See Raymond T. Boute, "The Euclidean definition of the functions div and mod",
-ACM Transactions on Programming Languages and Systems, April 1992.
-(PDF at https://core.ac.uk/download/pdf/187613369.pdf)
+For a discussion of the pros and cons of various versions of integer division,
+see Raymond T. Boute, "The Euclidean definition of the functions div and mod",
+ACM Transactions on Programming Languages and Systems, April 1992.  (PDF at
+https://core.ac.uk/download/pdf/187613369.pdf)
 -}
 
 

--- a/plutus-tx/src/Language/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/Language/PlutusTx/Ratio.hs
@@ -91,15 +91,17 @@ Plutus Core provides built-in functions 'divideInteger', 'modInteger',
 functions 'div', 'mod', 'quot', and 'rem' respectively.
 
 The operations 'div' and 'mod' go together, as do 'quot' and 'rem': * DO NOT use
-'div' with 'rem' or 'quot' with 'mod' *.  For most purposes users shoud probably use
-'div' and 'mod': see below for details.
+'div' with 'rem' or 'quot' with 'mod' *.  For most purposes users shoud probably
+use 'div' and 'mod': see below for details.
 
 For any integers a and b with b nonzero we have
 
   a * (a  `div` b) + a `mod` b = a
   a * (a `quot` b) + a `rem` b = a
 
-(all operations give a "divide by zero" error if b = 0).
+(all operations give a "divide by zero" error if b = 0).  The analagous
+identities for div/rem and quot/mod don't hold in general, and this can
+lead to problems if you use the wrong combination of operations.
 
 For positive divisors b, div truncates downwards and mod always returns a
 non-negative result (0 <= a `mod` b <= b-1), which is consistent with standard
@@ -117,10 +119,15 @@ shown below.
 | -41 -5 |  8  -1  |   8  -1  |
 -------------------------------
 
+For many purposes (in particular if you're doing modular arithmetic),
+a positive remainder is what you want.  Using 'div' and 'mod' achieves
+this for positive values of b (but not for b negative, although doing
+artimetic modulo a negative number would be unusual).
+
 There is another possibility (Euclidean division) which is arguably more
-mathematically correct than both of these. Given integers a and b with b != 0,
-this returns numbers q and r with a = q*b+r and 0 <= r < |b|.  For the numbers
-above this gives
+mathematically correct than both div/mod and quot/rem. Given integers a and b
+with b != 0, this returns numbers q and r with a = q*b+r and 0 <= r < |b|.  For
+the numbers above this gives
 
 -------------------
 |   n  d |  q   r |
@@ -131,9 +138,8 @@ above this gives
 | -41 -5 |  9   4 |
 -------------------
 
-We get a positive remainder in all cases (which is desirable), but note for
-instance that the pairs (41,5) and (-41,-5) give different results, which might
-be unexpected.
+We get a positive remainder in all cases, but note for instance that the pairs
+(41,5) and (-41,-5) give different results, which might be unexpected.
 
 For a discussion of the pros and cons of various versions of integer division,
 see Raymond T. Boute, "The Euclidean definition of the functions div and mod",


### PR DESCRIPTION
This fixes a problem with the output format for the `plc erase` command pointed out by @raduom: asking to output Flat actually output CBOR.  It's a one-word change so I'll probably just merge it without review.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
