### PR TITLE
plc-mini - a formally verified interpreter for a (very) small fragment of PLC

### DIFF
--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -311,9 +311,10 @@
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
           buildable = true;
-          modules = [ "Hutton" "Parser" ];
+          modules = [ "Lambda" "ParserL" ];
           hsSourceDirs = [ "plc-mini" ];
           mainPath = [ "Main.hs" ];
           };

--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -304,6 +304,17 @@
           hsSourceDirs = [ "exe" ];
           mainPath = [ "Main.hs" ];
           };
+        "plc-mini" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "plc-mini" ];
+          mainPath = [ "Main.hs" ];
+          };
         };
       tests = {
         "plutus-core-test" = {

--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -229,6 +229,7 @@
           "Language/PlutusCore/Generators/NEAT/Common"
           "Language/PlutusCore/Generators/NEAT/Spec"
           "Language/PlutusCore/Generators/NEAT/Type"
+          "Language/PlutusCore/Generators/NEAT/Term"
           "Language/PlutusCore/Lexer"
           "Language/PlutusCore/Parser"
           "Language/PlutusCore/Error"
@@ -312,7 +313,7 @@
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             ];
           buildable = true;
-          modules = [ "Lang" "Parser" ];
+          modules = [ "Hutton" "Parser" ];
           hsSourceDirs = [ "plc-mini" ];
           mainPath = [ "Main.hs" ];
           };

--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -312,6 +312,7 @@
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             ];
           buildable = true;
