### PR TITLE
SCP-1355: Add max reserve ratio to stablecoin

### DIFF
--- a/nix/stack.materialized/plutus-tx.nix
+++ b/nix/stack.materialized/plutus-tx.nix
@@ -68,6 +68,7 @@
           "Language/PlutusTx/IsData"
           "Language/PlutusTx/IsData/Class"
           "Language/PlutusTx/Eq"
+          "Language/PlutusTx/Either"
           "Language/PlutusTx/Functor"
           "Language/PlutusTx/Lattice"
           "Language/PlutusTx/List"

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -48,6 +48,7 @@ library
         Language.PlutusTx.IsData
         Language.PlutusTx.IsData.Class
         Language.PlutusTx.Eq
+        Language.PlutusTx.Either
         Language.PlutusTx.Functor
         Language.PlutusTx.Lattice
         Language.PlutusTx.List

--- a/plutus-tx/src/Language/PlutusTx/Either.hs
+++ b/plutus-tx/src/Language/PlutusTx/Either.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Either (isLeft, isRight, either) where
+
+import           Prelude (Bool (..), Either (..), String)
+
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+{-# INLINABLE isLeft #-}
+-- | Return `True` if the given value is a `Left`-value, `False` otherwise.
+isLeft :: Either a b -> Bool
+isLeft (Left _)  = True
+isLeft (Right _) = False
+
+{-# INLINABLE isRight #-}
+-- | Return `True` if the given value is a `Right`-value, `False` otherwise.
+isRight :: Either a b -> Bool
+isRight (Left _)  = False
+isRight (Right _) = True
+
+{-# INLINABLE either #-}
+-- | PlutusTx version of 'Prelude.either'
+either :: (a -> c) -> (b -> c) -> Either a b -> c
+either f _ (Left x)  = f x
+either _ g (Right y) = g y

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -37,6 +37,8 @@ module Language.PlutusTx.Prelude (
     snd,
     -- * Maybe
     module Maybe,
+    -- * Either
+    module Either,
     -- * Lists
     module List,
     fold,
@@ -68,6 +70,7 @@ import           Language.PlutusTx.Builtins    (ByteString, concatenate, dropByt
                                                 equalsByteString, greaterThanByteString, lessThanByteString, sha2_256,
                                                 sha3_256, takeByteString, verifySignature)
 import qualified Language.PlutusTx.Builtins    as Builtins
+import           Language.PlutusTx.Either      as Either
 import           Language.PlutusTx.Eq          as Eq
 import           Language.PlutusTx.Functor     as Functor
 import           Language.PlutusTx.Lattice     as Lattice
@@ -81,10 +84,10 @@ import           Language.PlutusTx.Semigroup   as Semigroup
 import           Language.PlutusTx.String      as String
 import           Prelude                       as Prelude hiding (Applicative (..), Eq (..), Functor (..), Monoid (..),
                                                            Num (..), Ord (..), Rational, Semigroup (..), all, any,
-                                                           const, divMod, elem, error, filter, foldMap, foldl, foldr,
-                                                           fst, id, length, map, max, maybe, min, not, null, quotRem,
-                                                           reverse, round, sequence, snd, traverse, zip, (!!), ($),
-                                                           (&&), (++), (<$>), (||))
+                                                           const, divMod, either, elem, error, filter, foldMap, foldl,
+                                                           foldr, fst, id, length, map, max, maybe, min, not, null,
+                                                           quotRem, reverse, round, sequence, snd, traverse, zip, (!!),
+                                                           ($), (&&), (++), (<$>), (||))
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Stablecoin.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Stablecoin.hs
@@ -414,11 +414,11 @@ checkTransition theClient sc i@Input{inpConversionRate} = do
                     Just ((TypedScriptTxOut{tyTxOutData}, _), _) -> do
                         case checkValidState sc tyTxOutData obsValue of
                             Right _ -> logInfo @String "Current state OK"
-                            Left w  -> logWarn $ "Current state is invalid: " <> show w
+                            Left w  -> logInfo $ "Current state is invalid: " <> show w <> ". The transition may still be allowed."
                         case applyInput sc tyTxOutData i of
                             Just (_, newState) -> case checkValidState sc newState obsValue of
                                 Right _ -> logInfo @String "New state OK"
-                                Left w  -> logWarn $ "New state is invalid: " <> show w
+                                Left w  -> logWarn $ "New state is invalid: " <> show w <> ". The transition is not allowed."
                             Nothing -> logWarn @String "applyInput is Nothing (transition failed)"
                     Nothing -> logWarn @String "Unable to find current state."
             Left e -> logWarn $ "Unable to decode oracle value from datum: " <> show e

--- a/plutus-use-cases/test/Spec/Stablecoin.hs
+++ b/plutus-use-cases/test/Spec/Stablecoin.hs
@@ -98,7 +98,7 @@ tests = testGroup "Stablecoin"
             -- redeem 10 stablecoins at an exchange rate of 2 Ada : 1 USD (so we get 20 lovelace from the bank)
             redeemStableCoins (SC 10) (Ratio.fromInteger 2) hdl
 
-    , let expectedLogMsg = "New state is invalid: MaxReserves {allowed = BC {unBC = (200 % 1)}, actual = BC {unBC = (201 % 1)}}" in
+    , let expectedLogMsg = "New state is invalid: MaxReserves {allowed = BC {unBC = (200 % 1)}, actual = BC {unBC = (201 % 1)}}. The transition is not allowed." in
       checkPredicate "Cannot exceed the maximum reserve ratio"
         (valueAtAddress stablecoinAddress (== (initialDeposit <> initialFee <> Ada.lovelaceValueOf 50))
         .&&. assertNoFailedTransactions
@@ -110,13 +110,16 @@ tests = testGroup "Stablecoin"
             mintStableCoins (SC 50) one hdl
 
             -- At this point we have:
-            -- Stablecoins: 50 (equiv. to 50 Lovelace on the 1:1 conversion rate)
+            -- Stablecoins: 50 (equiv. to 50 Lovelace on the 1:1 conversion
+            -- rate)
             -- Max. reserve ratio: 4:1
-            -- Reserves: 151 Lovelace (100 from minting reserve coins, 50 from minting stablecoins, 2 from fees)
-            -- Maximum reserves: 200 Lovelace (50 stablecoins * 4 (Lovelace / stablecoin))
+            -- Reserves: 151 Lovelace (100 from minting reserve coins, 50 from
+            -- minting stablecoins, 1 from fees)
+            -- Maximum reserves: 200 Lovelace (50 stablecoins * 4 (Lovelace /
+            -- stablecoin))
 
-            -- The next transition is not allowed as it would bring the reserve ratio
-            -- above the maximum
+            -- The next transition is not allowed as it would bring the reserve
+            -- ratio above the maximum.
             mintReserveCoins (RC 49) one hdl
 
 

--- a/plutus-use-cases/test/Spec/Stablecoin.hs
+++ b/plutus-use-cases/test/Spec/Stablecoin.hs
@@ -43,6 +43,7 @@ coin = Stablecoin
     { scOracle = walletPubKey oracle
     , scFee = onePercent
     , scMinReserveRatio = zero
+    , scMaxReserveRatio = 500 % 1
     , scReservecoinDefaultPrice = BC 1
     , scBaseCurrency = (adaSymbol, adaToken)
     , scStablecoinTokenName = "stablecoin"


### PR DESCRIPTION
* Add a maxReserveRatio parameter to the stablecoin
* Prevent transitions that would bring the reserve ratio above the maximum
* Add some logging to inform of invalid transitions
* Add either functions to prelude

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
