### PR TITLE
SCP-1796 Marlowe Playground Frontend - Fix blockly CodeChange event

### DIFF
--- a/marlowe-playground-client/src/Blockly/Events.purs
+++ b/marlowe-playground-client/src/Blockly/Events.purs
@@ -6,14 +6,15 @@ module Blockly.Events
   , FinishLoadingEvent
   , MoveEvent
   , UIEvent
+  , element
   , newParentId
   , oldParentId
   , oldInputName
   , newInputName
   ) where
 
-import Data.Maybe (Maybe(..))
 import Data.Function.Uncurried (Fn4, runFn4)
+import Data.Maybe (Maybe(..))
 import Web.Event.Event (Event)
 
 class HasEvent a where
@@ -41,6 +42,9 @@ foreign import data UIEvent :: Type
 instance hasEventUIEvent :: HasEvent UIEvent where
   fromEvent :: Event -> Maybe UIEvent
   fromEvent = readBlocklyEventType "ui"
+
+element :: UIEvent -> Maybe String
+element = readProperty "element"
 
 ------------------------------------------------------------
 foreign import data FinishLoadingEvent :: Type

--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -6,7 +6,12 @@ var JSONbig = require("json-bigint");
 exports.createBlocklyInstance_ = function () {
   return require("node-blockly/browser");
 };
-
+exports.debugBlockly_ = function debugBlockly_ (name, state) {
+  if (typeof window.blockly === 'undefined') {
+    window.blockly = {};
+  }
+  window.blockly[name] = state
+}
 exports.getElementById_ = function (id) {
   return document.getElementById(id);
 };

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -97,6 +97,11 @@ foreign import workspaceXML_ :: EffectFn2 Blockly Workspace XML
 
 foreign import loadWorkspace_ :: EffectFn3 Blockly Workspace XML Unit
 
+-- This function exposes the blockly state in the global window so it's easier to debug/test functionalities
+-- It is only called once per editor at the creation of the editor, so it doesn't consume resources and
+-- could be left enabled.
+foreign import debugBlockly_ :: EffectFn2 String BlocklyState Unit
+
 newtype ElementId
   = ElementId String
 
@@ -107,6 +112,7 @@ createBlocklyInstance rootBlockName workspaceElementId toolboxElementId = do
   blockly <- createBlocklyInstance_
   toolbox <- runEffectFn1 getElementById_ (unwrap toolboxElementId)
   workspace <- runEffectFn3 createWorkspace_ blockly (unwrap workspaceElementId) (config toolbox)
+  runEffectFn2 debugBlockly_ (unwrap workspaceElementId) { blockly, workspace, rootBlockName }
   pure { blockly, workspace, rootBlockName }
   where
   config toolbox =

--- a/marlowe-playground-client/src/Blockly/Types.purs
+++ b/marlowe-playground-client/src/Blockly/Types.purs
@@ -1,6 +1,8 @@
 module Blockly.Types where
 
-import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent, UIEvent)
+import Prelude
+import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent, UIEvent, element)
+import Data.Maybe (Maybe(..))
 
 foreign import data Blockly :: Type
 
@@ -20,3 +22,13 @@ data BlocklyEvent
   | Move MoveEvent
   | FinishLoading FinishLoadingEvent
   | UI UIEvent
+
+isDragStart :: BlocklyEvent -> Boolean
+isDragStart (UI event) = eq (Just "dragStart") $ element event
+
+isDragStart _ = false
+
+isDragStop :: BlocklyEvent -> Boolean
+isDragStop (UI event) = eq (Just "dragStop") $ element event
+
+isDragStop _ = false

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -1,19 +1,22 @@
 module BlocklyComponent.Types where
 
 import Prelude hiding (div)
-import Blockly.Internal (BlockDefinition, XML)
 import Blockly.Generator (Generator)
