### PR TITLE
wrap blockly in a TEA-style submodule

### DIFF
--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -1,0 +1,51 @@
+module BlocklyEditor.State where
+
+import Prelude
+import BlocklyEditor.Types (Action(..), State, _errorMessage, _marloweCode)
+import Control.Monad.Except (ExceptT(..), except, runExceptT)
+import Data.Bifunctor (lmap)
+import Data.Either (note, Either(..))
+import Data.Lens (assign)
+import Data.Maybe (Maybe(..))
+import Debug.Trace (spy)
+import Effect.Aff.Class (class MonadAff)
+import Halogen (HalogenM, query)
+import Halogen as H
+import Halogen.Blockly as Blockly
+import MainFrame.Types (ChildSlots, _blocklySlot)
+import Marlowe.Parser as Parser
+import Text.Extra as Text
+import Text.Pretty (pretty)
+
+handleAction ::
+  forall m.
+  MonadAff m =>
+  Action ->
+  HalogenM State Action ChildSlots Void m Unit
+handleAction (HandleBlocklyMessage Blockly.CodeChange) = do
+  eContract <-
+    runExceptT do
+      code <- ExceptT <<< map (note "Blockly Workspace is empty") $ query _blocklySlot unit $ H.request Blockly.GetCode
+      except <<< lmap (unexpected <<< show) $ Parser.parseContract (Text.stripParens code)
+  case eContract of
+    Left e -> do
+      assign _errorMessage $ Just e
+      assign _marloweCode Nothing
+    Right contract -> do
+      assign _errorMessage Nothing
+      assign _marloweCode $ Just $ show $ pretty contract
+  where
+  unexpected s = "An unexpected error has occurred, please raise a support issue at https://github.com/input-output-hk/plutus/issues/new: " <> s
+
+handleAction (InitBlocklyProject code) = do
+  assign _marloweCode $ Just code
+  void $ query _blocklySlot unit $ H.tell (Blockly.SetCode code)
+
+handleAction SendToSimulator = pure unit
+
+handleAction ViewAsMarlowe = pure unit
+
+handleAction Save = pure unit
+
+editorGetValue :: forall state action msg m. HalogenM state action ChildSlots msg m (Maybe String)
+editorGetValue = query _blocklySlot unit $ H.request Blockly.GetCode

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -1,0 +1,40 @@
+module BlocklyEditor.Types where
+
+import Prelude
+import Analytics (class IsEvent, defaultEvent)
+import Data.Lens (Lens')
+import Data.Lens.Record (prop)
+import Data.Maybe (Maybe(..))
+import Data.Symbol (SProxy(..))
+import Halogen.Blockly as Blockly
+
+data Action
+  = HandleBlocklyMessage Blockly.Message
+  | InitBlocklyProject String
+  | SendToSimulator
+  | ViewAsMarlowe
+  | Save
+
+instance blocklyActionIsEvent :: IsEvent Action where
+  toEvent (HandleBlocklyMessage _) = Just $ (defaultEvent "HandleBlocklyMessage") { category = Just "Blockly" }
+  toEvent (InitBlocklyProject _) = Just $ (defaultEvent "InitBlocklyProject") { category = Just "Blockly" }
+  toEvent SendToSimulator = Just $ (defaultEvent "SendToSimulator") { category = Just "Blockly" }
+  toEvent ViewAsMarlowe = Just $ (defaultEvent "ViewAsMarlowe") { category = Just "Blockly" }
+  toEvent Save = Just $ (defaultEvent "Save") { category = Just "Blockly" }
+
+type State
+  = { errorMessage :: Maybe String
+    , marloweCode :: Maybe String
+    }
+
+_errorMessage :: Lens' State (Maybe String)
+_errorMessage = prop (SProxy :: SProxy "errorMessage")
+
+_marloweCode :: Lens' State (Maybe String)
+_marloweCode = prop (SProxy :: SProxy "marloweCode")
+
+initialState :: State
+initialState =
+  { errorMessage: Nothing
+  , marloweCode: Nothing
+  }

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -1,0 +1,48 @@
+module BlocklyEditor.View where
+
+import Prelude hiding (div)
+import BlocklyEditor.Types (Action(..), State, _marloweCode)
+import Data.Lens ((^.))
+import Data.Maybe (Maybe(..), isJust)
+import Effect.Aff.Class (class MonadAff)
+import Halogen (ComponentHTML)
+import Halogen.Blockly as Blockly
+import Halogen.Classes (disabled, group)
+import Halogen.HTML (HTML, button, div, slot, text, div_)
+import Halogen.HTML.Events (onClick)
+import Halogen.HTML.Properties (classes, enabled)
+import MainFrame.Types (ChildSlots, _blocklySlot)
+import Marlowe.Blockly as MB
+
+render ::
+  forall m.
+  MonadAff m =>
+  State ->
+  ComponentHTML Action ChildSlots m
+render state =
+  div_
+    [ slot _blocklySlot unit (Blockly.blockly MB.rootBlockName MB.blockDefinitions) unit (Just <<< HandleBlocklyMessage)
+    , MB.toolbox
+    , MB.workspaceBlocks
+    ]
+
+otherActions ::
+  forall p.
+  State -> HTML p Action
+otherActions state =
+  div [ classes [ group ] ]
+    [ button
+        [ onClick $ const $ Just ViewAsMarlowe
+        , enabled hasCode
+        , classes [ disabled hasCode ]
+        ]
+        [ text "View as Marlowe" ]
+    , button
+        [ onClick $ const $ Just SendToSimulator
+        , enabled hasCode
+        , classes [ disabled hasCode ]
+        ]
+        [ text "Send To Simulator" ]
+    ]
+  where
+  hasCode = isJust $ state ^. _marloweCode

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -67,17 +67,6 @@ handleAction _ (ShowBottomPanel val) = do
 
 handleAction _ SendResultToSimulator = pure unit
 
--- FIXME: I think we want to change this action to be called from the simulator
---        with the action "soon to be implemented" ViewAsBlockly
-handleAction _ SendResultToBlockly = do
-  mContract <- use _compilationResult
-  case mContract of
-    Success (Right result) -> do
-      let
-        source = view (_InterpreterResult <<< _result) result
-      void $ query _blocklySlot unit (Blockly.SetCode source unit)
-    _ -> pure unit
-
 handleAction _ (InitHaskellProject contents) = do
   editorSetValue contents
   liftEffect $ LocalStorage.setItem bufferLocalStorageKey contents

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -22,9 +22,6 @@ data Action
   | HandleEditorMessage Monaco.Message
   | ShowBottomPanel Boolean
   | SendResultToSimulator
-  -- FIXME: I think we want to change this action to be called from the simulator
-  --        with the action "soon to be implemented" ViewAsBlockly
-  | SendResultToBlockly
   | InitHaskellProject String
 
 defaultEvent :: String -> Event
@@ -36,7 +33,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
   toEvent (ShowBottomPanel _) = Just $ defaultEvent "ShowBottomPanel"
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
-  toEvent SendResultToBlockly = Just $ defaultEvent "SendResultToBlockly"
   toEvent (InitHaskellProject _) = Just $ defaultEvent "InitHaskellProject"
 
 type State

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -118,15 +118,6 @@ handleAction _ (ShowBottomPanel val) = do
 
 handleAction _ SendResultToSimulator = pure unit
 
-handleAction _ SendResultToBlockly = do
-  mContract <- use _compilationResult
-  case mContract of
-    CompiledSuccessfully result -> do
-      let
-        source = view (_result <<< to show) result
-      void $ query _blocklySlot unit (Blockly.SetCode source unit)
-    _ -> pure unit
-
 handleAction _ (InitJavascriptProject prunedContent) = do
   editorSetValue prunedContent
   liftEffect $ LocalStorage.setItem jsBufferLocalStorageKey prunedContent

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -40,10 +40,6 @@ data Action
   | HandleEditorMessage Monaco.Message
   | ShowBottomPanel Boolean
   | SendResultToSimulator
-  -- FIXME: I think we want to change this action to be called from the simulator
-  --        with the action "soon to be implemented" ViewAsBlockly.
-  --        Actually, in the JavaScript editor there isn't even a button to send to blockly.
-  | SendResultToBlockly
   | InitJavascriptProject String
 
 defaultEvent :: String -> Event
@@ -55,7 +51,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
   toEvent (ShowBottomPanel _) = Just $ defaultEvent "ShowBottomPanel"
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
-  toEvent SendResultToBlockly = Just $ defaultEvent "SendResultToBlockly"
   toEvent (InitJavascriptProject _) = Just $ defaultEvent "InitJavascriptProject"
 
 type DecorationIds

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -2,6 +2,9 @@ module MainFrame.State (mkMainFrame) where
 
 import Prelude hiding (div)
 import Auth (AuthRole(..), authStatusAuthRole, _GithubUser)
+import BlocklyEditor.State as BlocklyEditor
+import BlocklyEditor.Types (_marloweCode)
+import BlocklyEditor.Types as BE
 import ConfirmUnsavedNavigation.Types (Action(..)) as ConfirmUnsavedNavigation
 import Control.Monad.Except (ExceptT(..), lift, runExceptT)
 import Control.Monad.Maybe.Extra (hoistMaybe)
@@ -17,6 +20,7 @@ import Data.Lens.Index (ix)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (unwrap)
+import Debug.Trace (spy)
 import Demos.Types (Action(..), Demo(..)) as Demos
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect)
@@ -42,8 +46,7 @@ import JavascriptEditor.Types (CompilationState(..))
 import Language.Haskell.Monaco as HM
 import LocalStorage as LocalStorage
 import LoginPopup (openLoginPopup, informParentAndClose)
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklySlot, _createGistResult, _gistId, _hasUnsavedChanges, _haskellEditorSlot, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorPageSlot, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _walletSlot, _workflow)
-import MainFrame.Types (BlocklySubAction(..)) as BL
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _blocklySlot, _createGistResult, _gistId, _hasUnsavedChanges, _haskellEditorSlot, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorPageSlot, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _walletSlot, _workflow)
 import MainFrame.View (render)
 import Marlowe (SPParams_, getApiGistsByGistId)
 import Marlowe as Server
