### PR TITLE
SCP-1825 - Split Marlowe into "Marlowe Core" and "Extended Marlowe" in Playground

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -31,7 +31,7 @@ import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe (SPParams_, postRunghc)
 import Marlowe.Holes (fromTerm)
 import Marlowe.Parser (parseContract)
-import Marlowe.ExtendedMarlowe (Contract)
+import Marlowe.Extended (Contract)
 import Monaco (IMarkerData, markerSeverity)
 import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -31,7 +31,7 @@ import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe (SPParams_, postRunghc)
 import Marlowe.Holes (fromTerm)
 import Marlowe.Parser (parseContract)
-import Marlowe.Semantics (Contract)
+import Marlowe.ExtendedMarlowe (Contract)
 import Monaco (IMarkerData, markerSeverity)
 import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -32,7 +32,7 @@ import Language.Javascript.Monaco as JSM
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import Marlowe (SPParams_)
-import Marlowe.ExtendedMarlowe (Contract)
+import Marlowe.Extended (Contract)
 import Monaco (IRange, getModel, isError, setValue)
 import Network.RemoteData (RemoteData(..))
 import Servant.PureScript.Settings (SPSettings_)

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -32,7 +32,7 @@ import Language.Javascript.Monaco as JSM
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import Marlowe (SPParams_)
-import Marlowe.Semantics (Contract)
+import Marlowe.ExtendedMarlowe (Contract)
 import Monaco (IRange, getModel, isError, setValue)
 import Network.RemoteData (RemoteData(..))
 import Servant.PureScript.Settings (SPSettings_)

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -15,7 +15,7 @@ import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JS
-import Marlowe.ExtendedMarlowe (Contract)
+import Marlowe.Extended (Contract)
 import StaticAnalysis.Types (AnalysisState(..))
 import Text.Pretty (pretty)
 

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -15,7 +15,7 @@ import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JS
-import Marlowe.Semantics (Contract)
+import Marlowe.ExtendedMarlowe (Contract)
 import StaticAnalysis.Types (AnalysisState(..))
 import Text.Pretty (pretty)
 

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
@@ -12,7 +12,7 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Foreign.Generic (decodeJSON)
-import Marlowe.Semantics (Contract)
+import Marlowe.ExtendedMarlowe (Contract)
 import Monaco (ITextModel)
 
 data CompilationError

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
@@ -12,7 +12,7 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Foreign.Generic (decodeJSON)
-import Marlowe.ExtendedMarlowe (Contract)
+import Marlowe.Extended (Contract)
 import Monaco (ITextModel)
 
 data CompilationError

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -1073,15 +1073,15 @@ statementToTerm g block name p = case statementToCode g block name of
 
 instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) where
   blockDefinition DepositActionType g block = do
-    accountOwner <- statementToTerm g block "party" Parser.party
+    accountOwner <- statementToTerm g block "party" Parser.partyExtended
     tok <- statementToTerm g block "token" Parser.token
-    party <- statementToTerm g block "from_party" Parser.party
+    party <- statementToTerm g block "from_party" Parser.partyExtended
     amount <- statementToTerm g block "value" (Parser.value unit)
     contract <- statementToTerm g block "contract" Parser.contract
     pure $ mkDefaultTerm (Case (mkDefaultTerm (Deposit accountOwner party tok amount)) contract)
   blockDefinition ChoiceActionType g block = do
     choiceName <- getFieldValue block "choice_name"
-    choiceOwner <- statementToTerm g block "party" Parser.party
+    choiceOwner <- statementToTerm g block "party" Parser.partyExtended
     let
       choiceId = ChoiceId choiceName choiceOwner
 
@@ -1101,10 +1101,10 @@ instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) w
 
 instance hasBlockDefinitionPayee :: HasBlockDefinition PayeeType (Term Payee) where
   blockDefinition AccountPayeeType g block = do
-    accountOwner <- statementToTerm g block "party" Parser.party
+    accountOwner <- statementToTerm g block "party" Parser.partyExtended
     pure $ mkDefaultTerm (Account accountOwner)
   blockDefinition PartyPayeeType g block = do
-    party <- statementToTerm g block "party" Parser.party
+    party <- statementToTerm g block "party" Parser.partyExtended
     pure $ mkDefaultTerm (Party party)
 
 instance hasBlockDefinitionParty :: HasBlockDefinition PartyType (Term Party) where
@@ -1127,9 +1127,9 @@ instance hasBlockDefinitionToken :: HasBlockDefinition TokenType (Term Token) wh
 instance hasBlockDefinitionContract :: HasBlockDefinition ContractType (Term Contract) where
   blockDefinition CloseContractType _ _ = pure $ mkDefaultTerm Close
   blockDefinition PayContractType g block = do
-    accountOwner <- statementToTerm g block "party" Parser.party
+    accountOwner <- statementToTerm g block "party" Parser.partyExtended
     tok <- statementToTerm g block "token" Parser.token
-    payee <- statementToTerm g block "payee" Parser.payee
+    payee <- statementToTerm g block "payee" Parser.payeeExtended
     value <- statementToTerm g block "value" (Parser.value unit)
     contract <- statementToTerm g block "contract" Parser.contract
     pure $ mkDefaultTerm (Pay accountOwner payee tok value contract)
