### PR TITLE
SCP-1733 Marlowe Playground Frontend: Refactor the bottom panel into a reusable component

### DIFF
--- a/marlowe-playground-client/src/BottomPanel/State.purs
+++ b/marlowe-playground-client/src/BottomPanel/State.purs
@@ -9,9 +9,9 @@ import Halogen (HalogenM, modify_)
 import MainFrame.Types (ChildSlots)
 
 handleAction ::
-  forall m panel panelAction.
-  Action panel panelAction ->
-  HalogenM (State panel) (Action panel panelAction) ChildSlots Void m Unit
+  forall m panel action.
+  Action panel action ->
+  HalogenM (State panel) (Action panel action) ChildSlots Void m Unit
 handleAction (SetVisibility val) = assign _showBottomPanel val
 
 handleAction (ChangePanel view) =

--- a/marlowe-playground-client/src/BottomPanel/State.purs
+++ b/marlowe-playground-client/src/BottomPanel/State.purs
@@ -1,0 +1,21 @@
+module BottomPanel.State
+  ( handleAction
+  ) where
+
+import Prelude hiding (div)
+import BottomPanel.Types (Action(..), State, _panelView, _showBottomPanel)
+import Data.Lens (assign, set)
+import Halogen (HalogenM, modify_)
+import MainFrame.Types (ChildSlots)
+
+handleAction ::
+  forall m panel panelAction.
+  Action panel panelAction ->
+  HalogenM (State panel) (Action panel panelAction) ChildSlots Void m Unit
+handleAction (SetVisibility val) = assign _showBottomPanel val
+
+handleAction (ChangePanel view) =
+  modify_
+    (set _panelView view <<< set _showBottomPanel true)
+
+handleAction (PanelAction _) = pure unit

--- a/marlowe-playground-client/src/BottomPanel/Types.purs
+++ b/marlowe-playground-client/src/BottomPanel/Types.purs
@@ -8,19 +8,21 @@ import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 
--- This action is parameterized in the `panel` type so we can have type safety on the different panels
--- we have, and the panelAction, which is needed to allow the contents of the panel, to fire actions
--- on the parent. The `panel` type could eventually be refactored into just having a Map/Record, if we dont
--- care for it to be type safe, and the PanelAction could eventually be refactored to Variants/Run.
-data Action panel panelAction
+-- This component is an UI element that allows you to have different panels with titles at the bottom of the page. Because the children of this component is set by the page, the Action type
+-- is parameterized in two types:
+--   * The `panel` type defines the possible panels we can have inside this widget. Each page that uses this widget defines a type (normally called BottomPanelView) with the possible panels.
+--     This type needs to implement Eq for the render function to show the current selected pane. By allowing this to be a sum type, we can get the type safety in the render functions that
+--     we need to implement all possible panels. If we don't care about that, we could refactor to a Map/Record and lose this parameter.
+--   * The `action` type allows the posibility for a panel to fire actions on the parent page by using the PanelAction constructor. I think it could be eventually be refactored as a Variant/Run.
+data Action panel action
   = SetVisibility Boolean
   | ChangePanel panel
-  | PanelAction panelAction
+  | PanelAction action
 
 defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "BottomPanel." <> s
 
-instance actionIsEvent :: (Show panel, IsEvent panelAction) => IsEvent (Action panel panelAction) where
+instance actionIsEvent :: (Show panel, IsEvent action) => IsEvent (Action panel action) where
   toEvent (SetVisibility true) = Just $ defaultEvent "Show"
   toEvent (SetVisibility false) = Just $ defaultEvent "Hide"
   toEvent (ChangePanel view) = Just $ (defaultEvent "ChangePanel") { label = Just $ show view }

