### PR TITLE
Add a parameter for enabling Haskell profiling

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -49,6 +49,19 @@ this can at least potentially cause problems or cause you to be missing
 bug workarounds.
 ====
 
+=== How to build the code with profiling
+
+If you launch `nix-shell` with the `enableHaskellProfiling` argument set to true, you will get a shell where all the dependencies have been built with profiling.
+
+Like this: `nix-shell --arg enableHaskellProfiling true`
+
+Then you can do e.g. `cabal run --enableProfiling ...`.
+
+[WARNING]
+====
+This is not curently cached, so may result in you rebuilding all of our dependencies with profiling on your machine.
+====
+
 === How to setup `haskell-language-server`
 
 The `nix-shell` environment has a `haskell-language-server` binary for the right version of GHC.

--- a/default.nix
+++ b/default.nix
@@ -11,22 +11,24 @@
 , config ? { allowUnfreePredicate = (import ./lib.nix).unfreePredicate; }
   # Overrides for niv
 , sourcesOverride ? { }
-  # { pkgs plutusMusl plutus }
-, packages ? import ./nix { inherit system crossSystem config sourcesOverride rev checkMaterialization; }
+  # { pkgs pkgsMusl plutus }
+, packages ? import ./nix { inherit system crossSystem config sourcesOverride rev checkMaterialization enableHaskellProfiling; }
   # An explicit git rev to use, passed when we are in Hydra
 , rev ? null
   # Whether to check that the pinned shas for haskell.nix are correct. We want this to be
   # false, generally, since it does more work, but we set it to true in the CI
 , checkMaterialization ? false
+  # Whether to build our Haskell packages (and their dependencies) with profiling enabled.
+, enableHaskellProfiling ? false
 }:
 let
-  inherit (packages) pkgs plutus plutusMusl;
+  inherit (packages) pkgs plutus pkgsMusl;
   inherit (pkgs) lib haskell-nix;
   inherit (plutus) haskell iohkNix git-rev set-git-rev agdaPackages;
   inherit (plutus) easyPS sphinxcontrib-haddock;
 in
 rec {
-  inherit pkgs plutus plutusMusl;
+  inherit pkgs plutus pkgsMusl;
 
   inherit (plutus) web-ghc;
   inherit (plutus.lib) buildNodeModules;
@@ -68,15 +70,15 @@ rec {
     }) client server-invoker generated-purescript generate-purescript;
   };
 