@@ -1174,7 +1174,7 @@ instance hasBlockDefinitionObservation :: HasBlockDefinition ObservationType (Te
     pure $ mkDefaultTerm (NotObs observation)
   blockDefinition ChoseSomethingObservationType g block = do
     choiceName <- getFieldValue block "choice_name"
-    choiceOwner <- statementToTerm g block "party" Parser.party
+    choiceOwner <- statementToTerm g block "party" Parser.partyExtended
     let
       choiceId = ChoiceId choiceName choiceOwner
     pure $ mkDefaultTerm (ChoseSomething choiceId)
@@ -1203,7 +1203,7 @@ instance hasBlockDefinitionObservation :: HasBlockDefinition ObservationType (Te
 
 instance hasBlockDefinitionValue :: HasBlockDefinition ValueType (Term Value) where
   blockDefinition AvailableMoneyValueType g block = do
-    accountOwner <- statementToTerm g block "party" Parser.party
+    accountOwner <- statementToTerm g block "party" Parser.partyExtended
     tok <- statementToTerm g block "token" Parser.token
     pure $ mkDefaultTerm (AvailableMoney accountOwner tok)
   blockDefinition ConstantValueType g block = do
@@ -1231,7 +1231,7 @@ instance hasBlockDefinitionValue :: HasBlockDefinition ValueType (Term Value) wh
     pure $ mkDefaultTerm (Scale (mkDefaultTermWrapper (Rational numerator denominator)) value)
   blockDefinition ChoiceValueValueType g block = do
     choiceName <- getFieldValue block "choice_name"
-    choiceOwner <- statementToTerm g block "party" Parser.party
+    choiceOwner <- statementToTerm g block "party" Parser.partyExtended
     let
       choiceId = ChoiceId choiceName choiceOwner
     pure $ mkDefaultTerm (ChoiceValue choiceId)

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -1,4 +1,4 @@
-module Marlowe.ExtendedMarlowe where
+module Marlowe.Extended where
 
 import Prelude
 import Control.Alt ((<|>))

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -10,22 +10,22 @@ import Data.Traversable (traverse)
 import Foreign (ForeignError(..), fail)
 import Foreign.Class (class Encode, class Decode, encode, decode)
 import Foreign.Index (hasProperty)
-import Marlowe.Semantics (AccountId, Bound, ChoiceId, Party, Rational(..), Timeout, Token, ValueId, decodeProp)
+import Marlowe.Semantics (decodeProp)
 import Marlowe.Semantics as S
 import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty)
 
 data Value
-  = AvailableMoney AccountId Token
+  = AvailableMoney S.AccountId S.Token
   | Constant BigInteger
   | NegValue Value
   | AddValue Value Value
   | SubValue Value Value
   | MulValue Value Value
-  | Scale Rational Value
-  | ChoiceValue ChoiceId
+  | Scale S.Rational Value
+  | ChoiceValue S.ChoiceId
   | SlotIntervalStart
   | SlotIntervalEnd
-  | UseValue ValueId
+  | UseValue S.ValueId
   | Cond Observation Value Value
 
 derive instance genericValue :: Generic Value _
@@ -60,7 +60,7 @@ instance encodeJsonValue :: Encode Value where
       { multiply: lhs
       , times: rhs
       }
-  encode (Scale (Rational num den) val) =
+  encode (Scale (S.Rational num den) val) =
     encode
       { multiply: val
       , times: num
@@ -106,7 +106,7 @@ instance decodeJsonValue :: Decode Value where
         )
       <|> ( if (hasProperty "divide_by" a) then
             ( Scale
-                <$> ( Rational <$> decodeProp "times" a
+                <$> ( S.Rational <$> decodeProp "times" a
                       <*> decodeProp "divide_by" a
                   )
                 <*> decodeProp "multiply" a
@@ -137,7 +137,7 @@ data Observation
   = AndObs Observation Observation
   | OrObs Observation Observation
   | NotObs Observation
-  | ChoseSomething ChoiceId
+  | ChoseSomething S.ChoiceId
   | ValueGE Value Value
   | ValueGT Value Value
   | ValueLT Value Value
@@ -244,8 +244,8 @@ instance hasArgsObservation :: Args Observation where
   hasNestedArgs a = genericHasNestedArgs a
 
 data Action
-  = Deposit AccountId Party Token Value
-  | Choice ChoiceId (Array Bound)
+  = Deposit S.AccountId S.Party S.Token Value
+  | Choice S.ChoiceId (Array S.Bound)
   | Notify Observation
 
 derive instance genericAction :: Generic Action _
@@ -296,8 +296,8 @@ instance hasArgsAction :: Args Action where
   hasNestedArgs a = genericHasNestedArgs a
 
 data Payee
-  = Account AccountId
-  | Party Party
+  = Account S.AccountId
+  | Party S.Party
 
 derive instance genericPayee :: Generic Payee _
 
@@ -358,10 +358,10 @@ instance hasArgsCase :: Args Case where
 
 data Contract
   = Close
-  | Pay AccountId Payee Token Value Contract
+  | Pay S.AccountId Payee S.Token Value Contract
   | If Observation Contract Contract
-  | When (Array Case) Timeout Contract
-  | Let ValueId Value Contract
+  | When (Array Case) S.Timeout Contract
+  | Let S.ValueId Value Contract
   | Assert Observation Contract
 
 derive instance genericContract :: Generic Contract _

--- a/marlowe-playground-client/src/Marlowe/ExtendedMarlowe.purs
+++ b/marlowe-playground-client/src/Marlowe/ExtendedMarlowe.purs
@@ -1,0 +1,519 @@
+module Marlowe.ExtendedMarlowe where
+
+import Prelude
+import Control.Alt ((<|>))
+import Data.BigInteger (BigInteger)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse)
+import Foreign (ForeignError(..), fail)
+import Foreign.Class (class Encode, class Decode, encode, decode)
+import Foreign.Index (hasProperty)
+import Marlowe.Semantics (AccountId, Bound, ChoiceId, Party, Rational(..), Timeout, Token, ValueId, decodeProp)
+import Marlowe.Semantics as S
+import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty)
+
+data Value
+  = AvailableMoney AccountId Token
+  | Constant BigInteger
+  | NegValue Value
+  | AddValue Value Value
+  | SubValue Value Value
+  | MulValue Value Value
+  | Scale Rational Value
+  | ChoiceValue ChoiceId
+  | SlotIntervalStart
+  | SlotIntervalEnd
+  | UseValue ValueId
+  | Cond Observation Value Value
+
+derive instance genericValue :: Generic Value _
+
+derive instance eqValue :: Eq Value
+
+derive instance ordValue :: Ord Value
+
+instance encodeJsonValue :: Encode Value where
+  encode (AvailableMoney accId tok) =
+    encode
+      { amount_of_token: tok
+      , in_account: accId
+      }
+  encode (Constant val) = encode val
+  encode (NegValue val) =
+    encode
+      { negate: val
+      }
+  encode (AddValue lhs rhs) =
+    encode
+      { add: lhs
+      , and: rhs
+      }
+  encode (SubValue lhs rhs) =
+    encode
+      { value: lhs
+      , minus: rhs
+      }
+  encode (MulValue lhs rhs) =
+    encode
+      { multiply: lhs
+      , times: rhs
+      }
+  encode (Scale (Rational num den) val) =
+    encode
+      { multiply: val
+      , times: num
+      , divide_by: den
+      }
+  encode (ChoiceValue choiceId) =
+    encode
+      { value_of_choice: choiceId
+      }
+  encode SlotIntervalStart = encode "slot_interval_start"
+  encode SlotIntervalEnd = encode "slot_interval_end"
+  encode (UseValue valueId) =
+    encode
+      { use_value: valueId
+      }
+  encode (Cond cond thenValue elseValue) =
+    encode
+      { if: cond
+      , then: thenValue
+      , else: elseValue
+      }
+
+instance decodeJsonValue :: Decode Value where
+  decode a =
+    ( ifM ((\x -> x == "slot_interval_start") <$> decode a)
+        (pure SlotIntervalStart)
+        (fail (ForeignError "Not \"slot_interval_start\" string"))
+    )
+      <|> ( ifM ((\x -> x == "slot_interval_end") <$> decode a)
+            (pure SlotIntervalEnd)
+            (fail (ForeignError "Not \"slot_interval_end\" string"))
+        )
+      <|> ( AvailableMoney <$> decodeProp "in_account" a
+            <*> decodeProp "amount_of_token" a
+        )
+      <|> (Constant <$> decode a)
+      <|> (NegValue <$> decodeProp "negate" a)
+      <|> ( AddValue <$> decodeProp "add" a
+            <*> decodeProp "and" a
+        )
+      <|> ( SubValue <$> decodeProp "value" a
+            <*> decodeProp "minus" a
+        )
+      <|> ( if (hasProperty "divide_by" a) then
+            ( Scale
+                <$> ( Rational <$> decodeProp "times" a
+                      <*> decodeProp "divide_by" a
+                  )
+                <*> decodeProp "multiply" a
+            )
+          else
+            ( MulValue <$> decodeProp "multiply" a
+                <*> decodeProp "times" a
+            )
+        )
+      <|> (ChoiceValue <$> decodeProp "value_of_choice" a)
+      <|> (UseValue <$> decodeProp "use_value" a)
+      <|> ( Cond <$> decodeProp "if" a
+            <*> decodeProp "then" a
+            <*> decodeProp "else" a
+        )
+
+instance showValue :: Show Value where
+  show v = genericShow v
+
+instance prettyValue :: Pretty Value where
+  pretty v = genericPretty v
+
+instance hasArgsValue :: Args Value where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+data Observation
+  = AndObs Observation Observation
+  | OrObs Observation Observation
+  | NotObs Observation
+  | ChoseSomething ChoiceId
+  | ValueGE Value Value
+  | ValueGT Value Value
+  | ValueLT Value Value
+  | ValueLE Value Value
+  | ValueEQ Value Value
+  | TrueObs
+  | FalseObs
+
+derive instance genericObservation :: Generic Observation _
+
+derive instance eqObservation :: Eq Observation
+
+derive instance ordObservation :: Ord Observation
+
+instance encodeJsonObservation :: Encode Observation where
+  encode (AndObs lhs rhs) =
+    encode
+      { both: lhs
+      , and: rhs
+      }
+  encode (OrObs lhs rhs) =
+    encode
+      { either: lhs
+      , or: rhs
+      }
+  encode (NotObs obs) =
+    encode
+      { not: obs
+      }
+  encode (ChoseSomething choiceId) =
+    encode
+      { chose_something_for: choiceId
+      }
+  encode (ValueGE lhs rhs) =
+    encode
+      { value: lhs
+      , ge_than: rhs
+      }
+  encode (ValueGT lhs rhs) =
+    encode
+      { value: lhs
+      , gt: rhs
+      }
+  encode (ValueLT lhs rhs) =
+    encode
+      { value: lhs
+      , lt: rhs
+      }
+  encode (ValueLE lhs rhs) =
+    encode
+      { value: lhs
+      , le_than: rhs
+      }
+  encode (ValueEQ lhs rhs) =
+    encode
+      { value: lhs
+      , equal_to: rhs
+      }
+  encode TrueObs = encode true
+  encode FalseObs = encode false
+
+instance decodeJsonObservation :: Decode Observation where
+  decode a =
+    ( ifM (decode a)
+        (pure TrueObs)
+        (fail (ForeignError "Not a boolean"))
+    )
+      <|> ( ifM (not <$> decode a)
+            (pure FalseObs)
+            (fail (ForeignError "Not a boolean"))
+        )
+      <|> ( AndObs <$> decodeProp "both" a
+            <*> decodeProp "and" a
+        )
+      <|> ( OrObs <$> decodeProp "either" a
+            <*> decodeProp "or" a
+        )
+      <|> (NotObs <$> decodeProp "not" a)
+      <|> (ChoseSomething <$> decodeProp "chose_something_for" a)
+      <|> ( ValueGE <$> decodeProp "value" a
+            <*> decodeProp "ge_than" a
+        )
+      <|> ( ValueGT <$> decodeProp "value" a
+            <*> decodeProp "gt" a
+        )
+      <|> ( ValueLT <$> decodeProp "value" a
+            <*> decodeProp "lt" a
+        )
+      <|> ( ValueLE <$> decodeProp "value" a
+            <*> decodeProp "le_than" a
+        )
+      <|> ( ValueEQ <$> decodeProp "value" a
+            <*> decodeProp "equal_to" a
+        )
+
+instance showObservation :: Show Observation where
+  show o = genericShow o
+
+instance prettyObservation :: Pretty Observation where
+  pretty v = genericPretty v
+
+instance hasArgsObservation :: Args Observation where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+data Action
+  = Deposit AccountId Party Token Value
+  | Choice ChoiceId (Array Bound)
+  | Notify Observation
+
+derive instance genericAction :: Generic Action _
+
+derive instance eqAction :: Eq Action
+
+derive instance ordAction :: Ord Action
+
+instance encodeJsonAction :: Encode Action where
+  encode (Deposit accountId party token value) =
+    encode
+      { party: party
+      , deposits: value
+      , of_token: token
+      , into_account: accountId
+      }
+  encode (Choice choiceId boundArray) =
+    encode
+      { choose_between: boundArray
+      , for_choice: choiceId
+      }
+  encode (Notify obs) =
+    encode
+      { notify_if: obs
+      }
+
+instance decodeJsonAction :: Decode Action where
+  decode a =
+    ( Deposit <$> decodeProp "into_account" a
+        <*> decodeProp "party" a
+        <*> decodeProp "of_token" a
+        <*> decodeProp "deposits" a
+    )
+      <|> ( Choice <$> decodeProp "for_choice" a
+            <*> decodeProp "choose_between" a
+        )
+      <|> (Notify <$> decodeProp "notify_if" a)
+
+instance showAction :: Show Action where
+  show (Choice cid bounds) = "(Choice " <> show cid <> " " <> show bounds <> ")"
+  show v = genericShow v
+
+instance prettyAction :: Pretty Action where
+  pretty v = genericPretty v
+
+instance hasArgsAction :: Args Action where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+data Payee
+  = Account AccountId
+  | Party Party
+
+derive instance genericPayee :: Generic Payee _
+
+derive instance eqPayee :: Eq Payee
+
+derive instance ordPayee :: Ord Payee
+
+instance encodeJsonPayee :: Encode Payee where
+  encode (Account accountId) = encode { account: accountId }
+  encode (Party party) = encode { party: party }
+
+instance decodeJsonPayee :: Decode Payee where
+  decode a =
+    (Account <$> decodeProp "account" a)
+      <|> (Party <$> decodeProp "party" a)
+
+instance showPayee :: Show Payee where
+  show v = genericShow v
+
+instance prettyPayee :: Pretty Payee where
+  pretty v = genericPretty v
+
+instance hasArgsPayee :: Args Payee where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+data Case
+  = Case Action Contract
+
+derive instance genericCase :: Generic Case _
+
+derive instance eqCase :: Eq Case
+
+derive instance ordCase :: Ord Case
+
+instance encodeJsonCase :: Encode Case where
+  encode (Case action cont) =
+    encode
+      { case: action
+      , then: cont
+      }
+
+instance decodeJsonCase :: Decode Case where
+  decode a =
+    ( Case <$> decodeProp "case" a
+        <*> decodeProp "then" a
+    )
+
+instance showCase :: Show Case where
+  show (Case action contract) = "Case " <> show action <> " " <> show contract
+
+instance prettyCase :: Pretty Case where
+  pretty v = genericPretty v
+
+instance hasArgsCase :: Args Case where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+data Contract
+  = Close
+  | Pay AccountId Payee Token Value Contract
+  | If Observation Contract Contract
+  | When (Array Case) Timeout Contract
+  | Let ValueId Value Contract
+  | Assert Observation Contract
+
+derive instance genericContract :: Generic Contract _
+
+derive instance eqContract :: Eq Contract
+
+derive instance ordContract :: Ord Contract
+
+instance encodeJsonContract :: Encode Contract where
+  encode Close = encode "close"
+  encode (Pay accId payee token val cont) =
+    encode
+      { pay: val
+      , token: token
+      , from_account: accId
+      , to: payee
+      , then: cont
+      }
+  encode (If obs contTrue contFalse) =
+    encode
+      { if: obs
+      , then: contTrue
+      , else: contFalse
+      }
+  encode (When cases timeout cont) =
+    encode
+      { when: cases
+      , timeout: timeout
+      , timeout_continuation: cont
+      }
+  encode (Let valId val cont) =
+    encode
+      { let: valId
+      , be: val
+      , then: cont
+      }
+  encode (Assert obs cont) =
+    encode
+      { assert: obs
+      , then: cont
+      }
+
+instance decodeJsonContract :: Decode Contract where
+  decode a =
+    ( ifM ((\x -> x == "close") <$> decode a)
+        (pure Close)
+        (fail (ForeignError "Not \"close\" string"))
+    )
+      <|> ( Pay <$> decodeProp "from_account" a
+            <*> decodeProp "to" a
+            <*> decodeProp "token" a
+            <*> decodeProp "pay" a
+            <*> decodeProp "then" a
+        )
+      <|> ( If <$> decodeProp "if" a
+            <*> decodeProp "then" a
+            <*> decodeProp "else" a
+        )
+      <|> ( When <$> decodeProp "when" a
+            <*> decodeProp "timeout" a
+            <*> decodeProp "timeout_continuation" a
+        )
+      <|> ( Let <$> decodeProp "let" a
+            <*> decodeProp "be" a
+            <*> decodeProp "then" a
+        )
+      <|> ( Assert <$> decodeProp "assert" a
+            <*> decodeProp "then" a
+        )
+
+instance showContract :: Show Contract where
+  show v = genericShow v
+
+instance prettyContract :: Pretty Contract where
+  pretty v = genericPretty v
+
+instance hasArgsContract :: Args Contract where
+  hasArgs a = genericHasArgs a
+  hasNestedArgs a = genericHasNestedArgs a
+
+convertPayeeIfNoExtensions :: Payee -> Maybe S.Payee
+convertPayeeIfNoExtensions (Account accId) = Just $ S.Account accId
+
+convertPayeeIfNoExtensions (Party roleName) = Just $ S.Party roleName
+
+convertValueIfNoExtensions :: Value -> Maybe S.Value
+convertValueIfNoExtensions (Constant c) = Just $ S.Constant c
+
+convertValueIfNoExtensions (AvailableMoney accId tok) = S.AvailableMoney <$> pure accId <*> pure tok
+
+convertValueIfNoExtensions (NegValue v) = S.NegValue <$> convertValueIfNoExtensions v
+
+convertValueIfNoExtensions (AddValue lhs rhs) = S.AddValue <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertValueIfNoExtensions (SubValue lhs rhs) = S.SubValue <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertValueIfNoExtensions (MulValue lhs rhs) = S.MulValue <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertValueIfNoExtensions (Scale f v) = S.Scale <$> pure f <*> convertValueIfNoExtensions v
+
+convertValueIfNoExtensions (ChoiceValue choId) = Just $ S.ChoiceValue choId
+
+convertValueIfNoExtensions SlotIntervalStart = Just $ S.SlotIntervalStart
+
+convertValueIfNoExtensions SlotIntervalEnd = Just $ S.SlotIntervalEnd
+
+convertValueIfNoExtensions (UseValue vId) = Just $ S.UseValue vId
+
+convertValueIfNoExtensions (Cond obs lhs rhs) = S.Cond <$> convertObservationIfNoExtensions obs <*> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions :: Observation -> Maybe S.Observation
+convertObservationIfNoExtensions (AndObs lhs rhs) = S.AndObs <$> convertObservationIfNoExtensions lhs <*> convertObservationIfNoExtensions rhs
+
+convertObservationIfNoExtensions (OrObs lhs rhs) = S.OrObs <$> convertObservationIfNoExtensions lhs <*> convertObservationIfNoExtensions rhs
+
+convertObservationIfNoExtensions (NotObs v) = S.NotObs <$> convertObservationIfNoExtensions v
+
+convertObservationIfNoExtensions (ChoseSomething choId) = Just $ S.ChoseSomething choId
+
+convertObservationIfNoExtensions (ValueGE lhs rhs) = S.ValueGE <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions (ValueGT lhs rhs) = S.ValueGT <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions (ValueLT lhs rhs) = S.ValueLT <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions (ValueLE lhs rhs) = S.ValueLE <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions (ValueEQ lhs rhs) = S.ValueEQ <$> convertValueIfNoExtensions lhs <*> convertValueIfNoExtensions rhs
+
+convertObservationIfNoExtensions TrueObs = Just S.TrueObs
+
+convertObservationIfNoExtensions FalseObs = Just S.FalseObs
+
+convertActionIfNoExtensions :: Action -> Maybe S.Action
+convertActionIfNoExtensions (Deposit accId party tok val) = S.Deposit <$> pure accId <*> pure party <*> pure tok <*> convertValueIfNoExtensions val
+
+convertActionIfNoExtensions (Choice choId bounds) = Just $ S.Choice choId bounds
+
+convertActionIfNoExtensions (Notify obs) = S.Notify <$> convertObservationIfNoExtensions obs
+
+convertCaseIfNoExtensions :: Case -> Maybe S.Case
+convertCaseIfNoExtensions (Case act c) = S.Case <$> convertActionIfNoExtensions act <*> convertContractIfNoExtensions c
+
+convertContractIfNoExtensions :: Contract -> Maybe S.Contract
+convertContractIfNoExtensions Close = Just S.Close
+
+convertContractIfNoExtensions (Pay accId payee tok val cont) = S.Pay <$> pure accId <*> convertPayeeIfNoExtensions payee <*> pure tok <*> convertValueIfNoExtensions val <*> convertContractIfNoExtensions cont
+
+convertContractIfNoExtensions (If obs cont1 cont2) = S.If <$> convertObservationIfNoExtensions obs <*> convertContractIfNoExtensions cont1 <*> convertContractIfNoExtensions cont2
+
+convertContractIfNoExtensions (When cases tim cont) = S.When <$> traverse convertCaseIfNoExtensions cases <*> pure tim <*> convertContractIfNoExtensions cont
+
+convertContractIfNoExtensions (Let varId val cont) = S.Let <$> pure varId <*> convertValueIfNoExtensions val <*> convertContractIfNoExtensions cont
+
+convertContractIfNoExtensions (Assert obs cont) = S.Assert <$> convertObservationIfNoExtensions obs <*> convertContractIfNoExtensions cont

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -18,7 +18,7 @@ import Data.String.CodeUnits (fromCharArray)
 import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkArgName)
 import Marlowe.Semantics (Rational(..), CurrencySymbol, Input(..), PubKey, Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended as EM
 import Text.Parsing.StringParser (Pos)
 import Type.Proxy (Proxy(..))
 

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -18,6 +18,7 @@ import Data.String.CodeUnits (fromCharArray)
 import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkArgName)
 import Marlowe.Semantics (Rational(..), CurrencySymbol, Input(..), PubKey, Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
+import Marlowe.ExtendedMarlowe as EM
 import Text.Parsing.StringParser (Pos)
 import Type.Proxy (Proxy(..))
 
@@ -334,8 +335,11 @@ genPartyValue = oneOf $ pk :| [ role ]
 
   role = S.Role <$> genTokenNameValue
 
-genPayeeValue :: forall m. MonadGen m => MonadRec m => m S.Payee
-genPayeeValue = oneOf $ (S.Account <$> genPartyValue) :| [ S.Party <$> genPartyValue ]
+genPayeeValueCore :: forall m. MonadGen m => MonadRec m => m S.Payee
+genPayeeValueCore = oneOf $ (S.Account <$> genPartyValue) :| [ S.Party <$> genPartyValue ]
+
+genPayeeValueExtended :: forall m. MonadGen m => MonadRec m => m EM.Payee
+genPayeeValueExtended = oneOf $ (EM.Account <$> genPartyValue) :| [ EM.Party <$> genPartyValue ]
 
 genValueIdValue :: forall m. MonadGen m => MonadRec m => m S.ValueId
 genValueIdValue = S.ValueId <$> genString
@@ -376,7 +380,7 @@ genTransactionWarning ::
 genTransactionWarning =
   oneOf
     $ (TransactionNonPositiveDeposit <$> genPartyValue <*> genPartyValue <*> genTokenValue <*> genBigInteger)
-    :| [ TransactionNonPositivePay <$> genPartyValue <*> genPayeeValue <*> genTokenValue <*> genBigInteger
-      , TransactionPartialPay <$> genPartyValue <*> genPayeeValue <*> genTokenValue <*> genBigInteger <*> genBigInteger
+    :| [ TransactionNonPositivePay <$> genPartyValue <*> genPayeeValueCore <*> genTokenValue <*> genBigInteger
+      , TransactionPartialPay <$> genPartyValue <*> genPayeeValueCore <*> genTokenValue <*> genBigInteger <*> genBigInteger
       , TransactionShadowing <$> genValueIdValue <*> genBigInteger <*> genBigInteger
       ]

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -30,7 +30,7 @@ import Foreign (readString)
 import Foreign.Generic (class Decode, class Encode, ForeignError(..), decode, encode)
 import Marlowe.Semantics (PubKey, Rational(..), Slot, TokenName)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended as EM
 import Monaco (CompletionItem, IRange, completionItemKind)
 import Text.Extra as Text
 import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty, hasArgs, hasNestedArgs, pretty)

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -30,6 +30,7 @@ import Foreign (readString)
 import Foreign.Generic (class Decode, class Encode, ForeignError(..), decode, encode)
 import Marlowe.Semantics (PubKey, Rational(..), Slot, TokenName)
 import Marlowe.Semantics as S
+import Marlowe.ExtendedMarlowe as EM
 import Monaco (CompletionItem, IRange, completionItemKind)
 import Text.Extra as Text
 import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty, hasArgs, hasNestedArgs, pretty)
@@ -639,10 +640,10 @@ instance hasArgsAction :: Args Action where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance actionFromTerm :: FromTerm Action S.Action where
-  fromTerm (Deposit a b c d) = S.Deposit <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d
-  fromTerm (Choice a b) = S.Choice <$> fromTerm a <*> (traverse fromTerm b)
-  fromTerm (Notify a) = S.Notify <$> fromTerm a
+instance actionFromTerm :: FromTerm Action EM.Action where
+  fromTerm (Deposit a b c d) = EM.Deposit <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d
+  fromTerm (Choice a b) = EM.Choice <$> fromTerm a <*> (traverse fromTerm b)
+  fromTerm (Notify a) = EM.Notify <$> fromTerm a
 
 instance actionMarloweType :: IsMarloweType Action where
   marloweType _ = ActionType
@@ -672,9 +673,9 @@ instance hasArgsPayee :: Args Payee where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance payeeFromTerm :: FromTerm Payee S.Payee where
-  fromTerm (Account a) = S.Account <$> fromTerm a
-  fromTerm (Party (Term a _)) = S.Party <$> fromTerm a
+instance payeeFromTerm :: FromTerm Payee EM.Payee where
+  fromTerm (Account a) = EM.Account <$> fromTerm a
+  fromTerm (Party (Term a _)) = EM.Party <$> fromTerm a
   fromTerm _ = Nothing
 
 instance payeeMarloweType :: IsMarloweType Payee where
@@ -705,8 +706,8 @@ instance hasArgsCase :: Args Case where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance caseFromTerm :: FromTerm Case S.Case where
-  fromTerm (Case a b) = S.Case <$> fromTerm a <*> fromTerm b
+instance caseFromTerm :: FromTerm Case EM.Case where
+  fromTerm (Case a b) = EM.Case <$> fromTerm a <*> fromTerm b
 
 instance caseMarloweType :: IsMarloweType Case where
   marloweType _ = CaseType
@@ -744,19 +745,19 @@ instance hasArgsValue :: Args Value where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance valueFromTerm :: FromTerm Value S.Value where
-  fromTerm (AvailableMoney a b) = S.AvailableMoney <$> fromTerm a <*> fromTerm b
-  fromTerm (Constant a) = pure $ S.Constant a
-  fromTerm (NegValue a) = S.NegValue <$> fromTerm a
-  fromTerm (AddValue a b) = S.AddValue <$> fromTerm a <*> fromTerm b
-  fromTerm (SubValue a b) = S.SubValue <$> fromTerm a <*> fromTerm b
-  fromTerm (MulValue a b) = S.MulValue <$> fromTerm a <*> fromTerm b
-  fromTerm (Scale a b) = S.Scale <$> fromTerm a <*> fromTerm b
-  fromTerm (ChoiceValue a) = S.ChoiceValue <$> fromTerm a
-  fromTerm SlotIntervalStart = pure S.SlotIntervalStart
-  fromTerm SlotIntervalEnd = pure S.SlotIntervalEnd
-  fromTerm (UseValue a) = S.UseValue <$> fromTerm a
-  fromTerm (Cond c a b) = S.Cond <$> fromTerm c <*> fromTerm a <*> fromTerm b
+instance valueFromTerm :: FromTerm Value EM.Value where
+  fromTerm (AvailableMoney a b) = EM.AvailableMoney <$> fromTerm a <*> fromTerm b
+  fromTerm (Constant a) = pure $ EM.Constant a
+  fromTerm (NegValue a) = EM.NegValue <$> fromTerm a
+  fromTerm (AddValue a b) = EM.AddValue <$> fromTerm a <*> fromTerm b
+  fromTerm (SubValue a b) = EM.SubValue <$> fromTerm a <*> fromTerm b
+  fromTerm (MulValue a b) = EM.MulValue <$> fromTerm a <*> fromTerm b
+  fromTerm (Scale a b) = EM.Scale <$> fromTerm a <*> fromTerm b
+  fromTerm (ChoiceValue a) = EM.ChoiceValue <$> fromTerm a
+  fromTerm SlotIntervalStart = pure EM.SlotIntervalStart
+  fromTerm SlotIntervalEnd = pure EM.SlotIntervalEnd
+  fromTerm (UseValue a) = EM.UseValue <$> fromTerm a
+  fromTerm (Cond c a b) = EM.Cond <$> fromTerm c <*> fromTerm a <*> fromTerm b
 
 instance valueIsMarloweType :: IsMarloweType Value where
   marloweType _ = ValueType
@@ -801,18 +802,18 @@ instance hasArgsObservation :: Args Observation where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance observationFromTerm :: FromTerm Observation S.Observation where
-  fromTerm (AndObs a b) = S.AndObs <$> fromTerm a <*> fromTerm b
-  fromTerm (OrObs a b) = S.OrObs <$> fromTerm a <*> fromTerm b
-  fromTerm (NotObs a) = S.NotObs <$> fromTerm a
-  fromTerm (ChoseSomething a) = S.ChoseSomething <$> fromTerm a
-  fromTerm (ValueGE a b) = S.ValueGE <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueGT a b) = S.ValueGT <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueLT a b) = S.ValueLT <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueLE a b) = S.ValueLE <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueEQ a b) = S.ValueEQ <$> fromTerm a <*> fromTerm b
-  fromTerm TrueObs = pure S.TrueObs
-  fromTerm FalseObs = pure S.FalseObs
+instance observationFromTerm :: FromTerm Observation EM.Observation where
+  fromTerm (AndObs a b) = EM.AndObs <$> fromTerm a <*> fromTerm b
+  fromTerm (OrObs a b) = EM.OrObs <$> fromTerm a <*> fromTerm b
+  fromTerm (NotObs a) = EM.NotObs <$> fromTerm a
+  fromTerm (ChoseSomething a) = EM.ChoseSomething <$> fromTerm a
+  fromTerm (ValueGE a b) = EM.ValueGE <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueGT a b) = EM.ValueGT <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueLT a b) = EM.ValueLT <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueLE a b) = EM.ValueLE <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueEQ a b) = EM.ValueEQ <$> fromTerm a <*> fromTerm b
+  fromTerm TrueObs = pure EM.TrueObs
+  fromTerm FalseObs = pure EM.FalseObs
 
 instance observationIsMarloweType :: IsMarloweType Observation where
   marloweType _ = ObservationType
