### PR TITLE
Fix annoyance in output of serialised code in PLC command

### DIFF
--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -422,7 +422,7 @@ writeCBOR outp cborMode prog = do
             DeBruijn -> serialiseDbProgramCBOR (() <$ prog)
   case outp of
     FileOutput file -> BSL.writeFile file cbor
-    StdOutput       -> BSL.putStr cbor >> T.putStrLn ""
+    StdOutput       -> BSL.putStr cbor
 
 ---------------- Serialise a program using Flat ----------------
 
@@ -442,7 +442,7 @@ writeFlat outp flatMode prog = do
             DeBruijn -> serialiseDbProgramFlat (() <$ prog)
   case outp of
     FileOutput file -> BSL.writeFile file flatProg
-    StdOutput       -> BSL.putStr flatProg >> T.putStrLn ""  -- FIXME: no newline
+    StdOutput       -> BSL.putStr flatProg
 
 
 ---------------- Write an AST as PLC source ----------------


### PR DESCRIPTION
The `convert` option of the `plc` command can convert Plutus Core between various formats (textual, CBOR, Flat, ...).  For some reason, I'd made it add a newline at the end when it was writing to stdout, even for binary formats.  This is just annoying, so this two-line PR removes it.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
