### PR TITLE
hydra: update required job constituents

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -37,10 +37,9 @@ lib.fix (jobsets: ciJobsets // {
         ++ (allJobs [ "linux" "docs" "papers" ] jobsets)
         ++ (allJobs [ "linux" "plutus-playground" ] jobsets)
         ++ (allJobs [ "linux" "marlowe-playground" ] jobsets)
+        ++ (allJobs [ "darwin" "plutus-playground" ] jobsets)
+        ++ (allJobs [ "darwin" "marlowe-playground" ] jobsets)
         ++ (allJobs [ "linux" "plutus-scb" ] jobsets)
-        # Developer scripts so they're definitely cached
-        ++ (allJobs [ "linux" "dev" "scripts" ] jobsets)
-        ++ (allJobs [ "darwin" "dev" "scripts" ] jobsets)
         # Shell environment so it never breaks
         ++ (if (lib.hasAttrByPath [ "linux" "shell" ] jobsets) then [ jobsets.linux.shell ] else [ ])
         ++ (if (lib.hasAttrByPath [ "darwin" "shell" ] jobsets) then [ jobsets.darwin.shell ] else [ ]);


### PR DESCRIPTION
This updates the job constituents as follows:

- adds plutus-playground and marlowe-playground on darwin
- removes obsolete `dev.scripts` attributes

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
