### PR TITLE
Basic Apps tutorial typo: `SplitValue` should be `SplitData`

### DIFF
--- a/doc/tutorials/basic-apps.rst
+++ b/doc/tutorials/basic-apps.rst
@@ -36,7 +36,7 @@ These instances enable the serialisation of ``SplitData`` to different formats.
 JSON objects are passed between the frontend (for example, the Playground) and the app instance.
 :hsobj:`Language.PlutusTx.IsData` is used for values that are attached to transactions, for example as the <redeemer> of a script output.
 This class is used by the Plutus app at runtime to construct ``Data`` values.
-Finally, :hsobj:`Language.PlutusTx.makeLift` is a Template Haskell statement that generates an instance of the :hsobj:`Language.PlutusTx.Lift.Class.Lift` class for ``SplitValue``.
+Finally, :hsobj:`Language.PlutusTx.makeLift` is a Template Haskell statement that generates an instance of the :hsobj:`Language.PlutusTx.Lift.Class.Lift` class for ``SplitData``.
 This class is used by the Plutus compiler at compile-time to construct Plutus core programs.
 
 Defining the validator script


### PR DESCRIPTION
I started going through the plutus tutorials and this line threw me off, I couldn't find a reference to `SplitValue` anywhere so I assumed it actually meant `SplitData`.

If it turns out `SplitValue` is actually the correct term, can we add some context here?
