### PR TITLE
Preliminary work-around of some performance problems

### DIFF
--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -23,17 +23,20 @@ module Ledger.Scripts(
     Script (..),
     scriptSize,
     fromCompiledCode,
+    applyScript,
     ScriptError (..),
     evaluateScript,
     runScript,
     runMonetaryPolicyScript,
     -- * Script wrappers
     mkValidatorScript,
+    mkValidatorScript',
     Validator,
     unValidatorScript,
     Redeemer(..),
     Datum(..),
     mkMonetaryPolicyScript,
+    mkMonetaryPolicyScript',
     MonetaryPolicy (..),
     unMonetaryPolicyScript,
     Context(..),
@@ -209,11 +212,19 @@ instance FromJSON Data where
 mkValidatorScript :: CompiledCode (Data -> Data -> Data -> ()) -> Validator
 mkValidatorScript = Validator . fromCompiledCode
 
+mkValidatorScript' :: Script -> Validator
+mkValidatorScript' = Validator
+
 unValidatorScript :: Validator -> Script
 unValidatorScript = getValidator
 
 mkMonetaryPolicyScript :: CompiledCode (Data -> ()) -> MonetaryPolicy
 mkMonetaryPolicyScript = MonetaryPolicy . fromCompiledCode
+
+mkMonetaryPolicyScript' :: CompiledCode (a -> Data -> ()) -> CompiledCode a -> MonetaryPolicy
+mkMonetaryPolicyScript' p = \ arg -> MonetaryPolicy $ pS `applyScript` fromCompiledCode arg
+  where
+    pS = fromCompiledCode p
 
 unMonetaryPolicyScript :: MonetaryPolicy -> Script
 unMonetaryPolicyScript = getMonetaryPolicy

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/Credential.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/Credential.hs
@@ -23,7 +23,7 @@ import qualified Language.PlutusTx                                     as Plutus
 import           Language.PlutusTx.Coordination.Contracts.TokenAccount (Account (..))
 import           Language.PlutusTx.Prelude
 import           Ledger.Crypto                                         (PubKeyHash)
-import           Ledger.Scripts                                        (MonetaryPolicy, mkMonetaryPolicyScript,
+import           Ledger.Scripts                                        (MonetaryPolicy, mkMonetaryPolicyScript',
                                                                         monetaryPolicyHash)
 import qualified Ledger.Typed.Scripts                                  as Scripts
 import           Ledger.Validation                                     (PolicyCtx (..), txSignedBy)
@@ -58,10 +58,9 @@ validateForge CredentialAuthority{unCredentialAuthority} PolicyCtx{policyCtxTxIn
     txinfo `txSignedBy` unCredentialAuthority
 
 policy :: CredentialAuthority -> MonetaryPolicy
-policy credential = mkMonetaryPolicyScript $
-    $$(PlutusTx.compile [|| \c -> Scripts.wrapMonetaryPolicy (validateForge c) ||])
-        `PlutusTx.applyCode`
-            PlutusTx.liftCode credential
+policy = mkMonetaryPolicyScript' p . PlutusTx.liftCode
+  where
+    p = $$(PlutusTx.compile [|| \c -> Scripts.wrapMonetaryPolicy (validateForge c) ||])
 
 -- | A single credential of the given name
 token :: Credential -> Value

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/StateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Prism/StateMachine.hs
@@ -88,11 +88,12 @@ credentialStateMachine cd = StateMachine.mkStateMachine (transition cd) isFinal 
 scriptInstance ::
   UserCredential
   -> Scripts.ScriptInstance (StateMachine IDState IDAction)
-scriptInstance credentialData =
-    let val = $$(PlutusTx.compile [|| validator ||]) `PlutusTx.applyCode` PlutusTx.liftCode credentialData
-        validator d = StateMachine.mkValidator (credentialStateMachine d)
-        wrap = Scripts.wrapValidator @IDState @IDAction
-    in Scripts.validator @(StateMachine IDState IDAction) val $$(PlutusTx.compile [|| wrap ||])
+scriptInstance = validatorScript . PlutusTx.liftCode
+    where
+        val             = $$(PlutusTx.compile [|| validator ||])
+        validator d     = StateMachine.mkValidator (credentialStateMachine d)
+        wrap            = Scripts.wrapValidator @IDState @IDAction
+        validatorScript = Scripts.validator' @(StateMachine IDState IDAction) val $$(PlutusTx.compile [|| wrap ||])
 
 machineClient ::
     Scripts.ScriptInstance (StateMachine IDState IDAction)


### PR DESCRIPTION
***This PR is meant to be a starting point for emulator performance discussions. Do not merge.***

I had a quick look at why the Prism tests are so slow. Profiling shows 60% of the time is spent building the credential `policy` and the prism state machine `scriptInstance`. Most of that time goes into `Ledger.Scripts.fromCompiledCode` which converts a script from named variables to a de Bruijn representation.

The problem is that these scripts are parameterised by things like the credential authority and the user getting the credential, so every time the test issues credentials the instance and policy are built from scratch. The size of the code is non-trivial so this adds up.

What I did in this PR (in the quickest and dirtiest way) was separate the (small, dynamic) arguments to the script from the (big, static) script code, which allows you to share the `fromCompiledCode` call of the static parts. This makes the Prism QuickCheck tests about three times faster (although that's still not very fast).

Some ideas for proper solutions (though I'm not familiar enough with the system to evaluate feasibility):
- Have the compiler produce de Bruijn representation directly.
- Have the emulator memoize policies and script instances (fwiw the parameters are all `Hashable`).