### PR TITLE
buildNodeModules: filter src

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,7 @@ rec {
     haddock = plutus.plutus-haddock-combined;
 
     inherit (pkgs.callPackage ./plutus-playground-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
+      inherit (plutus.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonPlutus webCommonPlayground;
     }) client server-invoker generated-purescript generate-purescript start-backend;
   };
@@ -57,14 +57,14 @@ rec {
     tutorial = docs.marlowe-tutorial;
 
     inherit (pkgs.callPackage ./marlowe-playground-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
+      inherit (plutus.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonMarlowe webCommonPlayground;
     }) client server-invoker generated-purescript generate-purescript start-backend;
   };
 
   marlowe-dashboard = pkgs.recurseIntoAttrs rec {
     inherit (pkgs.callPackage ./marlowe-dashboard-client {
-      inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
+      inherit (plutus.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
       inherit set-git-rev haskell webCommon webCommonMarlowe;
     }) client server-invoker generated-purescript generate-purescript;
   };
@@ -82,7 +82,7 @@ rec {
   };
 
   plutus-pab = pkgs.recurseIntoAttrs (pkgs.callPackage ./plutus-pab-client {
-    inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix;
+    inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix filterNpm;
     inherit set-git-rev haskell webCommon webCommonPlutus;
   });
 

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules, filterNpm }:
 let
   dashboard-exe = set-git-rev haskell.packages.marlowe-dashboard-server.components.exes.marlowe-dashboard-server;
   server-invoker = dashboard-exe;
@@ -17,7 +17,7 @@ let
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
-    projectDir = cleanSrc;
+    projectDir = filterNpm cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = { };

--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, webCommonPlayground, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonMarlowe, webCommonPlayground, buildPursPackage, buildNodeModules, filterNpm }:
 let
   playground-exe = set-git-rev haskell.packages.marlowe-playground-server.components.exes.marlowe-playground-server;
 
@@ -41,7 +41,7 @@ let
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
-    projectDir = cleanSrc;
+    projectDir = filterNpm cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = {

--- a/nix/lib/filter-npm.nix
+++ b/nix/lib/filter-npm.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+
+# Store Path -> Store Path
+# Picks `package.json` and `package-lock.json` from a path
+src: pkgs.lib.cleanSourceWith {
+  inherit src;
+  filter = name: type:
+    let
+      baseName = baseNameOf (toString name);
+    in
+    baseName == "package.json" || baseName == "package-lock.json";
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -191,6 +191,7 @@ let
     inherit gitignore-nix;
     haddock-combine = pkgs.callPackage ../lib/haddock-combine.nix { inherit sphinxcontrib-haddock; };
     latex = pkgs.callPackage ../lib/latex.nix { };
+    filterNpm = pkgs.callPackage ../lib/filter-npm.nix { };
     npmlock2nix = pkgs.callPackage sources.npmlock2nix { };
     buildPursPackage = pkgs.callPackage ../lib/purescript.nix { inherit easyPS;inherit (pkgs) nodejs; };
     buildNodeModules = pkgs.callPackage ../lib/node_modules.nix ({

--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, buildPursPackage, buildNodeModules, filterNpm }:
 let
   server-invoker = set-git-rev haskell.packages.plutus-pab.components.exes.plutus-pab;
 
@@ -28,8 +28,9 @@ let
 
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
+
   nodeModules = buildNodeModules {
-    projectDir = cleanSrc;
+    projectDir = filterNpm cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
   };

--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, webCommonPlayground, buildPursPackage, buildNodeModules }:
+{ pkgs, gitignore-nix, set-git-rev, haskell, webCommon, webCommonPlutus, webCommonPlayground, buildPursPackage, buildNodeModules, filterNpm }:
 let
   playground-exe = set-git-rev haskell.packages.plutus-playground-server.components.exes.plutus-playground-server;
 
@@ -45,7 +45,7 @@ let
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
-    projectDir = cleanSrc;
+    projectDir = filterNpm cleanSrc;
     packageJson = ./package.json;
     packageLockJson = ./package-lock.json;
   };


### PR DESCRIPTION
**Summary**: filter down the source for buildModules to just `package.json` and
`package-lock.json` to avoid useless rebuilds.

I have been annoyed for quite a while by seeing countless rebuilds of `nodeModules` of any of the clients which includes lengthy rebuilds of sass and libxml. With the changes of this PR this won't be happening anymore.

-----

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
