### PR TITLE
SCP-1791 - Split Contract in simulator and clean-up

### DIFF
--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -362,8 +362,7 @@ handleAction (BlocklyEditorAction action) = do
   case action of
     BE.SendToSimulator -> do
       mCode <- use (_blocklyEditorState <<< _marloweCode)
-      for_ mCode \contents -> do
-        sendToSimulation contents
+      for_ mCode \contents -> sendToSimulation contents
     BE.ViewAsMarlowe -> do
       -- TODO: doing an effect that returns a maybe value and doing an action on the possible
       -- result is a pattern that we have repeated a lot in this file. See if we could refactor

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -362,9 +362,8 @@ handleAction (BlocklyEditorAction action) = do
   case action of
     BE.SendToSimulator -> do
       mCode <- use (_blocklyEditorState <<< _marloweCode)
-      for_ mCode \code -> do
-        selectView Simulation
-        void $ toSimulation $ Simulation.handleAction (ST.LoadContract code)
+      for_ mCode \contents -> do
+        sendToSimulation contents
     BE.ViewAsMarlowe -> do
       -- TODO: doing an effect that returns a maybe value and doing an action on the possible
       -- result is a pattern that we have repeated a lot in this file. See if we could refactor

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -24,6 +24,7 @@ import Data.Newtype (unwrap)
 import Demos.Types (Action(..), Demo(..)) as Demos
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect)
+import Effect.Class.Console as Console
 import Env (Env)
 import Foreign.Generic (decodeJSON, encodeJSON)
 import Gist (Gist, _GistId, gistDescription, gistId)
@@ -384,8 +385,10 @@ handleAction (SimulationAction action) = do
     _ -> pure unit
 
 handleAction (HandleWalletMessage Wallet.SendContractToWallet) = do
-  contract <- toSimulation $ Simulation.getCurrentContract
-  void $ query _walletSlot unit (Wallet.LoadContract contract unit)
+  mContract <- toSimulation $ Simulation.getCurrentContract
+  case mContract of
+    Nothing -> liftEffect $ Console.warn "Could not import contract from simulator"
+    Just contract -> void $ query _walletSlot unit (Wallet.LoadContract contract unit)
 
 handleAction (ChangeView view) = selectView view
 

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -25,7 +25,7 @@ import Data.List.NonEmpty as NEL
 import Data.List.Types (NonEmptyList)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.NonEmptyList.Extra (tailIfNotEmpty)
+import Data.NonEmptyList.Extra (extendWith, tailIfNotEmpty)
 import Data.RawJson (RawJson(..))
 import Data.Traversable (for_)
 import Data.Tuple (Tuple(..))
@@ -92,8 +92,7 @@ handleAction StartSimulation = do
     --       the Actions said: "No available actions". Now it works fine, but I don't like the fact that if you call
     --       StartSimulation with a NEL of more than 1 element, you'd get weird behaviours. We should revisit the logic
     --       on _oldContracts, ResetSimulation, etc.
-    assign (_currentMarloweState <<< _executionState) (emptyExecutionStateWithSlot initialSlot)
-    modifying _marloweState (map (updatePossibleActions <<< updateStateP))
+    modifying _marloweState (extendWith (updatePossibleActions <<< updateStateP <<< (set _executionState (emptyExecutionStateWithSlot initialSlot))))
     mCurrContract <- use _currentContract
     case mCurrContract of
       Just currContract -> do

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -266,8 +266,6 @@ type State
     , bottomPanelState :: BottomPanel.State BottomPanelView
     , marloweState :: NonEmptyList MarloweState
     , helpContext :: HelpContext
-    -- QUESTION: What is the use of oldContract?
-    , oldContract :: Maybe String
     }
 
 _showRightPanel :: Lens' State Boolean
@@ -288,16 +286,12 @@ _helpContext = prop (SProxy :: SProxy "helpContext")
 _bottomPanelState :: Lens' State (BottomPanel.State BottomPanelView)
 _bottomPanelState = prop (SProxy :: SProxy "bottomPanelState")
 
