### PR TITLE
Ensure that CBOR serialisation omits unit annotations (SCP-1489)

### DIFF
--- a/plutus-benchmark/flat/Codec.hs
+++ b/plutus-benchmark/flat/Codec.hs
@@ -27,12 +27,12 @@ import           Flat                               (Flat, flat, unflat)
 
 type Tm name = Term name DefaultUni DefaultFun ()
 
-data Codec name = Codec
-  { serialize   :: name -> BS.ByteString
-  , deserialize :: BS.ByteString -> name
+data Codec a = Codec
+  { serialize   :: a -> BS.ByteString
+  , deserialize :: BS.ByteString -> a
   }
 
-fromDecoded :: Show error => Either error name -> name
+fromDecoded :: Show error => Either error a -> a
 fromDecoded (Left err) = error $ show err
 fromDecoded (Right  v) = v
 
@@ -59,13 +59,13 @@ cborCodec = Codec
   , deserialize = deserializeRestoringUnits . LBS.fromStrict
   }
 
-withZlib :: Codec name -> Codec name
+withZlib :: Codec a -> Codec a
 withZlib codec = Codec
   { serialize = LBS.toStrict . Zlib.compress . LBS.fromStrict . serialize codec
   , deserialize = (deserialize codec) . LBS.toStrict . Zlib.decompress . LBS.fromStrict
   }
 
