### PR TITLE
Refactor the generator interpreter.

### DIFF
--- a/plutus-ledger/src/Ledger/Generators.hs
+++ b/plutus-ledger/src/Ledger/Generators.hs
@@ -250,8 +250,14 @@ validateMockchain (Mockchain blck _) tx = either Just (const Nothing) result whe
     idx    = Index.initialise [blck]
     result = Index.runValidation (Index.validateTransaction h tx) idx
 
--- | Split a value into max. n positive-valued parts such that the sum of the
---   parts equals the original value.
+{- | Split a value into max. n positive-valued parts such that the sum of the
+     parts equals the original value.
+
+     I noticed how for values of `mx` > 1000 the resulting lists are much smaller than
+     one would expect. I think this may be caused by the way we select the next value
+     for the split. It looks like the available funds get exhausted quite fast, which
+     makes the function return before generating anything close to `mx` values.
+-}
 splitVal :: (MonadGen m, Integral n) => Int -> n -> m [n]
 splitVal _  0     = pure []
 splitVal mx init' = go 0 0 [] where


### PR DESCRIPTION
I pulled out of the interpreter a function that generates a random Tx,
so we can avoid calling `createSystemRandom` on each run of the
function.

I will need a fast way of generating transactions, so I also removed all
of the other effects (like logging) which don't make much sense for my
use case.

I found some surprising behaviour when benchmarking some of the Tx
generation code and added some comments to try and explain why the
generating functions behave the way they do.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A pkgsLocal.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
