### PR TITLE
Improve nix/purescript workflow

### DIFF
--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -11,10 +11,9 @@ Check the [backend documentation](../marlowe-playground-server/README.md) for mo
 
 Now we will build and run the front end:
 ```bash
-# First generate the purescript bridge files
-$(nix-build -A marlowe-playground.server-invoker)/bin/marlowe-playground psgenerator ./marlowe-playground-client/generated
-# Now we will build and run the client on localhost
 cd marlowe-playground-client
+# Generate the purescript bridge files
+marlowe-playground-generate-purs
 # Download javascript dependencies
 npm install
 # Install purescript depdendencies

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -7,7 +7,7 @@
     "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development --host 0.0.0.0 --display verbose",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",
-    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' '../web-common/**/*.purs'",
+    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' './web-common/**/*.purs'",
     "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config webpack.test.config.js --mode=development && node --max-old-space-size=8192 dist/test.js",
     "docs": "spago docs",
     "repl": "spago repl"

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -7,7 +7,7 @@
     "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development --host 0.0.0.0 --display verbose",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",
-    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' './web-common/**/*.purs'",
+    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' 'web-common/**/*.purs'",
     "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config webpack.test.config.js --mode=development && node --max-old-space-size=8192 dist/test.js",
     "docs": "spago docs",
     "repl": "spago repl"

--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -37,6 +37,6 @@ You can edit this file as you like.
   [ "src/**/*.purs"
   , "test/**/*.purs"
   , "generated/**/*.purs"
-  , "../web-common/**/*.purs"
+  , "./web-common/**/*.purs"
   ]
 }

--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -37,6 +37,6 @@ You can edit this file as you like.
   [ "src/**/*.purs"
   , "test/**/*.purs"
   , "generated/**/*.purs"
-  , "./web-common/**/*.purs"
+  , "web-common/**/*.purs"
   ]
 }

--- a/marlowe-playground-client/web-common
+++ b/marlowe-playground-client/web-common
@@ -1,0 +1,1 @@
+../web-common

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                '../web-common/**/*.purs'
+                                './web-common/**/*.purs'
                             ],
                             psc: null,
                             bundle: !(isWebpackDevServer || isWatch),
@@ -107,7 +107,7 @@ module.exports = {
 
     resolve: {
         modules: [
-            'node_modules'
+            'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {
             grammar: path.resolve(__dirname, './grammar.ne'),

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                './web-common/**/*.purs'
+                                'web-common/**/*.purs'
                             ],
                             psc: null,
                             bundle: !(isWebpackDevServer || isWatch),

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -107,6 +107,9 @@ module.exports = {
 
     resolve: {
         modules: [
+            // We need the second entry for node to be able to
+            // locate `node_modules` from client directory when 
+            // modules are referenced from inside `web-common`.
             'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {

--- a/marlowe-playground-client/webpack.test.config.js
+++ b/marlowe-playground-client/webpack.test.config.js
@@ -56,6 +56,9 @@ module.exports = {
 
     resolve: {
         modules: [
+            // We need the second entry for node to be able to
+            // locate `node_modules` from client directory when 
+            // modules are referenced from inside `web-common`.
             'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {

--- a/marlowe-playground-client/webpack.test.config.js
+++ b/marlowe-playground-client/webpack.test.config.js
@@ -40,7 +40,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                './web-common/**/*.purs',
+                                'web-common/**/*.purs',
                                 'test/**/*.purs'
                             ],
                         }

--- a/marlowe-playground-client/webpack.test.config.js
+++ b/marlowe-playground-client/webpack.test.config.js
@@ -40,7 +40,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                '../web-common/**/*.purs',
+                                './web-common/**/*.purs',
                                 'test/**/*.purs'
                             ],
                         }
@@ -56,7 +56,7 @@ module.exports = {
 
     resolve: {
         modules: [
-            'node_modules'
+            'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {
             grammar: path.resolve(__dirname, './grammar.ne'),

--- a/nix/lib/purescript.nix
+++ b/nix/lib/purescript.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     ln -sf ${webCommon} web-common
 
     sh ${spagoPackages.installSpagoStyle}
-    sh ${spagoPackages.buildSpagoStyle} src/**/*.purs test/**/*.purs generated/**/*.purs ./web-common/**/*.purs
+    sh ${spagoPackages.buildSpagoStyle} src/**/*.purs test/**/*.purs generated/**/*.purs web-common/**/*.purs
     ${nodejs}/bin/npm run webpack
   '';
   doCheck = true;

--- a/nix/lib/purescript.nix
+++ b/nix/lib/purescript.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation {
     shopt -s globstar
     ln -s ${nodeModules}/node_modules node_modules
     ln -s ${psSrc} generated
-    ln -s ${webCommon} ../web-common
+    ln -sf ${webCommon} web-common
 
     sh ${spagoPackages.installSpagoStyle}
-    sh ${spagoPackages.buildSpagoStyle} src/**/*.purs test/**/*.purs generated/**/*.purs ../web-common/**/*.purs
+    sh ${spagoPackages.buildSpagoStyle} src/**/*.purs test/**/*.purs generated/**/*.purs ./web-common/**/*.purs
     ${nodejs}/bin/npm run webpack
   '';
   doCheck = true;

--- a/plutus-playground-client/README.md
+++ b/plutus-playground-client/README.md
@@ -7,10 +7,9 @@ Please view the instructions for building the server [here](../plutus-playground
 ## Client
 
 ```sh
