### PR TITLE
plutus-playground: Delete unused field from EvaluationResult

### DIFF
--- a/playground-common/src/Playground/Interpreter/Util.hs
+++ b/playground-common/src/Playground/Interpreter/Util.hs
@@ -100,8 +100,7 @@ evaluationResultFold :: [Wallet] -> EmulatorEventFoldM effs EvaluationResult
 evaluationResultFold wallets =
     let pkh wallet = (pubKeyHash (walletPubKey wallet), wallet)
     in Playground.Types.EvaluationResult
-            <$> L.generalize (reverse <$> Folds.blockchain)
-            <*> L.generalize (reverse <$> Folds.annotatedBlockchain)
+            <$> L.generalize (reverse <$> Folds.annotatedBlockchain)
             <*> L.generalize (filter isInteresting <$> Folds.emulatorLog)
             <*> renderInstanceTrace (walletInstanceTag <$> wallets)
             <*> fmap (fmap (uncurry SimulatorWallet) . Map.toList) (funds wallets)

--- a/playground-common/src/Playground/Types.hs
+++ b/playground-common/src/Playground/Types.hs
@@ -26,7 +26,7 @@ import           GHC.Generics                                    (Generic)
 import           Language.Haskell.Interpreter                    (CompilationError, SourceCode)
 import qualified Language.Haskell.Interpreter                    as HI
 import           Language.Plutus.Contract.Effects.ExposeEndpoint (EndpointDescription)
-import           Ledger                                          (PubKeyHash, Tx, fromSymbol, pubKeyHash)
+import           Ledger                                          (PubKeyHash, fromSymbol, pubKeyHash)
 import qualified Ledger.Ada                                      as Ada
 import           Ledger.Scripts                                  (ValidatorHash)
 import           Ledger.Slot                                     (Slot)
@@ -134,8 +134,7 @@ pubKeys Evaluation {..} = pubKeyHash . walletPubKey . simulatorWalletWallet <$> 
 
 data EvaluationResult =
     EvaluationResult
-        { resultBlockchain  :: [[Tx]] -- ^ The blockchain, newest blocks first
-        , resultRollup      :: [[AnnotatedTx]] -- ^ Annotated blockchain, newest blocks first
+        { resultRollup      :: [[AnnotatedTx]] -- ^ Annotated blockchain, newest blocks first
         , emulatorLog       :: [EmulatorEvent] -- ^ The emulator log, newest events first
         , emulatorTrace     :: Text
         , fundsDistribution :: [SimulatorWallet]

--- a/plutus-playground-client/src/Types.purs
+++ b/plutus-playground-client/src/Types.purs
@@ -317,9 +317,6 @@ _createGistResult = _Newtype <<< prop (SProxy :: SProxy "createGistResult")
 _gistUrl :: Lens' State (Maybe String)
 _gistUrl = _Newtype <<< prop (SProxy :: SProxy "gistUrl")
 
-_resultBlockchain :: Lens' EvaluationResult Blockchain
-_resultBlockchain = _Newtype <<< prop (SProxy :: SProxy "resultBlockchain")
-
 _walletKeys :: Lens' EvaluationResult (Array (JsonTuple PubKeyHash Wallet))
 _walletKeys = _Newtype <<< prop (SProxy :: SProxy "walletKeys")
 

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -42,7 +42,7 @@ import           Playground.Types                                (CompilationRes
                                                                   SimulatorWallet (SimulatorWallet), adaCurrency,
                                                                   argument, argumentValues, caller, emulatorLog,
                                                                   endpointDescription, fundsDistribution, program,
-                                                                  resultBlockchain, simulatorWalletBalance,
+                                                                  resultRollup, simulatorWalletBalance,
                                                                   simulatorWalletWallet, sourceCode, walletKeys,
                                                                   wallets)
 import           Playground.Usecases                             (crowdFunding, errorHandling, game, vesting)
@@ -51,6 +51,7 @@ import           Test.Tasty                                      (TestTree, test
 import           Test.Tasty.HUnit                                (Assertion, assertEqual, assertFailure, testCase)
 import           Wallet.Emulator.Types                           (Wallet (Wallet))
 import           Wallet.Rollup.Render                            (showBlockchain)
+import           Wallet.Rollup.Types                             (AnnotatedTx (tx))
 
 tests :: TestTree
 tests =
@@ -223,7 +224,7 @@ hasFundsDistribution _ (Left err) = assertFailure $ show err
 hasFundsDistribution requiredDistribution (Right InterpreterResult {result = EvaluationResult {..}}) = do
     unless (requiredDistribution == fundsDistribution) $ do
         Text.putStrLn $
-            either id id $ showBlockchain walletKeys resultBlockchain
+            either id id $ showBlockchain walletKeys $ fmap (fmap tx) resultRollup
         traverse_ print $ reverse emulatorLog
     assertEqual "" requiredDistribution fundsDistribution
 


### PR DESCRIPTION
The field is not used anywhere on the client, and it's redundant anyway because the `resultRollup` field contains all the transactions.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
