### PR TITLE
SCP-1687: use freer logging in Cardano.Node.Server

### DIFF
--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -72,7 +72,8 @@ import qualified Plutus.PAB.Core.ContractInstance                as Instance
 import           Plutus.PAB.Events.Contract                      (ContractInstanceId (..))
 import           Plutus.PAB.PABLogMsg                            (AppMsg (..), ChainIndexServerMsg,
                                                                   ContractExeLogMsg (..), MetadataLogMessage,
-                                                                  PABLogMsg (..), SigningProcessMsg, WalletMsg)
+                                                                  MockServerLogMsg, PABLogMsg (..), SigningProcessMsg,
+                                                                  WalletMsg)
 import           Plutus.PAB.Types                                (Config (Config), ContractExe (..), PABError,
                                                                   RequestProcessingConfig (..), chainIndexConfig,
                                                                   metadataServerConfig, nodeServerConfig,
@@ -444,7 +445,9 @@ runCliCommand trace _ Config {..} serviceAvailability MockWallet =
                 chainIndexUrl = ChainIndex.ciBaseUrl chainIndexConfig
 
 -- Run mock node server
-runCliCommand _ _ Config {nodeServerConfig} serviceAvailability MockNode = NodeServer.main nodeServerConfig serviceAvailability
+runCliCommand trace _ Config {nodeServerConfig} serviceAvailability MockNode = liftIO $ NodeServer.main t nodeServerConfig serviceAvailability
+    where
+        t = toMockNodeServerLog trace
 
 -- Run mock metadata server
 runCliCommand t _ Config {metadataServerConfig} serviceAvailability Metadata = liftIO $ Metadata.main trace metadataServerConfig serviceAvailability
@@ -588,6 +591,9 @@ toWalletLog = convertLog $ PABMsg . SWalletMsg
 
 toMetaDataLog :: Trace m AppMsg -> Trace m MetadataLogMessage
 toMetaDataLog = convertLog $ PABMsg . SMetaDataLogMsg
+
+toMockNodeServerLog :: Trace m AppMsg -> Trace m MockServerLogMsg
+toMockNodeServerLog = convertLog $ PABMsg . SMockserverLogMsg
 
 pabComponentName :: Text.Text
 pabComponentName = "pab"

--- a/plutus-pab/src/Cardano/Node/API.hs
+++ b/plutus-pab/src/Cardano/Node/API.hs
@@ -7,7 +7,7 @@ module Cardano.Node.API
     , FollowerAPI
     ) where
 
-import           Cardano.Node.Types      (FollowerID)
+import           Cardano.Node.Types      (FollowerID, MockServerLogMsg)
 import           Control.Monad.Freer.Log (LogMessage)
 import           Ledger                  (Block, Slot, Tx)
 import           Servant.API             (Capture, Get, JSON, NoContent, Post, Put, ReqBody, (:<|>), (:>))
@@ -23,7 +23,7 @@ type API
 -- Routes that are not guaranteed to exist on the real node
 type NodeAPI
      = "random-tx" :> Get '[ JSON] Tx
-       :<|> "consume-event-history" :> Post '[ JSON] [LogMessage ChainEvent]
+       :<|> "consume-event-history" :> Post '[ JSON] [LogMessage MockServerLogMsg]
 
 -- Protocol 1 of the node (node followers can request new blocks)
 type FollowerAPI

--- a/plutus-pab/src/Cardano/Node/API.hs
+++ b/plutus-pab/src/Cardano/Node/API.hs
@@ -11,7 +11,6 @@ import           Cardano.Node.Types      (FollowerID, MockServerLogMsg)
 import           Control.Monad.Freer.Log (LogMessage)
 import           Ledger                  (Block, Slot, Tx)
 import           Servant.API             (Capture, Get, JSON, NoContent, Post, Put, ReqBody, (:<|>), (:>))
-import           Wallet.Emulator.Chain   (ChainEvent)
 
 type API
      = "healthcheck" :> Get '[ JSON] NoContent

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -11,7 +11,7 @@ module Cardano.Node.Client where
 import           Cardano.Node.API          (API)
 import           Cardano.Node.Follower     (NodeFollowerEffect (..))
 import           Cardano.Node.RandomTx     (GenRandomTx (..))
-import           Cardano.Node.Types        (FollowerID)
+import           Cardano.Node.Types        (FollowerID, MockServerLogMsg)
 import           Control.Monad             (void)
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
@@ -22,13 +22,12 @@ import           Ledger                    (Block, Slot, Tx)
 import           Servant                   (NoContent, (:<|>) (..))
 import           Servant.Client            (ClientEnv, ClientError, ClientM, client, runClientM)
 import           Wallet.Effects            (NodeClientEffect (..))
-import           Wallet.Emulator.Chain     (ChainEvent)
 
 healthcheck :: ClientM NoContent
 getCurrentSlot :: ClientM Slot
 addTx :: Tx -> ClientM NoContent
 randomTx :: ClientM Tx
-consumeEventHistory :: ClientM [LogMessage ChainEvent]
+consumeEventHistory :: ClientM [LogMessage MockServerLogMsg]
 newFollower :: ClientM FollowerID
 getBlocks :: FollowerID -> ClientM [Block]
 (healthcheck, addTx, getCurrentSlot, randomTx, consumeEventHistory, newFollower, getBlocks) =

--- a/plutus-pab/src/Cardano/Node/Follower.hs
+++ b/plutus-pab/src/Cardano/Node/Follower.hs
@@ -14,11 +14,10 @@ import           Control.Monad.Freer.Extra.Log
 import           Control.Monad.Freer.Extra.State
 import           Control.Monad.Freer.State
 import           Control.Monad.Freer.TH          (makeEffect)
