### PR TITLE
SCP-1792 - Add template variables to Extended Marlowe language and Blockly

### DIFF
--- a/marlowe-playground-client/src/Help.purs
+++ b/marlowe-playground-client/src/Help.purs
@@ -182,6 +182,13 @@ In order to progress a Marlowe contract, a party must provide an evidence. For P
 So, Role parties will look like (Role "alice"), (Role "bob") and so on.
 """
 
+marloweTypeMarkerText ExtendedTimeoutType =
+  """
+Timeout is the slot number after which the When will no longer accept any new events: Case branches will become unusable, and the contract will continue as specified by the timeout continuation.
+
+Timeouts accept templates, this means that instead of writing a specific slot number it is possible to fill Timeouts by using a template parameter that can be filled just before deploying or simulating the contract, for example: SlotParam "maturityDate"
+"""
+
 helpForConstructor :: String -> Maybe String
 helpForConstructor constructor =
   let

--- a/marlowe-playground-client/src/Help.purs
+++ b/marlowe-playground-client/src/Help.purs
@@ -182,7 +182,7 @@ In order to progress a Marlowe contract, a party must provide an evidence. For P
 So, Role parties will look like (Role "alice"), (Role "bob") and so on.
 """
 
-marloweTypeMarkerText ExtendedTimeoutType =
+marloweTypeMarkerText TimeoutType =
   """
 Timeout is the slot number after which the When will no longer accept any new events: Case branches will become unusable, and the contract will continue as specified by the timeout continuation.
 

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,7 +25,7 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
-import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), ExtendedTimeout(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
+import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Timeout(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (Rational(..))
 import Record (merge)

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -17,41 +17,41 @@ import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedAr
 class ToCore a b where
   toCore :: a -> Maybe b
 
-data ExtendedTimeout
+data Timeout
   = SlotParam String
   | Slot BigInteger
 
-derive instance genericExtendedTimeout :: Generic ExtendedTimeout _
+derive instance genericTimeout :: Generic Timeout _
 
-derive instance eqExtendedTimeout :: Eq ExtendedTimeout
+derive instance eqTimeout :: Eq Timeout
 
-derive instance ordExtendedTimeout :: Ord ExtendedTimeout
+derive instance ordTimeout :: Ord Timeout
 
-instance encodeJsonExtendedTimeout :: Encode ExtendedTimeout where
+instance encodeJsonTimeout :: Encode Timeout where
   encode (SlotParam str) = encode { slot_param: str }
   encode (Slot val) = encode val
 
-instance decodeJsonExtendedTimeout :: Decode ExtendedTimeout where
+instance decodeJsonTimeout :: Decode Timeout where
   decode a =
     ( SlotParam <$> decodeProp "slot_param" a
         <|> (Slot <$> decode a)
     )
 
-instance showExtendedTimeout :: Show ExtendedTimeout where
+instance showTimeout :: Show Timeout where
   show (Slot x) = show x
   show v = genericShow v
 
-instance prettyExtendedTimeout :: Pretty ExtendedTimeout where
+instance prettyTimeout :: Pretty Timeout where
   pretty (Slot x) = pretty x
   pretty v = genericPretty v
 
-instance hasArgsExtendedTimeout :: Args ExtendedTimeout where
+instance hasArgsTimeout :: Args Timeout where
   hasArgs (Slot _) = false
   hasArgs x = genericHasArgs x
   hasNestedArgs (Slot _) = false
   hasNestedArgs x = genericHasNestedArgs x
 
-instance toCoreExtendedTimeout :: ToCore ExtendedTimeout S.Slot where
+instance toCoreTimeout :: ToCore Timeout S.Slot where
   toCore (SlotParam _) = Nothing
   toCore (Slot x) = Just (S.Slot x)
 
@@ -445,7 +445,7 @@ data Contract
   = Close
   | Pay S.AccountId Payee S.Token Value Contract
   | If Observation Contract Contract
-  | When (Array Case) ExtendedTimeout Contract
+  | When (Array Case) Timeout Contract
   | Let S.ValueId Value Contract
   | Assert Observation Contract
 

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -12,14 +12,53 @@ import Foreign.Class (class Encode, class Decode, encode, decode)
 import Foreign.Index (hasProperty)
 import Marlowe.Semantics (decodeProp)
 import Marlowe.Semantics as S
-import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty)
+import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty, pretty)
 
 class ToCore a b where
   toCore :: a -> Maybe b
 
+data ExtendedTimeout
+  = SlotParam String
+  | Slot BigInteger
+
+derive instance genericExtendedTimeout :: Generic ExtendedTimeout _
+
+derive instance eqExtendedTimeout :: Eq ExtendedTimeout
+
+derive instance ordExtendedTimeout :: Ord ExtendedTimeout
+
+instance encodeJsonExtendedTimeout :: Encode ExtendedTimeout where
+  encode (SlotParam str) = encode { slot_param: str }
+  encode (Slot val) = encode val
+
+instance decodeJsonExtendedTimeout :: Decode ExtendedTimeout where
+  decode a =
+    ( SlotParam <$> decodeProp "slot_param" a
+        <|> (Slot <$> decode a)
+    )
+
+instance showExtendedTimeout :: Show ExtendedTimeout where
+  show (Slot x) = show x
+  show v = genericShow v
+
+instance prettyExtendedTimeout :: Pretty ExtendedTimeout where
+  pretty (Slot x) = pretty x
+  pretty v = genericPretty v
+
+instance hasArgsExtendedTimeout :: Args ExtendedTimeout where
+  hasArgs (Slot _) = false
+  hasArgs x = genericHasArgs x
+  hasNestedArgs (Slot _) = false
+  hasNestedArgs x = genericHasNestedArgs x
+
+instance toCoreExtendedTimeout :: ToCore ExtendedTimeout S.Slot where
+  toCore (SlotParam _) = Nothing
+  toCore (Slot x) = Just (S.Slot x)
+
 data Value
   = AvailableMoney S.AccountId S.Token
   | Constant BigInteger
+  | ConstantParam String
   | NegValue Value
   | AddValue Value Value
   | SubValue Value Value
@@ -44,6 +83,7 @@ instance encodeJsonValue :: Encode Value where
       , in_account: accId
       }
   encode (Constant val) = encode val
+  encode (ConstantParam str) = encode { constant_param: str }
   encode (NegValue val) =
     encode
       { negate: val
@@ -100,6 +140,8 @@ instance decodeJsonValue :: Decode Value where
             <*> decodeProp "amount_of_token" a
         )
       <|> (Constant <$> decode a)
+      <|> ( ConstantParam <$> decodeProp "constant_param" a
+        )
       <|> (NegValue <$> decodeProp "negate" a)
       <|> ( AddValue <$> decodeProp "add" a
             <*> decodeProp "and" a
@@ -138,6 +180,7 @@ instance hasArgsValue :: Args Value where
 
 instance toCoreValue :: ToCore Value S.Value where
   toCore (Constant c) = Just $ S.Constant c
+  toCore (ConstantParam _) = Nothing
   toCore (AvailableMoney accId tok) = S.AvailableMoney <$> pure accId <*> pure tok
   toCore (NegValue v) = S.NegValue <$> toCore v
   toCore (AddValue lhs rhs) = S.AddValue <$> toCore lhs <*> toCore rhs
@@ -402,7 +445,7 @@ data Contract
   = Close
   | Pay S.AccountId Payee S.Token Value Contract
   | If Observation Contract Contract
-  | When (Array Case) S.Timeout Contract
+  | When (Array Case) ExtendedTimeout Contract
   | Let S.ValueId Value Contract
   | Assert Observation Contract
 
@@ -488,6 +531,6 @@ instance toCoreContract :: ToCore Contract S.Contract where
   toCore Close = Just S.Close
   toCore (Pay accId payee tok val cont) = S.Pay <$> pure accId <*> toCore payee <*> pure tok <*> toCore val <*> toCore cont
   toCore (If obs cont1 cont2) = S.If <$> toCore obs <*> toCore cont1 <*> toCore cont2
-  toCore (When cases tim cont) = S.When <$> traverse toCore cases <*> pure tim <*> toCore cont
+  toCore (When cases tim cont) = S.When <$> traverse toCore cases <*> toCore tim <*> toCore cont
   toCore (Let varId val cont) = S.Let <$> pure varId <*> toCore val <*> toCore cont
   toCore (Assert obs cont) = S.Assert <$> toCore obs <*> toCore cont

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -53,7 +53,7 @@ genRational = do
 genSlot :: forall m. MonadGen m => MonadRec m => m Slot
 genSlot = Slot <$> genBigInteger
 
-genTimeout :: forall m. MonadGen m => MonadRec m => m H.ExtendedTimeout
+genTimeout :: forall m. MonadGen m => MonadRec m => m H.Timeout
 genTimeout = H.Slot <$> genBigInteger
 
 genValueId :: forall m. MonadGen m => MonadRec m => MonadReader Boolean m => m ValueId

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -50,7 +50,7 @@ data MarloweType
   | BoundType
   | TokenType
   | PartyType
-  | ExtendedTimeoutType
+  | TimeoutType
 
 derive instance eqMarloweType :: Eq MarloweType
 
@@ -108,7 +108,7 @@ readMarloweType "TokenType" = Just TokenType
 
 readMarloweType "PartyType" = Just PartyType
 
-readMarloweType "ExtendedTimeoutType" = Just ExtendedTimeoutType
+readMarloweType "TimeoutType" = Just TimeoutType
 
 readMarloweType _ = Nothing
 
@@ -197,7 +197,7 @@ getMarloweConstructors ContractType =
     [ (Tuple "Close" eaa)
     , (Tuple "Pay" $ aa [ DataArg PartyType, DataArg PayeeType, DataArg TokenType, DataArg ValueType, DataArg ContractType ])
     , (Tuple "If" $ aa [ DataArg ObservationType, DataArgIndexed 1 ContractType, DataArgIndexed 2 ContractType ])
-    , (Tuple "When" $ aa [ EmptyArrayArg, DataArg ExtendedTimeoutType, DataArg ContractType ])
+    , (Tuple "When" $ aa [ EmptyArrayArg, DataArg TimeoutType, DataArg ContractType ])
     , (Tuple "Let" $ aa [ DefaultString "valueId", DataArg ValueType, DataArg ContractType ])
     , (Tuple "Assert" $ aa [ DataArg ObservationType, DataArg ContractType ])
     ]
@@ -212,7 +212,7 @@ getMarloweConstructors PartyType =
     , (Tuple "Role" $ aa [ DefaultString "token" ])
     ]
 
-getMarloweConstructors ExtendedTimeoutType =
+getMarloweConstructors TimeoutType =
   Map.fromFoldable
     [ (Tuple "Slot" $ SimpleArgument $ DefaultNumber zero)
     , (Tuple "SlotParam" $ aa [ DefaultString "slotParameterName" ])
@@ -543,38 +543,38 @@ instance boundIsMarloweType :: IsMarloweType Bound where
 instance boundHasMarloweHoles :: HasMarloweHoles Bound where
   getHoles (Bound a b) m = m
 
-data ExtendedTimeout
+data Timeout
   = Slot BigInteger
   | SlotParam String
 
-derive instance genericExtendedTimeout :: Generic ExtendedTimeout _
+derive instance genericTimeout :: Generic Timeout _
 
-derive instance eqExtendedTimeout :: Eq ExtendedTimeout
+derive instance eqTimeout :: Eq Timeout
 
-derive instance ordExtendedTimeout :: Ord ExtendedTimeout
+derive instance ordTimeout :: Ord Timeout
 
-instance showExtendedTimeout :: Show ExtendedTimeout where
+instance showTimeout :: Show Timeout where
   show (Slot x) = show x
   show v = genericShow v
 
-instance prettyExtendedTimeout :: Pretty ExtendedTimeout where
+instance prettyTimeout :: Pretty Timeout where
   pretty (Slot x) = pretty x
   pretty (SlotParam x) = genericPretty (SlotParam x)
 
-instance hasArgsExtendedTimeout :: Args ExtendedTimeout where
+instance hasArgsTimeout :: Args Timeout where
   hasArgs (Slot _) = false
   hasArgs x = genericHasArgs x
   hasNestedArgs (Slot _) = false
   hasNestedArgs x = genericHasNestedArgs x
 
-instance extendedTimeoutFromTerm :: FromTerm ExtendedTimeout EM.ExtendedTimeout where
+instance timeoutFromTerm :: FromTerm Timeout EM.Timeout where
   fromTerm (Slot b) = pure $ EM.Slot b
   fromTerm (SlotParam b) = pure $ EM.SlotParam b
 
-instance extendedTimeoutIsMarloweType :: IsMarloweType ExtendedTimeout where
-  marloweType _ = ExtendedTimeoutType
+instance timeoutIsMarloweType :: IsMarloweType Timeout where
+  marloweType _ = TimeoutType
 
-instance extendedTimeoutHasMarloweHoles :: HasMarloweHoles ExtendedTimeout where
+instance timeoutHasMarloweHoles :: HasMarloweHoles Timeout where
   getHoles (Slot a) m = m
   getHoles (SlotParam a) m = m
 
@@ -893,7 +893,7 @@ data Contract
   = Close
   | Pay AccountId (Term Payee) (Term Token) (Term Value) (Term Contract)
   | If (Term Observation) (Term Contract) (Term Contract)
-  | When (Array (Term Case)) (Term ExtendedTimeout) (Term Contract)
+  | When (Array (Term Case)) (Term Timeout) (Term Contract)
   | Let (TermWrapper ValueId) (Term Value) (Term Contract)
   | Assert (Term Observation) (Term Contract)
 

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -129,6 +129,10 @@ data Argument
   | NewtypeArg
   | GenArg MarloweType
 
+-- | TermGenerator is a decorator for Array Argument. Array Argument is used, among other things, for generating
+-- | terms from holes. But, by default, it includes the constructor name, e.g: "Slot ?slotNumber"
+-- | In the case of Slot, we just want to generate the argument, i.e: "0", not "Slot 0",
+-- | that is what SimpleArgument does. See implementation of `constructMarloweType` function.
 data TermGenerator
   = ArgumentArray (Array Argument)
   | SimpleArgument Argument

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -133,89 +133,82 @@ data TermGenerator
   = ArgumentArray (Array Argument)
   | SimpleArgument Argument
 
--- Shorter version of constructors for keeping code short
-aa :: Array Argument -> TermGenerator
-aa = ArgumentArray
-
-eaa :: TermGenerator
-eaa = ArgumentArray []
-
 getMarloweConstructors :: MarloweType -> Map String TermGenerator
-getMarloweConstructors ChoiceIdType = Map.singleton "ChoiceId" $ aa [ DefaultString "choiceNumber", DataArg PartyType ]
+getMarloweConstructors ChoiceIdType = Map.singleton "ChoiceId" $ ArgumentArray [ DefaultString "choiceNumber", DataArg PartyType ]
 
 getMarloweConstructors ValueIdType = mempty
 
 getMarloweConstructors ActionType =
   Map.fromFoldable
-    [ (Tuple "Deposit" $ aa [ DataArg PartyType, NamedDataArg "from_party", DataArg TokenType, DataArg ValueType ])
-    , (Tuple "Choice" $ aa [ GenArg ChoiceIdType, ArrayArg "bounds" ])
-    , (Tuple "Notify" $ aa [ DataArg ObservationType ])
+    [ (Tuple "Deposit" $ ArgumentArray [ DataArg PartyType, NamedDataArg "from_party", DataArg TokenType, DataArg ValueType ])
+    , (Tuple "Choice" $ ArgumentArray [ GenArg ChoiceIdType, ArrayArg "bounds" ])
+    , (Tuple "Notify" $ ArgumentArray [ DataArg ObservationType ])
     ]
 
 getMarloweConstructors PayeeType =
   Map.fromFoldable
-    [ (Tuple "Account" $ aa [ DataArg PartyType ])
-    , (Tuple "Party" $ aa [ DataArg PartyType ])
+    [ (Tuple "Account" $ ArgumentArray [ DataArg PartyType ])
+    , (Tuple "Party" $ ArgumentArray [ DataArg PartyType ])
     ]
 
-getMarloweConstructors CaseType = Map.singleton "Case" $ aa [ DataArg ActionType, DataArg ContractType ]
+getMarloweConstructors CaseType = Map.singleton "Case" $ ArgumentArray [ DataArg ActionType, DataArg ContractType ]
 
 getMarloweConstructors ValueType =
   Map.fromFoldable
-    [ (Tuple "AvailableMoney" $ aa [ DataArg PartyType, DataArg TokenType ])
-    , (Tuple "Constant" $ aa [ DefaultNumber zero ])
-    , (Tuple "ConstantParam" $ aa [ DefaultString "parameterName" ])
-    , (Tuple "NegValue" $ aa [ DataArg ValueType ])
-    , (Tuple "AddValue" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "SubValue" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "MulValue" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "Scale" $ aa [ DefaultRational (Rational one one), DataArg ValueType ])
-    , (Tuple "ChoiceValue" $ aa [ GenArg ChoiceIdType ])
-    , (Tuple "SlotIntervalStart" eaa)
-    , (Tuple "SlotIntervalEnd" eaa)
-    , (Tuple "UseValue" $ aa [ DefaultString "valueId" ])
-    , (Tuple "Cond" $ aa [ DataArg ObservationType, DataArg ValueType, DataArg ValueType ])
+    [ (Tuple "AvailableMoney" $ ArgumentArray [ DataArg PartyType, DataArg TokenType ])
+    , (Tuple "Constant" $ ArgumentArray [ DefaultNumber zero ])
+    , (Tuple "ConstantParam" $ ArgumentArray [ DefaultString "parameterName" ])
+    , (Tuple "NegValue" $ ArgumentArray [ DataArg ValueType ])
+    , (Tuple "AddValue" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "SubValue" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "MulValue" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "Scale" $ ArgumentArray [ DefaultRational (Rational one one), DataArg ValueType ])
+    , (Tuple "ChoiceValue" $ ArgumentArray [ GenArg ChoiceIdType ])
+    , (Tuple "SlotIntervalStart" $ ArgumentArray [])
+    , (Tuple "SlotIntervalEnd" $ ArgumentArray [])
+    , (Tuple "UseValue" $ ArgumentArray [ DefaultString "valueId" ])
+    , (Tuple "Cond" $ ArgumentArray [ DataArg ObservationType, DataArg ValueType, DataArg ValueType ])
     ]
 
 getMarloweConstructors ObservationType =
   Map.fromFoldable
-    [ (Tuple "AndObs" $ aa [ DataArgIndexed 1 ObservationType, DataArgIndexed 2 ObservationType ])
-    , (Tuple "OrObs" $ aa [ DataArgIndexed 1 ObservationType, DataArgIndexed 2 ObservationType ])
-    , (Tuple "NotObs" $ aa [ DataArg ObservationType ])
-    , (Tuple "ChoseSomething" $ aa [ GenArg ChoiceIdType ])
-    , (Tuple "ValueGE" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "ValueGT" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "ValueLE" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "ValueLT" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "ValueEQ" $ aa [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
-    , (Tuple "TrueObs" eaa)
-    , (Tuple "FalseObs" eaa)
+    [ (Tuple "AndObs" $ ArgumentArray [ DataArgIndexed 1 ObservationType, DataArgIndexed 2 ObservationType ])
+    , (Tuple "OrObs" $ ArgumentArray [ DataArgIndexed 1 ObservationType, DataArgIndexed 2 ObservationType ])
+    , (Tuple "NotObs" $ ArgumentArray [ DataArg ObservationType ])
+    , (Tuple "ChoseSomething" $ ArgumentArray [ GenArg ChoiceIdType ])
+    , (Tuple "ValueGE" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "ValueGT" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "ValueLE" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "ValueLT" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "ValueEQ" $ ArgumentArray [ DataArgIndexed 1 ValueType, DataArgIndexed 2 ValueType ])
+    , (Tuple "TrueObs" $ ArgumentArray [])
+    , (Tuple "FalseObs" $ ArgumentArray [])
     ]
 
 getMarloweConstructors ContractType =
   Map.fromFoldable
-    [ (Tuple "Close" eaa)
-    , (Tuple "Pay" $ aa [ DataArg PartyType, DataArg PayeeType, DataArg TokenType, DataArg ValueType, DataArg ContractType ])
-    , (Tuple "If" $ aa [ DataArg ObservationType, DataArgIndexed 1 ContractType, DataArgIndexed 2 ContractType ])
-    , (Tuple "When" $ aa [ EmptyArrayArg, DataArg TimeoutType, DataArg ContractType ])
-    , (Tuple "Let" $ aa [ DefaultString "valueId", DataArg ValueType, DataArg ContractType ])
-    , (Tuple "Assert" $ aa [ DataArg ObservationType, DataArg ContractType ])
+    [ (Tuple "Close" $ ArgumentArray [])
+    , (Tuple "Pay" $ ArgumentArray [ DataArg PartyType, DataArg PayeeType, DataArg TokenType, DataArg ValueType, DataArg ContractType ])
+    , (Tuple "If" $ ArgumentArray [ DataArg ObservationType, DataArgIndexed 1 ContractType, DataArgIndexed 2 ContractType ])
+    , (Tuple "When" $ ArgumentArray [ EmptyArrayArg, DataArg TimeoutType, DataArg ContractType ])
+    , (Tuple "Let" $ ArgumentArray [ DefaultString "valueId", DataArg ValueType, DataArg ContractType ])
+    , (Tuple "Assert" $ ArgumentArray [ DataArg ObservationType, DataArg ContractType ])
     ]
 
-getMarloweConstructors BoundType = Map.singleton "Bound" $ aa [ DefaultNumber zero, DefaultNumber zero ]
+getMarloweConstructors BoundType = Map.singleton "Bound" $ ArgumentArray [ DefaultNumber zero, DefaultNumber zero ]
 
-getMarloweConstructors TokenType = Map.singleton "Token" $ aa [ DefaultString "", DefaultString "" ]
+getMarloweConstructors TokenType = Map.singleton "Token" $ ArgumentArray [ DefaultString "", DefaultString "" ]
 
 getMarloweConstructors PartyType =
   Map.fromFoldable
-    [ (Tuple "PK" $ aa [ DefaultString "pubKey" ])
-    , (Tuple "Role" $ aa [ DefaultString "token" ])
+    [ (Tuple "PK" $ ArgumentArray [ DefaultString "pubKey" ])
+    , (Tuple "Role" $ ArgumentArray [ DefaultString "token" ])
     ]
 
 getMarloweConstructors TimeoutType =
   Map.fromFoldable
     [ (Tuple "Slot" $ SimpleArgument $ DefaultNumber zero)
-    , (Tuple "SlotParam" $ aa [ DefaultString "slotParameterName" ])
+    , (Tuple "SlotParam" $ ArgumentArray [ DefaultString "slotParameterName" ])
     ]
 
 allMarloweConstructors :: Map String TermGenerator

--- a/marlowe-playground-client/src/Marlowe/Monaco.js
+++ b/marlowe-playground-client/src/Marlowe/Monaco.js
@@ -59,6 +59,7 @@ exports.daylightTheme_ = {
         { token: "PAYEE", foreground: blue },
         { token: "PARTY", foreground: blue },
         { token: "BOUND", foreground: blue },
+        { token: "TIMEOUT", foreground: blue },
         { token: "VALUE_ID", foreground: blue },
         { token: "CASE", foreground: blue },
         { token: "ACTION", foreground: blue },

--- a/marlowe-playground-client/src/Marlowe/Monaco.ts
+++ b/marlowe-playground-client/src/Marlowe/Monaco.ts
@@ -163,6 +163,7 @@ const marloweLexer = moo.compile({
       VALUE: [
         'AvailableMoney',
         'Constant',
+        'ConstantParam',
         'NegValue',
         'AddValue',
         'SubValue',
@@ -178,6 +179,7 @@ const marloweLexer = moo.compile({
       PAYEE: ['Account', 'Party'],
       PARTY: ['PK', 'Role'],
       BOUND: ['Bound'],
+      TIMEOUT: ['SlotParam'],
       VALUE_ID: ['ValueId'],
       CASE: ['Case'],
       ACTION: ['Deposit', 'Choice', 'Notify'],

--- a/marlowe-playground-client/src/Marlowe/Parser.purs
+++ b/marlowe-playground-client/src/Marlowe/Parser.purs
@@ -16,7 +16,8 @@ import Data.Maybe (Maybe(..))
 import Data.String (length)
 import Data.String.CodeUnits (fromCharArray)
 import Data.Unit (Unit, unit)
-import Marlowe.Holes (class FromTerm, AccountId, Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), fromTerm, getRange, mkHole)
+import Marlowe.Holes (class FromTerm, AccountId, Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), ExtendedTimeout(SlotParam), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), fromTerm, getRange, mkHole)
+import Marlowe.Holes as H
 import Marlowe.Semantics (CurrencySymbol, Rational(..), PubKey, Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..), TokenName)
 import Marlowe.Semantics as S
 import Prelude (class Show, bind, const, discard, pure, show, void, zero, ($), (*>), (-), (<$), (<$>), (<*), (<*>), (<<<))
@@ -32,10 +33,12 @@ type HelperFunctions a
     , mkTermWrapper :: a -> Range -> TermWrapper a
     , getRange :: Term a -> Range
     , mkBigInteger :: Int -> BigInteger
-    , mkTimeout :: Int -> Range -> TermWrapper Slot
+    , mkSlot :: BigInteger -> Slot
+    , mkExtendedSlot :: BigInteger -> ExtendedTimeout
+    , mkExtendedSlotParam :: String -> ExtendedTimeout
     , mkClose :: Contract
     , mkPay :: AccountId -> Term Payee -> Term Token -> Term Value -> Term Contract -> Contract
-    , mkWhen :: Array (Term Case) -> (TermWrapper Slot) -> Term Contract -> Contract
+    , mkWhen :: Array (Term Case) -> Term ExtendedTimeout -> Term Contract -> Contract
     , mkIf :: Term Observation -> Term Contract -> Term Contract -> Contract
     , mkLet :: TermWrapper ValueId -> Term Value -> Term Contract -> Contract
     , mkAssert :: Term Observation -> Term Contract -> Contract
@@ -64,6 +67,7 @@ type HelperFunctions a
     , mkFalseObs :: Observation
     , mkAvailableMoney :: AccountId -> Term Token -> Value
     , mkConstant :: BigInteger -> Value
+    , mkConstantParam :: String -> Value
     , mkNegValue :: Term Value -> Value
     , mkAddValue :: Term Value -> Term Value -> Value
     , mkSubValue :: Term Value -> Term Value -> Value
@@ -84,7 +88,9 @@ helperFunctions =
   , mkTermWrapper: TermWrapper
   , getRange: getRange
   , mkBigInteger: BigInteger.fromInt
-  , mkTimeout: \v pos -> TermWrapper (Slot (BigInteger.fromInt v)) pos
+  , mkSlot: Slot
+  , mkExtendedSlot: H.Slot
+  , mkExtendedSlotParam: SlotParam
   , mkClose: Close
   , mkPay: Pay
   , mkWhen: When
@@ -116,6 +122,7 @@ helperFunctions =
   , mkFalseObs: FalseObs
   , mkAvailableMoney: AvailableMoney
   , mkConstant: Constant
+  , mkConstantParam: ConstantParam
   , mkNegValue: NegValue
   , mkAddValue: AddValue
   , mkSubValue: SubValue
@@ -253,15 +260,8 @@ valueId = ValueId <$> text
 slot :: Parser Slot
 slot = Slot <$> maybeParens bigInteger
 
-slotTerm :: Parser (Term Slot)
-slotTerm = parseTerm slot
-
-timeout :: Parser (TermWrapper Slot)
-timeout = do
-  result <- bigIntegerTerm
-  case result of
-    (Hole _ _ pos) -> fail ""
-    (Term v pos) -> pure $ TermWrapper (Slot v) pos
+extendedTimeout :: Parser (Term ExtendedTimeout)
+extendedTimeout = parseTerm ((SlotParam <$> maybeParens (string "SlotParam" **> text)) <|> (H.Slot <$> maybeParens bigInteger))
 
 accountIdExtended :: Parser AccountId
 accountIdExtended = parseTerm $ parens partyExtended
@@ -302,6 +302,7 @@ rational = do
 recValue :: Unit -> Parser Value
 recValue _ =
   (AvailableMoney <$> (string "AvailableMoney" **> accountIdExtended) <**> parseTerm (parens token))
+    <|> (ConstantParam <$> (string "ConstantParam" **> text))
     <|> (Constant <$> (string "Constant" **> bigInteger))
     <|> (NegValue <$> (string "NegValue" **> value'))
     <|> (AddValue <$> (string "AddValue" **> value') <**> value')
@@ -436,7 +437,7 @@ recContract =
       <**> contract'
   )
     <|> (If <$> (string "If" **> observation') <**> contract' <**> contract')
-    <|> (When <$> (string "When" **> (array (maybeParens (parseTerm case')))) <**> timeout <**> contract')
+    <|> (When <$> (string "When" **> (array (maybeParens (parseTerm case')))) <**> extendedTimeout <**> contract')
     <|> (Let <$> (string "Let" **> termWrapper valueId) <**> value' <**> contract')
     <|> (Assert <$> (string "Assert" **> observation') <**> contract')
     <|> (fail "not a valid Contract")

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -62,6 +62,8 @@ testFor TokenType = mkTest false TokenType (parse Parser.token)
 
 testFor PartyType = mkTest false PartyType (parse Parser.partyExtended)
 
+testFor ExtendedTimeoutType = mkTest false ExtendedTimeoutType (parse Parser.extendedTimeout)
+
 all :: TestSuite
 all =
   suite "Completion Items Tests" do

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -62,7 +62,7 @@ testFor TokenType = mkTest false TokenType (parse Parser.token)
 
 testFor PartyType = mkTest false PartyType (parse Parser.partyExtended)
 
-testFor ExtendedTimeoutType = mkTest false ExtendedTimeoutType (parse Parser.extendedTimeout)
+testFor TimeoutType = mkTest false TimeoutType (parse Parser.timeout)
 
 all :: TestSuite
 all =


### PR DESCRIPTION
This PR adds two constructs:
* `ConstantParam` (of type `Value`)
* `SlotParam` (of type `ExtendedTimeout`)

Originally, `Timeout` was simply a number, and `ExtendedTimeout` still accepts that, but also `SlotParam "string"`, which is a bit odd with `Term` and blockly, but it seems I got it to work more or less sensibly. I changed it in blockly to be a `string` instead of a number, and it will write a `SlotParam` if you write anything that doesn't parse as a number. Feels a bit like an easter egg, but the alternative was to adding a `Slot` type of block, and it seemed a worse solution, maybe we'll have to eventually.

I haven't added them to Haskell, or JavaScript, or added interface for instantiating in the simulator. There are Jira tickets for all of those in the pipeline, but I don't want to diverge much from `master`.

Deployed in https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
