### PR TITLE
[Builtins] Type scheme inference for polymorphic built-in functions

### DIFF
--- a/plutus-core/src/Language/PlutusCore/Builtins.hs
+++ b/plutus-core/src/Language/PlutusCore/Builtins.hs
@@ -218,9 +218,8 @@ instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni Default
             ((>) @BS.ByteString)
             (runCostingFunTwoArguments . paramGtByteString)
     toBuiltinMeaning IfThenElse =
-        toStaticBuiltinMeaning
-            ((\b x y -> if b then x else y)
-                :: a ~ Opaque term (TyVarRep ('TyNameRep "a" 0)) => Bool -> a -> a -> a)
+       toStaticBuiltinMeaning
+            (\b x y -> if b then x else y)
             (runCostingFunThreeArguments . paramIfThenElse)
     toBuiltinMeaning CharToString =
         toStaticBuiltinMeaning

--- a/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
@@ -291,7 +291,8 @@ instance
     , a ~?~ var
     -- If @a@ is equal to @var@ then unification was successful and we just used the fresh id and
     -- so we need to bump it up. Otherwise @var@ was discarded and so the fresh id is still fresh.
-    , j ~ If (a == var) (i + 1) i
+    -- Replacing @(===)@ with @(==)@ causes errors at use site, for whatever reason.
+    , j ~ If (a === var) (i + 1) i
     ) => TrySpecializeAsVar i j term a
 
 -- See https://github.com/effectfully/sketches/tree/master/poly-type-of-saga/part2-enumerate-type-vars

--- a/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
@@ -173,7 +173,8 @@ Polymorphic built-in functions are handled via automatic specialization of all H
 variables as types representing PLC type variables, as long as each Haskell variable appears as a
 direct argument to @(->)@ (both possible positions are fine) and not buried somewhere inside
 (i.e. automatic derivation can handle neither @f a@, @ListRep a@, nor @f Int@. Nor is @a -> b@
-allowed to the left of an @(->)@). We'll call functions having such types "simply-polymorphic".
+allowed to the left of an @(->)@. Where all lower-case names are Haskell type variables).
+We'll call functions having such types "simply-polymorphic".
 See the docs of 'EnumerateFromTo' for details.
 
 The end result is that the user only has to specify the type of the denotation of a built-in
@@ -282,7 +283,7 @@ type GetName i = Lookup i '["a", "b", "c", "d", "e", "f", "g", "h"]
 
 -- | Try to specialize @a@ as a type representing a Plutus type variable.
 -- @i@ is a fresh id and @j@ is a final one (either @i + 1@ or @i@ depending on whether
--- specialization is successful or not).
+-- specialization attempt is successful or not).
 type TrySpecializeAsVar :: Nat -> Nat -> GHC.Type -> GHC.Type -> GHC.Constraint
 class TrySpecializeAsVar i j term a | i term a -> j
 instance
@@ -298,9 +299,9 @@ instance
 -- See https://github.com/effectfully/sketches/tree/master/poly-type-of-saga/part2-enumerate-type-vars
 -- for a detailed elaboration on how this works.
 -- | Specialize each Haskell type variable in @a@ as a type representing a Plutus Core type variable
