### PR TITLE
SCP-1832 Marlowe Playground Frontend: Refactor term to accept blockly locations (concrete type version)

### DIFF
--- a/marlowe-playground-client/src/AppM.purs
+++ b/marlowe-playground-client/src/AppM.purs
@@ -1,11 +1,11 @@
 module AppM where
 
 import Prelude
-import Control.Monad.Reader.Trans (class MonadAsk, ReaderT, ask, asks, runReaderT)
+import Control.Monad.Reader.Trans (class MonadAsk, ReaderT, asks, runReaderT)
 import Effect.Aff (Aff)
 import Env (Env)
-import Effect.Class (class MonadEffect, liftEffect)
-import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (class MonadEffect)
+import Effect.Aff.Class (class MonadAff)
 import Type.Equality (class TypeEquals, from)
 
 newtype AppM a
@@ -28,15 +28,11 @@ derive newtype instance monadEffectAppM :: MonadEffect AppM
 
 derive newtype instance monadAffAppM :: MonadAff AppM
 
--- | We can't write instances for type
--- | synonyms, and we defined our environment (`Env`) as a type synonym for convenience. To get
--- | around this, we can use `TypeEquals` to assert that types `a` and `b` are in fact the same.
+-- | We can't write instances for type synonyms, and we defined our environment (`Env`) as
+-- | a type synonym for convenience. To get around this, we can use `TypeEquals` to assert that
+-- | types `a` and `b` are in fact the same.
 -- |
--- | In our case, we'll write a `MonadAsk` (an alternate name for `Reader`) instance for the type
--- | `e`, and assert it is our `Env` type. This is how we can write a type class instance for a
--- | type synonym, which is otherwise disallowed.
--- |
--- | With this instance, any monad `m` with the `MonadAsk Env m` constraint can read from the
--- | environment we defined. This is done with the `ask` function.
+-- | In our case, we'll write a `MonadAsk` instance for the type `e`, and assert it is our `Env` type.
+-- | This is how we can write a type class instance for a type synonym, which is otherwise disallowed.
 instance monadAskAppM :: TypeEquals e Env => MonadAsk e AppM where
   ask = AppM $ asks from

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -20,7 +20,7 @@ import Halogen as H
 import Halogen.BlocklyCommons (blocklyEvents, runWithoutEventSubscription, detectCodeChanges)
 import Halogen.HTML (HTML)
 import Marlowe.Blockly (buildBlocks, buildGenerator)
-import Marlowe.Holes (Term(..))
+import Marlowe.Holes (Term(..), Location(..))
 import Marlowe.Parser as Parser
 import Prim.TypeError (class Warn, Text)
 import Text.Extra as Text
@@ -63,7 +63,7 @@ handleQuery (SetCode code next) = do
     let
       contract =
         either
-          (const $ Hole blocklyState.rootBlockName Proxy zero)
+          (const $ Hole blocklyState.rootBlockName Proxy NoLocation)
           identity
           $ Parser.parseContract (Text.stripParens code)
     -- Create the blocks temporarily disabling the blockly events until they settle

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,7 +25,7 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
-import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Timeout(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
+import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Location(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Timeout(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (Rational(..))
 import Record (merge)
@@ -1046,7 +1046,7 @@ class HasBlockDefinition a b | a -> b where
 
 baseContractDefinition :: Generator -> Block -> Either String (Term Contract)
 baseContractDefinition g block = case statementToCode g block (show BaseContractType) of
-  Either.Left _ -> pure $ Hole "contract" Proxy zero
+  Either.Left _ -> pure $ Hole "contract" Proxy NoLocation
   Either.Right s -> parse (mkDefaultTerm <$> Parser.contract) s
 
 getAllBlocks :: Block -> Array Block
@@ -1084,7 +1084,7 @@ boundsDefinition g block = traverse (boundDefinition g) (getAllBlocks block)
 
 statementToTerm :: forall a. Generator -> Block -> String -> Parser a -> Either String (Term a)
 statementToTerm g block name p = case statementToCode g block name of
-  Either.Left _ -> pure $ Hole name Proxy zero
+  Either.Left _ -> pure $ Hole name Proxy NoLocation
   Either.Right s -> parse (mkDefaultTerm <$> p) s
 
 instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) where
@@ -1106,7 +1106,7 @@ instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) w
     let
       mTopboundBlock = getBlockInputConnectedTo boundsInput
     bounds <- case mTopboundBlock of
-      Either.Left _ -> pure [ Hole "bounds" Proxy zero ]
+      Either.Left _ -> pure [ Hole "bounds" Proxy NoLocation ]
       Either.Right topboundBlock -> boundsDefinition g topboundBlock
     contract <- statementToTerm g block "contract" Parser.contract
     pure $ mkDefaultTerm (Case (mkDefaultTerm (Choice choiceId bounds)) contract)
@@ -1126,7 +1126,7 @@ instance hasBlockDefinitionPayee :: HasBlockDefinition PayeeType (Term Payee) wh
 instance hasBlockDefinitionParty :: HasBlockDefinition PartyType (Term Party) where
   blockDefinition PKPartyType g block = do
     case getFieldValue block "pubkey" of
-      Either.Left _ -> pure $ Hole "n" Proxy zero
+      Either.Left _ -> pure $ Hole "n" Proxy NoLocation
       Either.Right pk -> pure $ mkDefaultTerm (PK pk)
   blockDefinition RolePartyType g block = do
     role <- getFieldValue block "role"

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -4,58 +4,39 @@ module Marlowe.Linter
   , MaxTimeout
   , Warning(..)
   , WarningDetail(..)
-  , AdditionalContext
   , _holes
   , hasHoles
   , _warnings
-  , suggestions
-  , markers
-  , format
-  , provideCodeActions
-  , getWarningRange
   ) where
 
 import Prelude
 import Control.Monad.State as CMS
