### PR TITLE
Fix purty (yet) again

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -97,6 +97,12 @@ let
   # including stylish-haskell support
   nix-pre-commit-hooks = import (sources."pre-commit-hooks.nix");
 
+  # purty is unable to process several files but that is what pre-commit
+  # does. pre-commit-hooks.nix does provide a wrapper for that but when
+  # we pin our own `tools` attribute that gets overwritten so we have to
+  # instead provide the wrapper.
+  purty-pre-commit = pkgs.callPackage ./purty-pre-commit { inherit purty; };
+
   # easy-purescript-nix has some kind of wacky internal IFD
   # usage that breaks the logic that makes source fetchers
   # use native dependencies. This isn't easy to fix, since
@@ -149,7 +155,7 @@ in
   inherit sphinx-markdown-tables sphinxemoji sphinxcontrib-haddock;
   inherit nix-pre-commit-hooks nodejs-headers;
   inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios;
-  inherit purty purs spago;
+  inherit purty purty-pre-commit purs spago;
   inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps;
   inherit iohkNix set-git-rev web-ghc thorp;
   inherit easyPS plutus-haddock-combined;

--- a/nix/pkgs/purty-pre-commit/default.nix
+++ b/nix/pkgs/purty-pre-commit/default.nix
@@ -1,0 +1,8 @@
+{ writeScriptBin, purty }:
+
+writeScriptBin "purty" ''
+  #!/usr/bin/env bash
+  for f in "$@"; do
+    ${purty}/bin/purty validate $f
+  done
+''

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
   inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt;
   inherit (plutus) haskell agdaPackages stylish-haskell sphinxcontrib-haddock nix-pre-commit-hooks;
   inherit (plutus) agdaWithStdlib;
-  inherit (plutus) purty purs spargo;
+  inherit (plutus) purty purty-pre-commit purs spargo;
 
   # For Sphinx, and ad-hoc usage
   sphinxTools = python3.withPackages (ps: [ sphinxcontrib-haddock.sphinxcontrib-domaintools ps.sphinx ps.sphinx_rtd_theme ]);
@@ -22,7 +22,7 @@ let
       stylish-haskell = stylish-haskell;
       nixpkgs-fmt = nixpkgs-fmt;
       shellcheck = pkgs.shellcheck;
-      purty = purty;
+      purty = purty-pre-commit;
     };
     hooks = {
       purty.enable = true;


### PR DESCRIPTION
Introduce `purty-pre-commit` wrapper script to be used
for pinning purty in the hooks `tools` attribute.

The issue is that purty cannot handle being passed multiple paths
but that is exactly what pre-commmit wants to do. In order to deal
with that i added a wrapper script in pre-commit-hooks.nix but the
moment we specify *our* version of purty this wrapper is overwritten
so we have to provide our own.

On the plus side it is now using the recently added `validate`
command which leads to better output when linting fails.

**PS**: Careful while reviewing this PR, i might have sneezed on it ...


------


Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