@@ -90,6 +93,7 @@ initialState =
   , haskellState: HE.initialState
   , javascriptState: JS.initialState
   , marloweEditorState: ME.initialState
+  , blocklyEditorState: BE.initialState
   , simulationState: ST.mkState
   , jsEditorKeybindings: DefaultBindings
   , activeJSDemo: mempty
@@ -149,6 +153,12 @@ toJavascriptEditor ::
   Functor m =>
   HalogenM JS.State JS.Action ChildSlots Void m a -> HalogenM State Action ChildSlots Void m a
 toJavascriptEditor = mapSubmodule _javascriptState JavascriptAction
+
+toBlocklyEditor ::
+  forall m a.
+  Functor m =>
+  HalogenM BE.State BE.Action ChildSlots Void m a -> HalogenM State Action ChildSlots Void m a
+toBlocklyEditor = mapSubmodule _blocklyEditorState BlocklyEditorAction
 
 toProjects ::
   forall m a.
@@ -306,10 +316,20 @@ handleAction s (HaskellAction action) = do
       let
         contract = fold mContract
       sendToSimulation s contract
-    HE.SendResultToBlockly -> do
-      selectView BlocklyEditor
     (HE.HandleEditorMessage (Monaco.TextChanged _)) -> assign _hasUnsavedChanges true
     (HE.InitHaskellProject _) -> assign _hasUnsavedChanges false
