### PR TITLE
[WIP] Add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,55 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1605370193,
+        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "locked": {
+        "narHash": "sha256-f37hiTS1xOKenIQyyvHIOenpvcv6drFrwf1I53iIwpg=",
+        "path": "/home/manveru/github/input-output-hk/haskell.nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/manveru/github/input-output-hk/haskell.nix",
+        "type": "path"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1604368813,
+        "narHash": "sha256-UOLaURSO448k+4bGJlaSMYeo2F5F6CuFo9VoYDkhmsk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d105075a1fd870b1d1617a6008cb38b443e65433",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d105075a1fd870b1d1617a6008cb38b443e65433",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "haskell-nix": "haskell-nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -17,13 +17,17 @@
     },
     "haskell-nix": {
       "locked": {
-        "narHash": "sha256-f37hiTS1xOKenIQyyvHIOenpvcv6drFrwf1I53iIwpg=",
-        "path": "/home/manveru/github/input-output-hk/haskell.nix",
-        "type": "path"
+        "lastModified": 1607066036,
+        "narHash": "sha256-0Q9YhTUq4f5g8Ax/FwQWRci7kW/TRVFuZD/YyssEuXg=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "180779b7f530dcd2a45c7d00541f0f3e3d8471b5",
+        "type": "github"
       },
       "original": {
-        "path": "/home/manveru/github/input-output-hk/haskell.nix",
-        "type": "path"
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
               builtins.fetchTarball { inherit (sourceInfo) url sha256; };
           in
           builtins.mapAttrs (_: fetch) sourcesInfo
-          // __trace "${toString nixpkgs}" { inherit nixpkgs; };
+          // { inherit nixpkgs; };
         plutusPackages = import ./nix {
           inherit system sources;
           rev = "TODO-fix-flake-rev";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Flake for Plutus";
+
+  inputs = {
+    nixpkgs.url =
+      "github:NixOS/nixpkgs?rev=d105075a1fd870b1d1617a6008cb38b443e65433";
+    # haskell-nix.url = "github:input-output-hk/haskell.nix";
+    haskell-nix.url = "path:/home/manveru/github/input-output-hk/haskell.nix";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, haskell-nix, flake-utils, ... }:
+    (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: rec {
+      overlay = import ./overlay.nix { inherit system self; };
+
+      legacyPackages = nixpkgs.legacyPackages.${system};
+
+      packages = let inherit (import ./nix { }) ownOverlays;
+      in import ./nix {
+        inherit system;
+        config = { allowUnfreePredicate = (import ./lib.nix).unfreePredicate; };
+        rev = self.rev;
+        pkgs = { overlays, config, ... }:
+          import nixpkgs {
+            inherit config;
+            overlays = [ haskell-nix.overlay ] ++ ownOverlays;
+          };
+      };
+
+      apps.web-ghc = flake-utils.lib.mkApp { drv = legacyPackages.web-ghc; };
+    }));
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,8 @@
             fetch = sourceInfo:
               builtins.fetchTarball { inherit (sourceInfo) url sha256; };
           in
-          builtins.mapAttrs (_: fetch) sourcesInfo;
+          builtins.mapAttrs (_: fetch) sourcesInfo
+          // __trace "${toString nixpkgs}" { inherit nixpkgs; };
         plutusPackages = import ./nix {
           inherit system sources;
           rev = "TODO-fix-flake-rev";

--- a/flake.nix
+++ b/flake.nix
@@ -15,17 +15,57 @@
 
       legacyPackages = nixpkgs.legacyPackages.${system};
 
-      packages = let inherit (import ./nix { }) ownOverlays;
-      in import ./nix {
-        inherit system;
-        config = { allowUnfreePredicate = (import ./lib.nix).unfreePredicate; };
-        rev = self.rev;
-        pkgs = { overlays, config, ... }:
-          import nixpkgs {
-            inherit config;
-            overlays = [ haskell-nix.overlay ] ++ ownOverlays;
+      packages = let
+        inherit (import ./nix { }) ownOverlays;
+        sources = let
+          sourcesInfo =
+            builtins.fromJSON (builtins.readFile ./nix/sources.json);
+          fetch = sourceInfo:
+            builtins.fetchTarball { inherit (sourceInfo) url sha256; };
+        in builtins.mapAttrs (_: fetch) sourcesInfo;
+
+        iohkNix = import sources.iohk-nix { };
+        overlays = [
+          haskell-nix.overlay
+        ]
+        # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
+          ++ iohkNix.overlays.haskell-nix-extra
+          # iohkNix: nix utilities and niv:
+          ++ iohkNix.overlays.iohkNix
+          # our own overlays:
+          ++ [
+            # Modifications to derivations from nixpkgs
+            (import ./nix/overlays/nixpkgs-overrides.nix)
+            # This contains musl-specific stuff, but it's all guarded by appropriate host-platform
+            # checks, so we can include it unconditionally
+            (import ./nix/overlays/musl.nix)
+            # fix r-modules
+            (import ./nix/overlays/r.nix)
+          ];
+        pkgs = import nixpkgs {
+          config = {
+            allowUnfreePredicate = (import ./lib.nix).unfreePredicate;
           };
-      };
+          localSystem = system;
+          overlays = overlays;
+        };
+
+        plutusMusl = import sources.nixpkgs {
+          inherit system;
+          crossSystem = pkgs.lib.systems.examples.musl64;
+          overlays = overlays;
+          config = haskell-nix.config // {
+            allowUnfreePredicate = (import ./lib.nix).unfreePredicate;
+          };
+        };
+
+        rev = null;
+
+        plutus = import ./nix/pkgs {
+          inherit rev pkgs plutusMusl sources;
+          checkMaterialization = false;
+        };
+      in plutus;
 
       apps.web-ghc = flake-utils.lib.mkApp { drv = legacyPackages.web-ghc; };
     }));