-import           Data.Text.Prettyprint.Doc       (Pretty (..), (<+>))
 
 import qualified Data.Map                        as Map
 
-import           Cardano.Node.Types              (FollowerID, NodeFollowerState, _NodeFollowerState)
+import           Cardano.Node.Types
 import           Ledger                          (Block, Slot)
 import           Wallet.Emulator.Chain           (ChainState)
 import qualified Wallet.Emulator.Chain           as Chain
@@ -30,20 +29,6 @@ data NodeFollowerEffect r where
 
 makeEffect ''NodeFollowerEffect
 
-data NodeFollowerLogMsg =
-    NewFollowerId FollowerID
-    | GetBlocksFor FollowerID
-    | LastBlock Int
-    | NewLastBlock Int
-    | GetCurrentSlot Slot
-
-instance Pretty NodeFollowerLogMsg where
-    pretty  = \case
-        NewFollowerId newID -> "New follower ID:" <+> pretty newID
-        GetBlocksFor i      -> "Get blocks for" <+> pretty i
-        LastBlock i         -> "Last block:" <+> pretty i
-        NewLastBlock i      -> "New last block:" <+> pretty i
-        GetCurrentSlot s    -> "Get current slot:" <+> pretty s
 
 handleNodeFollower ::
     ( Member (State ChainState) effs

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
 
 module Cardano.Node.Mock where
 
@@ -14,43 +12,37 @@ import           Control.Concurrent              (threadDelay)
 import           Control.Concurrent.MVar         (MVar, modifyMVar_, putMVar, takeMVar)
 import           Control.Lens                    (over, set, unto, view)
 import           Control.Monad                   (forever, unless, void)
-import           Control.Monad.Freer             (Eff, Member, interpret, reinterpret, runM)
+import           Control.Monad.Freer             (Eff, Member, interpret, reinterpret, runM, subsume)
 import           Control.Monad.Freer.Extras      (handleZoomedState)
-import           Control.Monad.Freer.Log         (LogMessage, handleLogWriter, mapLog, renderLogMessages)
+import           Control.Monad.Freer.Log         (LogMessage (..), handleLogWriter, mapLog, renderLogMessages)
 import           Control.Monad.Freer.Reader      (Reader)
 import qualified Control.Monad.Freer.Reader      as Eff
 import           Control.Monad.Freer.State       (State)
 import qualified Control.Monad.Freer.State       as Eff
 import qualified Control.Monad.Freer.Writer      as Eff
 import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import           Control.Monad.Logger            (MonadLogger, logDebugN)
 import           Data.Foldable                   (traverse_)
 import           Data.List                       (genericDrop)
 import           Data.Text                       (Text)
-import           Data.Text.Prettyprint.Doc       (Pretty (pretty), (<+>))
 import           Data.Time.Units                 (Second, toMicroseconds)
 import           Data.Time.Units.Extra           ()
 import           Servant                         (NoContent (NoContent))
 
-import           Ledger                          (Block, Slot (Slot), Tx)
-
-import qualified Ledger
-import           Ledger.Tx                       (outputs)
-
-import           Cardano.Node.Follower           (NodeFollowerEffect, NodeFollowerLogMsg)
+import           Cardano.BM.Data.Trace           (Trace)
+import           Cardano.Node.Follower           (NodeFollowerEffect)
 import           Cardano.Node.RandomTx
-import           Cardano.Node.Types              as T
+import           Cardano.Node.Types
 import           Cardano.Protocol.ChainEffect    as CE
 import           Cardano.Protocol.FollowerEffect as FE
 import qualified Cardano.Protocol.Socket.Client  as Client
 import qualified Cardano.Protocol.Socket.Server  as Server
 import           Control.Monad.Freer.Extra.Log
-
+import           Ledger                          (Block, Slot (Slot), Tx)
+import           Ledger.Tx                       (outputs)
 import           Plutus.PAB.Arbitrary            ()
-import           Plutus.PAB.Utils                (tshow)
-
+import           Plutus.PAB.Monitoring           (runLogEffects)
 import qualified Wallet.Emulator                 as EM
-import           Wallet.Emulator.Chain           (ChainControlEffect, ChainEffect, ChainEvent, ChainState)
+import           Wallet.Emulator.Chain           (ChainControlEffect, ChainEffect, ChainState)
 import qualified Wallet.Emulator.Chain           as Chain
 
 healthcheck :: Monad m => m NoContent
@@ -59,21 +51,13 @@ healthcheck = pure NoContent
 getCurrentSlot :: (Member (State ChainState) effs) => Eff effs Slot
 getCurrentSlot = Eff.gets (view EM.currentSlot)
 
-data MockNodeLogMsg =
-        AddingSlot
-        | AddingTx Tx
-
-instance Pretty MockNodeLogMsg where
-    pretty AddingSlot   = "Adding slot"
-    pretty (AddingTx t) = "AddingTx" <+> pretty (Ledger.txId t)
-
 addBlock ::
-    ( Member (LogMsg MockNodeLogMsg) effs
+    ( Member (LogMsg MockServerLogMsg) effs
     , Member ChainControlEffect effs
     )
     => Eff effs ()
 addBlock = do
-    logInfo AddingSlot
+    logInfo $ BlockOperation NewSlot
     void Chain.processBlock
 
 getBlocksSince ::
@@ -87,7 +71,7 @@ getBlocksSince (Slot slotNumber) = do
     chainNewestFirst <- Eff.gets (view Chain.chainNewestFirst)
     pure $ genericDrop slotNumber $ reverse chainNewestFirst
 
-consumeEventHistory :: MonadIO m => MVar AppState -> m [LogMessage ChainEvent]
+consumeEventHistory :: MonadIO m => MVar AppState -> m [LogMessage MockServerLogMsg]
 consumeEventHistory stateVar =
     liftIO $ do
         oldState <- takeMVar stateVar
@@ -96,38 +80,28 @@ consumeEventHistory stateVar =
         putMVar stateVar newState
         pure events
 
-addTx :: (Member (LogMsg MockNodeLogMsg) effs, Member ChainEffect effs) => Tx -> Eff effs NoContent
+addTx :: (Member (LogMsg MockServerLogMsg) effs, Member ChainEffect effs) => Tx -> Eff effs NoContent
 addTx tx = do
-    logInfo $ AddingTx tx
+    logInfo $ BlockOperation $ NewTransaction tx
     Chain.queueTx tx
     pure NoContent
 
-data NodeServerMsg =
-    NodeServerFollowerMsg NodeFollowerLogMsg
-    | NodeGenRandomTxMsg GenRandomTxMsg
-    | NodeMockNodeMsg MockNodeLogMsg
 
-instance Pretty NodeServerMsg where
-    pretty = \case
-        NodeServerFollowerMsg m -> pretty m
-        NodeGenRandomTxMsg m    -> pretty m
-        NodeMockNodeMsg m       -> pretty m
 
 type NodeServerEffects m
      = '[ GenRandomTx
-        , LogMsg GenRandomTxMsg
+        , LogMsg MockServerLogMsg
         , NodeFollowerEffect
         , LogMsg NodeFollowerLogMsg
         , ChainControlEffect
         , ChainEffect
         , State NodeFollowerState
         , State ChainState
-        , LogMsg ChainEvent
+        , LogMsg MockServerLogMsg
         , Reader Client.ClientHandler
         , Reader Server.ServerHandler
         , State AppState
-        , LogMsg MockNodeLogMsg
-        , LogMsg NodeServerMsg
+        , LogMsg MockServerLogMsg
         , LogMsg Text
         , m]
 
@@ -137,26 +111,27 @@ runChainEffects ::
  -> Client.ClientHandler
  -> MVar AppState
  -> Eff (NodeServerEffects IO) a
- -> IO ([LogMessage ChainEvent], a)
+ -> IO ([LogMessage MockServerLogMsg], a)
 runChainEffects serverHandler clientHandler stateVar eff = do
     oldAppState <- liftIO $ takeMVar stateVar
     ((a, events), newState) <- liftIO
         $ runM
         $ runStderrLog
         $ interpret renderLogMessages
-        $ interpret (mapLog NodeMockNodeMsg)
         $ Eff.runState oldAppState
         $ Eff.runReader serverHandler
         $ Eff.runReader clientHandler
         $ Eff.runWriter
-        $ reinterpret (handleLogWriter @ChainEvent @[LogMessage ChainEvent] (unto return))
-        $ interpret (handleZoomedState T.chainState)
-        $ interpret (handleZoomedState T.followerState)
-        $ CE.handleChain
-        $ interpret Chain.handleControlChain
-        $ interpret (mapLog NodeServerFollowerMsg)
+        $ reinterpret (handleLogWriter @MockServerLogMsg @[LogMessage MockServerLogMsg] (unto return))
+        $ interpret (handleZoomedState chainState)
+        $ interpret (handleZoomedState followerState)
+        $ interpret (mapLog ProcessingChainEvent)
+        $ reinterpret CE.handleChain
+        $ interpret (mapLog ProcessingChainEvent)
+        $ reinterpret Chain.handleControlChain
+        $ interpret (mapLog FollowerMsg)
         $ FE.handleNodeFollower
-        $ interpret (mapLog NodeGenRandomTxMsg)
+        $ subsume
         $ runGenRandomTx
         $ do result <- eff
              void Chain.processBlock
@@ -165,15 +140,15 @@ runChainEffects serverHandler clientHandler stateVar eff = do
     pure (events, a)
 
 processChainEffects ::
-       (MonadIO m, MonadLogger m)
-    => Server.ServerHandler
+    Trace IO MockServerLogMsg
+    -> Server.ServerHandler
     -> Client.ClientHandler
     -> MVar AppState
     -> Eff (NodeServerEffects IO) a
-    -> m a
-processChainEffects serverHandler clientHandler stateVar eff = do
+    -> IO a
+processChainEffects trace serverHandler clientHandler stateVar eff = do
     (events, result) <- liftIO $ runChainEffects serverHandler clientHandler stateVar eff
-    traverse_ (\event -> logDebugN $ "Event: " <> tshow (pretty event)) events
+    runLogEffects trace $ traverse_ (\(LogMessage _ chainEvent) -> logDebug chainEvent) events
     liftIO $
         modifyMVar_
             stateVar
@@ -183,46 +158,47 @@ processChainEffects serverHandler clientHandler stateVar eff = do
 -- | Calls 'addBlock' at the start of every slot, causing pending transactions
 --   to be validated and added to the chain.
 slotCoordinator ::
-    (MonadIO m, MonadLogger m)
- => Second
+    Trace IO MockServerLogMsg
+ ->  Second
  -> Server.ServerHandler
  -> Client.ClientHandler
  -> MVar AppState
- -> m ()
-slotCoordinator slotLength serverHandler clientHandler stateVar =
+ -> IO a
+slotCoordinator trace slotLength serverHandler clientHandler stateVar =
     forever $ do
-        void $ processChainEffects serverHandler clientHandler stateVar addBlock
+        void $ processChainEffects trace serverHandler clientHandler stateVar addBlock
         liftIO $ threadDelay $ fromIntegral $ toMicroseconds slotLength
 
 -- | Generates a random transaction once in each 'mscRandomTxInterval' of the
 --   config
 transactionGenerator ::
-    (MonadIO m, MonadLogger m)
- => Second
+  Trace IO MockServerLogMsg
+ -> Second
  -> Server.ServerHandler
  -> Client.ClientHandler
  -> MVar AppState
- -> m ()
-transactionGenerator itvl serverHandler clientHandler stateVar =
+ -> IO ()
+transactionGenerator trace interval serverHandler clientHandler stateVar =
     forever $ do
-        liftIO $ threadDelay $ fromIntegral $ toMicroseconds itvl
-        processChainEffects serverHandler clientHandler stateVar $ do
+        liftIO $ threadDelay $ fromIntegral $ toMicroseconds interval
+        processChainEffects trace serverHandler clientHandler stateVar $ do
             tx' <- genRandomTx
             unless (null $ view outputs tx') (void $ addTx tx')
 
 -- | Discards old blocks according to the 'BlockReaperConfig'. (avoids memory
 --   leak)
 blockReaper ::
-    (MonadIO m, MonadLogger m)
- => BlockReaperConfig
+  Trace IO MockServerLogMsg
+ -> BlockReaperConfig
  -> Server.ServerHandler
  -> Client.ClientHandler
  -> MVar AppState
- -> m ()
-blockReaper BlockReaperConfig {brcInterval, brcBlocksToKeep} serverHandler clientHandler stateVar =
+ -> IO ()
+blockReaper tracer BlockReaperConfig {brcInterval, brcBlocksToKeep} serverHandler clientHandler stateVar =
     forever $ do
         void $
             processChainEffects
+                tracer
                 serverHandler
                 clientHandler
                 stateVar

--- a/plutus-pab/src/Cardano/Node/RandomTx.hs
+++ b/plutus-pab/src/Cardano/Node/RandomTx.hs
@@ -10,7 +10,6 @@
 module Cardano.Node.RandomTx(
     -- $randomTx
     GenRandomTx(..)
-    , GenRandomTxMsg(..)
     , generateTx
     , genRandomTx
     , runGenRandomTx
@@ -28,7 +27,6 @@ import           Data.List.NonEmpty            (NonEmpty (..))
 import qualified Data.Map                      as Map
 import           Data.Maybe                    (fromMaybe)
 import qualified Data.Set                      as Set
-import           Data.Text.Prettyprint.Doc     (Pretty (..))
 import qualified Hedgehog.Gen                  as Gen
 import           System.Random.MWC             as MWC
 
@@ -44,6 +42,7 @@ import qualified Ledger.Tx                     as Tx
 import qualified Wallet.Emulator               as EM
 import           Wallet.Emulator.Chain         (ChainState)
 
+import           Cardano.Node.Types            (MockServerLogMsg (..))
 import           Control.Monad.Freer.Extra.Log
 
 -- $randomTx
@@ -54,14 +53,10 @@ data GenRandomTx r where
 
 makeEffect ''GenRandomTx
 
-data GenRandomTxMsg = GeneratingRandomTransaction
-
-instance Pretty GenRandomTxMsg where
-    pretty GeneratingRandomTransaction = "Generating a random transaction"
 
 runGenRandomTx ::
        ( Member (State ChainState) effs
-       , Member (LogMsg GenRandomTxMsg) effs
+       , Member (LogMsg MockServerLogMsg) effs
        , LastMember m effs
        , MonadIO m
        )
@@ -71,7 +66,7 @@ runGenRandomTx =
     Eff.interpret $ \case
       GenRandomTx -> do
         chainState <- Eff.get
-        logDebug GeneratingRandomTransaction
+        logDebug CreatingRandomTransaction
         Eff.sendM $
           liftIO $ do
             gen <- MWC.createSystemRandom

--- a/plutus-pab/src/Cardano/Node/Server.hs
+++ b/plutus-pab/src/Cardano/Node/Server.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Cardano.Node.Server
@@ -11,14 +11,15 @@ module Cardano.Node.Server
 import           Control.Concurrent              (MVar, forkIO, newMVar)
 import           Control.Concurrent.Availability (Availability, available)
 import           Control.Monad                   (void)
-import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import           Control.Monad.Logger            (logInfoN, runStdoutLoggingT)
+import           Control.Monad.Freer.Extra.Log   (logInfo)
+import           Control.Monad.IO.Class          (liftIO)
 import           Data.Function                   ((&))
 import           Data.Proxy                      (Proxy (Proxy))
 import qualified Network.Wai.Handler.Warp        as Warp
 import           Servant                         (Application, hoistServer, serve, (:<|>) ((:<|>)))
 import           Servant.Client                  (BaseUrl (baseUrlPort))
 
+import           Cardano.BM.Data.Trace           (Trace)
 import           Cardano.Node.API                (API)
 import           Cardano.Node.Follower           (getBlocks, newFollower)
 import           Cardano.Node.Mock
@@ -26,63 +27,61 @@ import           Cardano.Node.RandomTx           (genRandomTx)
 import           Cardano.Node.Types
 import qualified Cardano.Protocol.Socket.Client  as Client
 import qualified Cardano.Protocol.Socket.Server  as Server
-
 import           Plutus.PAB.Arbitrary            ()
-import           Plutus.PAB.Utils                (tshow)
+import           Plutus.PAB.Monitoring           (runLogEffects)
 
 app ::
-    Server.ServerHandler
+ Trace IO MockServerLogMsg
+ -> Server.ServerHandler
  -> Client.ClientHandler
  -> MVar AppState
  -> Application
-app serverHandler clientHandler stateVar =
+app trace serverHandler clientHandler stateVar =
     serve (Proxy @API) $
     hoistServer
         (Proxy @API)
-        (runStdoutLoggingT . processChainEffects serverHandler clientHandler stateVar)
+        (liftIO . processChainEffects trace serverHandler clientHandler stateVar)
         (healthcheck :<|> addTx :<|> getCurrentSlot :<|>
          (genRandomTx :<|>
           consumeEventHistory stateVar) :<|>
-          (newFollower :<|> getBlocks)
-          )
+          (newFollower :<|> getBlocks))
 
-main :: MonadIO m => MockServerConfig -> Availability -> m ()
-main MockServerConfig { mscBaseUrl
-                      , mscRandomTxInterval
-                      , mscBlockReaper
-                      , mscSlotLength
-                      , mscInitialTxWallets
-                      , mscSocketPath
-                      } availability =
-    runStdoutLoggingT $ do
-        serverHandler <- liftIO $
-            Server.runServerNode mscSocketPath (_chainState $ initialAppState mscInitialTxWallets)
-        clientHandler <- liftIO $ Client.runClientNode mscSocketPath
-        -- Local chain state (node client)
-        clientStateVar <- liftIO $ newMVar (initialAppState mscInitialTxWallets)
-        -- Global chain state (node server)
-        serverStateVar <- liftIO $ newMVar (initialAppState mscInitialTxWallets)
+data Ctx = Ctx { serverHandler :: Server.ServerHandler
+               , clientHandler :: Client.ClientHandler
+               , serverState   ::  MVar AppState
+               , clientState   :: MVar AppState
+               , mockTrace     :: Trace IO MockServerLogMsg
+               }
 
-        logInfoN "Starting slot coordination thread."
-        void $
-            liftIO $
-            forkIO $ runStdoutLoggingT $ slotCoordinator mscSlotLength serverHandler clientHandler serverStateVar
-        case mscRandomTxInterval of
-            Nothing -> logInfoN "No random transactions will be generated."
-            Just i -> do
-                logInfoN "Starting transaction generator thread."
-                void $
-                    liftIO $
-                    forkIO $ runStdoutLoggingT $ transactionGenerator i serverHandler clientHandler serverStateVar
-        case mscBlockReaper of
-            Nothing -> logInfoN "Old blocks will be kept in memory forever"
-            Just cfg -> do
-                logInfoN "Starting block reaper thread."
-                void $
-                    liftIO $
-                    forkIO $ runStdoutLoggingT $ blockReaper cfg serverHandler clientHandler serverStateVar
-        let mscPort = baseUrlPort mscBaseUrl
-        let warpSettings :: Warp.Settings
-            warpSettings = Warp.defaultSettings & Warp.setPort mscPort & Warp.setBeforeMainLoop (available availability)
-        logInfoN $ "Starting mock node server on port: " <> tshow mscPort
-        liftIO $ Warp.runSettings warpSettings $ app serverHandler clientHandler clientStateVar
+main :: Trace IO MockServerLogMsg -> MockServerConfig -> Availability -> IO ()
+main trace MockServerConfig {..} availability = runLogEffects trace $ do
+    serverHandler <- liftIO $ Server.runServerNode mscSocketPath (_chainState $ initialAppState mscInitialTxWallets)
+    clientHandler <- liftIO $ Client.runClientNode mscSocketPath
+    clientState <- liftIO $ newMVar (initialAppState mscInitialTxWallets)
+    serverState <- liftIO $ newMVar (initialAppState mscInitialTxWallets)
+
+    let ctx = Ctx serverHandler clientHandler serverState clientState trace
+
+    runSlotCoordinator ctx mscSlotLength
+    maybe (logInfo NoRandomTxGeneration) (runRandomTxGeneration ctx) mscRandomTxInterval
+    maybe (logInfo KeepingOldBlocks) (runBlockReaper ctx) mscBlockReaper
+
+    logInfo $ StartingMockServer servicePort
+    liftIO $ Warp.runSettings warpSettings $ app trace serverHandler clientHandler clientState
+
+        where
+            servicePort = baseUrlPort mscBaseUrl
+
+            warpSettings = Warp.defaultSettings & Warp.setPort servicePort & Warp.setBeforeMainLoop (available availability)
+
+            runRandomTxGeneration Ctx {..} randomTxInterval = do
+                logInfo StartingRandomTx
+                void $ liftIO $ forkIO $ transactionGenerator trace randomTxInterval serverHandler clientHandler serverState
+
+            runBlockReaper Ctx {..} reaperConfig = do
+                logInfo RemovingOldBlocks
+                void $ liftIO $ forkIO $ blockReaper trace reaperConfig serverHandler clientHandler serverState
+
+            runSlotCoordinator Ctx {..} slotLength = do
+                logInfo StartingSlotCoordination
+                void $ liftIO $ forkIO $ slotCoordinator trace slotLength serverHandler clientHandler serverState

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -8,12 +8,38 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
 
-module Cardano.Node.Types where
+{-| This module exports data types for logging, events and configuration
+-}
+module Cardano.Node.Types
+    (
+      -- * Logging types
+      MockServerLogMsg (..)
+    , NodeFollowerLogMsg (..)
+    , FollowerID
 
-import           Cardano.BM.Data.Tracer         (ToObject (..))
-import           Cardano.BM.Data.Tracer.Extras  (Tagged (..), mkObjectStr)
-import           Control.Lens                   (Iso', iso, makeLenses, view)
-import           Control.Monad.Freer.Log        (LogMessage)
+     -- * Event types
+    , BlockEvent (..)
+
+     -- *  State types
+    , AppState (..)
+    , NodeFollowerState (..)
+    , _NodeFollowerState
+    , initialAppState
+    , initialChainState
+    , initialFollowerState
+
+    -- * Lens functions
+    , chainState
+    , eventHistory
+    , followerState
+
+    -- * Config types
+    , MockServerConfig (..)
+    , BlockReaperConfig (..)
+    )
+        where
+
+import           Control.Lens                   (makeLenses, makePrisms, view)
 import           Data.Aeson                     (FromJSON, ToJSON)
 import           Data.Map                       (Map)
 import qualified Data.Map                       as Map
@@ -21,67 +47,27 @@ import           Data.Text.Prettyprint.Doc      (Pretty (..), pretty, (<+>))
 import           Data.Time.Units                (Second)
 import           Data.Time.Units.Extra          ()
 import           GHC.Generics                   (Generic)
-import qualified Language.Plutus.Contract.Trace as Trace
 import           Ledger                         (Slot, Tx, txId)
 import           Servant                        (FromHttpApiData, ToHttpApiData)
 import           Servant.Client                 (BaseUrl)
+
+import           Cardano.BM.Data.Tracer         (ToObject (..))
+import           Cardano.BM.Data.Tracer.Extras  (Tagged (..), mkObjectStr)
+import           Control.Monad.Freer.Log        (LogMessage)
+import qualified Language.Plutus.Contract.Trace as Trace
 import           Wallet.Emulator                (Wallet)
 import qualified Wallet.Emulator                as EM
 import           Wallet.Emulator.Chain          (ChainEvent, ChainState)
 import qualified Wallet.Emulator.MultiAgent     as MultiAgent
 
-data BlockReaperConfig =
-    BlockReaperConfig
-        { brcInterval     :: Second
-        , brcBlocksToKeep :: Int
-        }
-    deriving (Show, Eq, Generic, FromJSON)
 
+-- Configuration ------------------------------------------------------------------------------------------------------
 
-data GenRandomTxMsg = GeneratingRandomTransaction
-
-instance Pretty GenRandomTxMsg where
-    pretty GeneratingRandomTransaction = "Generating a random transaction"
-
-data NodeFollowerLogMsg =
-    NewFollowerId FollowerID
-    | GetBlocksFor FollowerID
-    | LastBlock Int
-    | NewLastBlock Int
-    | GetCurrentSlot Slot
-    deriving (Show, Eq, Generic, FromJSON, ToJSON)
-
-instance Pretty NodeFollowerLogMsg where
-    pretty  = \case
-        NewFollowerId newID -> "New follower ID:" <+> pretty newID
-        GetBlocksFor i      -> "Get blocks for" <+> pretty i
-        LastBlock i         -> "Last block:" <+> pretty i
-        NewLastBlock i      -> "New last block:" <+> pretty i
-        GetCurrentSlot s    -> "Get current slot:" <+> pretty s
-
-instance ToObject NodeFollowerLogMsg where
-    toObject _ = \case
-        NewFollowerId fId  -> mkObjectStr "new follower id" (Tagged @"id" fId)
-        GetBlocksFor bId   -> mkObjectStr "Get blocks for " (Tagged @"id" bId)
-        LastBlock bId      -> mkObjectStr "Last block" (Tagged @"id" bId)
-        NewLastBlock bId   -> mkObjectStr "New last block" (Tagged @"id" bId)
-        GetCurrentSlot bId -> mkObjectStr "Get current slot" (Tagged @"id" bId)
-
-data NodeServerMsg =
-    NodeServerFollowerMsg NodeFollowerLogMsg
-    | NodeGenRandomTxMsg GenRandomTxMsg
-    | NodeMockNodeMsg MockNodeLogMsg
-
-
-instance Pretty NodeServerMsg where
-    pretty = \case
-        NodeServerFollowerMsg m -> pretty m
-        NodeGenRandomTxMsg m    -> pretty m
-        NodeMockNodeMsg m       -> pretty m
-
+-- | Mock Node server configuration
 data MockServerConfig =
     MockServerConfig
         { mscBaseUrl          :: BaseUrl
+        -- ^ base url of the service
         , mscSlotLength       :: Second
         -- ^ Duration of one slot
         , mscRandomTxInterval :: Maybe Second
@@ -95,45 +81,19 @@ data MockServerConfig =
         }
     deriving (Show, Eq, Generic, FromJSON)
 
+-- | Configuration for 'Cardano.Node.Mock.blockReaper'
+data BlockReaperConfig =
+    BlockReaperConfig
+        { brcInterval     :: Second -- ^ interval in seconds for discarding blocks
+        , brcBlocksToKeep :: Int    -- ^ number of blocks to keep
+        }
+    deriving (Show, Eq, Generic, FromJSON)
 
 
-data MockNodeLogMsg =
-        AddingSlot
-        | AddingTx Tx
+-- Logging ------------------------------------------------------------------------------------------------------------
 
-instance Pretty MockNodeLogMsg where
-    pretty AddingSlot   = "Adding slot"
-    pretty (AddingTx t) = "AddingTx" <+> pretty (Ledger.txId t)
-
-initialChainState :: Trace.InitialDistribution -> ChainState
-initialChainState =
-    view EM.chainState .
-    MultiAgent.emulatorStateInitialDist . Map.mapKeys EM.walletPubKey
-
-
-newtype NodeFollowerState = NodeFollowerState { _unNodeFollowerState :: Map FollowerID Int }
-    deriving (Show)
-
-_NodeFollowerState :: Iso' NodeFollowerState (Map FollowerID Int)
-_NodeFollowerState = iso _unNodeFollowerState NodeFollowerState
-
-initialFollowerState :: NodeFollowerState
-initialFollowerState = NodeFollowerState Map.empty
-
-newtype FollowerID = FollowerID Int
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving newtype (ToJSON, FromJSON, ToHttpApiData, FromHttpApiData, Integral, Enum, Real, Num, Pretty)
-
-
-data BlockEvent = NewSlot
-    | NewTransaction Tx
-    deriving (Generic, Show, ToJSON, FromJSON)
-
-instance Pretty BlockEvent where
-    pretty = \case
-        NewSlot          -> "Adding a new slot"
-        NewTransaction t -> "Adding a transaction " <+> pretty (Ledger.txId t)
-
+-- | Top-level logging data type for structural logging
+-- inside the Mock Node server.
 data MockServerLogMsg =
     StartingSlotCoordination
     | NoRandomTxGeneration
@@ -170,14 +130,62 @@ instance ToObject MockServerLogMsg where
         StartingSlotCoordination  ->  mkObjectStr "" ()
         ProcessingChainEvent e    ->  mkObjectStr "Processing chain event" (Tagged @"event" e)
         BlockOperation e          ->  mkObjectStr "Block operation" (Tagged @"event" e)
-        CreatingRandomTransaction -> mkObjectStr "Creating random transaction" ()
+        CreatingRandomTransaction ->  mkObjectStr "Creating random transaction" ()
         FollowerMsg m             -> toObject v m
 
+-- | logging type for 'Cardano.Node.Follower'
+data NodeFollowerLogMsg =
+    NewFollowerId FollowerID
+    | GetBlocksFor FollowerID
+    | LastBlock Int
+    | NewLastBlock Int
+    | GetCurrentSlot Slot
+    deriving (Show, Eq, Generic, FromJSON, ToJSON)
+
+instance Pretty NodeFollowerLogMsg where
+    pretty  = \case
+        NewFollowerId newID -> "New follower ID:" <+> pretty newID
+        GetBlocksFor i      -> "Get blocks for" <+> pretty i
+        LastBlock i         -> "Last block:" <+> pretty i
+        NewLastBlock i      -> "New last block:" <+> pretty i
+        GetCurrentSlot s    -> "Get current slot:" <+> pretty s
+
+instance ToObject NodeFollowerLogMsg where
+    toObject _ = \case
+        NewFollowerId fId  -> mkObjectStr "new follower id" (Tagged @"id" fId)
+        GetBlocksFor bId   -> mkObjectStr "Get blocks for " (Tagged @"id" bId)
+        LastBlock bId      -> mkObjectStr "Last block" (Tagged @"id" bId)
+        NewLastBlock bId   -> mkObjectStr "New last block" (Tagged @"id" bId)
+        GetCurrentSlot bId -> mkObjectStr "Get current slot" (Tagged @"id" bId)
+
+newtype FollowerID = FollowerID Int
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving newtype (ToJSON, FromJSON, ToHttpApiData, FromHttpApiData, Integral, Enum, Real, Num, Pretty)
+
+data BlockEvent = NewSlot
+    | NewTransaction Tx
+    deriving (Generic, Show, ToJSON, FromJSON)
+
+instance Pretty BlockEvent where
+    pretty = \case
+        NewSlot          -> "Adding a new slot"
+        NewTransaction t -> "Adding a transaction " <+> pretty (Ledger.txId t)
+
+
+-- State --------------------------------------------------------------------------------------------------------------
+
+
+newtype NodeFollowerState = NodeFollowerState { unNodeFollowerState :: Map FollowerID Int }
+    deriving (Show)
+
+makePrisms 'NodeFollowerState
+
+-- | Application State
 data AppState =
     AppState
-        { _chainState    :: ChainState
-        , _eventHistory  :: [LogMessage MockServerLogMsg]
-        , _followerState :: NodeFollowerState
+        { _chainState    :: ChainState -- ^ blockchain state
+        , _eventHistory  :: [LogMessage MockServerLogMsg] -- ^ history of all log messages
+        , _followerState :: NodeFollowerState -- ^ follower state
         }
     deriving (Show)
 
@@ -192,3 +200,13 @@ initialAppState wallets =
         , _eventHistory = mempty
         , _followerState = initialFollowerState
         }
+
+-- | Empty initial 'NodeFollowerState'
+initialFollowerState :: NodeFollowerState
+initialFollowerState = NodeFollowerState Map.empty
+
+-- | 'ChainState' with initial values
+initialChainState :: Trace.InitialDistribution -> ChainState
+initialChainState =
+    view EM.chainState .
+    MultiAgent.emulatorStateInitialDist . Map.mapKeys EM.walletPubKey

--- a/plutus-pab/src/Cardano/Protocol/ChainEffect.hs
+++ b/plutus-pab/src/Cardano/Protocol/ChainEffect.hs
@@ -47,8 +47,8 @@ handleChain ::
     , LastMember m effs
     , MonadIO m
     )
- => Eff (EC.ChainEffect ': effs) ~> Eff effs
-handleChain = interpret $ \case
+ => EC.ChainEffect ~> Eff effs
+handleChain =  \case
   EC.QueueTx tx -> do
     clientHandler <- ask
     liftIO $ Client.queueTx clientHandler tx

--- a/plutus-pab/src/Cardano/Protocol/FollowerEffect.hs
+++ b/plutus-pab/src/Cardano/Protocol/FollowerEffect.hs
@@ -14,7 +14,7 @@ import           Control.Monad.IO.Class
 import           Data.Foldable                  (traverse_)
 
 import qualified Cardano.Node.Follower          as NF
-import qualified Cardano.Node.Types             as NT
+import           Cardano.Node.Types
 import qualified Cardano.Protocol.Socket.Client as Client
 import           Ledger                         (Block)
 import           Wallet.Emulator.Chain          (ChainState (..), addBlock)
@@ -23,9 +23,9 @@ import           Wallet.Emulator.Chain          (ChainState (..), addBlock)
      a follower effect. -}
 handleNodeFollower
   :: ( Member (State ChainState) effs
-     , Member (State NT.NodeFollowerState) effs
+     , Member (State NodeFollowerState) effs
      , Member (Reader Client.ClientHandler) effs
-     , Member (LogMsg NF.NodeFollowerLogMsg) effs
+     , Member (LogMsg NodeFollowerLogMsg) effs
      , LastMember m effs
      , MonadIO m
      )

--- a/plutus-pab/src/Plutus/PAB/Effects/MultiAgent.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/MultiAgent.hs
@@ -53,9 +53,9 @@ import           Eventful.Store.Memory              (EventMap, emptyEventMap)
 
 import           Cardano.ChainIndex.Server          (ChainIndexServerMsg)
 import qualified Cardano.ChainIndex.Types           as CI
-import           Cardano.Node.Follower              (NodeFollowerEffect, NodeFollowerLogMsg)
+import           Cardano.Node.Follower              (NodeFollowerEffect)
 import qualified Cardano.Node.Follower              as NF
-import qualified Cardano.Node.Types                 as NF
+import           Cardano.Node.Types
 import           Ledger.Slot                        (Slot)
 
 import           Plutus.PAB.Core                    (CoreMsg)
@@ -173,7 +173,7 @@ type PABControlEffects =
 type MultiAgentEffs =
     '[State (Map Wallet AgentState)
     , State Chain.ChainState
-    , State NF.NodeFollowerState
+    , State NodeFollowerState
     , Error WalletAPIError
     , Chain.ChainEffect
     , Error PABError

--- a/plutus-pab/src/Plutus/PAB/MockApp.hs
+++ b/plutus-pab/src/Plutus/PAB/MockApp.hs
@@ -33,7 +33,7 @@ module Plutus.PAB.MockApp
     , blockchainNewestFirst
     ) where
 
