### PR TITLE
Move disallowedRequisites only to the CI build

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -96,9 +96,4 @@ haskell.project.shellFor {
   + lib.optionalString stdenv.isLinux ''
     ${utillinux}/bin/taskset -pc 0-1000 $$
   '';
-
-  # The shell should never depend on any of our Haskell packages, which can
-  # sometimes happen by accident. In practice, everything depends transitively
-  # on 'plutus-core', so this does the job.
-  disallowedRequisites = [ haskell.packages.plutus-core.components.library ];
 }


### PR DESCRIPTION
This is a useful guard, but it breaks lorri due to a bug. Not sure when
we'll be able to resolve that, but in the mean time we can just set it
on the version that's built in CI, so we'll still catch the problem but
it won't trip up lorri.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