--- a/flake.nix
+++ b/flake.nix
@@ -4,69 +4,42 @@
   inputs = {
     nixpkgs.url =
       "github:NixOS/nixpkgs?rev=d105075a1fd870b1d1617a6008cb38b443e65433";
-    # haskell-nix.url = "github:input-output-hk/haskell.nix";
-    haskell-nix.url = "path:/home/manveru/github/input-output-hk/haskell.nix";
+    haskell-nix.url = "github:input-output-hk/haskell.nix";
+    # haskell-nix.url = "path:/home/manveru/github/input-output-hk/haskell.nix";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, haskell-nix, flake-utils, ... }:
-    (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: rec {
-      overlay = import ./overlay.nix { inherit system self; };
+    (flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
+      let
+        sources =
+          let
+            sourcesInfo =
+              builtins.fromJSON (builtins.readFile ./nix/sources.json);
+            fetch = sourceInfo:
+              builtins.fetchTarball { inherit (sourceInfo) url sha256; };
+          in
+          builtins.mapAttrs (_: fetch) sourcesInfo;
+        plutusPackages = import ./nix {
+          inherit system sources;
+          rev = "TODO-fix-flake-rev";
+          haskellNixOverlays = [ haskell-nix.overlay ];
+        };
+        inherit (plutusPackages) pkgs plutusMusl plutus ownOverlays;
+      in
+      rec {
+        legacyPackages = pkgs;
+        # overlays = ownOverlays;
 
-      legacyPackages = nixpkgs.legacyPackages.${system};
-
-      packages = let
-        inherit (import ./nix { }) ownOverlays;
-        sources = let
-          sourcesInfo =
-            builtins.fromJSON (builtins.readFile ./nix/sources.json);
-          fetch = sourceInfo:
-            builtins.fetchTarball { inherit (sourceInfo) url sha256; };
-        in builtins.mapAttrs (_: fetch) sourcesInfo;
-
-        iohkNix = import sources.iohk-nix { };
-        overlays = [
-          haskell-nix.overlay
-        ]
-        # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-          ++ iohkNix.overlays.haskell-nix-extra
-          # iohkNix: nix utilities and niv:
-          ++ iohkNix.overlays.iohkNix
-          # our own overlays:
-          ++ [
-            # Modifications to derivations from nixpkgs
-            (import ./nix/overlays/nixpkgs-overrides.nix)
-            # This contains musl-specific stuff, but it's all guarded by appropriate host-platform
-            # checks, so we can include it unconditionally
-            (import ./nix/overlays/musl.nix)
-            # fix r-modules
-            (import ./nix/overlays/r.nix)
-          ];
-        pkgs = import nixpkgs {
-          config = {
-            allowUnfreePredicate = (import ./lib.nix).unfreePredicate;
-          };
-          localSystem = system;
-          overlays = overlays;
+        packages = {
+          web-ghc-server = plutus.haskell.project.hsPkgs.web-ghc.components.exes.web-ghc-server;
         };
 
-        plutusMusl = import sources.nixpkgs {
-          inherit system;
-          crossSystem = pkgs.lib.systems.examples.musl64;
-          overlays = overlays;
-          config = haskell-nix.config // {
-            allowUnfreePredicate = (import ./lib.nix).unfreePredicate;
-          };
+        devShell = import ./shell.nix { packages = plutusPackages; };
+
+        apps.web-ghc = flake-utils.lib.mkApp {
+          exePath = "/bin/web-ghc-server"; # This is only needed because haskell.nix exePath includes $out
+          drv = packages.web-ghc-server;
         };
-
-        rev = null;
-
-        plutus = import ./nix/pkgs {
-          inherit rev pkgs plutusMusl sources;
-          checkMaterialization = false;
-        };
-      in plutus;
-
-      apps.web-ghc = flake-utils.lib.mkApp { drv = legacyPackages.web-ghc; };
-    }));
+      }));
 }

