### PR TITLE
SCP-1847: Extract control effects from "MultiAgentEffect"

### DIFF
--- a/plutus-contract/src/Plutus/Trace/Effects/EmulatorControl.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/EmulatorControl.hs
@@ -35,7 +35,7 @@ import           Plutus.Trace.Scheduler                 (EmSystemCall, MessageCa
                                                          ThreadCall (Thaw), mkSysCall)
 import qualified Wallet.Emulator                        as EM
 import           Wallet.Emulator.Chain                  (ChainState)
-import           Wallet.Emulator.MultiAgent             (EmulatorState, MultiAgentEffect, walletControlAction)
+import           Wallet.Emulator.MultiAgent             (EmulatorState, MultiAgentControlEffect, walletControlAction)
 import           Wallet.Emulator.Wallet                 (SigningProcess, Wallet, WalletState)
 import qualified Wallet.Emulator.Wallet                 as W
 import           Wallet.Types                           (ContractInstanceId)
@@ -72,7 +72,7 @@ handleEmulatorControl ::
     ( Member (State EmulatorThreads) effs
     , Member (State EmulatorState) effs
     , Member (Error EmulatorRuntimeError) effs
-    , Member MultiAgentEffect effs
+    , Member MultiAgentControlEffect effs
     , Member (Yield (EmSystemCall effs2 EmulatorMessage) (Maybe EmulatorMessage)) effs
     )
     => EmulatorControl

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -72,7 +72,7 @@ import           Plutus.Trace.Scheduler                  (EmSystemCall, ThreadId
 import           Wallet.Emulator.Chain                   (ChainControlEffect, ChainEffect)
 import qualified Wallet.Emulator.Chain                   as ChainState
 import           Wallet.Emulator.MultiAgent              (EmulatorEvent, EmulatorEvent' (..), EmulatorState,
-                                                          MultiAgentEffect, schedulerEvent)
+                                                          MultiAgentControlEffect, MultiAgentEffect, schedulerEvent)
 import           Wallet.Emulator.Stream                  (EmulatorConfig (..), EmulatorErr (..), defaultEmulatorConfig,
                                                           initialChainState, runTraceStream)
 import qualified Wallet.Emulator.Wallet                  as Wallet
