### PR TITLE
Update basic-forging-policies.rst wrong number of arguments

### DIFF
--- a/doc/tutorials/basic-forging-policies.rst
+++ b/doc/tutorials/basic-forging-policies.rst
@@ -18,7 +18,7 @@ Forging policies, like validators, receive some information from the validating 
 - The :term:`redeemer`, which is some script-specific data specified by the party performing the forging.
 - The :term:`forging context`, which contains a representation of the spending transaction, as well as the hash of the forging policy which is currently being run.
 
-The forging policy is a function which receives these three inputs as *arguments*.
+The forging policy is a function which receives these two inputs as *arguments*.
 The validating node is responsible for passing them in and running the forging policy.
 As with validator scripts, the arguments are passed encoded as :hsobj:`Language.PlutusTx.Data.Data`.
 


### PR DESCRIPTION
Monetary policy scripts/forging policies just have 2 arguments (ctrl+v/c is evil) 😄 

Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