--- by deconstucting @a@ into an applied @(->)@ (we don't recurse to the left of @(->)@, only to the
+-- by deconstructing @a@ into an applied @(->)@ (we don't recurse to the left of @(->)@, only to the
 -- right) and trying to specialize every argument type as a PLC type variable
--- (via 'TrySpecializeAsVar') until no deconstuction is possible, at which point we've got a result
+-- (via 'TrySpecializeAsVar') until no deconstruction is possible, at which point we've got a result
 -- type which we also try to specialize as a type representing a PLC type variable.
 type EnumerateFromTo :: Nat -> Nat -> GHC.Type -> GHC.Type -> GHC.Constraint
 class EnumerateFromTo i j term a | i term a -> j

--- a/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Meaning.hs
@@ -33,7 +33,7 @@ import           Data.Functor.Compose
 import qualified Data.Kind                                        as GHC
 import           Data.Proxy
 import           Data.Type.Bool
--- import           Data.Type.Equality
+import           Data.Type.Equality
 import           GHC.TypeLits
 
 -- | The meaning of a dynamic built-in function consists of its type represented as a 'TypeScheme',
@@ -281,9 +281,13 @@ type family x === y where
     x === x = 'True
     x === y = 'False
 
-class (x === y) ~ can => CanUnify can (x :: a) (y :: b)
-instance {-# INCOHERENT #-} (x ~ y, can ~ 'True) => CanUnify can (x :: a) (y :: a)
-instance (x === y) ~ 'False => CanUnify 'False (x :: a) (y :: b)
+-- class (x === y) ~ can => CanUnify can (x :: a) (y :: b)
+-- instance {-# INCOHERENT #-} (x ~~ y, can ~ 'True) => CanUnify can (x :: a) (y :: b)
+-- instance (x === y) ~ 'False => CanUnify 'False (x :: a) (y :: b)
+
+class CanUnify can (x :: a) (y :: b)
+instance {-# INCOHERENT #-} (x ~~ y, can ~ 'True) => CanUnify can (x :: a) (y :: b)
+instance CanUnify 'False (x :: a) (y :: b)
 
 -- type (~?~) :: forall a b. a -> b -> GHC.Constraint
 -- type x ~?~ y = CanUnify (x === y) x y
@@ -315,7 +319,7 @@ type MonoArgOf :: forall b. b -> b
 type family MonoArgOf y where
     MonoArgOf (_ x) = x
 
-type ArgOf :: forall b a. b -> a
+type ArgOf :: forall a b. b -> a
 type family ArgOf b where
     ArgOf (_ x) = x
 
@@ -338,12 +342,43 @@ instance
     , appF' ~ TyAppRep f'
     , (f === appF') ~ can
     , CanUnify can f appF'
-    , EnumerateFromToRep i0 iN j0 jN term (If can f' Else)  -- Could also have mutual recursion here.
-    , EnumerateFromToArg j0 jN k0 kN term x                 -- Note the mutual recursion.
-    ) => EnumerateFromToRep i0 iN k0 kN term (f x :: k)
+    , EnumerateFromToRep i0 iN j0 jN term (If can f' Else)
+    , EnumerateFromToRep j0 jN k0 kN term x
+    ) => EnumerateFromToRep i0 iN k0 kN term (f (x :: a) :: b)
+
+-- class (x === y) ~ can => Can'tUnify can (x :: a) (y :: b)
+-- instance {-# INCOHERENT #-} ((x === y) ~ can, can ~ 'False) => Can'tUnify can (x :: a) (y :: b)
+-- instance x ~~ y => Can'tUnify 'True (x :: a) (y :: b)
 
 type EnumerateFromToArg :: forall b. Nat -> Nat -> Nat -> Nat -> GHC.Type -> b -> GHC.Constraint
 class EnumerateFromToArg i0 iN j0 jN term y | i0 iN term y -> j0 jN
+
+-- -- Isn't it funny how to be lazy at the type level you need to do the opposite thing compared
+-- -- to what you'd do at the term level?
+-- type LazyAnd :: Bool -> Bool -> Bool
+-- type family LazyAnd b c where
+--     LazyAnd 'True 'True = 'True
+--     LazyAnd _     _     = 'False
+
+-- class Can'tUnify (can :: Bool) (res :: Bool) (x :: a) (y :: b) | can -> res
+-- instance {-# INCOHERENT #-} res ~ 'True => Can'tUnify can res (x :: a) (y :: b)
+-- instance res ~ 'False => Can'tUnify 'True res (x :: a) (y :: b)
+
+-- -- This at least makes @Builtins.hs@ type check. But still fails on
+-- -- @id :: la ~ Opaque term (ListRep a) => la -> la@ for some inexplicable reason.
+-- instance {-# INCOHERENT #-}
+--     ( rep ~ ArgOf y
+--     , opaque ~ Opaque term rep
+--     , (y === opaque) ~ can1
+--     , can ~ (can1 `LazyAnd` res)
+--     , Can'tUnify (y === term) res y opaque
+--     , CanUnify can y opaque
+--     , EnumerateFromToRep i0 iN j0 jN term (If can rep Else)
+--     ) => EnumerateFromToArg i0 iN j0 jN term (y :: b)
+
+-- instance {-# OVERLAPPING #-} (i0 ~ j0, iN ~ jN) => EnumerateFromToArg i0 iN j0 jN term term
+
+-- TODO: unify the two type classes by matching on @can@?
 
 instance {-# INCOHERENT #-}
     ( rep ~ ArgOf y
@@ -354,14 +389,21 @@ instance {-# INCOHERENT #-}
     ) => EnumerateFromToArg i0 iN j0 jN term (y :: b)
 
 instance
-    ( f' ~ MonoArgOf (MonoArgOf f)
-    , opaqueF' ~ Compose (Opaque term) (TyAppRep f')
+    ( f' ~ MonoArgOf (ArgOf f)
+    , opaqueF' ~ Compose (Opaque term) (TyAppRep @a f')
     , (f === opaqueF') ~ can
     , CanUnify can f opaqueF'
     , EnumerateFromToRep i0 iN j0 jN term (If can f' Else)
-    , EnumerateFromToArg j0 jN k0 kN term (If can Else f)
-    , EnumerateFromToArg k0 kN l0 lN term x
-    ) => EnumerateFromToArg i0 iN l0 lN term (f x)
+    , EnumerateFromToRep j0 jN k0 kN term (If can x Else)
+    -- GHC is too stupid to realize that @term === Opaque term rep@ can't be 'True'. How so?
+    -- Isn't @term@ supposed to be rigid? And even if it's somehow not, 'Opaque' certainly is,
+    -- so that should have been a straightforward failing occurs check. This is really annoying.
+    -- What this means is that @ListRep@ works without a fully elaborated type signature while
+    -- something like @EitherRep@ wouldn't.
+    -- , EnumerateFromToArg k0 kN l0 lN term (If can Else f)
+    , k0 ~ l0, kN ~ lN
+    , EnumerateFromToArg l0 lN m0 mN term (If can Else x)
+    ) => EnumerateFromToArg i0 iN m0 mN term (f (x :: a) :: b)
 
 type EnumerateFromTo :: Nat -> Nat -> Nat -> Nat -> GHC.Type -> GHC.Type -> GHC.Constraint
 class EnumerateFromTo i0 iN j0 jN term a | i0 iN term a -> j0 jN

--- a/plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -48,7 +48,6 @@ import           Language.PlutusCore.Universe
 
 import           Control.Monad.Except
 import qualified Data.ByteString                                    as BS
-import           Data.Functor.Compose
 import qualified Data.Kind                                          as GHC (Type)
 import           Data.Proxy
 import           Data.String
@@ -453,10 +452,3 @@ instance KnownBuiltinType term Integer => KnownType term Int where
         unless (fromIntegral (minBound :: Int) <= i && i <= fromIntegral (maxBound :: Int)) $
             throwingWithCause _EvaluationFailure () $ Just term
         pure $ fromIntegral i
-
-instance KnownTypeAst term (g (f a)) => KnownTypeAst term (Compose g f a) where
-    toTypeAst _ = toTypeAst $ Proxy @(g (f a))
-
-instance KnownType term (g (f a)) => KnownType term (Compose g f a) where
-    makeKnown = makeKnown . getCompose
-    readKnown = fmap Compose . readKnown

--- a/plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -48,6 +48,7 @@ import           Language.PlutusCore.Universe
 
 import           Control.Monad.Except
 import qualified Data.ByteString                                    as BS
+import           Data.Functor.Compose
 import qualified Data.Kind                                          as GHC (Type)
 import           Data.Proxy
 import           Data.String
@@ -452,3 +453,10 @@ instance KnownBuiltinType term Integer => KnownType term Int where
         unless (fromIntegral (minBound :: Int) <= i && i <= fromIntegral (maxBound :: Int)) $
             throwingWithCause _EvaluationFailure () $ Just term
         pure $ fromIntegral i
+
+instance KnownTypeAst term (g (f a)) => KnownTypeAst term (Compose g f a) where
+    toTypeAst _ = toTypeAst $ Proxy @(g (f a))
+
+instance KnownType term (g (f a)) => KnownType term (Compose g f a) where
+    makeKnown = makeKnown . getCompose
+    readKnown = fmap Compose . readKnown

--- a/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
+++ b/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
@@ -147,11 +147,15 @@ instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni Ex
             mempty
     toBuiltinMeaning IdFInteger =
         toStaticBuiltinMeaning
-            (Prelude.id :: a ~ f Integer => a -> a)
+            (Prelude.id
+                :: a ~ Opaque term (TyAppRep (TyVarRep ('TyNameRep "f" 0)) Integer)
+                => a -> a)
             mempty
     toBuiltinMeaning IdList =
         toStaticBuiltinMeaning
-            (Prelude.id :: la ~ Opaque term (ListRep a) => la -> la)
+            (Prelude.id
+                :: a ~ Opaque term (ListRep (TyVarRep ('TyNameRep "a" 0)))
+                => a -> a)
             mempty
     toBuiltinMeaning IdRank2 =
         toStaticBuiltinMeaning

--- a/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
+++ b/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
@@ -25,6 +25,7 @@ import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Evaluation.Machine.ExBudgeting
 import           Language.PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import           Language.PlutusCore.Evaluation.Machine.ExMemory
+import           Language.PlutusCore.Evaluation.Machine.Exception
 import           Language.PlutusCore.Generators.Interesting
 import           Language.PlutusCore.MkPlc                                  hiding (error)
 import           Language.PlutusCore.Pretty
@@ -39,6 +40,7 @@ import           Data.Either
 import qualified Data.Kind                                                  as GHC (Type)
 import           Data.Proxy
 import           Data.Text.Prettyprint.Doc
+import           Data.Void
 import           GHC.Generics
 import           GHC.Ix
 import           Hedgehog                                                   hiding (Opaque, Size, Var)
@@ -108,6 +110,7 @@ data ExtensionFun
     | IdFInteger
     | IdList
     | IdRank2
+    | Absurd
     deriving (Show, Eq, Ord, Enum, Bounded, Ix, Generic, Hashable)
     deriving ExMemoryUsage via (GenericExMemoryUsage ExtensionFun)
 
@@ -132,6 +135,15 @@ data ListRep (a :: GHC.Type)
 instance KnownTypeAst uni a => KnownTypeAst uni (ListRep a) where
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
 type instance ToBinds (ListRep a) = ToBinds a
+
+instance KnownTypeAst uni Void where
+    toTypeAst _ = runQuote $ do
+        a <- freshTyName "a"
+        pure $ TyForall () a (Type ()) $ TyVar () a
+instance KnownType term Void where
+    makeKnown = absurd
+    readKnown = throwingWithCause _UnliftingError "Can't unlift a 'Void'" . Just
+type instance ToBinds Void = '[]
 
 instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni ExtensionFun where
     type DynamicPart uni ExtensionFun = ()
@@ -165,6 +177,12 @@ instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni Ex
                    , afa ~ Opaque term (TyForallRep a (TyAppRep (TyVarRep f) (TyVarRep a)))
                    )
                 => afa -> afa)
+            mempty
+    toBuiltinMeaning Absurd =
+        toStaticBuiltinMeaning
+            (absurd
+                :: a ~ Opaque term (TyVarRep ('TyNameRep "a" 0))
+                => Void -> a)
             mempty
 
 -- | Check that 'Factorial' from the above computes to the same thing as
@@ -299,6 +317,16 @@ test_IdRank2 =
         tyAct @?= tyExp
         typecheckEvaluateCek defBuiltinsRuntimeExt term @?= Right (EvaluationSuccess res)
 
+-- | Test that the type of PLC @Absurd@ is inferred correctly.
+test_Absurd :: TestTree
+test_Absurd =
+    testCase "Absurd" $ do
+        let tyAct = typeOfBuiltinFunction @DefaultUni Absurd
+            tyExp = let a = TyName . Name "a" $ Unique 0
+                        tyForallA = TyForall () a (Type ())
+                    in tyForallA . TyFun () (tyForallA $ TyVar () a) $ TyVar () a
+        tyAct @?= tyExp
+
 test_definition :: TestTree
 test_definition =
     testGroup "definition"
@@ -308,4 +336,5 @@ test_definition =
         , test_IdFInteger
         , test_IdList
         , test_IdRank2
+        , test_Absurd
         ]

--- a/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
+++ b/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
@@ -131,7 +131,7 @@ defBuiltinsRuntimeExt = toBuiltinsRuntime (defDefaultFunDyn, ()) (defaultCostMod
 data ListRep (a :: GHC.Type)
 instance KnownTypeAst uni a => KnownTypeAst uni (ListRep a) where
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
-type instance ToBinds (ListRep a) = TypeToBinds a
+type instance ToBinds (ListRep a) = ToBinds a
 
 instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni ExtensionFun where
     type DynamicPart uni ExtensionFun = ()
@@ -139,34 +139,29 @@ instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni Ex
     toBuiltinMeaning Factorial = toStaticBuiltinMeaning (\(n :: Integer) -> product [1..n]) mempty
     toBuiltinMeaning Const =
         toStaticBuiltinMeaning
-            (const
-                :: ( a ~ Opaque term (TyVarRep ('TyNameRep "a" 0))
-                   , b ~ Opaque term (TyVarRep ('TyNameRep "b" 1))
-                   )
-                => a -> b -> a)
+            const
             mempty
     toBuiltinMeaning Id =
         toStaticBuiltinMeaning
-            (Prelude.id :: a ~ Opaque term (TyVarRep ('TyNameRep "a" 0)) => a -> a)
+            Prelude.id
             mempty
     toBuiltinMeaning IdFInteger =
         toStaticBuiltinMeaning
-            (Prelude.id
-                :: a ~ Opaque term (TyAppRep (TyVarRep ('TyNameRep "f" 0)) (Transparent Integer))
-                => a -> a)
+            -- (Prelude.id
+            --     :: a ~ Opaque term (TyAppRep (TyVarRep ('TyNameRep "f" 0)) Integer)
+            --     => a -> a)
+            (Prelude.id :: a ~ f Integer => a -> a)
             mempty
     toBuiltinMeaning IdList =
         toStaticBuiltinMeaning
-            (Prelude.id
-                :: a ~ Opaque term (ListRep (Opaque term (TyVarRep ('TyNameRep "a" 0))))
-                => a -> a)
+            (Prelude.id :: la ~ Opaque term (ListRep a) => la -> la)
             mempty
     toBuiltinMeaning IdRank2 =
         toStaticBuiltinMeaning
             (Prelude.id
                 :: ( f ~ 'TyNameRep "f" 0
                    , a ~ 'TyNameRep @GHC.Type "a" 1
-                   , afa ~ Opaque term (TyForallRep a (TyAppRep (TyVarRep f) (TyVarRep a)))
+                   , afa ~ Opaque term (TyForallRep @GHC.Type a (TyAppRep (TyVarRep f) (TyVarRep a)))
                    )
                 => afa -> afa)
             mempty

--- a/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
+++ b/plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
@@ -147,9 +147,6 @@ instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni Ex
             mempty
     toBuiltinMeaning IdFInteger =
         toStaticBuiltinMeaning
-            -- (Prelude.id
-            --     :: a ~ Opaque term (TyAppRep (TyVarRep ('TyNameRep "f" 0)) Integer)
-            --     => a -> a)
             (Prelude.id :: a ~ f Integer => a -> a)
             mempty
     toBuiltinMeaning IdList =
@@ -161,7 +158,7 @@ instance (GShow uni, GEq uni, uni `Includes` Integer) => ToBuiltinMeaning uni Ex
             (Prelude.id
                 :: ( f ~ 'TyNameRep "f" 0
                    , a ~ 'TyNameRep @GHC.Type "a" 1
-                   , afa ~ Opaque term (TyForallRep @GHC.Type a (TyAppRep (TyVarRep f) (TyVarRep a)))
+                   , afa ~ Opaque term (TyForallRep a (TyAppRep (TyVarRep f) (TyVarRep a)))
                    )
                 => afa -> afa)
             mempty


### PR DESCRIPTION
I got curious if there was any way to infer type schemes for polymorphic built-in functions with providing only those types that help resolve inherent ambiguity. I.e. no types at all for functions like `IfThenElse`, `Id` and `Const` and minimal types for functions with higher-kinded type variables. This PR shows how to do that. Note that the shiny new automatic inference machinery does not break the "I'll specify the type signature manually" case.

Supporting the higher-kinds case costs a lot in terms of code complexty and we don't seem to need that at this point and due to stupid behaviour of GHC I can't handle the general case anyway, so I'm going to rewrite this to handle only type variables of kind `*`. But the temptation to show off was too high, so I couldn't resist showing this development in its current form.