### PR TITLE
Use implicit-hie to generate hie-*.yaml

### DIFF
--- a/hie-cabal.yaml
+++ b/hie-cabal.yaml
@@ -1,138 +1,628 @@
 cradle:
-  multi:
-  - path: ./plutus-core/generators
-    config: { cradle: { cabal: { component: "lib:plutus-core" } } }
-  - path: ./plutus-core/prelude
-    config: { cradle: { cabal: { component: "lib:plutus-core" } } }
-  - path: ./plutus-core/src
-    config: { cradle: { cabal: { component: "lib:plutus-core" } } }
-  - path: ./plutus-core/exe
-    config: { cradle: { cabal: { component: "plutus-core:plc" } } }
-  - path: ./plutus-core/untyped-plutus-core
-    config: { cradle: { cabal: { component: "lib:untyped-plutus-core" } } }
-  - path: ./plutus-core/plutus-ir
-    config: { cradle: { cabal: { component: "lib:plutus-core" } } }
-  - path: ./plutus-core/common
-    config: { cradle: { cabal: { component: "lib:plutus-core" } } }
-  - path: ./plutus-core/test
-    config: { cradle: { cabal: { component: "plutus-core:plutus-core-test" } } }
-  - path: ./plutus-core/untyped-plutus-core-test
-    config: { cradle: { cabal: { component: "lib:untyped-plutus-core-test" } } }
-  - path: ./plutus-core/plutus-ir-test
-    config: { cradle: { cabal: { component: "plutus-core:plutus-ir-test" } } }
-  - path: ./plutus-core/bench
-    config: { cradle: { cabal: { component: "plutus-core:plutus-core-bench" } } }
-  - path: ./plutus-core/weigh
-    config: { cradle: { cabal: { component: "plutus-core:plutus-core-weigh" } } }
-  - path: ./plutus-core/budgeting-bench
-    config: { cradle: { cabal: { component: "plutus-core:plutus-core-budgeting-bench" } } }
-  - path: ./plutus-core/cost-model-creation
-    config: { cradle: { none: } } # inline-r makes hls segfault
-  - path: ./plutus-core/create-cost-model
-    config: { cradle: { none: } }
-  - path: ./plutus-core/test-cost-model
-    config: { cradle: { none: } }
+  cabal:
+    - path: "deployment-server/src"
+      component: "lib:deployment-server"
 
-  - path: ./prettyprinter-configurable/src
-    config: { cradle: { cabal: { component: "lib:prettyprinter-configurable" } } }
-  - path: ./prettyprinter-configurable/test
-    config: { cradle: { cabal: { component: "prettyprinter-configurable:prettyprinter-configurable-test" } } }
-  - path: ./prettyprinter-configurable/doctest
-    config: { cradle: { cabal: { component: "prettyprinter-configurable:prettyprinter-configurable-doctest" } } }
+    - path: "deployment-server/app/Main.hs"
+      component: "deployment-server:exe:deployment-server-exe"
 
-  - path: ./plutus-tx/src
-    config: { cradle: { cabal: { component: "lib:plutus-tx" } } }
-  - path: ./plutus-tx-plugin/src
-    config: { cradle: { cabal: { component: "lib:plutus-tx-plugin" } } }
-  - path: ./plutus-tx-plugin/test
-    config: { cradle: { cabal: { component: "plutus-tx-plugin:plutus-tx-tests" } } }
+    - path: "deployment-server/app/Paths_deployment_server.hs"
+      component: "deployment-server:exe:deployment-server-exe"
 
-  - path: ./doc
-    config: { cradle: { cabal: { component: "plutus-doc:doc-doctests" } } }
+    - path: "deployment-server/test"
+      component: "deployment-server:test:deployment-server-test"
 
-  - path: ./playground-common/src
-    config: { cradle: { cabal: { component: "lib:playground-common" } } }
-  - path: ./playground-common/test
-    config: { cradle: { cabal: { component: "playground-common:playground-common-test" } } }
+    - path: "doc/tutorials/Main.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./marlowe-playground-server/src
-    config: { cradle: { cabal: { component: "lib:marlowe-playground-server" } } }
-  - path: ./marlowe-playground-server/test
-    config: { cradle: { cabal: { component: "marlowe-playground-server:marlowe-playground-server-test" } } }
+    - path: "doc/tutorials/PlutusTx.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./plutus-playground-server/src
-    config: { cradle: { cabal: { component: "lib:plutus-playground-server" } } }
-  - path: ./plutus-playground-server/test
-    config: { cradle: { cabal: { component: "plutus-playground-server:plutus-playground-server-test" } } }
+    - path: "doc/tutorials/BasicValidators.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./marlowe/src
-    config: { cradle: { cabal: { component: "lib:marlowe" } } }
-  - path: ./marlowe/test
-    config: { cradle: { cabal: { component: "marlowe:marlowe-test" } } }
+    - path: "doc/tutorials/BasicPolicies.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./marlowe-actus/src
-    config: { cradle: { cabal: { component: "lib:marlowe-actus" } } }
-  - path: ./marlowe-actus/test
-    config: { cradle: { cabal: { component: "marlowe-actus:marlowe-actus-test" } } }
+    - path: "iots-export/src"
+      component: "lib:iots-export"
 
-  - path: ./marlowe-symbolic/src
-    config: { cradle: { cabal: { component: "lib:marlowe-symbolic" } } }
+    - path: "iots-export/test"
+      component: "iots-export:test:iots-export-test"
 
