### PR TITLE
Preserving simulation state after a failed compilation (SCP-1751).

### DIFF
--- a/plutus-playground-client/src/MainFrame/Lenses.purs
+++ b/plutus-playground-client/src/MainFrame/Lenses.purs
@@ -12,6 +12,7 @@ module MainFrame.Lenses
   , _lastEvaluatedSimulation
   , _compilationResult
   , _successfulCompilationResult
+  , _lastSuccessfulCompilationResult
   , _authStatus
   , _createGistResult
   , _gistUrl
@@ -45,8 +46,8 @@ import Data.Maybe (Maybe, fromMaybe)
 import Data.Symbol (SProxy(..))
 import Editor.Types (State) as Editor
 import Gist (Gist)
-import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, SourceCode, _InterpreterResult)
-import MainFrame.Types (State, View, WebData)
+import Language.Haskell.Interpreter (InterpreterResult, SourceCode, _InterpreterResult)
+import MainFrame.Types (State, View, WebCompilationResult, WebData)
 import Network.RemoteData (_Success)
 import Playground.Types (CompilationResult, ContractCall, ContractDemo, EvaluationResult, FunctionSchema, KnownCurrency, PlaygroundError, Simulation, SimulatorWallet)
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
@@ -89,11 +90,14 @@ _successfulEvaluationResult = _evaluationResult <<< _Success <<< _Right
 _lastEvaluatedSimulation :: Lens' State (Maybe Simulation)
 _lastEvaluatedSimulation = _Newtype <<< prop (SProxy :: SProxy "lastEvaluatedSimulation")
 
-_compilationResult :: Lens' State (WebData (Either InterpreterError (InterpreterResult CompilationResult)))
+_compilationResult :: Lens' State WebCompilationResult
 _compilationResult = _Newtype <<< prop (SProxy :: SProxy "compilationResult")
 
 _successfulCompilationResult :: Traversal' State CompilationResult
 _successfulCompilationResult = _compilationResult <<< _Success <<< _Right <<< _InterpreterResult <<< _result
+
+_lastSuccessfulCompilationResult :: Lens' State WebCompilationResult
+_lastSuccessfulCompilationResult = _Newtype <<< prop (SProxy :: SProxy "lastSuccessfulCompilationResult")
 
 _authStatus :: Lens' State (WebData AuthStatus)
 _authStatus = _Newtype <<< prop (SProxy :: SProxy "authStatus")

--- a/plutus-playground-client/src/MainFrame/Lenses.purs
+++ b/plutus-playground-client/src/MainFrame/Lenses.purs
@@ -96,7 +96,7 @@ _compilationResult = _Newtype <<< prop (SProxy :: SProxy "compilationResult")
 _successfulCompilationResult :: Traversal' State CompilationResult
 _successfulCompilationResult = _compilationResult <<< _Success <<< _Right <<< _InterpreterResult <<< _result
 
-_lastSuccessfulCompilationResult :: Lens' State WebCompilationResult
+_lastSuccessfulCompilationResult :: Lens' State (Maybe (InterpreterResult CompilationResult))
 _lastSuccessfulCompilationResult = _Newtype <<< prop (SProxy :: SProxy "lastSuccessfulCompilationResult")
 
 _authStatus :: Lens' State (WebData AuthStatus)

--- a/plutus-playground-client/src/MainFrame/State.purs
+++ b/plutus-playground-client/src/MainFrame/State.purs
@@ -361,8 +361,7 @@ handleAction CompileProgram = do
 
               newCurrencies = preview (_details <<< _knownCurrencies) newCompilationResult
             case lastSuccessfulCompilationResult of
-              Nothing ->
-                assign _simulations $ defaultSimulations newCurrencies
+              Nothing -> assign _simulations $ defaultSimulations newCurrencies
               Just oldCompilationResult -> do
                 let
                   oldSignatures = preview (_result <<< _functionSchema) (unwrap oldCompilationResult)
@@ -375,10 +374,9 @@ handleAction CompileProgram = do
       pure unit
 
 defaultSimulations :: Maybe (Array KnownCurrency) -> Cursor Simulation
-defaultSimulations newCurrencies =
-  case newCurrencies of
-    Just currencies -> Cursor.singleton $ mkSimulation currencies 1
-    Nothing -> Cursor.empty
+defaultSimulations newCurrencies = case newCurrencies of
+  Just currencies -> Cursor.singleton $ mkSimulation currencies 1
+  Nothing -> Cursor.empty
 
 handleSimulationAction ::
   Value ->

--- a/plutus-playground-client/src/MainFrame/State.purs
+++ b/plutus-playground-client/src/MainFrame/State.purs
@@ -21,7 +21,7 @@ import Control.Monad.Reader (class MonadAsk, runReaderT)
 import Control.Monad.State.Class (class MonadState, gets)
 import Control.Monad.State.Extra (zoomStateT)
 import Control.Monad.Trans.Class (lift)
-import Cursor (_current)
+import Cursor (Cursor, _current)
 import Cursor as Cursor
 import Data.Array (catMaybes, (..))
 import Data.Array (deleteAt, snoc) as Array
@@ -104,7 +104,7 @@ mkInitialState editorState = do
         , contractDemos
         , currentDemoName: Nothing
         , compilationResult: NotAsked
