### PR TITLE
plutus-playground: Fix the display of contract instance log messages

### DIFF
--- a/plutus-playground-client/src/Chain.purs
+++ b/plutus-playground-client/src/Chain.purs
@@ -27,11 +27,11 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import Icons (Icon(..), icon)
 import Language.PlutusTx.AssocMap as AssocMap
-import Plutus.Trace.Emulator.Types (ContractInstanceLog(..))
+import Plutus.Trace.Emulator.Types (ContractInstanceLog(..), _ContractInstanceTag)
 import Ledger.Slot (Slot(..))
 import Ledger.TxId (TxId(TxId))
 import Ledger.Value (CurrencySymbol, TokenName)
-import Playground.Lenses (_tokenName)
+import Playground.Lenses (_tokenName, _contractInstanceTag)
 import Playground.Types (EvaluationResult(EvaluationResult), SimulatorWallet)
 import Prelude (const, map, show, unit, ($), (<$>), (<<<), (<>))
 import Types (ChildSlots, HAction(..), View(..), _balancesChartSlot, _simulatorWalletBalance, _simulatorWalletWallet, _walletId)
@@ -132,7 +132,7 @@ emulatorEventPane (WalletEvent (Wallet walletId) logMessage) =
 
 emulatorEventPane (InstanceEvent (ContractInstanceLog { _cilMessage, _cilTag })) =
   div_
-    [ text $ show _cilMessage <> ": " <> show _cilMessage ]
+    [ text $ (view _contractInstanceTag _cilTag) <> ": " <> show _cilMessage ]
 
 -- TODO: Figure out which of the remaining log messages we want to display.
 -- (Note that most of the remaining log messages aren't produced at the

--- a/web-common/src/Playground/Lenses.purs
+++ b/web-common/src/Playground/Lenses.purs
@@ -40,6 +40,9 @@ _schema = prop (SProxy :: SProxy "schema")
 _txConfirmed :: forall s r a. Newtype s { unTxConfirmed :: a | r } => Lens' s a
 _txConfirmed = _Newtype <<< prop (SProxy :: SProxy "unTxConfirmed")
 
+_contractInstanceTag :: forall s r a. Newtype s { unContractInstanceTag :: a | r } => Lens' s a
+_contractInstanceTag = _Newtype <<< prop (SProxy :: SProxy "unContractInstanceTag")
+
 _txId :: Lens' TxId String
 _txId = _Newtype <<< prop (SProxy :: SProxy "getTxId")
 


### PR DESCRIPTION
* Instead of showing the contract instance tag and the message, it showed the message twice

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
