### PR TITLE
SCP-1823 untyped evaluation in plc-agda

### DIFF
--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-metatheory.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-metatheory.nix
@@ -232,9 +232,15 @@
           "MAlonzo/Code/Type/RenamingSubstitution"
           "MAlonzo/Code/Utils"
           "MAlonzo/RTE"
+          "MAlonzo/Code/Algorithmic/Erasure"
+          "MAlonzo/Code/Declarative"
+          "MAlonzo/Code/Untyped"
+          "MAlonzo/Code/Untyped/Reduction"
+          "MAlonzo/Code/Untyped/RenamingSubstitution"
           "Opts"
           "Raw"
           "Scoped"
+          "Untyped"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-metatheory.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-metatheory.nix
@@ -232,9 +232,15 @@
           "MAlonzo/Code/Type/RenamingSubstitution"
           "MAlonzo/Code/Utils"
           "MAlonzo/RTE"
+          "MAlonzo/Code/Algorithmic/Erasure"
+          "MAlonzo/Code/Declarative"
+          "MAlonzo/Code/Untyped"
+          "MAlonzo/Code/Untyped/Reduction"
+          "MAlonzo/Code/Untyped/RenamingSubstitution"
           "Opts"
           "Raw"
           "Scoped"
+          "Untyped"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/generators/Language/PlutusCore/Generators/NEAT/Spec.hs
@@ -38,6 +38,7 @@ import           Language.PlutusCore.Generators.NEAT.Common
 import           Language.PlutusCore.Generators.NEAT.Type
 import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Pretty
