### PR TITLE
GHC-friendly implementation of Data.Row.(.\/)

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -87,7 +87,7 @@ module Language.Plutus.Contract(
     ) where
 
 import           Data.Aeson                                        (ToJSON (toJSON))
-import           Data.Row
+import           Data.Row                                          hiding (type (.\/))
 
 import           Language.Plutus.Contract.Effects.AwaitSlot        as AwaitSlot
 import           Language.Plutus.Contract.Effects.AwaitTxConfirmed as AwaitTxConfirmed
@@ -99,6 +99,7 @@ import           Language.Plutus.Contract.Effects.UtxoAt           as UtxoAt
 import           Language.Plutus.Contract.Effects.WatchAddress     as WatchAddress
 import           Language.Plutus.Contract.Effects.WriteTx
 
+import           Data.Row.Extras                                   (type (.\/))
 import           Language.Plutus.Contract.Request                  (ContractRow)
 import           Language.Plutus.Contract.Typed.Tx                 as Tx
 import           Language.Plutus.Contract.Types                    (AsCheckpointError (..), AsContractError (..),

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism.hs
@@ -91,7 +91,8 @@ type PrismSchema =
     .\/ UnlockExchangeSchema
     .\/ Endpoint "role" Role
 
-{- The above type seems to take GHC an awful lot of time to figure out -}
+{- With the implementation of .\/ from row-types, GHC chokes on the above type because of the four
+   repeated BlockchainActions. Using our own implementation from Data.Row.Extras everything is fine. -}
 
 data PrismError =
     UnlockSTOErr UnlockError


### PR DESCRIPTION
GHC really doesn't like the one from row-types when there are many overlapping rows. This
bites us in the Prism use-case, where we combine four different schemas that all contain
BlockchainActions.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] ~~Relevant tickets are mentioned in commit messages~~
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