@@ -106,6 +106,7 @@ type EmulatorTrace a =
 handleEmulatorTrace ::
     forall effs a.
     ( Member MultiAgentEffect effs
+    , Member MultiAgentControlEffect effs
     , Member (State EmulatorThreads) effs
     , Member (State EmulatorState) effs
     , Member (Error EmulatorRuntimeError) effs
@@ -134,6 +135,7 @@ runEmulatorStream conf = runTraceStream conf . interpretEmulatorTrace conf
 --   blockchain effects.
 interpretEmulatorTrace :: forall effs a.
     ( Member MultiAgentEffect effs
+    , Member MultiAgentControlEffect effs
     , Member (Error EmulatorRuntimeError) effs
     , Member ChainEffect effs
     , Member ChainControlEffect effs

--- a/plutus-contract/src/Plutus/Trace/Emulator/System.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/System.hs
@@ -23,7 +23,8 @@ import           Data.Foldable                 (traverse_)
 import           Data.Maybe                    (maybeToList)
 import           Wallet.Effects                (startWatching)
 import           Wallet.Emulator.Chain         (ChainControlEffect, ChainEffect, getCurrentSlot, processBlock)
-import           Wallet.Emulator.MultiAgent    (MultiAgentEffect, walletAction, walletControlAction)
+import           Wallet.Emulator.MultiAgent    (MultiAgentControlEffect, MultiAgentEffect, walletAction,
+                                                walletControlAction)
 
 import           Data.String                   (IsString (..))
 import           Plutus.Trace.Emulator.Types   (EmulatorMessage (..))
@@ -68,6 +69,7 @@ just arrive later.
 launchSystemThreads :: forall effs.
     ( Member ChainControlEffect effs
     , Member MultiAgentEffect effs
+    , Member MultiAgentControlEffect effs
     , Member ChainEffect effs
     )
     => [Wallet]
@@ -105,6 +107,7 @@ blockMaker = go where
 -- | Thread for a simulated agent. See note [Simulated Agents]
 agentThread :: forall effs effs2.
     ( Member MultiAgentEffect effs2
+    , Member MultiAgentControlEffect effs2
     , Member (Yield (EmSystemCall effs EmulatorMessage) (Maybe EmulatorMessage)) effs2
     )
     => Wallet

--- a/plutus-contract/src/Plutus/Trace/Playground.hs
+++ b/plutus-contract/src/Plutus/Trace/Playground.hs
@@ -57,7 +57,7 @@ import           Streaming                                  (Stream)
 import           Streaming.Prelude                          (Of)
 import           Wallet.Emulator.Chain                      (ChainControlEffect, ChainEffect)
 import           Wallet.Emulator.MultiAgent                 (EmulatorEvent, EmulatorEvent' (..), EmulatorState,
-                                                             MultiAgentEffect, schedulerEvent)
+                                                             MultiAgentControlEffect, MultiAgentEffect, schedulerEvent)
 import           Wallet.Emulator.Stream                     (EmulatorConfig (..), EmulatorErr (..),
                                                              defaultEmulatorConfig, initialChainState, runTraceStream)
 import           Wallet.Emulator.Wallet                     (Wallet (..))
@@ -133,6 +133,7 @@ runPlaygroundStream conf contract =
 
 interpretPlaygroundTrace :: forall s e effs a.
     ( Member MultiAgentEffect effs
+    , Member MultiAgentControlEffect effs
     , Member (Error EmulatorRuntimeError) effs
     , Member ChainEffect effs
     , Member ChainControlEffect effs

--- a/plutus-contract/src/Wallet/Emulator/Stream.hs
+++ b/plutus-contract/src/Wallet/Emulator/Stream.hs
@@ -31,7 +31,7 @@ import           Control.Lens                           (filtered, makeLenses, p
 import           Control.Monad.Freer                    (Eff, Member, interpret, reinterpret, run, subsume, type (~>))
 import           Control.Monad.Freer.Coroutine          (Yield, yield)
 import           Control.Monad.Freer.Error              (Error, runError)
-import           Control.Monad.Freer.Extras             (raiseEnd6, wrapError)
+import           Control.Monad.Freer.Extras             (raiseEnd7, wrapError)
 import           Control.Monad.Freer.Log                (LogLevel, LogMessage (..), LogMsg (..), logMessageContent,
                                                          mapMLog)
 import           Control.Monad.Freer.State              (State, gets, runState)
@@ -53,8 +53,8 @@ import           Wallet.API                             (WalletAPIError)
 import           Wallet.Emulator                        (EmulatorEvent, EmulatorEvent')
 import qualified Wallet.Emulator                        as EM
 import           Wallet.Emulator.Chain                  (ChainControlEffect, ChainEffect, _SlotAdd)
-import           Wallet.Emulator.MultiAgent             (EmulatorState, EmulatorTimeEvent (..), MultiAgentEffect,
-                                                         chainEvent, eteEvent)
+import           Wallet.Emulator.MultiAgent             (EmulatorState, EmulatorTimeEvent (..), MultiAgentControlEffect,
+                                                         MultiAgentEffect, chainEvent, eteEvent)
 import           Wallet.Emulator.Wallet                 (Wallet (..), walletAddress)
 
 -- TODO: Move these two to 'Wallet.Emulator.XXX'?
@@ -109,6 +109,7 @@ runTraceStream :: forall effs.
     -> Eff '[ State EmulatorState
             , LogMsg EmulatorEvent'
             , MultiAgentEffect
+            , MultiAgentControlEffect
             , ChainEffect
             , ChainControlEffect
             , Error EmulatorRuntimeError
@@ -128,7 +129,7 @@ runTraceStream conf =
     . EM.processEmulated
     . subsume
     . subsume @(State EmulatorState)
-    . raiseEnd6
+    . raiseEnd7
 
 data EmulatorConfig =
     EmulatorConfig

--- a/plutus-contract/src/Wallet/Emulator/Types.hs
+++ b/plutus-contract/src/Wallet/Emulator/Types.hs
@@ -81,11 +81,12 @@ processEmulated :: forall effs.
     , Member (State EmulatorState) effs
     , Member (LogMsg EmulatorEvent') effs
     )
-    => Eff (MultiAgentEffect ': ChainEffect ': ChainControlEffect ': effs)
+    => Eff (MultiAgentEffect ': MultiAgentControlEffect ': ChainEffect ': ChainControlEffect ': effs)
     ~> Eff effs
 processEmulated act =
     act
         & handleMultiAgent
+        & handleMultiAgentControl
         & reinterpret2 @ChainEffect @(State ChainState) @(LogMsg ChainEvent) handleChain
         & interpret (Eff.handleZoomedState chainState)
         & interpret (mapLog (review chainEvent))


### PR DESCRIPTION
* `MultiAgentEffect` currently has emulator actions and emulator control actions
* We need to extract emulator control actions so that functions that only use regular emulator actions can also run in other contexts, such as the PAB

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