--- a/nix/overlays/nixpkgs-overrides.nix
+++ b/nix/overlays/nixpkgs-overrides.nix
@@ -1,5 +1,6 @@
+{ sources }:
 self: super: {
-  nix-gitignore = super.callPackage ((import ../sources.nix).nix-gitignore) { };
+  nix-gitignore = super.callPackage (sources.nix-gitignore) { };
   # We can *nearly* replace this with upstream nixpkgs, but unfortunately we also need a patch
   # that hasn't been merged upstream yet. And you can't override the pieces of a 'bundlerApp'.
   asciidoctor = super.callPackage ../pkgs/asciidoctor { };

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -84,7 +84,7 @@ let
   # `set-git-rev` is a function that can be called on a haskellPackages
   # package to inject the git revision post-compile
   set-git-rev = pkgs.callPackage ./set-git-rev {
-    inherit (haskell.packages) ghcWithPackages;
+    inherit (haskell.project) ghcWithPackages;
     inherit git-rev;
   };
 

--- a/nix/pkgs/web-ghc/default.nix
+++ b/nix/pkgs/web-ghc/default.nix
@@ -2,7 +2,7 @@
 let
   web-ghc-server = set-git-rev haskell.packages.web-ghc.components.exes.web-ghc-server;
 
-  runtimeGhc = haskell.packages.ghcWithPackages (ps: [
+  runtimeGhc = haskell.project.ghcWithPackages (ps: [
     ps.playground-common
     ps.plutus-playground-server
     ps.plutus-use-cases

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c583fb3e775d0f071b58a53f82f726cec623c800",
-        "sha256": "0pzsaxwap6jmmpcyzwvygbrfcanjzkwfrmlqac4jnjrfixd8g27s",
+        "rev": "180779b7f530dcd2a45c7d00541f0f3e3d8471b5",
+        "sha256": "0y5r0k5wmn1zcip52ifkdy8vpj252q21fzqcy1hgxq9a6n2mh3yi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/c583fb3e775d0f071b58a53f82f726cec623c800.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/180779b7f530dcd2a45c7d00541f0f3e3d8471b5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/shell.nix
+++ b/shell.nix
@@ -76,7 +76,7 @@ let
   ]);
 
 in
-haskell.packages.shellFor {
+haskell.project.shellFor {
   nativeBuildInputs = nixpkgsInputs ++ localInputs ++ [ agdaWithStdlib sphinxTools ];
 
   # we have a local passwords store that we use for deployments etc.


### PR DESCRIPTION
@manveru, I found a couple of places where `nix/sources.nix` was still used instead of `sources`.  Putting a dummy `rev` value in gets rid of one of them (I guess the `iohk-nix` repo is the culprit there, but you pointed out that that get git rev function won't work in a flake anyway).

I was also able to refactor some of the code back out of the `flake.nix` and into `nix/default.nix` adding some arguments and passing the `nixpkgs` thorough as `sources.nixpkgs`.

Some stuff seems to work fine ok on darwin now:

```
~/iohk/plutus$ nix build .#web-ghc-server
~/iohk/plutus$ ./result/bin/web-ghc-server --help
Usage: web-ghc-server [-v|--version] COMMAND

Available options:
  -h,--help                Show this help text
  -v,--version             Show the version

Available commands:
  webserver                
~/iohk/plutus$ nix run .#web-ghc -- --help
Usage: web-ghc-server [-v|--version] COMMAND

Available options:
  -h,--help                Show this help text
  -v,--version             Show the version

Available commands:
  webserver                
```

Sadly `nix develop` does segfaults:

```
~/iohk/plutus$ nix develop
trace: To make project.plan-nix for hoogle a fixed-output derivation but not materialized, set `plan-sha256` to the output of the 'calculateMaterializedSha' script in 'passthru'.
trace: To materialize project.plan-nix for hoogle entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
Segmentation fault: 11
```