### PR TITLE
SCP-1890 refactor type reduction machinery + implement CC machine

### DIFF
--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -1,0 +1,120 @@
+---
+title: CC machine for types
+layout: page
+---
+
+```
+module Type.CC where
+```
+
+## Imports
+
+```
+open import Type
+open import Type.RenamingSubstitution
+open import Type.Reduction hiding (step)
+
+open import Data.Product
+```
+
+```
+-- K -- type of the whole thing
+-- J -- type of the hole
+data EvalCtx : (K J : Kind) → Set where
+  []   : EvalCtx K K
+  _·r_ : {A : ∅ ⊢⋆ K ⇒ J} → Value⋆ A → EvalCtx K I → EvalCtx J I
+  _l·_ : EvalCtx (K ⇒ J) I → (∅ ⊢⋆ K) → EvalCtx J I
+  _⇒r_     : {A : ∅ ⊢⋆ *} → Value⋆ A → EvalCtx * I → EvalCtx * I
+  _l⇒_     : EvalCtx * I → (∅ ⊢⋆ *) → EvalCtx * I
+  μr     : {A : ∅ ⊢⋆ (K ⇒ *) ⇒ K ⇒ *} → Value⋆ A → EvalCtx K I → EvalCtx * I
+  μl     : EvalCtx ((K ⇒ *) ⇒ K ⇒ *) I →  (B : ∅ ⊢⋆ K) → EvalCtx * I
+
+open import Relation.Binary.PropositionalEquality hiding ([_])
+open import Data.Sum
+
+-- expose the bottom inner layer of the evalctx
+dissect : (E : EvalCtx K J) → K ≡ J ⊎ Σ Kind λ I → EvalCtx K I × Frame I J
+dissect [] = inj₁ refl
+dissect (V ·r E) with dissect E 
+... | inj₁ refl = inj₂ (-, [] , V ·-)
+... | inj₂ (_ , E' , f) = inj₂ (-, V ·r E' , f)
+dissect (E l· B) with dissect E 
+... | inj₁ refl = inj₂ (-, [] , -· B)
+... | inj₂ (_ , E' , f) = inj₂ (-, E' l· B , f)
+dissect (V ⇒r E) with dissect E
+... | inj₁ refl = inj₂ (-, [] , V ⇒-)
+... | inj₂ (_ , E' , f) = inj₂ (-, V ⇒r E' , f)
+dissect (E l⇒ B) with dissect E
+... | inj₁ refl = inj₂ (-, [] , -⇒ B)
+... | inj₂ (_ , E' , f) = inj₂ (-, E' l⇒ B , f)
+dissect (μr V E) with dissect E
+... | inj₁ refl         = inj₂ (-, [] , μ V -)
+... | inj₂ (_ , E' , f) = inj₂ (-, μr V E' , f)
+dissect (μl E B) with dissect E
+... | inj₁ refl = inj₂ (-, [] , μ- B)
+... | inj₂ (_ , E' , f) = inj₂ (-, μl E' B , f)
+
+closeEvalCtx : EvalCtx K J → ∅ ⊢⋆ J → ∅ ⊢⋆ K
+closeEvalCtx []       C = C
+closeEvalCtx (V ·r E) C = discharge V · closeEvalCtx E C
+closeEvalCtx (E l· B) C = closeEvalCtx E C · B
+closeEvalCtx (V ⇒r E) C = discharge V ⇒ closeEvalCtx E C
+closeEvalCtx (E l⇒ B) C = closeEvalCtx E C ⇒ B
+closeEvalCtx (μr V E) C = μ (discharge V) (closeEvalCtx E C)
+closeEvalCtx (μl E B) C = μ (closeEvalCtx E C) B
+
+-- this reaches down inside the evaluation context and changes the
+-- scope of the hole
+--
+-- it could also take a frame instead of an evalctx as it's second arg
+focusEvalCtx : EvalCtx K J → EvalCtx J I → EvalCtx K I
+focusEvalCtx []       E' = E'
+focusEvalCtx (V ·r E) E' = V ·r focusEvalCtx E E'
+focusEvalCtx (E l· B) E' = focusEvalCtx E E' l· B
+focusEvalCtx (V ⇒r E) E' = V ⇒r focusEvalCtx E E'
+focusEvalCtx (E l⇒ B) E' = focusEvalCtx E E' l⇒ B
+focusEvalCtx (μr V E) E' = μr V (focusEvalCtx E E')
+focusEvalCtx (μl E B) E' = μl (focusEvalCtx E E') B
+```
+
+```
+data State (K : Kind) : Kind → Set where
+  _▻_ : EvalCtx K J → ∅ ⊢⋆ J → State K J
+  _◅_ : EvalCtx K J  → {A : ∅ ⊢⋆ J} → Value⋆ A → State K J
+  □   : {A : ∅ ⊢⋆ K} →  Value⋆ A → State K K
+```
+
+```
+closeState : State K J → ∅ ⊢⋆ K
+closeState (E ▻ A) = closeEvalCtx E A
+closeState (E ◅ V) = closeEvalCtx E (discharge V)
+closeState (□ A)   = discharge A
+```
+
+
+## The machine
+
+The `step` function performs one step of computation. It takes a state
+and return a new state. The kind index `K` refers to the kind of the
+outer type which is preserved. The second index `J/J'` refers to the
+kind of the subtype in focus which may change.
+
+```
+step : State K J → ∃ λ J' → State K J'
+step (E ▻ Π A)                      = -, E ◅ V-Π A
+step (E ▻ (A ⇒ B))                  = -, focusEvalCtx E ([] l⇒ B)  ▻ A
+step (E ▻ ƛ A)                      = -, E ◅ V-ƛ A
+step (E ▻ (A · B))                  = -, focusEvalCtx E ([] l· B) ▻ A
+step (E ▻ μ A B)                    = -, focusEvalCtx E (μl [] B) ▻ A
+step (E ▻ con c)                    = -, E ◅ V-con c
+step (□ V)                          = -, □ V
+step (E ◅ V) with dissect E
+... | inj₁ refl = -, □ V
+... | inj₂ (_ , E' , -· B) = -, focusEvalCtx E' (V ·r [])  ▻ B
+... | inj₂ (_ , E' , (V-ƛ N ·-)) =
+  -, E' ▻ (N [ discharge V ])
+... | inj₂ (_ , E' , -⇒ B) = -, focusEvalCtx E' (V ⇒r [])  ▻ B
+... | inj₂ (_ , E' , W ⇒-) = -, E' ◅ (W V-⇒ V)
+... | inj₂ (_ , E' , μ- B) = -, focusEvalCtx E' (μr V []) ▻ B
+... | inj₂ (_ , E' , μ W -) = -, E' ◅ V-μ W V
+```

