### PR TITLE
[Builtins] Automatially kind check types of built-in functions

### DIFF
--- a/plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
@@ -65,7 +65,7 @@ newtype DenotationContext term = DenotationContext
 typeSchemeResult :: TypeScheme term args res -> AsKnownType term res
 typeSchemeResult (TypeSchemeResult _)     = AsKnownType
 typeSchemeResult (TypeSchemeArrow _ schB) = typeSchemeResult schB
-typeSchemeResult (TypeSchemeAll _ _ schK) = typeSchemeResult $ schK Proxy
+typeSchemeResult (TypeSchemeAll _ schK)   = typeSchemeResult $ schK Proxy
 
 -- | Get the 'Denotation' of a variable.
 denoteVariable

--- a/plutus-core/generators/Language/PlutusCore/Generators/Internal/Dependent.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/Internal/Dependent.hs
@@ -32,7 +32,7 @@ data AsKnownType term a where
     AsKnownType :: KnownType term a => AsKnownType term a
 
 instance GShow (UniOf term) => Pretty (AsKnownType term a) where
-    pretty a@AsKnownType = pretty $ toTypeAst @(UniOf term) a
+    pretty a@AsKnownType = pretty $ toTypeAst @_ @(UniOf term) a
 
 instance GShow (UniOf term) => GEq (AsKnownType term) where
     a `geq` b = do

--- a/plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
@@ -153,17 +153,17 @@ genIterAppValue (Denotation object embed meta scheme) = result where
         -> ([Plain Term uni fun] -> [Plain Term uni fun])
         -> FoldArgs args res
         -> PlcGenT uni fun m (IterAppValue uni fun head (Plain Term uni fun) res)
-    go (TypeSchemeResult _)       term args y = do  -- Computed the result.
+    go (TypeSchemeResult _)     term args y = do  -- Computed the result.
         let pia = IterApp object $ args []
         return $ IterAppValue term pia y
-    go (TypeSchemeArrow _ schB)   term args f = do  -- Another argument is required.
+    go (TypeSchemeArrow _ schB) term args f = do  -- Another argument is required.
         BuiltinGensT genTb <- ask
         TermOf v x <- liftT $ genTb AsKnownType  -- Get a Haskell and the correspoding PLC values.
         let term' = Apply () term v              -- Apply the term to the PLC value.
             args' = args . (v :)                 -- Append the PLC value to the spine.
             y     = f x                          -- Apply the Haskell function to the generated argument.
         go schB term' args' y
-    go (TypeSchemeAll _ _ schK) term args f =
+    go (TypeSchemeAll _ schK)   term args f =
         go (schK Proxy) term args f
 
 -- | Generate a PLC 'Term' of the specified type and the corresponding Haskell value.

--- a/plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
@@ -23,7 +23,7 @@ saturatesScheme ::  [Arg tyname name uni fun a] -> TypeScheme term args res -> M
 saturatesScheme _ TypeSchemeResult{}                       = Just True
 -- Consume one argument
 saturatesScheme (TermArg _ : args) (TypeSchemeArrow _ sch) = saturatesScheme args sch
-saturatesScheme (TypeArg _ : args) (TypeSchemeAll _ _ k)   = saturatesScheme args (k Proxy)
+saturatesScheme (TypeArg _ : args) (TypeSchemeAll _ k)     = saturatesScheme args (k Proxy)
 -- Under-applied, not saturated
 saturatesScheme [] TypeSchemeArrow{}                       = Just False
 saturatesScheme [] TypeSchemeAll{}                         = Just False

--- a/plutus-core/src/Language/PlutusCore/Builtins.hs
+++ b/plutus-core/src/Language/PlutusCore/Builtins.hs
@@ -222,7 +222,8 @@ instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni Default
             (runCostingFunTwoArguments . paramGtByteString)
     toBuiltinMeaning IfThenElse =
         toStaticBuiltinMeaning
-            ((\b x y -> if b then x else y) :: a ~ Opaque term (TyVarRep "a" 0) => Bool -> a -> a -> a)
+            ((\b x y -> if b then x else y)
+                :: a ~ Opaque term (TyVarRep ('TyNameRep "a" 0)) => Bool -> a -> a -> a)
             (runCostingFunThreeArguments . paramIfThenElse)
     toBuiltinMeaning CharToString =
         toStaticBuiltinMeaning

--- a/plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -42,7 +42,7 @@ applyTypeSchemed name = go where
             _  -> throwingWithCause _ConstAppError       -- Too many arguments.
                     (TooManyArgumentsConstAppError name args)
                     Nothing
-    go (TypeSchemeAll _ _ schK)  f exF args =
+    go (TypeSchemeAll _ schK)    f exF args =
         go (schK Proxy) f exF args
     go (TypeSchemeArrow _ schB)  f exF args = case args of
         []          ->

--- a/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
@@ -38,7 +38,7 @@ withGenArgsRes (TypeSchemeResult _)     y k = k [] y
 withGenArgsRes (TypeSchemeArrow _ schB) f k = do
     TermOf v x <- forAllNoShow $ genTypedBuiltinDef AsKnownType
     withGenArgsRes schB (f x) (k . (v :))
-withGenArgsRes (TypeSchemeAll _ _ schK) f k = withGenArgsRes (schK Proxy) f k
+withGenArgsRes (TypeSchemeAll _ schK)   f k = withGenArgsRes (schK Proxy) f k
 
 type AppErr = EvaluationException () DefaultFun (Term Name DefaultUni DefaultFun ())
 


### PR DESCRIPTION
This

1. adds handling of higher-kinded type variables by the machinery that automatically derives type schemes
2. makes reflected types intrinsically typed. Now if you attempt to define a built-in function whose type is ill-kinded, GHC will tell you there's a kidn mismatch. Kinds do not need to be specified explicitly anymore as they are inferred automatically by GHC (unless there's an actual ambiguity)
