### PR TITLE
SCP-1663: Do the debruijn transformation in the plugin

### DIFF
--- a/nix/stack.materialized/plutus-benchmark.nix
+++ b/nix/stack.materialized/plutus-benchmark.nix
@@ -94,6 +94,7 @@
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             ];
           buildable = true;
           hsSourceDirs = [ "nofib/test" ];
@@ -111,6 +112,7 @@
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             ];
           buildable = true;
           modules = [ "Common" "Paths_plutus_benchmark" ];

--- a/nix/stack.materialized/plutus-use-cases.nix
+++ b/nix/stack.materialized/plutus-use-cases.nix
@@ -141,6 +141,7 @@
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))

--- a/plutus-benchmark/flat/Dataset.hs
+++ b/plutus-benchmark/flat/Dataset.hs
@@ -11,7 +11,7 @@ import           Data.Either                                           (fromRigh
 import           Data.Text                                             (Text)
 
 import           Language.Plutus.Contract.Trace
-import           Language.PlutusCore                                   (DefaultFun (..), Name (..), runQuoteT)
+import           Language.PlutusCore                                   (DefaultFun (..), runQuoteT)
 import           Language.PlutusCore.Universe
 import qualified Language.PlutusTx.Coordination.Contracts.Crowdfunding as Crowdfunding
 import qualified Language.PlutusTx.Coordination.Contracts.Escrow       as Escrow
@@ -19,7 +19,6 @@ import qualified Language.PlutusTx.Coordination.Contracts.Future       as Future
 import qualified Language.PlutusTx.Coordination.Contracts.Game         as Game
 import qualified Language.PlutusTx.Coordination.Contracts.Vesting      as Vesting
 import           Language.UntypedPlutusCore
-import           Language.UntypedPlutusCore.DeBruijn
 import qualified Ledger                                                as Ledger
 import qualified Ledger.Ada                                            as Ada
 import           Ledger.Crypto
@@ -93,7 +92,7 @@ runQuote
   -> Term Name DefaultUni DefaultFun ()
 runQuote tm = do
   (fromRight $ error "Failed to assign names to terms")
-    . runExcept . runQuoteT $ unDeBruijnTerm tm
+    . runExcept @FreeVariableError . runQuoteT $ unDeBruijnTerm tm
 
 contractsWithNames :: [ (Text, Term Name DefaultUni DefaultFun ()) ]
 contractsWithNames = map (second (runQuote . nameDeBruijn . getTerm . Plutus.unScript . Plutus.unValidatorScript))
@@ -111,4 +110,3 @@ contractsWithIndices = map (second (getTerm . Plutus.unScript . Plutus.unValidat
   , ("vesting-indices", Vesting.vestingScript vesting)
   , ("escrow-indices", Plutus.validatorScript $ Escrow.scriptInstance escrowParams)
   , ("future-indices", Future.validator theFuture Future.testAccounts) ]
-

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
@@ -6,7 +6,6 @@
 
 module Plutus.Benchmark.Clausify where
 
-import           Language.PlutusCore          (Name (..))
 import           Language.PlutusCore.Builtins
 import           Language.PlutusCore.Universe
 import qualified Language.PlutusTx            as Tx
@@ -183,7 +182,7 @@ runClausify :: StaticFormula -> [LRVars]
 runClausify = clauses . getFormula
 
 {-# INLINABLE mkClausifyTerm #-}
-mkClausifyTerm :: StaticFormula -> Term Name DefaultUni DefaultFun ()
+mkClausifyTerm :: StaticFormula -> Term NamedDeBruijn DefaultUni DefaultFun ()
 mkClausifyTerm formula =
  let (Program _ _ code) = Tx.getPlc $
                              $$(Tx.compile [|| runClausify ||])

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights.hs
@@ -8,7 +8,6 @@ import           Plutus.Benchmark.Knights.ChessSetList
 import           Plutus.Benchmark.Knights.KnightHeuristic
 import           Plutus.Benchmark.Knights.Queue
 
-import           Language.PlutusCore                      (Name (..))
 import           Language.PlutusCore.Builtins
 import qualified Language.PlutusCore.Pretty               as PLC
 import           Language.PlutusCore.Universe
@@ -91,7 +90,7 @@ runKnights :: Integer -> Integer -> [Solution]
 runKnights depth boardSize = depthSearch depth (root boardSize) grow isFinished
 
 {-# INLINABLE mkKnightsTerm #-}
-mkKnightsTerm :: Integer -> Integer -> Term Name DefaultUni DefaultFun ()
+mkKnightsTerm :: Integer -> Integer -> Term NamedDeBruijn DefaultUni DefaultFun ()
 mkKnightsTerm depth boardSize =
   let (Program _ _ code) = Tx.getPlc $
                              $$(Tx.compile [|| runKnights ||])

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/LastPiece.hs
@@ -15,7 +15,6 @@
 module Plutus.Benchmark.LastPiece where
 
 import           Data.Char                    (isSpace)
-import           Language.PlutusCore          (Name (..))
 import           Language.PlutusCore.Builtins
 import qualified Language.PlutusCore.Pretty   as PLC
 import           Language.PlutusCore.Universe
@@ -297,7 +296,7 @@ unindent d = map (dropWhile isSpace) $ (lines . show $ d)
 runLastPiece :: Solution
 runLastPiece = search (1,2) Female initialBoard initialPieces
 
-mkLastPieceTerm :: Term Name DefaultUni DefaultFun ()
+mkLastPieceTerm :: Term NamedDeBruijn DefaultUni DefaultFun ()
 mkLastPieceTerm =
   let (Program _ _ code) = getPlc $ $$(compile [|| runLastPiece ||])
   in code

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -18,7 +18,6 @@ import           Data.Char                    (isSpace)
 import           GHC.Generics
 import qualified Prelude                      (Eq (..), String)
 
-import           Language.PlutusCore          (Name (..))
 import           Language.PlutusCore.Builtins (DefaultFun)
 import qualified Language.PlutusCore.Pretty   as PLC
 import           Language.PlutusCore.Universe
@@ -291,7 +290,7 @@ runPrimalityTest :: Integer -> Result
 runPrimalityTest n = testInteger n initState
 
 -- % Run the program on an arbitrary integer, for testing
-mkPrimalityTestTerm :: Integer -> Term Name DefaultUni DefaultFun ()
+mkPrimalityTestTerm :: Integer -> Term NamedDeBruijn DefaultUni DefaultFun ()
 mkPrimalityTestTerm n =
   let (Program _ _ code) = Tx.getPlc $
                            $$(Tx.compile [|| runPrimalityTest ||])
@@ -305,7 +304,7 @@ runFixedPrimalityTest pid = runPrimalityTest (getPrime pid)
 
 -- % Run the program on a number known to be prime, for benchmarking
 -- (primes take a long time, composite numbers generally don't).
-mkPrimalityBenchTerm :: PrimeID -> Term Name DefaultUni DefaultFun ()
+mkPrimalityBenchTerm :: PrimeID -> Term NamedDeBruijn DefaultUni DefaultFun ()
 mkPrimalityBenchTerm pid =
   let (Program _ _ code) = Tx.getPlc $
         $$(Tx.compile [|| runFixedPrimalityTest ||])

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
@@ -22,7 +22,6 @@ import           GHC.Generics
 import qualified Prelude
 import           System.Environment
 
-import           Language.PlutusCore          (Name (..))
 import           Language.PlutusCore.Builtins
 import qualified Language.PlutusCore.Pretty   as PLC
 import           Language.PlutusCore.Universe
@@ -92,7 +91,7 @@ runQueens :: Integer -> Algorithm -> [State]
 runQueens n alg = nqueens n (lookupAlgorithm alg)
 
 -- % Compile a Plutus Core term which runs nqueens on given arguments
-mkQueensTerm :: Integer -> Algorithm -> Term Name DefaultUni DefaultFun ()
+mkQueensTerm :: Integer -> Algorithm -> Term NamedDeBruijn DefaultUni DefaultFun ()
 mkQueensTerm sz alg =
   let (Program _ _ code) =
         Tx.getPlc $

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -99,7 +99,7 @@ benchmark nofib
     nofib/bench
   other-modules:
     Common
-    Paths_plutus_benchmark  
+    Paths_plutus_benchmark
   build-depends:
       base >=4.7 && <5
     , plutus-benchmark
@@ -109,6 +109,7 @@ benchmark nofib
     , containers -any
     , criterion -any
     , filepath -any
+    , mtl -any
 
 benchmark nofib-hs
   import: lang
@@ -118,7 +119,7 @@ benchmark nofib-hs
     nofib/bench
   other-modules:
     Common
-    Paths_plutus_benchmark  
+    Paths_plutus_benchmark
   build-depends:
       base >=4.7 && <5
     , plutus-benchmark
@@ -165,6 +166,7 @@ test-suite plutus-benchmark-nofib-tests
       , tasty -any
       , tasty-hunit -any
       , tasty-quickcheck -any
+      , mtl -any
 
 benchmark flat
   import: lang

--- a/plutus-core/common/PlcTestUtils.hs
+++ b/plutus-core/common/PlcTestUtils.hs
@@ -33,7 +33,6 @@ import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Universe
 
 import qualified Language.UntypedPlutusCore                        as UPLC
-import qualified Language.UntypedPlutusCore.DeBruijn               as UPLC
 import qualified Language.UntypedPlutusCore.Evaluation.Machine.Cek as UPLC
 
 import           Control.Exception
@@ -60,6 +59,9 @@ instance ToUPlc a uni fun => ToUPlc (ExceptT SomeException IO a) uni fun where
 
 instance ToUPlc (UPLC.Program TPLC.Name uni fun ()) uni fun where
     toUPlc = pure
+
+instance ToUPlc (UPLC.Program UPLC.NamedDeBruijn uni fun ()) uni fun where
+    toUPlc p = withExceptT @_ @FreeVariableError toException $ TPLC.runQuoteT $ UPLC.unDeBruijnProgram p
 
 pureTry :: Exception e => a -> Either e a
 pureTry = unsafePerformIO . try . evaluate
@@ -99,28 +101,28 @@ goldenTPlc
     => String -> a -> TestNested
 goldenTPlc name value = nestedGoldenVsDocM name $ ppThrow $ do
     p <- toTPlc value
-    withExceptT toException $ deBruijnProgram p
+    withExceptT @_ @FreeVariableError toException $ deBruijnProgram p
 
 goldenTPlcCatch
     :: ToTPlc a DefaultUni TPLC.DefaultFun
     => String -> a -> TestNested
 goldenTPlcCatch name value = nestedGoldenVsDocM name $ ppCatch $ do
     p <- toTPlc value
-    withExceptT toException $ deBruijnProgram p
+    withExceptT @_ @FreeVariableError toException $ deBruijnProgram p
 
 goldenUPlc
     :: ToUPlc a DefaultUni TPLC.DefaultFun
      => String -> a -> TestNested
 goldenUPlc name value = nestedGoldenVsDocM name $ ppThrow $ do
     p <- toUPlc value
-    withExceptT toException $ UPLC.deBruijnProgram p
+    withExceptT @_ @FreeVariableError toException $ UPLC.deBruijnProgram p
 
 goldenUPlcCatch
     :: ToUPlc a DefaultUni TPLC.DefaultFun
     => String -> a -> TestNested
 goldenUPlcCatch name value = nestedGoldenVsDocM name $ ppCatch $ do
     p <- toUPlc value
-    withExceptT toException $ UPLC.deBruijnProgram p
+    withExceptT @_ @FreeVariableError toException $ UPLC.deBruijnProgram p
 
 goldenTEval
     :: ToTPlc a DefaultUni TPLC.DefaultFun

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -18,7 +18,6 @@ import qualified Language.PlutusCore.StdLib.Data.ChurchNat         as StdLib
 import qualified Language.PlutusCore.StdLib.Data.Integer           as StdLib
 import qualified Language.PlutusCore.StdLib.Data.Unit              as StdLib
 import qualified Language.UntypedPlutusCore                        as UPLC
-import qualified Language.UntypedPlutusCore.DeBruijn               as UPLC
 import qualified Language.UntypedPlutusCore.Evaluation.Machine.Cek as UPLC
 
 import           Codec.Serialise
@@ -318,7 +317,7 @@ typedDeBruijnNotSupportedError =
 -- | Convert an untyped program to one where the 'name' type is de Bruijn indices.
 toDeBruijn :: UntypedProgram a -> IO (UntypedProgramDeBruijn a)
 toDeBruijn prog = do
-  r <- PLC.runQuoteT $ runExceptT (UPLC.deBruijnProgram prog)
+  r <- PLC.runQuoteT $ runExceptT @UPLC.FreeVariableError (UPLC.deBruijnProgram prog)
   case r of
     Left e  -> hPutStrLn stderr (show e) >> exitFailure
     Right p -> return $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) p
@@ -330,7 +329,7 @@ toDeBruijn prog = do
 fromDeBruijn :: UntypedProgramDeBruijn a -> IO (UntypedProgram a)
 fromDeBruijn prog = do
     let namedProgram = UPLC.programMapNames (\(UPLC.DeBruijn ix) -> UPLC.NamedDeBruijn "v" ix) prog
-    case PLC.runQuote $ runExceptT $ UPLC.unDeBruijnProgram namedProgram of
+    case PLC.runQuote $ runExceptT @UPLC.FreeVariableError $ UPLC.unDeBruijnProgram namedProgram of
       Left e  -> hPutStrLn stderr (show e) >> exitFailure
       Right p -> return p
 

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
@@ -27,7 +27,6 @@ module Language.PlutusCore.Generators.NEAT.Spec
   ) where
 
 import           Language.PlutusCore
-import           Language.PlutusCore.DeBruijn
 import           Language.PlutusCore.Evaluation.Machine.Cek
 import           Language.PlutusCore.Evaluation.Machine.Ck
 import           Language.PlutusCore.Generators.NEAT.Common

--- a/plutus-core/plutus-ir-test/TestLib.hs
+++ b/plutus-core/plutus-ir-test/TestLib.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 module TestLib where
@@ -20,7 +21,6 @@ import           Control.Monad.Reader         as Reader
 
 import qualified Language.PlutusCore          as PLC
 import qualified Language.PlutusCore.Constant as PLC
-import qualified Language.PlutusCore.DeBruijn as PLC
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote
@@ -101,12 +101,12 @@ ppCatch value = render <$> (either (pretty . show) prettyPlcClassicDebug <$> run
 goldenPlcFromPir :: ToTPlc a PLC.DefaultUni PLC.DefaultFun => Parser a -> String -> TestNested
 goldenPlcFromPir = goldenPirM (\ast -> ppThrow $ do
                                 p <- toTPlc ast
-                                withExceptT toException $ PLC.deBruijnProgram p)
+                                withExceptT @_ @PLC.FreeVariableError toException $ PLC.deBruijnProgram p)
 
 goldenPlcFromPirCatch :: ToTPlc a PLC.DefaultUni PLC.DefaultFun => Parser a -> String -> TestNested
 goldenPlcFromPirCatch = goldenPirM (\ast -> ppCatch $ do
                                            p <- toTPlc ast
-                                           withExceptT toException $ PLC.deBruijnProgram p)
+                                           withExceptT @_ @PLC.FreeVariableError toException $ PLC.deBruijnProgram p)
 
 goldenEvalPir :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => Parser a -> String -> TestNested
 goldenEvalPir = goldenPirM (\ast -> ppThrow $ runUPlc [ast])

--- a/plutus-core/plutus-ir/Language/PlutusIR/Error.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Error.hs
@@ -53,6 +53,8 @@ instance PLC.AsTypeError (Error uni fun a) (PIR.Term PIR.TyName PIR.Name uni fun
 instance AsTypeErrorExt (Error uni fun a) uni a where
     _TypeErrorExt = _PIRTypeError
 
+instance PLC.AsFreeVariableError (Error uni fun a) where
+    _FreeVariableError = _PLCError . PLC._FreeVariableError
 
 -- Pretty-printing
 ------------------

--- a/plutus-core/src/Language/PlutusCore.hs
+++ b/plutus-core/src/Language/PlutusCore.hs
@@ -52,6 +52,13 @@ module Language.PlutusCore
     , termAnn
     , typeAnn
     , mapFun
+    -- * DeBruijn representation
+    , DeBruijn (..)
+    , NamedDeBruijn (..)
+    , deBruijnProgram
+    , deBruijnTerm
+    , unDeBruijnProgram
+    , unDeBruijnTerm
     -- * Lexer
     , AlexPosn (..)
     -- * Formatting
@@ -75,8 +82,12 @@ module Language.PlutusCore
     -- * Errors
     , Error (..)
     , AsError (..)
+    , NormCheckError (..)
     , AsNormCheckError (..)
     , UniqueError (..)
+    , AsUniqueError (..)
+    , FreeVariableError (..)
+    , AsFreeVariableError (..)
     -- * Base functors
     , TermF (..)
     , TypeF (..)
@@ -110,6 +121,7 @@ import           Language.PlutusCore.Builtins
 import           Language.PlutusCore.CBOR                  ()
 import qualified Language.PlutusCore.Check.Uniques         as Uniques
 import           Language.PlutusCore.Core
+import           Language.PlutusCore.DeBruijn
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.Machine.Ck
 import           Language.PlutusCore.Flat                  ()

--- a/plutus-core/src/Language/PlutusCore/DeBruijn.hs
+++ b/plutus-core/src/Language/PlutusCore/DeBruijn.hs
@@ -11,6 +11,7 @@ module Language.PlutusCore.DeBruijn
     , TyDeBruijn (..)
     , NamedTyDeBruijn (..)
     , FreeVariableError (..)
+    , AsFreeVariableError (..)
     , deBruijnTy
     , deBruijnTerm
     , deBruijnProgram
@@ -34,19 +35,19 @@ import qualified Data.Bimap                            as BM
 
 -- | Convert a 'Type' with 'TyName's into a 'Type' with 'NamedTyDeBruijn's.
 deBruijnTy
-    :: MonadError FreeVariableError m
+    :: (AsFreeVariableError e, MonadError e m)
     => Type TyName uni ann -> m (Type NamedTyDeBruijn uni ann)
 deBruijnTy = flip runReaderT (Levels 0 BM.empty) . deBruijnTyM
 
 -- | Convert a 'Term' with 'TyName's and 'Name's into a 'Term' with 'NamedTyDeBruijn's and 'NamedDeBruijn's.
 deBruijnTerm
-    :: MonadError FreeVariableError m
+    :: (AsFreeVariableError e, MonadError e m)
     => Term TyName Name uni fun ann -> m (Term NamedTyDeBruijn NamedDeBruijn uni fun ann)
 deBruijnTerm = flip runReaderT (Levels 0 BM.empty) . deBruijnTermM
 
 -- | Convert a 'Program' with 'TyName's and 'Name's into a 'Program' with 'NamedTyDeBruijn's and 'NamedDeBruijn's.
 deBruijnProgram
-    :: MonadError FreeVariableError m
+    :: (AsFreeVariableError e, MonadError e m)
     => Program TyName Name uni fun ann -> m (Program NamedTyDeBruijn NamedDeBruijn uni fun ann)
 deBruijnProgram (Program ann ver term) = Program ann ver <$> deBruijnTerm term
 
@@ -56,7 +57,7 @@ we are not only altering the recursive type, but also the name type parameters.
 These are normally constant in a catamorphic application.
 -}
 deBruijnTyM
-    :: (MonadReader Levels m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, AsFreeVariableError e, MonadError e m)
     => Type TyName uni ann
     -> m (Type NamedTyDeBruijn uni ann)
 deBruijnTyM = \case
@@ -77,7 +78,7 @@ deBruijnTyM = \case
     TyBuiltin ann con -> pure $ TyBuiltin ann con
 
 deBruijnTermM
-    :: (MonadReader Levels m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, AsFreeVariableError e, MonadError e m)
     => Term TyName Name uni fun ann
     -> m (Term NamedTyDeBruijn NamedDeBruijn uni fun ann)
 deBruijnTermM = \case
@@ -102,24 +103,24 @@ deBruijnTermM = \case
 
 -- | Convert a 'Type' with 'NamedTyDeBruijn's into a 'Type' with 'TyName's.
 unDeBruijnTy
-    :: (MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Type NamedTyDeBruijn uni ann -> m (Type TyName uni ann)
 unDeBruijnTy = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTyM
 
 -- | Convert a 'Term' with 'NamedTyDeBruijn's and 'NamedDeBruijn's into a 'Term' with 'TyName's and 'Name's.
 unDeBruijnTerm
-    :: (MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Term NamedTyDeBruijn NamedDeBruijn uni fun ann -> m (Term TyName Name uni fun ann)
 unDeBruijnTerm = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTermM
 
 -- | Convert a 'Program' with 'NamedTyDeBruijn's and 'NamedDeBruijn's into a 'Program' with 'TyName's and 'Name's.
 unDeBruijnProgram
-    :: (MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Program NamedTyDeBruijn NamedDeBruijn uni fun ann -> m (Program TyName Name uni fun ann)
 unDeBruijnProgram (Program ann ver term) = Program ann ver <$> unDeBruijnTerm term
 
 unDeBruijnTyM
-    :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Type NamedTyDeBruijn uni ann
     -> m (Type TyName uni ann)
 unDeBruijnTyM = \case
@@ -140,7 +141,7 @@ unDeBruijnTyM = \case
     TyBuiltin ann con -> pure $ TyBuiltin ann con
 
 unDeBruijnTermM
-    :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Term NamedTyDeBruijn NamedDeBruijn uni fun ann
     -> m (Term TyName Name uni fun ann)
 unDeBruijnTermM = \case

--- a/plutus-core/src/Language/PlutusCore/Error.hs
+++ b/plutus-core/src/Language/PlutusCore/Error.hs
@@ -19,6 +19,8 @@ module Language.PlutusCore.Error
     , AsUniqueError (..)
     , TypeError (..)
     , AsTypeError (..)
+    , FreeVariableError (..)
+    , AsFreeVariableError (..)
     , Error (..)
     , AsError (..)
     , throwingEither
@@ -27,17 +29,18 @@ module Language.PlutusCore.Error
 import           PlutusPrelude
 
 import           Language.PlutusCore.Core
+import           Language.PlutusCore.DeBruijn.Internal
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Universe
 
-import           Control.Lens                       hiding (use)
+import           Control.Lens                          hiding (use)
 import           Control.Monad.Error.Lens
 import           Control.Monad.Except
-import qualified Data.Text                          as T
+import qualified Data.Text                             as T
 import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Internal (Doc (Text))
+import           Data.Text.Prettyprint.Doc.Internal    (Doc (Text))
 
 {- Note [Annotations and equality]
 Equality of two errors DOES DEPEND on their annotations.
@@ -67,7 +70,6 @@ makeClassyPrisms ''ParseError
 instance Pretty ann => Show (ParseError ann)
     where
       show = show . pretty
-
 
 data UniqueError ann
     = MultiplyDefined Unique ann ann
@@ -104,6 +106,7 @@ data Error uni fun ann
     | UniqueCoherencyErrorE (UniqueError ann)
     | TypeErrorE (TypeError (Term TyName Name uni fun ()) uni fun ann)
     | NormCheckErrorE (NormCheckError TyName Name uni fun ann)
+    | FreeVariableErrorE FreeVariableError
     deriving (Show, Eq, Generic, NFData, Functor)
 makeClassyPrisms ''Error
 
@@ -119,6 +122,9 @@ instance AsTypeError (Error uni fun ann) (Term TyName Name uni fun ()) uni fun a
 instance (tyname ~ TyName, name ~ Name) =>
             AsNormCheckError (Error uni fun ann) tyname name uni fun ann where
     _NormCheckError = _NormCheckErrorE
+
+instance AsFreeVariableError (Error uni fun ann) where
+    _FreeVariableError = _FreeVariableErrorE
 
 instance Pretty ann => Pretty (ParseError ann) where
     pretty (LexErr s)                       = "Lexical error:" <+> Text (length s) (T.pack s)
@@ -181,3 +187,4 @@ instance (GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun, Prett
     prettyBy _      (UniqueCoherencyErrorE e) = pretty e
     prettyBy config (TypeErrorE e)            = prettyBy config e
     prettyBy config (NormCheckErrorE e)       = prettyBy config e
+    prettyBy _      (FreeVariableErrorE e)    = pretty e

--- a/plutus-core/src/Language/PlutusCore/Flat.hs
+++ b/plutus-core/src/Language/PlutusCore/Flat.hs
@@ -299,6 +299,14 @@ instance Flat DeBruijn where
     encode (DeBruijn i) = encode i
     decode = DeBruijn <$> decode
 
+instance Flat NamedDeBruijn where
+    encode (NamedDeBruijn txt index) = encode txt <> encode index
+    decode = NamedDeBruijn <$> decode <*> decode
+
 instance Flat TyDeBruijn where
     encode (TyDeBruijn n) = encode n
     decode = TyDeBruijn <$> decode
+
+instance Flat NamedTyDeBruijn where
+    encode (NamedTyDeBruijn n) = encode n
+    decode = NamedTyDeBruijn <$> decode

--- a/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
@@ -16,7 +16,6 @@ import           Language.PlutusCore.Evaluation.Machine.ExBudgeting
 import           Language.PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import           Language.PlutusCore.Evaluation.Machine.Exception
 import           Language.PlutusCore.Generators
-import           Language.PlutusCore.Name
 import           Language.PlutusCore.Universe
 
 import           Control.Monad.Except

--- a/plutus-core/untyped-plutus-core-test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core-test/Evaluation/Machines.hs
@@ -18,7 +18,6 @@ import           Language.PlutusCore.Evaluation.Machine.ExMemory
 import           Language.PlutusCore.Evaluation.Machine.Exception
 import           Language.PlutusCore.FsTree
 import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Name
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Universe
 

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore.hs
@@ -8,9 +8,11 @@ import           Language.UntypedPlutusCore.Check.Uniques      as Uniques
 import           Language.UntypedPlutusCore.Parser             as Parser
 import           Language.UntypedPlutusCore.Rename             as Rename
 
+import           Language.PlutusCore.Name                      as Export
 import           Language.UntypedPlutusCore.Core               as Export
 import           Language.UntypedPlutusCore.Core.Instance.CBOR as Export
 import           Language.UntypedPlutusCore.Core.Instance.Flat as Export
+import           Language.UntypedPlutusCore.DeBruijn           as Export
 import           Language.UntypedPlutusCore.Size               as Export
 import           Language.UntypedPlutusCore.Subst              as Export
 -- Also has some functions

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/DeBruijn.hs
@@ -9,6 +9,7 @@ module Language.UntypedPlutusCore.DeBruijn
     , DeBruijn (..)
     , NamedDeBruijn (..)
     , FreeVariableError (..)
+    , AsFreeVariableError (..)
     , deBruijnTerm
     , deBruijnProgram
     , unDeBruijnTerm
@@ -33,18 +34,18 @@ This module is just a boring port of the typed version.
 
 -- | Convert a 'Term' with 'TyName's and 'Name's into a 'Term' with 'TyDeBruijn's and 'DeBruijn's.
 deBruijnTerm
-    :: MonadError FreeVariableError m
+    :: (AsFreeVariableError e, MonadError e m)
     => Term Name uni fun ann -> m (Term NamedDeBruijn uni fun ann)
 deBruijnTerm = flip runReaderT (Levels 0 BM.empty) . deBruijnTermM
 
 -- | Convert a 'Program' with 'TyName's and 'Name's into a 'Program' with 'TyDeBruijn's and 'DeBruijn's.
 deBruijnProgram
-    :: MonadError FreeVariableError m
+    :: (AsFreeVariableError e, MonadError e m)
     => Program Name uni fun ann -> m (Program NamedDeBruijn uni fun ann)
 deBruijnProgram (Program ann ver term) = Program ann ver <$> deBruijnTerm term
 
 deBruijnTermM
-    :: (MonadReader Levels m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, AsFreeVariableError e, MonadError e m)
     => Term Name uni fun ann
     -> m (Term NamedDeBruijn uni fun ann)
 deBruijnTermM = \case
@@ -65,18 +66,18 @@ deBruijnTermM = \case
 
 -- | Convert a 'Term' with 'TyDeBruijn's and 'DeBruijn's into a 'Term' with 'TyName's and 'Name's.
 unDeBruijnTerm
-    :: (MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Term NamedDeBruijn uni fun ann -> m (Term Name uni fun ann)
 unDeBruijnTerm = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTermM
 
 -- | Convert a 'Program' with 'TyDeBruijn's and 'DeBruijn's into a 'Program' with 'TyName's and 'Name's.
 unDeBruijnProgram
-    :: (MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Program NamedDeBruijn uni fun ann -> m (Program Name uni fun ann)
 unDeBruijnProgram (Program ann ver term) = Program ann ver <$> unDeBruijnTerm term
 
 unDeBruijnTermM
-    :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
+    :: (MonadReader Levels m, MonadQuote m, AsFreeVariableError e, MonadError e m)
     => Term NamedDeBruijn uni fun ann
     -> m (Term Name uni fun ann)
 unDeBruijnTermM = \case

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -54,35 +54,34 @@ module Ledger.Scripts(
     acceptingMonetaryPolicy
     ) where
 
-import qualified Prelude                             as Haskell
+import qualified Prelude                          as Haskell
 
-import           Codec.CBOR.Decoding                 (decodeBytes)
-import           Codec.Serialise                     (Serialise, decode, encode, serialise)
-import           Control.DeepSeq                     (NFData)
-import           Control.Monad.Except                (MonadError, runExceptT, throwError)
-import           Crypto.Hash                         (Digest, SHA256, hash)
-import           Data.Aeson                          (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
-import qualified Data.Aeson                          as JSON
-import qualified Data.Aeson.Extras                   as JSON
-import qualified Data.ByteArray                      as BA
-import qualified Data.ByteString.Lazy                as BSL
-import           Data.Hashable                       (Hashable)
+import           Codec.CBOR.Decoding              (decodeBytes)
+import           Codec.Serialise                  (Serialise, decode, encode, serialise)
+import           Control.DeepSeq                  (NFData)
+import           Control.Monad.Except             (MonadError, runExceptT, throwError)
+import           Crypto.Hash                      (Digest, SHA256, hash)
+import           Data.Aeson                       (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import qualified Data.Aeson                       as JSON
+import qualified Data.Aeson.Extras                as JSON
+import qualified Data.ByteArray                   as BA
+import qualified Data.ByteString.Lazy             as BSL
+import           Data.Hashable                    (Hashable)
 import           Data.String
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Extras
-import           Flat                                (flat, unflat)
-import           GHC.Generics                        (Generic)
-import           IOTS                                (IotsType (iotsDefinition))
-import qualified Language.PlutusCore                 as PLC
-import           Language.PlutusTx                   (CompiledCode, IsData (..), compile, getPlc, makeLift)
-import           Language.PlutusTx.Builtins          as Builtins
-import           Language.PlutusTx.Evaluation        (ErrorWithCause (..), EvaluationError (..), evaluateCekTrace)
-import           Language.PlutusTx.Lift              (liftCode)
+import           Flat                             (flat, unflat)
+import           GHC.Generics                     (Generic)
+import           IOTS                             (IotsType (iotsDefinition))
+import qualified Language.PlutusCore              as PLC
+import           Language.PlutusTx                (CompiledCode, IsData (..), compile, getPlc, makeLift)
+import           Language.PlutusTx.Builtins       as Builtins
+import           Language.PlutusTx.Evaluation     (ErrorWithCause (..), EvaluationError (..), evaluateCekTrace)
+import           Language.PlutusTx.Lift           (liftCode)
 import           Language.PlutusTx.Prelude
-import qualified Language.UntypedPlutusCore          as UPLC
-import qualified Language.UntypedPlutusCore.DeBruijn as UPLC
-import           Ledger.Orphans                      ()
-import           LedgerBytes                         (LedgerBytes (..))
+import qualified Language.UntypedPlutusCore       as UPLC
+import           Ledger.Orphans                   ()
+import           LedgerBytes                      (LedgerBytes (..))
 
 -- | A script on the chain. This is an opaque type as far as the chain is concerned.
 newtype Script = Script { unScript :: UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun () }
@@ -158,12 +157,10 @@ scriptSize (Script s) = UPLC.programSize s
 fromCompiledCode :: CompiledCode a -> Script
 fromCompiledCode = fromPlc . getPlc
 
-fromPlc :: UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun () -> Script
-fromPlc (UPLC.Program a v t) = case UPLC.deBruijnTerm $ t of
-    Right t' ->
-        let nameless = UPLC.termMapNames UPLC.unNameDeBruijn t'
-        in Script $ UPLC.Program a v nameless
-    Left _   -> Haskell.error "Debruijn failed"
+fromPlc :: UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun () -> Script
+fromPlc (UPLC.Program a v t) =
+    let nameless = UPLC.termMapNames UPLC.unNameDeBruijn t
+    in Script $ UPLC.Program a v nameless
 
 -- | Given two 'Script's, compute the 'Script' that consists of applying the first to the second.
 applyScript :: Script -> Script -> Script
@@ -184,7 +181,7 @@ evaluateScript s = do
             let (UPLC.Program a v t) = unScript s
                 named = UPLC.termMapNames (\(UPLC.DeBruijn ix) -> UPLC.NamedDeBruijn "" ix) t
             in UPLC.Program a v named
-    p <- case PLC.runQuote $ runExceptT $ UPLC.unDeBruijnProgram namedProgram of
+    p <- case PLC.runQuote $ runExceptT @PLC.FreeVariableError $ UPLC.unDeBruijnProgram namedProgram of
         Right p -> return p
         Left e  -> throwError $ MalformedScript $ show e
     let (logOut, _tally, result) = evaluateCekTrace p

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Error.hs
@@ -16,19 +16,18 @@ module Language.PlutusTx.Compiler.Error (
     , throwPlain
     , pruneContext) where
 
-import qualified Language.PlutusIR.Compiler        as PIR
+import qualified Language.PlutusIR.Compiler as PIR
 
-import qualified Language.Haskell.TH               as TH
-import qualified Language.PlutusCore               as PLC
-import qualified Language.PlutusCore.Check.Uniques as PLC
-import qualified Language.PlutusCore.Pretty        as PLC
-import qualified Language.PlutusIR                 as PIR
+import qualified Language.Haskell.TH        as TH
+import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore.Pretty as PLC
+import qualified Language.PlutusIR          as PIR
 
 import           Control.Lens
 import           Control.Monad.Except
 
-import qualified Data.Text                         as T
-import qualified Data.Text.Prettyprint.Doc         as PP
+import qualified Data.Text                  as T
+import qualified Data.Text.Prettyprint.Doc  as PP
 import           Data.Typeable
 
 -- | An error with some (nested) context. The integer argument to 'WithContextC' represents

--- a/plutus-tx-plugin/src/Language/PlutusTx/PLCTypes.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/PLCTypes.hs
@@ -12,4 +12,4 @@ type PLCProgram uni fun = PLC.Program PLC.TyName PLC.Name uni fun ()
 type PLCVar uni fun = PLC.VarDecl PLC.TyName PLC.Name uni fun ()
 type PLCTyVar = PLC.TyVarDecl PLC.TyName ()
 
-type UPLCProgram uni fun = UPLC.Program PLC.Name uni fun ()
+type UPLCProgram uni fun = UPLC.Program UPLC.NamedDeBruijn uni fun ()

--- a/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
@@ -334,7 +334,7 @@ runCompiler opts expr = do
     when (poDoTypecheck opts) . void $
         liftExcept $ PLC.typecheckPipeline plcTcConfig plcP
 
-    let uplcP = UPLC.eraseProgram plcP
+    uplcP <- liftExcept $ UPLC.deBruijnProgram $ UPLC.eraseProgram plcP
     pure (spirP, uplcP)
 
   where

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 module Lib where
@@ -11,24 +11,26 @@ import           Common
 import           PlcTestUtils
 
 import           Language.Haskell.TH
-import           Language.PlutusTx.Prelude
 
-import qualified Language.PlutusTx.Builtins   as Builtins
+import qualified Language.PlutusTx.Builtins          as Builtins
 import           Language.PlutusTx.Code
 import           Language.PlutusTx.Evaluation
-import           Language.PlutusTx.Prelude
 import           Language.PlutusTx.TH
 
-import           Language.PlutusCore.Pretty   (PrettyConst)
-import qualified Language.PlutusCore.Universe as PLC
-import qualified Language.UntypedPlutusCore   as UPLC
+import qualified Language.PlutusCore                 as PLC
+import           Language.PlutusCore.Pretty          (PrettyConst)
+import qualified Language.PlutusCore.Universe        as PLC
+import qualified Language.UntypedPlutusCore          as UPLC
+import qualified Language.UntypedPlutusCore.DeBruijn as UPLC
 
 import           Data.Text.Prettyprint.Doc
-import           Flat                         (Flat)
+import           Flat                                (Flat)
 
 instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun) =>
             ToUPlc (CompiledCodeIn uni fun a) uni fun where
-    toUPlc = catchAll . getPlc
+    toUPlc v = do
+        v' <- catchAll $ getPlc v
+        toUPlc v'
 
 goldenPir
     :: (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Flat, Pretty fun, Flat fun)

--- a/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
@@ -1,3 +1,3 @@
 (delay
-  (lam case_GHC_Types_True_7 (lam case_GHC_Types_False_8 case_GHC_Types_True_7))
+  (lam case_GHC_Types_True_3 (lam case_GHC_Types_False_4 case_GHC_Types_True_3))
 )

--- a/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
@@ -1,51 +1,47 @@
 (delay
   (lam
-    case_EmptyRose_121
+    case_EmptyRose_29
     [
-      case_EmptyRose_121
+      case_EmptyRose_29
       (delay
         (lam
-          case_Nil_157
+          case_Nil_35
           (lam
-            case_Cons_158
+            case_Cons_36
             [
               [
-                case_Cons_158
+                case_Cons_36
                 (delay
                   (lam
-                    case_EmptyRose_121
+                    case_EmptyRose_29
                     [
-                      case_EmptyRose_121
-                      (delay (lam case_Nil_140 (lam case_Cons_141 case_Nil_140))
-                      )
+                      case_EmptyRose_29
+                      (delay (lam case_Nil_31 (lam case_Cons_32 case_Nil_31)))
                     ]
                   )
                 )
               ]
               (delay
                 (lam
-                  case_Nil_157
+                  case_Nil_35
                   (lam
-                    case_Cons_158
+                    case_Cons_36
                     [
                       [
-                        case_Cons_158
+                        case_Cons_36
                         (delay
                           (lam
-                            case_EmptyRose_121
+                            case_EmptyRose_29
                             [
-                              case_EmptyRose_121
+                              case_EmptyRose_29
                               (delay
-                                (lam
-                                  case_Nil_140 (lam case_Cons_141 case_Nil_140)
-                                )
+                                (lam case_Nil_31 (lam case_Cons_32 case_Nil_31))
                               )
                             ]
                           )
                         )
                       ]
-                      (delay (lam case_Nil_140 (lam case_Cons_141 case_Nil_140))
-                      )
+                      (delay (lam case_Nil_31 (lam case_Cons_32 case_Nil_31)))
                     ]
                   )
                 )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_107 (lam case_False_108 case_False_108)))
+(delay (lam case_True_28 (lam case_False_29 case_False_29)))

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_104 (lam case_False_105 case_True_104)))
+(delay (lam case_True_26 (lam case_False_27 case_True_26)))

--- a/plutus-tx-plugin/test/Plugin/Laziness/joinErrorEval.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Laziness/joinErrorEval.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_Unit_37 case_Unit_37))
+(delay (lam case_Unit_22 case_Unit_22))

--- a/plutus-tx-plugin/test/Plugin/Primitives/andApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/andApply.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_10 (lam case_False_11 case_False_11)))
+(delay (lam case_True_5 (lam case_False_6 case_False_6)))

--- a/plutus-tx-plugin/test/Plugin/Primitives/equalsByteString.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/equalsByteString.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_13 (lam case_False_14 case_True_13)))
+(delay (lam case_True_9 (lam case_False_10 case_True_9)))

--- a/plutus-tx-plugin/test/Plugin/Primitives/intEqApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/intEqApply.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_13 (lam case_False_14 case_True_13)))
+(delay (lam case_True_9 (lam case_False_10 case_True_9)))

--- a/plutus-tx-plugin/test/Plugin/Primitives/ltByteString.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/ltByteString.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_13 (lam case_False_14 case_True_13)))
+(delay (lam case_True_9 (lam case_False_10 case_True_9)))

--- a/plutus-tx-plugin/test/TH/all.plc.golden
+++ b/plutus-tx-plugin/test/TH/all.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_123 (lam case_False_124 case_True_123)))
+(delay (lam case_True_27 (lam case_False_28 case_True_27)))

--- a/plutus-tx/src/Language/PlutusTx/Code.hs
+++ b/plutus-tx/src/Language/PlutusTx/Code.hs
@@ -35,8 +35,8 @@ import qualified Data.ByteString.Lazy             as BSL
 data CompiledCodeIn uni fun a =
     -- | Serialized UPLC code and possibly serialized PIR code.
     SerializedCode BS.ByteString (Maybe BS.ByteString)
-    -- | Deserialized UPLC program and possibly deserialized PIR program.
-    | DeserializedCode (UPLC.Program PLC.Name uni fun ()) (Maybe (PIR.Program PLC.TyName PLC.Name uni fun ()))
+    -- | Deserialized UPLC program, and possibly deserialized PIR program.
+    | DeserializedCode (UPLC.Program UPLC.NamedDeBruijn uni fun ()) (Maybe (PIR.Program PLC.TyName PLC.Name uni fun ()))
 
 -- | 'CompiledCodeIn' instantiated with default built-in types and functions.
 type CompiledCode = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun
@@ -64,7 +64,7 @@ instance Exception ImpossibleDeserialisationFailure
 -- | Get the actual Plutus Core program out of a 'CompiledCodeIn'.
 getPlc
     :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun)
-    => CompiledCodeIn uni fun a -> UPLC.Program PLC.Name uni fun ()
+    => CompiledCodeIn uni fun a -> UPLC.Program UPLC.NamedDeBruijn uni fun ()
 getPlc wrapper = case wrapper of
     SerializedCode plc _ -> case unflat (BSL.fromStrict plc) of
         Left e  -> throw $ ImpossibleDeserialisationFailure e

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -163,6 +163,7 @@ benchmark plutus-use-cases-bench
         plutus-core -any,
         lens -any,
         memory -any,
+        mtl -any,
         plutus-tx -any,
         plutus-use-cases -any,
         plutus-ledger -any,


### PR DESCRIPTION
This way it's done at compile-time, rather than runtime, which should
shave some time off the tests.

Most of the noise is moving the de-bruijn passes to use prismatic errors so they're easier to slot in to other places.

I don't see much difference in the tests locally, but this should address Ulf's observation in https://github.com/input-output-hk/plutus/pull/2555.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