-  - path: ./plutus-ledger/src
-    config: { cradle: { cabal: { component: "lib:plutus-ledger" } } }
-  - path: ./plutus-ledger/test
-    config: { cradle: { cabal: { component: "plutus-ledger:plutus-ledger-test" } } }
+    - path: "marlowe/src"
+      component: "lib:marlowe"
 
-  - path: ./plutus-contract/src
-    config: { cradle: { cabal: { component: "lib:plutus-contract" } } }
-  - path: ./plutus-contract/test
-    config: { cradle: { cabal: { component: "plutus-contract:plutus-contract-test" } } }
+    - path: "marlowe/test"
+      component: "marlowe:test:marlowe-test"
 
-  - path: ./plutus-scb/src
-    config: { cradle: { cabal: { component: "lib:plutus-scb" } } }
-  - path: ./plutus-scb/app
-    config: { cradle: { cabal: { component: "plutus-scb:plutus-scb" } } }
-  - path: ./plutus-scb/test
-    config: { cradle: { cabal: { component: "plutus-scb:plutus-scb-test" } } }
+    - path: "marlowe-actus/src"
+      component: "lib:marlowe-actus"
 
-  - path: ./plutus-use-cases/src
-    config: { cradle: { cabal: { component: "lib:plutus-use-cases" } } }
-  - path: ./plutus-use-cases/test
-    config: { cradle: { cabal: { component: "plutus-use-cases:plutus-use-cases-test" } } }
+    - path: "marlowe-actus/app/Main.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-  - path: ./deployment-server/src
-    config: { cradle: { cabal: { component: "lib:deployment-server" } } }
-  - path: ./deployment-server/test
-    config: { cradle: { cabal: { component: "deployment-server:deployment-server-test" } } }
+    - path: "marlowe-actus/src/Main.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-  - path: ./iots-export/src
-    config: { cradle: { cabal: { component: "lib:iots-export" } } }
-  - path: ./iots-export/test
-    config: { cradle: { cabal: { component: "iots-export:iots-export-test" } } }
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/MarloweCompat.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-  - path: ./plutus-metatheory/src
-    config: { cradle: { cabal: { component: "lib:plutus-metatheory" } } }
-  - path: ./plutus-metatheory/test
-    config: { cradle: { cabal: { component: "plutus-metatheory:test1" } } }
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Generator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-  - path: ./web-ghc/src
-    config: { cradle: { cabal: { component: "lib:web-ghc" } } }
-  - path: ./web-ghc/app
-    config: { cradle: { cabal: { component: "exe:web-ghc-server" } } }
-  - path: ./web-ghc/test
-    config: { cradle: { cabal: { component: "web-ghc:web-ghc-test" } } }
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Analysis.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-  - path: ./plutus-benchmark/nofib.exe
-    config: { cradle: {cabal: {component: "exe:nofib-exe" } } }
-  - path: ./plutus-benchmark/lib
-    config: { cradle: {cabal: {component: "lib:plutus-benchmark" } } }
-  - path: ./plutus-benchmark/nofib
-    config: { cradle: {cabal: {component: "plutus-benchmark:nofib" } } }
-  - path: ./plutus-benchmark/nofib
-    config: { cradle: {cabal: {component: "plutus-benchmark:nofib-hs" } } }
-  - path: ./plutus-benchmark/validation
-    config: { cradle: {cabal: {component: "plutus-benchmark:validation" } } }
-  - path: ./plutus-benchmark/nofib/test
-    config: { cradle: {cabal: {component: "plutus-benchmark:plutus-benchmark-nofib-tests" } } }
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/BusinessEvents.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
 