-import Data.Array (catMaybes, fold, foldMap, take)
-import Data.Array as Array
-import Data.Array.NonEmpty (index)
 import Data.Bifunctor (bimap)
 import Data.BigInteger (BigInteger)
-import Data.Either (Either(..), hush)
 import Data.Foldable (foldM)
 import Data.FoldableWithIndex (traverseWithIndex_)
-import Data.Function (on)
-import Data.Functor (mapFlipped)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Ord (genericCompare)
-import Data.Lens (Lens', modifying, over, set, to, view, (^.))
+import Data.Lens (Lens', modifying, over, set, view)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
-import Data.List (List(..))
+import Data.List (List)
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe, isNothing, maybe)
+import Data.Maybe (Maybe(..), isNothing, maybe)
 import Data.Newtype (class Newtype)
 import Data.Ord (abs)
 import Data.Set (Set)
 import Data.Set as Set
-import Data.String (codePointFromChar, fromCodePointArray, length, takeWhile, toCodePointArray)
-import Data.String.Regex (match, regex)
-import Data.String.Regex.Flags (noFlags)
 import Data.Symbol (SProxy(..))
-import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested (type (/\), (/\))
-import Help (holeText)
 import Marlowe.Extended as EM
-import Marlowe.Holes (Action(..), Bound(..), Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType, Observation(..), Range, Term(..), TermGenerator, TermWrapper(..), Value(..), constructMarloweType, fromTerm, getHoles, getMarloweConstructors, getRange, holeSuggestions, insertHole, readMarloweType)
+import Marlowe.Holes (Action(..), Bound(..), Case(..), Contract(..), Holes, Location(..), Observation(..), Term(..), TermWrapper(..), Value(..), compareLocation, fromTerm, getHoles, getLocation, insertHole)
 import Marlowe.Holes as Holes
-import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), emptyState, evalValue, makeEnvironment)
 import Marlowe.Semantics as S
-import Monaco (CodeAction, CompletionItem, IMarkerData, IRange, TextEdit, Uri, markerSeverity)
-import Monaco as Monaco
+import Monaco (TextEdit)
 import Pretty (showPrettyMoney, showPrettyParty, showPrettyToken)
 import StaticAnalysis.Reachability (initialisePrefixMap, stepPrefixMap)
 import StaticAnalysis.Types (ContractPath, ContractPathStep(..), PrefixMap)
@@ -76,10 +57,14 @@ instance semigroupMax :: Semigroup MaxTimeout where
 instance monoidMaxTimeout :: Monoid MaxTimeout where
   mempty = MaxTimeout zero
 
+-- We could eventually see if we can make Warning polymorphic on the location, even if Term cannot be.
+-- for the moment we don't have static guarantees on the Location type, but runtype exceptions if it
+-- is missused.
 newtype Warning
   = Warning
   { warning :: WarningDetail
-  , range :: IRange
+  , location :: Location
+  -- FIXME: The Maybe TextEdit only makes sense for LinterText
   , refactoring :: Maybe TextEdit
   }
 
@@ -123,60 +108,14 @@ instance showWarningDetail :: Show WarningDetail where
       <> " but the account only has "
       <> showPrettyMoney availableAmount
 
-shortWarning :: WarningDetail -> String
-shortWarning NegativePayment = ""
-
-shortWarning NegativeDeposit = ""
-
-shortWarning TimeoutNotIncreasing = ""
-
-shortWarning UnreachableCaseEmptyChoice = ""
-
-shortWarning InvalidBound = ""
-
-shortWarning UnreachableCaseFalseNotify = ""
-
-shortWarning UnreachableContract = ""
-
-shortWarning UndefinedChoice = ""
-
-shortWarning UndefinedUse = ""
-
-shortWarning ShadowedLet = ""
-
-shortWarning DivisionByZero = ""
-
-shortWarning (SimplifiableValue _ _) = "Simplify Value"
-
-shortWarning (SimplifiableObservation _ _) = ""
-
-shortWarning (PayBeforeDeposit _) = ""
-
-shortWarning (PartialPayment _ _ _ _) = ""
-
-warningType :: Warning -> String
-warningType (Warning { warning }) = case warning of
-  NegativePayment -> "NegativePayment"
-  NegativeDeposit -> "NegativeDeposit"
-  TimeoutNotIncreasing -> "TimeoutNotIncreasing"
-  UnreachableCaseEmptyChoice -> "UnreachableCaseEmptyChoice"
-  InvalidBound -> "InvalidBound"
-  UnreachableCaseFalseNotify -> "UnreachableCaseFalseNotify"
-  UnreachableContract -> "UnreachableContract"
-  UndefinedChoice -> "UndefinedChoice"
-  UndefinedUse -> "UndefinedUse"
-  ShadowedLet -> "ShadowedLet"
-  DivisionByZero -> "DivisionByZero"
-  (SimplifiableValue _ _) -> "SimplifiableValue"
-  (SimplifiableObservation _ _) -> "SimplifiableObservation"
-  (PayBeforeDeposit _) -> "PayBeforeDeposit"
-  (PartialPayment _ _ _ _) -> "PartialPayment"
-
 derive instance genericWarningDetail :: Generic WarningDetail _
 
 instance eqWarningDetail :: Eq WarningDetail where
   eq = genericEq
 