--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -12,23 +12,12 @@ module Type.CC where
 ```
 open import Type
 open import Type.RenamingSubstitution
-open import Type.Reduction hiding (step)
+open import Type.ReductionC hiding (step)
 
 open import Data.Product
 ```
 
 ```
--- K -- type of the whole thing
--- J -- type of the hole
-data EvalCtx : (K J : Kind) → Set where
-  []   : EvalCtx K K
-  _·r_ : {A : ∅ ⊢⋆ K ⇒ J} → Value⋆ A → EvalCtx K I → EvalCtx J I
-  _l·_ : EvalCtx (K ⇒ J) I → (∅ ⊢⋆ K) → EvalCtx J I
-  _⇒r_     : {A : ∅ ⊢⋆ *} → Value⋆ A → EvalCtx * I → EvalCtx * I
-  _l⇒_     : EvalCtx * I → (∅ ⊢⋆ *) → EvalCtx * I
-  μr     : {A : ∅ ⊢⋆ (K ⇒ *) ⇒ K ⇒ *} → Value⋆ A → EvalCtx K I → EvalCtx * I
-  μl     : EvalCtx ((K ⇒ *) ⇒ K ⇒ *) I →  (B : ∅ ⊢⋆ K) → EvalCtx * I
-
 open import Relation.Binary.PropositionalEquality hiding ([_])
 open import Data.Sum
 
@@ -53,15 +42,6 @@ dissect (μr V E) with dissect E
 dissect (μl E B) with dissect E
 ... | inj₁ refl = inj₂ (-, [] , μ- B)
 ... | inj₂ (_ , E' , f) = inj₂ (-, μl E' B , f)
-
-closeEvalCtx : EvalCtx K J → ∅ ⊢⋆ J → ∅ ⊢⋆ K
-closeEvalCtx []       C = C
-closeEvalCtx (V ·r E) C = discharge V · closeEvalCtx E C
-closeEvalCtx (E l· B) C = closeEvalCtx E C · B
-closeEvalCtx (V ⇒r E) C = discharge V ⇒ closeEvalCtx E C
-closeEvalCtx (E l⇒ B) C = closeEvalCtx E C ⇒ B
-closeEvalCtx (μr V E) C = μ (discharge V) (closeEvalCtx E C)
-closeEvalCtx (μl E B) C = μ (closeEvalCtx E C) B
 
 -- this reaches down inside the evaluation context and changes the
 -- scope of the hole

--- a/plutus-metatheory/src/Type/CK.lagda.md
+++ b/plutus-metatheory/src/Type/CK.lagda.md
@@ -36,7 +36,6 @@ performs one step of computation, preserves the kind of the overall
 type and the intermediate data structures are indexed by kinds to
 enable this.
 
-
 ## Stack
 
 A stack is a sequence of frames. It allows us to specify a single hole
@@ -86,7 +85,6 @@ closeState (s ▻ A)   = closeStack s A
 closeState (_◅_ s A) = closeStack s (discharge A)
 closeState (□ A)     = discharge A
 ```
-
 
 ## The machine
 

--- a/plutus-metatheory/src/Type/CK.lagda.md
+++ b/plutus-metatheory/src/Type/CK.lagda.md
@@ -76,7 +76,6 @@ data State (K : Kind) : Kind → Set where
   _▻_ : Stack K J → ∅ ⊢⋆ J → State K J
   _◅_ : Stack K J → {A : ∅ ⊢⋆ J} → Value⋆ A → State K J
   □   : {A : ∅ ⊢⋆ K} →  Value⋆ A → State K K
-  -- ◆ : ∀ (J : Kind) →  State K J -- impossible in the type language
 ```
 
 Analogously to `Frame` and `Stack` we can also close a `State`:

--- a/plutus-metatheory/src/Type/CK.lagda.md
+++ b/plutus-metatheory/src/Type/CK.lagda.md
@@ -36,40 +36,6 @@ performs one step of computation, preserves the kind of the overall
 type and the intermediate data structures are indexed by kinds to
 enable this.
 
-## Frames
-
-A frame corresponds to a type with a hole in it for a missing sub
-type. It is indexed by two kinds. The first index is the kind of the
-outer type that the frame corresponds to, the second index refers to
-the kind of the missing subterm. The frame datatypes has constructors
-for all the different places in a type that we might need to make a
-hole.
-
-```
-data Frame : Kind → Kind → Set where
-  -·_     : ∅ ⊢⋆ K → Frame J (K ⇒ J)
-  _·-     : {A : ∅ ⊢⋆ K ⇒ J} → Value⋆ A → Frame J K
-  -⇒_     : ∅ ⊢⋆ * → Frame * *
-  _⇒-     : {A : ∅ ⊢⋆ *} → Value⋆ A → Frame * *
-  μ-_     : (B : ∅ ⊢⋆ K) → Frame * ((K ⇒ *) ⇒ K ⇒ *)
-  μ_-     : {A : ∅ ⊢⋆ (K ⇒ *) ⇒ K ⇒ *} → Value⋆ A → Frame * K
-```
-
-Given a frame and type to plug in to it we can close the frame and
-recover a type with no hole. By indexing frames by kinds we can
-specify exactly what kind the plug needs to have and ensure we don't
-plug in something of the wrong kind. We can also ensure what kind the
-returned type will have.
-
-```
-closeFrame : Frame K J → ∅ ⊢⋆ J → ∅ ⊢⋆ K
-closeFrame (-· B)  A = A · B
-closeFrame (_·- A) B = discharge A · B
-closeFrame (-⇒ B)  A = A ⇒ B
-closeFrame (_⇒- A) B = discharge A ⇒ B
-closeFrame (μ_- A) B = μ (discharge A) B
-closeFrame (μ- B)  A = μ A B
-```
 
 ## Stack
 

--- a/plutus-metatheory/src/Type/CK.lagda.md
+++ b/plutus-metatheory/src/Type/CK.lagda.md
@@ -12,7 +12,7 @@ module Type.CK where
 ```
 open import Type
 open import Type.RenamingSubstitution