@@ -851,13 +852,13 @@ instance hasArgsContract :: Args Contract where
   hasArgs a = genericHasArgs a
   hasNestedArgs a = genericHasNestedArgs a
 
-instance contractFromTerm :: FromTerm Contract S.Contract where
-  fromTerm Close = pure S.Close
-  fromTerm (Pay a b c d e) = S.Pay <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d <*> fromTerm e
-  fromTerm (If a b c) = S.If <$> fromTerm a <*> fromTerm b <*> fromTerm c
-  fromTerm (When as (TermWrapper b _) c) = S.When <$> (traverse fromTerm as) <*> pure b <*> fromTerm c
-  fromTerm (Let a b c) = S.Let <$> fromTerm a <*> fromTerm b <*> fromTerm c
-  fromTerm (Assert a b) = S.Assert <$> fromTerm a <*> fromTerm b
+instance contractFromTerm :: FromTerm Contract EM.Contract where
+  fromTerm Close = pure EM.Close
+  fromTerm (Pay a b c d e) = EM.Pay <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d <*> fromTerm e
+  fromTerm (If a b c) = EM.If <$> fromTerm a <*> fromTerm b <*> fromTerm c
+  fromTerm (When as (TermWrapper b _) c) = EM.When <$> (traverse fromTerm as) <*> pure b <*> fromTerm c
+  fromTerm (Let a b c) = EM.Let <$> fromTerm a <*> fromTerm b <*> fromTerm c
+  fromTerm (Assert a b) = EM.Assert <$> fromTerm a <*> fromTerm b
 
 instance contractIsMarloweType :: IsMarloweType Contract where
   marloweType _ = ContractType

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -53,7 +53,7 @@ import Marlowe.Holes as Holes
 import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), emptyState, evalValue, makeEnvironment)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended as EM
 import Monaco (CodeAction, CompletionItem, IMarkerData, IRange, TextEdit, Uri, markerSeverity)
 import Monaco as Monaco
 import Pretty (showPrettyMoney, showPrettyParty, showPrettyToken)

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -35,7 +35,7 @@ import Marlowe.Linter as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import Marlowe.ExtendedMarlowe (Contract)
+import Marlowe.Extended (Contract)
 import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _selectedHole, _showErrorDetail)
 import Monaco (IMarker, isError, isWarning)
 import Network.RemoteData as RemoteData

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -35,7 +35,7 @@ import Marlowe.Linter as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import Marlowe.Semantics (Contract)
+import Marlowe.ExtendedMarlowe (Contract)
 import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _selectedHole, _showErrorDetail)
 import Monaco (IMarker, isError, isWarning)
 import Network.RemoteData as RemoteData