-import           Cardano.Node.Types                    (NodeFollowerState)
+import           Cardano.Node.Types                    (MockServerLogMsg, NodeFollowerState)
 import qualified Cardano.Node.Types                    as NodeServer
 import           Control.Lens                          hiding (use)
 import           Control.Monad                         (void)
@@ -70,7 +70,7 @@ import           Test.QuickCheck.Instances.UUID        ()
 
 import qualified Cardano.ChainIndex.Server             as ChainIndex
 import qualified Cardano.ChainIndex.Types              as ChainIndex
-import           Cardano.Node.Follower                 (NodeFollowerLogMsg)
+import           Cardano.Node.Types                    (NodeFollowerLogMsg)
 import           Wallet.API                            (WalletAPIError)
 import           Wallet.Emulator.Chain                 (ChainControlEffect, ChainEffect, ChainEvent, ChainState,
                                                         handleChain, handleControlChain)
@@ -124,7 +124,7 @@ type MockAppEffects =
 
 data MockAppReport =
     MockAppReport
-        { marFinalChainEvents      :: [LogMessage ChainEvent]
+        { marFinalChainEvents      :: [LogMessage MockServerLogMsg]
         , marFinalEmulatorEvents   :: [LogMessage MockAppLog]
         , marFinalChainIndexEvents :: [LogMessage ChainIndexEvent]
         }

--- a/plutus-pab/src/Plutus/PAB/PABLogMsg.hs
+++ b/plutus-pab/src/Plutus/PAB/PABLogMsg.hs
@@ -14,6 +14,7 @@ module Plutus.PAB.PABLogMsg(
     SigningProcessMsg,
     MetadataLogMessage,
     WalletMsg,
+    MockServerLogMsg,
     AppMsg(..)
     ) where
 
@@ -30,6 +31,7 @@ import           Cardano.BM.Data.Tracer             (ToObject (..), TracingVerbo
 import           Cardano.BM.Data.Tracer.Extras      (Tagged (..), mkObjectStr)
 import           Cardano.ChainIndex.Types           (ChainIndexServerMsg)
 import           Cardano.Metadata.Types             (MetadataLogMessage)
+import           Cardano.Node.Types                 (MockServerLogMsg)
 import           Cardano.SigningProcess.Types       (SigningProcessMsg)
 import           Cardano.Wallet.Types               (WalletMsg)
 import           Language.Plutus.Contract.State     (ContractRequest)
@@ -88,6 +90,7 @@ data PABLogMsg =
     | SSigningProcessMsg SigningProcessMsg
     | SWalletMsg WalletMsg
     | SMetaDataLogMsg MetadataLogMessage
+    | SMockserverLogMsg MockServerLogMsg
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -105,6 +108,7 @@ instance Pretty PABLogMsg where
         SSigningProcessMsg m   -> pretty m
         SWalletMsg m           -> pretty m
         SMetaDataLogMsg m      -> pretty m
+        SMockserverLogMsg m    -> pretty m
 
 
 -- | Messages from the Signing Process
@@ -209,6 +213,7 @@ instance ToObject PABLogMsg where
         SSigningProcessMsg m   -> toObject v m
         SWalletMsg m           -> toObject v m
         SMetaDataLogMsg m      -> toObject v m
+        SMockserverLogMsg m    -> toObject v m
 
 instance ToObject ContractExeLogMsg where
     toObject v = \case


### PR DESCRIPTION
**TL;DR**: Update Node Mock Server to use the tracer from iohk-monitoring

- Introduce Cardano.Node.Types.MockServerLogMsg
- Refactor Cardano.Node.Server.main

----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge