### PR TITLE
SCP-1647 Marlowe Playground Frontend - Disable send to simulator if blockly has holes

### DIFF
--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -25,6 +25,7 @@ instance blocklyActionIsEvent :: IsEvent Action where
 type State
   = { errorMessage :: Maybe String
     , marloweCode :: Maybe String
+    , hasHoles :: Boolean
     }
 
 _errorMessage :: Lens' State (Maybe String)
@@ -33,8 +34,12 @@ _errorMessage = prop (SProxy :: SProxy "errorMessage")
 _marloweCode :: Lens' State (Maybe String)
 _marloweCode = prop (SProxy :: SProxy "marloweCode")
 
+_hasHoles :: Lens' State Boolean
+_hasHoles = prop (SProxy :: SProxy "hasHoles")
+
 initialState :: State
 initialState =
   { errorMessage: Nothing
   , marloweCode: Nothing
+  , hasHoles: false
   }

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -1,16 +1,16 @@
 module BlocklyEditor.View where
 
 import Prelude hiding (div)
-import BlocklyEditor.Types (Action(..), State, _marloweCode)
+import BlocklyEditor.Types (Action(..), State, _hasHoles, _marloweCode)
 import Data.Lens ((^.))
 import Data.Maybe (Maybe(..), isJust)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Blockly as Blockly
-import Halogen.Classes (disabled, group)
+import Halogen.Classes (group)
 import Halogen.HTML (HTML, button, div, slot, text, div_)
 import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (classes, enabled)
+import Halogen.HTML.Properties (classes, disabled, enabled)
 import MainFrame.Types (ChildSlots, _blocklySlot)
 import Marlowe.Blockly as MB
 
@@ -34,15 +34,15 @@ otherActions state =
     [ button
         [ onClick $ const $ Just ViewAsMarlowe
         , enabled hasCode
-        , classes [ disabled hasCode ]
         ]
         [ text "View as Marlowe" ]
     , button
         [ onClick $ const $ Just SendToSimulator
-        , enabled hasCode
-        , classes [ disabled hasCode ]
+        , enabled (hasCode && not hasHoles)
         ]
         [ text "Send To Simulator" ]
     ]
   where
   hasCode = isJust $ state ^. _marloweCode
+
+  hasHoles = state ^. _hasHoles

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -18,7 +18,7 @@ import Data.List.NonEmpty as NEL
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Newtype (class Newtype)
+import Data.Newtype (class Newtype, unwrap)
 import Data.Set (Set)
 import Data.Set as Set
 import Data.String (Pattern(..), contains, splitAt, toLower)
@@ -475,6 +475,9 @@ instance encodeHoles :: Encode Holes where
 
 instance decodeHoles :: Decode Holes where
   decode f = Holes <$> decode f
+
+isEmpty :: Holes -> Boolean
+isEmpty = Map.isEmpty <<< unwrap
 
 insertHole :: forall a. IsMarloweType a => Term a -> Holes -> Holes
 insertHole (Term _ _) m = m

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -6,6 +6,7 @@ module Marlowe.Linter
   , WarningDetail(..)
   , AdditionalContext
   , _holes
+  , hasHoles
   , _warnings
   , suggestions
   , markers
@@ -48,6 +49,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested (type (/\), (/\))
 import Help (holeText)
 import Marlowe.Holes (Action(..), Argument, Bound(..), Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType, Observation(..), Term(..), TermWrapper(..), Value(..), Range, constructMarloweType, fromTerm, getHoles, getMarloweConstructors, getRange, holeSuggestions, insertHole, readMarloweType)
+import Marlowe.Holes as Holes
 import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), emptyState, evalValue, makeEnvironment)
 import Marlowe.Semantics as Semantics
@@ -217,6 +219,9 @@ _holes = _Newtype <<< prop (SProxy :: SProxy "holes")
 
 _warnings :: Lens' State (Set Warning)
 _warnings = _Newtype <<< prop (SProxy :: SProxy "warnings")
+
+hasHoles :: State -> Boolean
+hasHoles = not Holes.isEmpty <<< view _holes
 
 newtype LintEnv
   = LintEnv


### PR DESCRIPTION
This pull request runs the linter on the blockly generated code and disables the "send to simulator" button if the contract has holes.

By doing this PR I found an inconsistency with the `CodeChange` message fired by blockly. When you add a block to a contract, the `CodeChange` event is fired successfully, but when you remove a block from a contract, the event is fired while you are still dragging, so the code hasn't actually change yet. 

This causes a bug, as the linter thinks the contract has no holes while it does, and a separate  `CodeChange` needs to be fired before it disables the button.

I submit this PR as is because the changes needed to correctly track `CodeChange` is way bigger than this, and will be done in a separate PR.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [X] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