-_oldContract :: Lens' State (Maybe String)
-_oldContract = prop (SProxy :: SProxy "oldContract")
-
 mkState :: State
 mkState =
   { showRightPanel: true
   , marloweState: NEL.singleton emptyMarloweState
   , helpContext: MarloweHelp
   , bottomPanelState: BottomPanel.initialState CurrentStateView
-  , oldContract: Nothing
   }
 
 data Action
@@ -308,9 +302,7 @@ data Action
   | MoveSlot Slot
   | SetSlot Slot
   | AddInput Input (Array Bound)
-  | RemoveInput Input
   | SetChoice ChoiceId ChosenNum
-  | ResetContract
   | ResetSimulator
   | Undo
   | LoadContract String
@@ -330,10 +322,8 @@ instance isEventAction :: IsEvent Action where
   toEvent (MoveSlot _) = Just $ defaultEvent "MoveSlot"
   toEvent (SetSlot _) = Just $ defaultEvent "SetSlot"
   toEvent (AddInput _ _) = Just $ defaultEvent "AddInput"
-  toEvent (RemoveInput _) = Just $ defaultEvent "RemoveInput"
   toEvent (SetChoice _ _) = Just $ defaultEvent "SetChoice"
   toEvent ResetSimulator = Just $ defaultEvent "ResetSimulator"
-  toEvent ResetContract = Just $ defaultEvent "ResetContract"
   toEvent Undo = Just $ defaultEvent "Undo"
   toEvent (LoadContract _) = Just $ defaultEvent "LoadContract"
   toEvent (ChangeHelpContext help) = Just $ (defaultEvent "ChangeHelpContext") { label = Just $ show help }

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -10,7 +10,7 @@ import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Lens (Getter', Lens', Prism', Traversal', lens, preview, prism, set, to)
+import Data.Lens (Getter', Lens', Prism', Traversal', Optic', lens, preview, prism, set, to)
 import Data.Lens.At (at)
 import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (_Newtype)
@@ -22,9 +22,12 @@ import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.Profunctor.Choice (class Choice)
+import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Help (HelpContext(..))
+import Marlowe.Extended as EM
 import Marlowe.Holes (Holes)
 import Marlowe.Semantics (AccountId, Assets, Bound, ChoiceId, ChosenNum, Contract, Input, Party(..), Payment, Slot, SlotInterval, Token, TransactionError, TransactionInput, TransactionWarning, aesonCompatibleOptions, emptyState)
 import Marlowe.Semantics as S
@@ -132,6 +135,7 @@ type ExecutionStateRecord
     , state :: S.State
     , slot :: Slot
     , moneyInContract :: Assets
+    , contract :: S.Contract
     }
 
 _possibleActions :: forall s a. Lens' { possibleActions :: a | s } a
@@ -155,6 +159,9 @@ _slot = prop (SProxy :: SProxy "slot")
 _moneyInContract :: forall s a. Lens' { moneyInContract :: a | s } a
 _moneyInContract = prop (SProxy :: SProxy "moneyInContract")
 
+_contract :: forall s a. Lens' { contract :: a | s } a
+_contract = prop (SProxy :: SProxy "contract")
+
 _log :: forall s a. Lens' { log :: a | s } a
 _log = prop (SProxy :: SProxy "log")
 
@@ -166,10 +173,15 @@ _payments = _log <<< to (mapMaybe f)
   f (OutputEvent _ payment) = Just payment
 
 type InitialConditionsRecord
-  = { initialSlot :: Slot }
+  = { initialSlot :: Slot
+    , extendedContract :: Maybe EM.Contract
+    }
 
 _initialSlot :: forall s a. Lens' { initialSlot :: a | s } a
 _initialSlot = prop (SProxy :: SProxy "initialSlot")
+
+_extendedContract :: forall s a. Lens' { extendedContract :: a | s } a
+_extendedContract = prop (SProxy :: SProxy "extendedContract")
 
 data ExecutionState
   = SimulationRunning ExecutionStateRecord
@@ -193,8 +205,8 @@ _SimulationNotStarted =
           anotherCase -> Left anotherCase
       )
 