--- a/marlowe-playground-client/src/BottomPanel/Types.purs
+++ b/marlowe-playground-client/src/BottomPanel/Types.purs
@@ -1,0 +1,44 @@
+module BottomPanel.Types where
+
+import Prelude
+import Analytics (class IsEvent, Event)
+import Analytics as A
+import Data.Lens (Lens')
+import Data.Lens.Record (prop)
+import Data.Maybe (Maybe(..))
+import Data.Symbol (SProxy(..))
+
+-- This action is parameterized in the `panel` type so we can have type safety on the different panels
+-- we have, and the panelAction, which is needed to allow the contents of the panel, to fire actions
+-- on the parent. The `panel` type could eventually be refactored into just having a Map/Record, if we dont
+-- care for it to be type safe, and the PanelAction could eventually be refactored to Variants/Run.
+data Action panel panelAction
+  = SetVisibility Boolean
+  | ChangePanel panel
+  | PanelAction panelAction
+
+defaultEvent :: String -> Event
+defaultEvent s = A.defaultEvent $ "BottomPanel." <> s
+
+instance actionIsEvent :: (Show panel, IsEvent panelAction) => IsEvent (Action panel panelAction) where
+  toEvent (SetVisibility true) = Just $ defaultEvent "Show"
+  toEvent (SetVisibility false) = Just $ defaultEvent "Hide"
+  toEvent (ChangePanel view) = Just $ (defaultEvent "ChangePanel") { label = Just $ show view }
+  toEvent (PanelAction action) = A.toEvent action
+
+type State panel
+  = { showBottomPanel :: Boolean
+    , panelView :: panel
+    }
+
+initialState :: forall panel. panel -> State panel
+initialState view =
+  { showBottomPanel: false
+  , panelView: view
+  }
+
+_showBottomPanel :: forall panel. Lens' (State panel) Boolean
+_showBottomPanel = prop (SProxy :: SProxy "showBottomPanel")
+
+_panelView :: forall panel. Lens' (State panel) panel
+_panelView = prop (SProxy :: SProxy "panelView")

--- a/marlowe-playground-client/src/BottomPanel/View.purs
+++ b/marlowe-playground-client/src/BottomPanel/View.purs
@@ -16,12 +16,18 @@ type PanelTitle panel
     }
 
 render ::
-  forall p panel panelAction.
+  forall p panel action.
+  -- The panel equality restriction allow us to identify the current selected panel.
   Eq panel =>
+  -- panelTitles is an ordered list of the titles we'll show in the widget. The caller needs to provide a
+  -- `title` name to display, the `view` that is selected when the title is clicked and a list
+  -- of `classes` to optionally style the titles.
   Array (PanelTitle panel) ->
-  (panel -> HTML p (Action panel panelAction)) ->
+  -- The panelContents function receives the active panel and returns it's content. The `action` type parameter
+  -- is what allow us to fire an action from the child that is intended to be interpreted on the parent.
+  (panel -> HTML p (Action panel action)) ->
   State panel ->