--- a/marlowe-playground-client/src/Simulator.purs
+++ b/marlowe-playground-client/src/Simulator.purs
@@ -23,7 +23,7 @@ import Marlowe.Linter as L
 import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (Action(..), Bound(..), ChoiceId(..), ChosenNum, Contract(..), Environment(..), Input, IntervalResult(..), Observation, Party, Slot, SlotInterval(..), State, TransactionError(..), TransactionInput(..), TransactionOutput(..), _minSlot, boundFrom, computeTransaction, emptyState, evalValue, extractRequiredActionsWithTxs, fixInterval, moneyInContract, timeouts)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
+import Marlowe.Extended (convertContractIfNoExtensions)
 import SimulationPage.Types (ActionInput(..), ActionInputId(..), ExecutionState(..), ExecutionStateRecord, MarloweEvent(..), MarloweState, Parties, _SimulationRunning, _contract, _currentMarloweState, _editorErrors, _executionState, _holes, _log, _marloweState, _moneyInContract, _moveToAction, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, otherActionsParty)
 
 minimumBound :: Array Bound -> ChosenNum

--- a/marlowe-playground-client/src/Simulator.purs
+++ b/marlowe-playground-client/src/Simulator.purs
@@ -23,7 +23,8 @@ import Marlowe.Linter as L
 import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (Action(..), Bound(..), ChoiceId(..), ChosenNum, Contract(..), Environment(..), Input, IntervalResult(..), Observation, Party, Slot, SlotInterval(..), State, TransactionError(..), TransactionInput(..), TransactionOutput(..), _minSlot, boundFrom, computeTransaction, emptyState, evalValue, extractRequiredActionsWithTxs, fixInterval, moneyInContract, timeouts)
 import Marlowe.Semantics as S