-withPureZlib :: Codec name -> Codec name
+withPureZlib :: Codec a -> Codec a
 withPureZlib codec = Codec
   { serialize = serialize (withZlib codec)
   , deserialize = (deserialize codec) . LBS.toStrict . fromDecoded . PureZlib.decompress . LBS.fromStrict

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -5,7 +5,6 @@ module Main where
 import           Prelude                                           ((<>))
 import qualified Prelude                                           as P
 
-import           Codec.Serialise
 import           Control.Monad
 import           Control.Monad                                     ()
 import           Control.Monad.Trans.Except                        (runExceptT)
@@ -201,8 +200,8 @@ data CborMode = Named | DeBruijn
 writeCBOR :: CborMode -> Program Name DefaultUni DefaultFun () -> IO ()
 writeCBOR cborMode prog =
     case cborMode of
-      Named    -> BSL.putStr $ serialise prog
-      DeBruijn -> toDeBruijn prog >>= BSL.putStr . serialise
+      Named    -> BSL.putStr $ serialiseOmittingUnits prog
+      DeBruijn -> toDeBruijn prog >>= BSL.putStr . serialiseOmittingUnits
 
 description :: String
 description = "This program provides operations on a number of Plutus programs "

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -6,6 +6,7 @@
 module Main (main) where
 
 import qualified Language.PlutusCore                               as PLC
+import qualified Language.PlutusCore.CBOR                          as PLC
 import qualified Language.PlutusCore.Evaluation.Machine.Cek        as PLC
 import qualified Language.PlutusCore.Evaluation.Machine.Ck         as PLC
 import qualified Language.PlutusCore.Generators                    as Gen
@@ -365,10 +366,11 @@ getBinaryInput (FileInput file) = BSL.readFile file
 loadASTfromCBOR :: Language -> AstNameType -> Input -> IO (Program ())
 loadASTfromCBOR language cborMode inp =
     case (language, cborMode) of
-         (TypedPLC,   Named)    -> getBinaryInput inp <&> deserialiseOrFail >>= handleResult TypedProgram
-         (UntypedPLC, Named)    -> getBinaryInput inp <&> deserialiseOrFail >>= handleResult UntypedProgram
+         (TypedPLC,   Named)    -> getBinaryInput inp <&> PLC.deserialiseRestoringUnitsOrFail >>= handleResult TypedProgram
+         (UntypedPLC, Named)    -> getBinaryInput inp <&> UPLC.deserialiseRestoringUnitsOrFail >>= handleResult UntypedProgram
          (TypedPLC,   DeBruijn) -> typedDeBruijnNotSupportedError
-         (UntypedPLC, DeBruijn) -> getBinaryInput inp <&> deserialiseOrFail >>= mapM fromDeBruijn >>= handleResult UntypedProgram
+         (UntypedPLC, DeBruijn) -> getBinaryInput inp <&> UPLC.deserialiseRestoringUnitsOrFail >>=
+                                   mapM fromDeBruijn >>= handleResult UntypedProgram
     where handleResult wrapper =
               \case
                Left (DeserialiseFailure offset msg) ->
@@ -402,16 +404,16 @@ getProgram language fmt inp =
                return $ PLC.AlexPn 0 0 0 <$ prog  -- No source locations in CBOR, so we have to make them up.
 
 
----------------- Serialise an program using CBOR ----------------
+---------------- Serialise a program using CBOR ----------------
 
-serialiseProgramCBOR :: Serialise a => Program a -> BSL.ByteString
-serialiseProgramCBOR (TypedProgram p)   = serialise p
-serialiseProgramCBOR (UntypedProgram p) = serialise p
+serialiseProgramCBOR :: Program () -> BSL.ByteString
+serialiseProgramCBOR (TypedProgram p)   = PLC.serialiseOmittingUnits p
+serialiseProgramCBOR (UntypedProgram p) = UPLC.serialiseOmittingUnits p
 
 -- | Convert names to de Bruijn indices and then serialise
-serialiseDbProgramCBOR :: Serialise a => Program a -> IO (BSL.ByteString)
+serialiseDbProgramCBOR :: Program () -> IO (BSL.ByteString)
 serialiseDbProgramCBOR (TypedProgram _)   = typedDeBruijnNotSupportedError
-serialiseDbProgramCBOR (UntypedProgram p) = serialise <$> toDeBruijn p
+serialiseDbProgramCBOR (UntypedProgram p) = UPLC.serialiseOmittingUnits <$> toDeBruijn p
 
 writeCBOR :: Output -> AstNameType -> Program a -> IO ()
 writeCBOR outp cborMode prog = do

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Instance/CBOR.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Instance/CBOR.hs
@@ -51,38 +51,9 @@ instance ( Closed uni
     encode (Program ann v t) = encode ann <> encode v <> encode t
     decode = Program <$> decode <*> decode <*> decode
 
-{- Note [Serialising unit annotations]
-
-Serialising the unit annotation takes up space: () is converted to the
-CBOR `null` value, which is encoded as the byte 0xF6.  In typical
-examples these account for 30% or more of the bytes in a serialised
-PLC program.  We don't actually need to serialise unit annotations
-since we know where they're going to appear when we're deserialising,
-and we know what the value has to be.  The `InvisibleUnit` type below
-has instances which takes care of this for us: if we have an
-`InvisibleUnit`-annotated program `prog` then `serialise prog` will
-serialise a program omitting the annotations, and `deserialise` (with
-an appropriate type ascription) will give us back an
-`InvisibleUnit`-annotated program.
-
-We usually deal with ()-annotated ASTs, so the annotations have to be
-converted to and from `InvisibleUnit` if we wish to save space.  The
-obvious way to do this is to use `InvisibleUnit <$ ...` and
-`() <$ ...`, but these have the disadvantage that they have to traverse the
-entire AST and visit every annotation, adding an extra cost which may
-be undesirable when deserialising things on-chain.  However,
-`InvisibleUnit` has the same underlying representation as `()`, and
-we can exploit this using Data.Coerce.coerce to convert entire ASTs
-with no run-time overhead.
--}
-
-newtype InvisibleUnit = InvisibleUnit ()
-
-instance Serialise InvisibleUnit where
-    encode = mempty
-    decode = pure (InvisibleUnit ())
-
 {- Note [Serialising Scripts]
+
+See also Note [Serialising unit annotations] in Language.PlutusCore.CBOR.
 
 At first sight, all we need to do to serialise a script without unit
 annotations appearing in the CBOR is to coerce from `()` to
@@ -99,6 +70,7 @@ Generic encoding, but would introduce a lot of extra code.  Instead,
 we provide a wrapper class with an instance which performs the
 coercions for us.  This is used in `Ledger.Scripts.Script` to
 derive a suitable instance of `Serialise` for scripts. -}
+
 
 newtype OmitUnitAnnotations name uni fun = OmitUnitAnnotations { restoreUnitAnnotations :: Program name uni fun () }
     deriving Serialise via Program name uni fun InvisibleUnit


### PR DESCRIPTION
As discussed in a recent Slack thread, we went to some trouble to enable PLC ASTs to be serialised to CBOR without including unit annotations, but then failed to use that in a number of places where we should have.  This PR fixes that: ASTs are now serialised without units in the `plc` and `nofib-exe` excutables and in the `plutus-benchmarks:flat` benchmarks; I also restored unit-less serialisation for typed ASTs.  There are a number of other places where `serialise` is used, for example in the typed and untyped versions of `Size.hs`, where serialisation is used to compute script sizes; there's also something going on in `plutus-tx-plugin`, but I'm not sure what.  I haven't attempted to fix these (but perhaps I should) because @raduom is currently working to get rid of CBOR and these uses should go away (and apologies to Radu if this conflicts with his work).  I would like to keep the CBOR instances somewhere because as I said elsewhere I think they'd be useful so that we can produce CBOR for consumption by other tools.  I think this would only be required in the two executables mentioned above, and presumably in the benchmarks because their purpose is partly to demonstrate that Flat is superior to CBOR.

The earlier version of the benchmarks did serialise units, inflating the sizes of scripts by about 25%.  Without units the uncompressed CBOR encoding is better, but still not as good as Flat; however, compressed CBOR is always smaller than compressed Flat for de Bruijn-indexed ASTs: see https://gist.github.com/kwxm/ef4654b461bf9d4fe8783e95367ef783 for a comparison of the "before" and "after" results.




<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