+    _ -> pure unit
+
+handleAction s (JavascriptAction action) = do
+  toJavascriptEditor (JavascriptEditor.handleAction s action)
+  case action of
+    JS.SendResultToSimulator -> do
+      mContract <- peruse (_javascriptState <<< JS._ContractString)
+      let
+        contract = fold mContract
+      sendToSimulation s contract
+    (JS.HandleEditorMessage (Monaco.TextChanged _)) -> assign _hasUnsavedChanges true
+    (JS.InitJavascriptProject _) -> assign _hasUnsavedChanges false
     _ -> pure unit
 
 handleAction s (MarloweEditorAction action) = do
@@ -322,52 +342,40 @@ handleAction s (MarloweEditorAction action) = do
     ME.ViewAsBlockly -> do
       mSource <- MarloweEditor.editorGetValue
       for_ mSource \source -> do
-        void $ query _blocklySlot unit (Blockly.SetCode source unit)
+        void $ toBlocklyEditor $ BlocklyEditor.handleAction (BE.InitBlocklyProject source)
         assign _workflow (Just Blockly)
         selectView BlocklyEditor
     (ME.HandleEditorMessage (Monaco.TextChanged _)) -> assign _hasUnsavedChanges true
     (ME.InitMarloweProject _) -> assign _hasUnsavedChanges false
     _ -> pure unit
 