-open import Type.Reduction hiding (step)
+open import Type.ReductionF hiding (step)
 
 open import Data.Product
 ```
@@ -109,4 +109,21 @@ step ((s , (V ⇒-)) ◅ W)             = -, s ◅ (V V-⇒ W)
 step ((s , μ- B) ◅ A)               = -, (s , μ A -) ▻ B
 step ((s , μ A -) ◅ B)              = -, s ◅ V-μ A B
 step (□ V)                          = -, □ V
+```
+
+reflexive transitive closure of step:
+
+```
+variable
+ I' : Kind
+
+open import Relation.Binary.PropositionalEquality
+
+data _-→s_ : State K J → State K I → Set where
+  base  : (s : State K J)
+        → s -→s s
+  step* : (s : State K J)(s' : State K I)(s'' : State K I')
+        → step s ≡ (I , s')
+        → s' -→s s''
+        → s -→s s''
 ```

--- a/plutus-metatheory/src/Type/ReductionC.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionC.lagda.md
@@ -1,0 +1,237 @@
+---
+title: Type Reduction, contextual style
+layout: page
+---
+
+```
+module Type.ReductionC where
+```
+
+The rules are presented in 'contextual style' with a first order
+presentation of closing an evaluation context.
+
+Right now this file is not used in other things. In the rest of the
+formalisation we compute types via NBE. Instead, it acts as a warmup
+to understanding reduction of types, progress, etc.
+
+This version of reduction does not compute under binders. The NBE
+version does full normalisation.
+
+## Imports
+
+```
+open import Type
+open import Type.RenamingSubstitution
+open import Builtin.Constant.Type
+open import Relation.Nullary
+open import Data.Product
+open import Data.Empty
+
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+```
+
+## Values
+
+Values, types in the empty context that cannot reduce any furter,
+presented as a predicate. We don't reduce under either lambda or pi
+binders here.
+
+```
+data Value⋆ : ∅ ⊢⋆ J → Set where
+
+  V-Π : (N : ∅ ,⋆ K ⊢⋆ *)
+        -----------------
+      → Value⋆ (Π N)
+
+  _V-⇒_ : Value⋆ A
+        → Value⋆ B
+          --------------
+        → Value⋆ (A ⇒ B)
+
+  V-ƛ : (N : ∅ ,⋆ K ⊢⋆ J)
+        -----------------
+      → Value⋆ (ƛ N)
+
+  V-con : (tcn : TyCon)
+          ----------------
+        → Value⋆ (con tcn)
+
+  V-μ : Value⋆ A
+      → Value⋆ B
+        --------------
+      → Value⋆ (μ A B)
+```
+
+Converting a value back into a term. For this representation of values
+this is trivial:
+
+```
+discharge : {A : ∅ ⊢⋆ K} → Value⋆ A → ∅ ⊢⋆ K
+discharge {A = A} V = A
+```
+
+## Eval contexts
+
+```
+data EvalCtx : (K J : Kind) → Set where
+  []   : EvalCtx K K
+  _·r_ : {A : ∅ ⊢⋆ K ⇒ J} → Value⋆ A → EvalCtx K I → EvalCtx J I
+  _l·_ : EvalCtx (K ⇒ J) I → (∅ ⊢⋆ K) → EvalCtx J I
+  _⇒r_     : {A : ∅ ⊢⋆ *} → Value⋆ A → EvalCtx * I → EvalCtx * I
+  _l⇒_     : EvalCtx * I → (∅ ⊢⋆ *) → EvalCtx * I
+  μr     : {A : ∅ ⊢⋆ (K ⇒ *) ⇒ K ⇒ *} → Value⋆ A → EvalCtx K I → EvalCtx * I
+  μl     : EvalCtx ((K ⇒ *) ⇒ K ⇒ *) I →  (B : ∅ ⊢⋆ K) → EvalCtx * I
+
+closeEvalCtx : EvalCtx K J → ∅ ⊢⋆ J → ∅ ⊢⋆ K
+closeEvalCtx []       C = C
+closeEvalCtx (V ·r E) C = discharge V · closeEvalCtx E C
+closeEvalCtx (E l· B) C = closeEvalCtx E C · B
+closeEvalCtx (V ⇒r E) C = discharge V ⇒ closeEvalCtx E C
+closeEvalCtx (E l⇒ B) C = closeEvalCtx E C ⇒ B
+closeEvalCtx (μr V E) C = μ (discharge V) (closeEvalCtx E C)
+closeEvalCtx (μl E B) C = μ (closeEvalCtx E C) B
+
+-- inductive version of closeEvalCtx, it doesn't seem to help
+data _~_⟦_⟧ : ∅ ⊢⋆ K → EvalCtx K J → ∅ ⊢⋆ J → Set where
+  ~[] : (P : ∅ ⊢⋆ K) → P ~ [] ⟦ P ⟧
+  ~·r : ∀(P : ∅ ⊢⋆ I){A : ∅ ⊢⋆ K ⇒ J}(V : Value⋆ A)(B : ∅ ⊢⋆ K) E
+      → B ~ E ⟦ P ⟧
+      → (discharge V · B) ~ V ·r E ⟦ P ⟧
+  ~l· : ∀(P : ∅ ⊢⋆ I)(A : ∅ ⊢⋆ K ⇒ J)(B : ∅ ⊢⋆ K) E
+      → A ~ E ⟦ P ⟧
+      → (A · B) ~ E l· B ⟦ P ⟧
+```
+
+## Frames
+
+A frame corresponds to a type with a hole in it for a missing sub
+type. It is indexed by two kinds. The first index is the kind of the
+outer type that the frame corresponds to, the second index refers to
+the kind of the missing subterm. The frame datatypes has constructors
+for all the different places in a type that we might need to make a
+hole.
+
+```
+data Frame : Kind → Kind → Set where
+  -·_     : ∅ ⊢⋆ K → Frame J (K ⇒ J)
+  _·-     : {A : ∅ ⊢⋆ K ⇒ J} → Value⋆ A → Frame J K
+  -⇒_     : ∅ ⊢⋆ * → Frame * *
+  _⇒-     : {A : ∅ ⊢⋆ *} → Value⋆ A → Frame * *
+  μ-_     : (B : ∅ ⊢⋆ K) → Frame * ((K ⇒ *) ⇒ K ⇒ *)
+  μ_-     : {A : ∅ ⊢⋆ (K ⇒ *) ⇒ K ⇒ *} → Value⋆ A → Frame * K
+```
+
+Given a frame and type to plug in to it we can close the frame and
+recover a type with no hole. By indexing frames by kinds we can
+specify exactly what kind the plug needs to have and ensure we don't
+plug in something of the wrong kind. We can also ensure what kind the
+returned type will have.
+
+```
+closeFrame : Frame K J → ∅ ⊢⋆ J → ∅ ⊢⋆ K
+closeFrame (-· B)  A = A · B
+closeFrame (_·- A) B = discharge A · B
+closeFrame (-⇒ B)  A = A ⇒ B
+closeFrame (_⇒- A) B = discharge A ⇒ B
+closeFrame (μ_- A) B = μ (discharge A) B
+closeFrame (μ- B)  A = μ A B
+
+-- this can also be given by an inductive definition
+```
+
+
+## Reduction
+
+Reduction is intrinsically kind preserving. This doesn't require proof.
+
+```
+infix 2 _—→⋆_
+infix 2 _—↠⋆_
+
+data _—→⋆_ : ∀{J} → (∅ ⊢⋆ J) → (∅ ⊢⋆ J) → Set where
+  contextRule : ∀{K K'} → (E : EvalCtx K K')
+    → ∀{A A' : ∅ ⊢⋆ K'}
+    → A —→⋆ A'
+    → {B B' : ∅ ⊢⋆ K}
+    → B  ≡ closeEvalCtx E A
+    → B' ≡ closeEvalCtx E A'
+      --------------------
+    → B —→⋆ B'
+    -- ^ explicit equality proofs make pattern matching easier and this uglier
+
+  β-ƛ : Value⋆ B
+        -------------------
+      → ƛ A · B —→⋆ A [ B ]
+```
+
+## Reflexive transitie closure of reduction
+
+```
+data _—↠⋆_ : (∅ ⊢⋆ J) → (∅ ⊢⋆ J) → Set where
+
+  refl—↠⋆ : --------
+             A —↠⋆ A
+
+  trans—↠⋆ : A —→⋆ B
+           → B —↠⋆ C
+             -------
+           → A —↠⋆ C
+```
+
+## Progress
+
+An enumeration of possible outcomes of progress: a step or we hit a value.
+
+```
+data Progress⋆ (A : ∅ ⊢⋆ K) : Set where
+  step : A —→⋆ B
+         -----------
+       → Progress⋆ A
+  done : Value⋆ A
+         -----------
+       → Progress⋆ A
+```
+
+The progress proof. For any type in the empty context we can make
+progres. Note that there is no case for variables as there are no
+variables in the empty context.
+
+```
+progress⋆ : (A : ∅ ⊢⋆ K) → Progress⋆ A
+progress⋆ (` ())
+progress⋆ (μ A B) with progress⋆ A
+... | step p  = step (contextRule (μl [] B) p refl refl)
+... | done VA with progress⋆ B
+... | step p  = step (contextRule (μr VA []) p refl refl)
+... | done VB = done (V-μ VA VB)
+progress⋆ (Π A) = done (V-Π A)
+progress⋆ (A ⇒ B) with progress⋆ A
+... | step p = step (contextRule ([] l⇒ B) p refl refl)
+... | done VA with progress⋆ B
+... | step q  = step (contextRule (VA ⇒r []) q refl refl)
+... | done VB = done (VA V-⇒ VB)
+progress⋆ (ƛ A) = done (V-ƛ A)
+progress⋆ (A · B) with progress⋆ A
+... | step p =
+  step (contextRule ([] l· B) p refl refl)
+... | done V with progress⋆ B
+... | step p =
+  step (contextRule (V ·r []) p refl refl)
+progress⋆ (.(ƛ _) · B) | done (V-ƛ A) | done VB = step (β-ƛ VB)
+progress⋆ (con tcn) = done (V-con tcn)
+```
+
+## Determinism of Reduction:
+
+A type is a value or it can make a step, but not both:
+
+```
+--notboth : (A : ∅ ⊢⋆ K) → ¬ (Value⋆ A × (Σ (∅ ⊢⋆ K) (A —→⋆_)))
+```
+
+Reduction is deterministic. There is only one possible reduction step
+a type can make.
+
+```
+--det : (p : A —→⋆ B)(q : A —→⋆ B') → B ≡ B'
+```

--- a/plutus-metatheory/src/Type/ReductionF.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionF.lagda.md
@@ -4,7 +4,7 @@ layout: page
 ---
 
 ```
-module Type.Reduction where
+module Type.ReductionF where
 ```
 
 Right now this file is not used in other things. In the rest of the
@@ -100,6 +100,8 @@ closeFrame (-⇒ B)  A = A ⇒ B
 closeFrame (_⇒- A) B = discharge A ⇒ B
 closeFrame (μ_- A) B = μ (discharge A) B
 closeFrame (μ- B)  A = μ A B
+
+-- this can also be given by an inductive definition
 ```
 
 
@@ -119,7 +121,7 @@ data _—→⋆_ : ∀{J} → (∅ ⊢⋆ J) → (∅ ⊢⋆ J) → Set where
     → B' ≡ closeFrame f A'
       --------------------
     → B —→⋆ B'
-    -- ^ explicit proofs make pattern matching easier
+    -- ^ explicit equality proofs make pattern matching easier and this uglier
 
   β-ƛ : Value⋆ B
         -------------------

--- a/plutus-metatheory/src/Type/ReductionS.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionS.lagda.md
@@ -1,0 +1,199 @@
+---
+title: Type Reduction, structural style
+layout: page
+---
+
+```
+module Type.ReductionS where
+```
+
+Right now this file is not used in other things. In the rest of the
+formalisation we compute types via NBE. Instead, it acts as a warmup
+to understanding reduction of types, progress, etc.
+
+This version of reduction does not compute under binders. The NBE
+version does full normalisation.
+
+## Imports
+
+```
+open import Type
+open import Type.RenamingSubstitution
+open import Builtin.Constant.Type
+open import Relation.Nullary
+open import Data.Product
+open import Data.Empty
+
+open import Agda.Builtin.Nat
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+```
+
+## Values
+
+Values, types in the empty context that cannot reduce any furter,
+presented as a predicate. We don't reduce under either lambda or pi
+binders here.
+
+```
+data Value⋆ : ∅ ⊢⋆ J → Set where
+
+  V-Π : (N : ∅ ,⋆ K ⊢⋆ *)
+        -----------------
+      → Value⋆ (Π N)
+
+  _V-⇒_ : Value⋆ A
+        → Value⋆ B
+          --------------
+        → Value⋆ (A ⇒ B)
+
+  V-ƛ : (N : ∅ ,⋆ K ⊢⋆ J)
+        -----------------
+      → Value⋆ (ƛ N)
+
+  V-con : (tcn : TyCon)
+          ----------------
+        → Value⋆ (con tcn)
+
+  V-μ : Value⋆ A
+      → Value⋆ B
+        --------------
+      → Value⋆ (μ A B)
+```
+
+Converting a value back into a term. For this representation of values
+this is trivial:
+
+```
+discharge : {A : ∅ ⊢⋆ K} → Value⋆ A → ∅ ⊢⋆ K
+discharge {A = A} V = A
+```
+
+## Reduction
+
+Reduction is intrinsically kind preserving. This doesn't require proof.
+
+```
+infix 2 _—→⋆_
+infix 2 _—↠⋆_
+
+data _—→⋆_ : (∅ ⊢⋆ J) → (∅ ⊢⋆ J) → Set where
+  ξ-⇒₁ : A —→⋆ A'
+         -----------------
+       → A ⇒ B —→⋆ A' ⇒ B
+
+  ξ-⇒₂ : Value⋆ A
+    → B —→⋆ B'
+      -----------------
+    → A ⇒ B —→⋆ A ⇒ B'
+
+  ξ-·₁ : A —→⋆ A'
+         ----------------
+       → A · B —→⋆ A' · B
+
+  ξ-·₂ : Value⋆ A
+       → B —→⋆ B'
+         ----------------
+       → A · B —→⋆ A · B'
+
+  β-ƛ : Value⋆ B
+        -------------------
+      → ƛ A · B —→⋆ A [ B ]
+
+  ξ-μ₁ : A —→⋆ A'
+         ----------------
+       → μ A B —→⋆ μ A' B
+
+  ξ-μ₂ : Value⋆ A
+       → B —→⋆ B'
+         ----------------
+       → μ A B —→⋆ μ A B'
+```
+
+## Reflexive transitie closure of reduction
+
+```
+data _—↠⋆_ : (∅ ⊢⋆ J) → (∅ ⊢⋆ J) → Set where
+
+  refl—↠⋆ : --------
+             A —↠⋆ A
+
+  trans—↠⋆ : A —→⋆ B
+           → B —↠⋆ C
+             -------
+           → A —↠⋆ C
+```
+
+## Progress
+
+An enumeration of possible outcomes of progress: a step or we hit a value.
+
+```
+data Progress⋆ (A : ∅ ⊢⋆ K) : Set where
+  step : A —→⋆ B
+         -----------
+       → Progress⋆ A
+  done : Value⋆ A
+         -----------
+       → Progress⋆ A
+```
+
+The progress proof. For any type in the empty context we can make
+progres. Note that ther is no case for variables as there are no
+variables in the empty context.
+
+```
+progress⋆ : (A : ∅ ⊢⋆ K) → Progress⋆ A
+progress⋆ (` ())
+progress⋆ (μ A B) with progress⋆ A
+... | step p  = step (ξ-μ₁ p)
+... | done VA with progress⋆ B
+... | step p  = step (ξ-μ₂ VA p)
+... | done VB = done (V-μ VA VB)
+progress⋆ (Π A) = done (V-Π A)
+progress⋆ (A ⇒ B) with progress⋆ A
+... | step p = step (ξ-⇒₁ p)
+... | done VA with progress⋆ B
+... | step q  = step (ξ-⇒₂ VA q)
+... | done VB = done (VA V-⇒ VB)
+progress⋆ (ƛ A) = done (V-ƛ A)
+progress⋆ (A · B) with progress⋆ A
+... | step p = step (ξ-·₁ p)
+... | done VA with progress⋆ B
+... | step p = step (ξ-·₂ VA p)
+progress⋆ (.(ƛ _) · B) | done (V-ƛ A) | done VB = step (β-ƛ VB)
+progress⋆ (con tcn) = done (V-con tcn)
+```
+
+## Determinism of Reduction:
+
+A type is a value or it can make a step, but not both:
+
+```
+notboth : (A : ∅ ⊢⋆ K) → ¬ (Value⋆ A × (Σ (∅ ⊢⋆ K) (A —→⋆_)))
+notboth .(_ ⇒ _) ((V V-⇒ W) , .(_ ⇒ _) , ξ-⇒₁ p)   = notboth _ (V , _ , p)
+notboth .(_ ⇒ _) ((V V-⇒ W) , .(_ ⇒ _) , ξ-⇒₂ _ p) = notboth _ (W , _ , p)
+notboth .(μ _ _) (V-μ V W   , .(μ _ _)  , ξ-μ₁ p)   = notboth _ (V , _ , p)
+notboth .(μ _ _) (V-μ V W   , .(μ _ _)  , ξ-μ₂ _ p) = notboth _ (W , _ , p)
+```
+
+Reduction is deterministic. There is only one possible reduction step
+a type can make.
+
+```
+det : (p : A —→⋆ B)(q : A —→⋆ B') → B ≡ B'
+det (ξ-⇒₁ p) (ξ-⇒₁ q) = cong (_⇒ _) (det p q)
+det (ξ-⇒₁ p) (ξ-⇒₂ w q) = ⊥-elim (notboth _ (w , _ , p))
+det (ξ-⇒₂ v p) (ξ-⇒₁ q) = ⊥-elim (notboth _ (v , _ , q))
+det (ξ-⇒₂ v p) (ξ-⇒₂ w q) = cong (_ ⇒_) (det p q)
+det (ξ-·₁ p) (ξ-·₁ q) = cong (_· _) (det p q)
+det (ξ-·₁ p) (ξ-·₂ w q) = ⊥-elim (notboth _ (w , _ , p))
+det (ξ-·₂ v p) (ξ-·₁ q) = ⊥-elim (notboth _ (v , _ , q))
+det (ξ-·₂ v p) (ξ-·₂ w q) = cong (_ ·_) (det p q)
+det (ξ-·₂ v p) (β-ƛ w) = ⊥-elim (notboth _ (w , _ , p))
+det (β-ƛ v) (ξ-·₂ w q) = ⊥-elim (notboth _ (v , _ , q))
+det (β-ƛ v) (β-ƛ w) = refl
+det (ξ-μ₁ p) (ξ-μ₁ q) = cong (λ X → μ X _) (det p q)
+det (ξ-μ₁ p) (ξ-μ₂ w q) = ⊥-elim (notboth _ (w , _ , p))
+det (ξ-μ₂ v p) (ξ-μ₁ q) = ⊥-elim (notboth _ (v , _ , q))
+det (ξ-μ₂ v p) (ξ-μ₂ w q) = cong (μ _) (det p q)
+```

--- a/plutus-metatheory/src/index.lagda.md
+++ b/plutus-metatheory/src/index.lagda.md
@@ -56,7 +56,10 @@ proof.
 import Type
 import Type.RenamingSubstitution
 import Type.Equality
-import Type.Reduction
+import Type.ReductionS
+import Type.ReductionF
+import Type.ReductionC
+import Type.CC
 import Type.CK
 ```
 


### PR DESCRIPTION
In this PR 

1. refactor reduction, progress, val 'xor' reduction, and determinism proofs to use frames.
2. Define CC machine.

For later:

3. Prove equivalence of CC machine and reduction.
4. Refactor CK machine to be relational.
5. Prove equivalence of CC and CK machine.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
