### PR TITLE
SCP-1496 - Linting: only show unreachable subtrees once

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -22,8 +22,7 @@ import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
 import Servant.PureScript.Settings (SPSettings_)
-import Simulation.State (_result)
-import Simulation.Types (WebData)
+import Simulation.Types (WebData, _result)
 import StaticData (bufferLocalStorageKey)
 import StaticData as StaticData
 import MainFrame.Types (ChildSlots, _blocklySlot, _haskellEditorSlot)

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -30,8 +30,7 @@ import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..), isLoading)
 import Prelude (bind, const, mempty, pure, show, zero, ($), (&&), (<$>), (<<<), (<>))
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
-import Simulation.State (MarloweEvent(..), _SimulationRunning, _SimulationNotStarted, _contract, _editorErrors, _editorWarnings, _executionState, _initialSlot, _log, _slot, _state, _transactionError, _transactionWarnings)
-import Simulation.Types (Action(..), AnalysisState(..), BottomPanelView(..), ReachabilityAnalysisData(..), State, _analysisState, _bottomPanelView, _marloweState, _showBottomPanel, _showErrorDetail, isContractValid)
+import Simulation.Types (Action(..), AnalysisState(..), BottomPanelView(..), MarloweEvent(..), ReachabilityAnalysisData(..), State, _SimulationNotStarted, _SimulationRunning, _analysisState, _bottomPanelView, _contract, _editorErrors, _editorWarnings, _executionState, _initialSlot, _log, _marloweState, _showBottomPanel, _showErrorDetail, _slot, _state, _transactionError, _transactionWarnings, isContractValid)
 import Text.Parsing.StringParser.Basic (lines)
 
 bottomPanel :: forall p. State -> HTML p Action
@@ -511,13 +510,13 @@ analysisResultPane state =
                     ]
                 ]
             ]
-        UnreachableSubcontract contractPaths ->
+        UnreachableSubcontract { unreachableSubcontracts } ->
           explanation
             ( [ h3 [ classes [ ClassName "analysis-result-title" ] ] [ text "Reachability Analysis Result: Unreachable Subcontract Found" ]
               , text "Static analysis found the following subcontracts that are unreachable:"
               ]
                 <> [ ul [ classes [ ClassName "indented-enum-initial" ] ] do
-                      contractPath <- toUnfoldable (toList contractPaths)
+                      contractPath <- toUnfoldable (toList unreachableSubcontracts)
                       pure (li_ [ text (show contractPath) ])
                   ]
             )

--- a/marlowe-playground-client/src/Simulation/State.purs
+++ b/marlowe-playground-client/src/Simulation/State.purs
@@ -3,14 +3,9 @@ module Simulation.State where
 import Control.Bind
 import Control.Monad.State (class MonadState)
 import Data.Array (fromFoldable, mapMaybe, sort, toUnfoldable, uncons)