-import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended (toCore)
+import Marlowe.Extended as EM
 import SimulationPage.Types (ActionInput(..), ActionInputId(..), ExecutionState(..), ExecutionStateRecord, MarloweEvent(..), MarloweState, Parties, _SimulationRunning, _contract, _currentMarloweState, _editorErrors, _executionState, _holes, _log, _marloweState, _moneyInContract, _moveToAction, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, otherActionsParty)
 
 minimumBound :: Array Bound -> ChosenNum
@@ -91,7 +92,7 @@ updateContractInStateP text state = case parseContract text of
     in
       -- We reuse the extended Marlowe parser for now since it is a superset
       case mContract of
-        Just extendedContract -> case convertContractIfNoExtensions extendedContract of
+        Just extendedContract -> case toCore (extendedContract :: EM.Contract) of
           Just contract -> set _editorErrors [] <<< set _contract (Just contract) $ state
           Nothing -> (set _holes mempty) state
         Nothing ->

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -20,6 +20,7 @@ import Network.RemoteData (RemoteData(..))
 import Pretty (showPrettyToken)
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
 import StaticAnalysis.Types (AnalysisState(..), MultiStageAnalysisData(..), _analysisState)
+import Types (WarningAnalysisError(..))
 
 analyzeButton ::
   forall p action. Boolean -> Boolean -> String -> action -> HTML p action
