### PR TITLE
Switch to hercules-ci/gitignore.nix for a cool 2x eval speedup

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,6 @@ rec {
   inherit pkgs plutus pkgsMusl;
 
   inherit (plutus) web-ghc;
-  inherit (plutus.lib) buildNodeModules;
 
   inherit (haskell.packages.plutus-pab.components.exes)
     plutus-game
@@ -39,17 +38,17 @@ rec {
     plutus-atomic-swap
     plutus-pay-to-wallet;
 
-  webCommon = pkgs.callPackage ./web-common { };
-  webCommonPlutus = pkgs.callPackage ./web-common-plutus { };
-  webCommonMarlowe = pkgs.callPackage ./web-common-marlowe { };
-  webCommonPlayground = pkgs.callPackage ./web-common-playground { };
+  webCommon = pkgs.callPackage ./web-common { inherit (plutus.lib) gitignore-nix; };
+  webCommonPlutus = pkgs.callPackage ./web-common-plutus { inherit (plutus.lib) gitignore-nix; };
+  webCommonMarlowe = pkgs.callPackage ./web-common-marlowe { inherit (plutus.lib) gitignore-nix; };
+  webCommonPlayground = pkgs.callPackage ./web-common-playground { inherit (plutus.lib) gitignore-nix; };
 
   plutus-playground = pkgs.recurseIntoAttrs rec {
     tutorial = docs.site;
     haddock = plutus.plutus-haddock-combined;
 
     inherit (pkgs.callPackage ./plutus-playground-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules;
+      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonPlutus webCommonPlayground;
     }) client server-invoker generated-purescript generate-purescript start-backend;
   };
@@ -58,14 +57,14 @@ rec {
     tutorial = docs.marlowe-tutorial;
 
     inherit (pkgs.callPackage ./marlowe-playground-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules;
+      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonMarlowe webCommonPlayground;
     }) client server-invoker generated-purescript generate-purescript start-backend;
   };
 
   marlowe-dashboard = pkgs.recurseIntoAttrs rec {
     inherit (pkgs.callPackage ./marlowe-dashboard-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules;
+      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonMarlowe;
     }) client server-invoker generated-purescript generate-purescript;
   };
@@ -83,7 +82,7 @@ rec {
   };
 
   plutus-pab = pkgs.recurseIntoAttrs (pkgs.callPackage ./plutus-pab-client {
-    inherit (plutus.lib) buildPursPackage buildNodeModules;
+    inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
     inherit set-git-rev haskell webCommon webCommonPlutus;
   });
 

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix-gitignore, set-git-rev, haskell, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules }:
 let
   dashboard-exe = set-git-rev haskell.packages.marlowe-dashboard-server.components.exes.marlowe-dashboard-server;
   server-invoker = dashboard-exe;
@@ -14,9 +14,10 @@ let
     $(nix-build --quiet --no-build-output ../default.nix -A plutus.haskell.packages.marlowe-dashboard-server.components.exes.marlowe-dashboard-server)/bin/marlowe-dashboard-server psgenerator ./generated
   '';
 