-        , lastSuccessfulCompilationResult: NotAsked
+        , lastSuccessfulCompilationResult: Nothing
         , simulations: Cursor.empty
         , actionDrag: Nothing
         , evaluationResult: NotAsked
@@ -257,7 +257,7 @@ handleAction (LoadScript key) = do
       assign (_editorState <<< _lastCompiledCode) (Just contractDemoEditorContents)
       assign (_editorState <<< _currentCodeIsCompiled) true
       assign _compilationResult (Success <<< Right $ contractDemoContext)
-      assign _lastSuccessfulCompilationResult (Success <<< Right $ contractDemoContext)
+      assign _lastSuccessfulCompilationResult (Just contractDemoContext)
       assign _evaluationResult NotAsked
       assign _createGistResult NotAsked
 
@@ -343,36 +343,42 @@ handleAction CompileProgram = do
           -- If there are compilation errors, add editor annotations and expand the feedback pane.
           editorSetAnnotations $ toAnnotations errors
           assign (_editorState <<< _feedbackPaneMinimised) false
-        Success (Right _) ->
+        Success (Right compilationResult) ->
           -- If compilation was successful, clear editor annotations and save the successful result.
           when (isSuccess newCompilationResult) do
             editorSetAnnotations []
             assign (_editorState <<< _currentCodeIsCompiled) true
             assign (_editorState <<< _lastCompiledCode) (Just contents)
-            assign _lastSuccessfulCompilationResult newCompilationResult
-            -- If we have a result with new signatures, we can only hold onto the old actions if
+            assign _lastSuccessfulCompilationResult (Just compilationResult)
+            -- If we have a result with new signatures, we can only hold onto any old actions if
             -- the signatures still match. Any change means we'll have to clear out the existing
             -- simulation. Same thing for currencies. Potentially we could be smarter about this.
             -- But for now, let's at least be correct.
             -- Note we test against the last _successful_ compilation result, so that a failed
             -- compilation in between times doesn't unnecessarily wipe the old actions.
             let
-              oldSignatures = preview (_details <<< _functionSchema) lastSuccessfulCompilationResult
-
               newSignatures = preview (_details <<< _functionSchema) newCompilationResult
 
-              oldCurrencies = preview (_details <<< _knownCurrencies) lastSuccessfulCompilationResult
-
               newCurrencies = preview (_details <<< _knownCurrencies) newCompilationResult
-            unless
-              (oldSignatures == newSignatures && oldCurrencies == newCurrencies)
-              ( assign _simulations
-                  $ case newCurrencies of
-                      Just currencies -> Cursor.singleton $ mkSimulation currencies 1
-                      Nothing -> Cursor.empty
-              )
+            case lastSuccessfulCompilationResult of
+              Nothing ->
+                assign _simulations $ defaultSimulations newCurrencies
+              Just oldCompilationResult -> do
+                let
+                  oldSignatures = preview (_result <<< _functionSchema) (unwrap oldCompilationResult)
+
+                  oldCurrencies = preview (_result <<< _knownCurrencies) (unwrap oldCompilationResult)
+                unless
+                  (oldSignatures == newSignatures && oldCurrencies == newCurrencies)
+                  (assign _simulations $ defaultSimulations newCurrencies)
         _ -> pure unit
       pure unit
+
+defaultSimulations :: Maybe (Array KnownCurrency) -> Cursor Simulation
+defaultSimulations newCurrencies =
+  case newCurrencies of
+    Just currencies -> Cursor.singleton $ mkSimulation currencies 1
+    Nothing -> Cursor.empty
 
 handleSimulationAction ::
   Value ->

--- a/plutus-playground-client/src/MainFrame/Types.purs
+++ b/plutus-playground-client/src/MainFrame/Types.purs
@@ -52,7 +52,7 @@ newtype State
   , currentDemoName :: Maybe String
   , editorState :: Editor.State
   , compilationResult :: WebCompilationResult
-  , lastSuccessfulCompilationResult :: WebCompilationResult
+  , lastSuccessfulCompilationResult :: Maybe (InterpreterResult CompilationResult)
   , simulations :: Cursor Simulation
   , actionDrag :: Maybe Int
   , evaluationResult :: WebEvaluationResult

--- a/plutus-playground-client/src/MainFrame/Types.purs
+++ b/plutus-playground-client/src/MainFrame/Types.purs
@@ -52,6 +52,7 @@ newtype State
   , currentDemoName :: Maybe String
   , editorState :: Editor.State
   , compilationResult :: WebCompilationResult
+  , lastSuccessfulCompilationResult :: WebCompilationResult
   , simulations :: Cursor Simulation
   , actionDrag :: Maybe Int
   , evaluationResult :: WebEvaluationResult


### PR DESCRIPTION
When the signatures or currencies of the contract change, we have to clear out any previous simulations data. Currently we check the new signatures and currencies against the last compilation result; this fix changes things so we check them against the last _successful_ compilation result. This way, you don't lose your simulations data just by introducing an error in your code.

While I was at it, I also noticed and fixed a style bug in the feedback pane, which wasn't being set to minimised at the start of compilation (it should be, otherwise you potentially see the resize bar at the top of it).

Additional note: the pre-commit purty check passed my penultimate commit, while hydra (rightly) failed it. So something seems to be amiss with the pre-commit check.