@@ -82,7 +83,7 @@ analysisResultPane state =
                     ]
                 ]
             ]
-        Failure (AjaxError { description }) ->
+        Failure (WarningAnalysisAjaxError (AjaxError { description })) ->
           let
             err = case description of
               DecodingError e -> "Decoding error: " <> e
@@ -100,6 +101,16 @@ analysisResultPane state =
                       ]
                   ]
               ]
+        Failure WarningAnalysisIsExtendedMarloweError ->
+          explanation
+            [ h3 [ classes [ ClassName "analysis-result-title" ] ] [ text "Error during warning analysis" ]
+            , text "Analysis failed for the following reason:"
+            , ul [ classes [ ClassName "indented-enum-initial" ] ]
+                [ li_
+                    [ b_ [ spanText "The code has templates. Static analysis can only be run in core Marlowe code." ]
+                    ]
+                ]
+            ]
         Loading -> text ""
       ReachabilityAnalysis reachabilitySubResult -> case reachabilitySubResult of
         AnalysisNotStarted ->
@@ -123,7 +134,7 @@ analysisResultPane state =
                           ]
                     )
             )
-        AnalyisisFailure err ->
+        AnalysisFailure err ->
           explanation
             [ h3 [ classes [ ClassName "analysis-result-title" ] ] [ text "Error during reachability analysis" ]
             , text "Reachability analysis failed for the following reason:"
@@ -170,7 +181,7 @@ analysisResultPane state =
                           ]
                     )
             )