-emptyExecutionStateWithSlot :: Slot -> ExecutionState
-emptyExecutionStateWithSlot sn =
+emptyExecutionStateWithSlot :: Slot -> S.Contract -> ExecutionState
+emptyExecutionStateWithSlot sn cont =
   SimulationRunning
     { possibleActions: mempty
     , pendingInputs: mempty
@@ -204,17 +216,21 @@ emptyExecutionStateWithSlot sn =
     , state: emptyState sn
     , slot: sn
     , moneyInContract: mempty
+    , contract: cont
     }
 
-simulationNotStartedWithSlot :: Slot -> ExecutionState
-simulationNotStartedWithSlot slot = SimulationNotStarted { initialSlot: slot }
+simulationNotStartedWithSlot :: Slot -> Maybe EM.Contract -> ExecutionState
+simulationNotStartedWithSlot slot mContract =
+  SimulationNotStarted
+    { initialSlot: slot
+    , extendedContract: mContract
+    }
 
-simulationNotStarted :: ExecutionState
+simulationNotStarted :: Maybe EM.Contract -> ExecutionState
 simulationNotStarted = simulationNotStartedWithSlot zero
 
 type MarloweState
   = { executionState :: ExecutionState
-    , contract :: Maybe Contract
     , holes :: Holes
     -- NOTE: as part of the marlowe editor and simulator split this part of the
     --       state wont be used, but it is left as it is because it may make sense
@@ -225,9 +241,6 @@ type MarloweState
 
 _executionState :: forall s a. Lens' { executionState :: a | s } a
 _executionState = prop (SProxy :: SProxy "executionState")
-
-_contract :: forall s a. Lens' { contract :: a | s } a
-_contract = prop (SProxy :: SProxy "contract")
 
 _editorErrors :: forall s a. Lens' { editorErrors :: a | s } a
 _editorErrors = prop (SProxy :: SProxy "editorErrors")
@@ -242,22 +255,20 @@ _holes = prop (SProxy :: SProxy "holes")
 _result :: forall s a. Lens' { result :: a | s } a
 _result = prop (SProxy :: SProxy "result")
 
-emptyMarloweState :: MarloweState
-emptyMarloweState =
-  { contract: Nothing
-  , editorErrors: mempty
+emptyMarloweState :: Maybe EM.Contract -> MarloweState
+emptyMarloweState mContract =
+  { editorErrors: mempty
   , editorWarnings: mempty
   , holes: mempty
-  , executionState: simulationNotStarted
+  , executionState: simulationNotStarted mContract
   }
 
-emptyMarloweStateWithSlot :: Slot -> MarloweState
-emptyMarloweStateWithSlot sn =
-  { contract: Nothing
-  , editorErrors: mempty
+emptyMarloweStateWithSlot :: Slot -> S.Contract -> MarloweState
+emptyMarloweStateWithSlot sn cont =
+  { editorErrors: mempty
   , editorWarnings: mempty
   , holes: mempty
-  , executionState: emptyExecutionStateWithSlot sn
+  , executionState: emptyExecutionStateWithSlot sn cont
   }
 
 --
@@ -277,8 +288,8 @@ _marloweState = prop (SProxy :: SProxy "marloweState")
 _currentMarloweState :: forall s. Lens' { marloweState :: NonEmptyList MarloweState | s } MarloweState
 _currentMarloweState = _marloweState <<< _Head
 
-_currentContract :: Lens' State (Maybe Contract)
-_currentContract = _currentMarloweState <<< _contract
+_currentContract :: forall s p. Strong p => Choice p => Optic' p { marloweState :: NonEmptyList MarloweState | s } Contract
+_currentContract = _currentMarloweState <<< _executionState <<< _SimulationRunning <<< _contract
 
 _helpContext :: Lens' State HelpContext
 _helpContext = prop (SProxy :: SProxy "helpContext")
@@ -289,7 +300,7 @@ _bottomPanelState = prop (SProxy :: SProxy "bottomPanelState")
 mkState :: State
 mkState =
   { showRightPanel: true
-  , marloweState: NEL.singleton emptyMarloweState
+  , marloweState: NEL.singleton (emptyMarloweState Nothing)
   , helpContext: MarloweHelp
   , bottomPanelState: BottomPanel.initialState CurrentStateView
   }

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -1,13 +1,12 @@
 module SimulationPage.View where
 
 import Prelude hiding (div)
-import BottomPanel.Types (_showBottomPanel)
-import BottomPanel.Types as BottomPanel
+import BottomPanel.Types as BottomPanelTypes
 import BottomPanel.View as BottomPanel
 import Data.Array (concatMap, intercalate, reverse, sortWith)
 import Data.Array as Array
 import Data.BigInteger (BigInteger, fromString, fromInt)
-import Data.Lens (has, only, to, view, (^.))
+import Data.Lens (has, only, previewOn, to, view, (^.))
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.NonEmptyList (_Head)
 import Data.Map (Map)
@@ -19,11 +18,10 @@ import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Halogen (RefLabel(..))
 import Halogen.Classes (aHorizontal, bold, btn, codeEditor, expanded, flex, fullHeight, group, justifyBetween, justifyCenter, noMargins, plusBtn, scroll, sidebarComposer, smallBtn, smallSpaceBottom, spaceBottom, spaceRight, spanText, textSecondaryColor, textXs, uppercase)
-import Halogen.Classes as Classes
 import Halogen.Extra (renderSubmodule)
 import Halogen.HTML (ClassName(..), ComponentHTML, HTML, aside, b_, br_, button, div, div_, em_, h6, h6_, input, li, p, p_, section, slot, span, span_, strong_, text, ul)
 import Halogen.HTML.Events (onClick, onValueChange)
-import Halogen.HTML.Properties (InputType(..), class_, classes, disabled, enabled, placeholder, type_, value)
+import Halogen.HTML.Properties (InputType(..), class_, classes, disabled, placeholder, type_, value)
 import Halogen.Monaco (Settings, monacoComponent)
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe.Monaco (daylightTheme, languageExtensionPoint)
@@ -33,7 +31,7 @@ import Monaco (Editor)
 import Monaco as Monaco
 import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
-import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId, BottomPanelView(..), ExecutionState(..), MarloweEvent(..), State, _SimulationRunning, _bottomPanelState, _contract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _showRightPanel, _slot, _transactionError, _transactionWarnings, otherActionsParty)
+import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId, BottomPanelView(..), ExecutionState(..), MarloweEvent(..), State, _SimulationRunning, _bottomPanelState, _currentContract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _showRightPanel, _slot, _transactionError, _transactionWarnings, otherActionsParty)
 import Simulator (hasHistory, inFuture)
 
 render ::
@@ -64,7 +62,7 @@ render state =
 
   showRightPanel = state ^. _showRightPanel
 
-  wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state panelView
+  wrapBottomPanelContents panelView = BottomPanelTypes.PanelAction <$> panelContents state panelView
 
 otherActions :: forall p. State -> HTML p Action
 otherActions state =
@@ -248,7 +246,7 @@ simulationStateWidget state =
   let
     currentSlot = state ^. (_currentMarloweState <<< _executionState <<< _SimulationRunning <<< _slot <<< to show)
 
-    expirationSlot = state ^. (_marloweState <<< _Head <<< _contract <<< to contractMaxTime)
+    expirationSlot = contractMaxTime (previewOn state _currentContract)
 
     contractMaxTime = case _ of
       Nothing -> "Closed"

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -9,14 +9,14 @@ import Data.BigInteger (BigInteger)
 import Data.BigInteger as BigInteger
 import Data.Either (Either(..))
 import Data.Foldable (foldl, for_, intercalate, traverse_)
-import Data.Lens (_Just, assign, has, modifying, over, preview, to, toArrayOf, traversed, use, (^.), (^?))
+import Data.Lens (_Just, assign, has, modifying, over, preview, previewOn, to, toArrayOf, traversed, use, (^.), (^?))
 import Data.Lens.Extra (peruse)
 import Data.Lens.Index (ix)
 import Data.List.NonEmpty as NEL
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Map.Lens (_MaxIndex, _NextIndex)
-import Data.Maybe (Maybe(..), fromMaybe, isNothing)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing, maybe)
 import Data.Newtype (unwrap)
 import Data.NonEmptyList.Extra (extendWith)
 import Data.NonEmptyList.Lens (_Tail)
