### PR TITLE
SCP-1835: Split up 'SysCall'

### DIFF
--- a/plutus-contract/src/Plutus/Trace/Effects/EmulatorControl.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/EmulatorControl.hs
@@ -31,8 +31,8 @@ import           Control.Monad.Freer.TH                 (makeEffect)
 import           Data.Maybe                             (fromMaybe)
 import           Plutus.Trace.Emulator.ContractInstance (EmulatorRuntimeError, getThread)
 import           Plutus.Trace.Emulator.Types            (EmulatorMessage (Freeze), EmulatorThreads)
-import           Plutus.Trace.Scheduler                 (Priority (Normal), SysCall (Message, Thaw), SystemCall,
-                                                         mkSysCall)
+import           Plutus.Trace.Scheduler                 (EmSystemCall, MessageCall (Message), Priority (Normal),
+                                                         ThreadCall (Thaw), mkSysCall)
 import qualified Wallet.Emulator                        as EM
 import           Wallet.Emulator.Chain                  (ChainState)
 import           Wallet.Emulator.MultiAgent             (EmulatorState, MultiAgentEffect, walletControlAction)
@@ -73,7 +73,7 @@ handleEmulatorControl ::
     , Member (State EmulatorState) effs
     , Member (Error EmulatorRuntimeError) effs
     , Member MultiAgentEffect effs
-    , Member (Yield (SystemCall effs2 EmulatorMessage) (Maybe EmulatorMessage)) effs
+    , Member (Yield (EmSystemCall effs2 EmulatorMessage) (Maybe EmulatorMessage)) effs
     )
     => EmulatorControl
     ~> Eff effs
@@ -83,11 +83,11 @@ handleEmulatorControl = \case
     FreezeContractInstance i -> do
         threadId <- getThread i
         -- see note [Freeze and Thaw]
-        void $ mkSysCall @effs2 @EmulatorMessage Normal (Message threadId Freeze)
+        void $ mkSysCall @effs2 @EmulatorMessage Normal (Left $ Message threadId Freeze)
     ThawContractInstance i -> do
         threadId <- getThread i
         -- see note [Freeze and Thaw]
-        void $ mkSysCall @effs2 @EmulatorMessage Normal (Thaw threadId)
+        void $ mkSysCall @effs2 @EmulatorMessage Normal (Right $ Thaw threadId)
     ChainState -> gets (view EM.chainState)
 
 makeEffect ''EmulatorControl

--- a/plutus-contract/src/Plutus/Trace/Effects/Waiting.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/Waiting.hs
@@ -21,7 +21,7 @@ import           Control.Monad.Freer.TH        (makeEffect)
 import           Ledger.Slot                   (Slot)
 import           Numeric.Natural               (Natural)
 import           Plutus.Trace.Emulator.Types   (EmulatorMessage (NewSlot))
-import           Plutus.Trace.Scheduler        (Priority (Sleeping), SystemCall, sleep)
+import           Plutus.Trace.Scheduler        (EmSystemCall, Priority (Sleeping), sleep)
 
 data Waiting r where
     WaitUntilSlot :: Slot -> Waiting Slot
@@ -45,7 +45,7 @@ waitNSlots n
 
 handleWaiting ::
     forall effs effs2.
