### PR TITLE
SCP-1330: State machine handles invalid transition

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE LambdaCase             #-}
 {-# LANGUAGE MonoLocalBinds         #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE NamedFieldPuns         #-}
@@ -21,6 +22,8 @@ module Language.Plutus.Contract.StateMachine(
     , SM.State(..)
     , OnChainState
     , WaitingResult(..)
+    , InvalidTransition(..)
+    , TransitionResult(..)
     -- * Constructing the machine instance
     , SM.mkValidator
     , SM.mkStateMachine
@@ -104,18 +107,29 @@ getStates (SM.StateMachineInstance _ si) refMap =
             pure (tout, tref)
     in rights $ fmap lkp $ Map.toList refMap
 
-data SMContractError s i =
-    InvalidTransition s i
-    | NonZeroValueAllocatedInFinalState
-    | ChooserError Text
+-- | An invalid transition
+data InvalidTransition s i =
+    InvalidTransition
+        { tfState :: Maybe (State s) -- ^ Current state. 'Nothing' indicates that there is no current state.
+        , tfInput :: i -- ^ Transition that was attempted but failed
+        }
+        deriving stock (Eq, Show, Generic)
+        deriving anyclass (ToJSON, FromJSON)
+
+-- | Result of an attempted transition
+data TransitionResult s i =
+    TransitionFailure (InvalidTransition s i) -- ^ The transition is not allowed
+    | TransitionSuccess s -- ^ The transition is allowed and results in a new state
+
+data SMContractError =
+    ChooserError Text
     | SMCContractError ContractError
-    | NoOnChainState
     deriving stock (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''SMContractError
 
-instance AsContractError (SMContractError s i) where
+instance AsContractError SMContractError where
     _ContractError = _SMCContractError
 
 -- | Client-side definition of a state machine.
@@ -123,7 +137,7 @@ data StateMachineClient s i = StateMachineClient
     { scInstance :: SM.StateMachineInstance s i
     -- ^ The instance of the state machine, defining the machine's transitions,
     --   its final states and its check function.
-    , scChooser  :: [OnChainState s i] -> Either (SMContractError s i) (OnChainState s i)
+    , scChooser  :: [OnChainState s i] -> Either SMContractError (OnChainState s i)
     -- ^ A function that chooses the relevant on-chain state, given a list of
     --   all potential on-chain states found at the contract address.
     }
@@ -133,7 +147,7 @@ data StateMachineClient s i = StateMachineClient
 defaultChooser ::
     forall state input
     . [OnChainState state input]
-    -> Either (SMContractError state input) (OnChainState state input)
+    -> Either SMContractError (OnChainState state input)
 defaultChooser [x] = Right x
 defaultChooser xs  =
     let msg = "Found " <> show (length xs) <> " outputs, expected 1"
@@ -155,7 +169,7 @@ mkStateMachineClient inst =
     Throws an @SMContractError@ if the number of outputs at the machine address is greater than one.
 -}
 getOnChainState ::
-    ( AsSMContractError e state i
+    ( AsSMContractError e
     , PlutusTx.IsData state
     , HasUtxoAt schema)
     => StateMachineClient state i
@@ -183,7 +197,7 @@ data WaitingResult a
 --   started then it returns the first state of the instance as soon as it
 --   has started.
 waitForUpdateUntil ::
-    ( AsSMContractError e state i
+    ( AsSMContractError e
     , AsContractError e
     , PlutusTx.IsData state
     , HasAwaitSlot schema
@@ -222,7 +236,7 @@ waitForUpdateUntil StateMachineClient{scInstance, scChooser} timeoutSlot = do
 --   started then it returns the first state of the instance as soon as it
 --   has started.
 waitForUpdate ::
-    ( AsSMContractError e state i
+    ( AsSMContractError e
     , AsContractError e
     , PlutusTx.IsData state
     , HasAwaitSlot schema
@@ -247,7 +261,7 @@ waitForUpdate StateMachineClient{scInstance, scChooser} = do
 -- If the guard returns @'Just' a@, @'Left' a@ is returned instead.
 runGuardedStep ::
     forall a e state schema input.
-    ( AsSMContractError e state input
+    ( AsSMContractError e
     , PlutusTx.IsData state
     , PlutusTx.IsData input
     , HasUtxoAt schema
@@ -258,22 +272,23 @@ runGuardedStep ::
     => StateMachineClient state input              -- ^ The state machine
     -> input                                       -- ^ The input to apply to the state machine
     -> (UnbalancedTx -> state -> state -> Maybe a) -- ^ The guard to check before running the step
-    -> Contract schema e (Either a state)
-runGuardedStep smc input guard = mapError (review _SMContractError) $ do
-    StateMachineTransition{smtConstraints,smtOldState=State{stateData=os}, smtNewState=State{stateData=ns}, smtLookups} <- mkStep smc input
-    pk <- ownPubKey
-    let lookups = smtLookups { Constraints.slOwnPubkey = Just $ pubKeyHash pk }
-    utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups smtConstraints)
-    case guard utx os ns of
-        Nothing -> do
-            submitTxConfirmed utx
-            pure $ Right ns
-        Just a  -> pure $ Left a
+    -> Contract schema e (Either a (TransitionResult state input))
+runGuardedStep smc input guard = mapError (review _SMContractError) $ mkStep smc input >>= \case
+    Right (StateMachineTransition{smtConstraints,smtOldState=State{stateData=os}, smtNewState=State{stateData=ns}, smtLookups}) -> do
+        pk <- ownPubKey
+        let lookups = smtLookups { Constraints.slOwnPubkey = Just $ pubKeyHash pk }
+        utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups smtConstraints)
+        case guard utx os ns of
+            Nothing -> do
+                submitTxConfirmed utx
+                pure $ Right $ TransitionSuccess ns
+            Just a  -> pure $ Left a
+    Left e -> pure $ Right $ TransitionFailure e
 
 -- | Run one step of a state machine, returning the new state.
 runStep ::
     forall e state schema input.
-    ( AsSMContractError e state input
+    ( AsSMContractError e
     , PlutusTx.IsData state
     , PlutusTx.IsData input
     , HasUtxoAt schema
@@ -285,9 +300,11 @@ runStep ::
     -- ^ The state machine
     -> input
     -- ^ The input to apply to the state machine
-    -> Contract schema e state
+    -> Contract schema e (TransitionResult state input)
 runStep smc input =
-    either absurd id <$> runGuardedStep smc input (\_ _ _ -> Nothing)
+    runGuardedStep smc input (\_ _ _ -> Nothing) >>= pure . \case
+        Left a  -> absurd a
+        Right a -> a
 
 -- | Initialise a state machine
 runInitialise ::
@@ -296,7 +313,7 @@ runInitialise ::
     , PlutusTx.IsData input
     , HasTxConfirmation schema
     , HasWriteTx schema
-    , AsSMContractError e state input
+    , AsSMContractError e
     )
     => StateMachineClient state input
     -- ^ The state machine
@@ -327,39 +344,42 @@ data StateMachineTransition state input =
 --   that can produce an actual transaction performing the transition
 mkStep ::
     forall e state schema input.
-    ( AsSMContractError e state input
+    ( AsSMContractError e
     , HasUtxoAt schema
     , PlutusTx.IsData state
     )
     => StateMachineClient state input
     -> input
-    -> Contract schema e (StateMachineTransition state input)
+    -> Contract schema e (Either (InvalidTransition state input) (StateMachineTransition state input))
 mkStep client@StateMachineClient{scInstance} input = do
     let StateMachineInstance{stateMachine=StateMachine{smTransition}, validatorInstance} = scInstance
     maybeState <- getOnChainState client
-    (onChainState, utxo) <- maybe (throwing_ _NoOnChainState) pure maybeState
-    let (TypedScriptTxOut{tyTxOutData=currentState, tyTxOutTxOut}, txOutRef) = onChainState
-        oldState = State{stateData = currentState, stateValue = Ledger.txOutValue tyTxOutTxOut}
-        inputConstraints = [InputConstraint{icRedeemer=input, icTxOutRef = Typed.tyTxOutRefRef txOutRef }]
+    case maybeState of
+        Nothing -> pure $ Left $ InvalidTransition Nothing input
+        Just (onChainState, utxo) -> do
+            let (TypedScriptTxOut{tyTxOutData=currentState, tyTxOutTxOut}, txOutRef) = onChainState
+                oldState = State{stateData = currentState, stateValue = Ledger.txOutValue tyTxOutTxOut}
+                inputConstraints = [InputConstraint{icRedeemer=input, icTxOutRef = Typed.tyTxOutRefRef txOutRef }]
 
-    case smTransition oldState input of
-        Just (newConstraints, newState)  ->
-            let lookups =
-                    Constraints.scriptInstanceLookups validatorInstance
-                    <> Constraints.unspentOutputs utxo
-                outputConstraints =
-                    if smFinal (SM.stateMachine scInstance) (stateData newState)
-                        then []
-                        else [OutputConstraint{ocDatum = stateData newState, ocValue = stateValue newState }]
-            in pure
-                StateMachineTransition
-                    { smtConstraints =
-                        newConstraints
-                            { txOwnInputs = inputConstraints
-                            , txOwnOutputs = outputConstraints
+            case smTransition oldState input of
+                Just (newConstraints, newState)  ->
+                    let lookups =
+                            Constraints.scriptInstanceLookups validatorInstance
+                            <> Constraints.unspentOutputs utxo
+                        outputConstraints =
+                            if smFinal (SM.stateMachine scInstance) (stateData newState)
+                                then []
+                                else [OutputConstraint{ocDatum = stateData newState, ocValue = stateValue newState }]
+                    in pure
+                        $ Right
+                        $ StateMachineTransition
+                            { smtConstraints =
+                                newConstraints
+                                    { txOwnInputs = inputConstraints
+                                    , txOwnOutputs = outputConstraints
+                                    }
+                            , smtOldState = oldState
+                            , smtNewState = newState
+                            , smtLookups = lookups
                             }
-                    , smtOldState = oldState
-                    , smtNewState = newState
-                    , smtLookups = lookups
-                    }
-        Nothing -> throwing _InvalidTransition (currentState, input)
+                Nothing -> pure $ Left $ InvalidTransition (Just oldState) input

--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine/OnChain.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine/OnChain.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -22,7 +24,9 @@ module Language.Plutus.Contract.StateMachine.OnChain(
     , mkValidator
     ) where
 
+import           Data.Aeson                       (FromJSON, ToJSON)
 import           Data.Void                        (Void)
+import           GHC.Generics                     (Generic)
 
 import qualified Language.PlutusTx                as PlutusTx
 import           Language.PlutusTx.Prelude        hiding (check)
@@ -33,8 +37,11 @@ import           Ledger                           (Address, Value)
 import           Ledger.Typed.Scripts
 import           Ledger.Validation                (TxInInfo (..), ValidatorCtx (..), findOwnInput)
 import           Ledger.Value                     (isZero)
+import qualified Prelude                          as Haskell
 
 data State s = State { stateData :: s, stateValue :: Value }
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
 
 -- | Specification of a state machine, consisting of a transition function that determines the
 -- next state from the current state and an input, and a checking function that checks the validity

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -163,7 +163,7 @@ data FutureAction =
 data FutureError =
     TokenSetupFailed Currency.CurrencyError
     -- ^ Something went wrong during the setup of the two tokens
-    | StateMachineError (SM.SMContractError FutureState FutureAction)
+    | StateMachineError SM.SMContractError
     | OtherFutureError ContractError
     | EscrowFailed EscrowError
     -- ^ The escrow that initialises the future contract failed
@@ -174,7 +174,7 @@ data FutureError =
 
 makeClassyPrisms ''FutureError
 
-instance AsSMContractError FutureError FutureState FutureAction where
+instance AsSMContractError FutureError where
     _SMContractError = _StateMachineError
 
 instance AsContractError FutureError where
@@ -518,7 +518,7 @@ settleFuture client = mapError (review _FutureError) $ do
 settleEarly
     :: ( HasEndpoint "settle-early" (SignedMessage (Observation Value)) s
        , HasBlockchainActions s
-       , AsSMContractError e FutureState FutureAction
+       , AsSMContractError e
        , AsContractError e
        )
     => SM.StateMachineClient FutureState FutureAction
@@ -535,7 +535,7 @@ increaseMargin
        , HasWriteTx s
        , HasOwnPubKey s
        , HasTxConfirmation s
-       , AsSMContractError e FutureState FutureAction
+       , AsSMContractError e
        , AsContractError e
        )
     => SM.StateMachineClient FutureState FutureAction

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -95,7 +95,7 @@ type GameStateMachineSchema =
 
 data GameError =
     GameContractError ContractError
-    | GameSMError (SM.SMContractError GameState GameInput)
+    | GameSMError SM.SMContractError
     deriving stock (Show)
 
 -- | Top-level contract, exposing both endpoints.

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PingPong.hs
@@ -61,13 +61,13 @@ type PingPongSchema =
 
 data PingPongError =
     PingPongContractError ContractError
-    | PingPongSMError (SM.SMContractError PingPongState Input)
+    | PingPongSMError SM.SMContractError
     | StoppedUnexpectedly
     deriving stock (Show)
 
 makeClassyPrisms ''PingPongError
 
-instance AsSMContractError PingPongError PingPongState Input where
+instance AsSMContractError PingPongError where
     _SMContractError = _PingPongSMError
 
 instance AsContractError PingPongError where

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/Mirror.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/Mirror.hs
@@ -100,6 +100,6 @@ data MirrorError =
     | IssueEndpointError ContractError
     | RevokeEndpointError ContractError
     | CreateTokenTxError ContractError
-    | StateMachineError (SMContractError IDState IDAction)
+    | StateMachineError SMContractError
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Stablecoin.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Stablecoin.hs
@@ -337,7 +337,7 @@ type StablecoinSchema =
 
 data StablecoinError =
     InitialiseEPError ContractError
-    | StateMachineError (SMContractError BankState Input)
+    | StateMachineError SMContractError
     | RunStepError ContractError
     deriving stock (Haskell.Show)
 

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -40,7 +40,8 @@ tests =
 
     , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 2x, pay - FAILURE"
         (MS.contract params)
-        (assertContractError w1 (\case { TContractError MS.MSStateMachineError{} -> True; _ -> False}) "contract should fail"
+        (assertNotDone w1 "contract should proceed after invalid transition"
+        /\ assertNoFailedTransactions
         /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
         /\ walletFundsChange w2 (Ada.lovelaceValueOf 0))
         (lockProposeSignPay 2 1)
@@ -54,7 +55,8 @@ tests =
 
     , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay x3 - FAILURE"
         (MS.contract params)
-        (assertContractError w2 (\case { TContractError MS.MSStateMachineError{} -> True; _ -> False}) "contract should fail"
+        (assertNotDone w2 "contract should proceed after invalid transition"
+        /\ assertNoFailedTransactions
         /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
         /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
         (lockProposeSignPay 3 2 >> callEndpoint @"propose-payment" w2 payment >> handleBlockchainEvents w2)


### PR DESCRIPTION
* Remove the `InvalidTransition s i` branch from `SMContractError`
* As a result, contracts that don't handle the invalid transition error don't immediately fail when an invalid transition is attempted

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
