### PR TITLE
Adding skeleton code for a closeable ajax error pane, which will be needed for the Plutus playground refresh.

### DIFF
--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -680,6 +680,9 @@ handleGistAction settings LoadGist = do
 
   toEither x NotAsked = x
 
+-- other gist actions are irrelevant here
+handleGistAction _ = pure unit
+
 loadGist ::
   forall m.
   MonadAff m =>

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -681,7 +681,7 @@ handleGistAction settings LoadGist = do
   toEither x NotAsked = x
 
 -- other gist actions are irrelevant here
-handleGistAction _ = pure unit
+handleGistAction _ _ = pure unit
 
 loadGist ::
   forall m.

--- a/plutus-playground-client/src/MainFrame.purs
+++ b/plutus-playground-client/src/MainFrame.purs
@@ -176,6 +176,8 @@ toEvent (GistAction (SetGistUrl _)) = Nothing
 
 toEvent (GistAction LoadGist) = Just $ (defaultEvent "LoadGist") { category = Just "Gist" }
 
+toEvent (GistAction (AjaxErrorPaneAction _)) = Nothing
+
 toEvent (ChangeView view) = Just $ (defaultEvent "View") { label = Just $ show view }
 
 toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript") { label = Just script }
@@ -467,6 +469,9 @@ handleGistAction LoadGist =
   toEither x Loading = x
 
   toEither x NotAsked = x
+
+-- other gist actions are irrelevant (but one will soon be needed for the refresh...)
+handleGistAction _ = pure unit
 
 handleActionWalletEvent :: (BigInteger -> SimulatorWallet) -> WalletEvent -> Array SimulatorWallet -> Array SimulatorWallet
 handleActionWalletEvent mkWallet AddWallet wallets =

--- a/web-common/src/AjaxUtils.purs
+++ b/web-common/src/AjaxUtils.purs
@@ -6,7 +6,7 @@ module AjaxUtils
   ) where
 
 import Prelude hiding (div)
-import Bootstrap (alertDanger_, btn, floatRight, hidden)
+import Bootstrap (alertDanger_, btn, floatRight)
 import Data.Foldable (intercalate)
 import Data.Maybe (Maybe(Just))
 import Foreign (MultipleErrors, renderForeignError)
@@ -31,10 +31,10 @@ ajaxErrorPane error =
         ]
     ]
 
-closeableAjaxErrorPane :: forall p. AjaxError -> Boolean -> HTML p AjaxErrorPaneAction
-closeableAjaxErrorPane error isOpen =
+closeableAjaxErrorPane :: forall p. AjaxError -> HTML p AjaxErrorPaneAction
+closeableAjaxErrorPane error =
   div
-    [ classes ajaxErrorClasses ]
+    [ class_ ajaxErrorClass ]
     [ alertDanger_
         [ button
             [ classes [ btn, floatRight, ClassName "ajax-error-close-button" ]
@@ -46,12 +46,6 @@ closeableAjaxErrorPane error isOpen =
         , helpText
         ]
     ]
-  where
-  ajaxErrorClasses =
-    if isOpen then
-      [ ajaxErrorClass ]
-    else
-      [ ajaxErrorClass, hidden ]
 
 ajaxErrorClass :: ClassName
 ajaxErrorClass = ClassName "ajax-error"

--- a/web-common/src/Gists/Types.purs
+++ b/web-common/src/Gists/Types.purs
@@ -3,6 +3,7 @@ module Gists.Types
   , parseGistUrl
   ) where
 
+import AjaxUtils (AjaxErrorPaneAction(..))
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Either (Either, note)
 import Data.String.Regex (Regex, match, regex)
@@ -14,6 +15,7 @@ data GistAction
   = PublishGist
   | SetGistUrl String
   | LoadGist
+  | AjaxErrorPaneAction AjaxErrorPaneAction
 
 gistIdInLinkRegex :: Either String Regex
 gistIdInLinkRegex = regex "^(.*/)?([0-9a-f]{32})$" ignoreCase


### PR DESCRIPTION
The new design for the Plutus playground refresh calls for the Ajax error pane in the Gist widget to be closeable. This PR adds the bones to make that possible. It requires adding a new `GistAction` (in `web-common/src/Gists/Types.purs`), which the Marlowe playground also uses. I think all that's needed is an extra case in the `MainFrame/State.purs` module to cover the new action (and do nothing with it). But I don't have the Marlowe playground running in my dev environment, so I'm hoping e.g. Hernan can check this quickly.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
