### PR TITLE
SCP-1729 - Fix ordering of traces in static analysis implementation

### DIFF
--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -430,11 +430,11 @@ isValidAndFailsWhen oa hasErr (Case (Choice choId bnds) cont:rest)
                then ensureBounds otherConcVal bnds .|| previousMatch otherSymInput pmSymState
                else previousMatch otherSymInput pmSymState
              _ -> previousMatch otherSymInput pmSymState
-     contTrace <- isValidAndFailsWhen oa hasErr rest timeout timCont
-                                      newPreviousMatch sState (pos + 1)
      (newCond, newTrace)
                <- applyInputConditions oa newLowSlot newHighSlot
                                        hasErr (Just symInput) timeout sState pos cont
+     contTrace <- isValidAndFailsWhen oa hasErr rest timeout timCont
+                                      newPreviousMatch sState (pos + 1)
      return (ite (newCond .&& sNot clashResult)
                  (ensureBounds concVal bnds .&& newTrace)
                  contTrace)
@@ -449,11 +449,11 @@ isValidAndFailsWhen oa hasErr (Case (Notify obs) cont:rest)
            case otherSymInput of
              SymNotify -> pmObsRes .|| previousMatch otherSymInput pmSymState
              _         -> previousMatch otherSymInput pmSymState
-     contTrace <- isValidAndFailsWhen oa hasErr rest timeout timCont
-                                      newPreviousMatch sState (pos + 1)
      (newCond, newTrace)
                <- applyInputConditions oa newLowSlot newHighSlot
                                        hasErr (Just symInput) timeout sState pos cont
+     contTrace <- isValidAndFailsWhen oa hasErr rest timeout timCont
+                                      newPreviousMatch sState (pos + 1)
      return (ite (newCond .&& obsRes .&& sNot clashResult) newTrace contTrace)
 
 --------------------------------------------------


### PR DESCRIPTION
Change order in static analysis of Choice and Notify to be consistent with Deposit

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] ~Reviewer requested~ Very minor change
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] ~Someone approved it~ Very minor change
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