+import Blockly.Internal (BlockDefinition, XML)
 import Blockly.Types as BT
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
+import Data.List (List)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
+import Halogen (SubscriptionId)
 
 type State
   = { blocklyState :: Maybe BT.BlocklyState
     , generator :: Maybe Generator
     , errorMessage :: Maybe String
-    , useEvents :: Boolean
+    , blocklyEventSubscription :: Maybe SubscriptionId
+    , eventsWhileDragging :: Maybe (List BT.BlocklyEvent)
     }
 
 _blocklyState :: Lens' State (Maybe BT.BlocklyState)
@@ -25,11 +28,17 @@ _generator = prop (SProxy :: SProxy "generator")
 _errorMessage :: Lens' State (Maybe String)
 _errorMessage = prop (SProxy :: SProxy "errorMessage")
 
-_useEvents :: Lens' State Boolean
-_useEvents = prop (SProxy :: SProxy "useEvents")
+_blocklyEventSubscription :: Lens' State (Maybe SubscriptionId)
+_blocklyEventSubscription = prop (SProxy :: SProxy "blocklyEventSubscription")
 
 emptyState :: State
-emptyState = { blocklyState: Nothing, generator: Nothing, errorMessage: Nothing, useEvents: false }
+emptyState =
+  { blocklyState: Nothing
+  , generator: Nothing
+  , errorMessage: Nothing
+  , blocklyEventSubscription: Nothing
+  , eventsWhileDragging: Nothing
+  }
 
 data Query a
   = Resize a

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -1,3 +1,4 @@
+-- TODO: rename modules from BlocklyEditor -> MarloweBlocklyEditor
 module BlocklyEditor.State where
 
 import Prelude

--- a/marlowe-playground-client/src/Halogen/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Halogen/ActusBlockly.purs
@@ -11,6 +11,7 @@ import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
 import Data.Lens (Lens', assign, set, use)
 import Data.Lens.Record (prop)
+import Data.List (List)
 import Data.Maybe (Maybe(..), isJust)
 import Data.Newtype (unwrap)
 import Data.Symbol (SProxy(..))
@@ -23,7 +24,7 @@ import Effect.Class (class MonadEffect)
 import Foreign.Generic (encodeJSON)
 import Halogen (ClassName(..), Component, HalogenM, RefLabel(..), liftEffect, mkComponent, modify_, raise)
 import Halogen as H
-import Halogen.BlocklyCommons (blocklyEvents, updateUnsavedChangesActionHandler)
+import Halogen.BlocklyCommons (blocklyEvents, detectCodeChanges)
 import Halogen.Classes (aHorizontal, expanded, panelSubHeader, panelSubHeaderMain, sidebarComposer, hide, alignedButtonInTheMiddle, alignedButtonLast)
 import Halogen.HTML (HTML, button, div, text, iframe, aside, section)
 import Halogen.HTML.Core (AttrName(..))
@@ -40,7 +41,7 @@ type State
     , generator :: Maybe Generator
     , errorMessage :: Maybe String
     , showShiny :: Boolean
-    , useEvents :: Boolean
+    , eventsWhileDragging :: Maybe (List BT.BlocklyEvent)
     }
 
 _actusBlocklyState :: Lens' State (Maybe BT.BlocklyState)
@@ -89,7 +90,7 @@ blockly rootBlockName blockDefinitions =
           , generator: Nothing
           , errorMessage: Just "(Labs is an experimental feature)"
           , showShiny: false
-          , useEvents: false
+          , eventsWhileDragging: Nothing
           }
     , render
     , eval:
@@ -192,7 +193,7 @@ handleAction RunAnalysis = do
   where
   unexpected s = "An unexpected error has occurred, please raise a support issue: " <> s
 
-handleAction (BlocklyEvent event) = updateUnsavedChangesActionHandler CodeChange event
+handleAction (BlocklyEvent event) = detectCodeChanges CodeChange event
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
+++ b/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
@@ -3,20 +3,30 @@
 module Halogen.BlocklyCommons where
 
 import Prelude hiding (div)