-# Add more as needed, I'm too lazy
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/ContractTerms.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/ContractState.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/Schedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/APPLICABILITY/Applicability.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/APPLICABILITY/ApplicabilityModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/PayoffModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/Payoff.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/PayoffFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransitionModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransition.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransitionFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/SCHED/ContractScheduleModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/SCHED/ContractSchedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitializationModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitialization.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitializationFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/DateShift.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/ScheduleGenerator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/YearFraction.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/ContractRoleSign.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Ops.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/MarloweCompat.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Generator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Analysis.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/BusinessEvents.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/ContractTerms.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/ContractState.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/Schedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/APPLICABILITY/Applicability.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/APPLICABILITY/ApplicabilityModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/PayoffModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/Payoff.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/PayoffFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransitionModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransition.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransitionFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/SCHED/ContractScheduleModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/SCHED/ContractSchedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitializationModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitialization.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitializationFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/DateShift.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/ScheduleGenerator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/YearFraction.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/ContractRoleSign.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Ops.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/test"
+      component: "marlowe-actus:test:marlowe-actus-test"
+
+    - path: "marlowe-playground-server/src"
+      component: "lib:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts"
+      component: "lib:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Main.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Main.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Webserver.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/PSGenerator.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Types.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Escrow.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Example.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/CouponBondGuaranteed.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/ZeroCouponBond.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Swap.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Option.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/ContractForDifference.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Webserver.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/PSGenerator.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Types.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Escrow.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Example.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/CouponBondGuaranteed.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/ZeroCouponBond.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Swap.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Option.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/ContractForDifference.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/test"
+      component: "marlowe-playground-server:test:marlowe-playground-server-test"
+
+    - path: "marlowe-symbolic/src"
+      component: "lib:marlowe-symbolic"
+
+    - path: "playground-common/src"
+      component: "lib:playground-common"
+
+    - path: "playground-common/test"
+      component: "playground-common:test:playground-common-test"
+
+    - path: "plutus-benchmark/nofib/src"
+      component: "lib:plutus-benchmark"
+
+    - path: "plutus-benchmark/nofib/exe/Main.hs"
+      component: "plutus-benchmark:exe:nofib-exe"
+
+    - path: "plutus-benchmark/nofib/bench/BenchPlc.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/Common.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/BenchHaskell.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/nofib/bench/Common.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/nofib/bench/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/validation/Main.hs"
+      component: "plutus-benchmark:bench:validation"
+
+    - path: "plutus-benchmark/validation/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:validation"
+
+    - path: "plutus-benchmark/nofib/test"
+      component: "plutus-benchmark:test:plutus-benchmark-nofib-tests"
+
+    - path: "plutus-benchmark/flat/Main.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Dataset.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Codec.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Report.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-contract/src"
+      component: "lib:plutus-contract"
+
+    - path: "plutus-contract/doctest"
+      component: "plutus-contract:test:contract-doctests"
+
+    - path: "plutus-contract/doc"
+      component: "plutus-contract:test:contract-doctests"
+
+    - path: "plutus-contract/test"
+      component: "plutus-contract:test:plutus-contract-test"
+
+    - path: "plutus-core/src"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/prelude"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/stdlib"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/examples"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/generators"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/common"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/plutus-ir"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/untyped-plutus-core"
+      component: "lib:plutus-core"
+
+    - path: "plutus-core/generate-evaluation-test/Main.hs"
+      component: "plutus-core:exe:plutus-core-generate-evaluation-test"
+
+    - path: "plutus-core/test"
+      component: "plutus-core:test:plutus-core-test"
+
+    - path: "plutus-core/plutus-ir-test"
+      component: "plutus-core:test:plutus-ir-test"
+
+    - path: "plutus-core/untyped-plutus-core-test"
+      component: "plutus-core:test:untyped-plutus-core-test"
+
+    - path: "plutus-core/bench/Bench.hs"
+      component: "plutus-core:bench:plutus-core-bench"
+
+    - path: "plutus-core/weigh/Bench.hs"
+      component: "plutus-core:bench:plutus-core-weigh"
+
+    - path: "plutus-core/exe/Main.hs"
+      component: "plutus-core:exe:plc"
+
+    - path: "plutus-core/budgeting-bench/Bench.hs"
+      component: "plutus-core:bench:plutus-core-budgeting-bench"
+
+    - path: "plutus-core/create-cost-model/CreateCostModel.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/cost-model-creation/CreateCostModel.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/create-cost-model/CostModelCreation.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/cost-model-creation/CostModelCreation.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/test-cost-model"
+      component: "plutus-core:test:plutus-core-test-cost-model"
+
+    - path: "plutus-core/cost-model-creation"
+      component: "plutus-core:test:plutus-core-test-cost-model"
+
+    - path: "plutus-ledger/src"
+      component: "lib:plutus-ledger"
+
+    - path: "plutus-ledger/test"
+      component: "plutus-ledger:test:plutus-ledger-test"
+
+    - path: "plutus-metatheory/src"
+      component: "lib:plutus-metatheory"
+
+    - path: "plutus-metatheory/exe/Main.hs"
+      component: "plutus-metatheory:exe:plc-agda"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test1"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test2"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test3"
+
+    - path: "plutus-playground-server/src"
+      component: "lib:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases"
+      component: "lib:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases"
+      component: "plutus-playground-server:lib:plutus-playground-usecases"
+
+    - path: "plutus-playground-server/app/Main.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Main.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Webserver.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Types.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/PSGenerator.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Crowdfunding.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/CrowdfundingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/ErrorHandling.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/ErrorHandlingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Game.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/GameSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/SimulationUtils.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Starter.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/StarterSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Vesting.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/VestingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Webserver.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Types.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/PSGenerator.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Crowdfunding.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/CrowdfundingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/ErrorHandling.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/ErrorHandlingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Game.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/GameSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/SimulationUtils.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Starter.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/StarterSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Vesting.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/VestingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/test"
+      component: "plutus-playground-server:test:plutus-playground-server-test"
+
+    - path: "plutus-scb/src"
+      component: "lib:plutus-scb"
+
+    - path: "plutus-scb/app/Main.hs"
+      component: "plutus-scb:exe:plutus-scb"
+
+    - path: "plutus-scb/app/PSGenerator.hs"
+      component: "plutus-scb:exe:plutus-scb"
+
+    - path: "plutus-scb/game-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/game-contract/default-language:.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/game-contract/Haskell2010.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/currency-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-currency"
+
+    - path: "plutus-scb/atomic-swap-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-atomic-swap"
+
+    - path: "plutus-scb/pay-to-wallet-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-pay-to-wallet"
+
+    - path: "plutus-scb/test"
+      component: "plutus-scb:test:plutus-scb-test"
+
+    - path: "plutus-scb/prism/credential-manager/Main.hs"
+      component: "plutus-scb:exe:prism-credential-manager"
+
+    - path: "plutus-scb/prism/mirror/Main.hs"
+      component: "plutus-scb:exe:prism-mirror"
+
+    - path: "plutus-scb/prism/unlock-sto/Main.hs"
+      component: "plutus-scb:exe:prism-unlock-sto"
+
+    - path: "plutus-scb/prism/unlock-exchange/Main.hs"
+      component: "plutus-scb:exe:prism-unlock-exchange"
+
+    - path: "plutus-tx/src"
+      component: "lib:plutus-tx"
+
+    - path: "plutus-tx/test"
+      component: "plutus-tx:test:plutus-tx-test"
+
+    - path: "plutus-tx-plugin/src"
+      component: "lib:plutus-tx-plugin"
+
+    - path: "plutus-tx-plugin/test"
+      component: "plutus-tx-plugin:test:plutus-tx-tests"
+
+    - path: "plutus-use-cases/src"
+      component: "lib:plutus-use-cases"
+
+    - path: "plutus-use-cases/test"
+      component: "plutus-use-cases:test:plutus-use-cases-test"
+
+    - path: "plutus-use-cases/bench/Bench.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Scott.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Recursion.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/IFix.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Opt.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "prettyprinter-configurable/src"
+      component: "lib:prettyprinter-configurable"
+
+    - path: "prettyprinter-configurable/test"
+      component: "prettyprinter-configurable:test:prettyprinter-configurable-test"
+
+    - path: "prettyprinter-configurable/doctest"
+      component: "prettyprinter-configurable:test:prettyprinter-configurable-doctest"
+
+    - path: "web-ghc/src"
+      component: "lib:web-ghc"
+
+    - path: "web-ghc/app/Main.hs"
+      component: "web-ghc:exe:web-ghc-server"
+
+    - path: "web-ghc/app/Webserver.hs"
+      component: "web-ghc:exe:web-ghc-server"
+
+    - path: "web-ghc/test"
+      component: "web-ghc:test:web-ghc-test"