-handleAction s (JavascriptAction action) = do
-  toJavascriptEditor (JavascriptEditor.handleAction s action)
+handleAction settings (BlocklyEditorAction action) = do
+  toBlocklyEditor $ BlocklyEditor.handleAction action
   case action of
-    JS.SendResultToSimulator -> do
-      mContract <- peruse (_javascriptState <<< JS._ContractString)
-      let
-        contract = fold mContract
-      sendToSimulation s contract
-    JS.SendResultToBlockly -> do
-      selectView BlocklyEditor
-    (JS.HandleEditorMessage (Monaco.TextChanged _)) -> assign _hasUnsavedChanges true
-    (JS.InitJavascriptProject _) -> assign _hasUnsavedChanges false
+    BE.SendToSimulator -> do
+      mCode <- use (_blocklyEditorState <<< _marloweCode)
+      for_ mCode \code -> do
+        selectView Simulation
+        void $ toSimulation $ Simulation.handleAction settings (ST.LoadContract code)
+    BE.ViewAsMarlowe -> do
+      -- TODO: doing an effect that returns a maybe value and doing an action on the possible
+      -- result is a pattern that we have repeated a lot in this file. See if we could refactor
+      -- into something like this: https://github.com/input-output-hk/plutus/pull/2560#discussion_r549892291
+      mCode <- use (_blocklyEditorState <<< _marloweCode)
+      for_ mCode \code -> do
+        selectView MarloweEditor
+        assign _workflow (Just Marlowe)
+        toMarloweEditor $ MarloweEditor.handleAction settings $ ME.InitMarloweProject code
+    (BE.HandleBlocklyMessage Blockly.CodeChange) -> assign _hasUnsavedChanges true
     _ -> pure unit
 
 handleAction settings (SimulationAction action) = do
   toSimulation (Simulation.handleAction settings action)
   case action of
-    -- TODO: reimplement once we have the simulator in blockly and marlowe
-    ST.ViewAsBlockly -> pure unit
     ST.EditSource -> do
       mLang <- use _workflow
       for_ mLang \lang -> selectView $ selectLanguageView lang
     _ -> pure unit
-
-handleAction settings (BlocklyEditorAction action) = case action of
-  BL.SendToSimulator -> do
-    mCode <- query _blocklySlot unit $ H.request Blockly.GetCode
-    for_ mCode \code -> do
-      selectView Simulation
-      void $ toSimulation $ Simulation.handleAction settings (ST.LoadContract code)
-  BL.ViewAsMarlowe -> do
-    -- TODO: doing an effect that returns a maybe value and doing an action on the possible
-    -- result is a pattern that we have repeated a lot in this file. See if we could refactor
-    -- into something like this: https://github.com/input-output-hk/plutus/pull/2560#discussion_r549892291
-    mCode <- query _blocklySlot unit $ H.request Blockly.GetCode
-    for_ mCode \code -> do
-      selectView MarloweEditor
-      assign _workflow (Just Marlowe)
-      toMarloweEditor $ MarloweEditor.handleAction settings $ ME.InitMarloweProject code
 
 handleAction _ (HandleWalletMessage Wallet.SendContractToWallet) = do
   contract <- toSimulation $ Simulation.getCurrentContract
@@ -378,8 +386,6 @@ handleAction settings (ChangeView view) = selectView view
 handleAction _ (ShowBottomPanel val) = do
   assign _showBottomPanel val
   pure unit
-
-handleAction settings (HandleBlocklyMessage Blockly.CodeChange) = assign _hasUnsavedChanges true
 
 handleAction _ (HandleActusBlocklyMessage ActusBlockly.Initialized) = pure unit
 
