### PR TITLE
plutus-doc: Add a missing module

### DIFF
--- a/doc/plutus-doc.cabal
+++ b/doc/plutus-doc.cabal
@@ -52,6 +52,7 @@ executable doc-doctests
       BasicValidators
       BasicPolicies
       BasicApps
+      HelloWorldApp
     build-depends:
       base >=4.9 && <5,
       template-haskell >=2.13.0.0,

--- a/doc/tutorials/HelloWorldApp.hs
+++ b/doc/tutorials/HelloWorldApp.hs
@@ -1,4 +1,6 @@
-module HelloWorld where
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+module HelloWorldApp where
 
 import qualified Data.Text                 as T
 import           Language.Plutus.Contract  hiding (when)
@@ -12,7 +14,7 @@ hello :: Contract BlockchainActions T.Text ()
 hello = logInfo @String "Hello, world"
 -- BLOCK2
 
-
+endpoints :: Contract BlockchainActions T.Text ()
 endpoints = hello
 
 mkSchemaDefinitions ''BlockchainActions

--- a/nix/stack.materialized/plutus-doc.nix
+++ b/nix/stack.materialized/plutus-doc.nix
@@ -57,6 +57,7 @@
             "BasicValidators"
             "BasicPolicies"
             "BasicApps"
+            "HelloWorldApp"
             ];
           hsSourceDirs = [ "tutorials" ];
           mainPath = ([


### PR DESCRIPTION
* Add `HelloWorldApp` to `plutus-doc.cabal` and make it compile

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
