### PR TITLE
SCP-1836: Change "runInstance" to use only message related syscalls

### DIFF
--- a/plutus-contract/src/Plutus/Trace/Effects/RunContract.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/RunContract.hs
@@ -211,6 +211,7 @@ mapYieldEm ::
     -> Eff effs c
 mapYieldEm = mapYield @_ @(EmSystemCall effs2 EmulatorMessage) (fmap Left) id
 
+-- | Handle a @Yield a b@ with a @Yield a' b'@ effect.
 mapYield ::
     forall a a' b b' effs c.
     (Member (Yield a' b') effs)
@@ -220,7 +221,6 @@ mapYield ::
     -> Eff effs c
 mapYield f g = \case
     Yield a cont -> send @(Yield a' b') $ Yield (f a) (lmap g cont)
-
 
 handleCallEndpoint :: forall s l e ep effs effs2.
     ( ContractConstraints s

--- a/plutus-contract/src/Plutus/Trace/Effects/RunContractPlayground.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/RunContractPlayground.hs
@@ -109,7 +109,13 @@ handleLaunchContract ::
 handleLaunchContract contract wllt = do
     i <- nextId
     let handle = ContractHandle{chContract=contract, chInstanceId = i, chInstanceTag = walletInstanceTag wllt}
-    void $ fork @effs2 @EmulatorMessage "contract instance" Normal (runReader wllt $ interpret (mapLog InstanceEvent) $ reinterpret (mapLog InstanceEvent) $ contractThread handle)
+    void
+        $ fork @effs2 @EmulatorMessage "contract instance" Normal
+        (_
+            $ runReader wllt
+            $ interpret (mapLog InstanceEvent)
+            $ reinterpret (mapLog InstanceEvent)
+            $ contractThread handle)
     modify @(Map Wallet ContractInstanceId) (set (at wllt) (Just i))
 
 handleCallEndpoint ::

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -22,6 +22,7 @@ module Plutus.Trace.Emulator.ContractInstance(
     contractThread
     , getThread
     , EmulatorRuntimeError
+    , runInstance
     -- * Instance state
     , ContractInstanceState(..)
     , emptyInstanceState
@@ -58,9 +59,8 @@ import           Plutus.Trace.Emulator.Types                   (ContractConstrai
                                                                 EmulatorRuntimeError (..), EmulatorThreads,
                                                                 addEventInstanceState, emptyInstanceState,
                                                                 instanceIdThreads, toInstanceState)
-import           Plutus.Trace.Scheduler                        (AgentSystemCall, EmSystemCall, MessageCall (..),
-                                                                Priority (..), ThreadId, mkAgentSysCall, mkSysCall,
-                                                                sleep)
+import           Plutus.Trace.Scheduler                        (AgentSystemCall, MessageCall (..), Priority (..),
+                                                                ThreadId, mkAgentSysCall)
 import qualified Wallet.API                                    as WAPI
 import           Wallet.Effects                                (ChainIndexEffect, ContractRuntimeEffect (..),
                                                                 NodeClientEffect, SigningProcessEffect, WalletEffect)
@@ -104,8 +104,8 @@ handleContractRuntime = interpret $ \case
                 ownId <- ask @ThreadId
                 let Notification{notificationContractEndpoint=EndpointDescription ep, notificationContractArg} = n
                     vl = object ["tag" JSON..= ep, "value" JSON..= EndpointValue notificationContractArg]
-                    e = Left $ Message threadId (EndpointCall ownId (EndpointDescription ep) vl)
-                -- _ <- mkSysCall @_ @EmulatorMessage Normal e
+                    e = Message threadId (EndpointCall ownId (EndpointDescription ep) vl)
+                _ <- mkAgentSysCall @_ @EmulatorMessage Normal e
                 logInfo $ NotificationSuccess n
                 pure Nothing
 

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -58,8 +58,9 @@ import           Plutus.Trace.Emulator.Types                   (ContractConstrai
                                                                 EmulatorRuntimeError (..), EmulatorThreads,
                                                                 addEventInstanceState, emptyInstanceState,
                                                                 instanceIdThreads, toInstanceState)
-import           Plutus.Trace.Scheduler                        (EmSystemCall, MessageCall (..), Priority (..), ThreadId,
-                                                                mkSysCall, sleep)
+import           Plutus.Trace.Scheduler                        (AgentSystemCall, EmSystemCall, MessageCall (..),
+                                                                Priority (..), ThreadId, mkAgentSysCall, mkSysCall,
+                                                                sleep)
 import qualified Wallet.API                                    as WAPI
 import           Wallet.Effects                                (ChainIndexEffect, ContractRuntimeEffect (..),
                                                                 NodeClientEffect, SigningProcessEffect, WalletEffect)
@@ -82,9 +83,9 @@ type ContractInstanceThreadEffs s e effs =
 -- | Handle 'ContractRuntimeEffect' by sending the notification to the
 --   receiving contract's thread
 handleContractRuntime ::
-    forall effs effs2.
+    forall effs2.
     ( Member (State EmulatorThreads) effs2
-    , Member (Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
+    , Member (Yield (AgentSystemCall EmulatorMessage) (Maybe EmulatorMessage)) effs2
     , Member (LogMsg ContractInstanceMsg) effs2
     , Member (Reader ThreadId) effs2
     )
@@ -104,7 +105,7 @@ handleContractRuntime = interpret $ \case
                 let Notification{notificationContractEndpoint=EndpointDescription ep, notificationContractArg} = n
                     vl = object ["tag" JSON..= ep, "value" JSON..= EndpointValue notificationContractArg]
                     e = Left $ Message threadId (EndpointCall ownId (EndpointDescription ep) vl)
-                _ <- mkSysCall @effs @EmulatorMessage Normal e
+                -- _ <- mkSysCall @_ @EmulatorMessage Normal e
                 logInfo $ NotificationSuccess n
                 pure Nothing
 
@@ -124,14 +125,14 @@ contractThread :: forall s e effs.
 contractThread ContractHandle{chInstanceId, chContract, chInstanceTag} = do
     ask @ThreadId >>= registerInstance chInstanceId
     interpret (mapLog (\m -> ContractInstanceLog m chInstanceId chInstanceTag))
-        $ handleContractRuntime @effs
+        $ handleContractRuntime
         $ runReader chInstanceId
         $ evalState (emptyInstanceState chContract)
         $ do
             logInfo Started
             logNewMessages @s @e
             logCurrentRequests @s @e
-            msg <- mkSysCall @effs @EmulatorMessage Normal (Left WaitForMessage)
+            msg <- mkAgentSysCall @_ @EmulatorMessage Normal WaitForMessage
             runInstance chContract msg
 
 registerInstance :: forall effs.
@@ -183,12 +184,12 @@ runInstance contract event = do
             Just Freeze -> do
                 logInfo Freezing
                 -- freeze ourselves, see note [Freeze and Thaw]
-                sleep @effs Frozen >>= runInstance contract
+                mkAgentSysCall Frozen WaitForMessage >>= runInstance contract
             Just (EndpointCall _ _ vl) -> do
                 logInfo $ ReceiveEndpointCall vl
                 e <- decodeEvent @s vl
                 _ <- respondToEvent @s @e e
-                sleep @effs Normal >>= runInstance contract
+                mkAgentSysCall Normal WaitForMessage >>= runInstance contract
             Just (ContractInstanceStateRequest sender) -> do
                 state <- get @(ContractInstanceStateInternal s e ())
 
@@ -197,8 +198,8 @@ runInstance contract event = do
                 -- us having to convert to 'Value' and back.
                 let stateJSON = JSON.toJSON $ toInstanceState state
                 logInfo $ SendingContractState sender
-                void $ mkSysCall @effs @EmulatorMessage Normal (Left $ Message sender $ ContractInstanceStateResponse stateJSON)
-                sleep @effs Normal >>= runInstance contract
+                void $ mkAgentSysCall Normal (Message sender $ ContractInstanceStateResponse stateJSON)
+                mkAgentSysCall Normal WaitForMessage >>= runInstance contract
             _ -> do
                 response <- respondToRequest @s @e handleBlockchainQueries
                 let prio =
@@ -214,7 +215,7 @@ runInstance contract event = do
                             -- other active threads have had their turn
                             (const Normal)
                             response
-                sleep @effs prio >>= runInstance contract
+                mkAgentSysCall prio WaitForMessage >>= runInstance contract
 
 decodeEvent ::
     forall s effs.

--- a/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
@@ -108,8 +108,8 @@ makeLenses ''EmulatorThreads
 type EmulatorAgentThreadEffs effs =
     LogMsg ContractInstanceLog
     ': Reader Wallet
-    ': Reader ThreadId
     ': Yield (AgentSystemCall EmulatorMessage) (Maybe EmulatorMessage)
+    ': Reader ThreadId
     ': effs
 
 data Emulator

--- a/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
@@ -72,7 +72,7 @@ import           Language.Plutus.Contract.Types     (ResumableResult (..), Suspe
 import qualified Language.Plutus.Contract.Types     as Contract.Types
 import           Ledger.Slot                        (Slot (..))
 import           Ledger.Tx                          (Tx)
-import           Plutus.Trace.Scheduler             (EmSystemCall, ThreadId)
+import           Plutus.Trace.Scheduler             (AgentSystemCall, ThreadId)
 import           Wallet.Emulator.Wallet             (Wallet (..))
 import           Wallet.Types                       (ContractInstanceId, EndpointDescription, Notification (..),
                                                      NotificationError)
@@ -109,7 +109,7 @@ type EmulatorAgentThreadEffs effs =
     LogMsg ContractInstanceLog
     ': Reader Wallet
     ': Reader ThreadId
-    ': Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)
+    ': Yield (AgentSystemCall EmulatorMessage) (Maybe EmulatorMessage)
     ': effs
 
 data Emulator

--- a/plutus-contract/src/Plutus/Trace/Scheduler.hs
+++ b/plutus-contract/src/Plutus/Trace/Scheduler.hs
@@ -155,7 +155,7 @@ data WithPriority t
     = WithPriority
         { _priority :: Priority
         , _thread   :: t
-        }
+        } deriving Functor
 
 type SuspendedThread effs systemEvent = WithPriority (EmThread effs systemEvent)
 

--- a/plutus-contract/src/Plutus/Trace/Scheduler.hs
+++ b/plutus-contract/src/Plutus/Trace/Scheduler.hs
@@ -225,6 +225,7 @@ mkThread tag prio action tid =
                 }
             }
 
+-- | Make a 'MessageCall' system call for some agent
 mkAgentSysCall :: forall effs systemEvent.
     Member (Yield (AgentSystemCall systemEvent) (Maybe systemEvent)) effs
     => Priority -- ^ The 'Priority' of the caller


### PR DESCRIPTION
* That way we can use `runThread` in other (non-emulator) contexts such as the PAB.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
