### PR TITLE
Create github workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: "Tests"
+on:
+  pull_request:
+jobs:
+  nix-instantiate:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-10.15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nixbuild/nix-quick-install-action@v4
+      - run: nix-instantiate release.nix --arg supportedSystems '[ builtins.currentSystem ]' --restrict-eval -I . --allowed-uris 'https://github.com/NixOS/nixpkgs https://github.com/input-output-hk https://github.com/NixOS/nixpkgs-channels' --option trusted-public-keys "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" --option substituters "https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/" --show-trace
+  nix-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nixbuild/nix-quick-install-action@v4
+      - run: nix-build -A tests --arg supportedSystems '[ builtins.currentSystem ]' --restrict-eval -I . --allowed-uris 'https://github.com/NixOS/nixpkgs https://github.com/input-output-hk https://github.com/NixOS/nixpkgs-channels' --option trusted-public-keys "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" --option substituters "https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/"


### PR DESCRIPTION
This PR adds a Github Action workflow which:

- runs `nix-instantiate release.nix --restrict-eval` on linux and macos
- runs `nix-build -A tests` on linux
---

- **Q**: We already have hydra, why would we want this? 
- **A**: I have tested various versions of this setup and my hydra job hasn't even been queued yet. The idea is not to replace hydra with this, but to get much earlier feedback on possible instantiation errors. Especially since we have 2 platforms and developers don't usually check both of them locally.

Quite some time is spent just for downloading stuff each time and i wonder if i could do some caching of `/nix/store` in some way to improve this but i couldn't find anything conclusive and it is still way faster than hydra anyway.

-----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested


Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