-    ( Member (Yield (SystemCall effs2 EmulatorMessage) (Maybe EmulatorMessage)) effs
+    ( Member (Yield (EmSystemCall effs2 EmulatorMessage) (Maybe EmulatorMessage)) effs
     )
     => Waiting
     ~> Eff effs

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -68,7 +68,7 @@ import           Control.Monad.Freer.Reader              (Reader)
 import           Control.Monad.Freer.State               (State, evalState)
 import qualified Data.Map                                as Map
 import           Data.Maybe                              (fromMaybe)
-import           Plutus.Trace.Scheduler                  (SystemCall, ThreadId, exit, runThreads)
+import           Plutus.Trace.Scheduler                  (EmSystemCall, ThreadId, exit, runThreads)
 import           Wallet.Emulator.Chain                   (ChainControlEffect, ChainEffect)
 import qualified Wallet.Emulator.Chain                   as ChainState
 import           Wallet.Emulator.MultiAgent              (EmulatorEvent, EmulatorEvent' (..), EmulatorState,
@@ -113,7 +113,7 @@ handleEmulatorTrace ::
     , Member ContractInstanceIdEff effs
     )
     => EmulatorTrace a
-    -> Eff (Reader ThreadId ': Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
+    -> Eff (Reader ThreadId ': Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
 handleEmulatorTrace action = do
     _ <- interpret (mapLog (UserThreadEvent . UserLog))
             . interpret handleEmulatedWalletAPI

--- a/plutus-contract/src/Plutus/Trace/Emulator/System.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/System.hs
@@ -27,7 +27,8 @@ import           Wallet.Emulator.MultiAgent    (MultiAgentEffect, walletAction, 
 
 import           Data.String                   (IsString (..))
 import           Plutus.Trace.Emulator.Types   (EmulatorMessage (..))
-import           Plutus.Trace.Scheduler        (Priority (..), SysCall (..), SystemCall, Tag, fork, mkSysCall, sleep)
+import           Plutus.Trace.Scheduler        (EmSystemCall, MessageCall (..), Priority (..), Tag, fork, mkSysCall,
+                                                sleep)
 import           Wallet.Emulator.ChainIndex    (chainIndexNotify)
 import           Wallet.Emulator.NodeClient    (ChainClientNotification (..), clientNotify)
 import           Wallet.Emulator.Wallet        (Wallet (..), walletAddress)
@@ -70,7 +71,7 @@ launchSystemThreads :: forall effs.
     , Member ChainEffect effs
     )
     => [Wallet]
-    -> Eff (Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
+    -> Eff (Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
 launchSystemThreads wallets = do
     _ <- sleep @effs @EmulatorMessage Sleeping
     -- 1. Threads for updating the agents' states. See note [Simulated Agents]
@@ -90,21 +91,21 @@ blockMakerTag = "block maker"
 blockMaker :: forall effs effs2.
     ( Member ChainControlEffect effs2
     , Member ChainEffect effs2
-    , Member (Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
+    , Member (Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
     )
     => Eff effs2 ()
 blockMaker = go where
     go = do
         newBlock <- processBlock
         newSlot <- getCurrentSlot
-        _ <- mkSysCall @effs Sleeping $ Broadcast $ NewSlot [newBlock] newSlot
+        _ <- mkSysCall @effs Sleeping $ Left $ Broadcast $ NewSlot [newBlock] newSlot
         _ <- sleep @effs @EmulatorMessage @effs2 Sleeping
         go
 
 -- | Thread for a simulated agent. See note [Simulated Agents]
 agentThread :: forall effs effs2.
     ( Member MultiAgentEffect effs2
-    , Member (Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
+    , Member (Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
     )
     => Wallet
     -> Eff effs2 ()

--- a/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
@@ -72,7 +72,7 @@ import           Language.Plutus.Contract.Types     (ResumableResult (..), Suspe
 import qualified Language.Plutus.Contract.Types     as Contract.Types
 import           Ledger.Slot                        (Slot (..))
 import           Ledger.Tx                          (Tx)
-import           Plutus.Trace.Scheduler             (SystemCall, ThreadId)
+import           Plutus.Trace.Scheduler             (EmSystemCall, ThreadId)
 import           Wallet.Emulator.Wallet             (Wallet (..))
 import           Wallet.Types                       (ContractInstanceId, EndpointDescription, Notification (..),
                                                      NotificationError)
@@ -109,7 +109,7 @@ type EmulatorAgentThreadEffs effs =
     LogMsg ContractInstanceLog
     ': Reader Wallet
     ': Reader ThreadId
-    ': Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage)
+    ': Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)
     ': effs
 
 data Emulator

--- a/plutus-contract/src/Plutus/Trace/Playground.hs
+++ b/plutus-contract/src/Plutus/Trace/Playground.hs
@@ -52,7 +52,7 @@ import           Plutus.Trace.Emulator.ContractInstance     (EmulatorRuntimeErro
 import           Plutus.Trace.Emulator.System               (launchSystemThreads)
 import           Plutus.Trace.Emulator.Types                (ContractConstraints, EmulatorMessage (..), EmulatorThreads,
                                                              walletInstanceTag)
-import           Plutus.Trace.Scheduler                     (SystemCall, ThreadId, exit, runThreads)
+import           Plutus.Trace.Scheduler                     (EmSystemCall, ThreadId, exit, runThreads)
 import           Streaming                                  (Stream)
 import           Streaming.Prelude                          (Of)
 import           Wallet.Emulator.Chain                      (ChainControlEffect, ChainEffect)
@@ -107,7 +107,7 @@ handlePlaygroundTrace ::
     )
     => Contract s e ()
     -> PlaygroundTrace a
-    -> Eff (Reader ThreadId ': Yield (SystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
+    -> Eff (Reader ThreadId ': Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage) ': effs) ()
 handlePlaygroundTrace contract action = do
     _ <- interpret handleEmulatedWalletAPI
             . interpret (handleWaiting @_ @effs)


### PR DESCRIPTION
* Split the `SysCall` type in the emulator into two
* My end goal is to call `Plutus.Trace.Emulator.ContractInstance.runInstance` from the PAB, with different effect handlers than we have in the emulator
  * This is much easier if the thread related operations in  `SysCall` are removed from the message related ones
  * `runInstance` only uses the latter
  * In the interest of having small PRs I'm going to split it up across several commits that can be reviewed individually
  * This PR is a purely syntactical change in `plutus-contract/src/Plutus/Trace/Scheduler.hs` and propagated from there

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
