### PR TITLE
Fix end line number error

### DIFF
--- a/web-common/src/Halogen/Monaco.purs
+++ b/web-common/src/Halogen/Monaco.purs
@@ -228,12 +228,15 @@ handleQuery (GetModelMarkers f) = do
       pure $ f markers
 
 handleQuery (GetDecorationRange decoratorId f) = do
-  withEditor \editor -> do
-    liftEffect do
+  mEditor <- H.gets _.editor
+  case mEditor of
+    Nothing -> pure Nothing
+    Just editor -> do
       model <- liftEffect $ Monaco.getModel editor
-      let
-        decoRange = Monaco.getDecorationRange model decoratorId
-      pure $ f decoRange
+      mRange <- liftEffect $ Monaco.getDecorationRange model decoratorId
+      case mRange of
+        Nothing -> pure Nothing
+        Just decoRange -> pure $ Just $ f decoRange
 
 handleQuery (SetDeltaDecorations first last f) = do
   withEditor \editor -> do

--- a/web-common/src/Halogen/Monaco.purs
+++ b/web-common/src/Halogen/Monaco.purs
@@ -16,6 +16,8 @@ import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Ord (genericCompare)
 import Data.Lens (view)
 import Data.Maybe (Maybe(..))
+import Control.Monad.Maybe.Trans (runMaybeT, MaybeT(..))
+import Control.Monad.Trans.Class (lift)
 import Data.Traversable (for_, traverse)
 import Effect (Effect)
 import Effect.Aff.Class (class MonadAff)
@@ -227,16 +229,12 @@ handleQuery (GetModelMarkers f) = do
       markers <- Monaco.getModelMarkers monaco model
       pure $ f markers
 
-handleQuery (GetDecorationRange decoratorId f) = do
-  mEditor <- H.gets _.editor
-  case mEditor of
-    Nothing -> pure Nothing
-    Just editor -> do
-      model <- liftEffect $ Monaco.getModel editor
-      mRange <- liftEffect $ Monaco.getDecorationRange model decoratorId
-      case mRange of
-        Nothing -> pure Nothing
-        Just decoRange -> pure $ Just $ f decoRange
+handleQuery (GetDecorationRange decoratorId f) =
+  runMaybeT do
+    editor <- MaybeT $ H.gets _.editor
+    model <- lift $ liftEffect $ Monaco.getModel editor
+    decoRange <- MaybeT $ liftEffect $ Monaco.getDecorationRange model decoratorId
+    pure $ f decoRange
 
 handleQuery (SetDeltaDecorations first last f) = do
   withEditor \editor -> do

--- a/web-common/src/Monaco.purs
+++ b/web-common/src/Monaco.purs
@@ -8,6 +8,7 @@ import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.Nullable (Nullable, toMaybe)
 import Data.String.Regex (Regex)
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple)
@@ -228,7 +229,7 @@ foreign import getModelMarkers_ :: EffectFn2 Monaco ITextModel (Array IMarker)
 
 foreign import addExtraTypeScriptLibsJS_ :: EffectFn1 Monaco Unit
 
-foreign import getDecorationRange_ :: Fn2 ITextModel String IRange
+foreign import getDecorationRange_ :: EffectFn2 ITextModel String (Nullable IRange)
 
 foreign import setStrictNullChecks_ :: EffectFn2 Monaco Boolean Unit
 
@@ -310,8 +311,8 @@ addExtraTypeScriptLibsJS = runEffectFn1 addExtraTypeScriptLibsJS_
 setStrictNullChecks :: Monaco -> Boolean -> Effect Unit
 setStrictNullChecks = runEffectFn2 setStrictNullChecks_
 
-getDecorationRange :: ITextModel -> String -> IRange
-getDecorationRange = runFn2 getDecorationRange_
+getDecorationRange :: ITextModel -> String -> Effect (Maybe IRange)
+getDecorationRange model id = toMaybe <$> runEffectFn2 getDecorationRange_ model id
 
 setDeltaDecorations :: Editor -> Int -> Int -> Effect String
 setDeltaDecorations = runEffectFn3 setDeltaDecorations_


### PR DESCRIPTION
Currently on master, when you load the main page you get the following JS error

![Screen Shot 2020-11-17 at 19 27 30](https://user-images.githubusercontent.com/2634059/99458690-b2701100-290b-11eb-85ea-3824a70d6903.png)

I found out that the reason was that even if the editor is running (probably hiding), the [getDecorationRange](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.itextmodel.html#getdecorationrange) was returning null, which is one of the expected results according to the documentation. 

To solve this I modified the FFI so that it returns a `Nullable` and then convert it to `Maybe`, and also made the function Effectful.

While implementing the handleQuery, I found out that I couldn't just use `withEditor` because it doesn't offer a way for the callback function to fail, which ended up becoming a pattern matching mess :/. Please @palas, @shmish111, if you know a way of using a pattern to avoid those cases I'd appreciate :)

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you changed any Purescript files:
   - [X] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