-import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.FoldableWithIndex (foldlWithIndex)
-import Data.Generic.Rep (class Generic)
-import Data.Lens (Getter', Lens', Prism', Traversal', has, lens, modifying, nearly, over, preview, previewOn, prism, set, to, use, view, (^.))
-import Data.Lens.At (at)
-import Data.Lens.Index (ix)
-import Data.Lens.Iso.Newtype (_Newtype)
+import Data.Lens (Lens', has, modifying, nearly, over, previewOn, set, to, use, view, (^.))
 import Data.Lens.NonEmptyList (_Head)
 import Data.Lens.Record (prop)
 import Data.List (List(..))
@@ -19,59 +14,20 @@ import Data.List.Types (NonEmptyList)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Newtype (unwrap, wrap)
 import Data.NonEmpty (foldl1, (:|))
 import Data.NonEmptyList.Extra (extendWith)
 import Data.NonEmptyList.Lens (_Tail)
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
-import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
-import Marlowe.Holes (Holes, fromTerm)
+import Marlowe.Holes (fromTerm)
 import Marlowe.Linter (lint)
 import Marlowe.Linter as L
 import Marlowe.Parser (parseContract)
-import Marlowe.Semantics (AccountId, Action(..), Assets, Bound(..), ChoiceId(..), ChosenNum, Contract(..), Environment(..), Input, IntervalResult(..), Observation, Party(..), Payment, Slot, SlotInterval(..), State, Token, TransactionError, TransactionInput(..), TransactionOutput(..), TransactionWarning, _minSlot, aesonCompatibleOptions, boundFrom, computeTransaction, emptyState, evalValue, extractRequiredActionsWithTxs, fixInterval, moneyInContract, timeouts)
+import Marlowe.Semantics (Action(..), Bound(..), ChoiceId(..), ChosenNum, Contract(..), Environment(..), Input, IntervalResult(..), Observation, Party, Slot, SlotInterval(..), State, TransactionInput(..), TransactionOutput(..), _minSlot, boundFrom, computeTransaction, emptyState, evalValue, extractRequiredActionsWithTxs, fixInterval, moneyInContract, timeouts)
 import Marlowe.Semantics as S
-import Monaco (IMarker)
-import Prelude (class Eq, class HeytingAlgebra, class Monoid, class Ord, class Semigroup, Unit, add, append, map, max, mempty, min, one, otherwise, zero, (#), ($), (<<<), (<>), (==), (>), (>=))
-
-data ActionInputId
-  = DepositInputId AccountId Party Token BigInteger
-  | ChoiceInputId ChoiceId
-  | NotifyInputId
-  | MoveToSlotId
-
-derive instance eqActionInputId :: Eq ActionInputId
-
-derive instance ordActionInputId :: Ord ActionInputId
-
-derive instance genericActionInputId :: Generic ActionInputId _
-
-instance encodeActionInputId :: Encode ActionInputId where
-  encode a = genericEncode aesonCompatibleOptions a
-
-instance decodeActionInputId :: Decode ActionInputId where
-  decode = genericDecode aesonCompatibleOptions
-
--- | On the front end we need Actions however we also need to keep track of the current
--- | choice that has been set for Choices
-data ActionInput
-  = DepositInput AccountId Party Token BigInteger
-  | ChoiceInput ChoiceId (Array Bound) ChosenNum
-  | NotifyInput
-  | MoveToSlot Slot
-
-derive instance eqActionInput :: Eq ActionInput
-
-derive instance ordActionInput :: Ord ActionInput
-
-derive instance genericActionInput :: Generic ActionInput _
-
-instance encodeActionInput :: Encode ActionInput where
-  encode a = genericEncode aesonCompatibleOptions a
-
-instance decodeActionInput :: Decode ActionInput where
-  decode = genericDecode aesonCompatibleOptions
+import Prelude (class HeytingAlgebra, class Ord, Unit, add, append, map, max, mempty, min, one, otherwise, zero, (#), ($), (<<<), (<>), (==), (>), (>=))
+import Simulation.Types (ActionInput(..), ActionInputId(..), ExecutionState(..), ExecutionStateRecord, MarloweEvent(..), MarloweState, Parties, _SimulationRunning, _contract, _editorErrors, _executionState, _holes, _log, _moneyInContract, _moveToAction, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, otherActionsParty)
 
 minimumBound :: Array Bound -> ChosenNum
 minimumBound bnds = case uncons (map boundFrom bnds) of
@@ -116,191 +72,8 @@ simplifyBoundList (Cons (Bound low1 high1) (Cons b2@(Bound low2 high2) rest))
 
 simplifyBoundList l = l
 
-data MarloweEvent
-  = InputEvent TransactionInput
-  | OutputEvent SlotInterval Payment
-
-derive instance genericMarloweEvent :: Generic MarloweEvent _
-
-instance encodeMarloweEvent :: Encode MarloweEvent where
-  encode a = genericEncode aesonCompatibleOptions a
-
-instance decodeMarloweEvent :: Decode MarloweEvent where
-  decode = genericDecode aesonCompatibleOptions
-
-newtype Parties
-  = Parties (Map Party (Map ActionInputId ActionInput))
-
-derive instance newtypeParties :: Newtype Parties _
-
-derive newtype instance semigroupParties :: Semigroup Parties
-
-derive newtype instance monoidParties :: Monoid Parties
-
-mapPartiesActionInput :: (ActionInput -> ActionInput) -> Parties -> Parties
-mapPartiesActionInput f (Parties m) = Parties $ (map <<< map) f m
-
-derive newtype instance encodeParties :: Encode Parties
-
-derive newtype instance decodeParties :: Decode Parties
-
-_actionInput :: Party -> ActionInputId -> Traversal' Parties ActionInput
-_actionInput party id = _Newtype <<< ix party <<< ix id
-
-_otherActions :: Traversal' Parties (Map ActionInputId ActionInput)
-_otherActions = _Newtype <<< ix otherActionsParty
-
-_moveToAction :: Lens' Parties (Maybe ActionInput)
-_moveToAction = lens get' set'
-  where
-  get' = preview (_actionInput otherActionsParty MoveToSlotId)
-
-  set' p ma =
-    let
-      m = case preview _otherActions p, ma of
-        Nothing, Nothing -> Nothing
-        Just m', Nothing -> Just $ Map.delete MoveToSlotId m'
-        Nothing, Just a -> Just $ Map.singleton MoveToSlotId a
-        Just m', Just a -> Just $ Map.insert MoveToSlotId a m'
-    in
-      set (_Newtype <<< at otherActionsParty) m p
-
-type ExecutionStateRecord
-  = { possibleActions :: Parties
-    , pendingInputs :: Array Input
-    , transactionError :: Maybe TransactionError
-    , transactionWarnings :: Array TransactionWarning
-    , log :: Array MarloweEvent
-    , state :: State
-    , slot :: Slot
-    , moneyInContract :: Assets
-    }
-
-_possibleActions :: forall s a. Lens' { possibleActions :: a | s } a
-_possibleActions = prop (SProxy :: SProxy "possibleActions")
-
-_pendingInputs :: forall s a. Lens' { pendingInputs :: a | s } a
-_pendingInputs = prop (SProxy :: SProxy "pendingInputs")
-
-_state :: forall s a. Lens' { state :: a | s } a
-_state = prop (SProxy :: SProxy "state")
-
-_transactionError :: forall s a. Lens' { transactionError :: a | s } a
-_transactionError = prop (SProxy :: SProxy "transactionError")
-
-_transactionWarnings :: forall s a. Lens' { transactionWarnings :: a | s } a
-_transactionWarnings = prop (SProxy :: SProxy "transactionWarnings")
-
-_slot :: forall s a. Lens' { slot :: a | s } a
-_slot = prop (SProxy :: SProxy "slot")
-
-_moneyInContract :: forall s a. Lens' { moneyInContract :: a | s } a
-_moneyInContract = prop (SProxy :: SProxy "moneyInContract")
-
-_log :: forall s a. Lens' { log :: a | s } a
-_log = prop (SProxy :: SProxy "log")
-
-_payments :: forall s. Getter' { log :: Array MarloweEvent | s } (Array Payment)
-_payments = _log <<< to (mapMaybe f)
-  where
-  f (InputEvent _) = Nothing
-
-  f (OutputEvent _ payment) = Just payment
-
-type InitialConditionsRecord
-  = { initialSlot :: Slot }
-
-_initialSlot :: forall s a. Lens' { initialSlot :: a | s } a
-_initialSlot = prop (SProxy :: SProxy "initialSlot")
-
-data ExecutionState
-  = SimulationRunning ExecutionStateRecord
-  | SimulationNotStarted InitialConditionsRecord
-
--- | Prism for the `ExecutionState` constructor of `SimulationRunning`.
-_SimulationRunning :: Prism' ExecutionState ExecutionStateRecord
-_SimulationRunning =
-  prism SimulationRunning
-    $ ( \x -> case x of
-          SimulationRunning record -> Right record
-          anotherCase -> Left anotherCase
-      )
-
--- | Prism for the `ExecutionState` constructor of `SimulationNotStarted`.
-_SimulationNotStarted :: Prism' ExecutionState InitialConditionsRecord
-_SimulationNotStarted =
-  prism SimulationNotStarted
-    $ ( \x -> case x of
-          SimulationNotStarted record -> Right record
-          anotherCase -> Left anotherCase
-      )
-
-emptyExecutionStateWithSlot :: Slot -> ExecutionState
-emptyExecutionStateWithSlot sn =
-  SimulationRunning
-    { possibleActions: mempty
-    , pendingInputs: mempty
-    , transactionError: Nothing
-    , transactionWarnings: mempty
-    , log: mempty
-    , state: emptyState sn
-    , slot: sn
-    , moneyInContract: mempty
-    }
-
-simulationNotStartedWithSlot :: Slot -> ExecutionState
-simulationNotStartedWithSlot slot = SimulationNotStarted { initialSlot: slot }
-
-simulationNotStarted :: ExecutionState
-simulationNotStarted = simulationNotStartedWithSlot zero
-
-type MarloweState
-  = { executionState :: ExecutionState
-    , contract :: Maybe Contract
-    , editorErrors :: Array IMarker
-    , editorWarnings :: Array IMarker
-    , holes :: Holes
-    }
-
-_executionState :: forall s a. Lens' { executionState :: a | s } a
-_executionState = prop (SProxy :: SProxy "executionState")
-
-_contract :: forall s a. Lens' { contract :: a | s } a
-_contract = prop (SProxy :: SProxy "contract")
-
-_editorErrors :: forall s a. Lens' { editorErrors :: a | s } a
-_editorErrors = prop (SProxy :: SProxy "editorErrors")
-
-_editorWarnings :: forall s a. Lens' { editorWarnings :: a | s } a
-_editorWarnings = prop (SProxy :: SProxy "editorWarnings")
-
-_holes :: forall s a. Lens' { holes :: a | s } a
-_holes = prop (SProxy :: SProxy "holes")
-
---- Language.Haskell.Interpreter ---
-_result :: forall s a. Lens' { result :: a | s } a
-_result = prop (SProxy :: SProxy "result")
-
-emptyMarloweState :: MarloweState
-emptyMarloweState =
-  { contract: Nothing
-  , editorErrors: mempty
-  , editorWarnings: mempty
-  , holes: mempty
-  , executionState: simulationNotStarted
-  }
-
-emptyMarloweStateWithSlot :: Slot -> MarloweState
-emptyMarloweStateWithSlot sn =
-  { contract: Nothing
-  , editorErrors: mempty
-  , editorWarnings: mempty
-  , holes: mempty
-  , executionState: emptyExecutionStateWithSlot sn
-  }
-
-getAsMuchStateAP :: forall m t0. MonadState { marloweState :: NonEmptyList MarloweState | t0 } m => m State
-getAsMuchStateAP = do
+getAsMuchStateAsPossible :: forall m t0. MonadState { marloweState :: NonEmptyList MarloweState | t0 } m => m State
+getAsMuchStateAsPossible = do
   executionState <- use (_currentMarloweState <<< _executionState)
   pure
     ( case executionState of
@@ -311,15 +84,11 @@ getAsMuchStateAP = do
 inFuture :: forall b r. HeytingAlgebra b => { marloweState :: NonEmptyList MarloweState | r } -> Slot -> b
 inFuture state slot = has (_currentMarloweState <<< _executionState <<< _SimulationRunning <<< _slot <<< nearly zero ((>) slot)) state
 
--- We have a special person for notifications
-otherActionsParty :: Party
-otherActionsParty = Role "marlowe_other_actions"
-
 updateContractInStateP :: String -> MarloweState -> MarloweState
 updateContractInStateP text state = case parseContract text of
   Right parsedContract ->
     let
-      lintResult = lint marloweState parsedContract
+      lintResult = lint Nil marloweState parsedContract
 
       mContract = fromTerm parsedContract
     in

--- a/marlowe-playground-client/src/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Simulation/Types.purs
@@ -4,30 +4,266 @@ module Simulation.Types where
 import Prelude
 import Analytics (class IsEvent, Event)
 import Analytics as A
+import Data.Array (mapMaybe)
 import Data.Array as Array
+import Data.BigInteger (BigInteger)
+import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Lens (Lens', to, view)
+import Data.Lens (Getter', Lens', Prism', Traversal', lens, preview, prism, set, to, view)
+import Data.Lens.At (at)
+import Data.Lens.Index (ix)
+import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.NonEmptyList (_Head)
 import Data.Lens.Record (prop)
 import Data.List (List)
 import Data.List.NonEmpty as NEL
 import Data.List.Types (NonEmptyList)
+import Data.Map (Map)
+import Data.Map as Map
 import Data.Maybe (Maybe(..), isJust)
+import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Data.Tuple.Nested (type (/\))
+import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Help (HelpContext(..))
-import Marlowe.Semantics (AccountId, Bound, Case, ChoiceId, ChosenNum, Contract, Input, Observation, Payee, Slot, Timeout, Token, Value, ValueId)
+import Marlowe.Holes (Holes)
+import Marlowe.Semantics (AccountId, Assets, Bound, Case, ChoiceId, ChosenNum, Contract, Input, Observation, Party(..), Payee, Payment, Slot, SlotInterval, Timeout, Token, TransactionError, TransactionInput, TransactionWarning, Value, ValueId, aesonCompatibleOptions, emptyState)
 import Marlowe.Semantics as S
 import Marlowe.Symbolic.Types.Response (Result)
+import Monaco (IMarker)
 import Network.RemoteData (RemoteData)
 import Projects.Types (Lang(..))
 import Servant.PureScript.Ajax (AjaxError)
-import Simulation.State (MarloweState, _contract, _editorErrors, emptyMarloweState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
+
+data ActionInputId
+  = DepositInputId AccountId Party Token BigInteger
+  | ChoiceInputId ChoiceId
+  | NotifyInputId
+  | MoveToSlotId
+
+derive instance eqActionInputId :: Eq ActionInputId
+
+derive instance ordActionInputId :: Ord ActionInputId
+
+derive instance genericActionInputId :: Generic ActionInputId _
+
+instance encodeActionInputId :: Encode ActionInputId where
+  encode a = genericEncode aesonCompatibleOptions a
+
+instance decodeActionInputId :: Decode ActionInputId where
+  decode = genericDecode aesonCompatibleOptions
+
+-- | On the front end we need Actions however we also need to keep track of the current
+-- | choice that has been set for Choices
+data ActionInput
+  = DepositInput AccountId Party Token BigInteger
+  | ChoiceInput ChoiceId (Array Bound) ChosenNum
+  | NotifyInput
+  | MoveToSlot Slot
+
+derive instance eqActionInput :: Eq ActionInput
+
+derive instance ordActionInput :: Ord ActionInput
+
+derive instance genericActionInput :: Generic ActionInput _
+
+instance encodeActionInput :: Encode ActionInput where
+  encode a = genericEncode aesonCompatibleOptions a
+
+instance decodeActionInput :: Decode ActionInput where
+  decode = genericDecode aesonCompatibleOptions
+
+newtype Parties
+  = Parties (Map Party (Map ActionInputId ActionInput))
+
+derive instance newtypeParties :: Newtype Parties _
+
+derive newtype instance semigroupParties :: Semigroup Parties
+
+derive newtype instance monoidParties :: Monoid Parties
+
+mapPartiesActionInput :: (ActionInput -> ActionInput) -> Parties -> Parties
+mapPartiesActionInput f (Parties m) = Parties $ (map <<< map) f m
+
+derive newtype instance encodeParties :: Encode Parties
+
+derive newtype instance decodeParties :: Decode Parties
+
+_actionInput :: Party -> ActionInputId -> Traversal' Parties ActionInput
+_actionInput party id = _Newtype <<< ix party <<< ix id
+
+_otherActions :: Traversal' Parties (Map ActionInputId ActionInput)
+_otherActions = _Newtype <<< ix otherActionsParty
+
+_moveToAction :: Lens' Parties (Maybe ActionInput)
+_moveToAction = lens get' set'
+  where
+  get' = preview (_actionInput otherActionsParty MoveToSlotId)
+
+  set' p ma =
+    let
+      m = case preview _otherActions p, ma of
+        Nothing, Nothing -> Nothing
+        Just m', Nothing -> Just $ Map.delete MoveToSlotId m'
+        Nothing, Just a -> Just $ Map.singleton MoveToSlotId a
+        Just m', Just a -> Just $ Map.insert MoveToSlotId a m'
+    in
+      set (_Newtype <<< at otherActionsParty) m p
+
+data MarloweEvent
+  = InputEvent TransactionInput
+  | OutputEvent SlotInterval Payment
+
+derive instance genericMarloweEvent :: Generic MarloweEvent _
+
+instance encodeMarloweEvent :: Encode MarloweEvent where
+  encode a = genericEncode aesonCompatibleOptions a
+
+instance decodeMarloweEvent :: Decode MarloweEvent where
+  decode = genericDecode aesonCompatibleOptions
+
+-- We have a special person for notifications
+otherActionsParty :: Party
+otherActionsParty = Role "marlowe_other_actions"
+
+type ExecutionStateRecord
+  = { possibleActions :: Parties
+    , pendingInputs :: Array Input
+    , transactionError :: Maybe TransactionError
+    , transactionWarnings :: Array TransactionWarning
+    , log :: Array MarloweEvent
+    , state :: S.State
+    , slot :: Slot
+    , moneyInContract :: Assets
+    }
+
+_possibleActions :: forall s a. Lens' { possibleActions :: a | s } a
+_possibleActions = prop (SProxy :: SProxy "possibleActions")
+
+_pendingInputs :: forall s a. Lens' { pendingInputs :: a | s } a
+_pendingInputs = prop (SProxy :: SProxy "pendingInputs")
+
+_state :: forall s a. Lens' { state :: a | s } a
+_state = prop (SProxy :: SProxy "state")
+
+_transactionError :: forall s a. Lens' { transactionError :: a | s } a
+_transactionError = prop (SProxy :: SProxy "transactionError")
+
+_transactionWarnings :: forall s a. Lens' { transactionWarnings :: a | s } a
+_transactionWarnings = prop (SProxy :: SProxy "transactionWarnings")
+
+_slot :: forall s a. Lens' { slot :: a | s } a
+_slot = prop (SProxy :: SProxy "slot")
+
+_moneyInContract :: forall s a. Lens' { moneyInContract :: a | s } a
+_moneyInContract = prop (SProxy :: SProxy "moneyInContract")
+
+_log :: forall s a. Lens' { log :: a | s } a
+_log = prop (SProxy :: SProxy "log")
+
+_payments :: forall s. Getter' { log :: Array MarloweEvent | s } (Array Payment)
+_payments = _log <<< to (mapMaybe f)
+  where
+  f (InputEvent _) = Nothing
+
+  f (OutputEvent _ payment) = Just payment
+
+type InitialConditionsRecord
+  = { initialSlot :: Slot }
+
+_initialSlot :: forall s a. Lens' { initialSlot :: a | s } a
+_initialSlot = prop (SProxy :: SProxy "initialSlot")
+
+data ExecutionState
+  = SimulationRunning ExecutionStateRecord
+  | SimulationNotStarted InitialConditionsRecord
+
+-- | Prism for the `ExecutionState` constructor of `SimulationRunning`.
+_SimulationRunning :: Prism' ExecutionState ExecutionStateRecord
+_SimulationRunning =
+  prism SimulationRunning
+    $ ( \x -> case x of
+          SimulationRunning record -> Right record
+          anotherCase -> Left anotherCase
+      )
+
+-- | Prism for the `ExecutionState` constructor of `SimulationNotStarted`.
+_SimulationNotStarted :: Prism' ExecutionState InitialConditionsRecord
+_SimulationNotStarted =
+  prism SimulationNotStarted
+    $ ( \x -> case x of
+          SimulationNotStarted record -> Right record
+          anotherCase -> Left anotherCase
+      )
+
+emptyExecutionStateWithSlot :: Slot -> ExecutionState
+emptyExecutionStateWithSlot sn =
+  SimulationRunning
+    { possibleActions: mempty
+    , pendingInputs: mempty
+    , transactionError: Nothing
+    , transactionWarnings: mempty
+    , log: mempty
+    , state: emptyState sn
+    , slot: sn
+    , moneyInContract: mempty
+    }
+
+simulationNotStartedWithSlot :: Slot -> ExecutionState
+simulationNotStartedWithSlot slot = SimulationNotStarted { initialSlot: slot }
+
+simulationNotStarted :: ExecutionState
+simulationNotStarted = simulationNotStartedWithSlot zero
+
+type MarloweState
+  = { executionState :: ExecutionState
+    , contract :: Maybe Contract
+    , editorErrors :: Array IMarker
+    , editorWarnings :: Array IMarker
+    , holes :: Holes
+    }
+
+_executionState :: forall s a. Lens' { executionState :: a | s } a
+_executionState = prop (SProxy :: SProxy "executionState")
+
+_contract :: forall s a. Lens' { contract :: a | s } a
+_contract = prop (SProxy :: SProxy "contract")
+
+_editorErrors :: forall s a. Lens' { editorErrors :: a | s } a
+_editorErrors = prop (SProxy :: SProxy "editorErrors")
+
+_editorWarnings :: forall s a. Lens' { editorWarnings :: a | s } a
+_editorWarnings = prop (SProxy :: SProxy "editorWarnings")
+
+_holes :: forall s a. Lens' { holes :: a | s } a
+_holes = prop (SProxy :: SProxy "holes")
+
+--- Language.Haskell.Interpreter ---
+_result :: forall s a. Lens' { result :: a | s } a
+_result = prop (SProxy :: SProxy "result")
+
+emptyMarloweState :: MarloweState
+emptyMarloweState =
+  { contract: Nothing
+  , editorErrors: mempty
+  , editorWarnings: mempty
+  , holes: mempty
+  , executionState: simulationNotStarted
+  }
+
+emptyMarloweStateWithSlot :: Slot -> MarloweState
+emptyMarloweStateWithSlot sn =
+  { contract: Nothing
+  , editorErrors: mempty
+  , editorWarnings: mempty
+  , holes: mempty
+  , executionState: emptyExecutionStateWithSlot sn
+  }
 
 type WebData
   = RemoteData AjaxError
@@ -69,17 +305,24 @@ type InProgressRecord
     , currContract :: Contract
     , currChildren :: RemainingSubProblemInfo
     , originalState :: S.State
+    , originalContract :: Contract
     , subproblems :: RemainingSubProblemInfo
     , numSubproblems :: Int
     , numSolvedSubproblems :: Int
     , unreachableSubcontracts :: List ContractPath
     }
 
+type UnreachableSubcontractRecord
+  = { originalState :: S.State
+    , originalContract :: Contract
+    , unreachableSubcontracts :: NonEmptyList ContractPath
+    }
+
 data ReachabilityAnalysisData
   = NotStarted
   | InProgress InProgressRecord
   | ReachabilityFailure String
-  | UnreachableSubcontract (NonEmptyList ContractPath)
+  | UnreachableSubcontract UnreachableSubcontractRecord
   | AllReachable
 
 data AnalysisState

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -52,7 +52,8 @@ import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), ChosenNum, Input(..), Party, Payee(..), Payment(..), PubKey, Slot, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
 import Marlowe.Semantics as S
 import Prelude (class Eq, class Ord, class Show, Unit, add, bind, const, discard, eq, flip, map, mempty, not, one, otherwise, pure, show, unit, when, zero, ($), (&&), (+), (-), (<$>), (<<<), (<>), (=<<), (==), (>=), (||), (>))
-import Simulation.State (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _currentMarloweState, _executionState, _marloweState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput, updateContractInStateP, updatePossibleActions, updateStateP)
+import Simulation.State (_currentMarloweState, _marloweState, updateContractInStateP, updatePossibleActions, updateStateP)
+import Simulation.Types (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _executionState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput)
 import Text.Extra (stripParens)
 import Text.Pretty (pretty)
 import Web.DOM.Document as D

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -10,8 +10,8 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Examples.Marlowe.Contracts as Contracts
 import Marlowe.Semantics (ChoiceId(..), Contract(..), Input(..), Token(..), Party(..))
-import Simulation.State (_SimulationRunning, _contract, _executionState, _pendingInputs, _transactionError, applyTransactions, emptyExecutionStateWithSlot, updateContractInState, updateMarloweState)
-import Simulation.Types (_marloweState, mkState)
+import Simulation.State (applyTransactions, updateContractInState, updateMarloweState)
+import Simulation.Types (_SimulationRunning, _contract, _executionState, _marloweState, _pendingInputs, _transactionError, emptyExecutionStateWithSlot, mkState)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
 

--- a/marlowe-playground-client/test/Marlowe/LintTests.purs
+++ b/marlowe-playground-client/test/Marlowe/LintTests.purs
@@ -4,6 +4,7 @@ import Prelude
 import Data.Array (singleton)
 import Data.BigInteger (fromInt)
 import Data.Either (Either(..))
+import Data.List (List(..))
 import Data.Map as Map
 import Data.Set (toUnfoldable)
 import Data.Tuple (Tuple(..), fst)
@@ -115,7 +116,7 @@ testWarningWithState :: forall a. S.State -> (a -> Array String) -> (a -> String
 testWarningWithState state makeWarning composeExpression expression = case parseContract $ composeExpression expression of
   Right contractTerm -> do
     let
-      State st = lint state contractTerm
+      State st = lint Nil state contractTerm
     Assert.equal (makeWarning expression) $ map show $ toUnfoldable $ st.warnings
   Left err -> failure (show err)
 


### PR DESCRIPTION
Contents:
- Only show unreachable subtrees only once in linting (even if there are several reasons it is unreachable)
- Refactor code so that we can add the results of the static analysis to the linting (preparation for SCP-952)
  * This required moving types from `marlowe-playground-client/src/Simulation/State.purs` to `marlowe-playground-client/src/Simulation/Types.purs`, in order to avoid cyclic dependency

Deployed in: https://pablo.marlowe.iohkdev.io/

Example test:

```haskell
If FalseObs (If TrueObs (If FalseObs (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close)) (If TrueObs (Assert TrueObs Close) (Assert TrueObs  Close))) (If FalseObs (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close)) (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close)))) (If TrueObs (If FalseObs (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close)) (If TrueObs (Assert TrueObs Close) (Assert TrueObs  Close))) (If FalseObs (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close)) (If TrueObs (Assert TrueObs Close) (Assert TrueObs Close))))
```

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
   - [x] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