-  HTML p (Action panel panelAction)
+  HTML p (Action panel action)
 render panelTitles panelContents state =
   div
     ( [ classes

--- a/marlowe-playground-client/src/BottomPanel/View.purs
+++ b/marlowe-playground-client/src/BottomPanel/View.purs
@@ -1,0 +1,65 @@
+module BottomPanel.View (render) where
+
+import Prelude hiding (div)
+import BottomPanel.Types (Action(..), State, _panelView, _showBottomPanel)
+import Data.Lens (to, (^.))
+import Data.Maybe (Maybe(..))
+import Halogen.Classes (aHorizontal, accentBorderBottom, active, activeClass, closeDrawerArrowIcon, collapsed, flex, flexTen, footerPanelBg, minimizeIcon)
+import Halogen.HTML (ClassName(..), HTML, a, a_, div, img, li, section, text, ul)
+import Halogen.HTML.Events (onClick)
+import Halogen.HTML.Properties (alt, class_, classes, src)
+
+type PanelTitle panel
+  = { view :: panel
+    , classes :: Array ClassName
+    , title :: String
+    }
+
+render ::
+  forall p panel panelAction.
+  Eq panel =>
+  Array (PanelTitle panel) ->
+  (panel -> HTML p (Action panel panelAction)) ->
+  State panel ->
+  HTML p (Action panel panelAction)
+render panelTitles panelContents state =
+  div
+    ( [ classes
+          ( if showingBottomPanel then
+              [ ClassName "simulation-bottom-panel" ]
+            else
+              [ ClassName "simulation-bottom-panel", collapsed ]
+          )
+      ]
+    )
+    [ div [ classes [ flex, ClassName "flip-x", ClassName "full-height" ] ]
+        [ div [ class_ flexTen ]
+            [ div [ classes [ footerPanelBg, active ] ]
+                [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
+                    [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal, accentBorderBottom ] ]
+                        [ ul [ class_ (ClassName "start-item") ]
+                            [ li [ class_ (ClassName "minimize-icon-container") ]
+                                [ a [ onClick $ const $ Just $ SetVisibility (state ^. _showBottomPanel <<< to not) ]
+                                    [ img [ classes (minimizeIcon $ state ^. _showBottomPanel), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
+                                ]
+                            ]
+                        , ul [ classes [ ClassName "demo-list", aHorizontal ] ]
+                            ( panelTitles
+                                <#> \panelTitle ->
+                                    li
+                                      [ classes (panelTitle.classes <> isActive panelTitle.view)
+                                      , onClick $ const $ Just $ ChangePanel $ panelTitle.view
+                                      ]
+                                      [ a_ [ text panelTitle.title ] ]
+                            )
+                        ]
+                    ]
+                , panelContents (state ^. _panelView)
+                ]
+            ]
+        ]
+    ]
+  where
+  isActive view = state ^. _panelView <<< (activeClass (eq view))
+
+  showingBottomPanel = state ^. _showBottomPanel

--- a/marlowe-playground-client/src/Halogen/Classes.purs
+++ b/marlowe-playground-client/src/Halogen/Classes.purs
@@ -238,10 +238,8 @@ spanText s = span [] [ text s ]
 sidebarComposer :: ClassName
 sidebarComposer = ClassName "sidebar-composer"
 
-codeEditor :: Boolean -> Array ClassName
-codeEditor true = [ ClassName "code-editor" ]
-
-codeEditor false = [ ClassName "code-editor", ClassName "expanded" ]
+codeEditor :: ClassName
+codeEditor = ClassName "code-editor"
 
 haskellEditor :: Boolean -> Array ClassName
 haskellEditor true = [ ClassName "code-panel", ClassName "haskell-editor" ]

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -34,7 +34,7 @@ render ::
 render state =
   div_
     [ section [ class_ (ClassName "code-panel") ]
-        [ div [ classes (codeEditor $ state ^. _showBottomPanel) ]
+        [ div [ classes [ codeEditor ] ]
             [ haskellEditor state ]
         ]
     , bottomPanel state

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -5,13 +5,13 @@ module JavascriptEditor.State
   ) where
 
 import Prelude hiding (div)
-import BottomPanel.State as BottomPanel
-import BottomPanel.Types as BottomPanel
+import BottomPanel.State (handleAction) as BottomPanel
+import BottomPanel.Types (Action(..), State) as BottomPanel
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (runMaybeT)
 import Data.Array as Array
 import Data.Either (Either(..))
-import Data.Lens (assign, to, use, view)
+import Data.Lens (assign, view)
 import Data.List ((:))
 import Data.List as List
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -20,17 +20,15 @@ import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect)
 import Examples.JS.Contracts as JSE
 import Halogen (Component, HalogenM, gets, liftEffect, query)
-import Halogen.Blockly as Blockly
 import Halogen.Extra (mapSubmodule)
 import Halogen.HTML (HTML)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import Halogen.Monaco (Message, Query, monacoComponent)
 import JavascriptEditor.Types (Action(..), BottomPanelView(..), CompilationState(..), State, _bottomPanelState, _compilationResult, _decorationIds, _keybindings)
-import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JSI
 import Language.Javascript.Monaco as JSM
 import LocalStorage as LocalStorage
-import MainFrame.Types (ChildSlots, _blocklySlot, _jsEditorSlot)
+import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import Marlowe (SPParams_)
 import Monaco (IRange, getModel, isError, setValue)
 import Servant.PureScript.Settings (SPSettings_)

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -1,7 +1,7 @@
-module MarloweEditor.BottomPanel (bottomPanel) where
+module MarloweEditor.BottomPanel (panelContents) where
 
 import Prelude hiding (div)
-import Data.Array (drop, head, length)
+import Data.Array (drop, head)
 import Data.Array as Array
 import Data.Foldable (foldMap)
 import Data.Lens (to, (^.))
@@ -12,73 +12,18 @@ import Data.Maybe (Maybe(..))
 import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple.Nested ((/\))
-import Halogen.Classes (aHorizontal, accentBorderBottom, active, activeClass, closeDrawerArrowIcon, collapsed, flex, flexLeft, flexTen, footerPanelBg, minimizeIcon, spanText, underline)
+import Halogen.Classes (aHorizontal, flexLeft, spanText, underline)
 import Halogen.Classes as Classes
-import Halogen.HTML (ClassName(..), HTML, a, a_, b_, br_, button, div, h2, h3, img, li, li_, ol, pre, section, span_, text, ul, ul_)
+import Halogen.HTML (ClassName(..), HTML, a, b_, br_, button, div, h2, h3, li, li_, ol, pre, section, span_, text, ul, ul_)
 import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (alt, class_, classes, enabled, src)
+import Halogen.HTML.Properties (class_, classes, enabled)
 import Marlowe.Semantics (ChoiceId(..), Input(..), Payee(..), Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..))
 import Marlowe.Symbolic.Types.Response as R
-import MarloweEditor.Types (Action(..), AnalysisState(..), BottomPanelView(..), MultiStageAnalysisData(..), State, _analysisState, _bottomPanelView, _editorErrors, _editorWarnings, _showBottomPanel, _showErrorDetail, contractHasErrors)
+import MarloweEditor.Types (Action(..), AnalysisState(..), BottomPanelView(..), MultiStageAnalysisData(..), State, _analysisState, _editorErrors, _editorWarnings, _showErrorDetail, contractHasErrors)
 import Network.RemoteData (RemoteData(..), isLoading)
 import Pretty (showPrettyToken)
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
 import Text.Parsing.StringParser.Basic (lines)
-
-bottomPanel :: forall p. State -> HTML p Action
-bottomPanel state =
-  div
-    ( [ classes
-          ( if showingBottomPanel then
-              [ ClassName "simulation-bottom-panel" ]
-            else
-              [ ClassName "simulation-bottom-panel", collapsed ]
-          )
-      ]
-    )
-    [ div [ classes [ flex, ClassName "flip-x", ClassName "full-height" ] ]
-        [ div [ class_ flexTen ]
-            [ div [ classes [ footerPanelBg, active ] ]
-                [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
-                    [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal, accentBorderBottom ] ]
-                        [ ul [ class_ (ClassName "start-item") ]
-                            [ li [ class_ (ClassName "minimize-icon-container") ]
-                                [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
-                                    [ img [ classes (minimizeIcon $ state ^. _showBottomPanel), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
-                                ]
-                            ]
-                        , ul [ classes [ ClassName "demo-list", aHorizontal ] ]
-                            [ li
-                                [ classes ([] <> isActive StaticAnalysisView)
-                                , onClick $ const $ Just $ ChangeBottomPanelView StaticAnalysisView
-                                ]
-                                [ a_ [ text "Static Analysis" ] ]
-                            , li
-                                [ classes ([] <> isActive MarloweWarningsView)
-                                , onClick $ const $ Just $ ChangeBottomPanelView MarloweWarningsView
-                                ]
-                                [ a_ [ text $ "Warnings" <> if Array.null warnings then "" else " (" <> show (length warnings) <> ")" ] ]
-                            , li
-                                [ classes ([] <> isActive MarloweErrorsView)
-                                , onClick $ const $ Just $ ChangeBottomPanelView MarloweErrorsView
-                                ]
-                                [ a_ [ text $ "Errors" <> if Array.null errors then "" else " (" <> show (length errors) <> ")" ] ]
-                            ]
-                        ]
-                    ]
-                , panelContents state (state ^. _bottomPanelView)
-                ]
-            ]
-        ]
-    ]
-  where
-  isActive view = state ^. _bottomPanelView <<< (activeClass (eq view))
-
-  warnings = state ^. _editorWarnings
-
-  errors = state ^. _editorErrors
-
-  showingBottomPanel = state ^. _showBottomPanel
 
 isStaticLoading :: AnalysisState -> Boolean
 isStaticLoading (WarningAnalysis remoteData) = isLoading remoteData

--- a/marlowe-playground-client/src/MarloweEditor/View.purs
+++ b/marlowe-playground-client/src/MarloweEditor/View.purs
@@ -36,8 +36,7 @@ render ::
 render state =
   div_
     [ section [ class_ (ClassName "code-panel") ]
-        -- FIXME: revisit why codeEditor requires to know if the bottom panel is being shown.
-        [ div [ classes (codeEditor $ state ^. (_bottomPanelState <<< _showBottomPanel)) ]
+        [ div [ classes [ codeEditor ] ]
             [ marloweEditor state ]
         ]
     , renderSubmodule _bottomPanelState BottomPanelAction (BottomPanel.render panelTitles wrapBottomPanelContents) state

--- a/marlowe-playground-client/src/SimulationPage/BottomPanel.purs
+++ b/marlowe-playground-client/src/SimulationPage/BottomPanel.purs
@@ -1,70 +1,22 @@
-module SimulationPage.BottomPanel (bottomPanel) where
+module SimulationPage.BottomPanel (panelContents) where
 
 import Prelude hiding (div)
-import Data.Array as Array
 import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.Foldable (foldMap)
-import Data.Lens (has, only, previewOn, to, (^.))
+import Data.Lens (previewOn, to, (^.))
 import Data.Lens.NonEmptyList (_Head)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), isJust)
+import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
-import Halogen.Classes (aHorizontal, accentBorderBottom, active, activeClass, closeDrawerArrowIcon, collapsed, first, flex, flexTen, footerPanelBg, minimizeIcon, rTable, rTable4cols, rTableCell, rTableEmptyRow)
+import Halogen.Classes (first, rTable, rTable4cols, rTableCell, rTableEmptyRow)
 import Halogen.Classes as Classes
-import Halogen.HTML (ClassName(..), HTML, a, a_, div, img, li, section, text, ul)
-import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (alt, class_, classes, src)
+import Halogen.HTML (ClassName(..), HTML, div, text)
+import Halogen.HTML.Properties (class_, classes)
 import Marlowe.Semantics (ChoiceId(..), Party, Token, ValueId(..), _accounts, _boundValues, _choices)
 import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
-import SimulationPage.Types (Action(..), BottomPanelView(..), State, _SimulationNotStarted, _SimulationRunning, _bottomPanelView, _executionState, _initialSlot, _marloweState, _showBottomPanel, _slot, _state, _transactionError, _transactionWarnings)
-
-bottomPanel :: forall p. State -> HTML p Action
-bottomPanel state =
-  div
-    ( [ classes
-          ( if showingBottomPanel then
-              [ ClassName "simulation-bottom-panel" ]
-            else
-              [ ClassName "simulation-bottom-panel", collapsed ]
-          )
-      ]
-    )
-    [ div [ classes [ flex, ClassName "flip-x", ClassName "full-height" ] ]
-        [ div [ class_ flexTen ]
-            [ div [ classes [ footerPanelBg, active ] ]
-                [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
-                    [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal, accentBorderBottom ] ]
-                        [ ul [ class_ (ClassName "start-item") ]
-                            [ li [ class_ (ClassName "minimize-icon-container") ]
-                                [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
-                                    [ img [ classes (minimizeIcon $ state ^. _showBottomPanel), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
-                                ]
-                            ]
-                        , ul [ classes [ ClassName "demo-list", aHorizontal ] ]
-                            [ li
-                                [ classes ((if hasRuntimeWarnings || hasRuntimeError then [ ClassName "error-tab" ] else []) <> isActive CurrentStateView)
-                                , onClick $ const $ Just $ ChangeSimulationView CurrentStateView
-                                ]
-                                [ a_ [ text "Current State" ] ]
-                            ]
-                        ]
-                    ]
-                , panelContents state (state ^. _bottomPanelView)
-                ]
-            ]
-        ]
-    ]
-  where
-  isActive view = state ^. _bottomPanelView <<< (activeClass (eq view))
-
-  -- QUESTION: what are runtimeWarnings and runtimeError? how can I reach that state?
-  hasRuntimeWarnings = has (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionWarnings <<< to Array.null <<< only false) state
-
-  hasRuntimeError = has (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionError <<< to isJust <<< only true) state
-
-  showingBottomPanel = state ^. _showBottomPanel
+import SimulationPage.Types (Action, BottomPanelView(..), State, _SimulationNotStarted, _SimulationRunning, _executionState, _initialSlot, _marloweState, _slot, _state)
 
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
 panelContents state CurrentStateView =

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -44,8 +44,7 @@ render ::
 render state =
   div [ classes [ fullHeight, scroll, ClassName "simulation-panel" ] ]
     [ section [ class_ (ClassName "code-panel") ]
-        -- FIXME: revisit why codeEditor requires to know if the bottom panel is being shown.
-        [ div [ classes (codeEditor $ state ^. (_bottomPanelState <<< _showBottomPanel)) ]
+        [ div [ classes [ codeEditor ] ]
             [ marloweEditor state ]
         , sidebar state
         ]


### PR DESCRIPTION
This PR refactors the bottom panel functionality that was shared through copy and paste in the HaskellEditor, JavaScriptEditor, MarloweEditor and Simulator pages into a single reusable component.

This way, the functionalities are reused and they share visual aspects. Before this PR for example, there was no way of "switching tabs" between generated code and code errors in the Javascript and Haskell editor. Granted, there can never coexist at the same time, but, they also didn't have a title that indicated what were the possible tabs.

We should take special attention to the types described in `BottomPanel.Types`, which defines the first use case we had for a sub-component to be able to display HTML and fire actions inside the sub-component but the actions being defined in the parent. Kind of how the `transclude` functionality used to work in Angular 1.

## Haskell editor before 
* Without errors or compiled output
<img width="1789" alt="Screen Shot 2021-01-21 at 20 09 29" src="https://user-images.githubusercontent.com/2634059/105423912-21782780-5c25-11eb-97d2-158c5b381769.png">
* With compiled output
<img width="1773" alt="Screen Shot 2021-01-21 at 20 07 30" src="https://user-images.githubusercontent.com/2634059/105423943-2e951680-5c25-11eb-8220-8e68d8d23f11.png">
* With errors
<img width="1785" alt="Screen Shot 2021-01-21 at 20 07 47" src="https://user-images.githubusercontent.com/2634059/105423974-394fab80-5c25-11eb-95bf-93c48412075b.png">

## Haskell editor with PR
* Without errors or compiled output
<img width="1788" alt="Screen Shot 2021-01-21 at 20 08 38" src="https://user-images.githubusercontent.com/2634059/105424036-52f0f300-5c25-11eb-9db7-4359ebb8119f.png">

* With compiled output
<img width="1784" alt="Screen Shot 2021-01-21 at 20 08 08" src="https://user-images.githubusercontent.com/2634059/105424059-5c7a5b00-5c25-11eb-8f40-05897ba3a8cf.png">

* With errors
<img width="1790" alt="Screen Shot 2021-01-21 at 20 08 27" src="https://user-images.githubusercontent.com/2634059/105424073-6603c300-5c25-11eb-97b1-e04f4d2289d3.png">

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
