### PR TITLE
SCP-1848: Contract instance doesn't need MultiAgent effect

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -80,12 +80,12 @@ import qualified Language.Plutus.Contract.Trace.RequestHandler     as RequestHan
 import qualified Ledger.Ada                                        as Ada
 import           Ledger.Value                                      (Value)
 
+import           Plutus.Trace.Emulator.Types                       (EmulatedWalletEffects)
 import           Wallet.API                                        (ChainIndexEffect, SigningProcessEffect)
 import           Wallet.Effects                                    (ContractRuntimeEffect, WalletEffect)
 import           Wallet.Emulator                                   (EmulatorState, Wallet)
 import qualified Wallet.Emulator                                   as EM
 import           Wallet.Emulator.LogMessages                       (TxBalanceMsg)
-import           Wallet.Emulator.MultiAgent                        (EmulatedWalletEffects)
 import qualified Wallet.Emulator.MultiAgent                        as EM
 import           Wallet.Emulator.Notify                            (EmulatorNotifyLogMsg (..))
 import           Wallet.Types                                      (ContractInstanceId, EndpointDescription (..),

--- a/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
@@ -20,6 +20,8 @@ module Plutus.Trace.Emulator.Types(
     , EmulatorThreads(..)
     , instanceIdThreads
     , EmulatorAgentThreadEffs
+    , EmulatedWalletEffects
+    , EmulatedWalletEffects'
     , ContractInstanceTag(..)
     , walletInstanceTag
     , ContractHandle(..)
@@ -52,7 +54,8 @@ module Plutus.Trace.Emulator.Types(
 
 import           Control.Lens
 import           Control.Monad.Freer.Coroutine
-import           Control.Monad.Freer.Log            (LogMsg)
+import           Control.Monad.Freer.Error
+import           Control.Monad.Freer.Log            (LogMessage, LogMsg, LogObserve)
 import           Control.Monad.Freer.Reader         (Reader)
 import           Data.Aeson                         (FromJSON, ToJSON)
 import qualified Data.Aeson                         as JSON
@@ -61,6 +64,7 @@ import qualified Data.Row.Internal                  as V
 import           Data.Sequence                      (Seq)
 import           Data.String                        (IsString (..))
 import           Data.Text                          (Text)
+import qualified Data.Text                          as T
 import           Data.Text.Prettyprint.Doc          (Pretty (..), braces, colon, fillSep, hang, parens, viaShow, vsep,
                                                      (<+>))
 import           GHC.Generics                       (Generic)
@@ -73,6 +77,9 @@ import qualified Language.Plutus.Contract.Types     as Contract.Types
 import           Ledger.Slot                        (Slot (..))
 import           Ledger.Tx                          (Tx)
 import           Plutus.Trace.Scheduler             (AgentSystemCall, ThreadId)
+import qualified Wallet.API                         as WAPI
+import qualified Wallet.Effects                     as Wallet
+import           Wallet.Emulator.LogMessages        (RequestHandlerLogMsg, TxBalanceMsg)
 import           Wallet.Emulator.Wallet             (Wallet (..))
 import           Wallet.Types                       (ContractInstanceId, EndpointDescription, Notification (..),
                                                      NotificationError)
@@ -104,13 +111,34 @@ newtype EmulatorThreads =
 
 makeLenses ''EmulatorThreads
 
--- | Effects available to emulator agent threads.
+-- | Effects that are used to handle requests by contract instances.
+--   In the emulator these effects are handled by 'Wallet.Emulator.MultiAgent'.
+--   In the PAB they are handled by the actual wallet/node/chain index,
+--   mediated by the PAB runtime.
+type EmulatedWalletEffects' effs =
+        Wallet.WalletEffect
+        ': Error WAPI.WalletAPIError
+        ': Wallet.NodeClientEffect
+        ': Wallet.ChainIndexEffect
+        ': Wallet.SigningProcessEffect
+        ': LogObserve (LogMessage T.Text)
+        ': LogMsg RequestHandlerLogMsg
+        ': LogMsg TxBalanceMsg
+        ': LogMsg T.Text
+        ': effs
+
+type EmulatedWalletEffects = EmulatedWalletEffects' '[]
+
+-- | Effects available to emulator agent threads. Includes emulated wallet
+--   effects and effects related to threading / waiting for messages.
 type EmulatorAgentThreadEffs effs =
     LogMsg ContractInstanceLog
-    ': Reader Wallet
-    ': Yield (AgentSystemCall EmulatorMessage) (Maybe EmulatorMessage)
-    ': Reader ThreadId
-    ': effs
+
+    ': EmulatedWalletEffects' (
+        Yield (AgentSystemCall EmulatorMessage) (Maybe EmulatorMessage)
+        ': Reader ThreadId
+        ': effs
+        )
 
 data Emulator
 


### PR DESCRIPTION
* In each contract instance thread we only use a single agent and this doesn't change during the lifetime of the instance
* So we don't actually need `MultiAgentEffect` inside `runInstance`
* This is the last of the emulator changes, after this we can actually use `runInstance` from inside the PAB \o/

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