@@ -38,14 +38,14 @@ import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), alt, class_, classes, enabled, placeholder, selected, src, type_, value)
 import Halogen.HTML.Properties (value) as HTML
 import Help (HelpContext(..), toHTML)
-import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
-import Marlowe.Semantics as S
 import Marlowe.Extended (toCore)
 import Marlowe.Extended as EM
 import Marlowe.Holes (fromTerm, gatherContractData)
 import Marlowe.Parser (parseContract)
+import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Contract(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
+import Marlowe.Semantics as S
 import Pretty (renderPrettyParty, renderPrettyPayee, renderPrettyToken, showPrettyMoney)
-import SimulationPage.Types (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _currentMarloweState, _marloweState, _executionState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput)
+import SimulationPage.Types (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _currentContract, _executionState, _marloweState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput)
 import Simulator (updateContractInStateP, updatePossibleActions, updateStateP)
 import Text.Extra (stripParens)
 import Text.Pretty (pretty)
@@ -133,7 +133,7 @@ handleQuery (LoadContract contractString next) = do
                 , owner: openWallet ^. _name
                 , parties: mempty
                 , started: false
-                , marloweState: NEL.singleton (emptyMarloweStateWithSlot slot)
+                , marloweState: NEL.singleton (emptyMarloweStateWithSlot slot contract)
                 }
             modifying _wallets (Map.union newWallets)
             assign _walletLoadedContract (Just loadedContract)
