### PR TITLE
Change the formatter fixing scripts to use find again

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,7 +88,7 @@ rec {
 
   tests = import ./nix/tests/default.nix {
     inherit pkgs iohkNix;
-    inherit (plutus) stylish-haskell purty;
+    inherit (plutus) fixStylishHaskell fixPurty;
     src = ./.;
   };
 

--- a/nix/pkgs/fix-stylish-haskell/default.nix
+++ b/nix/pkgs/fix-stylish-haskell/default.nix
@@ -1,21 +1,13 @@
-{ writeShellScriptBin, git, fd, stylish-haskell }:
+{ writeShellScriptBin, fd, stylish-haskell }:
 
 writeShellScriptBin "fix-stylish-haskell" ''
-  set -eou pipefail
-
-  ${git}/bin/git diff > pre-stylish.diff
+  # stylish-haskell can fail for some files that it can't parse, and fd will terminate
+  # if any of the exec commands fail. Rather than blacklisting the bad files, we simply
+  # ignore the exit code, which is usually unhelpful.
   ${fd}/bin/fd \
     --extension hs \
-    --exclude '*/dist/*' \
-    --exclude '*/docs/*' \
-    --exec ${stylish-haskell}/bin/stylish-haskell -i {}
-  ${git}/bin/git diff > post-stylish.diff
-  if (diff pre-stylish.diff post-stylish.diff > /dev/null)
-  then
-    echo "Changes by stylish have been made. Please commit them."
-  else
-    echo "No stylish changes were made."
-  fi
-  rm pre-stylish.diff post-stylish.diff
-  exit
+    --exclude 'dist-newstyle/*' \
+    --exclude 'dist/*' \
+    --exclude '.stack-work/*' \
+    --exec bash -c "${stylish-haskell}/bin/stylish-haskell -i {} || true"
 ''

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, iohkNix, stylish-haskell, purty, src }:
+{ pkgs, iohkNix, fixStylishHaskell, fixPurty, src }:
 let
   inherit (pkgs) lib;
   cleanSrc = lib.cleanSourceWith {
@@ -14,12 +14,12 @@ pkgs.recurseIntoAttrs {
 
   stylishHaskell = pkgs.callPackage ./stylish-haskell.nix {
     src = cleanSrc;
-    inherit stylish-haskell;
+    inherit fixStylishHaskell;
   };
 
   purty = pkgs.callPackage ./purty.nix {
     src = cleanSrc;
-    inherit purty;
+    inherit fixPurty;
   };
 
   nixpkgsFmt = pkgs.callPackage ./nixpkgs-fmt.nix {

--- a/nix/tests/purty.nix
+++ b/nix/tests/purty.nix
@@ -1,4 +1,4 @@
-{ runCommand, purty, src, lib, diffutils, glibcLocales }:
+{ runCommand, fixPurty, src, lib, diffutils, glibcLocales }:
 let
   # just purescript sources
   src' = lib.cleanSourceWith {
@@ -18,14 +18,14 @@ let
 in
 runCommand "purty-check"
 {
-  buildInputs = [ purty diffutils glibcLocales ];
+  buildInputs = [ fixPurty diffutils glibcLocales ];
 } ''
   set +e
   cp -a ${src'} orig
   cp -a ${src'} purty
   chmod -R +w purty
   cd purty
-  find . -type f -name "*.purs" -exec ${purty}/bin/purty --write {} \;
+  fix-purty
   cd ..
   diff --brief --recursive orig purty > /dev/null
   EXIT_CODE=$?

--- a/nix/tests/stylish-haskell.nix
+++ b/nix/tests/stylish-haskell.nix
@@ -1,4 +1,4 @@
-{ runCommand, stylish-haskell, src, lib, diffutils, glibcLocales }:
+{ runCommand, fixStylishHaskell, src, lib, diffutils, glibcLocales }:
 let
   # just haskell sources and the stylish-haskell config file
   src' = lib.cleanSourceWith {
@@ -9,20 +9,20 @@ let
         (
           (type == "regular" && hasSuffix ".hs" baseName) ||
           (type == "regular" && hasSuffix ".yaml" baseName) ||
-          (type == "directory" && (baseName != "docs" && baseName != "dist" && baseName != ".stack-work"))
+          (type == "directory" && (baseName != "dist-newstyle" && baseName != "dist" && baseName != ".stack-work"))
         );
   };
 in
 runCommand "stylish-check"
 {
-  buildInputs = [ stylish-haskell diffutils glibcLocales ];
+  buildInputs = [ fixStylishHaskell diffutils glibcLocales ];
 } ''
   set +e
   cp -a ${src'} orig
   cp -a ${src'} stylish
   chmod -R +w stylish
   cd stylish
-  find . -type f -name "*hs" -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
+  fix-stylish-haskell
   cd ..
   diff --brief --recursive orig stylish > /dev/null
   EXIT_CODE=$?


### PR DESCRIPTION
Some time ago, I changed them to use `fd`, which is significantly
faster. However, `fd` recently changed its behaviour: it used to be that
it matched `find`, whereby it would keep going if any individual `exec`
command failed. Now it stops. This interacts badly with our formatters,
which don't like all the files in our repo, and occasionally fail on one
or the other. We would prefer this not to stop them formatting the rest
of the files!

So we switch back to using `find`, which is slower but does what we
want.

I also shared the fixing script between the shell function and the CI
check, so they will line up better.

(Annals of failed changes: originally this PR included a change to use `execdir`, because if `stylish-haskell` is run from the file's directory instead of the project root then it will read the language extensions from the cabal file and we don't need them in `.stylish-haskell.yaml`. However, we *do* still need them because HLS runs the formatter from the root, so this didn't gain us anything and I reverted it :upside_down_face: )

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
