### PR TITLE
SCP-1701 - Move padding to be the suffix of the symbolic trace

### DIFF
--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -146,21 +146,34 @@ mkInitialSymState pt (Just State { accounts = accs
 -- The identifiers for Deposit and Choice are calculated using the When clause and
 -- the contract (which is concrete), and using the semantics after a counter example is
 -- found.
-convertToSymbolicTrace :: [(SInteger, SInteger, Maybe SymInput, Integer)] ->
-                          [(SInteger, SInteger, SInteger, SInteger)] -> SBool
-convertToSymbolicTrace [] [] = sTrue
-convertToSymbolicTrace [] ((a, b, c, d):t) = (a .== -1) .&& (b .== -1) .&& (c .== -1) .&&
-                                             (d .== -1) .&& convertToSymbolicTrace [] t
-convertToSymbolicTrace ((lowS, highS, inp, pos):t) ((a, b, c, d):t2) =
+convertRestToSymbolicTrace :: [(SInteger, SInteger, Maybe SymInput, Integer)] ->
+                              [(SInteger, SInteger, SInteger, SInteger)] -> SBool
+convertRestToSymbolicTrace [] [] = sTrue
+convertRestToSymbolicTrace ((lowS, highS, inp, pos):t) ((a, b, c, d):t2) =
   (lowS .== a) .&& (highS .== b) .&& (getSymValFrom inp .== c) .&& (literal pos .== d) .&&
-  convertToSymbolicTrace t t2
+  convertRestToSymbolicTrace t t2
   where
     getSymValFrom :: Maybe SymInput -> SInteger
     getSymValFrom Nothing                       = 0
     getSymValFrom (Just (SymDeposit _ _ _ val)) = val
     getSymValFrom (Just (SymChoice _ val))      = val
     getSymValFrom (Just SymNotify)              = 0
-convertToSymbolicTrace _ _ = error "Provided symbolic trace is not long enough"
+convertRestToSymbolicTrace _ _ = error "Symbolic trace is the wrong length"
+
+isPadding :: [(SInteger, SInteger, SInteger, SInteger)] -> SBool
+isPadding ((a, b, c, d):t) = (a .== -1) .&& (b .== -1) .&& (c .== -1) .&&
+                             (d .== -1) .&& isPadding t
+isPadding [] = sTrue
+
+convertToSymbolicTrace :: [(SInteger, SInteger, Maybe SymInput, Integer)] ->
+                          [(SInteger, SInteger, SInteger, SInteger)] -> SBool
+convertToSymbolicTrace refL symL =
+ let lenRefL = length refL
+     lenSymL = length symL in
+ if lenRefL <= lenSymL
+ then let lenPadding = lenSymL - lenRefL in
+          isPadding (take lenPadding symL) .&& convertRestToSymbolicTrace refL (drop lenPadding symL)
+ else error "Provided symbolic trace is not long enough"
 
 -- Symbolic version evalValue
 symEvalVal :: Value Observation -> SymState -> SInteger
@@ -506,7 +519,7 @@ generateParameters _ = error "Wrong number of labels generated"
 -- concrete values.
 groupResult :: [String] -> Map String Integer -> [(Integer, Integer, Integer, Integer)]
 groupResult (sl:sh:v:b:t) mappings =
-    if ib == -1 then []
+    if ib == -1 then groupResult t mappings
     else (isl, ish, iv, ib):groupResult t mappings
   where (Just isl) = M.lookup sl mappings
         (Just ish) = M.lookup sh mappings


### PR DESCRIPTION
Small refactoring that adds the padding (with -1) to the end of the symbolic trace instead of the beginning. This will make formal verification easier

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