+-- FIXME: This generic Ord requires a lot of instances defined in Marlowe.Holes and only for the fallback
+--        case in the ordWarning. I'm not sure if having a generic compare is worth, or we should have a
+--        manual definition that indicates which type of warning is "more severe"
 instance ordWarningDetail :: Ord WarningDetail where
   compare = genericCompare
 
@@ -187,21 +126,16 @@ instance eqWarning :: Eq Warning where
 
 -- We order Warnings by their Range first
 instance ordWarning :: Ord Warning where
-  compare a@(Warning { range: rangeA }) b@(Warning { range: rangeB }) =
+  compare a@(Warning { location: locA }) b@(Warning { location: locB }) =
     let
-      cmp f = (compare `on` f) rangeA rangeB
+      locCMP = compareLocation locA locB
     in
-      case cmp _.startLineNumber, cmp _.startColumn, cmp _.endLineNumber, cmp _.endColumn of
-        EQ, EQ, EQ, elc -> genericCompare a b
-        EQ, EQ, eln, _ -> eln
-        EQ, slc, _, _ -> slc
-        sln, _, _, _ -> sln
+      case locCMP of
+        EQ -> genericCompare a b
+        _ -> locCMP
 
 instance showWarning :: Show Warning where
   show (Warning warn) = show warn.warning
-
-getWarningRange :: Warning -> IRange
-getWarningRange (Warning warn) = warn.range
 
 newtype State
   = State
