### PR TITLE
SCP-1731 - Static analysis checks choice bounds after picking a branch in Choice (instead of before)

### DIFF
--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -435,8 +435,8 @@ isValidAndFailsWhen oa hasErr (Case (Choice choId bnds) cont:rest)
                                        hasErr (Just symInput) timeout sState pos cont
      contTrace <- isValidAndFailsWhen oa hasErr rest timeout timCont
                                       newPreviousMatch sState (pos + 1)
-     return (ite (newCond .&& sNot clashResult)
-                 (ensureBounds concVal bnds .&& newTrace)
+     return (ite (newCond .&& sNot clashResult .&& ensureBounds concVal bnds)
+                 newTrace
                  contTrace)
 isValidAndFailsWhen oa hasErr (Case (Notify obs) cont:rest)
                     timeout timCont previousMatch sState pos =


### PR DESCRIPTION
When testing the function that calculates hidden variables, it became apparent that the discrepancy between it and the static analysis implementation was due to the fact that static analysis was checking the bounds of choices after choosing which branch was activated in the When.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] ~Reviewer requested~ Very small change
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] ~Someone approved it~ Very small change
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