-        AnalyisisFailure err ->
+        AnalysisFailure err ->
           explanation
             [ h3 [ classes [ ClassName "analysis-result-title" ] ] [ text "Error during Close refund analysis" ]
             , text "Close refund analysis failed for the following reason:"

--- a/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
@@ -3,6 +3,7 @@ module CloseAnalysis where
 import Prelude hiding (div)
 import Data.Foldable (foldl)
 import Data.Lens (assign)
+import Data.Maybe (Maybe(..))
 import Data.Set (Set)
 import Data.Set as Set
 import Data.Tuple.Nested (type (/\), (/\))
@@ -11,6 +12,8 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (AccountId, Contract(..), Observation(..), Payee(..), Token, Value(..), emptyState)
 import Marlowe.Semantics as S
+import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
+import Marlowe.ExtendedMarlowe as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
 import StaticAnalysis.Types (AnalysisState(..), ContractPath, ContractZipper(..), MultiStageAnalysisData(..), MultiStageAnalysisProblemDef, _analysisState)
@@ -19,17 +22,20 @@ analyseClose ::
   forall m state action slots.
   MonadAff m =>
   SPSettings_ SPParams_ ->
-  Contract ->
+  EM.Contract ->
   HalogenM { analysisState :: AnalysisState | state } action slots Void m Unit
-analyseClose settings contract = do
-  assign _analysisState (CloseAnalysis AnalysisNotStarted)
-  -- when editor and simulator were together the analyse contract could be made
-  -- at any step of the simulator. Now that they are separate, it can only be done
-  -- with initial state
-  let
-    emptySemanticState = emptyState zero
-  newCloseAnalysisState <- startCloseAnalysis settings contract emptySemanticState
-  assign _analysisState (CloseAnalysis newCloseAnalysisState)
+analyseClose settings extendedContract = do
+  case convertContractIfNoExtensions extendedContract of
+    Just contract -> do
+      assign _analysisState (CloseAnalysis AnalysisNotStarted)
+      -- when editor and simulator were together the analyse contract could be made
+      -- at any step of the simulator. Now that they are separate, it can only be done
+      -- with initial state
+      let
+        emptySemanticState = emptyState zero
+      newCloseAnalysisState <- startCloseAnalysis settings contract emptySemanticState
+      assign _analysisState (CloseAnalysis newCloseAnalysisState)
+    Nothing -> assign _analysisState (CloseAnalysis $ AnalysisFailure "The code has templates. Static analysis can only be run in core Marlowe code.")
 
 extractAccountIdsFromZipper :: ContractZipper -> Set (AccountId /\ Token)
 extractAccountIdsFromZipper = go

--- a/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
@@ -12,8 +12,8 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (AccountId, Contract(..), Observation(..), Payee(..), Token, Value(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
 import StaticAnalysis.Types (AnalysisState(..), ContractPath, ContractZipper(..), MultiStageAnalysisData(..), MultiStageAnalysisProblemDef, _analysisState)

--- a/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/CloseAnalysis.purs
@@ -12,7 +12,7 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (AccountId, Contract(..), Observation(..), Payee(..), Token, Value(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended (toCore)
 import Marlowe.Extended as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
@@ -25,7 +25,7 @@ analyseClose ::
   EM.Contract ->
   HalogenM { analysisState :: AnalysisState | state } action slots Void m Unit
 analyseClose settings extendedContract = do
-  case convertContractIfNoExtensions extendedContract of
+  case toCore extendedContract of
     Just contract -> do
       assign _analysisState (CloseAnalysis AnalysisNotStarted)
       -- when editor and simulator were together the analyse contract could be made

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -21,6 +21,8 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (Contract(..), Observation(..), emptyState)
 import Marlowe.Semantics as S
+import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
+import Marlowe.ExtendedMarlowe as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
 import StaticAnalysis.Types (AnalysisState(..), ContractPath, ContractPathStep, ContractZipper(..), MultiStageAnalysisData(..), MultiStageAnalysisProblemDef, PrefixMap, _analysisState)
@@ -29,17 +31,20 @@ analyseReachability ::
   forall m state action slots.
   MonadAff m =>
   SPSettings_ SPParams_ ->
-  Contract ->
+  EM.Contract ->
   HalogenM { analysisState :: AnalysisState | state } action slots Void m Unit
-analyseReachability settings contract = do
-  assign _analysisState (ReachabilityAnalysis AnalysisNotStarted)
-  -- when editor and simulator were together the analyse contract could be made
-  -- at any step of the simulator. Now that they are separate, it can only be done
-  -- with initial state
-  let
-    emptySemanticState = emptyState zero
-  newReachabilityAnalysisState <- startReachabilityAnalysis settings contract emptySemanticState
-  assign _analysisState (ReachabilityAnalysis newReachabilityAnalysisState)
+analyseReachability settings extendedContract = do
+  case convertContractIfNoExtensions extendedContract of
+    Just contract -> do
+      assign _analysisState (ReachabilityAnalysis AnalysisNotStarted)
+      -- when editor and simulator were together the analyse contract could be made
+      -- at any step of the simulator. Now that they are separate, it can only be done
+      -- with initial state
+      let
+        emptySemanticState = emptyState zero
+      newReachabilityAnalysisState <- startReachabilityAnalysis settings contract emptySemanticState
+      assign _analysisState (ReachabilityAnalysis newReachabilityAnalysisState)
+    Nothing -> assign _analysisState (ReachabilityAnalysis $ AnalysisFailure "The code has templates. Static analysis can only be run in core Marlowe code.")
 
 expandSubproblem :: ContractZipper -> Contract -> (ContractPath /\ Contract)
 expandSubproblem z _ = zipperToContractPath z /\ closeZipperContract z (Assert FalseObs Close)

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -21,8 +21,8 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (Contract(..), Observation(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
 import StaticAnalysis.Types (AnalysisState(..), ContractPath, ContractPathStep, ContractZipper(..), MultiStageAnalysisData(..), MultiStageAnalysisProblemDef, PrefixMap, _analysisState)

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -21,7 +21,7 @@ import Halogen (HalogenM)
 import Marlowe (SPParams_)
 import Marlowe.Semantics (Contract(..), Observation(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended (toCore)
 import Marlowe.Extended as EM
 import Servant.PureScript.Settings (SPSettings_)
 import StaticAnalysis.StaticTools (closeZipperContract, startMultiStageAnalysis, zipperToContractPath)
@@ -34,7 +34,7 @@ analyseReachability ::
   EM.Contract ->
   HalogenM { analysisState :: AnalysisState | state } action slots Void m Unit
 analyseReachability settings extendedContract = do
-  case convertContractIfNoExtensions extendedContract of
+  case toCore extendedContract of
     Just contract -> do
       assign _analysisState (ReachabilityAnalysis AnalysisNotStarted)
       -- when editor and simulator were together the analyse contract could be made

--- a/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
@@ -24,8 +24,8 @@ import Marlowe (SPParams_)
 import Marlowe as Server
 import Marlowe.Semantics (Case(..), Contract(..), Observation(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
-import Marlowe.ExtendedMarlowe as EM
+import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended as EM
 import Marlowe.Symbolic.Types.Request as MSReq
 import Marlowe.Symbolic.Types.Response (Result(..))
 import Network.RemoteData (RemoteData(..))

--- a/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
@@ -24,7 +24,7 @@ import Marlowe (SPParams_)
 import Marlowe as Server
 import Marlowe.Semantics (Case(..), Contract(..), Observation(..), emptyState)
 import Marlowe.Semantics as S
-import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended (toCore)
 import Marlowe.Extended as EM
 import Marlowe.Symbolic.Types.Request as MSReq
 import Marlowe.Symbolic.Types.Response (Result(..))
@@ -48,7 +48,7 @@ analyseContract ::
   EM.Contract ->
   HalogenM { analysisState :: AnalysisState | state } action slots Void m Unit
 analyseContract settings extendedContract = do
-  case convertContractIfNoExtensions extendedContract of
+  case toCore extendedContract of
     Just contract -> do
       assign _analysisState (WarningAnalysis Loading)
       -- when editor and simulator were together the analyse contract could be made

--- a/marlowe-playground-client/src/StaticAnalysis/Types.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Types.purs
@@ -15,12 +15,12 @@ import Marlowe.Semantics (AccountId, Case, Contract, Observation, Payee, Timeout
 import Marlowe.Semantics as S
 import Marlowe.Symbolic.Types.Response (Result)
 import Network.RemoteData (isLoading)
-import Types (WebData)
+import Types (WarningAnalysisData)
 
 -------------------------------------------------------------------------------
 data AnalysisState
   = NoneAsked
-  | WarningAnalysis (WebData Result)
+  | WarningAnalysis (WarningAnalysisData Result)
   | ReachabilityAnalysis MultiStageAnalysisData
   | CloseAnalysis MultiStageAnalysisData
 
@@ -50,7 +50,7 @@ isCloseAnalysisLoading _ = false
 data MultiStageAnalysisData
   = AnalysisNotStarted
   | AnalysisInProgress AnalysisInProgressRecord
-  | AnalyisisFailure String
+  | AnalysisFailure String
   | AnalysisFoundCounterExamples AnalysisCounterExamplesRecord
   | AnalysisFinishedAndPassed
 

--- a/marlowe-playground-client/src/Types.purs
+++ b/marlowe-playground-client/src/Types.purs
@@ -3,8 +3,15 @@ module Types where
 import Network.RemoteData (RemoteData)
 import Servant.PureScript.Ajax (AjaxError)
 
+data WarningAnalysisError
+  = WarningAnalysisAjaxError AjaxError
+  | WarningAnalysisIsExtendedMarloweError
+
 type WebData
   = RemoteData AjaxError
+
+type WarningAnalysisData
+  = RemoteData WarningAnalysisError
 
 data MarloweError
   = MarloweError String

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -40,7 +40,8 @@ import Halogen.HTML.Properties (value) as HTML
 import Help (HelpContext(..), toHTML)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
 import Marlowe.Semantics as S
-import Marlowe.Extended (convertContractIfNoExtensions)
+import Marlowe.Extended (toCore)
+import Marlowe.Extended as EM
 import Marlowe.Holes (fromTerm, gatherContractData)
 import Marlowe.Parser (parseContract)
 import Pretty (renderPrettyParty, renderPrettyPayee, renderPrettyToken, showPrettyMoney)
@@ -108,7 +109,7 @@ handleQuery (LoadContract contractString next) = do
     Right contractTerm ->
       for_ (fromTerm contractTerm) \extendedContract -> do
         -- We reuse the extended Marlowe parser for now since it is a superset
-        for_ (convertContractIfNoExtensions extendedContract) \contract -> do
+        for_ (toCore (extendedContract :: EM.Contract)) \contract -> do
           idx <- use (_contracts <<< _NextIndex)
           mOpenWallet <- use _openWallet
           for_ mOpenWallet \openWallet -> do

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -38,13 +38,14 @@ import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), alt, class_, classes, enabled, placeholder, selected, src, type_, value)
 import Halogen.HTML.Properties (value) as HTML
 import Help (HelpContext(..), toHTML)
-import Marlowe.Holes (fromTerm, gatherContractData)
-import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
 import Marlowe.Semantics as S
+import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
+import Marlowe.Holes (fromTerm, gatherContractData)
+import Marlowe.Parser (parseContract)
 import Pretty (renderPrettyParty, renderPrettyPayee, renderPrettyToken, showPrettyMoney)
-import Simulator (updateContractInStateP, updatePossibleActions, updateStateP)
 import SimulationPage.Types (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _currentMarloweState, _marloweState, _executionState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput)
+import Simulator (updateContractInStateP, updatePossibleActions, updateStateP)
 import Text.Extra (stripParens)
 import Text.Pretty (pretty)
 import WalletSimulation.Types (Action(..), ChildSlots, LoadedContract, Message(..), Query(..), State, View(..), Wallet(..), _addInputError, _assetChanges, _assets, _contracts, _currentLoadedMarloweState, _helpContext, _initialized, _loadContractError, _loadedMarloweState, _name, _openWallet, _parties, _runningContracts, _showRightPanel, _started, _tokens, _view, _walletContracts, _walletLoadedContract, _wallets, mkState)
@@ -105,39 +106,41 @@ handleQuery (LoadContract contractString next) = do
   case parseContract contractString of
     Left err -> assign _loadContractError (Just $ show err)
     Right contractTerm ->
-      for_ (fromTerm contractTerm) \contract -> do
-        idx <- use (_contracts <<< _NextIndex)
-        mOpenWallet <- use _openWallet
-        for_ mOpenWallet \openWallet -> do
-          existingWallets <- use _wallets
-          slot <- use _slot
-          let
-            contractData = gatherContractData contractTerm { parties: mempty, tokens: mempty }
+      for_ (fromTerm contractTerm) \extendedContract -> do
+        -- We reuse the extended Marlowe parser for now since it is a superset
+        for_ (convertContractIfNoExtensions extendedContract) \contract -> do
+          idx <- use (_contracts <<< _NextIndex)
+          mOpenWallet <- use _openWallet
+          for_ mOpenWallet \openWallet -> do
+            existingWallets <- use _wallets
+            slot <- use _slot
+            let
+              contractData = gatherContractData contractTerm { parties: mempty, tokens: mempty }
 
-            parties = Set.mapMaybe fromTerm contractData.parties
+              parties = Set.mapMaybe fromTerm contractData.parties
 
-            tokens = Map.fromFoldable $ Set.map (\token -> Tuple token zero) $ Set.mapMaybe fromTerm contractData.tokens
+              tokens = Map.fromFoldable $ Set.map (\token -> Tuple token zero) $ Set.mapMaybe fromTerm contractData.tokens
 
-            newWallets = foldl (walletFromPK tokens) existingWallets parties
+              newWallets = foldl (walletFromPK tokens) existingWallets parties
 
-            -- A PK party should be owned by the wallet that is that PK but by default it is owned by the primary wallet
-            partiesMap = Map.fromFoldable $ Set.map (mkPartyPair openWallet newWallets) parties
+              -- A PK party should be owned by the wallet that is that PK but by default it is owned by the primary wallet
+              partiesMap = Map.fromFoldable $ Set.map (mkPartyPair openWallet newWallets) parties
 
-            loadedContract =
-              { contract
-              , idx
-              , owner: openWallet ^. _name
-              , parties: mempty
-              , started: false
-              , marloweState: NEL.singleton (emptyMarloweStateWithSlot slot)
-              }
-          modifying _wallets (Map.union newWallets)
-          assign _walletLoadedContract (Just loadedContract)
-          modifying _contracts (Map.insert idx loadedContract)
-          assign (_walletLoadedContract <<< _Just <<< _parties) partiesMap
-          modifying (_openWallet <<< _Just <<< _assets) (flip Map.union tokens)
-          modifying _tokens (Set.union (Map.keys tokens))
-          updateContractInState contractString
+              loadedContract =
+                { contract
+                , idx
+                , owner: openWallet ^. _name
+                , parties: mempty
+                , started: false
+                , marloweState: NEL.singleton (emptyMarloweStateWithSlot slot)
+                }
+            modifying _wallets (Map.union newWallets)
+            assign _walletLoadedContract (Just loadedContract)
+            modifying _contracts (Map.insert idx loadedContract)
+            assign (_walletLoadedContract <<< _Just <<< _parties) partiesMap
+            modifying (_openWallet <<< _Just <<< _assets) (flip Map.union tokens)
+            modifying _tokens (Set.union (Map.keys tokens))
+            updateContractInState contractString
   pure $ Just next
   where
   walletFromPK :: Map Token BigInteger -> Map String Wallet -> Party -> Map String Wallet

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -40,7 +40,7 @@ import Halogen.HTML.Properties (value) as HTML
 import Help (HelpContext(..), toHTML)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
 import Marlowe.Semantics as S
-import Marlowe.ExtendedMarlowe (convertContractIfNoExtensions)
+import Marlowe.Extended (convertContractIfNoExtensions)
 import Marlowe.Holes (fromTerm, gatherContractData)
 import Marlowe.Parser (parseContract)
 import Pretty (renderPrettyParty, renderPrettyPayee, renderPrettyToken, showPrettyMoney)

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -46,7 +46,7 @@ testFor ValueIdType = mkTest false ValueIdType (parse Parser.valueId)
 
 testFor ActionType = mkTest false ActionType (parse Parser.action)
 
-testFor PayeeType = mkTest false PayeeType (parse Parser.payee)
+testFor PayeeType = mkTest false PayeeType (parse Parser.payeeExtended)
 
 testFor CaseType = mkTest false CaseType (parse Parser.case')
 
@@ -60,7 +60,7 @@ testFor BoundType = mkTest false BoundType (parse Parser.bound)
 
 testFor TokenType = mkTest false TokenType (parse Parser.token)
 
-testFor PartyType = mkTest false PartyType (parse Parser.party)
+testFor PartyType = mkTest false PartyType (parse Parser.partyExtended)
 
 all :: TestSuite
 all =


### PR DESCRIPTION
This is a refactoring that aims to split Marlowe in two:
* "Marlowe Core" is the original `Semantics.purs`, and is used for static analysis and simulation
* and `Extended.purs` (Extended Marlowe) is, so far, essentially a copy of some key types of `Semantics.purs` that will eventually be modified to include template constructors. I have left out base constructs like `Party` and `ChoiceId`. I think it could be a good idea to eventually get rid of `Party` from "Extended Marlowe", in fact.

`Party` is a weird case, because it is not in the "Extended Marlowe" module but, because it has holes, I had to create two parsers for it, one that accepts holes and one that doesn't. Because I can only generate "Extended Marlowe" from the parser with holes, and Party is also in things like Inputs, which are not in "Extended Marlowe". Also `AccountId` because it is a type synonym of `Party`

"Extended Marlowe" is used by linting, and the hole system, and as a target for Haskell, JavaScript, and Blockly.

There are at least a few things that probably just work for now because I haven't changed "Extended Marlowe" to be different from "Marlowe Core":
* Starting the simulation, will need an interface for conversion (also the wallet, even though it is hidden right now)
* Linting, highlighting of reachability analysis
* Static Analysis, will also need an interface for conversion
* Serialisation-Deserialisation tests
* Generators

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