@@ -273,7 +207,7 @@ stepPrefixMapEnvGeneric (LintEnv env@{ unreachablePaths: Just upOld, isReachable
   pure $ LintEnv env { unreachablePaths = mUpNew, isReachable = oldReachable && (not $ isNothing mUpNew) }
 
 -- Wrapper for stepPrefixMap that marks unreachable code with a warning
-stepPrefixMapEnv :: forall a. Show a => LintEnv -> a -> Range -> ContractPathStep -> CMS.State State LintEnv
+stepPrefixMapEnv :: forall a. Show a => LintEnv -> a -> Location -> ContractPathStep -> CMS.State State LintEnv
 stepPrefixMapEnv env t pos cp = stepPrefixMapEnvGeneric env markUnreachable cp
   where
   markUnreachable = addWarning UnreachableContract t pos
@@ -287,15 +221,15 @@ stepPrefixMapEnv_ env cp = stepPrefixMapEnvGeneric env dontMarkUnreachable cp
 
 data TemporarySimplification a b
   = ConstantSimp
-    Range
+    Location
     Boolean -- Is simplified (it is not just a constant that was already a constant)
     a -- Constant
   | ValueSimp
-    Range
+    Location
     Boolean -- Is simplified (only root, no subtrees)
     (Term b) -- Value
 
-getSimpRange :: forall a b. TemporarySimplification a b -> Range
+getSimpRange :: forall a b. TemporarySimplification a b -> Location
 getSimpRange (ConstantSimp pos _ _) = pos
 
 getSimpRange (ValueSimp pos _ _) = pos
@@ -310,13 +244,13 @@ getValue f (ConstantSimp _ _ c) = f c
 
 getValue _ (ValueSimp _ _ v) = v
 
-simplifyTo :: forall a b. TemporarySimplification a b -> Range -> TemporarySimplification a b
+simplifyTo :: forall a b. TemporarySimplification a b -> Location -> TemporarySimplification a b
 simplifyTo (ConstantSimp _ _ c) pos = (ConstantSimp pos true c)
 
 simplifyTo (ValueSimp _ _ c) pos = (ValueSimp pos true c)
 
 simplifyRefactoring :: Term Value -> Term Value -> Maybe TextEdit
-simplifyRefactoring (Term _ range) to =
+simplifyRefactoring (Term _ (Range range)) to =
   let
     pv = show $ pretty to
 
@@ -326,8 +260,8 @@ simplifyRefactoring (Term _ range) to =
 
 simplifyRefactoring _ _ = Nothing
 
-addWarning :: forall a. Show a => WarningDetail -> a -> Range -> CMS.State State Unit
-addWarning warnDetail term range =
+addWarning :: forall a. Show a => WarningDetail -> a -> Location -> CMS.State State Unit
+addWarning warnDetail term location =
   let
     refactoring = case warnDetail of
       (SimplifiableValue from to) -> simplifyRefactoring from to
@@ -336,22 +270,22 @@ addWarning warnDetail term range =
     modifying _warnings $ Set.insert
       $ Warning
           { warning: warnDetail
-          , range
+          , location
           , refactoring
           }
 
 markSimplification :: forall a b. Show b => (a -> Term b) -> (Term b -> Term b -> WarningDetail) -> Term b -> TemporarySimplification a b -> CMS.State State Unit
 markSimplification f c oriVal x
-  | isSimplified x = addWarning (c oriVal (getValue f x)) oriVal (getRange oriVal)
+  | isSimplified x = addWarning (c oriVal (getValue f x)) oriVal (getLocation oriVal)
   | otherwise = pure unit
 
 constToObs :: Boolean -> Term Observation
-constToObs true = Term TrueObs zero
+constToObs true = Term TrueObs NoLocation
 
-constToObs false = Term FalseObs zero
+constToObs false = Term FalseObs NoLocation
 
 constToVal :: BigInteger -> Term Value
-constToVal x = Term (Constant x) zero
+constToVal x = Term (Constant x) NoLocation
 
 addMoneyToEnvAccount :: BigInteger -> S.AccountId -> S.Token -> LintEnv -> LintEnv
 addMoneyToEnvAccount amountToAdd accTerm tokenTerm = over _deposits (Map.alter (addMoney amountToAdd) (accTerm /\ tokenTerm))
@@ -427,8 +361,8 @@ lintContract env t@(Term (Pay acc payee token payment cont) pos) = do
 
 lintContract env (Term (If obs c1 c2) _) = do
   sa <- lintObservation env obs
-  c1Env <- stepPrefixMapEnv env c1 (getRange c1) IfTruePath
-  c2Env <- stepPrefixMapEnv env c2 (getRange c2) IfFalsePath
+  c1Env <- stepPrefixMapEnv env c1 (getLocation c1) IfTruePath
+  c2Env <- stepPrefixMapEnv env c2 (getLocation c2) IfFalsePath
   let
     reachable = view _isReachable
 
@@ -442,10 +376,10 @@ lintContract env (Term (If obs c1 c2) _) = do
       <$> ( case sa of
             (ConstantSimp _ _ c) ->
               if c then do
-                when c2Reachable $ addWarning UnreachableContract c2 (getRange c2)
+                when c2Reachable $ addWarning UnreachableContract c2 (getLocation c2)
                 pure (c1Reachable /\ false)
               else do
-                when c1Reachable $ addWarning UnreachableContract c1 (getRange c1)
+                when c1Reachable $ addWarning UnreachableContract c1 (getLocation c1)
                 pure (false /\ c2Reachable)
             _ -> do
               markSimplification constToObs SimplifiableObservation obs sa
@@ -811,160 +745,3 @@ lintAction env hole@(Hole _ _ _) = do
     isReachable = view _isReachable env
   modifying _holes (insertHole hole)
   pure $ NoEffect /\ isReachable
-
-type AdditionalContext
-  = { warnings :: Set Warning
-    , contract :: Maybe (Term Contract)
-    }
-
-suggestions :: String -> Boolean -> String -> IRange -> AdditionalContext -> Array CompletionItem
-suggestions original stripParens contractString range { contract } =
-  fromMaybe [] do
-    -- there will be no contract if it had errors, this is no good because we want to try to fix this
-    -- with contractString, which is a contract that comes from the MarloweCompletionItemProvider with
-    -- holes where possible errors are, so it might be able to be parsed.
-    parsedContract <- case contract of
-      Nothing -> hush $ parseContract contractString
-      c -> c
-    let
-      (Holes holes) = view _holes ((lint Nil) parsedContract)
-    v <- Map.lookup "monaco_suggestions" holes
-    { head } <- Array.uncons $ Set.toUnfoldable v
-    pure $ holeSuggestions original stripParens range head
-
--- FIXME: We have multiple model markers, 1 per quick fix. This is wrong though, we need only 1 but in MarloweCodeActionProvider we want to run the code
--- to generate the quick fixes from this single model marker
-markers :: List ContractPath -> Either ContractParseError (Term Contract) -> Tuple (Array IMarkerData) AdditionalContext
-markers unreachablePaths parsedContract = do
-  case (lint unreachablePaths <$> parsedContract) of
-    Left EmptyInput -> (Tuple [] { warnings: mempty, contract: Nothing })
-    Left e@(ContractParseError { message, row, column, token }) ->
-      let
-        whiteSpaceChar c = Set.member c $ Set.fromFoldable $ map codePointFromChar [ '\n', '\r', ' ', '\t' ]
-
-        word = takeWhile (not <<< whiteSpaceChar) token
-
-        markerData =
-          [ { startColumn: column
-            , startLineNumber: row
-            , endColumn: column + (length word)
-            , endLineNumber: row
-            , message: message
-            , severity: markerSeverity "Error"
-            , code: ""
-            , source: ""
-            }
-          ]
-      in
-        (Tuple markerData { warnings: mempty, contract: Nothing })
-    Right state ->
-      let
-        holesMarkers = state ^. (_holes <<< to holesToMarkers)
-
-        warningsMarkers = state ^. (_warnings <<< to Set.toUnfoldable <<< to (map warningToMarker))
-
-        -- we store the current warnings and the parsed contract in the halogen state so that they can be reused
-        additionalContext = { warnings: state ^. _warnings, contract: hush parsedContract }
-      in
-        (Tuple (holesMarkers <> warningsMarkers) additionalContext)
-
--- other types of warning could do with being refactored to a Warning ADT first so we don't need to repeat ourselves
-holesToMarkers :: Holes -> Array IMarkerData
-holesToMarkers (Holes holes) =
-  let
-    (allHoles :: Array _) = Set.toUnfoldable $ fold $ Map.values holes
-  in
-    foldMap holeToMarkers allHoles
-
-holeToMarker :: MarloweHole -> Map String TermGenerator -> String -> IMarkerData
-holeToMarker hole@(MarloweHole { name, marloweType, range: { startLineNumber, startColumn, endLineNumber, endColumn } }) m constructorName =
-  { startColumn
-  , startLineNumber
-  , endColumn
-  , endLineNumber
-  , message: holeText marloweType
-  , severity: markerSeverity "Warning"
-  , code: ""
-  , source: "Hole: " <> (dropEnd 4 $ show marloweType)
-  }
-  where
-  dropEnd :: Int -> String -> String
-  dropEnd n = fromCodePointArray <<< Array.dropEnd n <<< toCodePointArray
-
-holeToMarkers :: MarloweHole -> Array IMarkerData
-holeToMarkers hole@(MarloweHole { name, marloweType }) =
-  let
-    m = getMarloweConstructors marloweType
-
-    constructors = take 1 $ Set.toUnfoldable $ Map.keys m
-  in
-    map (holeToMarker hole m) constructors
-
-markerToHole :: IMarkerData -> MarloweType -> MarloweHole
-markerToHole markerData marloweType = MarloweHole { name: "unknown", marloweType, range: (Monaco.getRange markerData) }
-
-warningToMarker :: Warning -> IMarkerData
-warningToMarker warning =
-  let
-    { startColumn, startLineNumber, endColumn, endLineNumber } = getWarningRange warning
-  in
-    { startColumn
-    , startLineNumber
-    , endColumn
-    , endLineNumber
-    , message: show warning
-    , severity: markerSeverity "Warning"
-    , code: ""
-    , source: warningType warning
-    }
-
-format :: String -> String
-format contractString = case parseContract contractString of
-  Left _ -> contractString
-  Right contract -> show $ pretty contract
-
-provideLintCodeActions :: Uri -> AdditionalContext -> Array CodeAction
-provideLintCodeActions uri { warnings } = catMaybes <<< map codeAction <<< Set.toUnfoldable $ warnings
-  where
-  codeAction :: Warning -> Maybe CodeAction
-  codeAction (Warning { warning, range, refactoring: Just refactoring }) =
-    Just
-      { title: shortWarning warning
-      , edit: { edits: [ { resource: uri, edit: refactoring } ] }
-      , kind: "quickfix"
-      }
-
-  codeAction _ = Nothing
-
-provideCodeActions :: Uri -> Array IMarkerData -> AdditionalContext -> Array CodeAction
-provideCodeActions uri markers' additionalContext =
-  provideLintCodeActions uri additionalContext
-    <> (flip foldMap) markers' \(marker@{ source, startLineNumber, startColumn, endLineNumber, endColumn }) -> case regex "Hole: (\\w+)" noFlags of
-        Left _ -> []
-        Right r -> case readMarloweType =<< (join <<< (flip index 1)) =<< match r (source <> "Type") of
-          Nothing -> []
-          Just marloweType ->
-            let
-              m = getMarloweConstructors marloweType
-
-              hole = markerToHole marker marloweType
-
-              (constructors :: Array _) = Set.toUnfoldable $ Map.keys m
-
-              range =
-                { startLineNumber
-                , startColumn
-                , endLineNumber
-                , endColumn
-                }
-
-              actions =
-                mapFlipped constructors \constructorName ->
-                  let
-                    text = constructMarloweType constructorName hole m
-
-                    edit = { resource: uri, edit: { range, text } }
-                  in
-                    { title: constructorName, edit: { edits: [ edit ] }, kind: "quickfix" }
-            in
-              actions

--- a/marlowe-playground-client/src/Marlowe/LinterText.purs
+++ b/marlowe-playground-client/src/Marlowe/LinterText.purs
@@ -1,0 +1,279 @@
+module Marlowe.LinterText
+  ( AdditionalContext
+  , suggestions
+  , markers
+  , provideCodeActions
+  , format
+  , marloweHoleToSuggestionText
+  ) where
+
+import Prelude
+import Data.Array (catMaybes, fold, foldMap, take)
+import Data.Array as Array
+import Data.Array.NonEmpty (index)
+import Data.Either (Either(..), hush)
+import Data.Functor (mapFlipped)
+import Data.Lens (to, view, (^.))
+import Data.List (List(..))
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Set (Set)
+import Data.Set as Set
+import Data.String (Pattern(..), codePointFromChar, contains, fromCodePointArray, length, takeWhile, toCodePointArray)
+import Data.String.Regex (match, regex)
+import Data.String.Regex.Flags (noFlags)
+import Data.Tuple (Tuple(..))
+import Effect.Exception.Unsafe (unsafeThrow)
+import Help (holeText)
+import Marlowe.Holes (Contract, Holes(..), Location(..), MarloweHole(..), MarloweType, Term, TermGenerator, constructMarloweType, getMarloweConstructors, readMarloweType)
+import Marlowe.Linter (Warning(..), WarningDetail(..), _holes, _warnings, lint)
+import Marlowe.Parser (ContractParseError(..), parseContract)
+import Monaco (CodeAction, CompletionItem, IMarkerData, IRange, Uri, completionItemKind, markerSeverity)
+import Monaco as Monaco
+import StaticAnalysis.Types (ContractPath)
+import Text.Extra as Text
+import Text.Pretty (pretty)
+
+-- We cannot guarantee at the type level that the only type of location we handle in the Parser is a Range
+-- location, so we throw a useful error if we ever get to this situation
+locationToRange :: Location -> IRange
+locationToRange (Range range) = range
+
+locationToRange (BlockId _) = unsafeThrow "Unexpected BlockId location found in LinterText"
+
+locationToRange NoLocation = unsafeThrow "Unexpected NoLocation found in LinterText"
+
+getWarningRange :: Warning -> IRange
+getWarningRange (Warning { location }) = locationToRange location
+
+-- FIXME: We have multiple model markers, 1 per quick fix. This is wrong though, we need only 1 but in MarloweCodeActionProvider we want to run the code
+-- to generate the quick fixes from this single model marker
+markers :: List ContractPath -> Either ContractParseError (Term Contract) -> Tuple (Array IMarkerData) AdditionalContext
+markers unreachablePaths parsedContract = do
+  case (lint unreachablePaths <$> parsedContract) of
+    Left EmptyInput -> (Tuple [] { warnings: mempty, contract: Nothing })
+    Left e@(ContractParseError { message, row, column, token }) ->
+      let
+        whiteSpaceChar c = Set.member c $ Set.fromFoldable $ map codePointFromChar [ '\n', '\r', ' ', '\t' ]
+
+        word = takeWhile (not <<< whiteSpaceChar) token
+
+        markerData =
+          [ { startColumn: column
+            , startLineNumber: row
+            , endColumn: column + (length word)
+            , endLineNumber: row
+            , message: message
+            , severity: markerSeverity "Error"
+            , code: ""
+            , source: ""
+            }
+          ]
+      in
+        (Tuple markerData { warnings: mempty, contract: Nothing })
+    Right state ->
+      let
+        holesMarkers = state ^. (_holes <<< to holesToMarkers)
+
+        warningsMarkers = state ^. (_warnings <<< to Set.toUnfoldable <<< to (map warningToMarker))
+
+        -- we store the current warnings and the parsed contract in the halogen state so that they can be reused
+        additionalContext = { warnings: state ^. _warnings, contract: hush parsedContract }
+      in
+        (Tuple (holesMarkers <> warningsMarkers) additionalContext)
+
+-- other types of warning could do with being refactored to a Warning ADT first so we don't need to repeat ourselves
+holesToMarkers :: Holes -> Array IMarkerData
+holesToMarkers (Holes holes) =
+  let
+    (allHoles :: Array _) = Set.toUnfoldable $ fold $ Map.values holes
+  in
+    foldMap holeToMarkers allHoles
+
+holeToMarker :: MarloweHole -> Map String TermGenerator -> String -> IMarkerData
+holeToMarker hole@(MarloweHole { name, marloweType, location }) m constructorName =
+  let
+    -- If holeToMarker is called with the wrong Location type it will yield incorrect results.
+    -- That is why we want to make the Warnings polymorphic to the Location and to separate the linter
+    -- in 3. General linter that does not care about Location, MarloweLinter that deals with `Warning IRange`
+    -- and BlocklyLinter that deals with `Warning BlocklyId`
+    { startColumn, startLineNumber, endColumn, endLineNumber } = locationToRange location
+
+    dropEnd :: Int -> String -> String
+    dropEnd n = fromCodePointArray <<< Array.dropEnd n <<< toCodePointArray
+  in
+    { startColumn
+    , startLineNumber
+    , endColumn
+    , endLineNumber
+    , message: holeText marloweType
+    , severity: markerSeverity "Warning"
+    , code: ""
+    , source: "Hole: " <> (dropEnd 4 $ show marloweType)
+    }
+
+holeToMarkers :: MarloweHole -> Array IMarkerData
+holeToMarkers hole@(MarloweHole { name, marloweType }) =
+  let
+    m = getMarloweConstructors marloweType
+
+    constructors = take 1 $ Set.toUnfoldable $ Map.keys m
+  in
+    map (holeToMarker hole m) constructors
+
+markerToHole :: IMarkerData -> MarloweType -> MarloweHole
+markerToHole markerData marloweType = MarloweHole { name: "unknown", marloweType, location: Range (Monaco.getRange markerData) }
+
+warningType :: Warning -> String
+warningType (Warning { warning }) = case warning of
+  NegativePayment -> "NegativePayment"
+  NegativeDeposit -> "NegativeDeposit"
+  TimeoutNotIncreasing -> "TimeoutNotIncreasing"
+  UnreachableCaseEmptyChoice -> "UnreachableCaseEmptyChoice"
+  InvalidBound -> "InvalidBound"
+  UnreachableCaseFalseNotify -> "UnreachableCaseFalseNotify"
+  UnreachableContract -> "UnreachableContract"
+  UndefinedChoice -> "UndefinedChoice"
+  UndefinedUse -> "UndefinedUse"
+  ShadowedLet -> "ShadowedLet"
+  DivisionByZero -> "DivisionByZero"
+  (SimplifiableValue _ _) -> "SimplifiableValue"
+  (SimplifiableObservation _ _) -> "SimplifiableObservation"
+  (PayBeforeDeposit _) -> "PayBeforeDeposit"
+  (PartialPayment _ _ _ _) -> "PartialPayment"
+
+warningToMarker :: Warning -> IMarkerData
+warningToMarker warning =
+  let
+    { startColumn, startLineNumber, endColumn, endLineNumber } = getWarningRange warning
+  in
+    { startColumn
+    , startLineNumber
+    , endColumn
+    , endLineNumber
+    , message: show warning
+    , severity: markerSeverity "Warning"
+    , code: ""
+    , source: warningType warning
+    }
+
+shortWarning :: WarningDetail -> String
+shortWarning (SimplifiableValue _ _) = "Simplify Value"
+
+shortWarning _ = ""
+
+provideLintCodeActions :: Uri -> AdditionalContext -> Array CodeAction
+provideLintCodeActions uri { warnings } = catMaybes <<< map codeAction <<< Set.toUnfoldable $ warnings
+  where
+  codeAction :: Warning -> Maybe CodeAction
+  codeAction (Warning { warning, refactoring: Just refactoring }) =
+    Just
+      { title: shortWarning warning
+      , edit: { edits: [ { resource: uri, edit: refactoring } ] }
+      , kind: "quickfix"
+      }
+
+  codeAction _ = Nothing
+
+provideCodeActions :: Uri -> Array IMarkerData -> AdditionalContext -> Array CodeAction
+provideCodeActions uri markers' additionalContext =
+  provideLintCodeActions uri additionalContext
+    <> (flip foldMap) markers' \(marker@{ source, startLineNumber, startColumn, endLineNumber, endColumn }) -> case regex "Hole: (\\w+)" noFlags of
+        Left _ -> []
+        Right r -> case readMarloweType =<< (join <<< (flip index 1)) =<< match r (source <> "Type") of
+          Nothing -> []
+          Just marloweType ->
+            let
+              m = getMarloweConstructors marloweType
+
+              hole = markerToHole marker marloweType
+
+              (constructors :: Array _) = Set.toUnfoldable $ Map.keys m
+
+              range =
+                { startLineNumber
+                , startColumn
+                , endLineNumber
+                , endColumn
+                }
+
+              actions =
+                mapFlipped constructors \constructorName ->
+                  let
+                    text = constructMarloweType constructorName hole m
+
+                    edit = { resource: uri, edit: { range, text } }
+                  in
+                    { title: constructorName, edit: { edits: [ edit ] }, kind: "quickfix" }
+            in
+              actions
+
+type AdditionalContext
+  = { warnings :: Set Warning
+    , contract :: Maybe (Term Contract)
+    }
+
+marloweHoleToSuggestionText :: Boolean -> MarloweHole -> String -> String
+marloweHoleToSuggestionText stripParens firstHole@(MarloweHole { marloweType }) constructorName =
+  let
+    m = getMarloweConstructors marloweType
+
+    fullInsertText = constructMarloweType constructorName firstHole m
+  in
+    if stripParens then
+      Text.stripParens fullInsertText
+    else
+      fullInsertText
+
+marloweHoleToSuggestion :: String -> Boolean -> IRange -> MarloweHole -> String -> CompletionItem
+marloweHoleToSuggestion original stripParens range marloweHole@(MarloweHole { marloweType }) constructorName =
+  let
+    kind = completionItemKind "Constructor"
+
+    insertText = marloweHoleToSuggestionText stripParens marloweHole constructorName
+
+    preselect = contains (Pattern original) constructorName
+
+    -- Weirdly, the item that has sortText equal to the word you typed is shown at the _bottom_ of the list so
+    -- since we want it to be at the top (so if you typed `W` you would have `When` at the top) we make sure it
+    -- is the _only_ one that doesn't have the 'correct' sortText.
+    -- The weirdest thing happens here, if you use mempty instead of "*" then Debug.trace shows constructorName
+    -- and this causes the ordering in Monaco not to work, it's crazy that Debug.trace seems to display the wrong thing
+    sortText = if preselect then "*" else original
+  in
+    { label: constructorName
+    , kind
+    , range
+    , insertText
+    , filterText: original
+    , sortText
+    , preselect
+    }
+
+holeSuggestions :: String -> Boolean -> IRange -> MarloweHole -> Array CompletionItem
+holeSuggestions original stripParens range marloweHole@(MarloweHole { name, marloweType }) =
+  let
+    marloweHoles = getMarloweConstructors marloweType
+  in
+    map (marloweHoleToSuggestion original stripParens range marloweHole) $ Set.toUnfoldable $ Map.keys marloweHoles
+
+suggestions :: String -> Boolean -> String -> IRange -> AdditionalContext -> Array CompletionItem
+suggestions original stripParens contractString range { contract } =
+  fromMaybe [] do
+    -- there will be no contract if it had errors, this is no good because we want to try to fix this
+    -- with contractString, which is a contract that comes from the MarloweCompletionItemProvider with
+    -- holes where possible errors are, so it might be able to be parsed.
+    parsedContract <- case contract of
+      Nothing -> hush $ parseContract contractString
+      c -> c
+    let
+      (Holes holes) = view _holes ((lint Nil) parsedContract)
+    v <- Map.lookup "monaco_suggestions" holes
+    { head } <- Array.uncons $ Set.toUnfoldable v
+    pure $ holeSuggestions original stripParens range head
+
+format :: String -> String
+format contractString = case parseContract contractString of
+  Left _ -> contractString
+  Right contract -> show $ pretty contract

--- a/marlowe-playground-client/src/Marlowe/Monaco.purs
+++ b/marlowe-playground-client/src/Marlowe/Monaco.purs
@@ -16,8 +16,8 @@ import Data.Unfoldable as Unfoldable
 import Halogen (RefLabel(..))
 import Halogen.Monaco (Settings)
 import Help as Help
-import Marlowe.Linter (AdditionalContext)
-import Marlowe.Linter as Linter
+import Marlowe.LinterText (AdditionalContext)
+import Marlowe.LinterText as Linter
 import Monaco (CodeAction, CodeActionProvider, CompletionItem, CompletionItemProvider, DocumentFormattingEditProvider, Editor, HoverProvider, IMarkdownString, IMarkerData, IRange, IStandaloneThemeData, LanguageExtensionPoint(..), Theme, TokensProvider, Uri)
 
 foreign import hoverProvider_ :: Fn1 (String -> { contents :: Array IMarkdownString }) HoverProvider

--- a/marlowe-playground-client/src/Marlowe/Parser.js
+++ b/marlowe-playground-client/src/Marlowe/Parser.js
@@ -15,8 +15,19 @@ exports.parse_ = function (emptyInputError, parserError, success, fs, input) {
         if (error.token) {
             return parserError({ message: error.message, row: error.token.line, column: error.token.col, token: error.token.value });
         } else {
-            console.log(error.message.match(/[0-9]+/));
-            return parserError({ message: error.message, row: 1, column: 0, token: "" });
+            const message =  getErrorMessage(error);
+            console.log(message);
+            return parserError({ message, row: 1, column: 0, token: "" });
         }
     }
+}
+
+function getErrorMessage(error) {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return error.message;
+  }
+  return 'Unexpected error: ' + error;
 }

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -32,7 +32,7 @@ import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
 import Marlowe.Holes (fromTerm)
-import Marlowe.Linter as Linter
+import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -8,13 +8,14 @@ import Data.Enum (upFromIncluding)
 import Data.Map as Map
 import Data.Set as Set
 import Data.Traversable (traverse_)
-import Marlowe.Holes (MarloweHole(..), MarloweType(..), getMarloweConstructors, marloweHoleToSuggestionText)
+import Marlowe.Holes (MarloweHole(..), MarloweType(..), Location(..), getMarloweConstructors)
+import Marlowe.LinterText (marloweHoleToSuggestionText)
 import Marlowe.Parser (parse)
 import Marlowe.Parser as Parser
 import Test.Unit (TestSuite, failure, success, suite, test)
 
 mkHole :: MarloweType -> MarloweHole
-mkHole marloweType = MarloweHole { name: mempty, range: zero, marloweType }
+mkHole marloweType = MarloweHole { name: mempty, location: NoLocation, marloweType }
 
 holeSuggestions :: Boolean -> MarloweHole -> Array String
 holeSuggestions stripParens marloweHole@(MarloweHole { name, marloweType }) =


### PR DESCRIPTION
This PR modifies the `Term` data type to use `Location`s instead of `Range`s. This is a required step before being able to add warnings and static analysis to Blockly.

Initially the idea was to make `Term` polymorphic to not just `a` but also to a `loc`. 
![Screen Shot 2021-02-03 at 17 22 43](https://user-images.githubusercontent.com/2634059/106959588-9f562b80-6719-11eb-8f81-62bc37c037e5.png)

but this data type spread to virtually all data types in Marlowe.Hole, introducing a lot of complexity just to guarantee at the type level that we always use the same Location type. Instead, this approach uses a Sum type in Location and runtime exceptions in the places that they are used to guarantee (at runtime) that we don't mix locations.


Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