-# First generate the purescript bridge files
-$(nix-build -A plutus-playground.server-invoker)/bin/plutus-playground psgenerator ./plutus-playground-client/generated
-# Now we will build and run the client on localhost
 cd plutus-playground-client
+# Generate the purescript bridge files
+plutus-playground-generate-purs
 # Download javascript dependencies
 npm install
 # Install purescript depdendencies

--- a/plutus-playground-client/package.json
+++ b/plutus-playground-client/package.json
@@ -7,7 +7,7 @@
     "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",
-    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' '../web-common/**/*.purs'",
+    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' './web-common/**/*.purs'",
     "test": "spago --no-psa test",
     "test:watch": "spago test --no-psa --watch",
     "docs": "spago docs",

--- a/plutus-playground-client/package.json
+++ b/plutus-playground-client/package.json
@@ -7,7 +7,7 @@
     "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",
-    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' './web-common/**/*.purs'",
+    "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' 'web-common/**/*.purs'",
     "test": "spago --no-psa test",
     "test:watch": "spago test --no-psa --watch",
     "docs": "spago docs",

--- a/plutus-playground-client/spago.dhall
+++ b/plutus-playground-client/spago.dhall
@@ -33,6 +33,6 @@ You can edit this file as you like.
   [ "src/**/*.purs"
   , "test/**/*.purs"
   , "generated/**/*.purs"
-  , "./web-common/**/*.purs"
+  , "web-common/**/*.purs"
   ]
 }

--- a/plutus-playground-client/spago.dhall
+++ b/plutus-playground-client/spago.dhall
@@ -33,6 +33,6 @@ You can edit this file as you like.
   [ "src/**/*.purs"
   , "test/**/*.purs"
   , "generated/**/*.purs"
-  , "../web-common/**/*.purs"
+  , "./web-common/**/*.purs"
   ]
 }

--- a/plutus-playground-client/static/main.scss
+++ b/plutus-playground-client/static/main.scss
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700');
 
 @import 'variables.scss';
-@import '../../web-common/static/bootstrap.scss';
+@import '../web-common/static/bootstrap.scss';
 
 @import 'layout.scss';
 @import 'subheader.scss';

--- a/plutus-playground-client/static/transactions.scss
+++ b/plutus-playground-client/static/transactions.scss
@@ -4,8 +4,8 @@ $chart-tooltip: $gray-900;
 $chart-title: $gray-900;
 $chart-label: $gray-900;
 $chart-grid-stroke: $gray-500;
