### PR TITLE
SCP-1650 Marlowe Playground Frontend: Fix edit source button in the simulation

### DIFF
--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -37,6 +37,9 @@ import SimulationPage.Types as Simulation
 import Types (WebData)
 import WalletSimulation.Types as Wallet
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
+import Foreign.Class (class Decode, class Encode)
+import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
+import Data.Newtype (class Newtype)
 
 data ModalView
   = NewProject
@@ -310,3 +313,42 @@ _value = prop (SProxy :: SProxy "value")
 
 isActiveTab :: State -> View -> Array ClassName
 isActiveTab state activeView = state ^. _view <<< (activeClass (eq activeView))
+
+-----------------------------------------------------------
+newtype Session
+  = Session
+  { projectName :: String
+  , gistId :: Maybe GistId
+  , workflow :: Maybe Lang
+  }
+
+derive instance newtypeSession :: Newtype Session _
+
+derive instance eqSession :: Eq Session
+
+derive instance genericSession :: Generic Session _
+
+instance encodeSession :: Encode Session where
+  encode value = genericEncode defaultOptions value
+
+instance decodeSession :: Decode Session where
+  decode value = genericDecode defaultOptions value
+
+stateToSession :: State -> Session
+stateToSession { projectName
+, gistId
+, workflow
+} =
+  Session
+    { projectName
+    , gistId
+    , workflow
+    }
+
+sessionToState :: Session -> State -> State
+sessionToState (Session sessionData) defaultState =
+  defaultState
+    { projectName = sessionData.projectName
+    , gistId = sessionData.gistId
+    , workflow = sessionData.workflow
+    }

--- a/marlowe-playground-client/src/Projects/Types.purs
+++ b/marlowe-playground-client/src/Projects/Types.purs
@@ -10,6 +10,8 @@ import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Gist (Gist, GistId)
 import Network.RemoteData (RemoteData(..), _Loading)
+import Foreign.Class (class Decode, class Encode)
+import Foreign.Generic.EnumEncoding (defaultGenericEnumOptions, genericDecodeEnum, genericEncodeEnum)
 
 -----------------------------------------------------------
 data Lang
@@ -22,6 +24,12 @@ data Lang
 derive instance eqLang :: Eq Lang
 
 derive instance genericLang :: Generic Lang _
+
+instance encodeLang :: Encode Lang where
+  encode value = genericEncodeEnum defaultGenericEnumOptions value
+
+instance decodeLang :: Decode Lang where
+  decode value = genericDecodeEnum defaultGenericEnumOptions value
 
 -----------------------------------------------------------
 instance showLang :: Show Lang where

--- a/marlowe-playground-client/src/StaticData.purs
+++ b/marlowe-playground-client/src/StaticData.purs
@@ -8,6 +8,7 @@ module StaticData
   , marloweContract
   , marloweContracts
   , gistIdLocalStorageKey
+  , sessionStorageKey
   ) where
 
 import Data.Map (Map)
@@ -85,3 +86,6 @@ simulatorBufferLocalStorageKey = LocalStorage.Key "SimulationBuffer"
 gistIdLocalStorageKey ::
   LocalStorage.Key
 gistIdLocalStorageKey = LocalStorage.Key "GistId"
+
+sessionStorageKey :: LocalStorage.Key
+sessionStorageKey = LocalStorage.Key "MarlowePlaygroundSession"

--- a/web-common/src/SessionStorage.js
+++ b/web-common/src/SessionStorage.js
@@ -1,0 +1,7 @@
+exports._setItem = function (key, value) {
+    window.sessionStorage.setItem(key, value);
+};
+
+exports._getItem = function (key) {
+    return window.sessionStorage.getItem(key);
+};

--- a/web-common/src/SessionStorage.purs
+++ b/web-common/src/SessionStorage.purs
@@ -1,0 +1,18 @@
+module SessionStorage where
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
+import Prelude
+import LocalStorage (Key)
+
+foreign import _setItem :: EffectFn2 Key String Unit
+
+foreign import _getItem :: EffectFn1 Key (Nullable String)
+
+setItem :: Key -> String -> Effect Unit
+setItem = runEffectFn2 _setItem
+
+getItem :: Key -> Effect (Maybe String)
+getItem = map toMaybe <$> runEffectFn1 _getItem


### PR DESCRIPTION
This PR fixes bug 1650, where the edit source button in the simulation did not work after a refresh.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
