### PR TITLE
Fix erasure output format bug

### DIFF
--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -598,7 +598,7 @@ runErase (EraseOptions inp ifmt outp ofmt mode) = do
   case ofmt of
     Plc           -> writePlc outp mode untypedProg
     Cbor cborMode -> writeCBOR outp cborMode untypedProg
-    Flat flatMode -> writeCBOR outp flatMode untypedProg
+    Flat flatMode -> writeFlat outp flatMode untypedProg
 
 
 ---------------- Evaluation ----------------


### PR DESCRIPTION
This fixes a problem with the output format for the plc erase command pointed out by @raduom: asking to output erased code in Flat format actually output CBOR. It's a one-word change so I'll probably just merge it without review.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
