### PR TITLE
Remove superfluous environments from CEK VBuiltin values

### DIFF
--- a/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
@@ -104,7 +104,6 @@ data CekValue uni fun =
       [TypeWithMem uni] -- The types the builtin is to be instantiated at.
                         -- We need these to construct a term if the machine is returning a stuck partial application.
       [CekValue uni fun]    -- Arguments we've computed so far.
-      (CekValEnv uni fun)   -- Initial environment, used for evaluating every argument
     deriving (Show, Eq) -- Eq is just for tests.
 
 type CekValEnv uni fun = UniqueMap TermUnique (CekValue uni fun)
@@ -234,11 +233,11 @@ dischargeCekValue
     :: (Closed uni, uni `Everywhere` ExMemoryUsage)
     => CekValue uni fun -> TermWithMem uni fun
 dischargeCekValue = \case
-    VCon     ex val                        -> Constant ex val
-    VTyAbs   ex tn k body env              -> TyAbs ex tn k (dischargeCekValEnv env body)
-    VLamAbs  ex name ty body env           -> LamAbs ex name ty (dischargeCekValEnv env body)
-    VIWrap   ex ty1 ty2 val                -> IWrap ex ty1 ty2 $ dischargeCekValue val
-    VBuiltin ex bn arity0 _ tyargs args  _ -> mkBuiltinApplication ex bn arity0 tyargs (fmap dischargeCekValue args)
+    VCon     ex val                     -> Constant ex val
+    VTyAbs   ex tn k body env           -> TyAbs ex tn k (dischargeCekValEnv env body)
+    VLamAbs  ex name ty body env        -> LamAbs ex name ty (dischargeCekValEnv env body)
+    VIWrap   ex ty1 ty2 val             -> IWrap ex ty1 ty2 $ dischargeCekValue val
+    VBuiltin ex bn arity0 _ tyargs args -> mkBuiltinApplication ex bn arity0 tyargs (fmap dischargeCekValue args)
     {- We only discharge a value when (a) it's being returned by the machine,
        or (b) it's needed for an error message.  When we're discharging VBuiltin
        we use arity0 to get the type and term arguments into the right sequence. -}
@@ -258,11 +257,11 @@ instance AsConstant (CekValue uni fun) where
 
 instance ToExMemory (CekValue uni fun) where
     toExMemory = \case
-        VCon     ex _           -> ex
-        VTyAbs   ex _ _ _ _     -> ex
-        VLamAbs  ex _ _ _ _     -> ex
-        VIWrap   ex _ _ _       -> ex
-        VBuiltin ex _ _ _ _ _ _ -> ex
+        VCon     ex _         -> ex
+        VTyAbs   ex _ _ _ _   -> ex
+        VLamAbs  ex _ _ _ _   -> ex
+        VIWrap   ex _ _ _     -> ex
+        VBuiltin ex _ _ _ _ _ -> ex
 
 instance ExBudgetBuiltin fun (ExBudgetCategory fun) where
     exBudgetBuiltin = BBuiltin
@@ -353,11 +352,11 @@ computeCek ctx env (LamAbs ex name ty body) =
 computeCek ctx _ (Constant ex val) =
     -- TODO: budget?
     returnCek ctx (VCon ex val)
--- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] [] ρ
-computeCek ctx env (Builtin ex bn) = do
+-- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] []
+computeCek ctx _ (Builtin ex bn) = do
     -- TODO: budget?
   BuiltinRuntime _ arity _ _ <- asksM $ lookupBuiltin bn . cekEnvRuntime
-  returnCek ctx (VBuiltin ex bn arity arity [] [] env)
+  returnCek ctx (VBuiltin ex bn arity arity [] [])
 -- s ; ρ ▻ error A  ↦  <> A
 computeCek _ _ Error{} = throwing_ _EvaluationFailure
 -- s ; ρ ▻ x  ↦  s ◅ ρ[ x ]
@@ -437,7 +436,7 @@ instantiateEvaluate
        )
     => Context uni fun -> Type TyName uni ExMemory -> CekValue uni fun -> CekM uni fun (Plain Term uni fun)
 instantiateEvaluate ctx _ (VTyAbs _ _ _ body env) = computeCek ctx env body
-instantiateEvaluate ctx ty val@(VBuiltin ex bn arity0 arity tyargs args argEnv) =
+instantiateEvaluate ctx ty val@(VBuiltin ex bn arity0 arity tyargs args) =
     case arity of
       []             ->
           throwingDischarged _MachineError EmptyBuiltinArityMachineError val
@@ -446,11 +445,11 @@ instantiateEvaluate ctx ty val@(VBuiltin ex bn arity0 arity tyargs args argEnv) 
          we will have found this case in an earlier call to instantiateEvaluate
          or applyEvaluate and called applyBuiltin. -}
           throwingDischarged _MachineError BuiltinTermArgumentExpectedMachineError val'
-                        where val' = VBuiltin ex bn arity0 arity (tyargs++[ty]) args argEnv -- reconstruct the bad application
+                        where val' = VBuiltin ex bn arity0 arity (tyargs++[ty]) args -- reconstruct the bad application
       TypeArg:arity' ->
           case arity' of
             [] -> applyBuiltin ctx bn args  -- Final argument is a type argument
-            _  -> returnCek ctx $ VBuiltin ex bn arity0 arity' (tyargs++[ty]) args argEnv -- More arguments expected
+            _  -> returnCek ctx $ VBuiltin ex bn arity0 arity' (tyargs++[ty]) args -- More arguments expected
 instantiateEvaluate _ _ val =
         throwingDischarged _MachineError NonPolymorphicInstantiationMachineError val
 
@@ -470,17 +469,17 @@ applyEvaluate
     -> CekM uni fun (Plain Term uni fun)
 applyEvaluate ctx (VLamAbs _ name _ty body env) arg =
     computeCek ctx (extendEnv name arg env) body
-applyEvaluate ctx val@(VBuiltin ex bn arity0 arity tyargs args argEnv) arg = do
+applyEvaluate ctx val@(VBuiltin ex bn arity0 arity tyargs args) arg = do
     case arity of
       []        -> throwingDischarged _MachineError EmptyBuiltinArityMachineError val
                 -- Should be impossible: see instantiateEvaluate.
       TypeArg:_ -> throwingDischarged _MachineError UnexpectedBuiltinTermArgumentMachineError val'
-                   where val' = VBuiltin ex bn arity0 arity tyargs (args++[arg]) argEnv -- reconstruct the bad application
+                   where val' = VBuiltin ex bn arity0 arity tyargs (args++[arg]) -- reconstruct the bad application
       TermArg:arity' -> do
           let args' = args ++ [arg]
           case arity' of
             [] -> applyBuiltin ctx bn args' -- 'arg' was the final argument
-            _  -> returnCek ctx $ VBuiltin ex bn arity0 arity' tyargs args' argEnv  -- More arguments expected
+            _  -> returnCek ctx $ VBuiltin ex bn arity0 arity' tyargs args'  -- More arguments expected
 applyEvaluate _ val _ = throwingDischarged _MachineError NonFunctionalApplicationMachineError val
 
 -- | Apply a builtin to a list of CekValue arguments


### PR DESCRIPTION
When working on the specification, I noticed that the `VBuiltin` value used by the CEK machines contains an environment which is never used.  I think it was originally there for evaluation of the arguments to a builtin, but the appropriate environments are actually saved in the `[_ (N,ρ)]` frame (`FrameApplyArg`).  This removes the environment from `VBuiltin`.  

I think the comments in the CEK machine could do with some maintenance as well.  I'll make an issue so I don't forget that.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
