### PR TITLE
Expose generated-purescript for all clients

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ rec {
     inherit (pkgs.callPackage ./plutus-playground-client {
       inherit (plutus.lib) buildPursPackage;
       inherit set-git-rev haskell webCommon;
-    }) client server-invoker;
+    }) client server-invoker generated-purescript;
   };
 
   marlowe-playground = pkgs.recurseIntoAttrs rec {
@@ -55,7 +55,7 @@ rec {
     inherit (pkgs.callPackage ./marlowe-playground-client {
       inherit (plutus.lib) buildPursPackage;
       inherit set-git-rev haskell webCommon;
-    }) client server-invoker;
+    }) client server-invoker generated-purescript;
   };
 
   marlowe-symbolic-lambda = plutusMusl.callPackage ./marlowe-symbolic/lambda.nix {

--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -38,5 +38,5 @@ let
   };
 in
 {
-  inherit client server-invoker;
+  inherit client server-invoker generated-purescript;
 }

--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -40,5 +40,5 @@ let
   };
 in
 {
-  inherit client server-invoker;
+  inherit client server-invoker generated-purescript;
 }

--- a/plutus-scb-client/default.nix
+++ b/plutus-scb-client/default.nix
@@ -24,5 +24,5 @@ let
 
 in
 {
-  inherit client demo-scripts server-invoker;
+  inherit client demo-scripts server-invoker generated-purescript;
 }


### PR DESCRIPTION
`generated-purescript` is useful during development and thus needs to be
externally accessible.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