@@ -188,9 +188,10 @@ handleAction StartContract = do
     Nothing -> assign _loadContractError $ Just "Can't start since no contract has been loaded"
 
 handleAction ResetContract = do
+  mContract <- use _walletLoadedContract
   assign _slot zero
   assign (_contracts <<< traversed <<< _started) false
-  assign (_contracts <<< traversed <<< _marloweState) (NEL.singleton (emptyMarloweStateWithSlot zero))
+  assign (_contracts <<< traversed <<< _marloweState) (NEL.singleton (emptyMarloweStateWithSlot zero (maybe Close (\x -> x.contract) mContract)))
 
 handleAction ResetAll = do
   assign _initialized false
@@ -413,7 +414,7 @@ mainPanel state =
   contractString =
     fromMaybe mempty do
       contract <-
-        preview (_walletLoadedContract <<< _Just <<< _currentMarloweState <<< _contract <<< _Just) state
+        preview (_walletLoadedContract <<< _Just <<< _currentContract) state
           <|> preview (_walletLoadedContract <<< _Just <<< _contract) state
       pure $ show $ pretty contract
 
@@ -576,7 +577,7 @@ renderCurrentState state =
   div [ classes [ Classes.panelContents, active, ClassName "wallet-composer-state" ] ]
     [ div [ classes [ rTable, rTable4cols ] ]
         ( warningsRow <> errorRow
-            <> dataRow "Expiration Slot" (state ^. (_currentLoadedMarloweState <<< _contract <<< to contractMaxTime))
+            <> dataRow "Expiration Slot" (contractMaxTime (previewOn state (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _contract)))
             <> tableRow
                 { title: "Accounts"
                 , emptyMessage: "No accounts have been used"


### PR DESCRIPTION
In preparation for template instantiation, it is necessary to refactor the types in Simulator so that we use Core Marlowe for the simulation phase and Extended Marlowe for the instantiation phase.

There are also some vestiges of previous functionalities that are no longer used and clutter the implementation. For example, there is an `oldContract` field which @hrajchert already flagged with a comment, there is functionality for removing inputs which is not accessible anywhere, and there are snippets of code that are meant to do the same thing but either are implemented slightly differently or are just duplicated.

This PR:
- Adds "Start simulation" to history (so that it is affected by "Undo")
- Unifies calls to SendToSimulator
- Cleans-up and removes several spurious vestiges in Simulator
- Separates Contract into running and not running types

I am not very confident that I didn't break the Wallet emulator, but it is not accessible and I imagine we won't care much about it once we have the dashboard, so I thought it was not worth putting too much time into that at the moment.

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