--- a/hie-stack.yaml
+++ b/hie-stack.yaml
@@ -1,269 +1,628 @@
 cradle:
-  multi:
-  - path: ./plutus-core/generators
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:lib"
-  - path: ./plutus-core/prelude
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:lib"
-  - path: ./plutus-core/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:lib"
-  - path: ./plutus-core/plutus-ir
-    component: "plutus-core:lib"
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:lib"
-  - path: ./plutus-core/common
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:lib"
-  - path: ./plutus-core/exe
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:exe:plc"
-  - path: ./plutus-core/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:plutus-core-test"
-  - path: ./plutus-core/plutus-ir-test
-    component: "plutus-core:plutus-ir-test"
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:plutus-core-test"
-  - path: ./plutus-core/bench
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:plutus-core-bench"
-  - path: ./plutus-core/weigh
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:plutus-core-weigh"
-  - path: ./plutus-core/budgeting-bench
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:plutus-core-budgeting-bench"
-  - path: ./plutus-emulator/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-emulator:lib"
-  - path: ./plutus-emulator/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-emulator:plutus-emulator-test"
-  - path: ./plutus-tx/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-tx:lib"
-  - path: ./plutus-tx/compiler
-    config:
-      cradle:
-        stack:
-          component: "plutus-tx-compiler:lib"
-  - path: ./plutus-tx/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-tx:plutus-tx-test"
-  - path: ./plutus-ir/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-ir:lib"
-  - path: ./plutus-ir/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-ir:plutus-ir-test"
-  - path: ./plutus-playground-lib/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-playground-lib:lib"
-  - path: ./plutus-playground-lib/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-playground-lib:plutus-playground-lib-test"
-  - path: ./playground-common/src
-    config:
-      cradle:
-        stack:
-          component: "playground-common:lib"
-  - path: ./playground-common/test
-    config:
-      cradle:
-        stack:
-          component: "playground-common:playground-common-test"
-  - path: ./marlowe-playground-server/src
-    config:
-      cradle:
-        stack:
-          component: "marlowe-playground-server:lib"
-  - path: ./marlowe-playground-server/test
-    config:
-      cradle:
-        stack:
-          component: "marlowe-playground-server:marlowe-playground-server-test"
-  - path: ./marlowe-symbolic/src
-    config:
-      cradle:
-        stack:
-          component: "marlowe-symbolic:lib"
-  - path: ./marlowe-symbolic/test
-    config:
-      cradle:
-        stack:
-          component: "marlowe-symbolic:marlowe-symbolic-test"
-  - path: ./plutus-contract/src
-    config:
-      cradle:
-        stack:
-          component: "plutus-contract:lib"
-  - path: ./plutus-contract/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-contract:plutus-contract-test"
-  - path: ./deployment-server/src
-    config:
-      cradle:
-        stack:
-          component: "deployment-server:lib"
-  - path: ./deployment-server/test
-    config:
-      cradle:
-        stack:
-          component: "deployment-server:deployment-server-test"
-  - path: ./iots-export/src
-    config:
-      cradle:
-        stack:
-          component: "iots-export:lib"
-  - path: ./iots-export/test
-    config:
-      cradle:
-        stack:
-          component: "iots-export:iots-export-test"
-  - path: ./metatheory/src
-    config:
-      cradle:
-        stack:
-          component: "metatheory:lib"
-  - path: ./metatheory/test
-    config:
-      cradle:
-        stack:
-          component: "metatheory:metatheory-test"
-  - path: ./plutus-core/create-cost-model
-    config:
-      cradle:
-        none:
-        # stack:
-        #   component: "plutus-core:bench:plutus-core-create-cost-model"
-  - path: ./plutus-core/cost-model-creation
-    config:
-      cradle:
-        none:
-        # stack:
-        #   component: "plutus-core:bench:plutus-core-create-cost-model"
-  - path: ./plutus-core/test-cost-model
-    config:
-      cradle:
-        stack:
-          component: "plutus-core:test:plutus-core-test-cost-model"
+  stack:
+    - path: "deployment-server/src"
+      component: "deployment-server:lib"
 
-  - path: ./web-ghc/src
-    config:
-      cradle:
-        stack:
-          component: "web-ghc:lib"
+    - path: "deployment-server/app/Main.hs"
+      component: "deployment-server:exe:deployment-server-exe"
 