@@ -443,7 +449,7 @@ handleAction s (NewProjectAction (NewProject.CreateProject lang)) = do
   toHaskellEditor $ HaskellEditor.handleAction s $ HE.InitHaskellProject mempty
   toJavascriptEditor $ JavascriptEditor.handleAction s $ JS.InitJavascriptProject mempty
   toMarloweEditor $ MarloweEditor.handleAction s $ ME.InitMarloweProject mempty
-  void $ query _blocklySlot unit (Blockly.SetCode mempty unit)
+  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject mempty
   -- TODO: implement ActusBlockly.SetCode
   case lang of
     Haskell ->
@@ -455,6 +461,9 @@ handleAction s (NewProjectAction (NewProject.CreateProject lang)) = do
     Marlowe ->
       for_ (Map.lookup "Example" StaticData.marloweContracts) \contents -> do
         toMarloweEditor $ MarloweEditor.handleAction s $ ME.InitMarloweProject contents
+    Blockly ->
+      for_ (Map.lookup "Example" StaticData.marloweContracts) \contents -> do
+        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject contents
     _ -> pure unit
   selectView $ selectLanguageView lang
   modify_
@@ -478,7 +487,7 @@ handleAction s (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
         toMarloweEditor $ MarloweEditor.handleAction s $ ME.InitMarloweProject contents
     Blockly -> do
       for_ (preview (ix key) StaticData.marloweContracts) \contents -> do
-        void $ query _blocklySlot unit (Blockly.SetCode contents unit)
+        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject contents
     Actus -> pure unit
   modify_
     ( set _showModal Nothing
@@ -647,13 +656,14 @@ handleGistAction settings PublishGist = do
 
     -- playground is a meta-data file that we currently just use as a tag to check if a gist is a marlowe playground gist
     playground = "{}"
-  marlowe <- pruneEmpty <$> toSimulation Simulation.editorGetValue
-  haskell <- pruneEmpty <$> HaskellEditor.editorGetValue
-  blockly <- pruneEmpty <$> query _blocklySlot unit (H.request Blockly.GetWorkspace)
-  javascript <- pruneEmpty <$> (toJavascriptEditor JavascriptEditor.editorGetValue)
-  actus <- pruneEmpty <$> query _actusBlocklySlot unit (H.request ActusBlockly.GetWorkspace)
+  workflow <- use _workflow
+  marlowe <- if workflow /= Just Marlowe then pure Nothing else pruneEmpty <$> MarloweEditor.editorGetValue
+  blockly <- if workflow /= Just Blockly then pure Nothing else pruneEmpty <$> BlocklyEditor.editorGetValue
+  haskell <- if workflow /= Just Haskell then pure Nothing else pruneEmpty <$> HaskellEditor.editorGetValue
+  javascript <- if workflow /= Just Javascript then pure Nothing else pruneEmpty <$> (toJavascriptEditor JavascriptEditor.editorGetValue)
+  actus <- if workflow /= Just Actus then pure Nothing else pruneEmpty <$> query _actusBlocklySlot unit (H.request ActusBlockly.GetWorkspace)
   let
-    files = { playground, marlowe, haskell, blockly, javascript, actus }
+    files = { playground, marlowe, haskell, javascript, actus, blockly }
 
     newGist = mkNewGist description files
   void
@@ -725,8 +735,8 @@ loadGist ::
 loadGist settings gist = do
   let
     { marlowe
-    , haskell
     , blockly
+    , haskell
     , javascript
     , actus
     } = playgroundFiles gist
@@ -738,9 +748,7 @@ loadGist settings gist = do
   toHaskellEditor $ HaskellEditor.handleAction settings $ HE.InitHaskellProject $ fromMaybe mempty haskell
   toJavascriptEditor $ JavascriptEditor.handleAction settings $ JS.InitJavascriptProject $ fromMaybe mempty javascript
   toMarloweEditor $ MarloweEditor.handleAction settings $ ME.InitMarloweProject $ fromMaybe mempty marlowe
-  case blockly of
-    Nothing -> void $ query _blocklySlot unit (Blockly.SetCode mempty unit)
-    Just xml -> void $ query _blocklySlot unit (Blockly.LoadWorkspace xml unit)
+  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject $ fromMaybe mempty blockly
   -- Actus doesn't have a SetCode to reset for the moment, so we only set if present.
   -- TODO add SetCode to Actus
   for_ actus \xml -> query _actusBlocklySlot unit (ActusBlockly.LoadWorkspace xml unit)

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -3,6 +3,7 @@ module MainFrame.Types where
 import Prelude hiding (div)
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Auth (AuthStatus)
+import BlocklyEditor.Types as BE
 import ConfirmUnsavedNavigation.Types as ConfirmUnsavedNavigation
 import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
@@ -24,8 +25,8 @@ import Halogen.Monaco as Monaco
 import HaskellEditor.Types as HE
 import JavascriptEditor.Types (CompilationState)
 import JavascriptEditor.Types as JS
-import Network.RemoteData (_Loading)
 import MarloweEditor.Types as ME
+import Network.RemoteData (_Loading)
 import NewProject.Types as NewProject
 import Projects.Types (Lang(..))
 import Projects.Types as Projects
@@ -70,14 +71,13 @@ data Action
   | HandleKey H.SubscriptionId KeyboardEvent
   | HaskellAction HE.Action
   | SimulationAction Simulation.Action
-  | BlocklyEditorAction BlocklySubAction
+  | BlocklyEditorAction BE.Action
   | MarloweEditorAction ME.Action
   | JavascriptAction JS.Action
   | ShowBottomPanel Boolean
   | ChangeView View
   | ConfirmUnsavedNavigationAction Action ConfirmUnsavedNavigation.Action
   -- blockly
-  | HandleBlocklyMessage Blockly.Message
   | HandleActusBlocklyMessage AB.Message
   -- Wallet Actions
   | HandleWalletMessage Wallet.Message
@@ -106,7 +106,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (MarloweEditorAction action) = toEvent action
   toEvent (HandleWalletMessage action) = Just $ defaultEvent "HandleWalletMessage"
   toEvent (ChangeView view) = Just $ (defaultEvent "View") { label = Just (show view) }
-  toEvent (HandleBlocklyMessage _) = Just $ (defaultEvent "HandleBlocklyMessage") { category = Just "Blockly" }
   toEvent (HandleActusBlocklyMessage _) = Just $ (defaultEvent "HandleActusBlocklyMessage") { category = Just "ActusBlockly" }
   toEvent (ShowBottomPanel _) = Just $ defaultEvent "ShowBottomPanel"
   toEvent (ProjectsAction action) = toEvent action
@@ -121,17 +120,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent CloseModal = Just $ defaultEvent "CloseModal"
   toEvent (ChangeProjectName _) = Just $ defaultEvent "ChangeProjectName"
   toEvent (OpenLoginPopup _) = Just $ defaultEvent "OpenLoginPopup"
-
--- TODO: When we change Blockly into a submodule (SCP-1646) this is going to be part of the actions it provides
---       at the moment I put this to refactor "SendBlocklyToSimulator" into SendToSimulator and to
---       add another action
-data BlocklySubAction
-  = SendToSimulator
-  | ViewAsMarlowe
-
-instance blocklyActionIsEvent :: IsEvent BlocklySubAction where
-  toEvent SendToSimulator = Just $ (defaultEvent "SendToSimulator") { category = Just "Blockly" }
-  toEvent ViewAsMarlowe = Just $ (defaultEvent "ViewAsMarlowe") { category = Just "Blockly" }
 
 data View
   = HomePage
@@ -197,6 +185,7 @@ type State
     -- TODO: rename to javascriptEditorState
     , javascriptState :: JS.State
     , marloweEditorState :: ME.State
+    , blocklyEditorState :: BE.State
     , simulationState :: Simulation.State
     , projects :: Projects.State
     , newProject :: NewProject.State
@@ -234,6 +223,9 @@ _showBottomPanel = prop (SProxy :: SProxy "showBottomPanel")
 
 _marloweEditorState :: Lens' State ME.State
 _marloweEditorState = prop (SProxy :: SProxy "marloweEditorState")
+
+_blocklyEditorState :: Lens' State BE.State
+_blocklyEditorState = prop (SProxy :: SProxy "blocklyEditorState")
 
 _haskellState :: Lens' State HE.State
 _haskellState = prop (SProxy :: SProxy "haskellState")

--- a/marlowe-playground-client/src/Marlowe/Gists.purs
+++ b/marlowe-playground-client/src/Marlowe/Gists.purs
@@ -34,7 +34,7 @@ type PlaygroundFiles
   = { playground :: String
     , marlowe :: Maybe String
     , haskell :: Maybe String
-    , blockly :: Maybe XML
+    , blockly :: Maybe String
     , javascript :: Maybe String
     , actus :: Maybe XML
     }
@@ -46,7 +46,7 @@ toArray { playground, marlowe, haskell, blockly, javascript, actus } =
     <> catMaybes
         [ mkNewGistFile filenames.marlowe <$> marlowe
         , mkNewGistFile filenames.haskell <$> haskell
-        , mkNewGistFile filenames.blockly <<< unwrap <$> blockly
+        , mkNewGistFile filenames.blockly <$> blockly
         , mkNewGistFile filenames.javascript <$> javascript
         , mkNewGistFile filenames.actus <<< unwrap <$> actus
         ]
@@ -76,7 +76,7 @@ playgroundFiles gist =
   { playground: fromMaybe "{}" $ getFile filenames.playground
   , marlowe: getFile filenames.marlowe
   , haskell: getFile filenames.haskell
-  , blockly: wrap <$> getFile filenames.blockly
+  , blockly: getFile filenames.blockly
   , javascript: getFile filenames.javascript
   , actus: wrap <$> getFile filenames.actus
   }

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -44,7 +44,7 @@ import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError, errorToString)
 import Servant.PureScript.Settings (SPSettings_)
-import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId(..), ExecutionState(..), Parties(..), State, _SimulationNotStarted, _SimulationRunning, _bottomPanelView, _currentContract, _currentMarloweState, _executionState, _helpContext, _initialSlot, _marloweState, _moveToAction, _oldContract, _pendingInputs, _possibleActions, _showBottomPanel, _showRightPanel, _slot, emptyExecutionStateWithSlot, emptyMarloweState, mapPartiesActionInput)
+import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId(..), ExecutionState(..), Parties(..), State, _SimulationNotStarted, _SimulationRunning, _bottomPanelView, _currentContract, _currentMarloweState, _executionState, _helpContext, _initialSlot, _marloweState, _moveToAction, _oldContract, _pendingInputs, _possibleActions, _showBottomPanel, _showRightPanel, emptyExecutionStateWithSlot, emptyMarloweState, mapPartiesActionInput)
 import Simulator (applyInput, inFuture, moveToSignificantSlot, moveToSlot, nextSignificantSlot, updateContractInState, updateMarloweState, updatePossibleActions, updateStateP)
 import StaticData (simulatorBufferLocalStorageKey)
 import Text.Pretty (genericPretty)