-@import '../../web-common/static/chartist.scss';
-@import '../../web-common/static/chain.scss';
+@import '../web-common/static/chartist.scss';
+@import '../web-common/static/chain.scss';
 
 .transactions {
     border: 1px solid $gray-border-color;

--- a/plutus-playground-client/web-common
+++ b/plutus-playground-client/web-common
@@ -1,0 +1,1 @@
+../web-common

--- a/plutus-playground-client/webpack.config.js
+++ b/plutus-playground-client/webpack.config.js
@@ -101,6 +101,9 @@ module.exports = {
 
     resolve: {
         modules: [
+            // We need the second entry for node to be able to
+            // locate `node_modules` from client directory when 
+            // modules are referenced from inside `web-common`.
             'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {

--- a/plutus-playground-client/webpack.config.js
+++ b/plutus-playground-client/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                '../web-common/**/*.purs'
+                                'web-common/**/*.purs'
                             ],
                             psc: null,
                             bundle: !(isWebpackDevServer || isWatch),
@@ -101,7 +101,7 @@ module.exports = {
 
     resolve: {
         modules: [
-            'node_modules'
+            'node_modules', path.resolve(__dirname, './node_modules')
         ],
         alias: {
             static: path.resolve(__dirname, './static'),
@@ -119,7 +119,7 @@ module.exports = {
 
     plugins: [
         new HtmlWebpackPlugin({
-            template: '../web-common/static/index.html',
+            template: 'web-common/static/index.html',
             favicon: 'static/favicon.ico',
             title: 'Plutus Playground',
             productName: 'plutus',

--- a/plutus-scb-client/package.json
+++ b/plutus-scb-client/package.json
@@ -7,7 +7,7 @@
         "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development",
         "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
         "purs:compile": "spago build",
-        "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' '../web-common/**/*.purs'",
+        "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' 'web-common/**/*.purs'",
         "test": "spago --no-psa test",
         "test:watch": "spago test --no-psa --watch",
         "docs": "spago docs",

--- a/plutus-scb-client/spago.dhall
+++ b/plutus-scb-client/spago.dhall
@@ -32,6 +32,6 @@ You can edit this file as you like.
   [ "src/**/*.purs"
   , "test/**/*.purs"
   , "generated/**/*.purs"
-  , "../web-common/**/*.purs"
+  , "web-common/**/*.purs"
   ]
 }

--- a/plutus-scb-client/static/main.scss
+++ b/plutus-scb-client/static/main.scss
@@ -13,8 +13,8 @@ $nav-link-hover: $white;
 $nav-link-border-radius: 3px;
 $clipboard-button-color: $white;
 
-@import '../../web-common/static/common.scss';
-@import '../../web-common/static/chain.scss';
+@import '../web-common/static/common.scss';
+@import '../web-common/static/chain.scss';
 @include chain (
     $balances-table-background-color: $gray-800,
     $balances-table-border-color: $gray-700,

--- a/plutus-scb-client/web-common
+++ b/plutus-scb-client/web-common
@@ -1,0 +1,1 @@
+../web-common

--- a/plutus-scb-client/webpack.config.js
+++ b/plutus-scb-client/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs',
                                 '.spago/*/*/src/**/*.purs',
-                                '../web-common/**/*.purs'
+                                'web-common/**/*.purs'
                             ],
                             psc: null,
                             bundle: !(isWebpackDevServer || isWatch),
@@ -92,7 +92,7 @@ module.exports = {
 
     resolve: {
         modules: [
-            'node_modules'
+            'node_modules', path.resolve(__dirname, './node_modules')
         ],
         extensions: [ '.purs', '.js']
     },

--- a/plutus-scb-client/webpack.config.js
+++ b/plutus-scb-client/webpack.config.js
@@ -92,6 +92,9 @@ module.exports = {
 
     resolve: {
         modules: [
+            // We need the second entry for node to be able to
+            // locate `node_modules` from client directory when 
+            // modules are referenced from inside `web-common`.
             'node_modules', path.resolve(__dirname, './node_modules')
         ],
         extensions: [ '.purs', '.js']


### PR DESCRIPTION
This PR addresses some discrepancies between the usual developer workflow for the frontend clients and the nix build - more specifically the handling of `web-common`. More specifically this PR:

- symlinks `web-common` to plutus,marlowe and scb-client
- updates references to `../web-common`
- updates the webpack configuration so npm dependencies can be found when loaded from `web-common`

Additionally this PR introduces scripts to execute the purescript code generation:
- `plutus-playground-generate-purs`
- `marlowe-playground-generate-purs`
- `plutus-scb-generate-purs`

When executed they will write the respective code to `./generated` (after removing any potentially existing previous `generated` directory).

**Note**: nix builds and the development cycle workflow both seem to be working with this. I also asked @merivale to verify this. 


-----

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