-  - path: ./web-ghc/app
-    config:
-      cradle:
-        stack:
-          component: "web-ghc:exe:web-ghc-server"
+    - path: "deployment-server/app/Paths_deployment_server.hs"
+      component: "deployment-server:exe:deployment-server-exe"
 
-  - path: ./web-ghc/test
-    config:
-      cradle:
-        stack:
-          component: "web-ghc:test:web-ghc-test"
+    - path: "deployment-server/test"
+      component: "deployment-server:test:deployment-server-test"
 
-  - path: ./plutus-benchmark/lib
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:lib"
+    - path: "doc/tutorials/Main.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./plutus-benchmark/nofib
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:nofib"
+    - path: "doc/tutorials/PlutusTx.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./plutus-benchmark/nofib
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:nofib-hs"
+    - path: "doc/tutorials/BasicValidators.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./plutus-benchmark/validation
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:validation"
+    - path: "doc/tutorials/BasicPolicies.hs"
+      component: "plutus-doc:exe:doc-doctests"
 
-  - path: ./plutus-benchmark/nofib/exe
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:exe:nofib-exe"
+    - path: "iots-export/src"
+      component: "iots-export:lib"
 
-  - path: ./plutus-benchmark/nofib/test
-    config:
-      cradle:
-        stack:
-          component: "plutus-benchmark:plutus-benchmark-nofib-tests"
+    - path: "iots-export/test"
+      component: "iots-export:test:iots-export-test"
 
-# These use the plutus plugin - HIE doesn't support plugins yet
+    - path: "marlowe/src"
+      component: "marlowe:lib"
 
-  - path: ./marlowe
-    config:
-      cradle:
-        none:
-  - path: ./plutus-playground-server
-    config:
-      cradle:
-        none:
-  - path: ./plutus-tutorial
-    config:
-      cradle:
-        none:
-  - path: ./plutus-use-cases
-    config:
-      cradle:
-        none:
-  - path: ./plutus-scb
-    config:
-      cradle:
-        none:
+    - path: "marlowe/test"
+      component: "marlowe:test:marlowe-test"
 
