### PR TITLE
StateMachine.getOnChainState throws NoOnChainState

### DIFF
--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -22,28 +23,27 @@
 
 module Language.Marlowe.Client where
 import           Control.Lens
-import           Control.Monad                                 (void)
-import           Control.Monad.Error.Lens                      (catching)
-import           Language.Marlowe.Semantics                    hiding (Contract)
-import qualified Language.Marlowe.Semantics                    as Marlowe
+import           Control.Monad                         (void)
+import           Control.Monad.Error.Lens              (catching)
+import           Language.Marlowe.Semantics            hiding (Contract)
+import qualified Language.Marlowe.Semantics            as Marlowe
 import           Language.Plutus.Contract
-import           Language.Plutus.Contract.StateMachine         (AsSMContractError (..), StateMachine (..),
-                                                                StateMachineClient (..), Void, WaitingResult (..))
-import qualified Language.Plutus.Contract.StateMachine         as SM
-import qualified Language.Plutus.Contract.StateMachine.OnChain as SM
-import qualified Language.PlutusTx                             as PlutusTx
-import qualified Language.PlutusTx.AssocMap                    as AssocMap
-import qualified Language.PlutusTx.Prelude                     as P
-import           Ledger                                        (CurrencySymbol, Datum (..), Slot (..), TokenName,
-                                                                ValidatorCtx (..), mkValidatorScript, pubKeyHash,
-                                                                validatorHash, valueSpent)
-import           Ledger.Ada                                    (adaSymbol, adaValueOf)
+import           Language.Plutus.Contract.StateMachine (AsSMContractError (..), StateMachine (..),
+                                                        StateMachineClient (..), Void, WaitingResult (..))
+import qualified Language.Plutus.Contract.StateMachine as SM
+import qualified Language.PlutusTx                     as PlutusTx
+import qualified Language.PlutusTx.AssocMap            as AssocMap
+import qualified Language.PlutusTx.Prelude             as P
+import           Ledger                                (CurrencySymbol, Datum (..), Slot (..), TokenName,
+                                                        ValidatorCtx (..), mkValidatorScript, pubKeyHash, validatorHash,
+                                                        valueSpent)
+import           Ledger.Ada                            (adaSymbol, adaValueOf)
 import           Ledger.Constraints
-import qualified Ledger.Interval                               as Interval
-import           Ledger.Scripts                                (Validator)
-import qualified Ledger.Typed.Scripts                          as Scripts
-import           Ledger.Typed.Tx                               (TypedScriptTxOut (..), tyTxOutData)
-import qualified Ledger.Value                                  as Val
+import qualified Ledger.Interval                       as Interval
+import           Ledger.Scripts                        (Validator)
+import qualified Ledger.Typed.Scripts                  as Scripts
+import           Ledger.Typed.Tx                       (TypedScriptTxOut (..), tyTxOutData)
+import qualified Ledger.Value                          as Val
 
 type MarloweSlotRange = (Slot, Slot)
 type MarloweInput = (MarloweSlotRange, [Input])
@@ -82,7 +82,6 @@ data PartyAction
 
 marlowePlutusContract :: forall e. (AsContractError e
     , AsMarloweError e
-    , AsCheckpointError e
     , AsSMContractError e MarloweData MarloweInput
     )
     => Contract MarloweSchema e ()
@@ -108,31 +107,37 @@ marlowePlutusContract = do
             _     -> apply `select` wait `select` auto
     auto = do
         (params, party, untilSlot) <- endpoint @"auto" @(MarloweParams, Party, Slot) @MarloweSchema
-        let theClient@StateMachineClient{scInstance, scChooser} = mkMarloweClient params
-        utxo <- utxoAt (SM.machineAddress scInstance)
-        let states = SM.getStates scInstance utxo
-        case states of
-            [] -> do
+        let theClient = mkMarloweClient params
+        let getOnChainMarloweData :: Contract MarloweSchema e MarloweData
+            getOnChainMarloweData = do
+                ((st, _), _) <- SM.getOnChainState theClient
+                pure $ tyTxOutData st
+        let continueWith :: MarloweData -> Contract MarloweSchema e ()
+            continueWith md@MarloweData{marloweContract} = do
+                if canAutoExecuteContractForParty party marloweContract
+                then do autoExecuteContract theClient party md
+                else do apply `select` wait `select` auto
+
+        catching _SMContractError (continueWith =<< getOnChainMarloweData) $ \case
+            SM.NoOnChainState -> do
                 wr <- SM.waitForUpdateUntil theClient untilSlot
                 case wr of
                     ContractEnded -> do
                         logInfo @String $ "Contract Ended for party" <> show party
-                        marlowePlutusContract
+                        pure ()
                     Timeout _ -> do
                         logInfo @String $ "Contract Timeout for party" <> show party
-                        marlowePlutusContract
-                    WaitingResult md@MarloweData{marloweContract}
-                        | canAutoExecuteContractForParty party marloweContract -> autoExecuteContract theClient party md
-                    _ -> apply `select` wait `select` auto
-            states -> case scChooser states of
-                Left err -> do
-                    logError @String $ "Chooser err " <> show err
-                    apply `select` wait `select` auto
-                Right (st, _) -> do
-                    let md = tyTxOutData st
-                    autoExecuteContract theClient party md
+                        pure ()
+                    WaitingResult marloweData -> continueWith marloweData
+            error -> do
+                logError @String $ show error
+                apply `select` wait `select` auto
 
 
+    autoExecuteContract :: StateMachineClient MarloweData MarloweInput
+                      -> Party
+                      -> MarloweData
+                      -> Contract MarloweSchema e ()
     autoExecuteContract theClient party marloweData = do
         slot <- currentSlot
         let slotRange = (slot, slot + defaultTxValidationRange)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PingPong.hs
@@ -112,13 +112,14 @@ run ::
     -> Contract PingPongSchema PingPongError ()
     -> Contract PingPongSchema PingPongError ()
 run expectedState action = do
-    (st, _) <- SM.getOnChainState client
     let extractState = tyTxOutData . fst
         go Nothing = throwError StoppedUnexpectedly
         go (Just currentState)
             | extractState currentState == expectedState = action
             | otherwise = SM.waitForUpdate client >>= go
-    go (Just st)
+    maybeState <- SM.getOnChainState client
+    let datum = fmap fst maybeState
+    go datum
 
 runPing :: Contract PingPongSchema PingPongError ()
 runPing = run Ponged (endpoint @"ping" >> void (SM.runStep client Ping))


### PR DESCRIPTION
Marlowe and other contracts can re-use `getOnChainState` and handle the case when no onchain state is currently present.