### PR TITLE
buildPursPackage: fix compilation/test execution

### DIFF
--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -39,6 +39,7 @@ let
   client = buildPursPackage {
     inherit webCommon nodeModules;
     src = ./.;
+    checkPhase = "npm run test";
     name = "marlowe-playground-client";
     psSrc = generated-purescript;
     packages = pkgs.callPackage ./packages.nix { };

--- a/nix/lib/purescript.nix
+++ b/nix/lib/purescript.nix
@@ -19,6 +19,8 @@
 , webCommon
   # node_modules to use
 , nodeModules
+  # control execution of unit tests
+, checkPhase
 }:
 let
   # Cleans the source based on the patterns in ./.gitignore and the additionalIgnores
@@ -26,7 +28,7 @@ let
 
 in
 stdenv.mkDerivation {
-  inherit name;
+  inherit name checkPhase;
   src = cleanSrcs;
   buildInputs = [ nodeModules easyPS.purs easyPS.spago easyPS.psc-package ];
   buildPhase = ''
@@ -37,9 +39,10 @@ stdenv.mkDerivation {
     ln -s ${webCommon} ../web-common
 
     sh ${spagoPackages.installSpagoStyle}
-    sh ${spagoPackages.buildSpagoStyle}
+    sh ${spagoPackages.buildSpagoStyle} src/**/*.purs test/**/*.purs generated/**/*.purs ../web-common/**/*.purs
     ${nodejs}/bin/npm run webpack
   '';
+  doCheck = true;
   installPhase = ''
     mv dist $out
   '';

--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -37,6 +37,12 @@ let
     inherit webCommon nodeModules;
     src = ./.;
     name = "plutus-playground-client";
+    # ideally we would just use `npm run test` but
+    # this executes `spago` which *always* attempts to download
+    # remote files (which obviously fails in sandboxed builds)
+    checkPhase = ''
+      node -e 'require("./output/Test.Main").main()'
+    '';
     psSrc = generated-purescript;
     packages = pkgs.callPackage ./packages.nix { };
     spagoPackages = pkgs.callPackage ./spago-packages.nix { };

--- a/plutus-scb-client/default.nix
+++ b/plutus-scb-client/default.nix
@@ -19,6 +19,12 @@ let
       inherit webCommon nodeModules;
       src = ./.;
       name = "plutus-scb-client";
+      # ideally we would just use `npm run test` but
+      # this executes `spago` which *always* attempts to download
+      # remote files (which obviously fails in sandboxed builds)
+      checkPhase = ''
+        node -e 'require("./output/Test.Main").main()'
+      '';
       psSrc = generated-purescript;
       packages = pkgs.callPackage ./packages.nix { };
       spagoPackages = pkgs.callPackage ./spago-packages.nix { };


### PR DESCRIPTION
**summary**
This PR fixes the compilation/test execution of all frontend clients.

**some background**:
Compile all required sources and execute unit tests during the checkPhase.
The `checkPhase` is now a required argument to `buildPursPackage`. It
would be just always execute `npm run test` but this fails in cases
where `spago test` is used which (always) tries to download remote files.

**Notes**
- The scb-client is not currently being built by hydra so #2597 should be merged before this one
- Once scb-client *is* actually built by hydra it will fail because of some naming conflict. So we also need to wait for that.

--------

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