-import Blockly.Internal (addChangeListener, removeChangeListener)
 import Blockly.Events (fromEvent, newParentId, oldParentId)
-import Blockly.Types (BlocklyEvent, Workspace)
+import Blockly.Internal (addChangeListener, removeChangeListener)
+import Blockly.Types (BlocklyEvent, BlocklyState, Workspace, isDragStart, isDragStop)
 import Blockly.Types as BT
-import Data.Foldable (oneOf)
+import Data.Either (Either(..))
+import Data.Foldable (foldl, oneOf)
 import Data.Lens (Lens', assign, use)
 import Data.Lens.Record (prop)
+import Data.List (List(..), (:))
+import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Data.Traversable (for_)
-import Effect.Aff.Class (class MonadAff)
-import Halogen (HalogenM, raise)
+import Effect (Effect)
+import Effect.Aff (Aff, finally, makeAff, nonCanceler)
+import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (liftEffect)
+import Effect.Ref (Ref)
+import Effect.Ref as Ref
+import Effect.Timer (clearTimeout, setTimeout)
+import Halogen (HalogenM, SubscriptionId)
+import Halogen as H
 import Halogen.Query.EventSource (EventSource)
 import Halogen.Query.EventSource as EventSource
-import Web.Event.EventTarget (eventListener)
+import Web.Event.EventTarget (EventListener, eventListener)
 
 blocklyEvents ::
   forall m action.
@@ -44,31 +54,128 @@ blocklyEvents toAction workspace =
     addChangeListener workspace listener
     pure $ EventSource.Finalizer $ removeChangeListener workspace listener
 
-_useEvents :: forall state. Lens' { useEvents :: Boolean | state } Boolean
-_useEvents = prop (SProxy :: SProxy "useEvents")
+_eventsWhileDragging :: forall state. Lens' { eventsWhileDragging :: Maybe (List BlocklyEvent) | state } (Maybe (List BlocklyEvent))
+_eventsWhileDragging = prop (SProxy :: SProxy "eventsWhileDragging")
 
--- | Convert blockly events into halogen messages
+-- | Using the blockly events, detect when the contract has changed and fire a halogen message.
 -- |
--- | We only raise CodeChange events if we have enabled saving. This is because when we load code into blockly
--- | it builds the blocks asynchronously. We need some way to distinguish between a user having changed blockly
--- | and the loading of code having changed blockly. This division can be seen by looking for a UI event since
--- | if the user has done nothing then no UI events will have been fired. We also need to remember to set useEvents
--- | to false in our Blockly component when SetCode is called.
-updateUnsavedChangesActionHandler ::
+-- | There are two events that signal us that the contract has changed.
+-- |   * When the Change event is fired (which means that a property inside a block has changed)
+-- |   * When the Move event is fired and the old and new parent are different (which means that
+-- |     a block has been attached/detached)
+-- |
+-- | We also need to track the UI events to see if we are in the middle of a drag-n-drop.
+-- | When we attach a block into a new parent there is no problem, but when we detach a block there
+-- | is a small inconsistency.
+-- | When we start draging a block outside from its parent, Blockly will fire the Move event and let us
+-- | believe that the contract has changed. But if we ask Blockly to generate the contract at that point,
+-- | the result will include the block we just detached. So we need to accumulate the events fired during
+-- | drag-n-drop and analyze them once we drop it.
+detectCodeChanges ::
   forall m state action slots message.
   MonadAff m =>
   message ->
   BlocklyEvent ->
-  HalogenM { useEvents :: Boolean | state } action slots message m Unit
-updateUnsavedChangesActionHandler codeChange event = do
-  useEvents <- use _useEvents
-  case event of
-    (BT.UI _) -> assign _useEvents true
-    (BT.Change _) -> when useEvents $ raise codeChange
-    -- The move event only changes the unsaved status if the parent has changed (either by attaching or detaching
-    -- one block into another)
-    (BT.Move ev) -> when (useEvents && newParentId ev /= oldParentId ev) $ raise codeChange
-    (BT.FinishLoading _) -> pure unit
-    -- The create event by itself does not modify the contract. It is modified once it's attached or detached
-    -- from a parent, and that is covered by the Move event
-    (BT.Create _) -> pure unit
+  HalogenM { eventsWhileDragging :: Maybe (List BlocklyEvent) | state } action slots message m Unit
+detectCodeChanges codeChange event = do
+  mDraggingEvents <- use _eventsWhileDragging
+  case mDraggingEvents of
+    Nothing ->
+      -- If we are not inside a drag and drop, let's evaluate the event directly
+      if (doesEventModifiesContract event) then
+        H.raise codeChange
+      else
+        -- If the event starts a drag and drop, store it in the state
+        when (isDragStart event) $ assign _eventsWhileDragging (Just Nil)
+    Just eventsWhileDragging ->
+      -- If we are inside a drag and drop, accumulate the events and analyze them all together
+      if (not $ isDragStop event) then
+        assign _eventsWhileDragging (Just (event : eventsWhileDragging))
+      else do
+        let
+          hasChanged = foldl (\accu ev -> accu || doesEventModifiesContract ev) false eventsWhileDragging
+        when hasChanged $ H.raise codeChange
+        assign _eventsWhileDragging Nothing
+  where
+  doesEventModifiesContract :: BlocklyEvent -> Boolean
+  doesEventModifiesContract = case _ of
+    (BT.Change _) -> true
+    (BT.Move ev) -> newParentId ev /= oldParentId ev
+    _ -> false
+
+-- | This function listens to blockly events and debounces the event listener so that the resulting
+-- | Aff is completed after `time` milliseconds without events.
+-- | NOTE: The part of this code that depends on blockly is rather minimal (addChangeListener workspace and
+-- |       removeChangeListener workspace). We don't care about the contents of the event, just the fact that
+-- |       it is fired, so we can debounce it.
+-- |       If we need a debounce functionality later on, see if it makes sense to refactor this. I didn't do it
+-- |       for the PR that introduced this code as it's not clear at the moment wether the debounce should be
+-- |       tied to event listeners or if we can do it with plain Aff's
+waitForEvents :: Workspace -> Int -> Aff Unit
+waitForEvents workspace time = liftEffect (Ref.new Nothing) >>= waitForEventsAndCleanResources
+  where
+  -- Make sure that the event listener is removed no matter what
+  waitForEventsAndCleanResources :: Ref (Maybe EventListener) -> Aff Unit
+  waitForEventsAndCleanResources listenerRef =
+    finally
+      (liftEffect $ removeListener listenerRef)
+      (waitForEvent listenerRef)
+
+  waitForEvent :: Ref (Maybe EventListener) -> Aff Unit
+  waitForEvent listenerRef = makeAff resolver
+    where
+    resolver cb = do
+      -- The timerRef is a mutable reference to the timeoutId so we can
+      -- cancel the "debounce" timer every time there is a new event.
+      timerRef <- Ref.new Nothing
+      let
+        -- Helper fn that creates the timer that resolves the Aff if there
+        -- is no event in `time` milliseconds
+        resolveAfterTimeout = do
+          timeoutId <- setTimeout time $ cb $ Right unit
+          Ref.write (Just timeoutId) timerRef
+      -- Create the initial timer
+      resolveAfterTimeout
+      -- Create and subscribe the event listener
+      listener <-
+        eventListener \event -> do
+          -- Clear the previous timer and and fire a new one
+          mTimeoutId <- Ref.read timerRef
+          for_ mTimeoutId clearTimeout
+          resolveAfterTimeout
+      Ref.write (Just listener) listenerRef
+      addChangeListener workspace listener
+      -- We can return a nonCanceler because the cleanup is done in the finally
+      pure nonCanceler
+
+  removeListener :: Ref (Maybe EventListener) -> Effect Unit
+  removeListener listenerRef = do
+    mListener <- Ref.read listenerRef
+    for_ mListener \listener ->
+      removeChangeListener workspace listener
+
+-- Runs an effectful action temporarily disabling the blockly events, waiting
+-- `time` milliseconds for those events to settle, and then re-subscribe.
+runWithoutEventSubscription ::
+  forall m state action message slots.
+  MonadAff m =>
+  Int ->
+  (BlocklyEvent -> action) ->
+  Effect Unit ->
+  HalogenM { blocklyState :: Maybe BlocklyState, blocklyEventSubscription :: Maybe SubscriptionId | state } action slots message m Unit
+runWithoutEventSubscription time toAction doEffect = do
+  let
+    _blocklyEventSubscription = prop (SProxy :: SProxy "blocklyEventSubscription")
+
+    _blocklyState = prop (SProxy :: SProxy "blocklyState")
+  mSubscription <- use _blocklyEventSubscription
+  mBlocklyState <- use _blocklyState
+  for_ mBlocklyState \{ workspace } -> do
+    -- Unsubscribe from blockly events
+    for_ mSubscription H.unsubscribe
+    -- Do the efectful computation that will trigger events we want to skip
+    liftEffect doEffect
+    liftAff $ waitForEvents workspace time
+    -- Resubscribe to blockly events
+    newSubscription <- H.subscribe $ blocklyEvents toAction workspace
+    assign _blocklyEventSubscription (Just newSubscription)

--- a/marlowe-playground-client/src/LoginPopup.purs
+++ b/marlowe-playground-client/src/LoginPopup.purs
@@ -80,9 +80,12 @@ openLoginPopup = do
       mbListener <- Ref.read listenerRef
       for_ mbListener \listener ->
         removeEventListener messageEvent listener false windowEventTarget
-  featureString <- liftEffect $ features
-  _ <- liftEffect $ Window.open githubLoginPage "_blank" featureString window
-  listenerRef <- liftEffect $ Ref.new Nothing
+  listenerRef <-
+    liftEffect
+      $ do
+          featureString <- features
+          void $ Window.open githubLoginPage "_blank" featureString window
+          Ref.new Nothing
   -- Make sure that the event listener is removed no matter what
   finally
     (liftEffect $ removeWaitForEventListener listenerRef)

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -2,6 +2,7 @@ module MainFrame.State (mkMainFrame) where
 
 import Prelude hiding (div)
 import Auth (AuthRole(..), authStatusAuthRole, _GithubUser)
+import BlocklyComponent.Types as Blockly
 import BlocklyEditor.State as BlocklyEditor
 import BlocklyEditor.Types (_marloweCode)
 import BlocklyEditor.Types as BE
@@ -31,7 +32,6 @@ import Halogen (Component, liftEffect, query, subscribe')
 import Halogen as H
 import Halogen.ActusBlockly as ActusBlockly
 import Halogen.Analytics (withAnalytics)
-import BlocklyComponent.Types as Blockly
 import Halogen.Extra (mapSubmodule)
 import Halogen.HTML (HTML)
 import Halogen.Monaco (KeyBindings(DefaultBindings))
@@ -479,6 +479,7 @@ handleAction s (NewProjectAction (NewProject.CreateProject lang)) = do
   modify_
     ( set _showModal Nothing
         <<< set _workflow (Just lang)
+        <<< set _hasUnsavedChanges false
     )
 
 handleAction s (NewProjectAction NewProject.Cancel) = fullHandleAction s CloseModal
@@ -501,6 +502,7 @@ handleAction s (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
   modify_
     ( set _showModal Nothing
         <<< set _workflow (Just lang)
+        <<< set _hasUnsavedChanges false
     )
   selectView $ selectLanguageView lang
 


### PR DESCRIPTION
This PR solves 2 bugs that were related:
  * The has unsaved changes indicator was being triggered when loading up a project.
  * The "send to simulation" button was not disable when we had a full contract and we detach a node.

Both bugs were related to the CodeChange Blockly event not being fired correctly.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [X] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
