### PR TITLE
Marlowe playground FE: Fix webpack configuration

### DIFF
--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -28,8 +28,7 @@ module.exports = {
         contentBase: path.join(__dirname, "dist"),
         compress: true,
         port: 8009,
-        host: "0.0.0.0",
-        https: false,
+        https: true,
         proxy: {
             "/api": {
                 target: 'http://localhost:8080'


### PR DESCRIPTION
This PR fixes the Webpack configuration for local development. This is needed for opening/saving Gists within local development.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
