### PR TITLE
Bump HLS to 0.8.0

### DIFF
--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -57,7 +57,7 @@ let
   muslPackages = muslProject.hsPkgs;
 
   extraPackages = import ./extra.nix {
-    inherit lib haskell-nix fetchFromGitHub fetchFromGitLab buildPackages;
+    inherit stdenv lib haskell-nix fetchFromGitHub fetchFromGitLab buildPackages;
     inherit index-state checkMaterialization compiler-nix-name;
   };
 

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -4,7 +4,8 @@
 #
 # These are for e.g. developer usage, or for running formatting tests.
 ############################################################################
-{ lib
+{ stdenv
+, lib
 , haskell-nix
 , fetchFromGitHub
 , fetchFromGitLab
@@ -87,7 +88,11 @@
     # Plan issues with the benchmarks, can try removing later
     configureArgs = "--disable-benchmarks";
     # Invalidate and update if you change the version
-    plan-sha256 = "07p6z6jb87k8n0ihwxb8rdnjb7zddswds3pxca9dzsw47rd9czyd";
+    plan-sha256 =
+      # I don't know why this is platform-dependent!
+      if stdenv.isLinux
+      then "07p6z6jb87k8n0ihwxb8rdnjb7zddswds3pxca9dzsw47rd9czyd"
+      else "1s3cn381945hrs1fchg6bbkcf3abi0miqzc30bgpbfj23a8lhj2q";
     modules = [{
       packages.ghcide.patches = [ ../../patches/ghcide_partial_iface.patch ];
     }];

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -77,18 +77,17 @@
 (
   let hspkgs = haskell-nix.cabalProject {
     src = fetchFromGitHub {
-      name = "haskell-language-server";
       owner = "haskell";
       repo = "haskell-language-server";
-      rev = "0.7.1";
-      sha256 = "0gkzvjx4dgf53yicinqjshlj80gznx5khb62i7g3kqjr85iy0raa";
+      rev = "0.8.0";
+      sha256 = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
       fetchSubmodules = true;
     };
     inherit compiler-nix-name checkMaterialization;
     # Plan issues with the benchmarks, can try removing later
     configureArgs = "--disable-benchmarks";
     # Invalidate and update if you change the version
-    plan-sha256 = "0fps65f5dj1y8xr9478049j2541bkdjx0iw4ynknk9cnr512xcmk";
+    plan-sha256 = "07p6z6jb87k8n0ihwxb8rdnjb7zddswds3pxca9dzsw47rd9czyd";
     modules = [{
       packages.ghcide.patches = [ ../../patches/ghcide_partial_iface.patch ];
     }];

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -89,7 +89,7 @@
     configureArgs = "--disable-benchmarks";
     # Invalidate and update if you change the version
     plan-sha256 =
-      # I don't know why this is platform-dependent!
+      # See https://github.com/input-output-hk/nix-tools/issues/97
       if stdenv.isLinux
       then "07p6z6jb87k8n0ihwxb8rdnjb7zddswds3pxca9dzsw47rd9czyd"
       else "1s3cn381945hrs1fchg6bbkcf3abi0miqzc30bgpbfj23a8lhj2q";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -18,10 +18,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a4cc756399f44f0e961e6e27a43b88314ea32856",
-        "sha256": "0rl1b1xy5zw4mn3v9ch8xbnhgbfizfi4blaxn4cn50d4hd3q7mmd",
+        "rev": "a97132667c5bf098ac6123f4d163b8ae68348537",
+        "sha256": "1ddpzpkrqxyncrnq6cfaqmlk2kxg9nzm5x7jcrpa6iy9q0kjvk67",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/a4cc756399f44f0e961e6e27a43b88314ea32856.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/a97132667c5bf098ac6123f4d163b8ae68348537.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {


### PR DESCRIPTION
I want this since it finally uses a different build dir for `hie-bios`,
thus preventing the `cabal configure` thrashing when you run a cabal
command in the terminal while HLS is running.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
