### PR TITLE
Fix broken server-invoker reference

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -26,7 +26,7 @@ in
   plutusPlaygroundImage =
     let
       client = plutus-playground.client;
-      server-invoker = client.passthru.server-invoker;
+      server-invoker = plutus-playground.server-invoker;
     in
     dockerTools.buildLayeredImage {
       name = "plutus-playgrounds";
@@ -38,7 +38,7 @@ in
   marlowePlaygroundImage =
     let
       client = marlowe-playground.client;
-      server-invoker = client.passthru.server-invoker;
+      server-invoker = marlowe-playground.server-invoker;
     in
     dockerTools.buildLayeredImage {
       name = "marlowe-playground";


### PR DESCRIPTION
Update the server-invoker reference which isn't available as passthru
attribute anymore.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
