### PR TITLE
Plutus pab logging: ChainIndex / SigningProcess (SCP-1687)

### DIFF
--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-pab.nix
@@ -137,6 +137,7 @@
           "Cardano/SigningProcess/API"
           "Cardano/SigningProcess/Server"
           "Cardano/SigningProcess/Client"
+          "Cardano/SigningProcess/Types"
           "Cardano/Wallet/API"
           "Cardano/Wallet/Client"
           "Cardano/Wallet/Mock"

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
@@ -137,6 +137,7 @@
           "Cardano/SigningProcess/API"
           "Cardano/SigningProcess/Server"
           "Cardano/SigningProcess/Client"
+          "Cardano/SigningProcess/Types"
           "Cardano/Wallet/API"
           "Cardano/Wallet/Client"
           "Cardano/Wallet/Mock"

--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -69,7 +69,9 @@ import qualified Plutus.PAB.App                                  as App
 import qualified Plutus.PAB.Core                                 as Core
 import qualified Plutus.PAB.Core.ContractInstance                as Instance
 import           Plutus.PAB.Events.Contract                      (ContractInstanceId (..))
-import           Plutus.PAB.PABLogMsg                            (AppMsg (..), ContractExeLogMsg (..), PABLogMsg)
+import           Plutus.PAB.PABLogMsg                            (AppMsg (..), ChainIndexServerMsg,
+                                                                  ContractExeLogMsg (..),
+                                                                  PABLogMsg (SChainIndexServerMsg))
 import           Plutus.PAB.Types                                (Config (Config), ContractExe (..), PABError,
                                                                   RequestProcessingConfig (..), chainIndexConfig,
                                                                   metadataServerConfig, nodeServerConfig,
@@ -79,33 +81,39 @@ import           Plutus.PAB.Utils                                (logErrorS, ren
 import qualified Plutus.PAB.Webserver.Server                     as PABServer
 import           System.Exit                                     (ExitCode (ExitFailure), exitSuccess, exitWith)
 
+-- | Commands that can be interpreted with 'runCliCommand'
 data Command
-    = Migrate
-    | MockNode
-    | MockWallet
-    | ChainIndex
-    | Metadata
-    | ForkCommands [Command]
-    | SigningProcess
-    | InstallContract FilePath
-    | ActivateContract FilePath
-    | ContractState UUID
-    | UpdateContract UUID EndpointDescription JSON.Value
-    | ReportContractHistory UUID
-    | ReportInstalledContracts
-    | ReportActiveContracts
-    | ProcessContractInbox UUID
-    | ProcessAllContractOutboxes
-    | ReportTxHistory
-    | PABWebserver
-    | PSGenerator
-          { _outputDir :: !FilePath
+    = Migrate -- ^ Execute a database migration
+    | MockNode -- ^ Run the mock node service
+    | MockWallet -- ^ Run the mock wallet service
+    | ChainIndex -- ^ Run the chain index service
+    | Metadata -- ^ Run the mock meta-data service
+    | ForkCommands [Command] -- ^ Fork  a list of commands
+    | SigningProcess -- ^ Run the signing process service
+    | InstallContract FilePath -- ^ Install a contract
+    | ActivateContract FilePath -- ^ Activate a contract
+    | ContractState UUID -- ^ Display the contract identified by 'UUID'
+    | UpdateContract UUID EndpointDescription JSON.Value -- ^ Update the contract details of the contract identified by 'UUID'
+    | ReportContractHistory UUID -- ^ Get the history of the contract identified by 'UUID'
+    | ReportInstalledContracts -- ^ Get installed contracts
+    | ReportActiveContracts -- ^ Get active contracts
+    | ProcessContractInbox UUID -- ^ Run the contract-inbox service
+    | ProcessAllContractOutboxes -- ^ DEPRECATED
+    | ReportTxHistory -- ^ List transaction history
+    | PABWebserver -- ^ Run the PAB webserver
+    | PSGenerator -- ^ Generate purescript bridge code
+          { _outputDir :: !FilePath -- ^ Path to write generated code to
           }
-    | WriteDefaultConfig
-          { _outputFile :: !FilePath
+    | WriteDefaultConfig -- ^ Write default logging configuration
+          { _outputFile :: !FilePath -- ^ Path to write configuration to
           }
     deriving stock (Show, Eq, Generic)
     deriving anyclass JSON.ToJSON
+
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Command line parsing
+-----------------------------------------------------------------------------------------------------------------------
 
 versionOption :: Parser (a -> a)
 versionOption =
@@ -374,7 +382,12 @@ reportContractHistoryParser =
         (ReportContractHistory <$> contractIdParser)
         (fullDesc <> progDesc "Show the state history of a smart contract.")
 
-{- Note [Use of iohk-monitoring in PAB]
+-----------------------------------------------------------------------------------------------------------------------
+-- Command interpretation
+-----------------------------------------------------------------------------------------------------------------------
+
+{-
+#iohk-monitoring-pab#
 
 We use the 'iohk-monitoring' package to process the log messages that come
 out of the 'Control.Monad.Freer.Log' effects. We create a top-level 'Tracer'
@@ -409,75 +422,120 @@ We have to use 'natTracer' in some places to turn 'Trace IO a' into
 
 -}
 
-------------------------------------------------------------
--- | Translate the command line configuation into the actual code to be run.
+-- | Interpret a 'Command' in 'Eff' using the provided tracer and configurations
 --
-runCliCommand :: Trace IO AppMsg -> Configuration -> Config ->  Availability -> Command -> Eff (LogMsg AppMsg ': AppBackend (TraceLoggerT IO)) ()
+runCliCommand ::
+    Trace IO AppMsg  -- ^ PAB Tracer logging instance
+    -> Configuration -- ^ Monitoring configuration
+    -> Config        -- ^ PAB Configuration
+    -> Availability  -- ^ Token for signaling service availability
+    -> Command
+    -> Eff (LogMsg AppMsg ': AppBackend (TraceLoggerT IO)) ()
+
+-- Run database migration
 runCliCommand _ _ _ _ Migrate = raise App.migrate
+
+-- Run mock wallet service
 runCliCommand _ _ Config {walletServerConfig, nodeServerConfig, chainIndexConfig} serviceAvailability MockWallet =
     WalletServer.main
         walletServerConfig
         (NodeServer.mscBaseUrl nodeServerConfig)
         (ChainIndex.ciBaseUrl chainIndexConfig)
         serviceAvailability
-runCliCommand _ _ Config {nodeServerConfig} serviceAvailability MockNode =
-    NodeServer.main nodeServerConfig serviceAvailability
+
+-- Run mock node server
+runCliCommand _ _ Config {nodeServerConfig} serviceAvailability MockNode = NodeServer.main nodeServerConfig serviceAvailability
+
+-- Run mock metadata server
 runCliCommand _ _ Config {metadataServerConfig} serviceAvailability Metadata = raise $ Metadata.main metadataServerConfig serviceAvailability
-runCliCommand trace logConfig config serviceAvailability PABWebserver = raise $ PABServer.main (mapPABMsg trace) logConfig config serviceAvailability
+
+-- Run PAB webserver
+runCliCommand trace logConfig config serviceAvailability PABWebserver = raise $ PABServer.main (toPABMsg trace) logConfig config serviceAvailability
+
+-- Fork a list of commands
 runCliCommand trace logConfig config serviceAvailability (ForkCommands commands) =
     void . liftIO $ do
         threads <- traverse forkCommand commands
         putStrLn "Started all commands."
         waitAny threads
   where
-
     forkCommand ::  Command -> IO (Async ())
     forkCommand subcommand = do
       putStrLn $ "Starting: " <> show subcommand
-      -- see note [Use of iohk-monitoring in PAB]
+      -- see [note on monitoring in pab](#iohk-monitoring-pab)
       let trace' = monadLoggerTracer trace
-      asyncId <- async . void . runApp (mapPABMsg trace) logConfig config . handleLogMsgTrace trace' . runCliCommand trace logConfig config serviceAvailability $ subcommand
+      asyncId <- async . void . runApp (toPABMsg trace) logConfig config . handleLogMsgTrace trace' . runCliCommand trace logConfig config serviceAvailability $ subcommand
       putStrLn $ "Started: " <> show subcommand
       starting serviceAvailability
       pure asyncId
-runCliCommand _ _ Config {nodeServerConfig, chainIndexConfig} serviceAvailability ChainIndex =
-    ChainIndex.main chainIndexConfig (NodeServer.mscBaseUrl nodeServerConfig) serviceAvailability
+
+-- Run the chain-index service
+runCliCommand t _ Config {nodeServerConfig, chainIndexConfig} serviceAvailability ChainIndex =
+    liftIO $ ChainIndex.main (toChainIndexLog t) chainIndexConfig (NodeServer.mscBaseUrl nodeServerConfig) serviceAvailability
+
+
+-- Run the signing-process service
 runCliCommand _ _ Config {signingProcessConfig} serviceAvailability SigningProcess =
     SigningProcess.main signingProcessConfig serviceAvailability
+
+-- Install a contract
 runCliCommand _ _ _ _ (InstallContract path) = Core.installContract (ContractExe path)
+
+-- Activate a contract
 runCliCommand _ _ _ _ (ActivateContract path) = void $ Core.activateContract (ContractExe path)
+
+-- Get the state of a contract
 runCliCommand _ _ _ _ (ContractState uuid) = Core.reportContractState @ContractExe (ContractInstanceId uuid)
+
+-- Get all installed contracts
 runCliCommand _ _ _ _ ReportInstalledContracts = do
     logInfo InstalledContractsMsg
     traverse_ (logInfo . InstalledContract . render . pretty) =<< Core.installedContracts @ContractExe
+
+-- Get all active contracts
 runCliCommand _ _ _ _ ReportActiveContracts = do
     logInfo ActiveContractsMsg
     instances <- Map.toAscList <$> Core.activeContracts @ContractExe
     traverse_ (\(e, s) -> logInfo $ ContractInstance e (Set.toList s)) instances
+
+-- Get transaction history
 runCliCommand _ _ _ _ ReportTxHistory = do
     logInfo TransactionHistoryMsg
     traverse_ (logInfo . TxHistoryItem) =<< Core.txHistory @ContractExe
+
+-- Update a specific contract
 runCliCommand _ _ _ _ (UpdateContract uuid endpoint payload) =
     void $ Instance.callContractEndpoint @ContractExe (ContractInstanceId uuid) (getEndpointDescription endpoint) payload
+
+-- Get history of a specific contract
 runCliCommand _ _ _ _ (ReportContractHistory uuid) = do
     logInfo ContractHistoryMsg
     contracts <- Core.activeContractHistory @ContractExe (ContractInstanceId uuid)
     itraverse_ (\i -> logContract i) contracts
     where
       logContract index contract = logInfo $ ContractHistoryItem index contract
+
+-- DEPRECATED
 runCliCommand _ _ _ _ (ProcessContractInbox uuid) = do
     logInfo ProcessInboxMsg
     Core.processContractInbox @ContractExe (ContractInstanceId uuid)
+
+-- Run the process-outboxes command
 runCliCommand _ _ Config{requestProcessingConfig} _ ProcessAllContractOutboxes = do
     let RequestProcessingConfig{requestProcessingInterval} = requestProcessingConfig
     logInfo $ ProcessAllOutboxesMsg requestProcessingInterval
     forever $ do
         _ <- liftIO . threadDelay . fromIntegral $ toMicroseconds requestProcessingInterval
         handleError @PABError (Core.processAllContractOutboxes @ContractExe Instance.defaultMaxIterations) (logError . ContractExePABError)
+
+-- Generate PureScript bridge code
 runCliCommand _ _ _ _ PSGenerator {_outputDir} =
     liftIO $ PSGenerator.generate _outputDir
+
+-- Get default logging configuration
 runCliCommand _ _ _ _ WriteDefaultConfig{_outputFile} =
     liftIO $ defaultConfig >>= flip CM.exportConfiguration _outputFile
+
 
 main :: IO ()
 main = do
@@ -492,7 +550,7 @@ main = do
     (trace :: Trace IO AppMsg, switchboard) <- setupTrace_ logConfig pabComponentName
 
     -- 'TracerLoggerT IO' has instances for 'MonadLogger' and 'MonadUnliftIO'.
-    -- see note [Use of iohk-monitoring in PAB]
+    -- see [note on monitoring in pab](#iohk-monitoring-pab)
     let trace' = monadLoggerTracer trace
 
     -- enable EKG backend
@@ -501,7 +559,7 @@ main = do
 
     serviceAvailability <- newToken
     result <-
-        runApp (mapPABMsg trace) logConfig config
+        runApp (toPABMsg trace) logConfig config
             $ handleLogMsgTrace trace'
             $ runCliCommand trace logConfig config serviceAvailability cmd
     case result of
@@ -510,8 +568,15 @@ main = do
             exitWith (ExitFailure 1)
         Right _ -> exitSuccess
 
-mapPABMsg :: Trace m AppMsg -> Trace m PABLogMsg
-mapPABMsg = contramap (second (fmap PABMsg))
+-- Convert tracer structured log data
+convertLog :: (a -> b) -> Trace m b -> Trace m a
+convertLog f = contramap (second (fmap f))
+
+toPABMsg :: Trace m AppMsg -> Trace m PABLogMsg
+toPABMsg = convertLog PABMsg
+
+toChainIndexLog :: Trace m AppMsg -> Trace m ChainIndexServerMsg
+toChainIndexLog = convertLog $ PABMsg . SChainIndexServerMsg
 
 pabComponentName :: Text.Text
 pabComponentName = "pab"

--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -71,7 +71,8 @@ import qualified Plutus.PAB.Core.ContractInstance                as Instance
 import           Plutus.PAB.Events.Contract                      (ContractInstanceId (..))
 import           Plutus.PAB.PABLogMsg                            (AppMsg (..), ChainIndexServerMsg,
                                                                   ContractExeLogMsg (..),
-                                                                  PABLogMsg (SChainIndexServerMsg))
+                                                                  PABLogMsg (SChainIndexServerMsg, SSigningProcessMsg),
+                                                                  SigningProcessMsg)
 import           Plutus.PAB.Types                                (Config (Config), ContractExe (..), PABError,
                                                                   RequestProcessingConfig (..), chainIndexConfig,
                                                                   metadataServerConfig, nodeServerConfig,
@@ -475,8 +476,8 @@ runCliCommand t _ Config {nodeServerConfig, chainIndexConfig} serviceAvailabilit
 
 
 -- Run the signing-process service
-runCliCommand _ _ Config {signingProcessConfig} serviceAvailability SigningProcess =
-    SigningProcess.main signingProcessConfig serviceAvailability
+runCliCommand t _ Config {signingProcessConfig} serviceAvailability SigningProcess =
+    liftIO $ SigningProcess.main (toSigningProcessLog t) signingProcessConfig serviceAvailability
 
 -- Install a contract
 runCliCommand _ _ _ _ (InstallContract path) = Core.installContract (ContractExe path)
@@ -577,6 +578,9 @@ toPABMsg = convertLog PABMsg
 
 toChainIndexLog :: Trace m AppMsg -> Trace m ChainIndexServerMsg
 toChainIndexLog = convertLog $ PABMsg . SChainIndexServerMsg
+
+toSigningProcessLog :: Trace m AppMsg -> Trace m SigningProcessMsg
+toSigningProcessLog = convertLog $ PABMsg . SSigningProcessMsg
 
 pabComponentName :: Text.Text
 pabComponentName = "pab"

--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -387,8 +387,7 @@ reportContractHistoryParser =
 -- Command interpretation
 -----------------------------------------------------------------------------------------------------------------------
 
-{-
-#iohk-monitoring-pab#
+{- Note [Use of iohk-monitoring in PAB]
 
 We use the 'iohk-monitoring' package to process the log messages that come
 out of the 'Control.Monad.Freer.Log' effects. We create a top-level 'Tracer'
@@ -463,7 +462,7 @@ runCliCommand trace logConfig config serviceAvailability (ForkCommands commands)
     forkCommand ::  Command -> IO (Async ())
     forkCommand subcommand = do
       putStrLn $ "Starting: " <> show subcommand
-      -- see [note on monitoring in pab](#iohk-monitoring-pab)
+      -- see note [Use of iohk-monitoring in PAB]
       let trace' = monadLoggerTracer trace
       asyncId <- async . void . runApp (toPABMsg trace) logConfig config . handleLogMsgTrace trace' . runCliCommand trace logConfig config serviceAvailability $ subcommand
       putStrLn $ "Started: " <> show subcommand
@@ -551,7 +550,7 @@ main = do
     (trace :: Trace IO AppMsg, switchboard) <- setupTrace_ logConfig pabComponentName
 
     -- 'TracerLoggerT IO' has instances for 'MonadLogger' and 'MonadUnliftIO'.
-    -- see [note on monitoring in pab](#iohk-monitoring-pab)
+    -- see note [Use of iohk-monitoring in PAB]
     let trace' = monadLoggerTracer trace
 
     -- enable EKG backend

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -69,6 +69,7 @@ library
         Cardano.SigningProcess.API
         Cardano.SigningProcess.Server
         Cardano.SigningProcess.Client
+        Cardano.SigningProcess.Types
         Cardano.Wallet.API
         Cardano.Wallet.Client
         Cardano.Wallet.Mock

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE MonoLocalBinds    #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeOperators     #-}
 module Cardano.ChainIndex.Server(
     -- $chainIndex
     main
@@ -13,6 +15,7 @@ module Cardano.ChainIndex.Server(
     , syncState
     ) where
 
+import           Cardano.BM.Data.Trace           (Trace)
 import           Cardano.Node.Types              (FollowerID)
 import           Control.Concurrent              (forkIO, threadDelay)
 import           Control.Concurrent.MVar         (MVar, newMVar, putMVar, takeMVar)
@@ -24,12 +27,10 @@ import           Control.Monad.Freer.Log         (renderLogMessages)
 import           Control.Monad.Freer.State
 import qualified Control.Monad.Freer.State       as Eff
 import           Control.Monad.IO.Class          (MonadIO (..))
-import           Control.Monad.Logger            (MonadLogger, logDebugN, logInfoN, runStdoutLoggingT)
 import           Data.Foldable                   (fold, traverse_)
 import           Data.Function                   ((&))
 import           Data.Proxy                      (Proxy (Proxy))
 import           Data.Text                       (Text)
-import           Data.Text.Prettyprint.Doc       (Pretty (..), parens, (<+>))
 import           Data.Time.Units                 (Second, toMicroseconds)
 import           Ledger.Blockchain               (Block)
 import           Network.HTTP.Client             (defaultManagerSettings, newManager)
@@ -40,7 +41,8 @@ import           Servant.Client                  (BaseUrl (baseUrlPort), ClientE
 
 import           Ledger.Address                  (Address)
 import           Ledger.AddressMap               (AddressMap)
-import           Plutus.PAB.Utils                (tshow)
+import           Plutus.PAB.Monitoring           (handleLogMsgTrace)
+import           Plutus.PAB.PABLogMsg            (ChainIndexServerMsg (..))
 
 import           Cardano.ChainIndex.API
 import           Cardano.ChainIndex.Types
@@ -66,19 +68,27 @@ app stateVar =
         (processIndexEffects stateVar)
         (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
 
-main :: MonadIO m => ChainIndexConfig -> BaseUrl -> Availability -> m ()
-main ChainIndexConfig{ciBaseUrl} nodeBaseUrl availability = runStdoutLoggingT $ do
+handleChainIndexEffects ::
+    forall m.
+    MonadIO m
+    => Trace m ChainIndexServerMsg
+    -> Eff '[LogMsg ChainIndexServerMsg, m]
+    ~> m
+handleChainIndexEffects trace = runM . handleLogMsgTrace trace
+
+main :: Trace IO ChainIndexServerMsg -> ChainIndexConfig -> BaseUrl -> Availability -> IO ()
+main trace ChainIndexConfig{ciBaseUrl} nodeBaseUrl availability = handleChainIndexEffects trace $ do
     let port = baseUrlPort ciBaseUrl
     nodeClientEnv <-
         liftIO $ do
             nodeManager <- newManager defaultManagerSettings
             pure $ mkClientEnv nodeManager nodeBaseUrl
     mVarState <- liftIO $ newMVar initialAppState
-    logInfoN "Starting node client thread"
-    void $ liftIO $ forkIO $ runStdoutLoggingT $ updateThread 10 mVarState nodeClientEnv
+    logInfo StartingNodeClientThread
+    void $ liftIO $ forkIO $ handleChainIndexEffects trace $ updateThread 10 mVarState nodeClientEnv
     let warpSettings :: Warp.Settings
         warpSettings = Warp.defaultSettings & Warp.setPort port & Warp.setBeforeMainLoop (available availability)
-    logInfoN $ "Starting chain index on port: " <> tshow port
+    logInfo $ StartingChainIndex port
     liftIO $ Warp.runSettings warpSettings $ app mVarState
 
 healthcheck :: Monad m => m NoContent
@@ -93,22 +103,6 @@ watchedAddresses = WalletEffects.watchedAddresses
 confirmedBlocks :: (Member ChainIndexEffect effs) => Eff effs [Block]
 confirmedBlocks = WalletEffects.confirmedBlocks
 
-data ChainIndexServerMsg =
-    ObtainingFollowerID
-    | ObtainedFollowerID FollowerID
-    | UpdatingChainIndex FollowerID
-    | ReceivedBlocksTxns Int Int
-    | AskingNodeForNewBlocks
-    | AskingNodeForCurrentSlot
-
-instance Pretty ChainIndexServerMsg where
-    pretty = \case
-        ObtainingFollowerID -> "Obtaining follower ID"
-        ObtainedFollowerID i -> "Obtained follower ID:" <+> pretty i
-        UpdatingChainIndex i -> "Updating chain index with follower ID" <+> pretty i
-        ReceivedBlocksTxns blocks txns -> "Received" <+> pretty blocks <+> "blocks" <+> parens (pretty txns <+> "transactions")
-        AskingNodeForNewBlocks -> "Asking the node for new blocks"
-        AskingNodeForCurrentSlot -> "Asking the node for the current slot"
 
 -- | Update the chain index by asking the node for new blocks since the last
 --   time.
@@ -131,41 +125,46 @@ syncState = do
 
 -- | Get the latest transactions from the node and update the index accordingly
 updateThread ::
-    (MonadIO m, MonadLogger m)
+    forall effs.
+    ( LastMember IO effs
+    , Member (LogMsg ChainIndexServerMsg) effs
+    )
     => Second
     -- ^ Interval between two queries for new blocks
     -> MVar AppState
     -- ^ State of the chain index
     -> ClientEnv
     -- ^ Servant client for the node API
-    -> m ()
+    -> Eff effs ()
 updateThread updateInterval mv nodeClientEnv = do
-    logInfoN "Obtaining follower ID"
+    logInfo ObtainingFollowerID
     followerID <-
         liftIO $
         runClientM NodeClient.newFollower nodeClientEnv >>=
         either (error . show) pure
-    logInfoN $ "Follower ID: " <> tshow followerID
+    logInfo $ ObtainedFollowerID followerID
     forever $ do
         watching <- processIndexEffects mv WalletEffects.watchedAddresses
         unless (watching == mempty) (fetchNewBlocks followerID nodeClientEnv mv)
         liftIO $ threadDelay $ fromIntegral $ toMicroseconds updateInterval
 
 fetchNewBlocks ::
-       (MonadLogger m, MonadIO m)
+    forall effs.
+    ( LastMember IO effs
+    , Member (LogMsg ChainIndexServerMsg) effs
+    )
     => FollowerID
     -> ClientEnv
     -> MVar AppState
-    -> m ()
+    -> Eff effs ()
 fetchNewBlocks followerID nodeClientEnv mv = do
-    logInfoN "Asking the node for new blocks"
+    logInfo AskingNodeForNewBlocks
     newBlocks <-
         liftIO $
         runClientM (NodeClient.getBlocks followerID) nodeClientEnv >>=
         either (error . show) pure
-    logInfoN $ "Received " <> tshow (length newBlocks) <> " blocks (" <> tshow (length $ fold newBlocks) <> " transactions)"
-    logDebugN $ tshow newBlocks
-    logInfoN "Asking the node for the current slot"
+    logInfo (ReceivedBlocksTxns (length newBlocks) (length $ fold newBlocks))
+    logInfo AskingNodeForCurrentSlot
     curentSlot <-
         liftIO $
         runClientM NodeClient.getCurrentSlot nodeClientEnv >>=

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -45,7 +45,7 @@ import qualified Cardano.Node.Follower           as NodeFollower
 import           Control.Concurrent.Availability (Availability, available)
 import           Ledger.Address                  (Address)
 import           Ledger.AddressMap               (AddressMap)
-import           Plutus.PAB.Monitoring           (handleLogEffects)
+import           Plutus.PAB.Monitoring           (runLogEffects)
 import           Wallet.Effects                  (ChainIndexEffect)
 import qualified Wallet.Effects                  as WalletEffects
 import           Wallet.Emulator.ChainIndex      (ChainIndexControlEffect, ChainIndexEvent, ChainIndexState)
@@ -65,12 +65,12 @@ app stateVar =
         (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
 
 main :: Trace IO ChainIndexServerMsg -> ChainIndexConfig -> BaseUrl -> Availability -> IO ()
-main trace ChainIndexConfig{ciBaseUrl} nodeBaseUrl availability = handleLogEffects trace $ do
+main trace ChainIndexConfig{ciBaseUrl} nodeBaseUrl availability = runLogEffects trace $ do
     nodeClientEnv <- liftIO getNode
     mVarState <- liftIO $ newMVar initialAppState
 
     logInfo StartingNodeClientThread
-    void $ liftIO $ forkIO $ handleLogEffects trace $ updateThread 10 mVarState nodeClientEnv
+    void $ liftIO $ forkIO $ runLogEffects trace $ updateThread 10 mVarState nodeClientEnv
 
     logInfo $ StartingChainIndex servicePort
     liftIO $ Warp.runSettings warpSettings $ app mVarState

--- a/plutus-pab/src/Cardano/ChainIndex/Types.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Types.hs
@@ -1,21 +1,28 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE StrictData         #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeApplications   #-}
 
 module Cardano.ChainIndex.Types where
 
-import           Control.Lens               (makeLenses)
-import           Control.Monad.Freer.Log    (LogMessage)
-import           Data.Aeson                 (FromJSON, ToJSON)
-import           Data.Sequence              (Seq)
-import           GHC.Generics               (Generic)
-import           Servant.Client             (BaseUrl)
+import           Control.Lens                  (makeLenses)
+import           Control.Monad.Freer.Log       (LogMessage)
+import           Data.Aeson                    (FromJSON, ToJSON)
+import           Data.Sequence                 (Seq)
+import           Data.Text.Prettyprint.Doc     (Pretty (..), parens, (<+>))
+import           GHC.Generics                  (Generic)
+import           Servant.Client                (BaseUrl)
 
-import           Cardano.Node.Types         (FollowerID)
-import           Ledger.Address             (Address)
-import           Wallet.Emulator.ChainIndex (ChainIndexEvent, ChainIndexState)
+import           Cardano.BM.Data.Tracer        (ToObject (..))
+import           Cardano.BM.Data.Tracer.Extras (Tagged (..), mkObjectStr)
+import           Cardano.Node.Types            (FollowerID)
+import           Ledger.Address                (Address)
+import           Wallet.Emulator.ChainIndex    (ChainIndexEvent, ChainIndexState)
 
 data AppState =
     AppState
@@ -37,3 +44,49 @@ data ChainIndexConfig =
 
 makeLenses ''AppState
 makeLenses ''ChainIndexConfig
+
+-- | Messages from the ChainIndex Server
+data ChainIndexServerMsg =
+    -- | Obtaining a new follower
+    ObtainingFollowerID
+    -- | Obtained a new follower 'FollowerID'
+    | ObtainedFollowerID FollowerID
+    -- | Updating the chain index with 'FollowerID'
+    | UpdatingChainIndex FollowerID
+    -- | Requesting new blocks from the node
+    | AskingNodeForNewBlocks
+    -- | Requesting the current slot from the node
+    | AskingNodeForCurrentSlot
+    -- | Starting a node client thread
+    | StartingNodeClientThread
+    -- | Starting ChainIndex service
+    | StartingChainIndex
+        Int    -- ^ Port number
+      -- | Received transaction
+    | ReceivedBlocksTxns
+        Int    -- ^ Blocks
+        Int    -- ^ Transactions
+    deriving stock (Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty ChainIndexServerMsg where
+    pretty = \case
+        ObtainingFollowerID -> "Obtaining follower ID"
+        ObtainedFollowerID i -> "Obtained follower ID:" <+> pretty i
+        UpdatingChainIndex i -> "Updating chain index with follower ID" <+> pretty i
+        ReceivedBlocksTxns blocks txns -> "Received" <+> pretty blocks <+> "blocks" <+> parens (pretty txns <+> "transactions")
+        AskingNodeForNewBlocks -> "Asking the node for new blocks"
+        AskingNodeForCurrentSlot -> "Asking the node for the current slot"
+        StartingNodeClientThread -> "Starting node client thread"
+        StartingChainIndex port -> "Starting chain index on port: " <> pretty port
+
+instance ToObject ChainIndexServerMsg where
+    toObject _ = \case
+      ObtainingFollowerID      -> mkObjectStr "obtaining FollowerID" ()
+      ObtainedFollowerID fID   -> mkObjectStr "obtained FollowerID" (Tagged @"followerID" fID)
+      UpdatingChainIndex fID   -> mkObjectStr "updating chainIndex with FollowerID" (Tagged @"followerID" fID)
+      ReceivedBlocksTxns x y   -> mkObjectStr "received block transactions" (Tagged @"blocks" x, Tagged @"transactions" y)
+      AskingNodeForNewBlocks   -> mkObjectStr "asking for new blocks" ()
+      AskingNodeForCurrentSlot -> mkObjectStr "asking node for current slot" ()
+      StartingNodeClientThread -> mkObjectStr "starting node client thread" ()
+      StartingChainIndex p     -> mkObjectStr "starting chain index" (Tagged @"port" p)

--- a/plutus-pab/src/Cardano/SigningProcess/Server.hs
+++ b/plutus-pab/src/Cardano/SigningProcess/Server.hs
@@ -35,7 +35,7 @@ import           Servant.Client                  (BaseUrl (baseUrlPort))
 import           Cardano.BM.Data.Trace           (Trace)
 import           Cardano.SigningProcess.API      (API)
 import           Cardano.SigningProcess.Types    (SigningProcessMsg (..))
-import           Plutus.PAB.Monitoring           (handleLogEffects)
+import           Plutus.PAB.Monitoring           (runLogEffects)
 import qualified Wallet.API                      as WAPI
 import           Wallet.Effects                  (SigningProcessEffect)
 import qualified Wallet.Effects                  as WE
@@ -65,7 +65,7 @@ app stateVar =
         (uncurry WE.addSignatures)
 
 main :: Trace IO SigningProcessMsg -> SigningProcessConfig -> Availability -> IO ()
-main trace SigningProcessConfig{spWallet, spBaseUrl} availability = handleLogEffects trace $ do
+main trace SigningProcessConfig{spWallet, spBaseUrl} availability = runLogEffects trace $ do
     stateVar <- liftIO $ newMVar (defaultSigningProcess spWallet)
     logInfo $ StartingSigningProcess servicePort
     liftIO $ Warp.runSettings warpSettings $ app stateVar

--- a/plutus-pab/src/Cardano/SigningProcess/Server.hs
+++ b/plutus-pab/src/Cardano/SigningProcess/Server.hs
@@ -5,8 +5,10 @@
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE StrictData         #-}
 {-# LANGUAGE TypeApplications   #-}
+
 module Cardano.SigningProcess.Server(
     -- $signingProcess
     SigningProcessConfig(..)
@@ -15,28 +17,29 @@ module Cardano.SigningProcess.Server(
 
 import           Control.Concurrent.Availability (Availability, available)
 import           Control.Concurrent.MVar         (MVar, newMVar, putMVar, takeMVar)
-import           Control.Monad.Freer             (Eff, run)
+import           Control.Monad.Freer
 import           Control.Monad.Freer.Error       (Error)
 import qualified Control.Monad.Freer.Error       as Eff
+import           Control.Monad.Freer.Extra.Log
 import           Control.Monad.Freer.State       (State)
 import qualified Control.Monad.Freer.State       as Eff
 import           Control.Monad.IO.Class          (MonadIO (..))
-import           Control.Monad.Logger            (logInfoN, runStdoutLoggingT)
 import           Data.Aeson                      (FromJSON, ToJSON)
 import           Data.Function                   ((&))
 import           Data.Proxy                      (Proxy (..))
 import           GHC.Generics                    (Generic)
 import qualified Network.Wai.Handler.Warp        as Warp
-
 import           Servant                         (Application, hoistServer, serve)
 import           Servant.Client                  (BaseUrl (baseUrlPort))
+
+import           Cardano.BM.Data.Trace           (Trace)
+import           Cardano.SigningProcess.API      (API)
+import           Cardano.SigningProcess.Types    (SigningProcessMsg (..))
+import           Plutus.PAB.Monitoring           (handleLogEffects)
 import qualified Wallet.API                      as WAPI
 import           Wallet.Effects                  (SigningProcessEffect)
 import qualified Wallet.Effects                  as WE
 import           Wallet.Emulator.Wallet          (SigningProcess, Wallet, defaultSigningProcess, handleSigningProcess)
-
-import           Cardano.SigningProcess.API      (API)
-import           Plutus.PAB.Utils                (tshow)
 
 -- $ signingProcess
 -- The signing process that adds signatures to transactions.
@@ -61,14 +64,15 @@ app stateVar =
         (processSigningProcessEffects stateVar)
         (uncurry WE.addSignatures)
 
-main :: MonadIO m => SigningProcessConfig -> Availability -> m ()
-main SigningProcessConfig{spWallet, spBaseUrl} availability = runStdoutLoggingT $ do
+main :: Trace IO SigningProcessMsg -> SigningProcessConfig -> Availability -> IO ()
+main trace SigningProcessConfig{spWallet, spBaseUrl} availability = handleLogEffects trace $ do
     stateVar <- liftIO $ newMVar (defaultSigningProcess spWallet)
-    let spPort = baseUrlPort spBaseUrl
-    let warpSettings :: Warp.Settings
-        warpSettings = Warp.defaultSettings & Warp.setPort spPort & Warp.setBeforeMainLoop (available availability)
-    logInfoN $ "Starting signing process on port: " <> tshow spPort
+    logInfo $ StartingSigningProcess servicePort
     liftIO $ Warp.runSettings warpSettings $ app stateVar
+        where
+            servicePort = baseUrlPort spBaseUrl
+            isAvailable = available availability
+            warpSettings = Warp.defaultSettings & Warp.setPort servicePort & Warp.setBeforeMainLoop isAvailable
 
 type SigningProcessEffects =
     '[ SigningProcessEffect, State SigningProcess, Error WAPI.WalletAPIError]

--- a/plutus-pab/src/Cardano/SigningProcess/Types.hs
+++ b/plutus-pab/src/Cardano/SigningProcess/Types.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module Cardano.SigningProcess.Types
+    ( SigningProcessMsg (..)
+    ) where
+
+import           Data.Aeson                    (FromJSON, ToJSON)
+import           Data.Text.Prettyprint.Doc     (Pretty (..), (<+>))
+import           GHC.Generics                  (Generic)
+
+import           Cardano.BM.Data.Tracer        (ToObject (..))
+import           Cardano.BM.Data.Tracer.Extras (Tagged (..), mkObjectStr)
+
+newtype SigningProcessMsg =
+    StartingSigningProcess Int -- ^ Starting up on the specified port
+        deriving stock (Show, Generic)
+        deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty SigningProcessMsg where
+    pretty = \case
+        StartingSigningProcess port -> "Starting Signing Process on port " <+> pretty port
+
+instance ToObject SigningProcessMsg where
+    toObject _ = \case
+        StartingSigningProcess p -> mkObjectStr "starting signing process" (Tagged @"port" p)

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -238,7 +238,7 @@ mkEnv Config { dbConfig
 runApp :: Trace IO PABLogMsg -> CM.Configuration -> Config -> App a -> IO (Either PABError a)
 runApp theTrace logConfig config action =
     runTraceLoggerT
-    -- see [note on monitoring in pab](#iohk-monitoring-pab)
+    -- see note [Use of iohk-monitoring in PAB]
     (runAppBackend @(TraceLoggerT IO) (monadLoggerTracer theTrace) logConfig config action)
     (contramap (second (fmap SLoggerBridge)) theTrace)
 

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -238,8 +238,7 @@ mkEnv Config { dbConfig
 runApp :: Trace IO PABLogMsg -> CM.Configuration -> Config -> App a -> IO (Either PABError a)
 runApp theTrace logConfig config action =
     runTraceLoggerT
-
-    -- see note [Use of iohk-monitoring in PAB]
+    -- see [note on monitoring in pab](#iohk-monitoring-pab)
     (runAppBackend @(TraceLoggerT IO) (monadLoggerTracer theTrace) logConfig config action)
     (contramap (second (fmap SLoggerBridge)) theTrace)
 

--- a/plutus-pab/src/Plutus/PAB/MonadLoggerBridge.hs
+++ b/plutus-pab/src/Plutus/PAB/MonadLoggerBridge.hs
@@ -89,7 +89,7 @@ toLogLevel = \case
     LevelOther _ -> L.Info
 
 -- | Interpret 'MonadLogger' effect using a 'Trace'.
--- see note [Use of iohk-monitoring in PAB] for why this is necessary.
+-- see [note on monitoring in pab](#Main.iohk-monitoring-pab) for why this is necessary.
 newtype TraceLoggerT m a = TraceLoggerT { runTraceLoggerT :: Trace m MonadLoggerMsg -> m a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadThrow) via (ReaderT (Trace m MonadLoggerMsg) m)
 

--- a/plutus-pab/src/Plutus/PAB/MonadLoggerBridge.hs
+++ b/plutus-pab/src/Plutus/PAB/MonadLoggerBridge.hs
@@ -89,7 +89,8 @@ toLogLevel = \case
     LevelOther _ -> L.Info
 
 -- | Interpret 'MonadLogger' effect using a 'Trace'.
--- see [note on monitoring in pab](#Main.iohk-monitoring-pab) for why this is necessary.
+-- see note [Use of iohk-monitoring in PAB]
+
 newtype TraceLoggerT m a = TraceLoggerT { runTraceLoggerT :: Trace m MonadLoggerMsg -> m a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadCatch, MonadThrow) via (ReaderT (Trace m MonadLoggerMsg) m)
 

--- a/plutus-pab/src/Plutus/PAB/Monitoring.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring.hs
@@ -12,6 +12,7 @@ module Plutus.PAB.Monitoring(
   handleLogMsgTrace
   , handleLogMsgTraceMap
   , handleObserveTrace
+  , handleLogEffects
   -- * Conveniences for configuration
   , defaultConfig
   , loadConfig
@@ -105,6 +106,14 @@ toSeverity = \case
   L.Critical  -> Critical
   L.Alert     -> Alert
   L.Emergency -> Emergency
+
+handleLogEffects ::
+    forall m l.
+    MonadIO m
+    => Trace m l
+    -> Eff '[LogMsg l, m]
+    ~> m
+handleLogEffects trace = runM . handleLogMsgTrace trace
 
 -- | Handle the 'LogObserve' effect using the 'Cardano.BM.Observer.Monadic'
 --   observer functions

--- a/plutus-pab/src/Plutus/PAB/Monitoring.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring.hs
@@ -12,7 +12,7 @@ module Plutus.PAB.Monitoring(
   handleLogMsgTrace
   , handleLogMsgTraceMap
   , handleObserveTrace
-  , handleLogEffects
+  , runLogEffects
   -- * Conveniences for configuration
   , defaultConfig
   , loadConfig
@@ -107,13 +107,13 @@ toSeverity = \case
   L.Alert     -> Alert
   L.Emergency -> Emergency
 
-handleLogEffects ::
+runLogEffects ::
     forall m l.
     MonadIO m
     => Trace m l
     -> Eff '[LogMsg l, m]
     ~> m
-handleLogEffects trace = runM . handleLogMsgTrace trace
+runLogEffects trace = runM . handleLogMsgTrace trace
 
 -- | Handle the 'LogObserve' effect using the 'Cardano.BM.Observer.Monadic'
 --   observer functions

--- a/plutus-pab/src/Plutus/PAB/PABLogMsg.hs
+++ b/plutus-pab/src/Plutus/PAB/PABLogMsg.hs
@@ -5,17 +5,16 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+
 -- | PAB Log messages and instances
 module Plutus.PAB.PABLogMsg(
     PABLogMsg(..),
     ContractExeLogMsg(..),
     ChainIndexServerMsg(..),
+    SigningProcessMsg,
     AppMsg(..)
     ) where
 
-import           Cardano.BM.Data.Tracer             (ToObject (..), TracingVerbosity (..))
-import           Cardano.BM.Data.Tracer.Extras      (Tagged (..), mkObjectStr)
-import           Cardano.Node.Types                 (FollowerID)
 import           Data.Aeson                         (FromJSON, ToJSON, Value)
 import qualified Data.Aeson.Encode.Pretty           as JSON
 import qualified Data.ByteString.Lazy.Char8         as BSL8
@@ -24,6 +23,11 @@ import           Data.Text                          (Text)
 import           Data.Text.Prettyprint.Doc          (Pretty (..), colon, hang, parens, viaShow, vsep, (<+>))
 import           Data.Time.Units                    (Second)
 import           GHC.Generics                       (Generic)
+
+import           Cardano.BM.Data.Tracer             (ToObject (..), TracingVerbosity (..))
+import           Cardano.BM.Data.Tracer.Extras      (Tagged (..), mkObjectStr)
+import           Cardano.Node.Types                 (FollowerID)
+import           Cardano.SigningProcess.Types       (SigningProcessMsg)
 import           Language.Plutus.Contract.State     (ContractRequest)
 import           Ledger.Tx                          (Tx)
 import           Plutus.PAB.Core                    (CoreMsg (..))
@@ -111,6 +115,7 @@ data PABLogMsg =
     | SWebsocketMsg WebSocketLogMsg
     | SContractRuntimeMsg ContractRuntimeMsg
     | SChainIndexServerMsg ChainIndexServerMsg
+    | SSigningProcessMsg SigningProcessMsg
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -125,6 +130,10 @@ instance Pretty PABLogMsg where
         SWebsocketMsg m        -> pretty m
         SContractRuntimeMsg m  -> pretty m
         SChainIndexServerMsg m -> pretty m
+        SSigningProcessMsg m   -> pretty m
+
+
+-- | Messages from the Signing Process
 
 data ContractExeLogMsg =
     InvokeContractMsg
@@ -223,6 +232,8 @@ instance ToObject PABLogMsg where
         SWebsocketMsg e        -> toObject v e
         SContractRuntimeMsg e  -> toObject v e
         SChainIndexServerMsg m -> toObject v m
+        SSigningProcessMsg m   -> toObject v m
+
 
 instance ToObject ChainIndexServerMsg where
     toObject _ = \case


### PR DESCRIPTION
**Description**:
 Change `ChainIndex` and `SigningProcess` to use Tracer via `Freer.Log` (part of SCP-1687).

**Details**:
- Moved some definitions to local Type Module to resolve circular imports
- Additional minor refactorings
- Added some comments

-----

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
