### PR TITLE
Marlowe Playground Client: Fix runtime error on incomplete top level contract

### DIFF
--- a/marlowe-playground-client/src/Help.purs
+++ b/marlowe-playground-client/src/Help.purs
@@ -161,7 +161,7 @@ Observations are Boolean values derived by comparing values, and can be combined
 
 marloweTypeMarkerText ContractType =
   """
-Marlowe has five ways of building contracts. Four of these – Pay, Let, If and When – build a complex contract from simpler contracts, and the fifth, Close, is a simple contract. At each step of execution, as well as returning a new state and continuation contract, it is possible that effects – payments – and warnings can be generated too.
+Marlowe has six ways of building contracts. Five of these – Pay, Let, If, When and Assert – build a complex contract from simpler contracts, and the sixth, Close, is a simple contract. At each step of execution, as well as returning a new state and continuation contract, it is possible that effects – payments – and warnings can be generated too.
 """
 
 marloweTypeMarkerText BoundType =

--- a/marlowe-playground-client/src/Marlowe/Parser.js
+++ b/marlowe-playground-client/src/Marlowe/Parser.js
@@ -10,7 +10,13 @@ exports.parse_ = function (emptyInputError, parserError, success, fs, input) {
     const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar(fs)));
     try {
         parser.feed(input);
-        return success(parser.results[0]);
+        // When the top level contract is valid but incomplete, the parser.results is an empty array,
+        // which caused a runtime error.
+        if (parser.results.length == 0) {
+          return parserError({ message: "Incomplete top level contract", row: 1, column: 0, token: "" });
+        } else {
+          return success(parser.results[0]);
+        }
     } catch (error) {
         if (error.token) {
             return parserError({ message: error.message, row: error.token.line, column: error.token.col, token: error.token.value });

--- a/marlowe/doc/marlowe-data.adoc
+++ b/marlowe/doc/marlowe-data.adoc
@@ -136,7 +136,6 @@ The different kinds of values – all of which are `Integer` – are pretty much
 * `Scale` multiplies a `Value` by a rational constant, say, 2/3, and rounds the result using 'half even' aka 'banking' rounding. So, 14/10 rounds to 1, both 15/10 and 25/10 rounds to 2.
 * The start and end of the current _slot interval_; see below for further discussion of this.
 * `Cond` represents if-expressions, that is - first argument to `Cond` is a condition (`Observation`) to check, second is a `Value` to take when condition is satisfied and the last one is a `Value` for unsatisfied condition; for example: `(Cond FalseObs (Constant 1) (Constant 2))` is equivalent to `(Constant 2)`
-* `Assert` does not have any effect on the state of the contract, but it issues a warning when the `Observation` is false. It can be used to ensure that a property holds in any given point of the contract, since static analysis will fail if any execution causes an `Assert` to be false.
 
 Next we have observations
 

--- a/marlowe/doc/marlowe-step-by-step.adoc
+++ b/marlowe/doc/marlowe-step-by-step.adoc
@@ -2,7 +2,7 @@
 [#marlowe-step-by-step]
 == Marlowe step by step
 
-Marlowe has five ways of building contracts. Four of these – `Pay`, `Let`, `If` and `When` – build a complex contract from simpler contracts, and the fifth, `Close`, is a simple contract. At each step of execution, as well as returning a new state and continuation contract, it is possible that effects – payments – and warnings can be generated too.
+Marlowe has six ways of building contracts. Five of these – `Pay`, `Let`, `If`, `When` and `Assert` – build a complex contract from simpler contracts, and the sixth, `Close`, is a simple contract. At each step of execution, as well as returning a new state and continuation contract, it is possible that effects – payments – and warnings can be generated too.
 
 In explaining these contracts we will also explain Marlowe _values_, _observations_ and _actions_, which are used to supply external information and inputs to a running contract to control how it will evolve.
 

--- a/marlowe/doc/marlowe-step-by-step.adoc
+++ b/marlowe/doc/marlowe-step-by-step.adoc
@@ -67,3 +67,6 @@ In order to make sure that the contract makes progress eventually, the contract 
 A let contract `Let id val cont` allows a contract to _name a value_ using an identifier. In this case, the expression `val` is evaluated, and stored with the name `id`. The contract then continues as `cont`.
 
 As well as allowing us to use abbreviations, this mechanism also means that we can capture and save volatile values that might be changing with time, e.g. the current price of oil, or the current slot number, at a particular point in the execution of the contract, to be used later on in contract execution.
+
+=== Assert
+An assert contract `Assert obs cont` does not have any effect on the state of the contract, it immediately continues as `cont`, but it issues a warning when the observation `obs` is false. It can be used to ensure that a property holds in any given point of the contract, since static analysis will fail if any execution causes an assert to be false.

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -223,9 +223,9 @@ data Case a = Case Action a
   deriving anyclass (Pretty)
 
 
-{-| Marlowe has five ways of building contracts.
-    Four of these – 'Pay', 'Let', 'If' and 'When' –
-    build a complex contract from simpler contracts, and the fifth, 'Close',
+{-| Marlowe has six ways of building contracts.
+    Five of these – 'Pay', 'Let', 'If', 'When' and 'Assert' –
+    build a complex contract from simpler contracts, and the sixth, 'Close',
     is a simple contract.
     At each step of execution, as well as returning a new state and continuation contract,
     it is possible that effects – payments – and warnings can be generated too.


### PR DESCRIPTION
This PR solves the following bug:
If you create a new Marlowe contract and type a valid but incomplete top level contract such as 

```
Assert TrueObs 
```

then the parser yield's an undefined value, which ends up causing a runtime error somewhere else in the code.

![Screen Shot 2021-02-12 at 18 29 24](https://user-images.githubusercontent.com/2634059/107825070-3e55d580-6d61-11eb-8cdb-010165ff955a.png)

With this PR now it produces a parsing error (ideally this should be solved in the grammar, but this checks whatever reason the parser cant produce an output)

![Screen Shot 2021-02-12 at 18 33 10](https://user-images.githubusercontent.com/2634059/107825180-73622800-6d61-11eb-9d0b-d35e898477b6.png)


Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