+    - path: "marlowe-actus/src"
+      component: "marlowe-actus:lib"
+
+    - path: "marlowe-actus/app/Main.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Main.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/MarloweCompat.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Generator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Analysis.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/BusinessEvents.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/ContractTerms.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/ContractState.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Definitions/Schedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/APPLICABILITY/Applicability.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/APPLICABILITY/ApplicabilityModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/PayoffModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/Payoff.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/POF/PayoffFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransitionModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransition.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/STF/StateTransitionFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/SCHED/ContractScheduleModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/SCHED/ContractSchedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitializationModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitialization.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/INIT/StateInitializationFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/DateShift.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/ScheduleGenerator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/YearFraction.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Model/Utility/ContractRoleSign.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/app/Language/Marlowe/ACTUS/Ops.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/MarloweCompat.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Generator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Analysis.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/BusinessEvents.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/ContractTerms.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/ContractState.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Definitions/Schedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/APPLICABILITY/Applicability.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/APPLICABILITY/ApplicabilityModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/PayoffModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/Payoff.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/POF/PayoffFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransitionModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransition.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/STF/StateTransitionFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/SCHED/ContractScheduleModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/SCHED/ContractSchedule.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitializationModel.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitialization.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/INIT/StateInitializationFs.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/DateShift.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/ScheduleGenerator.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/YearFraction.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Model/Utility/ContractRoleSign.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/src/Language/Marlowe/ACTUS/Ops.hs"
+      component: "marlowe-actus:exe:marlowe-shiny"
+
+    - path: "marlowe-actus/test"
+      component: "marlowe-actus:test:marlowe-actus-test"
+
+    - path: "marlowe-playground-server/src"
+      component: "marlowe-playground-server:lib"
+
+    - path: "marlowe-playground-server/contracts"
+      component: "marlowe-playground-server:lib"
+
+    - path: "marlowe-playground-server/app/Main.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Main.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Webserver.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/PSGenerator.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Types.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Escrow.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Example.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/CouponBondGuaranteed.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/ZeroCouponBond.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Swap.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/Option.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/app/ContractForDifference.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Webserver.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/PSGenerator.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Types.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Escrow.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Example.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/CouponBondGuaranteed.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/ZeroCouponBond.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Swap.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/Option.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/contracts/ContractForDifference.hs"
+      component: "marlowe-playground-server:exe:marlowe-playground-server"
+
+    - path: "marlowe-playground-server/test"
+      component: "marlowe-playground-server:test:marlowe-playground-server-test"
+
+    - path: "marlowe-symbolic/src"
+      component: "marlowe-symbolic:lib"
+
+    - path: "playground-common/src"
+      component: "playground-common:lib"
+
+    - path: "playground-common/test"
+      component: "playground-common:test:playground-common-test"
+
+    - path: "plutus-benchmark/nofib/src"
+      component: "plutus-benchmark:lib"
+
+    - path: "plutus-benchmark/nofib/exe/Main.hs"
+      component: "plutus-benchmark:exe:nofib-exe"
+
+    - path: "plutus-benchmark/nofib/bench/BenchPlc.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/Common.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:nofib"
+
+    - path: "plutus-benchmark/nofib/bench/BenchHaskell.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/nofib/bench/Common.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/nofib/bench/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:nofib-hs"
+
+    - path: "plutus-benchmark/validation/Main.hs"
+      component: "plutus-benchmark:bench:validation"
+
+    - path: "plutus-benchmark/validation/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:validation"
+
+    - path: "plutus-benchmark/nofib/test"
+      component: "plutus-benchmark:test:plutus-benchmark-nofib-tests"
+
+    - path: "plutus-benchmark/flat/Main.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Dataset.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Codec.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Report.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-benchmark/flat/Paths_plutus_benchmark.hs"
+      component: "plutus-benchmark:bench:flat"
+
+    - path: "plutus-contract/src"
+      component: "plutus-contract:lib"
+
+    - path: "plutus-contract/doctest"
+      component: "plutus-contract:test:contract-doctests"
+
+    - path: "plutus-contract/doc"
+      component: "plutus-contract:test:contract-doctests"
+
+    - path: "plutus-contract/test"
+      component: "plutus-contract:test:plutus-contract-test"
+
+    - path: "plutus-core/src"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/prelude"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/stdlib"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/examples"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/generators"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/common"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/plutus-ir"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/untyped-plutus-core"
+      component: "plutus-core:lib"
+
+    - path: "plutus-core/generate-evaluation-test/Main.hs"
+      component: "plutus-core:exe:plutus-core-generate-evaluation-test"
+
+    - path: "plutus-core/test"
+      component: "plutus-core:test:plutus-core-test"
+
+    - path: "plutus-core/plutus-ir-test"
+      component: "plutus-core:test:plutus-ir-test"
+
+    - path: "plutus-core/untyped-plutus-core-test"
+      component: "plutus-core:test:untyped-plutus-core-test"
+
+    - path: "plutus-core/bench/Bench.hs"
+      component: "plutus-core:bench:plutus-core-bench"
+
+    - path: "plutus-core/weigh/Bench.hs"
+      component: "plutus-core:bench:plutus-core-weigh"
+
+    - path: "plutus-core/exe/Main.hs"
+      component: "plutus-core:exe:plc"
+
+    - path: "plutus-core/budgeting-bench/Bench.hs"
+      component: "plutus-core:bench:plutus-core-budgeting-bench"
+
+    - path: "plutus-core/create-cost-model/CreateCostModel.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/cost-model-creation/CreateCostModel.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/create-cost-model/CostModelCreation.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/cost-model-creation/CostModelCreation.hs"
+      component: "plutus-core:bench:plutus-core-create-cost-model"
+
+    - path: "plutus-core/test-cost-model"
+      component: "plutus-core:test:plutus-core-test-cost-model"
+
+    - path: "plutus-core/cost-model-creation"
+      component: "plutus-core:test:plutus-core-test-cost-model"
+
+    - path: "plutus-ledger/src"
+      component: "plutus-ledger:lib"
+
+    - path: "plutus-ledger/test"
+      component: "plutus-ledger:test:plutus-ledger-test"
+
+    - path: "plutus-metatheory/src"
+      component: "plutus-metatheory:lib"
+
+    - path: "plutus-metatheory/exe/Main.hs"
+      component: "plutus-metatheory:exe:plc-agda"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test1"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test2"
+
+    - path: "plutus-metatheory/test"
+      component: "plutus-metatheory:test:test3"
+
+    - path: "plutus-playground-server/src"
+      component: "plutus-playground-server:lib"
+
+    - path: "plutus-playground-server/usecases"
+      component: "plutus-playground-server:lib"
+
+    - path: "plutus-playground-server/usecases"
+      component: "plutus-playground-server:lib:plutus-playground-usecases"
+
+    - path: "plutus-playground-server/app/Main.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Main.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Webserver.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Types.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/PSGenerator.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Crowdfunding.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/CrowdfundingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/ErrorHandling.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/ErrorHandlingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Game.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/GameSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/SimulationUtils.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Starter.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/StarterSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/Vesting.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/app/VestingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Webserver.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Types.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/PSGenerator.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Crowdfunding.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/CrowdfundingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/ErrorHandling.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/ErrorHandlingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Game.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/GameSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/SimulationUtils.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Starter.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/StarterSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/Vesting.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/usecases/VestingSimulations.hs"
+      component: "plutus-playground-server:exe:plutus-playground-server"
+
+    - path: "plutus-playground-server/test"
+      component: "plutus-playground-server:test:plutus-playground-server-test"
+
+    - path: "plutus-scb/src"
+      component: "plutus-scb:lib"
+
+    - path: "plutus-scb/app/Main.hs"
+      component: "plutus-scb:exe:plutus-scb"
+
+    - path: "plutus-scb/app/PSGenerator.hs"
+      component: "plutus-scb:exe:plutus-scb"
+
+    - path: "plutus-scb/game-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/game-contract/default-language:.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/game-contract/Haskell2010.hs"
+      component: "plutus-scb:exe:plutus-game"
+
+    - path: "plutus-scb/currency-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-currency"
+
+    - path: "plutus-scb/atomic-swap-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-atomic-swap"
+
+    - path: "plutus-scb/pay-to-wallet-contract/Main.hs"
+      component: "plutus-scb:exe:plutus-pay-to-wallet"
+
+    - path: "plutus-scb/test"
+      component: "plutus-scb:test:plutus-scb-test"
+
+    - path: "plutus-scb/prism/credential-manager/Main.hs"
+      component: "plutus-scb:exe:prism-credential-manager"
+
+    - path: "plutus-scb/prism/mirror/Main.hs"
+      component: "plutus-scb:exe:prism-mirror"
+
+    - path: "plutus-scb/prism/unlock-sto/Main.hs"
+      component: "plutus-scb:exe:prism-unlock-sto"
+
+    - path: "plutus-scb/prism/unlock-exchange/Main.hs"
+      component: "plutus-scb:exe:prism-unlock-exchange"
+
+    - path: "plutus-tx/src"
+      component: "plutus-tx:lib"
+
+    - path: "plutus-tx/test"
+      component: "plutus-tx:test:plutus-tx-test"
+
+    - path: "plutus-tx-plugin/src"
+      component: "plutus-tx-plugin:lib"
+
+    - path: "plutus-tx-plugin/test"
+      component: "plutus-tx-plugin:test:plutus-tx-tests"
+
+    - path: "plutus-use-cases/src"
+      component: "plutus-use-cases:lib"
+
+    - path: "plutus-use-cases/test"
+      component: "plutus-use-cases:test:plutus-use-cases-test"
+
+    - path: "plutus-use-cases/bench/Bench.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Scott.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Recursion.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/IFix.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "plutus-use-cases/bench/Opt.hs"
+      component: "plutus-use-cases:bench:plutus-use-cases-bench"
+
+    - path: "prettyprinter-configurable/src"
+      component: "prettyprinter-configurable:lib"
+
+    - path: "prettyprinter-configurable/test"
+      component: "prettyprinter-configurable:test:prettyprinter-configurable-test"
+
+    - path: "prettyprinter-configurable/doctest"
+      component: "prettyprinter-configurable:test:prettyprinter-configurable-doctest"
+
+    - path: "web-ghc/src"
+      component: "web-ghc:lib"
+
+    - path: "web-ghc/app/Main.hs"
+      component: "web-ghc:exe:web-ghc-server"
+
+    - path: "web-ghc/app/Webserver.hs"
+      component: "web-ghc:exe:web-ghc-server"
+
+    - path: "web-ghc/test"
+      component: "web-ghc:test:web-ghc-test"

