### PR TITLE
Adding web-common-playground to plutus playground spago sources.

### DIFF
--- a/plutus-playground-client/spago.dhall
+++ b/plutus-playground-client/spago.dhall
@@ -35,5 +35,6 @@ You can edit this file as you like.
   , "generated/**/*.purs"
   , "web-common/**/*.purs"
   , "web-common-plutus/**/*.purs"
+  , "web-common-playground/**/*.purs"
   ]
 }


### PR DESCRIPTION
#2639 separated out some common code into `web-common-playground`, but didn't include this as a source in `plutus-playground-client/spago.dhall`. Just fixing that.