### PR TITLE
SCP-1589 - Static analysis for finding which Close constructs return money

### DIFF
--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -5,6 +5,7 @@ module MarloweEditor.State
   ) where
 
 import Prelude hiding (div)
+import CloseAnalysis (startCloseAnalysis)
 import Control.Monad.Except (ExceptT, lift, runExceptT)
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
@@ -151,6 +152,19 @@ handleAction settings AnalyseReachabilityContract =
           emptySemanticState = emptyState zero
         newReachabilityAnalysisState <- lift $ startReachabilityAnalysis settings contract emptySemanticState
         assign _analysisState (ReachabilityAnalysis newReachabilityAnalysisState)
+
+handleAction settings AnalyseContractForCloseRefund =
+  void
+    $ runMaybeT do
+        contents <- MaybeT $ editorGetValue
+        contract <- hoistMaybe $ parseContract' contents
+        -- when editor and simulator were together the analyse contract could be made
+        -- at any step of the simulator. Now that they are separate, it can only be done
+        -- with initial state
+        let
+          emptySemanticState = emptyState zero
+        newCloseAnalysisState <- lift $ startCloseAnalysis settings contract emptySemanticState
+        assign _analysisState (CloseAnalysis newCloseAnalysisState)
 
 handleAction _ Save = pure unit
 

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -44,6 +44,7 @@ data Action
   | SelectHole (Maybe String)
   | AnalyseContract
   | AnalyseReachabilityContract
+  | AnalyseContractForCloseRefund
   | Save
 
 defaultEvent :: String -> Event
@@ -66,6 +67,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
+  toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"
   toEvent Save = Just $ defaultEvent "Save"
 
 data ContractZipper
@@ -134,11 +136,14 @@ data AnalysisState
   = NoneAsked
   | WarningAnalysis (WebData Result)
   | ReachabilityAnalysis MultiStageAnalysisData
+  | CloseAnalysis MultiStageAnalysisData
 
 type MultiStageAnalysisProblemDef
   = { expandSubproblemImpl :: ContractZipper -> Contract -> (ContractPath /\ Contract)
     , isValidSubproblemImpl :: ContractZipper -> Contract -> Boolean
     , analysisDataSetter :: MultiStageAnalysisData -> AnalysisState
+    , shouldExamineChildren :: Boolean -> Boolean
+    , isProblemConterExample :: Boolean -> Boolean
     }
 
 data BottomPanelView

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -143,7 +143,7 @@ type MultiStageAnalysisProblemDef
     , isValidSubproblemImpl :: ContractZipper -> Contract -> Boolean
     , analysisDataSetter :: MultiStageAnalysisData -> AnalysisState
     , shouldExamineChildren :: Boolean -> Boolean
-    , isProblemConterExample :: Boolean -> Boolean
+    , isProblemCounterExample :: Boolean -> Boolean
     }
 
 data BottomPanelView

--- a/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
@@ -1,0 +1,75 @@
+module CloseAnalysis where
+
+import Data.Foldable (foldl)
+import Data.List (List(..))
+import Data.List.NonEmpty (toList)
+import Data.Maybe (Maybe(..))
+import Data.Set (Set)
+import Data.Set as Set
+import Data.Tuple.Nested (type (/\), (/\))
+import Effect.Aff.Class (class MonadAff)
+import Halogen (HalogenM)
+import MainFrame.Types (ChildSlots)
+import Marlowe (SPParams_)
+import Marlowe.Semantics (AccountId, Contract(..), Observation(..), Payee(..), Token, Value(..))
+import Marlowe.Semantics as S
+import MarloweEditor.Types (Action, AnalysisState(..), ContractPath, ContractZipper(..), MultiStageAnalysisData(..), MultiStageAnalysisProblemDef, State)
+import Prelude (Void, const, mempty, not, zero, ($), (&&), (==))
+import Servant.PureScript.Settings (SPSettings_)
+import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
+
+extractAccountIdsFromZipper :: ContractZipper -> Set (AccountId /\ Token)
+extractAccountIdsFromZipper = go
+  where
+  go (PayZip _ (Account accountId) token _ contZip) = Set.insert (accountId /\ token) $ go contZip
+
+  go (PayZip _ _ _ _ contZip) = go contZip
+
+  go (WhenCaseZip _ (S.Deposit accountId _ token _) contZip _ _ _) = Set.insert (accountId /\ token) $ go contZip
+
+  go (WhenCaseZip _ _ contZip _ _ _) = go contZip
+
+  go (IfTrueZip _ contZip _) = go contZip
+
+  go (IfFalseZip _ _ contZip) = go contZip
+
+  go (WhenTimeoutZip _ _ contZip) = go contZip
+
+  go (LetZip _ _ contZip) = go contZip
+
+  go (AssertZip _ contZip) = go contZip
+
+  go HeadZip = mempty
+
+addAssertionForAccountId :: Contract -> (AccountId /\ Token) -> Contract
+addAssertionForAccountId cont (accountId /\ token) = Assert (ValueEQ (AvailableMoney accountId token) (Constant zero)) cont
+
+-- We expect "contract" to be Close always, but we take it as a parameter anyway because it makes more sense
+expandSubproblem :: ContractZipper -> Contract -> (ContractPath /\ Contract)
+expandSubproblem zipper contract = zipperToContractPath zipper /\ closeZipperContract zipper modifiedContract
+  where
+  accountIds = extractAccountIdsFromZipper zipper
+
+  modifiedContract = foldl addAssertionForAccountId contract accountIds
+
+isValidSubproblem :: ContractZipper -> Contract -> Boolean
+isValidSubproblem _ Close = true
+
+isValidSubproblem _ _ = false
+
+closeAnalysisAnalysisDef :: MultiStageAnalysisProblemDef
+closeAnalysisAnalysisDef =
+  { analysisDataSetter: CloseAnalysis
+  , expandSubproblemImpl: expandSubproblem
+  , isValidSubproblemImpl: isValidSubproblem
+  , shouldExamineChildren: const true
+  , isProblemConterExample: not
+  }
+
+startCloseAnalysis ::
+  forall m.
+  MonadAff m =>
+  SPSettings_ SPParams_ ->
+  Contract ->
+  S.State -> HalogenM State Action ChildSlots Void m MultiStageAnalysisData
+startCloseAnalysis = startMultiStageAnalysis closeAnalysisAnalysisDef

