### PR TITLE
SCP-1471: Marlowe Playground: dont show save, save as and rename in the home page

### DIFF
--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -36,7 +36,7 @@ Whenever you change any of these files you should run `$(nix-build -A dev.script
 The code is formatted using [purty](https://gitlab.com/joneshf/purty), and there is a CI task that will fail if the code is not properly formatted. You can apply purty to the project by calling:
 
 ```bash
-$(nix-build -A dev.scripts.fixPurty)/bin/fix-purty
+nix-shell shell.nix --run fix-purty
 ```
 
 ## VSCode notes

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -168,13 +168,15 @@ modal state = case state ^. _showModal of
 menuBar :: forall p. State -> HTML p Action
 menuBar state =
   div [ classes [ ClassName "menu-bar" ] ]
-    [ menuButton (OpenModal NewProject) "New Project"
-    , gistModal (OpenModal OpenProject) "Open"
-    , menuButton (OpenModal OpenDemo) "Open Example"
-    , menuButton (OpenModal RenameProject) "Rename"
-    , gistModal (GistAction PublishGist) "Save"
-    , gistModal (OpenModal SaveProjectAs) "Save As..."
-    ]
+    $ [ menuButton (OpenModal NewProject) "New Project"
+      , gistModal (OpenModal OpenProject) "Open"
+      , menuButton (OpenModal OpenDemo) "Open Example"
+      ]
+    <> showInEditor
+        [ menuButton (OpenModal RenameProject) "Rename"
+        , gistModal (GistAction PublishGist) "Save"
+        , gistModal (OpenModal SaveProjectAs) "Save As..."
+        ]
   where
   menuButton action name =
     a [ onClick $ const $ Just action ]
@@ -186,6 +188,17 @@ menuBar state =
       menuButton action name
     else
       menuButton (OpenModal GithubLogin) name
+
+  -- Even if we end up writting more by selecting the cases in which the buttons should
+  -- appear, I prefer this to selecting which views we shouldn't show the buttons. The
+  -- reason is that if we add a new view, we don't need to adjust this.
+  -- TODO: Check if we should show the buttons for WalletEmulator and ActusBlocklyEditor
+  showInEditor buttons = case state ^. _view of
+    HaskellEditor -> buttons
+    JSEditor -> buttons
+    BlocklyEditor -> buttons
+    Simulation -> buttons
+    _ -> []
 
 marloweIcon :: forall p a. HTML p a
 marloweIcon =


### PR DESCRIPTION
This PR solves issue [SCP-1471](https://jira.iohk.io/projects/SCP/issues/SCP-1471).

<img width="1234" alt="Screen Shot 2020-11-16 at 17 00 40" src="https://user-images.githubusercontent.com/2634059/99301875-5fc02780-282d-11eb-9c66-6d9d873fd79e.png">

<img width="1218" alt="Screen Shot 2020-11-16 at 17 00 49" src="https://user-images.githubusercontent.com/2634059/99301908-68b0f900-282d-11eb-8f28-de9fd9aa9780.png">

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you changed any Purescript files:
   - [X] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
