### PR TITLE
Adding simulationId to hello world simulation.

### DIFF
--- a/plutus-playground-server/usecases/HelloWorldSimulations.hs
+++ b/plutus-playground-server/usecases/HelloWorldSimulations.hs
@@ -6,7 +6,7 @@ module HelloWorldSimulations where
 
 import           HelloWorld            (registeredKnownCurrencies)
 import           Playground.Types      (ContractCall (AddBlocks), Simulation (Simulation), simulationActions,
-                                        simulationName, simulationWallets)
+                                        simulationId, simulationName, simulationWallets)
 import           SimulationUtils       (simulatorWallet)
 import           Wallet.Emulator.Types (Wallet (Wallet), getWallet)
 

--- a/plutus-playground-server/usecases/HelloWorldSimulations.hs
+++ b/plutus-playground-server/usecases/HelloWorldSimulations.hs
@@ -21,6 +21,7 @@ simulations = [helloWorld]
     helloWorld =
         Simulation
             { simulationName = "Hello, world"
+            , simulationId = 1
             , simulationWallets
             , simulationActions = [ AddBlocks 1 ]
             }


### PR DESCRIPTION
#2610 added a `simulationId` to fix the simulation tab naming issue. Sorry, I meant to mention this would be necessary before merging #2603, but wasn't sure which would be merged first. And then it momentarily slipped my mind.