### PR TITLE
Fix some more things that were missing from Hydra

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -59,7 +59,7 @@ let
         in
         filterAttrsOnlyRecursive (_: drv: isBuildable drv) {
           # build relevant top level attributes from default.nix
-          inherit (packages) docs tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
+          inherit (packages) docs tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda marlowe-playground-lambda plutus-playground-lambda;
           # The haskell.nix IFD roots for the Haskell project. We include these so they won't be GCd and will be in the
           # cache for users
           inherit (plutus.haskell.project) roots;

--- a/default.nix
+++ b/default.nix
@@ -70,10 +70,10 @@ rec {
     inherit (haskell.muslProject) ghcWithPackages;
   };
 
-  plutus-scb = pkgs.callPackage ./plutus-scb-client {
+  plutus-scb = pkgs.recurseIntoAttrs (pkgs.callPackage ./plutus-scb-client {
     inherit (plutus.lib) buildPursPackage buildNodeModules;
     inherit set-git-rev haskell webCommon;
-  };
+  });
 
   tests = import ./nix/tests/default.nix {
     inherit pkgs iohkNix;


### PR DESCRIPTION
- We weren't recursing into `plutus-scb` due to a missing
`recurseIntoAttrs`
- Some of the lambdas were not listed (we should check they build!)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
