### PR TITLE
niv-updater: also blacklist nixpkgs

### DIFF
--- a/.github/workflows/niv-update.yml
+++ b/.github/workflows/niv-update.yml
@@ -15,5 +15,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          blacklist: 'hackage.nix,stackage.nix,haskell.nix,iohk-nix'
+          # nixpkgs,haskell.nix: most updates are a mass rebuild, so merging 
+          # an update will force devs  to re-download GHC etc. And even if 
+          # we don't want to merge  it, creating the PR will clog up Hydra.
+          #
+          # hackage.nix/stackage.nix: updates *daily*, just gives a new index,
+          # not worth doing unless you need it.
+          #
+          # iohk-nix: updates somewhat frequently due to random IOHK ops stuff,
+          # and is almost totally irrelevant to us at the moment.
+          blacklist: 'nixpkgs,hackage.nix,stackage.nix,haskell.nix,iohk-nix'
 


### PR DESCRIPTION
See comment in the workflow. It's basically always a mass-rebuild, and
it doesn't gain us much.

I considered just making the updater action run less frequently, but I
don't think we even want to update it every month!

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