-  marlowe-symbolic-lambda = plutusMusl.callPackage ./marlowe-symbolic/lambda.nix {
+  marlowe-symbolic-lambda = pkgsMusl.callPackage ./marlowe-symbolic/lambda.nix {
     inherit (haskell.muslProject) ghcWithPackages;
   };
 
-  marlowe-playground-lambda = plutusMusl.callPackage ./marlowe-playground-server/lambda.nix {
+  marlowe-playground-lambda = pkgsMusl.callPackage ./marlowe-playground-server/lambda.nix {
     inherit (haskell.muslProject) ghcWithPackages;
   };
 
-  plutus-playground-lambda = plutusMusl.callPackage ./plutus-playground-server/lambda.nix {
+  plutus-playground-lambda = pkgsMusl.callPackage ./plutus-playground-server/lambda.nix {
     inherit (haskell.muslProject) ghcWithPackages;
   };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@
 , sourcesOverride ? { }
 , rev ? null
 , checkMaterialization ? false
+, enableHaskellProfiling ? false
 }:
 let
   sources = import ./sources.nix { inherit pkgs; }
@@ -41,16 +42,16 @@ let
     config = haskellNix.config // config;
   };
 
-  plutusMusl = import sources.nixpkgs {
+  pkgsMusl = import sources.nixpkgs {
     system = "x86_64-linux";
     crossSystem = pkgs.lib.systems.examples.musl64;
     overlays = extraOverlays ++ overlays;
     config = haskellNix.config // config;
   };
 
-  plutus = import ./pkgs { inherit rev pkgs plutusMusl checkMaterialization sources; };
+  plutus = import ./pkgs { inherit rev pkgs pkgsMusl checkMaterialization enableHaskellProfiling sources; };
 
 in
 {
-  inherit pkgs plutusMusl plutus;
+  inherit pkgs pkgsMusl plutus;
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,10 +1,11 @@
 { pkgs
-, plutusMusl
+, pkgsMusl
 , checkMaterialization
 , system ? builtins.currentSystem
 , config ? { allowUnfreePredicate = (import ./lib.nix).unfreePredicate; }
 , rev ? null
 , sources
+, enableHaskellProfiling
 }:
 let
   inherit (pkgs) stdenv;
@@ -22,8 +23,8 @@ let
 
   # { index-state, project, projectPackages, packages, muslProject, muslPackages, extraPackages }
   haskell = pkgs.callPackage ./haskell {
-    inherit plutusMusl;
-    inherit agdaWithStdlib checkMaterialization;
+    inherit pkgsMusl;
+    inherit agdaWithStdlib checkMaterialization enableHaskellProfiling;
   };
 
   #

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , fetchFromGitLab
 , agdaWithStdlib
-, plutusMusl
+, pkgsMusl
 , stdenv
 , haskell-nix
 , buildPackages
@@ -11,6 +11,7 @@
 , R
 , rPackages
 , z3
+, enableHaskellProfiling
 }:
 let
   # The Hackage index-state from cabal.project
@@ -36,6 +37,7 @@ let
   project = import ./haskell.nix {
     inherit lib stdenv haskell-nix buildPackages nix-gitignore R rPackages z3;
     inherit agdaWithStdlib checkMaterialization compiler-nix-name;
+    inherit enableHaskellProfiling;
   };
 
   # All the packages defined by our project, including dependencies
@@ -49,8 +51,9 @@ let
 
   # The haskell project created by haskell-nix.stackProject' (musl version)
   muslProject = import ./haskell.nix {
-    inherit (plutusMusl) lib stdenv haskell-nix buildPackages nix-gitignore R rPackages z3;
+    inherit (pkgsMusl) lib stdenv haskell-nix buildPackages nix-gitignore R rPackages z3;
     inherit agdaWithStdlib checkMaterialization compiler-nix-name;
+    inherit enableHaskellProfiling;
   };
 
   # All the packages defined by our project, built for musl

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -12,6 +12,7 @@
 , R
 , checkMaterialization
 , compiler-nix-name
+, enableHaskellProfiling
 }:
 let
   r-packages = with rPackages; [ R tidyverse dplyr stringr MASS plotly shiny shinyjs purrr ];
@@ -141,7 +142,10 @@ let
           eventful-sql-common.package.ghcOptions = "-XDerivingStrategies -XStandaloneDeriving -XUndecidableInstances -XDataKinds -XFlexibleInstances -XMultiParamTypeClasses";
         };
       }
-    ];
+    ] ++ lib.optional enableHaskellProfiling {
+      enableLibraryProfiling = true;
+      enableExecutableProfiling = true;
+    };
   };
 
 in

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,8 @@
 , config ? { allowUnfreePredicate = (import ./lib.nix).unfreePredicate; }
 , rev ? "in-nix-shell"
 , sourcesOverride ? { }
-, packages ? import ./. { inherit crossSystem config sourcesOverride rev; }
+, packages ? import ./. { inherit crossSystem config sourcesOverride rev enableHaskellProfiling; }
+, enableHaskellProfiling ? false
 }:
 let
   inherit (packages) pkgs plutus plutusMusl plutus-playground marlowe-playground plutus-pab marlowe-dashboard;


### PR DESCRIPTION
Also exposes it in the shell, so you can do
`nix-shell --arg enableHaskellProfiling true`
and get a shell with profiling libraries. Does require rebuilding the
world though, maybe we should cache it.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A plutus.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