--- a/marlowe-playground-server/marlowe-playground-server.cabal
+++ b/marlowe-playground-server/marlowe-playground-server.cabal
@@ -22,9 +22,9 @@ library
         Lambda
         Marlowe.Contracts
         Marlowe.Config
+    -- Include 'contracts' so haskell.nix knows to include the files that we embed with TH
     hs-source-dirs:
         src
-        -- So haskell.nix knows to include the files that we embed with TH
         contracts
     default-language: Haskell2010
     build-depends:

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -35,6 +35,7 @@ let
   hlint = exeFromExtras "hlint";
   haskell-language-server = exeFromExtras "haskell-language-server";
   hie-bios = exeFromExtras "hie-bios";
+  gen-hie = haskell.extraPackages.implicit-hie.components.exes.gen-hie;
   haskellNixAgda = haskell.extraPackages.Agda;
 
   # We want to keep control of which version of Agda we use, so we supply our own and override
@@ -68,6 +69,7 @@ let
   fixPurty = pkgs.callPackage ./fix-purty { inherit purty; };
   fixStylishHaskell = pkgs.callPackage ./fix-stylish-haskell { inherit stylish-haskell; };
   updateMaterialized = haskell.project.stack-nix.passthru.updateMaterialized;
+  updateHie = pkgs.callPackage ./update-hie { inherit gen-hie; };
   updateMetadataSamples = pkgs.callPackage ./update-metadata-samples { };
   updateClientDeps = pkgs.callPackage ./update-client-deps {
     inherit (easyPS) purs psc-package spago spago2nix;
@@ -158,9 +160,9 @@ in
 {
   inherit sphinx-markdown-tables sphinxemoji sphinxcontrib-haddock;
   inherit nix-pre-commit-hooks;
-  inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios;
+  inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios gen-hie;
   inherit purty purty-pre-commit purs spago;
-  inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps;
+  inherit fixPurty fixStylishHaskell updateMaterialized updateHie updateMetadataSamples updateClientDeps;
   inherit iohkNix set-git-rev web-ghc thorp;
   inherit easyPS plutus-haddock-combined;
   inherit agdaWithStdlib;

--- a/nix/pkgs/fix-purty/default.nix
+++ b/nix/pkgs/fix-purty/default.nix
@@ -1,7 +1,6 @@
-{ writeScriptBin, runtimeShell, git, fd, purty }:
+{ writeShellScriptBin, runtimeShell, git, fd, purty }:
 
-writeScriptBin "fix-purty" ''
-  #!${runtimeShell}
+writeShellScriptBin "fix-purty" ''
   set -eou pipefail
 
   ${git}/bin/git diff > pre-purty.diff

--- a/nix/pkgs/fix-stylish-haskell/default.nix
+++ b/nix/pkgs/fix-stylish-haskell/default.nix
@@ -1,7 +1,6 @@
-{ writeScriptBin, git, fd, stylish-haskell, runtimeShell }:
+{ writeShellScriptBin, git, fd, stylish-haskell }:
 
-writeScriptBin "fix-stylish-haskell" ''
-  #!${runtimeShell}
+writeShellScriptBin "fix-stylish-haskell" ''
   set -eou pipefail
 
   ${git}/bin/git diff > pre-stylish.diff

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -73,7 +73,10 @@ in
     plan-sha256 = "0pxqq5lnh7kd8pyhfyh81pq2v00g9lzkb1db8065cdxya6nirpjs";
     modules = [{ reinstallableLibGhc = false; }];
   };
-  inherit (
+}
+  //
+  # We need to lift this let-binding out far enough, otherwise it can get evaluated several times!
+(
   let hspkgs = haskell-nix.cabalProject {
     src = fetchFromGitHub {
       name = "haskell-language-server";
@@ -95,6 +98,5 @@ in
     # Invalidate and update if you change the version
     plan-sha256 = "0rjpf8xnamn063hbzi4wij8h2aiv71ailbpgd4ykfkv7mlc9mzny";
   };
-  in { haskell-language-server = hspkgs.haskell-language-server; hie-bios = hspkgs.hie-bios; })
-    hie-bios haskell-language-server;
-}
+  in { inherit (hspkgs) haskell-language-server hie-bios implicit-hie; }
+)

