### PR TITLE
Adding last compiled code and last evaluated simulation to state.

### DIFF
--- a/plutus-playground-client/src/MainFrame.purs
+++ b/plutus-playground-client/src/MainFrame.purs
@@ -68,7 +68,7 @@ import Servant.PureScript.Ajax (errorToString)
 import Servant.PureScript.Settings (SPSettings_, defaultSettings)
 import StaticData (mkContractDemos)
 import StaticData as StaticData
-import Types (ChildSlots, DragAndDropEventType(..), HAction(..), Query, State(..), View(..), WalletEvent(..), WebData, _actionDrag, _authStatus, _blockchainVisualisationState, _compilationResult, _contractDemos, _createGistResult, _currentView, _evaluationResult, _functionSchema, _gistUrl, _knownCurrencies, _result, _resultRollup, _simulationActions, _simulationWallets, _simulations, _simulatorWalletBalance, _simulatorWalletWallet, _successfulCompilationResult, _walletId, getKnownCurrencies, toEvaluation)
+import Types (ChildSlots, DragAndDropEventType(..), HAction(..), Query, State(..), View(..), WalletEvent(..), WebData, _actionDrag, _authStatus, _blockchainVisualisationState, _compilationResult, _contractDemos, _createGistResult, _currentView, _evaluationResult, _functionSchema, _gistUrl, _lastCompiledCode, _lastEvaluatedSimulation, _knownCurrencies, _result, _resultRollup, _simulationActions, _simulationWallets, _simulations, _simulatorWalletBalance, _simulatorWalletWallet, _successfulCompilationResult, _walletId, getKnownCurrencies, toEvaluation)
 import Validation (_argumentValues, _argument)
 import ValueEditor (ValueEvent(..))
 import View as View
@@ -99,9 +99,11 @@ mkInitialState editorState = do
         , editorState
         , contractDemos
         , compilationResult: NotAsked
+        , lastCompiledCode: Nothing
         , simulations: Cursor.empty
         , actionDrag: Nothing
         , evaluationResult: NotAsked
+        , lastEvaluatedSimulation: Nothing
         , authStatus: NotAsked
         , createGistResult: NotAsked
         , gistUrl: Nothing
@@ -278,18 +280,20 @@ handleAction EvaluateActions =
   void
     $ runMaybeT
     $ do
+        simulation <- peruse (_simulations <<< _current)
         evaluation <-
           MaybeT do
             contents <- editorGetContents
-            simulation <- peruse (_simulations <<< _current)
             pure $ join $ toEvaluation <$> contents <*> simulation
         assign _evaluationResult Loading
         result <- lift $ postEvaluation evaluation
         assign _evaluationResult result
-        -- If we got a successful result, switch tab.
+        -- If we got a successful result, update last evaluated simulation and switch tab.
         case result of
           Success (Left _) -> pure unit
-          _ -> replaceViewOnSuccess result Simulations Transactions
+          _ -> do
+            updateSimulationOnSuccess result simulation
+            replaceViewOnSuccess result Simulations Transactions
         pure unit
 
 handleAction (LoadScript key) = do
@@ -355,10 +359,12 @@ handleAction CompileProgram = do
       assign _compilationResult Loading
       newCompilationResult <- postContract contents
       assign _compilationResult newCompilationResult
-      -- If we got a successful result, switch tab.
+      -- If we got a successful result, update last compiled code and switch tab.
       case newCompilationResult of
         Success (Left _) -> pure unit
-        _ -> replaceViewOnSuccess newCompilationResult Editor Simulations
+        _ -> do
+          updateCodeOnSuccess newCompilationResult mContents
+          replaceViewOnSuccess newCompilationResult Editor Simulations
       -- Update the error display.
       editorSetAnnotations
         $ case newCompilationResult of
@@ -478,6 +484,16 @@ handleActionWalletEvent _ (ModifyBalance walletIndex action) wallets =
     (ix walletIndex <<< _simulatorWalletBalance)
     (Schema.handleValueEvent action)
     wallets
+
+updateSimulationOnSuccess :: forall m e a. MonadState State m => RemoteData e a -> Maybe Simulation -> m Unit
+updateSimulationOnSuccess result simulation = do
+  when (isSuccess result)
+    (assign _lastEvaluatedSimulation simulation)
+
+updateCodeOnSuccess :: forall m e a. MonadState State m => RemoteData e a -> Maybe SourceCode -> m Unit
+updateCodeOnSuccess result code = do
+  when (isSuccess result)
+    (assign _lastCompiledCode code)
 
 replaceViewOnSuccess :: forall m e a. MonadState State m => RemoteData e a -> View -> View -> m Unit
 replaceViewOnSuccess result source target = do

--- a/plutus-playground-client/src/Types.purs
+++ b/plutus-playground-client/src/Types.purs
@@ -196,9 +196,11 @@ newtype State
   , contractDemos :: Array ContractDemo
   , editorState :: Editor.State
   , compilationResult :: WebData (Either InterpreterError (InterpreterResult CompilationResult))
+  , lastCompiledCode :: Maybe SourceCode
   , simulations :: Cursor Simulation
   , actionDrag :: Maybe Int
   , evaluationResult :: WebData (Either PlaygroundError EvaluationResult)
+  , lastEvaluatedSimulation :: Maybe Simulation
   , authStatus :: WebData AuthStatus
   , createGistResult :: WebData Gist
   , gistUrl :: Maybe String
@@ -216,6 +218,9 @@ _contractDemos = _Newtype <<< prop (SProxy :: SProxy "contractDemos")
 _editorState :: Lens' State Editor.State
 _editorState = _Newtype <<< prop (SProxy :: SProxy "editorState")
 
+_lastCompiledCode :: Lens' State (Maybe SourceCode)
+_lastCompiledCode = _Newtype <<< prop (SProxy :: SProxy "lastCompiledCode")
+
 _simulations :: Lens' State (Cursor Simulation)
 _simulations = _Newtype <<< prop (SProxy :: SProxy "simulations")
 
@@ -230,6 +235,9 @@ _simulationWallets = _Newtype <<< prop (SProxy :: SProxy "simulationWallets")
 
 _evaluationResult :: Lens' State (WebData (Either PlaygroundError EvaluationResult))
 _evaluationResult = _Newtype <<< prop (SProxy :: SProxy "evaluationResult")
+
+_lastEvaluatedSimulation :: Lens' State (Maybe Simulation)
+_lastEvaluatedSimulation = _Newtype <<< prop (SProxy :: SProxy "lastEvaluatedSimulation")
 
 _resultRollup :: Lens' EvaluationResult (Array (Array AnnotatedTx))
 _resultRollup = _Newtype <<< prop (SProxy :: SProxy "resultRollup")


### PR DESCRIPTION
This will allow comparing with the current code/simulation to check for changes. Specifically, this will enable us to disable the simulate/transactions buttons on the new interface when the code or simulation changes, forcing the user to recompile/reevaluate.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge