### PR TITLE
Mp save refactoring

### DIFF
--- a/marlowe-playground-client/src/Blockly/Events.purs
+++ b/marlowe-playground-client/src/Blockly/Events.purs
@@ -5,6 +5,7 @@ module Blockly.Events
   , ChangeEvent
   , FinishLoadingEvent
   , MoveEvent
+  , UIEvent
   , newParentId
   , oldParentId
   , oldInputName
@@ -33,6 +34,13 @@ foreign import data ChangeEvent :: Type
 instance hasEventChangeEvent :: HasEvent ChangeEvent where
   fromEvent :: Event -> Maybe ChangeEvent
   fromEvent = readBlocklyEventType "change"
+
+------------------------------------------------------------
+foreign import data UIEvent :: Type
+
+instance hasEventUIEvent :: HasEvent UIEvent where
+  fromEvent :: Event -> Maybe UIEvent
+  fromEvent = readBlocklyEventType "ui"
 
 ------------------------------------------------------------
 foreign import data FinishLoadingEvent :: Type

--- a/marlowe-playground-client/src/Blockly/Types.purs
+++ b/marlowe-playground-client/src/Blockly/Types.purs
@@ -5,7 +5,7 @@
 --   function types
 module Blockly.Types where
 
-import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent)
+import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent, UIEvent)
 
 foreign import data Blockly :: Type
 
@@ -24,3 +24,4 @@ data BlocklyEvent
   | Create CreateEvent
   | Move MoveEvent
   | FinishLoading FinishLoadingEvent
+  | UI UIEvent

--- a/marlowe-playground-client/src/Halogen/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Halogen/ActusBlockly.purs
@@ -39,7 +39,7 @@ type State
     , generator :: Maybe Generator
     , errorMessage :: Maybe String
     , showShiny :: Boolean
-    , hasUnsavedChanges :: Boolean
+    , useEvents :: Boolean
     }
 
 _actusBlocklyState :: Lens' State (Maybe BT.BlocklyState)
@@ -51,10 +51,6 @@ _generator = prop (SProxy :: SProxy "generator")
 _errorMessage :: Lens' State (Maybe String)
 _errorMessage = prop (SProxy :: SProxy "errorMessage")
 
--- We redefine this lens as importing the one from MainFrame causes a cyclic dependency
-_hasUnsavedChanges :: Lens' State Boolean
-_hasUnsavedChanges = prop (SProxy :: SProxy "hasUnsavedChanges")
-
 _showShiny :: Lens' State Boolean
 _showShiny = prop (SProxy :: SProxy "showShiny")
 
@@ -63,8 +59,6 @@ data Query a
   | SetError String a
   | GetWorkspace (XML -> a)
   | LoadWorkspace XML a
-  | HasUnsavedChanges (Boolean -> a)
-  | MarkProjectAsSaved a
 
 data ContractFlavour
   = FS
@@ -88,7 +82,14 @@ type DSL m a
 blockly :: forall m. MonadAff m => String -> Array BlockDefinition -> Component HTML Query Unit Message m
 blockly rootBlockName blockDefinitions =
   mkComponent
-    { initialState: const { actusBlocklyState: Nothing, generator: Nothing, errorMessage: Just "(Labs is an experimental feature)", showShiny: false, hasUnsavedChanges: false }
+    { initialState:
+        const
+          { actusBlocklyState: Nothing
+          , generator: Nothing
+          , errorMessage: Just "(Labs is an experimental feature)"
+          , showShiny: false
+          , useEvents: false
+          }
     , render
     , eval:
         H.mkEval
@@ -132,14 +133,6 @@ handleQuery (LoadWorkspace xml next) = do
           Blockly.loadWorkspace state.blockly workspaceRef xml
   assign _errorMessage Nothing
   pure $ Just next
-
-handleQuery (HasUnsavedChanges next) = do
-  val <- use _hasUnsavedChanges
-  pure $ Just $ next val
-
-handleQuery (MarkProjectAsSaved next) = do
-  assign _hasUnsavedChanges false
-  pure $ Just $ next
 
 handleAction :: forall m. MonadAff m => Action -> DSL m Unit
 handleAction (Inject rootBlockName blockDefinitions) = do

--- a/marlowe-playground-client/src/Halogen/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Halogen/ActusBlockly.purs
@@ -74,7 +74,6 @@ data Message
   = Initialized
   | CurrentTerms ContractFlavour String
   | CodeChange
-  | FinishLoading
 
 type DSL m a
   = HalogenM State Action () Message m a
@@ -207,7 +206,7 @@ handleAction RunAnalysis = do
   where
   unexpected s = "An unexpected error has occurred, please raise a support issue: " <> s
 
-handleAction (BlocklyEvent event) = updateUnsavedChangesActionHandler CodeChange FinishLoading event
+handleAction (BlocklyEvent event) = updateUnsavedChangesActionHandler CodeChange event
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/Halogen/Blockly.purs
+++ b/marlowe-playground-client/src/Halogen/Blockly.purs
@@ -66,8 +66,7 @@ data Action
   | BlocklyEvent BT.BlocklyEvent
 
 data Message
-  = FinishLoading
-  | CodeChange
+  = CodeChange
 
 type DSL slots m a
   = HalogenM State Action slots Message m a
@@ -192,7 +191,7 @@ handleAction (Inject rootBlockName blockDefinitions) = do
 
 handleAction (SetData _) = pure unit
 
-handleAction (BlocklyEvent event) = updateUnsavedChangesActionHandler CodeChange FinishLoading event
+handleAction (BlocklyEvent event) = updateUnsavedChangesActionHandler CodeChange event
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
+++ b/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
@@ -58,10 +58,9 @@ updateUnsavedChangesActionHandler ::
   forall m state action slots message.
   MonadAff m =>
   message ->
-  message ->
   BlocklyEvent ->
   HalogenM { useEvents :: Boolean | state } action slots message m Unit
-updateUnsavedChangesActionHandler codeChange finishLoading event = do
+updateUnsavedChangesActionHandler codeChange event = do
   useEvents <- use _useEvents
   case event of
     (BT.UI _) -> assign _useEvents true
@@ -69,7 +68,7 @@ updateUnsavedChangesActionHandler codeChange finishLoading event = do
     -- The move event only changes the unsaved status if the parent has changed (either by attaching or detaching
     -- one block into another)
     (BT.Move ev) -> when (useEvents && newParentId ev /= oldParentId ev) $ raise codeChange
-    (BT.FinishLoading _) -> raise finishLoading
+    (BT.FinishLoading _) -> pure unit
     -- The create event by itself does not modify the contract. It is modified once it's attached or detached
     -- from a parent, and that is covered by the Move event
     (BT.Create _) -> pure unit

--- a/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
+++ b/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
@@ -8,7 +8,7 @@ import Blockly.Events (fromEvent, newParentId, oldParentId)
 import Blockly.Types (BlocklyEvent, Workspace)
 import Blockly.Types as BT
 import Data.Foldable (oneOf)
-import Data.Lens (Lens', assign)
+import Data.Lens (Lens', assign, use)
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (for_)
@@ -37,35 +37,39 @@ blocklyEvents toAction workspace =
               , BT.Move <$> fromEvent event
               , BT.Change <$> fromEvent event
               , BT.FinishLoading <$> fromEvent event
+              , BT.UI <$> fromEvent event
               ]
         in
           for_ mEvent \ev -> EventSource.emit emitter (toAction ev)
     addChangeListener workspace listener
     pure $ EventSource.Finalizer $ removeChangeListener workspace listener
 
-_hasUnsavedChanges' :: forall r. Lens' { hasUnsavedChanges :: Boolean | r } Boolean
-_hasUnsavedChanges' = prop (SProxy :: SProxy "hasUnsavedChanges")
+_useEvents :: forall state. Lens' { useEvents :: Boolean | state } Boolean
+_useEvents = prop (SProxy :: SProxy "useEvents")
 
+-- | Convert blockly events into halogen messages
+-- |
+-- | We only raise CodeChange events if we have enabled saving. This is because when we load code into blockly
+-- | it builds the blocks asynchronously. We need some way to distinguish between a user having changed blockly
+-- | and the loading of code having changed blockly. This division can be seen by looking for a UI event since
+-- | if the user has done nothing then no UI events will have been fired. We also need to remember to set useEvents
+-- | to false in our Blockly component when SetCode is called.
 updateUnsavedChangesActionHandler ::
   forall m state action slots message.
   MonadAff m =>
   message ->
   message ->
   BlocklyEvent ->
-  HalogenM { hasUnsavedChanges :: Boolean | state } action slots message m Unit
+  HalogenM { useEvents :: Boolean | state } action slots message m Unit
 updateUnsavedChangesActionHandler codeChange finishLoading event = do
-  let
-    setUnsavedChangesToTrue = do
-      assign _hasUnsavedChanges' true
-      raise codeChange
+  useEvents <- use _useEvents
   case event of
-    (BT.Change _) -> setUnsavedChangesToTrue
+    (BT.UI _) -> assign _useEvents true
+    (BT.Change _) -> when useEvents $ raise codeChange
     -- The move event only changes the unsaved status if the parent has changed (either by attaching or detaching
     -- one block into another)
-    (BT.Move ev) -> when (newParentId ev /= oldParentId ev) setUnsavedChangesToTrue
-    (BT.FinishLoading _) -> do
-      assign _hasUnsavedChanges' false
-      raise finishLoading
+    (BT.Move ev) -> when (useEvents && newParentId ev /= oldParentId ev) $ raise codeChange
+    (BT.FinishLoading _) -> raise finishLoading
     -- The create event by itself does not modify the contract. It is modified once it's attached or detached
     -- from a parent, and that is covered by the Move event
     (BT.Create _) -> pure unit

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -10,17 +10,17 @@ import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.Reader (runReaderT)
 import Data.Array (catMaybes)
 import Data.Either (Either(..))
-import Data.Lens (assign, set, use, view)
+import Data.Lens (assign, use, view)
 import Data.Maybe (Maybe(..))
 import Data.String as String
 import Effect.Aff.Class (class MonadAff)
-import Halogen (HalogenM, liftEffect, modify_, query)
+import Halogen (HalogenM, liftEffect, query)
 import Halogen.Blockly as Blockly
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import HaskellEditor.Types (Action(..), State, _compilationResult, _haskellEditorKeybindings, _showBottomPanel)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), _InterpreterResult)
 import LocalStorage as LocalStorage
-import MainFrame.Types (ChildSlots, _blocklySlot, _hasUnsavedChanges', _haskellEditorSlot)
+import MainFrame.Types (ChildSlots, _blocklySlot, _haskellEditorSlot)
 import Marlowe (SPParams_, postRunghc)
 import Monaco (IMarkerData, markerSeverity)
 import Network.RemoteData (RemoteData(..))
@@ -40,10 +40,7 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction _ (HandleEditorMessage (Monaco.TextChanged text)) = do
   liftEffect $ LocalStorage.setItem bufferLocalStorageKey text
-  modify_
-    ( set _compilationResult NotAsked
-        <<< set _hasUnsavedChanges' true
-    )
+  assign _compilationResult NotAsked
 
 handleAction _ (ChangeKeyBindings bindings) = do
   assign _haskellEditorKeybindings bindings
@@ -84,9 +81,6 @@ handleAction _ SendResultToBlockly = do
 handleAction _ (InitHaskellProject contents) = do
   editorSetValue contents
   liftEffect $ LocalStorage.setItem bufferLocalStorageKey contents
-  assign _hasUnsavedChanges' false
-
-handleAction _ MarkProjectAsSaved = assign _hasUnsavedChanges' false
 
 runAjax ::
   forall m a.

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -26,7 +26,6 @@ data Action
   --        with the action "soon to be implemented" ViewAsBlockly
   | SendResultToBlockly
   | InitHaskellProject String
-  | MarkProjectAsSaved
 
 defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Haskell." <> s
@@ -39,13 +38,11 @@ instance actionIsEvent :: IsEvent Action where
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
   toEvent SendResultToBlockly = Just $ defaultEvent "SendResultToBlockly"
   toEvent (InitHaskellProject _) = Just $ defaultEvent "InitHaskellProject"
-  toEvent MarkProjectAsSaved = Just $ defaultEvent "MarkProjectAsSaved"
 
 type State
   = { keybindings :: KeyBindings
     , compilationResult :: WebData (Either InterpreterError (InterpreterResult String))
     , showBottomPanel :: Boolean
-    , hasUnsavedChanges :: Boolean
     }
 
 _haskellEditorKeybindings :: Lens' State KeyBindings
@@ -76,5 +73,4 @@ initialState =
   { keybindings: DefaultBindings
   , compilationResult: NotAsked
   , showBottomPanel: true
-  , hasUnsavedChanges: false
   }

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -45,7 +45,6 @@ data Action
   --        Actually, in the JavaScript editor there isn't even a button to send to blockly.
   | SendResultToBlockly
   | InitJavascriptProject String
-  | MarkProjectAsSaved
 
 defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Javascript." <> s
@@ -58,7 +57,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
   toEvent SendResultToBlockly = Just $ defaultEvent "SendResultToBlockly"
   toEvent (InitJavascriptProject _) = Just $ defaultEvent "InitJavascriptProject"
-  toEvent MarkProjectAsSaved = Just $ defaultEvent "MarkProjectAsSaved"
 
 type DecorationIds
   = { topDecorationId :: String
@@ -76,7 +74,6 @@ type State
     , compilationResult :: CompilationState
     , showBottomPanel :: Boolean
     , decorationIds :: Maybe DecorationIds
-    , hasUnsavedChanges :: Boolean
     }
 
 _keybindings :: Lens' State KeyBindings
@@ -97,5 +94,4 @@ initialState =
   , compilationResult: NotCompiled
   , showBottomPanel: true
   , decorationIds: Nothing
-  , hasUnsavedChanges: false
   }

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -399,7 +399,7 @@ handleAction settings (HandleActusBlocklyMessage (ActusBlockly.CurrentTerms flav
         Failure e -> void $ query _actusBlocklySlot unit (ActusBlockly.SetError ("Server error! " <> (showErrorDescription (runAjaxError e).description)) unit)
         _ -> void $ query _actusBlocklySlot unit (ActusBlockly.SetError "Unknown server error!" unit)
 
-handleAction settings (HandleActusBlocklyMessage ActusBlockly.CodeChange) = assign _hasUnsavedChanges true
+handleAction _ (HandleActusBlocklyMessage ActusBlockly.CodeChange) = assign _hasUnsavedChanges true
 
 -- TODO: modify gist action type to take a gistid as a parameter
 -- https://github.com/input-output-hk/plutus/pull/2498/files#r533478042

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -419,6 +419,7 @@ handleAction s (ProjectsAction action@(Projects.LoadProject lang gistId)) = do
         ( set _createGistResult (Success gist)
             <<< set _showModal Nothing
             <<< set _workflow (Just lang)
+            <<< set _hasUnsavedChanges true
         )
     Left error ->
       modify_
@@ -461,6 +462,7 @@ handleAction s (NewProjectAction (NewProject.CreateProject lang)) = do
   modify_
     ( set _showModal Nothing
         <<< set _workflow (Just lang)
+        <<< set _hasUnsavedChanges true
     )
 
 handleAction s (NewProjectAction NewProject.Cancel) = fullHandleAction s CloseModal
@@ -483,6 +485,12 @@ handleAction s (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
   modify_
     ( set _showModal Nothing
         <<< set _workflow (Just lang)
+        {- 
+        it is possible that you could load a demo that is already in the editor so there would in theory
+        be no unsaved changes however this is tricky with blockly and I think it's fine to say that if
+        you load a new demo then you have unsaved changes
+        -}
+        
         <<< set _hasUnsavedChanges true
     )
   selectView $ selectLanguageView lang

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -17,7 +17,6 @@ import Data.Lens.Index (ix)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (unwrap)
-import Debug.Trace (trace)
 import Demos.Types (Action(..), Demo(..)) as Demos
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect)
@@ -43,7 +42,7 @@ import JavascriptEditor.Types (CompilationState(..))
 import Language.Haskell.Monaco as HM
 import LocalStorage as LocalStorage
 import LoginPopup (openLoginPopup, informParentAndClose)
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State(State), View(..), _actusBlocklySlot, _authStatus, _blocklySlot, _createGistResult, _gistId, _hasUnsavedChanges, _haskellEditorSlot, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorPageSlot, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _walletSlot, _workflow)
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklySlot, _createGistResult, _gistId, _hasUnsavedChanges, _haskellEditorSlot, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorPageSlot, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _walletSlot, _workflow)
 import MainFrame.Types (BlocklySubAction(..)) as BL
 import MainFrame.View (render)
 import Marlowe (SPParams_, getApiGistsByGistId)
@@ -85,29 +84,28 @@ import Web.UIEvent.KeyboardEvent.EventTypes (keyup)
 
 initialState :: State
 initialState =
-  State
-    { view: HomePage
-    , jsCompilationResult: NotCompiled
-    , showBottomPanel: true
-    , haskellState: HE.initialState
-    , javascriptState: JS.initialState
-    , marloweEditorState: ME.initialState
-    , simulationState: ST.mkState
-    , jsEditorKeybindings: DefaultBindings
-    , activeJSDemo: mempty
-    , projects: Projects.emptyState
-    , newProject: NewProject.emptyState
-    , rename: Rename.emptyState
-    , saveAs: SaveAs.emptyState
-    , authStatus: NotAsked
-    , gistId: Nothing
-    , createGistResult: NotAsked
-    , loadGistResult: Right NotAsked
-    , projectName: "Untitled Project"
-    , showModal: Nothing
-    , hasUnsavedChanges: false
-    , workflow: Nothing
-    }
+  { view: HomePage
+  , jsCompilationResult: NotCompiled
+  , showBottomPanel: true
+  , haskellState: HE.initialState
+  , javascriptState: JS.initialState
+  , marloweEditorState: ME.initialState
+  , simulationState: ST.mkState
+  , jsEditorKeybindings: DefaultBindings
+  , activeJSDemo: mempty
+  , projects: Projects.emptyState
+  , newProject: NewProject.emptyState
+  , rename: Rename.emptyState
+  , saveAs: SaveAs.emptyState
+  , authStatus: NotAsked
+  , gistId: Nothing
+  , createGistResult: NotAsked
+  , loadGistResult: Right NotAsked
+  , projectName: "Untitled Project"
+  , showModal: Nothing
+  , hasUnsavedChanges: false
+  , workflow: Nothing
+  }
 
 ------------------------------------------------------------
 mkMainFrame ::
@@ -327,7 +325,7 @@ handleAction s (MarloweEditorAction action) = do
         void $ query _blocklySlot unit (Blockly.SetCode source unit)
         assign _workflow (Just Blockly)
         selectView BlocklyEditor
-    (ME.HandleEditorMessage (Monaco.TextChanged _)) -> trace "text changed" \_ -> assign _hasUnsavedChanges true
+    (ME.HandleEditorMessage (Monaco.TextChanged _)) -> assign _hasUnsavedChanges true
     (ME.InitMarloweProject _) -> assign _hasUnsavedChanges false
     _ -> pure unit
 

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -285,11 +285,8 @@ _projectName = _Newtype <<< prop (SProxy :: SProxy "projectName")
 _showModal :: Lens' State (Maybe ModalView)
 _showModal = _Newtype <<< prop (SProxy :: SProxy "showModal")
 
-_hasUnsavedChanges' :: forall r. Lens' { hasUnsavedChanges :: Boolean | r } Boolean
-_hasUnsavedChanges' = prop (SProxy :: SProxy "hasUnsavedChanges")
-
 _hasUnsavedChanges :: Lens' State Boolean
-_hasUnsavedChanges = _Newtype <<< _hasUnsavedChanges'
+_hasUnsavedChanges = _Newtype <<< prop (SProxy :: SProxy "hasUnsavedChanges")
 
 _workflow :: Lens' State (Maybe Lang)
 _workflow = _Newtype <<< prop (SProxy :: SProxy "workflow")

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -8,10 +8,8 @@ import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', has, (^.))
-import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
-import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Demos.Types as Demos
 import Gist (Gist, GistId)
@@ -188,108 +186,105 @@ _walletSlot :: SProxy "walletSlot"
 _walletSlot = SProxy
 
 -----------------------------------------------------------
-newtype State
-  = State
-  { view :: View
-  , jsCompilationResult :: CompilationState
-  , jsEditorKeybindings :: KeyBindings
-  , activeJSDemo :: String
-  , showBottomPanel :: Boolean
-  -- TODO: rename to haskellEditorState
-  , haskellState :: HE.State
-  -- TODO: rename to javascriptEditorState
-  , javascriptState :: JS.State
-  , marloweEditorState :: ME.State
-  , simulationState :: Simulation.State
-  , projects :: Projects.State
-  , newProject :: NewProject.State
-  , rename :: Rename.State
-  , saveAs :: SaveAs.State
-  , authStatus :: WebData AuthStatus
-  , gistId :: Maybe GistId
-  , createGistResult :: WebData Gist
-  , loadGistResult :: Either String (WebData Gist)
-  , projectName :: String
-  , showModal :: Maybe ModalView
-  -- The source of truth for the unsaved change lives inside each editor
-  -- The only reason we store a copy of the state here is because of the render function
-  -- in the Mainframe view, which uses this derived state to show an unsaved indicator.
-  -- Inside the Mainframe view we can inspect the state of the submodules (Haskell/JS/Marlowe)
-  -- as their state is part of the MainFrame state, but we cannot inspect the state of the
-  -- child components Blockly and ActusBlockly as we need a Query.
-  , hasUnsavedChanges :: Boolean
-  -- The initial language selected when you create/load a project indicates the workflow a user might take
-  -- A user can start with a haskell/javascript example that eventually gets compiled into
-  -- marlowe/blockly and run in the simulator, or can create a marlowe/blockly contract directly,
-  -- which can be used interchangeably. This is used all across the site to know what are the posible
-  -- transitions.
-  , workflow :: Maybe Lang
-  }
-
-derive instance newtypeState :: Newtype State _
+type State
+  = { view :: View
+    , jsCompilationResult :: CompilationState
+    , jsEditorKeybindings :: KeyBindings
+    , activeJSDemo :: String
+    , showBottomPanel :: Boolean
+    -- TODO: rename to haskellEditorState
+    , haskellState :: HE.State
+    -- TODO: rename to javascriptEditorState
+    , javascriptState :: JS.State
+    , marloweEditorState :: ME.State
+    , simulationState :: Simulation.State
+    , projects :: Projects.State
+    , newProject :: NewProject.State
+    , rename :: Rename.State
+    , saveAs :: SaveAs.State
+    , authStatus :: WebData AuthStatus
+    , gistId :: Maybe GistId
+    , createGistResult :: WebData Gist
+    , loadGistResult :: Either String (WebData Gist)
+    , projectName :: String
+    , showModal :: Maybe ModalView
+    -- The source of truth for the unsaved change lives inside each editor
+    -- The only reason we store a copy of the state here is because of the render function
+    -- in the Mainframe view, which uses this derived state to show an unsaved indicator.
+    -- Inside the Mainframe view we can inspect the state of the submodules (Haskell/JS/Marlowe)
+    -- as their state is part of the MainFrame state, but we cannot inspect the state of the
+    -- child components Blockly and ActusBlockly as we need a Query.
+    , hasUnsavedChanges :: Boolean
+    -- The initial language selected when you create/load a project indicates the workflow a user might take
+    -- A user can start with a haskell/javascript example that eventually gets compiled into
+    -- marlowe/blockly and run in the simulator, or can create a marlowe/blockly contract directly,
+    -- which can be used interchangeably. This is used all across the site to know what are the posible
+    -- transitions.
+    , workflow :: Maybe Lang
+    }
 
 _view :: Lens' State View
-_view = _Newtype <<< prop (SProxy :: SProxy "view")
+_view = prop (SProxy :: SProxy "view")
 
 _jsCompilationResult :: Lens' State CompilationState
-_jsCompilationResult = _Newtype <<< prop (SProxy :: SProxy "jsCompilationResult")
+_jsCompilationResult = prop (SProxy :: SProxy "jsCompilationResult")
 
 _jsEditorKeybindings :: Lens' State KeyBindings
-_jsEditorKeybindings = _Newtype <<< prop (SProxy :: SProxy "jsEditorKeybindings")
+_jsEditorKeybindings = prop (SProxy :: SProxy "jsEditorKeybindings")
 
 _activeJSDemo :: Lens' State String
-_activeJSDemo = _Newtype <<< prop (SProxy :: SProxy "activeJSDemo")
+_activeJSDemo = prop (SProxy :: SProxy "activeJSDemo")
 
 _showBottomPanel :: Lens' State Boolean
-_showBottomPanel = _Newtype <<< prop (SProxy :: SProxy "showBottomPanel")
+_showBottomPanel = prop (SProxy :: SProxy "showBottomPanel")
 
 _marloweEditorState :: Lens' State ME.State
-_marloweEditorState = _Newtype <<< prop (SProxy :: SProxy "marloweEditorState")
+_marloweEditorState = prop (SProxy :: SProxy "marloweEditorState")
 
 _haskellState :: Lens' State HE.State
-_haskellState = _Newtype <<< prop (SProxy :: SProxy "haskellState")
+_haskellState = prop (SProxy :: SProxy "haskellState")
 
 _javascriptState :: Lens' State JS.State
-_javascriptState = _Newtype <<< prop (SProxy :: SProxy "javascriptState")
+_javascriptState = prop (SProxy :: SProxy "javascriptState")
 
 _simulationState :: Lens' State Simulation.State
-_simulationState = _Newtype <<< prop (SProxy :: SProxy "simulationState")
+_simulationState = prop (SProxy :: SProxy "simulationState")
 
 _projects :: Lens' State Projects.State
-_projects = _Newtype <<< prop (SProxy :: SProxy "projects")
+_projects = prop (SProxy :: SProxy "projects")
 
 _newProject :: Lens' State NewProject.State
-_newProject = _Newtype <<< prop (SProxy :: SProxy "newProject")
+_newProject = prop (SProxy :: SProxy "newProject")
 
 _rename :: Lens' State Rename.State
-_rename = _Newtype <<< prop (SProxy :: SProxy "rename")
+_rename = prop (SProxy :: SProxy "rename")
 
 _saveAs :: Lens' State SaveAs.State
-_saveAs = _Newtype <<< prop (SProxy :: SProxy "saveAs")
+_saveAs = prop (SProxy :: SProxy "saveAs")
 
 _authStatus :: Lens' State (WebData AuthStatus)
-_authStatus = _Newtype <<< prop (SProxy :: SProxy "authStatus")
+_authStatus = prop (SProxy :: SProxy "authStatus")
 
 _gistId :: Lens' State (Maybe GistId)
-_gistId = _Newtype <<< prop (SProxy :: SProxy "gistId")
+_gistId = prop (SProxy :: SProxy "gistId")
 
 _createGistResult :: Lens' State (WebData Gist)
-_createGistResult = _Newtype <<< prop (SProxy :: SProxy "createGistResult")
+_createGistResult = prop (SProxy :: SProxy "createGistResult")
 
 _loadGistResult :: Lens' State (Either String (WebData Gist))
-_loadGistResult = _Newtype <<< prop (SProxy :: SProxy "loadGistResult")
+_loadGistResult = prop (SProxy :: SProxy "loadGistResult")
 
 _projectName :: Lens' State String
-_projectName = _Newtype <<< prop (SProxy :: SProxy "projectName")
+_projectName = prop (SProxy :: SProxy "projectName")
 
 _showModal :: Lens' State (Maybe ModalView)
-_showModal = _Newtype <<< prop (SProxy :: SProxy "showModal")
+_showModal = prop (SProxy :: SProxy "showModal")
 
 _hasUnsavedChanges :: Lens' State Boolean
-_hasUnsavedChanges = _Newtype <<< prop (SProxy :: SProxy "hasUnsavedChanges")
+_hasUnsavedChanges = prop (SProxy :: SProxy "hasUnsavedChanges")
 
 _workflow :: Lens' State (Maybe Lang)
-_workflow = _Newtype <<< prop (SProxy :: SProxy "workflow")
+_workflow = prop (SProxy :: SProxy "workflow")
 
 currentLang :: State -> Maybe Lang
 currentLang state = case state ^. _view of

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -208,12 +208,6 @@ type State
     , loadGistResult :: Either String (WebData Gist)
     , projectName :: String
     , showModal :: Maybe ModalView
-    -- The source of truth for the unsaved change lives inside each editor
-    -- The only reason we store a copy of the state here is because of the render function
-    -- in the Mainframe view, which uses this derived state to show an unsaved indicator.
-    -- Inside the Mainframe view we can inspect the state of the submodules (Haskell/JS/Marlowe)
-    -- as their state is part of the MainFrame state, but we cannot inspect the state of the
-    -- child components Blockly and ActusBlockly as we need a Query.
     , hasUnsavedChanges :: Boolean
     -- The initial language selected when you create/load a project indicates the workflow a user might take
     -- A user can start with a haskell/javascript example that eventually gets compiled into

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -25,7 +25,7 @@ import FileEvents as FileEvents
 import Halogen (HalogenM, liftEffect, modify_, query)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import LocalStorage as LocalStorage
-import MainFrame.Types (ChildSlots, _hasUnsavedChanges', _marloweEditorPageSlot)
+import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
 import Marlowe (SPParams_)
 import Marlowe as Server
 import Marlowe.Holes (fromTerm)
@@ -57,10 +57,7 @@ handleAction _ (ChangeKeyBindings bindings) = do
   void $ query _marloweEditorPageSlot unit (Monaco.SetKeyBindings bindings unit)
 
 handleAction _ (HandleEditorMessage (Monaco.TextChanged text)) = do
-  modify_
-    ( set _selectedHole Nothing
-        <<< set _hasUnsavedChanges' true
-    )
+  assign _selectedHole Nothing
   liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey text
   analysisState <- use _analysisState
   let
@@ -124,9 +121,6 @@ handleAction _ ViewAsBlockly = pure unit
 handleAction _ (InitMarloweProject contents) = do
   editorSetValue contents
   liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey contents
-  assign _hasUnsavedChanges' false
-
-handleAction _ MarkProjectAsSaved = assign _hasUnsavedChanges' false
 
 handleAction _ (SelectHole hole) = assign _selectedHole hole
 

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -41,7 +41,6 @@ data Action
   | SendToSimulator
   | ViewAsBlockly
   | InitMarloweProject String
-  | MarkProjectAsSaved
   | SelectHole (Maybe String)
   | AnalyseContract
   | AnalyseReachabilityContract
@@ -64,7 +63,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"
   toEvent ViewAsBlockly = Just $ defaultEvent "ViewAsBlockly"
   toEvent (InitMarloweProject _) = Just $ defaultEvent "InitMarloweProject"
-  toEvent MarkProjectAsSaved = Just $ defaultEvent "MarkProjectAsSaved"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
@@ -160,7 +158,6 @@ type State
     , showBottomPanel :: Boolean
     , showErrorDetail :: Boolean
     , bottomPanelView :: BottomPanelView
-    , hasUnsavedChanges :: Boolean
     , selectedHole :: Maybe String
     -- This is pagination information that we need to provide to the haskell backend
     -- so that it can do the analysis in chunks
@@ -199,7 +196,6 @@ initialState =
   , showBottomPanel: false
   , showErrorDetail: false
   , bottomPanelView: StaticAnalysisView
-  , hasUnsavedChanges: false
   , selectedHole: Nothing
   , analysisState: NoneAsked
   , editorErrors: mempty

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -268,7 +268,6 @@ type State
     , bottomPanelView :: BottomPanelView
     -- QUESTION: What is the use of oldContract?
     , oldContract :: Maybe String
-    , hasUnsavedChanges :: Boolean
     }
 
 _showRightPanel :: Lens' State Boolean
@@ -303,7 +302,6 @@ mkState =
   , showBottomPanel: true
   , bottomPanelView: CurrentStateView
   , oldContract: Nothing
-  , hasUnsavedChanges: false
   }
 
 data Action


### PR DESCRIPTION
Detecting if a project has unsaved changes and dealing with it correctly is quite tricky. We were in a situation where we had a lot of state duplicated so I have managed to remove that duplication. In addition there was an issue where it is difficult to know when a user has made a change to blockly or if code was moved from the marlowe editor. In the case where code is moved from marlowe editor to blockly, we don't want to mark as having unsaved changes (because the marlowe editor and blockly are considered "views" of the same code) however if the user changes something then of course we do. Since blockly was doing loads of stuff asynchronously and since the `finished_loading` doesn't actually mean that loading has finished 😒  we need a way to detect this. I realised that `ui` events are not fired when sending code from marlowe editor to blockly so we can use the first `ui` event to tell us that the user must have started doing something. Now we have a 'switch' called `State.useEvents` (better name welcome) that we turn off just before we transfer code from marlowe editor and turn back on again at the first `ui` event.

Additionally I removed the newtype wrapper of `MainFrame.State` as it was not needed any more and I also cleaned up a few things.

Deployed to https://david.marlowe.iohkdev.io/ (there should be no functional changes)
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