--- a/nix/pkgs/purty-pre-commit/default.nix
+++ b/nix/pkgs/purty-pre-commit/default.nix
@@ -1,7 +1,6 @@
-{ writeScriptBin, purty }:
+{ writeShellScriptBin, purty }:
 
-writeScriptBin "purty" ''
-  #!/usr/bin/env bash
+writeShellScriptBin "purty" ''
   for f in "$@"; do
     ${purty}/bin/purty validate $f
   done

--- a/nix/pkgs/update-client-deps/default.nix
+++ b/nix/pkgs/update-client-deps/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
-, writeScriptBin
-, runtimeShell
+, writeShellScriptBin
 , git
 , fd
 , coreutils
@@ -17,8 +16,7 @@
 , clang
 }:
 
-lib.meta.addMetaAttrs { platforms = lib.platforms.linux; } (writeScriptBin "update-client-deps" ''
-  #!${runtimeShell}
+lib.meta.addMetaAttrs { platforms = lib.platforms.linux; } (writeShellScriptBin "update-client-deps" ''
   set -eou pipefail
 
   export PATH=${lib.makeBinPath ([

--- a/nix/pkgs/update-hie/default.nix
+++ b/nix/pkgs/update-hie/default.nix
@@ -1,0 +1,5 @@
+{ writeShellScriptBin, gen-hie }:
+writeShellScriptBin "update-hie" ''
+  ${gen-hie}/bin/gen-hie --cabal > hie-cabal.yaml
+  ${gen-hie}/bin/gen-hie --stack > hie-stack.yaml
+''

--- a/nix/pkgs/update-metadata-samples/default.nix
+++ b/nix/pkgs/update-metadata-samples/default.nix
@@ -1,4 +1,4 @@
-{ writeScriptBin, runtimeShell, curl }:
+{ writeShellScriptBin, curl }:
 let
   metadataQueryPayload1 = {
     subjects = [
@@ -18,8 +18,7 @@ let
     ];
   };
 in
-writeScriptBin "update-metadata-samples" ''
-  #!${runtimeShell}
+writeShellScriptBin "update-metadata-samples" ''
   set -eou pipefail
 
   SERVER=https://api.cardano.org/staging

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -133,9 +133,9 @@ library
 
 test-suite contract-doctests
     type: exitcode-stdio-1.0
+    -- Include 'doc' so Haskell.nix finds the symlink sources
     hs-source-dirs:
         doctest
-        -- so Haskell.nix finds the symlink sources
         doc
     default-language: Haskell2010
     main-is: Main.hs

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -257,7 +257,6 @@ executable plutus-game
 executable plutus-currency
     main-is: Main.hs
     hs-source-dirs: currency-contract
-    other-modules:
     default-language: Haskell2010
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
@@ -270,7 +269,6 @@ executable plutus-currency
 executable plutus-atomic-swap
     main-is: Main.hs
     hs-source-dirs: atomic-swap-contract
-    other-modules:
     default-language: Haskell2010
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
@@ -282,7 +280,6 @@ executable plutus-atomic-swap
 executable plutus-pay-to-wallet
     main-is: Main.hs
     hs-source-dirs: pay-to-wallet-contract
-    other-modules:
     default-language: Haskell2010
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
@@ -338,7 +335,6 @@ executable prism-credential-manager
     import: lang
     main-is: Main.hs
     hs-source-dirs: prism/credential-manager
-    other-modules:
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
@@ -350,7 +346,6 @@ executable prism-mirror
     import: lang
     main-is: Main.hs
     hs-source-dirs: prism/mirror
-    other-modules:
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
@@ -362,7 +357,6 @@ executable prism-unlock-sto
     import: lang
     main-is: Main.hs
     hs-source-dirs: prism/unlock-sto
-    other-modules:
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
@@ -374,7 +368,6 @@ executable prism-unlock-exchange
     import: lang
     main-is: Main.hs
     hs-source-dirs: prism/unlock-exchange
-    other-modules:
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,

--- a/shell.nix
+++ b/shell.nix
@@ -64,11 +64,13 @@ let
     fixStylishHaskell
     haskell-language-server
     hie-bios
+    gen-hie
     hlint
     purs
     purty
     spago
     stylish-haskell
+    updateHie
     updateClientDeps
     updateMetadataSamples
   ]);


### PR DESCRIPTION
`implcit-hie` is the project that HLS uses to generate a cradle for a
cabal project when you don't have a `hie.yaml`. You can also just use it
to generate literal `hie.yaml` files, which is what I've done here, for both
the Cabal and Stack versions.

This is therefore a halfway house towards not needing the
`hie-*.yaml` files: they're checked in, so we can edit them if necessary,
or see where the generated output goes wrong (I had to make a few changes
to `.cabal` files to work around bugs).

Becuase I think we might want to tweak the otuput, I'm not asserting that the
checked-in files are exactly the output of `gen-hie` in CI, but there is an `update-hie`
script that will regenerate them. So as long as we keep the structure
broadly the same, you should be able to update them by running `update-hie`
and doing a bit of judicious `git add -p`.

TODO: explain this in CONTRIBUTING.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
