### PR TITLE
Fix shell dependency on plutus-playground-server

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,7 @@ rec {
     inherit (pkgs.callPackage ./plutus-playground-client {
       inherit (plutus.lib) buildPursPackage buildNodeModules;
       inherit set-git-rev haskell webCommon webCommonPlutus;
-    }) client server-invoker generated-purescript;
+    }) client server-invoker generated-purescript generate-purescript;
   };
 
   marlowe-playground = pkgs.recurseIntoAttrs rec {
@@ -57,7 +57,7 @@ rec {
     inherit (pkgs.callPackage ./marlowe-playground-client {
       inherit (plutus.lib) buildPursPackage buildNodeModules;
       inherit set-git-rev haskell webCommon webCommonMarlowe;
-    }) client server-invoker generated-purescript;
+    }) client server-invoker generated-purescript generate-purescript;
   };
 
   marlowe-symbolic-lambda = plutusMusl.callPackage ./marlowe-symbolic/lambda.nix {

--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -13,7 +13,7 @@ Now we will build and run the front end:
 ```bash
 cd marlowe-playground-client
 # Generate the purescript bridge files
-marlowe-playground-generate-purs
+$(nix-build ../default.nix -A marlowe-playground.generate-purescript)
 # Download javascript dependencies
 npm install
 # Install purescript depdendencies

--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -26,6 +26,12 @@ let
     ${playground-exe}/bin/marlowe-playground-server psgenerator $out
   '';
 
+  # For dev usage
+  generate-purescript = pkgs.writeShellScript "marlowe-playground-generate-purescript" ''
+    rm -rf ./generated
+    ${server-invoker}/bin/marlowe-playground-server psgenerator generated
+  '';
+
   nodeModules = buildNodeModules {
     projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
     packageJson = ./package.json;
@@ -55,5 +61,5 @@ let
   };
 in
 {
-  inherit client server-invoker generated-purescript;
+  inherit client server-invoker generated-purescript generate-purescript;
 }

--- a/plutus-playground-client/README.md
+++ b/plutus-playground-client/README.md
@@ -9,7 +9,7 @@ Please view the instructions for building the server [here](../plutus-playground
 ```sh
 cd plutus-playground-client
 # Generate the purescript bridge files
-plutus-playground-generate-purs
+$(nix-build ../default.nix -A plutus-playground.generate-purescript)
 # Download javascript dependencies
 npm install
 # Install purescript depdendencies

--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -27,6 +27,12 @@ let
     ${server-invoker}/bin/plutus-playground psgenerator $out
   '';
 
+  # For dev usage
+  generate-purescript = pkgs.writeShellScript "plutus-playground-generate-purescript" ''
+    rm -rf ./generated
+    ${server-invoker}/bin/plutus-playground psgenerator generated
+  '';
+
   nodeModules = buildNodeModules {
     projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
     packageJson = ./package.json;
@@ -53,5 +59,5 @@ let
   };
 in
 {
-  inherit client server-invoker generated-purescript;
+  inherit client server-invoker generated-purescript generate-purescript;
 }

--- a/plutus-scb-client/default.nix
+++ b/plutus-scb-client/default.nix
@@ -8,6 +8,12 @@ let
     ${server-invoker}/bin/plutus-scb psgenerator $out
   '';
 
+  # For dev usage
+  generate-purescript = pkgs.writeShellScript "plutus-scb-generate-purescript" ''
+    rm -rf ./generated
+    ${server-invoker}/bin/plutus-scb psgenerator generated
+  '';
+
   nodeModules = buildNodeModules {
     projectDir = nix-gitignore.gitignoreSource [ "/*.nix" "/*.md" ] ./.;
     packageJson = ./package.json;
@@ -38,5 +44,5 @@ let
 
 in
 {
-  inherit client demo-scripts server-invoker generated-purescript;
+  inherit client demo-scripts server-invoker generated-purescript generate-purescript;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -57,20 +57,6 @@ let
     zlib
   ] ++ (lib.optionals (!stdenv.isDarwin) [ rPackages.plotly R ]));
 
-  plutus-playground-generate-purs = pkgs.writeShellScriptBin "plutus-playground-generate-purs" ''
-    rm -rf ./generated
-    ${plutus-playground.server-invoker}/bin/plutus-playground psgenerator generated
-  '';
-  marlowe-playground-generate-purs = pkgs.writeShellScriptBin "marlowe-playground-generate-purs" ''
-    rm -rf ./generated
-    ${marlowe-playground.server-invoker}/bin/marlowe-playground psgenerator generated
-  '';
-  plutus-scb-generate-purs = pkgs.writeShellScriptBin "plutus-scb-generate-purs" ''
-    rm -rf ./generated
-    cp ${haskell.packages.plutus-scb.src}/plutus-scb.yaml.sample plutus-scb.yaml
-    ${plutus-scb.server-invoker}/bin/plutus-scb psgenerator generated
-  '';
-
   # local build inputs ( -> ./nix/pkgs/default.nix )
   localInputs = (with plutus; [
     cabal-install
@@ -80,9 +66,6 @@ let
     hie-bios
     gen-hie
     hlint
-    marlowe-playground-generate-purs
-    plutus-scb-generate-purs
-    plutus-playground-generate-purs
     purs
     purty
     spago
@@ -113,4 +96,9 @@ haskell.project.shellFor {
   + lib.optionalString stdenv.isLinux ''
     ${utillinux}/bin/taskset -pc 0-1000 $$
   '';
+
+  # The shell should never depend on any of our Haskell packages, which can
+  # sometimes happen by accident. In practice, everything depends transitively
+  # on 'plutus-core', so this does the job.
+  disallowedRequisites = [ haskell.packages.plutus-core.components.library ];
 }


### PR DESCRIPTION
https://github.com/input-output-hk/plutus/pull/2608 made the shell
depend on `plutus-playground-server`, and hence
transitively all our Haskell packages, and hence every Haskell source
file. This is slow, and makes lorri etc. thrash horribly.

This is why we don't have e.g. `updateMaterialized` as a shell script in
the shell, it has the same problem.

To prevent this happening in future, I put `plutus-core` in
`disallowedRequisites`.

This makes the workflow a bit worse, but the alternative is worse, I fear.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