--- a/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
@@ -63,7 +63,7 @@ closeAnalysisAnalysisDef =
   , expandSubproblemImpl: expandSubproblem
   , isValidSubproblemImpl: isValidSubproblem
   , shouldExamineChildren: const true
-  , isProblemConterExample: not
+  , isProblemCounterExample: not
   }
 
 startCloseAnalysis ::

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -39,7 +39,7 @@ reachabilityAnalysisDef =
   , expandSubproblemImpl: expandSubproblem
   , isValidSubproblemImpl: isValidSubproblem
   , shouldExamineChildren: identity
-  , isProblemConterExample: identity
+  , isProblemCounterExample: identity
   }
 
 startReachabilityAnalysis ::

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -38,6 +38,8 @@ reachabilityAnalysisDef =
   { analysisDataSetter: ReachabilityAnalysis
   , expandSubproblemImpl: expandSubproblem
   , isValidSubproblemImpl: isValidSubproblem
+  , shouldExamineChildren: identity
+  , isProblemConterExample: identity
   }
 
 startReachabilityAnalysis ::

--- a/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
@@ -212,7 +212,7 @@ stepSubproblem problemDef isCounterExample ( rad@{ currPath: oldPath
   , numSubproblems: oldTotalN
   , counterExampleSubcontracts: results
   }
-) = case getNextSubproblem problemDef.isValidSubproblemImpl oldSubproblems (if isCounterExample then oldChildren else Nil) of
+) = case getNextSubproblem problemDef.isValidSubproblemImpl oldSubproblems (if willExamineChildren then oldChildren else Nil) of
   Just ((contractZipper /\ subcontract /\ newChildren) /\ newSubproblems) ->
     let
       newPath /\ newContract = problemDef.expandSubproblemImpl contractZipper subcontract
@@ -238,11 +238,15 @@ stepSubproblem problemDef isCounterExample ( rad@{ currPath: oldPath
             }
         )
   where
+  willExamineChildren = problemDef.shouldExamineChildren isCounterExample
+
+  isProblemCounterExample = problemDef.isProblemConterExample isCounterExample
+
   newN = n + 1
 
-  newTotalN = oldTotalN - (if isCounterExample then 0 else countSubproblems problemDef.isValidSubproblemImpl oldChildren)
+  newTotalN = oldTotalN - (if willExamineChildren then 0 else countSubproblems problemDef.isValidSubproblemImpl oldChildren)
 
-  newResults = results <> (if isCounterExample then Nil else Cons oldPath Nil)
+  newResults = results <> (if isProblemCounterExample then Nil else Cons oldPath Nil)
 
 updateWithResponse ::
   forall m.

--- a/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
@@ -240,7 +240,7 @@ stepSubproblem problemDef isCounterExample ( rad@{ currPath: oldPath
   where
   willExamineChildren = problemDef.shouldExamineChildren isCounterExample
 
-  isProblemCounterExample = problemDef.isProblemConterExample isCounterExample
+  isProblemCounterExample = problemDef.isProblemCounterExample isCounterExample
 
   newN = n + 1
 


### PR DESCRIPTION
This PR implements a static analysis functionality that checks whether there is any `Close` construct that may refund money under some circumstances (any implicit refund caused by a `Close` construct):

![close_refund_analysis](https://user-images.githubusercontent.com/638102/105380245-9176b580-5c05-11eb-9e75-f0e2d48d1369.png)

Deployed to: https://pablo.marlowe.iohkdev.io/

Example that passes the analysis:
```haskell
When [(Case (Deposit (Role "party1") (Role "party1") (Token "" "") (Constant 500)) (When [(Case (Deposit (Role "party2") (Role "party2") (Token "" "") (Constant 300)) (Pay (Role "party1") (Party (Role "party2")) (Token "" "") (Constant 500) (Pay (Role "party2") (Party (Role "party1")) (Token "" "") (Constant 300) Close)))] 20 (Pay (Role "party1") (Party (Role "party1")) (Token "" "") (Constant 500) Close)))] 15 Close
```

Example that has one counter-example: Swap

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [x] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [x] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
