### PR TITLE
Fix problem with burning tokens

### DIFF
--- a/plutus-ledger/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger/src/Ledger/Constraints/OffChain.hs
@@ -395,7 +395,11 @@ processConstraint = \case
         let value = Value.singleton (Value.mpsSymbol mpsHash) tn i
         unbalancedTx . tx . Tx.forgeScripts %= Set.insert monetaryPolicyScript
         unbalancedTx . tx . Tx.forge <>= value
-        valueSpentActual <>= value
+        -- If i is negative we are burning tokens. This counts as an output, so we should subtract
+        -- the amount burned from valueSpentRequired, just as in `MustPayToPubKey` below.
+        -- Subtracting the amount burned is the same as adding the (negative) amount forged.
+        if i < 0 then valueSpentRequired <>= value
+                 else valueSpentActual   <>= value
     MustPayToPubKey pk vl -> do
         unbalancedTx . tx . Tx.outputs %= (Tx.TxOut (PubKeyAddress pk) vl Tx.PayToPubKey :)
         -- we can subtract vl from 'valueSpentRequired' because


### PR DESCRIPTION
tl;dr The constraint solver treated burn constraints as negative inputs, forcing it to add an extra pair of input/output to make up the "required spend" of zero tokens.

Transactions are constructed in three phases:

1. `Ledger.Constraints.OffChain.processContraints`:
   The constraints are traversed computing inputs, outputs and forges, and tracking two quantities: valueSpentActual, and valueSpentRequired.

2. `Ledger.Constraints.OffChain.addMissingValueSpent`:
   The positive part of `valueSpentRequired - valueSpentActual` is added as outputs to the pubkey signing the transaction.

3. `Language.Plutus.Contract.Wallet.balanceWallet`:
   The transaction is balanced, adding inputs and outputs to/from the wallet to make the sum of inputs, outputs and forges zero.

So what counts as valueSpentActual and valueSpentRequired in step 1?

Outside forging, `valueSpentActual` is increased every time an input is added to the transaction (`MustSpendPubKeyOutput` and `MustSpendScriptOutput`). Forging (`MustForgeValue`) a positive number of tokens is equivalent to spending an output, so we add these to `valueSpentActual` as well.

When adding an output (`MustPayToPubKey`/`MustPayToOtherScript`) the corresponding amount is subtracted from `valueSpentRequired`. In addition, `valueSpentRequired` is increased for `MustSpendValue` constraints. Since buring tokens (forging a negative amount of tokens) is a form of output we should subtract the number of tokens burned from `valueSpentRequired` in this case (**previously they were incorrectly subtracted from `valueSpentActual`**).

Some observations (not addressed by this PR):

- We only ever look at the difference between valueSpentActual and valueSpentRequired, so it would suffice to track a single Value representing the difference.
- Inputs are always added to valueSpentActual and outputs subtracted from valueSpentRequired, so we could skip this and add up inputs and outputs in step 2, leaving only the `valueSpentRequired` increases from `MustSpendValue`.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] ~~Relevant tickets are mentioned in commit messages~~
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