+import qualified Language.UntypedPlutusCore                                 as U
 
 import           Control.Monad.Except
 import           Control.Search                                             (Enumerable (..), Options (..), ctrex',
@@ -294,6 +295,10 @@ data Ctrex
     ClosedTypeG
     ClosedTermG
     [Term TyName Name DefaultUni DefaultFun ()]
+  | CtrexUntypedTermEvaluationMismatch
+    ClosedTypeG
+    ClosedTermG
+    [U.Term Name DefaultUni DefaultFun ()]
 
 instance Show TestFail where
   show (TypeError e)  = show e
@@ -356,6 +361,12 @@ instance Show Ctrex where
     where
       tpl = "Counterexample found: %s :: %s"
   show (CtrexTermEvaluationMismatch tyG tmG tms) =
+    printf tpl (show tmG) (show tyG) ++ results tms
+    where
+      tpl = "Counterexample found: %s :: %s\n"
+      results (t:ts) = "evaluation: " ++ show (pretty t) ++ "\n" ++ results ts
+      results []     = ""
+  show (CtrexUntypedTermEvaluationMismatch tyG tmG tms) =
     printf tpl (show tmG) (show tyG) ++ results tms
     where
       tpl = "Counterexample found: %s :: %s\n"

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -218,9 +218,15 @@ library
     MAlonzo.Code.Type.RenamingSubstitution
     MAlonzo.Code.Utils
     MAlonzo.RTE
+    MAlonzo.Code.Algorithmic.Erasure
+    MAlonzo.Code.Declarative
+    MAlonzo.Code.Untyped
+    MAlonzo.Code.Untyped.Reduction
+    MAlonzo.Code.Untyped.RenamingSubstitution
     Opts
     Raw
     Scoped
+    Untyped
 
   autogen-modules:
     MAlonzo.Code.Main
@@ -398,6 +404,11 @@ library
     MAlonzo.Code.Type.RenamingSubstitution
     MAlonzo.Code.Utils
     MAlonzo.RTE
+    MAlonzo.Code.Algorithmic.Erasure
+    MAlonzo.Code.Declarative
+    MAlonzo.Code.Untyped
+    MAlonzo.Code.Untyped.Reduction
+    MAlonzo.Code.Untyped.RenamingSubstitution
 
 executable plc-agda
   import: stuff

--- a/plutus-metatheory/src/Opts.hs
+++ b/plutus-metatheory/src/Opts.hs
@@ -32,7 +32,7 @@ evalMode = option auto
   (  long "mode"
   <> short 'm'
   <> metavar "MODE"
-  <> value CK
+  <> value TL
   <> showDefault
   <> help "Evaluation mode (U , TL, L, TCK, CK, TCEK)" )
 

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -146,6 +146,6 @@ data ERROR = TypeError T.Text
 
 data ScopeError = DeBError|FreeVariableError FreeVariableError
 
-data RuntimeError = GasError
+data RuntimeError = GasError | UserError | RuntimeTypeError
 
 

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -143,9 +143,9 @@ data ERROR = TypeError T.Text
            | ParseError (ParseError ())
            | ScopeError ScopeError
            | RuntimeError RuntimeError
+           deriving Show
 
-data ScopeError = DeBError|FreeVariableError FreeVariableError
-
-data RuntimeError = GasError | UserError | RuntimeTypeError
+data ScopeError = DeBError|FreeVariableError FreeVariableError deriving Show
+data RuntimeError = GasError | UserError | RuntimeTypeError deriving Show
 
 

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -147,3 +147,5 @@ data ERROR = TypeError T.Text
 data ScopeError = DeBError|FreeVariableError FreeVariableError
 
 data RuntimeError = GasError
+
+

--- a/plutus-metatheory/src/Untyped.hs
+++ b/plutus-metatheory/src/Untyped.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE GADTs #-}
+
+module Untyped where
+
+import           Language.PlutusCore.Builtins
+import           Language.PlutusCore.Universe
+import           Language.UntypedPlutusCore
+
+import           Data.ByteString              as BS
+import           Data.Text                    as T
+import           GHC.Natural
+
+
+-- Untyped (Raw) syntax
+
+data UTerm = UVar Integer
+           | ULambda UTerm
+           | UApp UTerm UTerm
+           | UCon UConstant
+           | UError
+           | UBuiltin DefaultFun
+           | UDelay UTerm
+           | UForce UTerm
+           deriving Show
+
+data UConstant = UConInt Integer
+               | UConBS BS.ByteString
+               | UConStr T.Text
+               | UConBool Bool
+               | UConChar Char
+               | UConUnit
+               deriving Show
+
+unIndex :: Index -> Integer
+unIndex (Index n) = naturalToInteger n
+
+convP :: Program NamedDeBruijn DefaultUni DefaultFun a -> UTerm
+convP (Program _ _ t) = conv t
+
+convC :: Some (ValueOf DefaultUni) -> UConstant
+convC (Some (ValueOf DefaultUniInteger    i)) = UConInt i
+convC (Some (ValueOf DefaultUniByteString b)) = UConBS b
+convC (Some (ValueOf DefaultUniString     s)) = UConStr (T.pack s)
+convC (Some (ValueOf DefaultUniChar       c)) = UConChar c
+convC (Some (ValueOf DefaultUniUnit       u)) = UConUnit
+convC (Some (ValueOf DefaultUniBool       b)) = UConBool b
+
+conv :: Term NamedDeBruijn DefaultUni DefaultFun a -> UTerm
+conv (Var _ x)      = UVar (unIndex (ndbnIndex x) - 1)
+conv (LamAbs _ _ t) = ULambda (conv t)
+conv (Apply _ t u)  = UApp (conv t) (conv u)
+conv (Builtin _ b)  = UBuiltin b
+conv (Constant _ c) = UCon (convC c)
+conv (Error _)      = UError
+conv (Delay _ t)    = UDelay (conv t)
+conv (Force _ t)    = UForce (conv t)
+
+uconvC :: UConstant -> Some (ValueOf DefaultUni)
+uconvC (UConInt i)  = Some (ValueOf DefaultUniInteger    i)
+uconvC (UConBS b)   = Some (ValueOf DefaultUniByteString b)
+uconvC (UConStr s)  = Some (ValueOf DefaultUniString     $ T.unpack s)
+uconvC (UConChar c) = Some (ValueOf DefaultUniChar       c)
+uconvC UConUnit     = Some (ValueOf DefaultUniUnit       ())
+uconvC (UConBool b) = Some (ValueOf DefaultUniBool       b)
+
+tmnames = ['a' .. 'z']
+
+uconv ::  Int -> UTerm -> Term NamedDeBruijn DefaultUni DefaultFun ()
+uconv i (UVar x)     = Var
+  ()
+  (NamedDeBruijn (T.pack [tmnames !! (i - 1 - fromIntegral x)])
+                 (Index (naturalFromInteger x)))
+uconv i (ULambda t)  = LamAbs
+  ()
+  (NamedDeBruijn (T.pack [tmnames !! i]) (Index 0))
+  (uconv (i+1) t)
+uconv i (UApp t u)   = Apply () (uconv i t) (uconv i u)
+uconv i (UCon u)     = Constant () (uconvC u)
+uconv i UError       = Error ()
+uconv i (UBuiltin b) = Builtin () b
+uconv i (UDelay t)   = Delay () (uconv i t)
+uconv i (UForce t)   = Force () (uconv i t)

--- a/plutus-metatheory/src/Untyped.lagda
+++ b/plutus-metatheory/src/Untyped.lagda
@@ -127,4 +127,36 @@ scopeCheckU (UBuiltin b) = return (builtin b)
 scopeCheckU (UDelay t)   = fmap delay (scopeCheckU t)
 scopeCheckU (UForce t)   = fmap force (scopeCheckU t)
 
+open import Data.Bool
+open import Raw
+
+decUTermCon : (C C' : TermCon) → Bool
+decUTermCon (integer i) (integer i') with i Data.Integer.≟ i'
+... | yes p = true
+... | no ¬p = false
+decUTermCon (bytestring b) (bytestring b') with equals b b'
+decUTermCon (bytestring b) (bytestring b') | false = false
+decUTermCon (bytestring b) (bytestring b') | true = true
+decUTermCon (string s) (string s') with s Data.String.≟ s'
+... | yes p = true
+... | no ¬p = false
+decUTermCon (bool b) (bool b') with b Data.Bool.≟ b'
+... | yes p = true
+... | no ¬p = false
+decUTermCon unit unit = true
+decUTermCon (char c) (char c') = true
+decUTermCon _ _ = false
+
+decUTm : (t t' : Untyped) → Bool
+decUTm (UVar x) (UVar x') with x Data.Nat.≟ x
+... | yes p = true
+... | no ¬p = false
+decUTm (ULambda t) (ULambda t') = decUTm t t'
+decUTm (UApp t u) (UApp t' u') = decUTm t t' ∧ decUTm u u'
+decUTm (UCon c) (UCon c') = decUTermCon c c'
+decUTm UError UError = true
+decUTm (UBuiltin b) (UBuiltin b') = decBuiltin b b'
+decUTm (UDelay t) (UDelay t') = decUTm t t'
+decUTm (UForce t) (UForce t') = decUTm t t'
+decUTm _ _ = false
 \end{code}

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -55,6 +55,9 @@ data _⊢ n : Set where
   con     : TermCon → n ⊢
   builtin : (b : Builtin) → n ⊢
   error   : n ⊢
+
+variable
+  n m o : ℕ
 ```
 
 ## Ugly printing for debugging
@@ -84,7 +87,8 @@ postulate showNat : ℕ → String
 uglyBuiltin : Builtin → String
 uglyBuiltin addInteger = "addInteger"
 uglyBuiltin _ = "other"
-ugly : ∀{n} → n  ⊢ → String
+
+ugly : n ⊢ → String
 ugly (` x) = "(` " +++ uglyFin x +++ ")"
 ugly (ƛ t) = "(ƛ " +++ ugly t +++ ")"
 ugly (t · u) = "( " +++ ugly t +++ " · " +++ ugly u +++ ")"
@@ -119,7 +123,7 @@ data Untyped : Set where
 ## Scope checking
 
 ```
-extricateU : ∀{n} → n ⊢ → Untyped
+extricateU : n ⊢ → Untyped
 extricateU (con c) = UCon c
 extricateU (` x) = UVar (Data.Fin.toℕ x)
 extricateU (ƛ t) = ULambda (extricateU t)
@@ -129,12 +133,12 @@ extricateU (delay t) = UDelay (extricateU t)
 extricateU (builtin b) = UBuiltin b
 extricateU error = UError
 
-ℕtoFin : ∀{n} → ℕ → Either ScopeError (Fin n)
+ℕtoFin : ℕ → Either ScopeError (Fin n)
 ℕtoFin {zero}  _       = inj₁ deBError
 ℕtoFin {suc m} zero    = return zero
 ℕtoFin {suc m} (suc n) = fmap suc (ℕtoFin n)
 
-scopeCheckU : ∀{n} → Untyped → Either ScopeError (n ⊢)
+scopeCheckU : Untyped → Either ScopeError (n ⊢)
 scopeCheckU (UVar x)     = fmap ` (ℕtoFin x)
 scopeCheckU (ULambda t)  = fmap ƛ (scopeCheckU t)
 scopeCheckU (UApp t u)   = do

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -1,20 +1,39 @@
-\begin{code}
-module Untyped where
-\end{code}
+---
+title: Untyped syntax
+layout: page
+---
 
-\begin{code}
+```
+module Untyped where
+```
+
+## Imports
+
+```
 open import Data.Nat
 open import Data.Fin hiding (_≤_)
 open import Data.Bool using (Bool;true;false)
 open import Data.Integer hiding (suc;_≤_)
 open import Data.String using (String) renaming (_++_ to _+++_)
 open import Data.Char
+open import Data.Sum
+open import Data.Product renaming (_,_ to _,,_)
+open import Relation.Nullary
+open import Data.String
+open import Data.Bool
 
+open import Raw
+open import Utils
+open import Scoped using (ScopeError;deBError)
 open import Builtin
-\end{code}
+```
 
+## Term constants
 
-\begin{code}
+Defined separetely here rather than using generic version used in the
+typed syntax.
+
+```
 data TermCon : Set where
   integer    : ℤ → TermCon
   bytestring : ByteString → TermCon
@@ -22,9 +41,11 @@ data TermCon : Set where
   bool       : Bool → TermCon
   char       : Char → TermCon
   unit       : TermCon
-\end{code}
+```
 
-\begin{code}
+## Well-scoped Syntax
+
+```
 data _⊢ n : Set where
   `       : Fin n → n ⊢
   ƛ       : suc n ⊢ → n ⊢
@@ -34,18 +55,11 @@ data _⊢ n : Set where
   con     : TermCon → n ⊢
   builtin : (b : Builtin) → n ⊢
   error   : n ⊢
-\end{code}
+```
 
+## Ugly printing for debugging
 
-\begin{code}
-open import Data.Sum
-open import Data.Product renaming (_,_ to _,,_)
-open import Relation.Nullary
-\end{code}
-
-\begin{code}
-open import Data.String
-
+```
 uglyFin : ∀{n} → Fin n → String
 uglyFin zero = "0"
 uglyFin (suc x) = "(S " +++ uglyFin x +++ ")"
@@ -79,9 +93,14 @@ ugly (force t) = "(f0rce " +++ ugly t +++ ")"
 ugly (delay t) = "(delay " +++ ugly t +++ ")"
 ugly (builtin b) = "(builtin " +++ uglyBuiltin b +++ ")"
 ugly error = "error"
-\end{code}
+```
 
-\begin{code}
+## Raw syntax
+
+This version is not intrinsically well-scoped. It's an easy to work
+with rendering of the untyped plutus-core syntax.
+
+```
 data Untyped : Set where
   UVar : ℕ → Untyped
   ULambda : Untyped → Untyped
@@ -95,7 +114,11 @@ data Untyped : Set where
 {-# FOREIGN GHC import Untyped #-}
 {-# COMPILE GHC Untyped = data UTerm (UVar | ULambda  | UApp | UCon | UError | UBuiltin | UDelay | UForce) #-}
 {-# COMPILE GHC TermCon = data UConstant (UConInt | UConBS | UConStr | UConBool | UConChar | UConUnit) #-}
+```
 
+## Scope checking
+
+```
 extricateU : ∀{n} → n ⊢ → Untyped
 extricateU (con c) = UCon c
 extricateU (` x) = UVar (Data.Fin.toℕ x)
@@ -105,9 +128,6 @@ extricateU (force t) = UForce (extricateU t)
 extricateU (delay t) = UDelay (extricateU t)
 extricateU (builtin b) = UBuiltin b
 extricateU error = UError
-
-open import Utils
-open import Scoped using (ScopeError;deBError)
 
 ℕtoFin : ∀{n} → ℕ → Either ScopeError (Fin n)
 ℕtoFin {zero}  _       = inj₁ deBError
@@ -126,10 +146,13 @@ scopeCheckU UError       = return error
 scopeCheckU (UBuiltin b) = return (builtin b)
 scopeCheckU (UDelay t)   = fmap delay (scopeCheckU t)
 scopeCheckU (UForce t)   = fmap force (scopeCheckU t)
+```
 
-open import Data.Bool
-open import Raw
+## Equality checking for raw terms
 
+Used to compare outputs in testing
+
+```
 decUTermCon : (C C' : TermCon) → Bool
 decUTermCon (integer i) (integer i') with i Data.Integer.≟ i'
 ... | yes p = true
@@ -159,4 +182,4 @@ decUTm (UBuiltin b) (UBuiltin b') = decBuiltin b b'
 decUTm (UDelay t) (UDelay t') = decUTm t t'
 decUTm (UForce t) (UForce t') = decUTm t t'
 decUTm _ _ = false
-\end{code}
+```

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -58,6 +58,7 @@ data _⊢ n : Set where
 
 variable
   n m o : ℕ
+  t t' u u' : n ⊢
 ```
 
 ## Ugly printing for debugging

--- a/plutus-metatheory/src/Untyped/Reduction.lagda
+++ b/plutus-metatheory/src/Untyped/Reduction.lagda
@@ -391,6 +391,18 @@ run t (suc n) | step p | t'' , q , mvt'' = t'' , trans—→⋆ p q , mvt''
 \end{code}
 
 \begin{code}
+deval : ∀{t} → Value t → 0 ⊢
+deval {t} _ = t
+
+progressor : ℕ → (t : 0 ⊢) → Either RuntimeError (Maybe (0 ⊢))
+progressor 0       t = inj₁ gasError
+progressor (suc n) t with progress t
+... | step {N = t'} p  = progressor n t'
+... | done v  = inj₂ $ just (deval v)
+... | error e = inj₂ $ nothing
+\end{code}
+
+\begin{code}
 open import Data.Empty
 open import Relation.Nullary
 

--- a/plutus-metatheory/src/Untyped/Reduction.lagda
+++ b/plutus-metatheory/src/Untyped/Reduction.lagda
@@ -399,7 +399,7 @@ progressor 0       t = inj₁ gasError
 progressor (suc n) t with progress t
 ... | step {N = t'} p  = progressor n t'
 ... | done v  = inj₂ $ just (deval v)
-... | error e = inj₁ userError
+... | error e = inj₂ $ just error -- userError
 \end{code}
 
 \begin{code}

--- a/plutus-metatheory/src/Untyped/Reduction.lagda
+++ b/plutus-metatheory/src/Untyped/Reduction.lagda
@@ -399,7 +399,7 @@ progressor 0       t = inj₁ gasError
 progressor (suc n) t with progress t
 ... | step {N = t'} p  = progressor n t'
 ... | done v  = inj₂ $ just (deval v)
-... | error e = inj₂ $ nothing
+... | error e = inj₁ userError
 \end{code}
 
 \begin{code}

--- a/plutus-metatheory/src/Untyped/Reduction.lagda.md
+++ b/plutus-metatheory/src/Untyped/Reduction.lagda.md
@@ -1,8 +1,15 @@
-\begin{code}
-module Untyped.Reduction where
-\end{code}
+---
+title: Untyped reduction
+style: page
+---
 
-\begin{code}
+```
+module Untyped.Reduction where
+```
+
+## Imports
+
+```
 open import Untyped
 open import Untyped.RenamingSubstitution
 open import Builtin
@@ -22,13 +29,21 @@ open import Relation.Nullary.Decidable
 open import Data.Fin using ()
 open import Utils hiding (_≤L_;_:<_)
 import Data.List
-\end{code}
+```
 
-\begin{code}
+## Fixyt
+
+```
 infix 2 _—→_
-\end{code}
+```
 
-\begin{code}
+## Builtin Arities
+
+Typed builtins can take type and term arguments in any order. We
+preserve this behaviour in the untyped language using delay/force. So,
+arities are not just numbers they are lists of type/term labels.
+
+```
 data Label : Set where
   Type : Label
   Term : Label
@@ -72,15 +87,19 @@ data _≤L_ : Bwd Label → Bwd Label → Set where
   skipTerm : ∀{L L'} → L :< Term ≤L L' → L ≤L L'
 
 infix 5 _≤L_
+```
 
+## Error, values, telescopes of values, builtins
+
+```
 -- for untyped reduction, error also includes thing like impossible
 -- applications
 data Error {n} : n ⊢ → Set where
   E-error : Error error
 
-\end{code}
+```
 
-\begin{code}
+```
 ITel : Builtin → Bwd Label → Set
 
 -- I cannot remember why there is both a FValue and a Value...
@@ -215,8 +234,11 @@ IBUILTIN _ _ = error , inr E-error
 
 IBUILTIN' : (b : Builtin) → ∀{L} → L ≡ arity b → ITel b L → Σ (0 ⊢) λ t → Value t ⊎ Error t
 IBUILTIN' b refl vs = IBUILTIN b vs
+```
 
+## Reduction
 
+```
 data _—→_ : 0 ⊢ → 0 ⊢ → Set where
   ξ-·₁ : {L L' M : 0 ⊢} → L —→ L' → L · M —→ L' · M
   ξ-·₂ : {L M M' : 0 ⊢} → FValue L → M —→ M' → L · M —→ L · M'
@@ -261,16 +283,18 @@ data _—→_ : 0 ⊢ → 0 ⊢ → Set where
   -- this is a runtime type error that ceases to be a type error after erasure
   -- E-runtime : {L : n ⊢} → L —→ error
 
-\end{code}
+```
 
 
-\begin{code}
+```
 data _—→⋆_ : 0 ⊢ → 0 ⊢ → Set where
   refl  : {t : 0 ⊢} → t —→⋆ t
   trans—→⋆ : {t t' t'' : 0 ⊢} → t —→ t' → t' —→⋆ t'' → t —→⋆ t''
-\end{code}
+```
 
-\begin{code}
+## Progress
+
+```
 data Progress (M : 0 ⊢) : Set where
   step : ∀{N}
     → M —→ N
@@ -377,9 +401,11 @@ progress (delay t)    = done V-delay
 progress (builtin b)  = done (ival b)
 progress (con tcn)    = done (V-con tcn)
 progress error       = error E-error
-\end{code}
+```
 
-\begin{code}
+## Iterating progress to run programs
+
+```
 run : ∀(t : 0 ⊢) → ℕ
   → Σ (0 ⊢) λ t' → t —→⋆ t' × (Maybe (Value t') ⊎ Error t')
 run t 0       = t , refl , inl nothing
@@ -388,9 +414,9 @@ run t (suc n) | done vt = t , refl , inl (just vt)
 run t (suc n) | error et = t , refl , inr et
 run t (suc n) | step {N = t'} p with run t' n
 run t (suc n) | step p | t'' , q , mvt'' = t'' , trans—→⋆ p q , mvt''
-\end{code}
+```
 
-\begin{code}
+```
 deval : ∀{t} → Value t → 0 ⊢
 deval {t} _ = t
 
@@ -400,9 +426,9 @@ progressor (suc n) t with progress t
 ... | step {N = t'} p  = progressor n t'
 ... | done v  = inj₂ $ just (deval v)
 ... | error e = inj₂ $ just error -- userError
-\end{code}
+```
 
-\begin{code}
+```
 open import Data.Empty
 open import Relation.Nullary
 
@@ -481,4 +507,4 @@ det E-delay· E-delay· = refl
 --temporary
 det (E-builtin .b) (E-builtin b) = refl
 -}
-\end{code}
+```

--- a/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
@@ -1,8 +1,15 @@
-\begin{code}
-module Untyped.RenamingSubstitution where
-\end{code}
+---
+title: Untyped renaming and substitution
+layout: page
+---
 
-\begin{code}
+```
+module Untyped.RenamingSubstitution where
+```
+
+## Imports
+
+```
 open import Untyped
 
 open import Data.Nat
@@ -11,9 +18,11 @@ open import Data.Vec
 open import Relation.Binary.PropositionalEquality
 open import Function
 open import Utils
-\end{code}
+```
 
-\begin{code}
+## Renaming
+
+```
 Ren : ℕ → ℕ → Set
 Ren m n = Fin m → Fin n
 
@@ -33,7 +42,11 @@ ren ρ error       = error
 
 weaken : ∀{n} → n ⊢ → suc n ⊢
 weaken t = ren suc t
+```
 
+Proofs that renaming forms a functor
+
+```
 lift-cong : ∀{m n}{ρ ρ' : Ren m n}
   → (∀ x → ρ x ≡ ρ' x)
   → (x : Fin (suc m))
@@ -86,7 +99,11 @@ ren-comp ρ ρ' (delay t)   = cong delay (ren-comp ρ ρ' t)
 ren-comp ρ ρ' (con c)     = refl
 ren-comp ρ ρ' (builtin b) = refl
 ren-comp ρ ρ' error       = refl 
+```
 
+## Substitution
+
+```
 Sub : ℕ → ℕ → Set
 Sub m n = Fin m → n ⊢
 
@@ -110,7 +127,11 @@ extend σ t (suc x) = σ x
 
 _[_] : ∀{n} → suc n ⊢ → n ⊢ → n ⊢
 t [ u ] = sub (extend ` u) t
+```
 
+Proofs that substitution forms a monad
+
+```
 lifts-cong : ∀{m n}{σ σ' : Sub m n}
   → (∀ x → σ x ≡ σ' x)
   → (x : Fin (suc m))
@@ -191,4 +212,15 @@ lifts-comp g f (suc x) = trans
   (sym (ren-sub f suc (g x)))
   (sub-ren suc (lifts f) (g x))
 
--- TODO: add sub-comp
+sub-comp : ∀{m n o}(g : Sub m n)(f : Sub n o)(t : m ⊢)
+  → sub (sub f ∘ g) t ≡ sub f (sub g t)
+sub-comp g f (` x)       = refl
+sub-comp g f (ƛ t)       =
+  cong ƛ (trans (sub-cong (lifts-comp g f) t) (sub-comp (lifts g) (lifts f) t))
+sub-comp g f (t · u)     = cong₂ _·_ (sub-comp g f t) (sub-comp g f u)
+sub-comp g f (force t)   = cong force (sub-comp g f t)
+sub-comp g f (delay t)   = cong delay (sub-comp g f t)
+sub-comp g f (con c)     = refl
+sub-comp g f (builtin b) = refl
+sub-comp g f error       = refl
+```

--- a/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Untyped/RenamingSubstitution.lagda.md
@@ -26,11 +26,11 @@ open import Utils
 Ren : ℕ → ℕ → Set
 Ren m n = Fin m → Fin n
 
-lift : ∀{m n} → Ren m n → Ren (suc m) (suc n)
+lift : Ren m n → Ren (suc m) (suc n)
 lift ρ zero = zero
 lift ρ (suc x) = suc (ρ x)
 
-ren     : ∀{m n} → Ren m n → m ⊢ → n ⊢
+ren : Ren m n → m ⊢ → n ⊢
 ren ρ (` x)       = ` (ρ x)
 ren ρ (ƛ t)       = ƛ (ren (lift ρ) t)
 ren ρ (t · u)     = ren ρ t · ren ρ u
@@ -40,21 +40,24 @@ ren ρ (con tcn)   = con tcn
 ren ρ (builtin b) = builtin b
 ren ρ error       = error
 
-weaken : ∀{n} → n ⊢ → suc n ⊢
+weaken : n ⊢ → suc n ⊢
 weaken t = ren suc t
 ```
 
 Proofs that renaming forms a functor
 
 ```
-lift-cong : ∀{m n}{ρ ρ' : Ren m n}
+lift-cong :
+    {ρ ρ' : Ren m n}
   → (∀ x → ρ x ≡ ρ' x)
   → (x : Fin (suc m))
+    --------------------
   → lift ρ x ≡ lift ρ' x
 lift-cong p zero    = refl
 lift-cong p (suc x) = cong suc (p x)
 
-ren-cong : ∀{m n}{ρ ρ' : Ren m n}
+ren-cong :
+    {ρ ρ' : Ren m n}
   → (∀ x → ρ x ≡ ρ' x)
   → (t : m ⊢)
   → ren ρ t ≡ ren ρ' t
@@ -67,17 +70,17 @@ ren-cong p (con c)     = refl
 ren-cong p (builtin b) = refl
 ren-cong p error       = refl
 
-lift-id : ∀{n} → (x : Fin (suc n)) → id x ≡ lift id x
+lift-id : (x : Fin (suc n)) → id x ≡ lift id x
 lift-id zero    = refl
 lift-id (suc x) = refl
 
-lift-comp : ∀{m n o}(g : Ren m n)(f : Ren n o)(x : Fin (suc m))
+lift-comp : (g : Ren m n)(f : Ren n o)(x : Fin (suc m))
   → lift (f ∘ g) x ≡ lift f (lift g x)
 lift-comp g f zero    = refl
 lift-comp g f (suc x) = refl
 
 
-ren-id : ∀{n} → (t : n ⊢) → t ≡ ren id t
+ren-id : (t : n ⊢) → t ≡ ren id t
 ren-id (` x)       = refl
 ren-id (ƛ t)       = cong ƛ (trans (ren-id t) (ren-cong lift-id t)) 
 ren-id (t · u)     = cong₂ _·_ (ren-id t) (ren-id u)
@@ -87,7 +90,7 @@ ren-id (con c)     = refl
 ren-id (builtin b) = refl
 ren-id error       = refl
 
-ren-comp : ∀{m n o}(g : Ren m n)(f : Ren n o)(t : m ⊢)
+ren-comp : (g : Ren m n)(f : Ren n o)(t : m ⊢)
   → ren (f ∘ g) t ≡ ren f (ren g t)
 ren-comp ρ ρ' (` x)            = refl
 ren-comp ρ ρ' (ƛ t)            = cong ƛ (trans
@@ -107,11 +110,11 @@ ren-comp ρ ρ' error       = refl
 Sub : ℕ → ℕ → Set
 Sub m n = Fin m → n ⊢
 
-lifts : ∀{m n} → Sub m n → Sub (suc m) (suc n)
+lifts : Sub m n → Sub (suc m) (suc n)
 lifts ρ zero = ` zero
 lifts ρ (suc x) = ren suc (ρ x)
 
-sub    : ∀{m n} → Sub m n → m ⊢ → n ⊢
+sub    : Sub m n → m ⊢ → n ⊢
 sub σ (` x)       = σ x
 sub σ (ƛ t)       = ƛ (sub (lifts σ) t) 
 sub σ (t · u)     = sub σ t · sub σ u
@@ -121,25 +124,25 @@ sub σ (con tcn)   = con tcn
 sub σ (builtin b) = builtin b
 sub σ error       = error
 
-extend : ∀{m n} → Sub m n → n ⊢ → Sub (suc m) n
+extend : Sub m n → n ⊢ → Sub (suc m) n
 extend σ t zero    = t
 extend σ t (suc x) = σ x
 
-_[_] : ∀{n} → suc n ⊢ → n ⊢ → n ⊢
+_[_] : suc n ⊢ → n ⊢ → n ⊢
 t [ u ] = sub (extend ` u) t
 ```
 
 Proofs that substitution forms a monad
 
 ```
-lifts-cong : ∀{m n}{σ σ' : Sub m n}
+lifts-cong : {σ σ' : Sub m n}
   → (∀ x → σ x ≡ σ' x)
   → (x : Fin (suc m))
   → lifts σ x ≡ lifts σ' x
 lifts-cong p zero    = refl
 lifts-cong p (suc x) = cong (ren suc) (p x) 
 
-sub-cong : ∀{m n}{σ σ' : Sub m n}
+sub-cong : {σ σ' : Sub m n}
   → (∀ x → σ x ≡ σ' x)
   → (t : m ⊢)
   → sub σ t ≡ sub σ' t
@@ -153,11 +156,11 @@ sub-cong p (con c)     = refl
 sub-cong p (builtin b) = refl
 sub-cong p error       = refl
 
-lifts-id : ∀{n} → (x : Fin (suc n)) → ` x ≡ lifts ` x
+lifts-id : (x : Fin (suc n)) → ` x ≡ lifts ` x
 lifts-id zero    = refl
 lifts-id (suc x) = refl
 
-sub-id : ∀{n} → (t : n ⊢) → t ≡ sub ` t
+sub-id : (t : n ⊢) → t ≡ sub ` t
 sub-id (` x)       = refl
 sub-id (ƛ t)       = cong ƛ (trans (sub-id t) (sub-cong lifts-id t))
 sub-id (t · u)     = cong₂ _·_ (sub-id t) (sub-id u)
@@ -167,12 +170,12 @@ sub-id (con c)     = refl
 sub-id (builtin b) = refl
 sub-id error       = refl
 
-lifts-lift : ∀{m n o}(g : Ren m n)(f : Sub n o)(x : Fin (suc m))
+lifts-lift : (g : Ren m n)(f : Sub n o)(x : Fin (suc m))
   → lifts (f ∘ g) x ≡ lifts f (lift g x)
 lifts-lift g f zero    = refl
 lifts-lift g f (suc x) = refl
 
-sub-ren : ∀{m n o}(ρ : Ren m n)(σ : Sub n o)(t : m ⊢)
+sub-ren : (ρ : Ren m n)(σ : Sub n o)(t : m ⊢)
   → sub (σ ∘ ρ) t ≡ sub σ (ren ρ t)
 sub-ren ρ σ (` x)       = refl
 sub-ren ρ σ (ƛ t)       = cong ƛ (trans
@@ -185,14 +188,14 @@ sub-ren ρ σ (con c)     = refl
 sub-ren ρ σ (builtin b) = refl
 sub-ren ρ σ error       = refl
 
-ren-lift-lifts : ∀{m n o}(g : Sub m n)(f : Ren n o)(x : Fin (suc m))
+ren-lift-lifts : (g : Sub m n)(f : Ren n o)(x : Fin (suc m))
   → lifts (ren f ∘ g) x ≡ ren (lift f) (lifts g x)
 ren-lift-lifts g f zero = refl
 ren-lift-lifts g f (suc x) = trans
   (sym (ren-comp f suc (g x)))
   (ren-comp suc (lift f) (g x))
 
-ren-sub : ∀{m n o}(σ : Sub m n)(ρ : Ren n o)(t : m ⊢)
+ren-sub : (σ : Sub m n)(ρ : Ren n o)(t : m ⊢)
   → sub (ren ρ ∘ σ) t ≡ ren ρ (sub σ t)
 ren-sub σ ρ (` x)               = refl
 ren-sub σ ρ (ƛ t)               = cong ƛ (trans
@@ -205,14 +208,14 @@ ren-sub σ ρ (con c)     = refl
 ren-sub σ ρ (builtin b) = refl
 ren-sub σ ρ error       = refl
 
-lifts-comp : ∀{m n o}(g : Sub m n)(f : Sub n o)(x : Fin (suc m))
+lifts-comp : (g : Sub m n)(f : Sub n o)(x : Fin (suc m))
   → lifts (sub f ∘ g) x ≡ sub (lifts f) (lifts g x)
 lifts-comp g f zero    = refl
 lifts-comp g f (suc x) = trans
   (sym (ren-sub f suc (g x)))
   (sub-ren suc (lifts f) (g x))
 
-sub-comp : ∀{m n o}(g : Sub m n)(f : Sub n o)(t : m ⊢)
+sub-comp : (g : Sub m n)(f : Sub n o)(t : m ⊢)
   → sub (sub f ∘ g) t ≡ sub f (sub g t)
 sub-comp g f (` x)       = refl
 sub-comp g f (ƛ t)       =

--- a/plutus-metatheory/src/Utils.lagda
+++ b/plutus-metatheory/src/Utils.lagda
@@ -171,6 +171,8 @@ withE f (inj₂ c) = inj₂ c
 
 data RuntimeError : Set where
   gasError : RuntimeError
+  userError : RuntimeError
+  runtimeTypeError : RuntimeError
 
-{-# COMPILE GHC RuntimeError = data RuntimeError (GasError) #-}
+{-# COMPILE GHC RuntimeError = data RuntimeError (GasError | UserError | RuntimeTypeError) #-}
 \end{code}

--- a/plutus-metatheory/test/TestNEAT.hs
+++ b/plutus-metatheory/test/TestNEAT.hs
@@ -4,23 +4,26 @@ import           Control.Monad.Except
 import           Data.Coolean
 import           Data.Either
 import           Data.List
-
 import           Language.PlutusCore
 import           Language.PlutusCore.Evaluation.Machine.Ck
 import           Language.PlutusCore.Generators.NEAT.Spec
 import           Language.PlutusCore.Generators.NEAT.Type
 import           Language.PlutusCore.Lexer
 import           Language.PlutusCore.Normalize
+import           Language.PlutusCore.Pretty
+import qualified Language.UntypedPlutusCore                as U
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           MAlonzo.Code.Main                         (checkKindAgda, checkTypeAgda, inferKindAgda, inferTypeAgda,
                                                             normalizeTypeAgda, normalizeTypeTermAgda, runCKAgda,
-                                                            runTCEKAgda, runTCKAgda, runTLAgda)
+                                                            runTCEKAgda, runTCKAgda, runTLAgda, runUAgda)
 import           MAlonzo.Code.Scoped                       (deBruijnifyK, unDeBruijnifyK)
 
 import           Language.PlutusCore.DeBruijn
 import           Raw                                       hiding (TypeError, tynames)
+
+import           Debug.Trace
 
 main :: IO ()
 main = defaultMain $ allTests defaultGenOptions
@@ -115,3 +118,24 @@ prop_Term tyG tmG = do
   tmEvsN <- withExceptT FVErrorP $ traverse unDeBruijnTerm tmEvs
 
   unless (length (nub tmEvsN) == 1) $ throwCtrex (CtrexTermEvaluationMismatch tyG tmG tmEvsN)
+  -- 4. untyped_reduce . erase == erase . typed_reduce
+
+  -- erase original named term
+  let tmU = U.erase tm
+  -- turn it into an untyped de Bruij term
+  tmUDB <- withExceptT FVErrorP $ U.deBruijnTerm tmU
+  -- reduce the untyped term
+  tmUDB' <- withExceptT (\e -> trace (show e) (Ctrex (CtrexTermEvaluationFail tyG tmG))) $ liftEither $ runUAgda tmUDB
+  -- turn it back into a named term
+  tmU' <- withExceptT FVErrorP $ U.unDeBruijnTerm tmUDB'
+  -- reduce the orignal de Bruijn typed term
+  tmDB'' <- withExceptT (\e -> trace (show e) (Ctrex (CtrexTermEvaluationFail tyG tmG))) $
+    liftEither $ runTLAgda tmDB
+  -- turn it back into a named term
+  tm'' <- withExceptT FVErrorP $ unDeBruijnTerm tmDB''
+  -- erase it after the fact
+  let tmU'' = U.erase tm''
+  unless (tmU' == tmU'') $
+    throwCtrex (CtrexUntypedTermEvaluationMismatch tyG tmG [tmU',tmU''])
+
+

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -48,9 +48,13 @@ blah Nothing     = []
 blah (Just mode) = ["--mode",mode]
 
 -- this is likely to raise either an exitFailure or exitSuccess exception
+modeType :: Maybe String -> [String]
+modeType (Just "U") = []
+modeType _          = ["-t"]
+
 runTest :: String -> Maybe String -> String -> IO ()
 runTest command mode test = do
-  example <- readProcess "plc" ["example","-t","-s",test] []
+  example <- readProcess "plc" (["example","-s",test] ++ modeType mode) []
   writeFile "tmp" example
   putStrLn $ "test: " ++ test ++ " [" ++ command ++ "]"
   withArgs ([command,"--file","tmp"] ++ blah mode)  M.main
@@ -72,7 +76,8 @@ runFailingTests command mode (test:tests) = catch
       ExitSuccess   -> exitSuccess)
 
 main = do
-  putStrLn "running succ L..."
+{-
+putStrLn "running succ L..."
   runSucceedingTests "evaluate" (Just "L") succeedingEvalTests
   putStrLn "running fail L"
   runFailingTests "evaluate" (Just "L") failingEvalTests
@@ -80,22 +85,19 @@ main = do
   runSucceedingTests "evaluate" (Just "CK") succeedingEvalTests
   putStrLn "running fail CK"
   runFailingTests "evaluate" (Just "CK") failingEvalTests
+-}
   putStrLn "running succ TCK"
   runSucceedingTests "evaluate" (Just "TCK") succeedingEvalTests
   putStrLn "running fail TCK"
   runFailingTests "evaluate" (Just "TCK") failingEvalTests
-  putStrLn "running succ TCEKC"
-  runSucceedingTests "evaluate" (Just "TCEKC") succeedingEvalTests
-  putStrLn "running fail TCEKC"
-  runFailingTests "evaluate" (Just "TCEKC") failingEvalTests
-  putStrLn "running succ TCEKV"
-  runSucceedingTests "evaluate" (Just "TCEKV") succeedingEvalTests
-  putStrLn "running fail TCEKV"
-  runFailingTests "evaluate" (Just "TCEKV") failingEvalTests
+  putStrLn "running succ TCEK"
+  runSucceedingTests "evaluate" (Just "TCEK") succeedingEvalTests
+  putStrLn "running fail TCEK"
+  runFailingTests "evaluate" (Just "TCEK") failingEvalTests
   putStrLn "running succ U..."
   runSucceedingTests "evaluate" (Just "U") succeedingEvalTests
-  putStrLn "running succ TC"
+  putStrLn "running fail U..."
   runFailingTests "evaluate" (Just "U") failingEvalTests
-  putStrLn "running succ U..."
+  putStrLn "running succ TC"
   runSucceedingTests "typecheck" Nothing succeedingTCTests
 

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -47,7 +47,6 @@ blah :: Maybe String -> [String]
 blah Nothing     = []
 blah (Just mode) = ["--mode",mode]
 
--- this is likely to raise either an exitFailure or exitSuccess exception
 modeType :: Maybe String -> [String]
 modeType (Just "U") = []
 modeType _          = ["-t"]


### PR DESCRIPTION
So far I have reinstated untyped evaluation in plc-agda. It takes a typed term, erases it, reduces it and then prints it out using my 'ugly printer'.

This is ok for testing against other plc-agda modes but to test against the plutus-core evaluator will require reusing plutus-core untyped machinery.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