+          modules = [ "Lang" "Parser" ];
           hsSourceDirs = [ "plc-mini" ];
           mainPath = [ "Main.hs" ];
           };

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Common.agda
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Common.agda
@@ -1,11 +1,26 @@
+{-| Description : Property based testing Name Utilities
+
+This file contains various naming related utilities used for
+generating Plutus Core types and terms.
+
+-}
+
+
+-- module Language.PlutusCore.Generators.NEAT.Common where
+
+module Language.PlutusCore.Generators.NEAT.Common where
+
+{-# FOREIGN AGDA2HS
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE EmptyCase           #-}
 {-# LANGUAGE EmptyDataDeriving   #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+#-}
 
-module Language.PlutusCore.Generators.NEAT.Common where
+
+{-# FOREIGN AGDA2HS
 
 --( Z
 --  , S (..)
@@ -25,12 +40,21 @@ import qualified Data.Stream               as Stream
 import qualified Data.Text                 as Text
 import           Language.PlutusCore.Name  (Name, TyName (..))
 import           Language.PlutusCore.Quote (MonadQuote (..), freshName)
+#-}
 
-data Z deriving (Typeable, Eq, Show)
+-- * Enumerating deBruijn indices
 
-data S n = FZ
-         | FS n
-             deriving (Typeable, Eq, Show, Functor)
+data Z : Set where
+
+{-# COMPILE AGDA2HS Z deriving (Typeable, Eq, Show) #-}
+
+data S (n : Set) : Set where
+  FZ : S n
+  FS : n → S n
+
+{-# COMPILE AGDA2HS S deriving (Typeable, Eq, Show, Functor) #-}
+
+{-# FOREIGN AGDA2HS
 
 instance Enumerable Z where
   enumerate = datatype []
@@ -89,4 +113,4 @@ mkTextNameStream prefix =
   Stream.map
     (\n -> prefix <> Text.pack (show n))
     (Stream.iterate (+1) (0 :: Integer))
-
+#-}

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
@@ -30,6 +30,7 @@ import           Language.PlutusCore
 import           Language.PlutusCore.Evaluation.Machine.Cek
 import           Language.PlutusCore.Evaluation.Machine.Ck
 import           Language.PlutusCore.Generators.NEAT.Common
+import           Language.PlutusCore.Generators.NEAT.Term
 import           Language.PlutusCore.Generators.NEAT.Type
 import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Pretty

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Term.hs
@@ -1,0 +1,317 @@
+{-# OPTIONS_GHC -fno-warn-orphans      #-}
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DeriveDataTypeable        #-}
+{-# LANGUAGE DeriveFunctor             #-}
+{-# LANGUAGE DerivingVia               #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TemplateHaskell           #-}
+
+module Language.PlutusCore.Generators.NEAT.Term where
+
+import           Language.PlutusCore.Generators.NEAT.Type
+
+import           Control.Enumerable
+import           Control.Monad.Except
+import           Data.Bifunctor.TH
+import           Data.Coolean                               (Cool, false, toCool, true, (&&&))
+import qualified Data.Stream                                as Stream
+import qualified Data.Text                                  as Text
+import           Language.PlutusCore
+import           Language.PlutusCore.Generators.NEAT.Common
+import           Text.Printf
+
+
+-- ** Enumerating terms
+data TermG tyname name
+    = VarG
+      name
+    | LamAbsG
+      (TermG tyname (S name))
+    | ApplyG
+      (TermG tyname name)
+      (TermG tyname name)
+      (TypeG tyname)
+    | TyAbsG
+      (TermG (S tyname) name)
+    | TyInstG
+      (TermG tyname name)
+      (TypeG (S tyname))
+      (TypeG tyname)
+      (Kind ())
+    deriving (Typeable, Eq, Show)
+
+deriveBifunctor ''TermG
+deriveEnumerable ''TermG
+
+type ClosedTermG = TermG Z Z
+
+-- * Converting types
+
+-- |Convert generated builtin types to Plutus builtin types.
+convertTypeBuiltin :: TypeBuiltinG -> Some (TypeIn DefaultUni)
+convertTypeBuiltin TyByteStringG = Some (TypeIn DefaultUniByteString)
+convertTypeBuiltin TyIntegerG    = Some (TypeIn DefaultUniInteger)
+convertTypeBuiltin TyStringG     = Some (TypeIn DefaultUniString)
+
+-- |Convert well-kinded generated types to Plutus types.
+--
+-- NOTE: Passes an explicit `TyNameState`, instead of using a State
+--       monad, as the type of the `TyNameState` changes throughout
+--       the computation.  Alternatively, this could be written using
+--       an indexed State monad.
+--
+-- NOTE: Roman points out that this is more like reader than state,
+--       however it doesn't fit easily into this pattern as the
+--       function `extTyNameState` is monadic (`MonadQuote`).
+convertType
+  :: (Show tyname, MonadQuote m, MonadError GenError m)
+  => TyNameState tyname -- ^ Type name environment with fresh name stream
+  -> Kind ()            -- ^ Kind of type below
+  -> TypeG tyname       -- ^ Type to convert
+  -> m (Type TyName DefaultUni ())
+convertType tns _ (TyVarG i) =
+  return (TyVar () (tynameOf tns i))
+convertType tns (Type _) (TyFunG ty1 ty2) =
+  TyFun () <$> convertType tns (Type ()) ty1 <*> convertType tns (Type ()) ty2
+convertType tns (Type _) (TyIFixG ty1 k ty2) =
+  TyIFix () <$> convertType tns k' ty1 <*> convertType tns k ty2
+  where
+    k' = KindArrow () (KindArrow () k (Type ())) (KindArrow () k (Type ()))
+convertType tns (Type _) (TyForallG k ty) = do
+  tns' <- extTyNameState tns
+  TyForall () (tynameOf tns' FZ) k <$> convertType tns' (Type ()) ty
+convertType _ _ (TyBuiltinG tyBuiltin) =
+  return (TyBuiltin () (convertTypeBuiltin tyBuiltin))
+convertType tns (KindArrow _ k1 k2) (TyLamG ty) = do
+  tns' <- extTyNameState tns
+  TyLam () (tynameOf tns' FZ) k1 <$> convertType tns' k2 ty
+convertType tns k2 (TyAppG ty1 ty2 k1) =
+  TyApp () <$> convertType tns (KindArrow () k1 k2) ty1 <*> convertType tns k1 ty2
+convertType _ k ty = throwError $ BadTypeG k ty
+
+-- |Convert generated closed types to Plutus types.
+convertClosedType
+  :: (MonadQuote m, MonadError GenError m)
+  => Stream.Stream Text.Text
+  -> Kind ()
+  -> ClosedTypeG
+  -> m (Type TyName DefaultUni ())
+convertClosedType tynames = convertType (emptyTyNameState tynames)
+
+
+-- ** Converting terms
+
+-- |Convert (well-typed) generated terms to Plutus terms.
+--
+-- NOTE: Passes an explicit `TyNameState` and `NameState`, instead of using a
+--       State monad, as the type of the `TyNameState` changes throughout the
+--       computation. This could be written using an indexed State monad.
+--
+--       No checking is performed during conversion. The type is given
+--       as it contains information needed to fully annotate a `Term`.
+--       `Term`, unlike `TermG`, contains all necessary type
+--       information to infer the type of the term. It is expected
+--       that this function is only called on a well-typed
+--       term. Violating this would point to an error in the
+--       generator/checker.
+convertTerm
+  :: (Show tyname, Show name, MonadQuote m, MonadError GenError m)
+  => TyNameState tyname -- ^ Type name environment with fresh name stream
+  -> NameState name     -- ^ Name environment with fresh name stream
+  -> TypeG tyname       -- ^ Type of term below
+  -> TermG tyname name  -- ^ Term to convert
+  -> m (Term TyName Name DefaultUni fun ())
+convertTerm _tns ns _ty (VarG i) =
+  return (Var () (nameOf ns i))
+convertTerm tns ns (TyFunG ty1 ty2) (LamAbsG tm) = do
+  ns' <- extNameState ns
+  ty1' <- convertType tns (Type ()) ty1
+  LamAbs () (nameOf ns' FZ) ty1' <$> convertTerm tns ns' ty2 tm
+convertTerm tns ns ty2 (ApplyG tm1 tm2 ty1) =
+  Apply () <$> convertTerm tns ns (TyFunG ty1 ty2) tm1 <*> convertTerm tns ns ty1 tm2
+convertTerm tns ns (TyForallG k ty) (TyAbsG tm) = do
+  tns' <- extTyNameState tns
+  TyAbs () (tynameOf tns' FZ) k <$> convertTerm tns' ns ty tm
+convertTerm tns ns _ (TyInstG tm cod ty k) =
+  TyInst () <$> convertTerm tns ns (TyForallG k cod) tm <*> convertType tns k ty
+convertTerm _ _ ty tm = throwError $ BadTermG ty tm
+
+-- |Convert generated closed terms to Plutus terms.
+convertClosedTerm
+  :: (MonadQuote m, MonadError GenError m)
+  => Stream.Stream Text.Text
+  -> Stream.Stream Text.Text
+  -> ClosedTypeG
+  -> ClosedTermG
+  -> m (Term TyName Name DefaultUni fun ())
+convertClosedTerm tynames names = convertTerm (emptyTyNameState tynames) (emptyNameState names)
+
+
+-- * Checking
+
+class Check t a where
+  check :: t -> a -> Cool
+
+
+-- ** Kind checking
+
+-- |Kind check builtin types.
+--
+-- NOTE: If we make |checkTypeBuiltinG| non-strict in its second argument,
+--       lazy-search will only ever return one of the various builtin types.
+--       Perhaps this is preferable?
+--
+instance Check (Kind ()) TypeBuiltinG where
+  check (Type _) TyByteStringG = true
+  check (Type _) TyIntegerG    = true
+  check (Type _) TyStringG     = true
+  check _        _             = false
+
+
+-- |Kind check types.
+checkKindG :: KCS n -> Kind () -> TypeG n -> Cool
+checkKindG kcs k (TyVarG i)
+  = varKindOk
+  where
+    varKindOk = toCool $ k == kindOf kcs i
+
+checkKindG kcs (Type _) (TyFunG ty1 ty2)
+  = ty1KindOk &&& ty2KindOk
+  where
+    ty1KindOk = checkKindG kcs (Type ()) ty1
+    ty2KindOk = checkKindG kcs (Type ()) ty2
+
+checkKindG kcs (Type _) (TyIFixG ty1 k ty2)
+  = ty1KindOk &&& ty2KindOk
+  where
+    ty1Kind   =
+      KindArrow () (KindArrow () k (Type ())) (KindArrow () k (Type ()))
+    ty1KindOk = checkKindG kcs ty1Kind ty1
+    ty2KindOk = checkKindG kcs k ty2
+
+checkKindG kcs (Type _) (TyForallG k body)
+  = tyKindOk
+  where
+    tyKindOk = checkKindG (extKCS k kcs) (Type ()) body
+
+checkKindG _ k (TyBuiltinG tyBuiltin)
+  = tyBuiltinKindOk
+  where
+    tyBuiltinKindOk = check k tyBuiltin
+
+checkKindG kcs (KindArrow () k1 k2) (TyLamG body)
+  = bodyKindOk
+  where
+    bodyKindOk = checkKindG (extKCS k1 kcs) k2 body
+
+checkKindG kcs k' (TyAppG ty1 ty2 k)
+  = ty1KindOk &&& ty2KindOk
+  where
+    ty1Kind   = KindArrow () k k'
+    ty1KindOk = checkKindG kcs ty1Kind ty1
+    ty2KindOk = checkKindG kcs k ty2
+
+checkKindG _ _ _ = false
+
+
+instance Check (Kind ()) ClosedTypeG where
+  check = checkKindG emptyKCS
+
+
+instance Check (Kind ()) (Normalized ClosedTypeG) where
+  check k ty = check k (unNormalized ty)
+
+
+-- ** Kind checking state
+
+newtype KCS tyname = KCS{ kindOf :: tyname -> Kind () }
+
+emptyKCS :: KCS Z
+emptyKCS = KCS{ kindOf = fromZ }
+
+extKCS :: forall tyname. Kind () -> KCS tyname -> KCS (S tyname)
+extKCS k KCS{..} = KCS{ kindOf = kindOf' }
+  where
+    kindOf' :: S tyname -> Kind ()
+    kindOf' FZ     = k
+    kindOf' (FS i) = kindOf i
+
+
+-- ** Type checking
+
+checkTypeG
+  :: Eq tyname
+  => KCS tyname
+  -> TCS tyname name
+  -> TypeG tyname
+  -> TermG tyname name
+  -> Cool
+checkTypeG _ tcs ty (VarG i)
+  = varTypeOk
+  where
+    varTypeOk = toCool $ ty == typeOf tcs i
+
+checkTypeG kcs tcs (TyForallG k ty) (TyAbsG tm)
+  = tmTypeOk
+  where
+    tmTypeOk = checkTypeG (extKCS k kcs) (firstTCS FS tcs) ty tm
+
+checkTypeG kcs tcs (TyFunG ty1 ty2) (LamAbsG tm)
+  = tyKindOk &&& tmTypeOk
+  where
+    tyKindOk = checkKindG kcs (Type ()) ty1
+    tmTypeOk = checkTypeG kcs (extTCS ty1 tcs) ty2 tm
+
+checkTypeG kcs tcs ty2 (ApplyG tm1 tm2 ty1)
+  = tm1TypeOk &&& tm2TypeOk
+  where
+    tm1TypeOk = checkTypeG kcs tcs (TyFunG ty1 ty2) tm1
+    tm2TypeOk = checkTypeG kcs tcs ty1 tm2
+
+checkTypeG kcs tcs vTy (TyInstG tm vCod ty k)
+  = tmTypeOk &&& tyKindOk &&& tyOk
+  where
+    tmTypeOk = checkTypeG kcs tcs (TyForallG k vCod) tm
+    tyKindOk = checkKindG kcs k ty
+    tyOk = vTy == normalizeTypeG (TyAppG (TyLamG vCod) ty k)
+
+checkTypeG _ _ _ _ = false
+
+instance Check ClosedTypeG ClosedTermG where
+  check = checkTypeG emptyKCS emptyTCS
+
+
+-- ** Type checking state
+
+newtype TCS tyname name = TCS{ typeOf :: name -> TypeG tyname }
+
+emptyTCS :: TCS tyname Z
+emptyTCS = TCS{ typeOf = fromZ }
+
+extTCS :: forall tyname name. TypeG tyname -> TCS tyname name -> TCS tyname (S name)
+extTCS ty TCS{..} = TCS{ typeOf = typeOf' }
+  where
+    typeOf' :: S name -> TypeG tyname
+    typeOf' FZ     = ty
+    typeOf' (FS i) = typeOf i
+
+firstTCS :: (tyname -> tyname') -> TCS tyname name -> TCS tyname' name
+firstTCS f tcs = TCS{ typeOf = fmap f . typeOf tcs }
+
+
+data GenError
+  = forall tyname. Show tyname => BadTypeG (Kind ()) (TypeG tyname)
+  | forall tyname name. (Show tyname, Show name) => BadTermG (TypeG tyname) (TermG tyname name)
+
+instance Show GenError where
+  show (BadTypeG k ty) =
+    printf "Test generation error: convert type %s at kind %s" (show ty) (show k)
+  show (BadTermG ty tm) =
+    printf "Test generation error: convert term %s at type %s" (show tm) (show ty)
+

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Type.agda
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Type.agda
@@ -26,13 +26,8 @@ module Language.PlutusCore.Generators.NEAT.Type where
 
 import           Control.Enumerable
 import           Control.Monad.Except
-import           Data.Bifunctor.TH
-import           Data.Coolean                               (Cool, false, toCool, true, (&&&))
-import qualified Data.Stream                                as Stream
-import qualified Data.Text                                  as Text
 import           Language.PlutusCore
 import           Language.PlutusCore.Generators.NEAT.Common
-import           Text.Printf
 
 #-}
 
@@ -78,7 +73,7 @@ data TypeG (n : Set) : Set where
 -- switched off deriving Functor
 
 ext : (m → n) → S m → S n
-ext f FZ     = FZ
+ext _ FZ     = FZ
 ext f (FS x) = FS (f x)
 
 {-# COMPILE AGDA2HS ext #-}
@@ -88,7 +83,7 @@ ren f (TyVarG x) = TyVarG (f x)
 ren f (TyFunG ty1 ty2) = TyFunG (ren f ty1) (ren f ty2)
 ren f (TyIFixG ty1 k ty2) = TyIFixG (ren f ty1) k (ren f ty2)
 ren f (TyForallG k ty) = TyForallG k (ren (ext f) ty)
-ren f (TyBuiltinG b) = TyBuiltinG b
+ren _ (TyBuiltinG b) = TyBuiltinG b
 ren f (TyLamG ty) = TyLamG (ren (ext f) ty)
 ren f (TyAppG ty1 ty2 k) = TyAppG (ren f ty1) (ren f ty2) k
 

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Type.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Type.hs
@@ -30,17 +30,8 @@ module Language.PlutusCore.Generators.NEAT.Type where
 
 import           Control.Enumerable
 import           Control.Monad.Except
-import           Data.Bifunctor.TH
-import           Data.Coolean                               (Cool, false, toCool, true, (&&&))
-import qualified Data.Stream                                as Stream
-import qualified Data.Text                                  as Text
 import           Language.PlutusCore
 import           Language.PlutusCore.Generators.NEAT.Common
-import           Text.Printf
-
-newtype Neutral a = Neutral
-  { unNeutral :: a
-  }
 
 data TypeBuiltinG = TyByteStringG
                   | TyIntegerG
@@ -59,7 +50,7 @@ data TypeG n = TyVarG n
                  deriving (Typeable, Eq, Show)
 
 ext :: (m -> n) -> S m -> S n
-ext f FZ     = FZ
+ext _ FZ     = FZ
 ext f (FS x) = FS (f x)
 
 ren :: (m -> n) -> TypeG m -> TypeG n
@@ -67,12 +58,16 @@ ren f (TyVarG x)          = TyVarG (f x)
 ren f (TyFunG ty1 ty2)    = TyFunG (ren f ty1) (ren f ty2)
 ren f (TyIFixG ty1 k ty2) = TyIFixG (ren f ty1) k (ren f ty2)
 ren f (TyForallG k ty)    = TyForallG k (ren (ext f) ty)
-ren f (TyBuiltinG b)      = TyBuiltinG b
+ren _ (TyBuiltinG b)      = TyBuiltinG b
 ren f (TyLamG ty)         = TyLamG (ren (ext f) ty)
 ren f (TyAppG ty1 ty2 k)  = TyAppG (ren f ty1) (ren f ty2) k
 
 instance Functor TypeG where
   fmap = ren
+
+newtype Neutral a = Neutral
+  { unNeutral :: a
+  }
 
 deriveEnumerable ''Kind
 

--- a/plutus-core/plc-mini/Hutton.agda
+++ b/plutus-core/plc-mini/Hutton.agda
@@ -27,17 +27,39 @@ variable
 
 -- an equational presentation of the semantics of the language
 data _≃_ : Exp → Exp → Set where
+  -- it's an equivalence relation
   reflE : e ≃ e
-  symE  : e1 ≃ e2 → e2 ≃ e1
-  transE : e1 ≃ e2 → e2 ≃ e3 → e1 ≃ e3
+  
+  symE  : e1 ≃ e2
+          -------
+        → e2 ≃ e1
+        
+  transE : e1 ≃ e2
+         → e2 ≃ e3
+           -------
+         → e1 ≃ e3
 
-  congE : e1 ≃ e2 → e3 ≃ e4 → Add e1 e3 ≃ Add e2 e4
+  -- it's a congruence
+  congE : e1 ≃ e2
+        → e3 ≃ e4
+          ---------------------
+        → Add e1 e3 ≃ Add e2 e4
 
+  -- some monoid laws (probably redundant)
+  
+          ------------------
   lunit : Add (Val 0) e ≃ e
+
+          -----------------
   runit : Add e (Val 0) ≃ e
+
+          ---------------------------------------
   assoc : Add (Add e1 e2) e3 ≃ Add e1 (Add e2 e3)
 
-  β     : ∀ n n' → Add (Val n) (Val n') ≃ Val (n + n')
+  -- computation rule
+  β     : ∀ n n'
+          -----------------------------------
+        → Add (Val n) (Val n') ≃ Val (n + n')
 
 open import Relation.Binary.PropositionalEquality
 open import Data.Nat.Properties
@@ -46,14 +68,15 @@ open import Data.Nat.Properties
 
 -- soundness
 eval-correct1 : e1 ≃ e2 → eval e1 ≡ eval e2
-eval-correct1 reflE = refl
-eval-correct1 (symE p) = sym (eval-correct1 p)
-eval-correct1 (transE p q) = trans (eval-correct1 p) (eval-correct1 q)
-eval-correct1 (congE p q) = cong₂ _+_ (eval-correct1 p) (eval-correct1 q)
-eval-correct1 lunit = refl
-eval-correct1 runit = +-identityʳ _
+eval-correct1 reflE             = refl
+eval-correct1 (symE p)          = sym (eval-correct1 p)
+eval-correct1 (transE p q)      = trans (eval-correct1 p) (eval-correct1 q)
+eval-correct1 (congE p q)       =
+  cong₂ _+_ (eval-correct1 p) (eval-correct1 q)
+eval-correct1 lunit             = refl
+eval-correct1 runit             = +-identityʳ _
 eval-correct1 (assoc {e1 = e1}) = +-assoc (eval e1) _ _
-eval-correct1 (β n n') = refl
+eval-correct1 (β n n')          = refl
 
 --completeness
 eval-correct2 : ∀ e → e ≃ Val (eval e)

--- a/plutus-core/plc-mini/Hutton.agda
+++ b/plutus-core/plc-mini/Hutton.agda
@@ -1,4 +1,4 @@
-module Lang where
+module Hutton where
 
 -- import the Ulf's Agdaized version of the Haskell prelude
 open import Haskell.Prelude hiding (e)
@@ -10,10 +10,6 @@ data Exp  : Set where
   Add : Exp → Exp → Exp
 
 {-# COMPILE AGDA2HS Exp deriving Show #-}
-
--- we postulate an instance for Show don't need it in Agda, just Haskell
-instance
-  postulate expShow : Show Exp
 
 -- a simple evaluator for Exp
 

--- a/plutus-core/plc-mini/Hutton.agda
+++ b/plutus-core/plc-mini/Hutton.agda
@@ -25,7 +25,7 @@ eval (Add e1 e2) = eval e1 + eval e2
 variable
   e e1 e2 e3 e4 : Exp
 
--- and equational presentation of the semantics of the language
+-- an equational presentation of the semantics of the language
 data _≃_ : Exp → Exp → Set where
   reflE : e ≃ e
   symE  : e1 ≃ e2 → e2 ≃ e1

--- a/plutus-core/plc-mini/Hutton.hs
+++ b/plutus-core/plc-mini/Hutton.hs
@@ -1,4 +1,4 @@
-module Lang where
+module Hutton where
 
 import           Numeric.Natural (Natural)
 

--- a/plutus-core/plc-mini/Lambda.agda
+++ b/plutus-core/plc-mini/Lambda.agda
@@ -1,0 +1,96 @@
+module Lambda where
+
+{-# FOREIGN AGDA2HS 
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+#-}
+
+
+-- import the Ulf's Agdaized version of the Haskell prelude
+open import Haskell.Prelude hiding (e)
+
+-- The syntax, nats and addition, aka Hutton's Razor
+
+data Tm (a : Set) : Set where
+  Lam : Tm (Maybe a) → Tm a
+  App : Tm a → Tm a → Tm a
+  Var : a → Tm a
+  Val : Nat → Tm a
+  Add : Tm a → Tm a → Tm a
+
+{-# COMPILE AGDA2HS Tm deriving Show #-}
+
+-- we postulate an instance for Show don't need it in Agda, just Haskell
+instance
+  postulate tmShow : Show (Tm a)
+
+ext : {a b : Set} → (a → b) → Maybe a → Maybe b
+ext ρ Nothing  = Nothing
+ext ρ (Just x) = Just (ρ x)
+
+{-# COMPILE AGDA2HS ext #-}
+
+ren : (a → b) → Tm a → Tm b
+ren ρ (Lam t)   = Lam (ren (ext ρ) t)
+ren ρ (App t u) = App (ren ρ t) (ren ρ u)
+ren ρ (Var x)   = Var (ρ x)
+ren ρ (Val n)   = Val n
+ren ρ (Add t u) = Add (ren ρ t) (ren ρ u)
+
+{-# COMPILE AGDA2HS ren #-}
+
+exts : (a → Tm b) → Maybe a → Tm (Maybe b)
+exts σ Nothing  = Var Nothing
+exts σ (Just x) = ren Just (σ x)
+
+{-# COMPILE AGDA2HS exts #-}
+
+sub : (a → Tm b) → Tm a → Tm b
+sub σ (Lam t)   = Lam (sub (exts σ) t)
+sub σ (App t u) = App (sub σ t) (sub σ u)
+sub σ (Var x)   = σ x
+sub σ (Val n)   = Val n
+sub σ (Add t u) = Add (sub σ t) (sub σ u)
+
+{-# COMPILE AGDA2HS sub #-}
+
+-- correctness of substitution
+
+
+sub1 : Tm (Maybe a) → Tm a → Tm a
+sub1 t u = sub (λ where (Just x) → Var x; Nothing → u) t
+
+{-# COMPILE AGDA2HS sub1 #-}
+
+data Empty : Set where
+
+{-# COMPILE AGDA2HS Empty deriving Show #-}
+
+step : Tm Empty → Maybe (Tm Empty)
+step (Lam t)               = Nothing
+step (App (Lam t) u)       = Just (sub1 t u) 
+step (App t u)             = fmap (λ t → App t u) (step t)
+step (Val n)               = Nothing
+step (Add (Val m) (Val n)) = Just (Val (m + n))
+step (Add (Val m) u)       = fmap (Add (Val m)) (step u)
+step (Add t u)             = fmap (λ t → Add t u) (step t)
+
+{-# COMPILE AGDA2HS step #-}
+
+data Gas : Set where
+  Z : Gas
+  S : Gas → Gas
+
+{-# COMPILE AGDA2HS Gas #-}
+
+stepper : Gas → Tm Empty → Maybe (Tm Empty)
+stepper Z     t = Nothing -- out of gas
+stepper (S n) t = maybe (Just t) (stepper n) (step t)
+
+{-# COMPILE AGDA2HS stepper #-}
+
+ex : Tm Empty
+ex = App (Lam (Add (Val 2) (Var Nothing))) (Val 2)
+
+{-# COMPILE AGDA2HS ex #-}

--- a/plutus-core/plc-mini/Lambda.hs
+++ b/plutus-core/plc-mini/Lambda.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE EmptyDataDecls    #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE LambdaCase        #-}
+
+module Lambda where
+
+import           Numeric.Natural (Natural)
+
+data Tm a = Lam (Tm (Maybe a))
+          | App (Tm a) (Tm a)
+          | Var a
+          | Val Natural
+          | Add (Tm a) (Tm a)
+              deriving Show
+
+ext :: (a -> b) -> Maybe a -> Maybe b
+ext ρ Nothing  = Nothing
+ext ρ (Just x) = Just (ρ x)
+
+ren :: (a -> b) -> Tm a -> Tm b
+ren ρ (Lam t)   = Lam (ren (ext ρ) t)
+ren ρ (App t u) = App (ren ρ t) (ren ρ u)
+ren ρ (Var x)   = Var (ρ x)
+ren ρ (Val n)   = Val n
+ren ρ (Add t u) = Add (ren ρ t) (ren ρ u)
+
+exts :: (a -> Tm b) -> Maybe a -> Tm (Maybe b)
+exts σ Nothing  = Var Nothing
+exts σ (Just x) = ren Just (σ x)
+
+sub :: (a -> Tm b) -> Tm a -> Tm b
+sub σ (Lam t)   = Lam (sub (exts σ) t)
+sub σ (App t u) = App (sub σ t) (sub σ u)
+sub σ (Var x)   = σ x
+sub σ (Val n)   = Val n
+sub σ (Add t u) = Add (sub σ t) (sub σ u)
+
+sub1 :: Tm (Maybe a) -> Tm a -> Tm a
+sub1 t u
+  = sub
+      (\case
+           Just x  -> Var x
+           Nothing -> u)
+      t
+
+data Empty deriving Show
+
+step :: Tm Empty -> Maybe (Tm Empty)
+step (Lam t)               = Nothing
+step (App (Lam t) u)       = Just (sub1 t u)
+step (App t u)             = fmap (\ t -> App t u) (step t)
+step (Val n)               = Nothing
+step (Add (Val m) (Val n)) = Just (Val (m + n))
+step (Add (Val m) u)       = fmap (Add (Val m)) (step u)
+step (Add t u)             = fmap (\ t -> Add t u) (step t)
+step (Var x)               = error "step: impossible"
+
+data Gas = Z
+         | S Gas
+
+stepper :: Gas -> Tm Empty -> Maybe (Tm Empty)
+stepper Z t     = Nothing
+stepper (S n) t = maybe (Just t) (stepper n) (step t)
+
+ex :: Tm Empty
+ex = App (Lam (Add (Val 2) (Var Nothing))) (Val 2)
+

--- a/plutus-core/plc-mini/Lambda.hs
+++ b/plutus-core/plc-mini/Lambda.hs
@@ -14,8 +14,7 @@ data Tm a = Lam (Tm (Maybe a))
               deriving Show
 
 ext :: (a -> b) -> Maybe a -> Maybe b
-ext ρ Nothing  = Nothing
-ext ρ (Just x) = Just (ρ x)
+ext = fmap
 
 ren :: (a -> b) -> Tm a -> Tm b
 ren ρ (Lam t)   = Lam (ren (ext ρ) t)

--- a/plutus-core/plc-mini/Lang.agda
+++ b/plutus-core/plc-mini/Lang.agda
@@ -1,0 +1,59 @@
+module Lang where
+
+open import Haskell.Prelude hiding (e)
+
+data Exp (a : Set) : Set where
+  Val : Nat → Exp a
+  Var : a → Exp a
+  Add : Exp a → Exp a → Exp a
+
+variable
+  e e1 e2 e3 e4 : Exp a
+
+instance
+  postulate
+    expShow : ⦃ Show a ⦄ → Show (Exp a)
+
+{-# COMPILE AGDA2HS Exp deriving Show #-}
+
+eval : (a -> Nat) -> Exp a -> Nat
+eval η (Var x) = η x
+eval η (Val n) = n
+eval η (Add e1 e2) = eval η e1 + eval η e2
+
+{-# COMPILE AGDA2HS eval #-}
+
+-- Equational Specification
+
+data _≃_ : Exp a → Exp a → Set where
+  reflE : e ≃ e
+  symE  : e1 ≃ e2 → e2 ≃ e1
+  transE : e1 ≃ e2 → e2 ≃ e3 → e1 ≃ e3
+
+  congE : e1 ≃ e2 → e3 ≃ e4 → Add e1 e3 ≃ Add e2 e4
+
+  lunit : Add (Val 0) e ≃ e
+  runit : Add e (Val 0) ≃ e
+  assoc : Add (Add e1 e2) e3 ≃ Add e1 (Add e2 e3)
+
+open import Relation.Binary.PropositionalEquality
+open import Data.Nat.Properties
+
+-- Proof that eval implmenents the spec
+
+eval-correct1 : ∀ η → e1 ≃ e2 → eval η e1 ≡ eval η e2
+eval-correct1 η reflE = refl
+eval-correct1 η (symE p) = sym (eval-correct1 η p)
+eval-correct1 η (transE p q) = trans (eval-correct1 η p) (eval-correct1 η q)
+eval-correct1 η (congE p q) = cong₂ _+_ (eval-correct1 η p) (eval-correct1 η q)
+eval-correct1 η lunit = refl
+eval-correct1 η runit = +-identityʳ _
+eval-correct1 η (assoc {e1 = e1}{e2}{e3}) = +-assoc (eval η e1) (eval η e2) (eval η e3)
+
+
+-- stability
+eval-correct2 : ∀ (η : a → Nat) n → eval η (Val n) ≡ n
+eval-correct2 η n = refl
+
+eval-correct3 : ∀ (η : a → Nat) x → eval η (Var x) ≡ η x
+eval-correct3 η n = refl

--- a/plutus-core/plc-mini/Lang.agda
+++ b/plutus-core/plc-mini/Lang.agda
@@ -1,19 +1,21 @@
 module Lang where
 
+-- import the Ulf's Agdaized version of the Haskell prelude
 open import Haskell.Prelude hiding (e)
+
+-- The syntax, nats and addition, aka Hutton's Razor
 
 data Exp  : Set where
   Val : Nat → Exp
   Add : Exp → Exp → Exp
 
-variable
-  e e1 e2 e3 e4 : Exp
-
-instance
-  postulate
-    expShow : Show Exp
-
 {-# COMPILE AGDA2HS Exp deriving Show #-}
+
+-- we postulate an instance for Show don't need it in Agda, just Haskell
+instance
+  postulate expShow : Show Exp
+
+-- a simple evaluator for Exp
 
 eval : Exp -> Nat
 eval (Val n) = n
@@ -21,8 +23,13 @@ eval (Add e1 e2) = eval e1 + eval e2
 
 {-# COMPILE AGDA2HS eval #-}
 
--- Equational Specification
+-- that's it, below is a specification and some proofs
 
+-- we introduce these variables names so we don't have to quantify over them
+variable
+  e e1 e2 e3 e4 : Exp
+
+-- and equational presentation of the semantics of the language
 data _≃_ : Exp → Exp → Set where
   reflE : e ≃ e
   symE  : e1 ≃ e2 → e2 ≃ e1
@@ -39,7 +46,7 @@ data _≃_ : Exp → Exp → Set where
 open import Relation.Binary.PropositionalEquality
 open import Data.Nat.Properties
 
--- Proof that eval implmenents the spec
+-- Proofs that eval implements the spec
 
 -- soundness
 eval-correct1 : e1 ≃ e2 → eval e1 ≡ eval e2

--- a/plutus-core/plc-mini/Lang.agda
+++ b/plutus-core/plc-mini/Lang.agda
@@ -2,30 +2,28 @@ module Lang where
 
 open import Haskell.Prelude hiding (e)
 
-data Exp (a : Set) : Set where
-  Val : Nat → Exp a
-  Var : a → Exp a
-  Add : Exp a → Exp a → Exp a
+data Exp  : Set where
+  Val : Nat → Exp
+  Add : Exp → Exp → Exp
 
 variable
-  e e1 e2 e3 e4 : Exp a
+  e e1 e2 e3 e4 : Exp
 
 instance
   postulate
-    expShow : ⦃ Show a ⦄ → Show (Exp a)
+    expShow : Show Exp
 
 {-# COMPILE AGDA2HS Exp deriving Show #-}
 
-eval : (a -> Nat) -> Exp a -> Nat
-eval η (Var x) = η x
-eval η (Val n) = n
-eval η (Add e1 e2) = eval η e1 + eval η e2
+eval : Exp -> Nat
+eval (Val n) = n
+eval (Add e1 e2) = eval e1 + eval e2
 
 {-# COMPILE AGDA2HS eval #-}
 
 -- Equational Specification
 
-data _≃_ : Exp a → Exp a → Set where
+data _≃_ : Exp → Exp → Set where
   reflE : e ≃ e
   symE  : e1 ≃ e2 → e2 ≃ e1
   transE : e1 ≃ e2 → e2 ≃ e3 → e1 ≃ e3
@@ -36,24 +34,31 @@ data _≃_ : Exp a → Exp a → Set where
   runit : Add e (Val 0) ≃ e
   assoc : Add (Add e1 e2) e3 ≃ Add e1 (Add e2 e3)
 
+  β     : ∀ n n' → Add (Val n) (Val n') ≃ Val (n + n')
+
 open import Relation.Binary.PropositionalEquality
 open import Data.Nat.Properties
 
 -- Proof that eval implmenents the spec
 
-eval-correct1 : ∀ η → e1 ≃ e2 → eval η e1 ≡ eval η e2
-eval-correct1 η reflE = refl
-eval-correct1 η (symE p) = sym (eval-correct1 η p)
-eval-correct1 η (transE p q) = trans (eval-correct1 η p) (eval-correct1 η q)
-eval-correct1 η (congE p q) = cong₂ _+_ (eval-correct1 η p) (eval-correct1 η q)
-eval-correct1 η lunit = refl
-eval-correct1 η runit = +-identityʳ _
-eval-correct1 η (assoc {e1 = e1}{e2}{e3}) = +-assoc (eval η e1) (eval η e2) (eval η e3)
+-- soundness
+eval-correct1 : e1 ≃ e2 → eval e1 ≡ eval e2
+eval-correct1 reflE = refl
+eval-correct1 (symE p) = sym (eval-correct1 p)
+eval-correct1 (transE p q) = trans (eval-correct1 p) (eval-correct1 q)
+eval-correct1 (congE p q) = cong₂ _+_ (eval-correct1 p) (eval-correct1 q)
+eval-correct1 lunit = refl
+eval-correct1 runit = +-identityʳ _
+eval-correct1 (assoc {e1 = e1}) = +-assoc (eval e1) _ _
+eval-correct1 (β n n') = refl
 
+--completeness
+eval-correct2 : ∀ e → e ≃ Val (eval e)
+eval-correct2 (Val n)     = reflE
+eval-correct2 (Add e1 e2) = transE
+  (congE (eval-correct2 e1) (eval-correct2 e2))
+  (β (eval e1) (eval e2))
 
 -- stability
-eval-correct2 : ∀ (η : a → Nat) n → eval η (Val n) ≡ n
-eval-correct2 η n = refl
-
-eval-correct3 : ∀ (η : a → Nat) x → eval η (Var x) ≡ η x
-eval-correct3 η n = refl
+eval-correct3 : ∀ n → eval (Val n) ≡ n
+eval-correct3 n = refl

--- a/plutus-core/plc-mini/Lang.hs
+++ b/plutus-core/plc-mini/Lang.hs
@@ -1,0 +1,14 @@
+module Lang where
+
+import           Numeric.Natural (Natural)
+
+data Exp a = Val Natural
+           | Var a
+           | Add (Exp a) (Exp a)
+               deriving Show
+
+eval :: (a -> Natural) -> Exp a -> Natural
+eval η (Var x)     = η x
+eval η (Val n)     = n
+eval η (Add e1 e2) = eval η e1 + eval η e2
+

--- a/plutus-core/plc-mini/Lang.hs
+++ b/plutus-core/plc-mini/Lang.hs
@@ -2,13 +2,11 @@ module Lang where
 
 import           Numeric.Natural (Natural)
 
-data Exp a = Val Natural
-           | Var a
-           | Add (Exp a) (Exp a)
-               deriving Show
+data Exp = Val Natural
+         | Add Exp Exp
+             deriving Show
 
-eval :: (a -> Natural) -> Exp a -> Natural
-eval η (Var x)     = η x
-eval η (Val n)     = n
-eval η (Add e1 e2) = eval η e1 + eval η e2
+eval :: Exp -> Natural
+eval (Val n)     = n
+eval (Add e1 e2) = eval e1 + eval e2
 

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -3,13 +3,15 @@ module Main where
 open import Haskell.Prelude hiding (_>>=_; _>>_; return)
 
 open import Lang
-{-# FOREIGN AGDA2HS import Lang #-}
 
-{-# FOREIGN AGDA2HS import Parser #-}
-{-# FOREIGN AGDA2HS import Prelude hiding (getContents) #-}
-{-# FOREIGN AGDA2HS import Data.ByteString.Lazy (getContents) #-}
+{-# FOREIGN AGDA2HS 
+import Lang
+import Parser
+import Prelude hiding (getContents)
+import Data.ByteString.Lazy (getContents)
+#-}
 
-
+-- IO and friends are not in the prelude yet...
 postulate
   IO : Set → Set
   _>>=_ : ∀{a b} → IO a → (a → IO b) → IO b
@@ -17,12 +19,13 @@ postulate
   return : ∀{a} → a → IO a
   putStrLn : String → IO ⊤
 
-
   ByteString : Set
   getContents : IO ByteString
   parse : ByteString → Maybe Exp
   pretty : Exp → String
 
+
+-- do would be nicer...
 main : IO ⊤
 main = getContents >>= \b -> maybe
   (putStrLn "parse error")

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -20,12 +20,12 @@ postulate
 
   ByteString : Set
   getContents : IO ByteString
-  parse : ByteString → Maybe (Exp String)
+  parse : ByteString → Maybe Exp
 
 main : IO ⊤
 main = getContents >>= \b -> maybe
   (putStrLn "parse error")
-  (λ e → putStrLn (show e) >> putStrLn (show (eval (λ _ → 0) e)))
+  (λ e → putStrLn (show e) >> putStrLn (show (eval e)))
   (parse b)
 
 {-# COMPILE AGDA2HS main #-}

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -2,10 +2,10 @@ module Main where
 
 open import Haskell.Prelude hiding (_>>=_; _>>_; return)
 
-open import Lang
+open import Hutton
 
 {-# FOREIGN AGDA2HS 
-import Lang
+import Hutton
 import Parser
 import Prelude hiding (getContents)
 import Data.ByteString.Lazy (getContents)

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -21,11 +21,12 @@ postulate
   ByteString : Set
   getContents : IO ByteString
   parse : ByteString → Maybe Exp
+  pretty : Exp → String
 
 main : IO ⊤
 main = getContents >>= \b -> maybe
   (putStrLn "parse error")
-  (λ e → putStrLn (show e) >> putStrLn (show (eval e)))
+  (putStrLn ∘ pretty ∘ Val ∘ eval)
   (parse b)
 
 {-# COMPILE AGDA2HS main #-}

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -21,7 +21,7 @@ postulate
 
   ByteString : Set
   getContents : IO ByteString
-  parse : ByteString → Maybe Exp
+  parseExp : ByteString → Maybe Exp
   pretty : Exp → String
 
 
@@ -30,7 +30,7 @@ main : IO ⊤
 main = getContents >>= \b -> maybe
   (putStrLn "parse error")
   (putStrLn ∘ pretty ∘ Val ∘ eval)
-  (parse b)
+  (parseExp b)
 
 {-# COMPILE AGDA2HS main #-}
 

--- a/plutus-core/plc-mini/Main.agda
+++ b/plutus-core/plc-mini/Main.agda
@@ -1,0 +1,33 @@
+module Main where
+
+open import Haskell.Prelude hiding (_>>=_; _>>_; return)
+
+open import Lang
+{-# FOREIGN AGDA2HS import Lang #-}
+
+{-# FOREIGN AGDA2HS import Parser #-}
+{-# FOREIGN AGDA2HS import Prelude hiding (getContents) #-}
+{-# FOREIGN AGDA2HS import Data.ByteString.Lazy (getContents) #-}
+
+
+postulate
+  IO : Set → Set
+  _>>=_ : ∀{a b} → IO a → (a → IO b) → IO b
+  _>>_ : ∀{a} → IO a → IO a → IO a
+  return : ∀{a} → a → IO a
+  putStrLn : String → IO ⊤
+
+
+  ByteString : Set
+  getContents : IO ByteString
+  parse : ByteString → Maybe (Exp String)
+
+main : IO ⊤
+main = getContents >>= \b -> maybe
+  (putStrLn "parse error")
+  (λ e → putStrLn (show e) >> putStrLn (show (eval (λ _ → 0) e)))
+  (parse b)
+
+{-# COMPILE AGDA2HS main #-}
+
+

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -1,12 +1,9 @@
 module Main where
 
-import           Lang
-
-import           Parser
-
-import           Prelude              hiding (getContents)
-
 import           Data.ByteString.Lazy (getContents)
+import           Lang
+import           Parser
+import           Prelude              hiding (getContents)
 
 main :: IO ()
 main

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -12,8 +12,6 @@ main :: IO ()
 main
   = getContents >>=
       \ b ->
-        maybe (putStrLn "parse error")
-          (\ e ->
-             putStrLn (showsPrec 0 e "") >> putStrLn (showsPrec 0 (eval e) ""))
+        maybe (putStrLn "parse error") (putStrLn . pretty . Val . eval)
           (parse b)
 

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -1,0 +1,20 @@
+module Main where
+
+import           Lang
+
+import           Parser
+
+import           Prelude              hiding (getContents)
+
+import           Data.ByteString.Lazy (getContents)
+
+main :: IO ()
+main
+  = getContents >>=
+      \ b ->
+        maybe (putStrLn "parse error")
+          (\ e ->
+             putStrLn (showsPrec 0 e "") >>
+               putStrLn (showsPrec 0 (eval (\ _ -> 0) e) ""))
+          (parse b)
+

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -10,5 +10,5 @@ main
   = getContents >>=
       \ b ->
         maybe (putStrLn "parse error") (putStrLn . pretty . Val . eval)
-          (parse b)
+          (parseExp b)
 

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -14,7 +14,6 @@ main
       \ b ->
         maybe (putStrLn "parse error")
           (\ e ->
-             putStrLn (showsPrec 0 e "") >>
-               putStrLn (showsPrec 0 (eval (\ _ -> 0) e) ""))
+             putStrLn (showsPrec 0 e "") >> putStrLn (showsPrec 0 (eval e) ""))
           (parse b)
 

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import           Data.ByteString.Lazy (getContents)
-import           Lang
+import           Hutton
 import           Parser
 import           Prelude              hiding (getContents)
 

--- a/plutus-core/plc-mini/Main.hs
+++ b/plutus-core/plc-mini/Main.hs
@@ -1,14 +1,19 @@
 module Main where
 
 import           Data.ByteString.Lazy (getContents)
-import           Hutton
-import           Parser
+import           Lambda
+import           ParserL
 import           Prelude              hiding (getContents)
 
 main :: IO ()
 main
   = getContents >>=
       \ b ->
-        maybe (putStrLn "parse error") (putStrLn . pretty . Val . eval)
+        case parse b of
+          Nothing -> putStrLn "parse error"
+          Just t -> case stepper (S . S . S $ Z) t of
+            Just t' -> putStrLn . pretty $ t'
+            Nothing -> putStrLn "runtime error"
+{-        maybe (putStrLn "parse error") (putStrLn . pretty . Val . eval)
           (parseExp b)
-
+-}

--- a/plutus-core/plc-mini/Parser.hs
+++ b/plutus-core/plc-mini/Parser.hs
@@ -17,7 +17,7 @@ type Prog = Language.PlutusCore.Program TyName Name DefaultUni DefaultFun Langua
 
 
 
-convCon :: Some (ValueOf DefaultUni) -> Maybe (Exp String)
+convCon :: Some (ValueOf DefaultUni) -> Maybe Exp
 convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 = Just $ Val (fromInteger i)
 convCon _ = Nothing
 
@@ -33,7 +33,7 @@ convTm _ = Nothing
 parseProg :: BSL.ByteString -> Either (ParseError ()) Prog
 parseProg = first (() <$) . runQuote . runExceptT . parseProgram
 
-parse :: BSL.ByteString -> Maybe (Exp String)
+parse :: BSL.ByteString -> Maybe Exp
 parse b = case parseProg b of
   Left _  -> Nothing
   Right p -> conv p

--- a/plutus-core/plc-mini/Parser.hs
+++ b/plutus-core/plc-mini/Parser.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE GADTs #-}
+
+module Parser where
+
+import           Lang
+
+import           Language.PlutusCore
+import qualified Language.PlutusCore.Lexer
+import qualified Language.PlutusCore.Parser
+
+import           Control.Monad.Trans.Except
+import           Data.Bifunctor
+import qualified Data.ByteString.Lazy       as BSL
+import           Numeric.Natural
+
+type Prog = Language.PlutusCore.Program TyName Name DefaultUni DefaultFun Language.PlutusCore.Lexer.AlexPosn
+
+
+
+convCon :: Some (ValueOf DefaultUni) -> Maybe (Exp String)
+convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 = Just $ Val (fromInteger i)
+convCon _ = Nothing
+
+conv (Program _ _ t) = convTm t
+
+convTm (Constant _ c) = convCon c
+convTm (Apply _ (Apply _ (Builtin _ AddInteger) t) u) = do
+  e1 <- convTm t
+  e2 <- convTm u
+  return $ Add e1 e2
+convTm _ = Nothing
+
+parseProg :: BSL.ByteString -> Either (ParseError ()) Prog
+parseProg = first (() <$) . runQuote . runExceptT . parseProgram
+
+parse :: BSL.ByteString -> Maybe (Exp String)
+parse b = case parseProg b of
+  Left _  -> Nothing
+  Right p -> conv p

--- a/plutus-core/plc-mini/Parser.hs
+++ b/plutus-core/plc-mini/Parser.hs
@@ -5,18 +5,17 @@ module Parser where
 import           Lang
 
 import           Language.PlutusCore
-import qualified Language.PlutusCore.Lexer
-import qualified Language.PlutusCore.Parser
+import           Language.PlutusCore.Lexer
+import           Language.PlutusCore.Parser
+import           Language.PlutusCore.Pretty
 
 import           Control.Monad.Trans.Except
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy       as BSL
 import           Numeric.Natural
 
-type Prog = Language.PlutusCore.Program TyName Name DefaultUni DefaultFun Language.PlutusCore.Lexer.AlexPosn
-
-
-
+type Prog = Program TyName Name DefaultUni DefaultFun AlexPosn
+type Tm   = Term TyName Name DefaultUni DefaultFun ()
 convCon :: Some (ValueOf DefaultUni) -> Maybe Exp
 convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 = Just $ Val (fromInteger i)
 convCon _ = Nothing
@@ -37,3 +36,13 @@ parse :: BSL.ByteString -> Maybe Exp
 parse b = case parseProg b of
   Left _  -> Nothing
   Right p -> conv p
+
+-- pretty printer
+
+unconv :: Exp -> Tm
+unconv (Val n) = Constant () (Some (ValueOf DefaultUniInteger (toInteger n)))
+unconv (Add e1 e2) =
+  Apply () (Apply () (Builtin () AddInteger) (unconv e1)) (unconv e2)
+
+pretty :: Exp -> String
+pretty e = display $ unconv e

--- a/plutus-core/plc-mini/Parser.hs
+++ b/plutus-core/plc-mini/Parser.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GADTs #-}
 
+-- This module wraps the PLC parser and pretty printer
+
 module Parser where
 
 import           Lang
@@ -16,8 +18,12 @@ import           Numeric.Natural
 
 type Prog = Program TyName Name DefaultUni DefaultFun AlexPosn
 type Tm   = Term TyName Name DefaultUni DefaultFun ()
+
+-- parser
+
 convCon :: Some (ValueOf DefaultUni) -> Maybe Exp
-convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 = Just $ Val (fromInteger i)
+convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 =
+  Just $ Val (fromInteger i)
 convCon _ = Nothing
 
 conv (Program _ _ t) = convTm t

--- a/plutus-core/plc-mini/Parser.hs
+++ b/plutus-core/plc-mini/Parser.hs
@@ -4,7 +4,7 @@
 
 module Parser where
 
-import           Lang
+import           Hutton
 
 import           Language.PlutusCore
 import           Language.PlutusCore.Lexer

--- a/plutus-core/plc-mini/ParserL.hs
+++ b/plutus-core/plc-mini/ParserL.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE EmptyDataDecls      #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+
+-- This module wraps the PLC parser and pretty printer
+
+module ParserL where
+
+import           Lambda
+
+import           Language.PlutusCore          as Plc
+import           Language.PlutusCore.DeBruijn
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Lexer
+import           Language.PlutusCore.Parser
+import           Language.PlutusCore.Pretty
+
+import           Control.Monad.Trans.Except
+import           Data.Bifunctor
+import qualified Data.ByteString.Lazy         as BSL
+import           Numeric.Natural
+
+type PlcProgN = Program TyName Name DefaultUni DefaultFun ()
+type PlcProgD = Program NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ()
+
+type PlcTermN = Term TyName Name DefaultUni DefaultFun ()
+type PlcTermD = Term NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun ()
+
+deBruijnify :: PlcProgN -> Either FreeVariableError PlcProgD
+deBruijnify = second (() <$) . runExcept . deBruijnProgram
+
+-- parser
+
+convCon :: Some (ValueOf DefaultUni) -> Maybe (Tm a)
+convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 =
+  Just $ Val (fromInteger i)
+convCon _ = Nothing
+
+--conv :: PlcProgD -> Maybe (Tm a)
+conv (Program _ _ t) = convTm t
+
+
+class Nat n
+instance Nat Empty
+instance Nat n => Nat (Maybe n)
+
+succ :: Nat n => n -> (Maybe n)
+succ n = Just n
+
+{-
+var :: Natural -> Maybe a
+var 0 = Nothing
+var 1 = Just Nothing
+-}
+--convTm :: PlcTermD -> Maybe (Tm a)
+convTm (Constant _ c) = convCon c
+convTm (Apply _ (Apply _ (Builtin _ AddInteger) t) u) = do
+  e1 <- convTm t
+  e2 <- convTm u
+  return $ Add e1 e2
+convTm (Plc.Var _ x) = return $ _
+convTm _ = Nothing
+
+parseProg :: BSL.ByteString -> Either (ParseError ()) PlcProgN
+parseProg = bimap (() <$) (() <$) . runQuote . runExceptT . parseProgram
+
+--parse :: BSL.ByteString -> Maybe (Tm Empty)
+parse b = case parseProg b of
+  Left _  -> Nothing
+  Right p -> case deBruijnify p of
+    Left _  -> Nothing
+    Right p -> conv p
+
+-- pretty printer
+
+unconv :: Tm a -> PlcTermN
+unconv (Val n) = Constant () (Some (ValueOf DefaultUniInteger (toInteger n)))
+unconv (Add e1 e2) =
+  Apply () (Apply () (Builtin () AddInteger) (unconv e1)) (unconv e2)
+
+pretty :: Tm a -> String
+pretty e = display $ unconv e

--- a/plutus-core/plc-mini/ParserL.hs
+++ b/plutus-core/plc-mini/ParserL.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE EmptyDataDecls      #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 
 -- This module wraps the PLC parser and pretty printer
@@ -19,6 +20,7 @@ import           Language.PlutusCore.Pretty
 import           Control.Monad.Trans.Except
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy         as BSL
+import           Data.Text
 import           Numeric.Natural
 
 type PlcProgN = Program TyName Name DefaultUni DefaultFun ()
@@ -37,35 +39,33 @@ convCon (Some (ValueOf DefaultUniInteger i)) | i >= 0 =
   Just $ Val (fromInteger i)
 convCon _ = Nothing
 
---conv :: PlcProgD -> Maybe (Tm a)
-conv (Program _ _ t) = convTm t
+conv :: PlcProgD -> Maybe (Tm Empty)
+conv (Program _ _ t) = convTm undefined t
 
-
-class Nat n
-instance Nat Empty
-instance Nat n => Nat (Maybe n)
-
-succ :: Nat n => n -> (Maybe n)
-succ n = Just n
 
 {-
 var :: Natural -> Maybe a
 var 0 = Nothing
 var 1 = Just Nothing
 -}
---convTm :: PlcTermD -> Maybe (Tm a)
-convTm (Constant _ c) = convCon c
-convTm (Apply _ (Apply _ (Builtin _ AddInteger) t) u) = do
-  e1 <- convTm t
-  e2 <- convTm u
+convTm :: (Natural -> a) -> PlcTermD -> Maybe (Tm a)
+convTm g (Constant _ c) = convCon c
+convTm g (Apply _ (Apply _ (Builtin _ AddInteger) t) u) = do
+  e1 <- convTm g t
+  e2 <- convTm g u
   return $ Add e1 e2
-convTm (Plc.Var _ x) = return $ _
-convTm _ = Nothing
+convTm g (Apply _ t u) = do
+  t' <- convTm g t
+  u' <- convTm g u
+  return (App t' u')
+convTm g (Plc.Var _ x) = return $ Lambda.Var (g (unIndex (ndbnIndex x) - 1))
+convTm g (LamAbs () _ _ t) = Lam <$> (convTm (\case {0 -> Nothing; n -> Just $ g (n-1)}) t)
+convTm g _ = Nothing
 
 parseProg :: BSL.ByteString -> Either (ParseError ()) PlcProgN
 parseProg = bimap (() <$) (() <$) . runQuote . runExceptT . parseProgram
 
---parse :: BSL.ByteString -> Maybe (Tm Empty)
+parse :: BSL.ByteString -> Maybe (Tm Empty)
 parse b = case parseProg b of
   Left _  -> Nothing
   Right p -> case deBruijnify p of
@@ -74,10 +74,20 @@ parse b = case parseProg b of
 
 -- pretty printer
 
-unconv :: Tm a -> PlcTermN
-unconv (Val n) = Constant () (Some (ValueOf DefaultUniInteger (toInteger n)))
-unconv (Add e1 e2) =
-  Apply () (Apply () (Builtin () AddInteger) (unconv e1)) (unconv e2)
+unIndex :: Index -> Natural
+unIndex (Index n) = n
+
+
+tmnames = ['a' .. 'z']
+
+
+
+unconv :: Int -> (a -> Name) -> Tm a -> PlcTermN
+unconv i g (Val n) = Constant () (Some (ValueOf DefaultUniInteger (toInteger n)))
+unconv i g (Add e1 e2) =
+  Apply () (Apply () (Builtin () AddInteger) (unconv i g e1)) (unconv i g e2)
+unconv i g (Lambda.Var x) = Plc.Var () (g x)
+unconv i g (Lam t) = LamAbs () (Name (pack [tmnames !! i]) undefined) (TyBuiltin () (Some (TypeIn DefaultUniInteger)))  (unconv (i+1) (\case {Nothing -> Name (pack [tmnames !! i]) undefined;Just x -> g x}) t)
 
 pretty :: Tm a -> String
-pretty e = display $ unconv e
+pretty e = display $ unconv 0 undefined e

--- a/plutus-core/plc-mini/notes.txt
+++ b/plutus-core/plc-mini/notes.txt
@@ -1,0 +1,63 @@
+* agda2hs - an Agda -> Haskell compiler that generates readable Haskell code
+
+  -- https://github.com/agda/agda2hs
+  -- Ulf Norell, Orestis Melkonian and I
+  -- started at last Agda meeting in October
+  -- standalone agda compiler backend (other backends, MAlonzo, latex, html)
+  -- a different approach to the MAlonzo compiler
+     -- which is designed to compile dependently typed programs
+
+  -- the agda2hs approach is to work inside the area where the
+     semantics of Haskell and Agda overlap where any given program is
+     basically 'the same' in both languages. Put another way, to write
+     Haskell in Agda. Then the compilation problem becomes trivial. It
+     doesn't compile the whole file, only annotated parts.
+
+  -- I will show two very minimal examples/sketches
+
+* example 1 -- mini Plutus-Core interpreter
+
+  a plug in replacement for the PLC interpreter for an extremely small
+  fragment of PLC (Hutton's razor)
+
+  -- small intepreter
+  -- code compiled to Haskell and hooked up to PLC parser/pretty printer
+  -- correctness proof in Agda
+
+* example 2 -- verified generator
+
+  -- verifying syntactic properties of the NEAT generator
+  -- we use NEAT to enumerate PLC programs for property based testing
+  -- initial work done by Wen Kokke
+  
+  -- PhD by Jonas Duregård/Chalmers
+  -- http://publications.lib.chalmers.se/records/fulltext/240807/240807.pdf
+  -- https://hackage.haskell.org/package/lazy-search
+
+  -- it uses a scope safe representation of terms which are
+     typechecked during generation. It's easy to prove syntactic
+     properties of this representation but they are hard to test.
+
+* applications
+
+  -- plug in verified replacement for a critical Haskell component
+  
+  -- verified model for testing, verified test generator etc.
+       e.g., verify some easy to verify but hard to test
+             properties of the NEAT PLC generator
+
+* verification strategy
+
+  -- direct correctness proof
+  -- Haskell compatible invariants
+  
+  -- model based - define a more refined model in Agda, show it
+     behaves the same as the Haskell like version in Agda (on correct
+     input for example)
+     
+     -- raising the bar: prove correctness against rigorous model
+        rather than test against it.
+
+  -- hybrid approach, some properties proved, some QuickCheck/NEAT,
+     even some model checked (tweak agda2hs to produce 'symbolic'
+     code.

--- a/plutus-core/plc-mini/test.plc
+++ b/plutus-core/plc-mini/test.plc
@@ -1,0 +1,3 @@
+(program 1.0.0
+  [[(builtin addInteger) (con integer 2)] (con integer 3)]
+)

--- a/plutus-core/plc-mini/test2.plc
+++ b/plutus-core/plc-mini/test2.plc
@@ -1,0 +1,3 @@
+(program 1.0.0
+  [(lam x (con integer) x) [[(builtin addInteger) (con integer 2)] (con integer 2)]]
+)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -419,6 +419,16 @@ executable plc
         text -any,
         transformers -any
 
+executable plc-mini
+  main-is: Main.hs
+  hs-source-dirs: plc-mini
+  build-depends:
+    base -any,
+    plutus-core,
+    transformers,
+    bytestring
+  
+        
 benchmark plutus-core-budgeting-bench
     import: lang
     type: exitcode-stdio-1.0

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -97,6 +97,7 @@ library
         Language.PlutusCore.Generators.NEAT.Common
         Language.PlutusCore.Generators.NEAT.Spec
         Language.PlutusCore.Generators.NEAT.Type
+        Language.PlutusCore.Generators.NEAT.Term       
         Language.PlutusCore.Lexer
         Language.PlutusCore.Parser
         Language.PlutusCore.Error
@@ -428,7 +429,7 @@ executable plc-mini
     transformers,
     bytestring
   other-modules:
-    Lang
+    Hutton
     Parser
         
 benchmark plutus-core-budgeting-bench

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -427,10 +427,11 @@ executable plc-mini
     base -any,
     plutus-core,
     transformers,
-    bytestring
+    bytestring,
+    text
   other-modules:
-    Hutton
-    Parser
+    Lambda
+    ParserL
         
 benchmark plutus-core-budgeting-bench
     import: lang

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -427,7 +427,9 @@ executable plc-mini
     plutus-core,
     transformers,
     bytestring
-  
+  other-modules:
+    Lang
+    Parser
         
 benchmark plutus-core-budgeting-bench
     import: lang

--- a/plutus-metatheory/test/TestNEAT.hs
+++ b/plutus-metatheory/test/TestNEAT.hs
@@ -8,6 +8,7 @@ import           Data.List
 import           Language.PlutusCore
 import           Language.PlutusCore.Evaluation.Machine.Ck
 import           Language.PlutusCore.Generators.NEAT.Spec
+import           Language.PlutusCore.Generators.NEAT.Term
 import           Language.PlutusCore.Generators.NEAT.Type
 import           Language.PlutusCore.Lexer
 import           Language.PlutusCore.Normalize


### PR DESCRIPTION
This is an experiment in using `agda2hs` to define a formally verified interpreter for a very small fragment of PLC in Agda which can be compiled to formally verified, readable Haskell and could form part of a larger Haskell program. It is compiled to readable Haskell via `agda2hs` and then hooked up to the production parser and pretty printer.

The fragment is just natural numbers and addition (Hutton's razor). This doesn't actually call agda2hs, I have just committed the agda code (`Lang.agda`, `Main.agda`) and the `agda2hs` compiled haskell code (`Lang.hs`, `Main.hs`):

* `Lang.agda` contains the syntax and the evaluator, an equational semantics/spec and some correctness proofs
* `Main.agda` is contains the `main` function.
* `Parser.hs` contains a wrapper around the plutus-core parser.

I have put this experiment in `plutus-core/plc-mini`. It probably shouldn't stay there.

The example program `plutus-core/plc-mini/test.plc`
```
(program 1.0.0
  [[(builtin addInteger) (con integer 2)] (con integer 3)]
)
```
can be executed as follows:
```
$ cabal v2-run plc-mini < plutus-core/plc-mini/test.plc
(con integer 5)
```

I also formally verified some properties of the NEAT generator which is a model of PLC - specifically properties of renaming and substitution for types. These are easy to prove and hard to test.