+  cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
-    projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
+    projectDir = cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = { };
@@ -24,7 +25,7 @@ let
 
   client = buildPursPackage {
     inherit pkgs nodeModules;
-    src = ./.;
+    src = cleanSrc;
     checkPhase = "npm run test";
     name = "marlowe-dashboard-client";
     extraSrcs = {

--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix-gitignore, set-git-rev, haskell, webCommon, webCommonMarlowe, webCommonPlayground, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, webCommonPlayground, buildPursPackage, buildNodeModules }:
 let
   playground-exe = set-git-rev haskell.packages.marlowe-playground-server.components.exes.marlowe-playground-server;
 
@@ -38,8 +38,10 @@ let
     $(nix-build ../default.nix --quiet --no-build-output -A marlowe-playground.server-invoker)/bin/marlowe-playground webserver
   '';
 
+  cleanSrc = gitignore-nix.gitignoreSource ./.;
+
   nodeModules = buildNodeModules {
-    projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
+    projectDir = cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = {
@@ -52,7 +54,7 @@ let
 
   client = buildPursPackage {
     inherit pkgs nodeModules;
-    src = ./.;
+    src = cleanSrc;
     checkPhase = ''
       ${pkgs.nodejs}/bin/npm run test
     '';

--- a/nix/lib/purescript.nix
+++ b/nix/lib/purescript.nix
@@ -1,7 +1,6 @@
 { stdenv
 , nodejs
 , easyPS
-, nix-gitignore
 }:
 
 { pkgs
@@ -21,16 +20,12 @@
 , checkPhase
 }:
 let
-  # Cleans the source based on the patterns in ./.gitignore and the additionalIgnores
-  cleanSrcs = nix-gitignore.gitignoreSource [ "/*.adoc" "/*.nix" ] src;
-
   addExtraSrc = k: v: "ln -sf ${v} ${k}";
   addExtraSrcs = builtins.concatStringsSep "\n" (builtins.attrValues (pkgs.lib.mapAttrs addExtraSrc extraSrcs));
   extraPSPaths = builtins.concatStringsSep " " (map (d: "${d}/**/*.purs") (builtins.attrNames extraSrcs));
 in
 stdenv.mkDerivation {
-  inherit name checkPhase;
-  src = cleanSrcs;
+  inherit name src checkPhase;
   buildInputs = [
     nodejs
     nodeModules

--- a/nix/overlays/nixpkgs-overrides.nix
+++ b/nix/overlays/nixpkgs-overrides.nix
@@ -1,4 +1,3 @@
 self: super: {
-  nix-gitignore = super.callPackage ((import ../sources.nix).nix-gitignore) { };
   z3 = super.callPackage ../pkgs/z3 { };
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -17,6 +17,8 @@ let
       sourcesOverride = { inherit (sources) nixpkgs; };
     };
 
+  gitignore-nix = pkgs.callPackage sources."gitignore.nix" { };
+
   # The git revision comes from `rev` if available (Hydra), otherwise
   # it is read using IFD and git, which is avilable on local builds.
   git-rev = if isNull rev then iohkNix.commitIdFromGitRepo ../../.git else rev;
@@ -24,6 +26,7 @@ let
   # { index-state, project, projectPackages, packages, muslProject, muslPackages, extraPackages }
   haskell = pkgs.callPackage ./haskell {
     inherit pkgsMusl;
+    inherit gitignore-nix;
     inherit agdaWithStdlib checkMaterialization enableHaskellProfiling;
   };
 
@@ -185,9 +188,10 @@ let
 
   # Collect everything to be exported under `plutus.lib`: builders/functions/utils
   lib = rec {
+    inherit gitignore-nix;
     haddock-combine = pkgs.callPackage ../lib/haddock-combine.nix { inherit sphinxcontrib-haddock; };
     latex = pkgs.callPackage ../lib/latex.nix { };
-    npmlock2nix = (pkgs.callPackage sources.npmlock2nix { });
+    npmlock2nix = pkgs.callPackage sources.npmlock2nix { };
     buildPursPackage = pkgs.callPackage ../lib/purescript.nix { inherit easyPS;inherit (pkgs) nodejs; };
     buildNodeModules = pkgs.callPackage ../lib/node_modules.nix ({
       inherit npmlock2nix;

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -7,7 +7,7 @@
 , haskell-nix
 , buildPackages
 , checkMaterialization
-, nix-gitignore
+, gitignore-nix
 , R
 , rPackages
 , z3
@@ -35,8 +35,8 @@ let
 
   # The haskell project created by haskell-nix.stackProject'
   project = import ./haskell.nix {
-    inherit lib stdenv haskell-nix buildPackages nix-gitignore R rPackages z3;
-    inherit agdaWithStdlib checkMaterialization compiler-nix-name;
+    inherit lib stdenv haskell-nix buildPackages R rPackages z3;
+    inherit agdaWithStdlib checkMaterialization compiler-nix-name gitignore-nix;
     inherit enableHaskellProfiling;
   };
 
@@ -51,8 +51,8 @@ let
 
   # The haskell project created by haskell-nix.stackProject' (musl version)
   muslProject = import ./haskell.nix {
-    inherit (pkgsMusl) lib stdenv haskell-nix buildPackages nix-gitignore R rPackages z3;
-    inherit agdaWithStdlib checkMaterialization compiler-nix-name;
+    inherit (pkgsMusl) lib stdenv haskell-nix buildPackages R rPackages z3;
+    inherit agdaWithStdlib checkMaterialization compiler-nix-name gitignore-nix;
     inherit enableHaskellProfiling;
   };
 

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -7,7 +7,7 @@
 , haskell-nix
 , agdaWithStdlib
 , buildPackages
-, nix-gitignore
+, gitignore-nix
 , z3
 , R
 , checkMaterialization
@@ -21,7 +21,7 @@ let
     # This is incredibly difficult to get right, almost everything goes wrong, see https://github.com/input-output-hk/haskell.nix/issues/496
     src = let root = ../../../.; in
       haskell-nix.haskellLib.cleanSourceWith {
-        filter = nix-gitignore.gitignoreFilter (nix-gitignore.gitignoreCompileIgnore [ ../../../.gitignore ] root) root;
+        filter = gitignore-nix.gitignoreFilter root;
         src = root;
         # Otherwise this depends on the name in the parent directory, which reduces caching, and is
         # particularly bad on Hercules, see https://github.com/hercules-ci/support/issues/40

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,6 +12,19 @@
         "url": "https://github.com/justinwoo/easy-purescript-nix/archive/c8c32741bc09e2ac0a94d5140cf51fa5de809e24.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "gitignore.nix": {
+        "branch": "master",
+        "builtin": false,
+        "description": "Nix function for filtering local git sources",
+        "homepage": "",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
+        "sha256": "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx",
+        "type": "tarball",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/c4662e662462e7bf3c2a968483478a665d00e717.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "hackage.nix": {
         "branch": "master",
         "description": "Automatically generated Nix expressions for Hackage",
@@ -60,19 +73,6 @@
         "sha256": "0v5jv129a8wg7hgpcjgkvi8kadmh4x8gm9vacb35jlwyvhf00kal",
         "type": "tarball",
         "url": "https://github.com/fzakaria/mvn2nix/archive/3af3a7e02bce9cccc77c582a589d742e4fb8540e.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nix-gitignore": {
-        "branch": "master",
-        "builtin": false,
-        "description": "A nix expression that filters source based on a .gitignore file.",
-        "homepage": "",
-        "owner": "siers",
-        "repo": "nix-gitignore",
-        "rev": "0b788a5875163ec210cd6597cb3757fd59e73902",
-        "sha256": "01cl7hamp9n2rk0xaqrbfzg7s3g9hl40y1q184zlmqvgqx4fysmr",
-        "type": "tarball",
-        "url": "https://github.com/siers/nix-gitignore/archive/0b788a5875163ec210cd6597cb3757fd59e73902.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixops": {

--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix-gitignore, set-git-rev, haskell, webCommon, webCommonPlutus, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, buildPursPackage, buildNodeModules }:
 let
   server-invoker = set-git-rev haskell.packages.plutus-pab.components.exes.plutus-pab;
 
@@ -26,8 +26,10 @@ let
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab webserver
   '';
 
+  cleanSrc = gitignore-nix.gitignoreSource ./.;
+
   nodeModules = buildNodeModules {
-    projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
+    projectDir = cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
   };
@@ -35,7 +37,7 @@ let
   client =
     buildPursPackage {
       inherit pkgs nodeModules;
-      src = ./.;
+      src = cleanSrc;
       name = "plutus-pab-client";
       extraSrcs = {
         web-common = webCommon;

--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix-gitignore, set-git-rev, haskell, webCommon, webCommonPlutus, webCommonPlayground, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, webCommonPlayground, buildPursPackage, buildNodeModules }:
 let
   playground-exe = set-git-rev haskell.packages.plutus-playground-server.components.exes.plutus-playground-server;
 
@@ -42,16 +42,17 @@ let
     $(nix-build --quiet --no-build-output ../default.nix -A plutus-playground.server-invoker)/bin/plutus-playground webserver
   '';
 
+  cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
-    projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
+    projectDir = cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
   };
 
   client = buildPursPackage {
     inherit pkgs nodeModules;
-    src = ./.;
+    src = cleanSrc;
     name = "plutus-playground-client";
     # ideally we would just use `npm run test` but
     # this executes `spago` which *always* attempts to download

--- a/web-common-marlowe/default.nix
+++ b/web-common-marlowe/default.nix
@@ -1,1 +1,1 @@
-{ lib, nix-gitignore }: nix-gitignore.gitignoreSource [ ] ./.
+{ lib, gitignore-nix }: gitignore-nix.gitignoreSource ./.

--- a/web-common-playground/default.nix
+++ b/web-common-playground/default.nix
@@ -1,1 +1,1 @@
-{ lib, nix-gitignore }: nix-gitignore.gitignoreSource [ ] ./.
+{ lib, gitignore-nix }: gitignore-nix.gitignoreSource ./.

--- a/web-common-plutus/default.nix
+++ b/web-common-plutus/default.nix
@@ -1,1 +1,1 @@
-{ lib, nix-gitignore }: nix-gitignore.gitignoreSource [ ] ./.
+{ lib, gitignore-nix }: gitignore-nix.gitignoreSource ./.

--- a/web-common/default.nix
+++ b/web-common/default.nix
@@ -1,1 +1,1 @@
-{ lib, nix-gitignore }: nix-gitignore.gitignoreSource [ ] ./.
+{ lib, gitignore-nix }: gitignore-nix.gitignoreSource ./.


### PR DESCRIPTION
I do remember this being problematic before, switching to the more
maintained project immediately gave us a 2x eval speedup...

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