@@ -183,8 +183,6 @@ handleAction _ (ShowRightPanel val) = assign _showRightPanel val
 handleAction _ (ShowBottomPanel val) = do
   assign _showBottomPanel val
   editorResize
-
-handleAction _ ViewAsBlockly = pure unit
 
 handleAction _ EditSource = pure unit
 

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -323,7 +323,6 @@ data Action
   | ChangeHelpContext HelpContext
   | ShowRightPanel Boolean
   | ShowBottomPanel Boolean
-  | ViewAsBlockly
   | EditSource
 
 defaultEvent :: String -> Event
@@ -346,7 +345,6 @@ instance isEventAction :: IsEvent Action where
   toEvent (ChangeHelpContext help) = Just $ (defaultEvent "ChangeHelpContext") { label = Just $ show help }
   toEvent (ShowRightPanel _) = Just $ defaultEvent "ShowRightPanel"
   toEvent (ShowBottomPanel _) = Just $ defaultEvent "ShowBottomPanel"
-  toEvent ViewAsBlockly = Just $ defaultEvent "ViewAsBlockly"
   toEvent EditSource = Just $ defaultEvent "EditSource"
 
 data Query a


### PR DESCRIPTION
Still need to try to remove anything marlowe-specific from Halogen.Blockly but I think we can leave this for another PR
deployed to https://david.marlowe.iohkdev.io/#/

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
