### PR TITLE
SCP-1849 - Add template instantiation mechanism to Marlowe UI in playground

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -30,16 +30,16 @@ import Language.Haskell.Monaco as HM
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe (postRunghc)
+import Marlowe.Extended (Contract)
 import Marlowe.Holes (fromTerm)
 import Marlowe.Parser (parseContract)
-import Marlowe.Extended (Contract)
 import Monaco (IMarkerData, markerSeverity)
 import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
 import StaticAnalysis.Reachability (analyseReachability)
 import StaticAnalysis.StaticTools (analyseContract)
-import StaticAnalysis.Types (AnalysisState(..), MultiStageAnalysisData(..), _analysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), MultiStageAnalysisData(..), _analysisExecutionState, _analysisState)
 import StaticData (haskellBufferLocalStorageKey)
 import Types (WebData)
 import Webghc.Server (CompileRequest(..))
@@ -117,7 +117,7 @@ compileAndAnalyze ::
   forall m.
   MonadAff m =>
   MonadAsk Env m =>
-  AnalysisState ->
+  AnalysisExecutionState ->
   (Contract -> HalogenM State Action ChildSlots Void m Unit) ->
   HalogenM State Action ChildSlots Void m Unit
 compileAndAnalyze initialAnalysisState doAnalyze = do
@@ -125,7 +125,7 @@ compileAndAnalyze initialAnalysisState doAnalyze = do
   case compilationResult of
     NotAsked -> do
       -- The initial analysis state allow us to show an "Analysing..." indicator
-      assign _analysisState initialAnalysisState
+      assign (_analysisState <<< _analysisExecutionState) initialAnalysisState
       handleAction Compile
       compileAndAnalyze initialAnalysisState doAnalyze
     Success (Right (InterpreterResult interpretedResult)) ->

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -102,8 +102,7 @@ handleAction (InitHaskellProject contents) = do
   editorSetValue contents
   liftEffect $ LocalStorage.setItem haskellBufferLocalStorageKey contents
 
-handleAction (SetIntegerTemplateParam templateType key value) = do
-  modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
+handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 
 handleAction AnalyseContract = compileAndAnalyze (WarningAnalysis Loading) $ analyseContract
 

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -18,7 +18,7 @@ import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, _Inter
 import Marlowe.Extended (IntegerTemplateType)
 import Marlowe.Parser (parseContract)
 import Network.RemoteData (RemoteData(..), _Loading, _Success)
-import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, initAnalysisState)
 import Text.Pretty (pretty)
 import Types (WebData)
 
@@ -86,10 +86,7 @@ initialState =
   { keybindings: DefaultBindings
   , compilationResult: NotAsked
   , bottomPanelState: BottomPanel.initialState GeneratedOutputView
-  , analysisState:
-      { templateContent: mempty
-      , analysisExecutionState: NoneAsked
-      }
+  , analysisState: initAnalysisState
   }
 
 isCompiling :: State -> Boolean

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -4,6 +4,7 @@ import Prelude
 import Analytics (class IsEvent, Event)
 import Analytics as A
 import BottomPanel.Types as BottomPanel
+import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -14,6 +15,7 @@ import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, _InterpreterResult)
+import Marlowe.Extended (IntegerTemplateType)
 import Marlowe.Parser (parseContract)
 import Network.RemoteData (RemoteData(..), _Loading, _Success)
 import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
@@ -28,6 +30,7 @@ data Action
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
   | SendResultToSimulator
   | InitHaskellProject String
+  | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
@@ -43,6 +46,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
   toEvent (InitHaskellProject _) = Just $ defaultEvent "InitHaskellProject"
+  toEvent (SetIntegerTemplateParam _ _ _) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -16,7 +16,7 @@ import Halogen.Monaco as Monaco
 import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, _InterpreterResult)
 import Marlowe.Parser (parseContract)
 import Network.RemoteData (RemoteData(..), _Loading, _Success)
-import StaticAnalysis.Types (AnalysisState(..))
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
 import Text.Pretty (pretty)
 import Types (WebData)
 
@@ -82,7 +82,10 @@ initialState =
   { keybindings: DefaultBindings
   , compilationResult: NotAsked
   , bottomPanelState: BottomPanel.initialState GeneratedOutputView
-  , analysisState: NoneAsked
+  , analysisState:
+      { templateContent: mempty
+      , analysisExecutionState: NoneAsked
+      }
   }
 
 isCompiling :: State -> Boolean

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -26,7 +26,7 @@ import Language.Haskell.Monaco as HM
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Network.RemoteData (RemoteData(..))
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton)
-import StaticAnalysis.Types (_analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
 
 render ::
   forall m.
@@ -152,11 +152,11 @@ panelContents state StaticAnalysisView =
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
     ]
   where
-  loadingWarningAnalysis = state ^. _analysisState <<< to isStaticLoading
+  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
 
-  loadingReachability = state ^. _analysisState <<< to isReachabilityLoading
+  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<< to isReachabilityLoading
 
-  loadingCloseAnalysis = state ^. _analysisState <<< to isCloseAnalysisLoading
+  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
   enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
 

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -146,7 +146,7 @@ panelContents state StaticAnalysisView =
   section
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
-    [ analysisResultPane state
+    [ analysisResultPane SetIntegerTemplateParam state
     , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
     , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -147,9 +147,9 @@ panelContents state StaticAnalysisView =
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
     [ analysisResultPane SetIntegerTemplateParam state
-    , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
-    , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
-    , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
+    , analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
+    , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
+    , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
     ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
@@ -158,7 +158,7 @@ panelContents state StaticAnalysisView =
 
   loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
-  enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
+  analysisEnabled = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
 
 panelContents state ErrorsView =
   section

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -142,8 +142,7 @@ handleAction (InitJavascriptProject prunedContent) = do
   editorSetValue prunedContent
   liftEffect $ LocalStorage.setItem jsBufferLocalStorageKey prunedContent
 
-handleAction (SetIntegerTemplateParam templateType key value) = do
-  modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
+handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 
 handleAction AnalyseContract = compileAndAnalyze (WarningAnalysis Loading) $ analyseContract
 

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -38,7 +38,7 @@ import Monaco (IRange, getModel, isError, setValue)
 import Network.RemoteData (RemoteData(..))
 import StaticAnalysis.Reachability (analyseReachability)
 import StaticAnalysis.StaticTools (analyseContract)
-import StaticAnalysis.Types (AnalysisState(..), MultiStageAnalysisData(..), _analysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), MultiStageAnalysisData(..), _analysisExecutionState, _analysisState)
 import StaticData (jsBufferLocalStorageKey)
 import StaticData as StaticData
 import Text.Parsing.StringParser.Basic (lines)
@@ -157,7 +157,7 @@ compileAndAnalyze ::
   forall m.
   MonadAff m =>
   MonadAsk Env m =>
-  AnalysisState ->
+  AnalysisExecutionState ->
   (Contract -> HalogenM State Action ChildSlots Void m Unit) ->
   HalogenM State Action ChildSlots Void m Unit
 compileAndAnalyze initialAnalysisState doAnalyze = do
@@ -165,7 +165,7 @@ compileAndAnalyze initialAnalysisState doAnalyze = do
   case compilationResult of
     NotCompiled -> do
       -- The initial analysis state allow us to show an "Analysing..." indicator
-      assign _analysisState initialAnalysisState
+      assign (_analysisState <<< _analysisExecutionState) initialAnalysisState
       handleAction Compile
       compileAndAnalyze initialAnalysisState doAnalyze
     CompiledSuccessfully (InterpreterResult interpretedResult) -> doAnalyze interpretedResult.result

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -4,6 +4,7 @@ import Prelude
 import Analytics (class IsEvent, Event)
 import Analytics as A
 import BottomPanel.Types as BottomPanel
+import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -15,7 +16,7 @@ import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JS
-import Marlowe.Extended (Contract)
+import Marlowe.Extended (Contract, IntegerTemplateType)
 import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
 import Text.Pretty (pretty)
 
@@ -45,6 +46,7 @@ data Action
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
   | SendResultToSimulator
   | InitJavascriptProject String
+  | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
@@ -59,6 +61,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent SendResultToSimulator = Just $ defaultEvent "SendResultToSimulator"
   toEvent (InitJavascriptProject _) = Just $ defaultEvent "InitJavascriptProject"
+  toEvent (SetIntegerTemplateParam _ _ _) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -16,7 +16,7 @@ import Halogen.Monaco as Monaco
 import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JS
 import Marlowe.Extended (Contract)
-import StaticAnalysis.Types (AnalysisState(..))
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
 import Text.Pretty (pretty)
 
 data CompilationState
@@ -105,7 +105,10 @@ initialState =
   , bottomPanelState: BottomPanel.initialState GeneratedOutputView
   , compilationResult: NotCompiled
   , decorationIds: Nothing
-  , analysisState: NoneAsked
+  , analysisState:
+      { templateContent: mempty
+      , analysisExecutionState: NoneAsked
+      }
   }
 
 data BottomPanelView

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -17,7 +17,7 @@ import Halogen.Monaco as Monaco
 import Language.Javascript.Interpreter (_result)
 import Language.Javascript.Interpreter as JS
 import Marlowe.Extended (Contract, IntegerTemplateType)
-import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, initAnalysisState)
 import Text.Pretty (pretty)
 
 data CompilationState
@@ -108,10 +108,7 @@ initialState =
   , bottomPanelState: BottomPanel.initialState GeneratedOutputView
   , compilationResult: NotCompiled
   , decorationIds: Nothing
-  , analysisState:
-      { templateContent: mempty
-      , analysisExecutionState: NoneAsked
-      }
+  , analysisState: initAnalysisState
   }
 
 data BottomPanelView

--- a/marlowe-playground-client/src/JavascriptEditor/View.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/View.purs
@@ -24,7 +24,7 @@ import JavascriptEditor.Types as JS
 import Language.Javascript.Interpreter (CompilationError(..), InterpreterResult(..))
 import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton)
-import StaticAnalysis.Types (_analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
 import Text.Pretty (pretty)
 
 render ::
@@ -145,11 +145,11 @@ panelContents state StaticAnalysisView =
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
     ]
   where
-  loadingWarningAnalysis = state ^. _analysisState <<< to isStaticLoading
+  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
 
-  loadingReachability = state ^. _analysisState <<< to isReachabilityLoading
+  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<< to isReachabilityLoading
 
-  loadingCloseAnalysis = state ^. _analysisState <<< to isCloseAnalysisLoading
+  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
   enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
 

--- a/marlowe-playground-client/src/JavascriptEditor/View.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/View.purs
@@ -140,9 +140,9 @@ panelContents state StaticAnalysisView =
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
     [ analysisResultPane SetIntegerTemplateParam state
-    , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
-    , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
-    , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
+    , analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
+    , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
+    , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
     ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
@@ -151,7 +151,7 @@ panelContents state StaticAnalysisView =
 
   loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
-  enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
+  analysisEnabled = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not (isCompiling state)
 
 panelContents state ErrorsView =
   section

--- a/marlowe-playground-client/src/JavascriptEditor/View.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/View.purs
@@ -139,7 +139,7 @@ panelContents state StaticAnalysisView =
   section
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
-    [ analysisResultPane state
+    [ analysisResultPane SetIntegerTemplateParam state
     , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
     , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -5,12 +5,16 @@ import Control.Alt ((<|>))
 import Data.BigInteger (BigInteger)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
+import Data.Lens (Lens')
+import Data.Lens.Iso.Newtype (_Newtype)
+import Data.Lens.Record (prop)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Set (Set)
 import Data.Set as Set
+import Data.Symbol (SProxy(..))
 import Data.Traversable (foldMap, traverse)
 import Foreign (ForeignError(..), fail)
 import Foreign.Class (class Encode, class Decode, encode, decode)
@@ -52,11 +56,26 @@ instance monoidPlaceholders :: Monoid Placeholders where
       , valuePlaceholderIds: mempty
       }
 
+data IntegerTemplateType
+  = SlotContent
+  | ValueContent
+
 newtype TemplateContent
   = TemplateContent
   { slotContent :: Map String BigInteger
   , valueContent :: Map String BigInteger
   }
+
+_slotContent :: Lens' TemplateContent (Map String BigInteger)
+_slotContent = _Newtype <<< prop (SProxy :: SProxy "slotContent")
+
+_valueContent :: Lens' TemplateContent (Map String BigInteger)
+_valueContent = _Newtype <<< prop (SProxy :: SProxy "valueContent")
+
+typeToLens :: IntegerTemplateType -> Lens' TemplateContent (Map String BigInteger)
+typeToLens SlotContent = _slotContent
+
+typeToLens ValueContent = _valueContent
 
 derive instance newTypeTemplateContent :: Newtype TemplateContent _
 

--- a/marlowe-playground-client/src/Marlowe/Extended.purs
+++ b/marlowe-playground-client/src/Marlowe/Extended.purs
@@ -34,27 +34,9 @@ newtype Placeholders
 
 derive instance newTypePlaceholders :: Newtype Placeholders _
 
-instance semigroupPlaceholders :: Semigroup Placeholders where
-  append ( Placeholders
-      { slotPlaceholderIds: slotPlaceholderIds1
-    , valuePlaceholderIds: valuePlaceholerIds1
-    }
-  ) ( Placeholders
-      { slotPlaceholderIds: slotPlaceholderIds2
-    , valuePlaceholderIds: valuePlaceholerIds2
-    }
-  ) =
-    Placeholders
-      { slotPlaceholderIds: slotPlaceholderIds1 <> slotPlaceholderIds2
-      , valuePlaceholderIds: valuePlaceholerIds1 <> valuePlaceholerIds2
-      }
+derive newtype instance semigroupPlaceholders :: Semigroup Placeholders
 
-instance monoidPlaceholders :: Monoid Placeholders where
-  mempty =
-    Placeholders
-      { slotPlaceholderIds: mempty
-      , valuePlaceholderIds: mempty
-      }
+derive newtype instance monoidPlaceholders :: Monoid Placeholders
 
 data IntegerTemplateType
   = SlotContent
@@ -79,46 +61,28 @@ typeToLens ValueContent = _valueContent
 
 derive instance newTypeTemplateContent :: Newtype TemplateContent _
 
-instance semigroupTemplateContent :: Semigroup TemplateContent where
-  append ( TemplateContent
-      { slotContent: slotContent1
-    , valueContent: valueContent1
-    }
-  ) ( TemplateContent
-      { slotContent: slotContent2
-    , valueContent: valueContent2
-    }
-  ) =
-    TemplateContent
-      { slotContent: slotContent1 <> slotContent2
-      , valueContent: valueContent1 <> valueContent2
-      }
+derive newtype instance semigroupTemplateContent :: Semigroup TemplateContent
 
-instance monoidTemplateContent :: Monoid TemplateContent where
-  mempty =
-    TemplateContent
-      { slotContent: mempty
-      , valueContent: mempty
-      }
+derive newtype instance monoidTemplateContent :: Monoid TemplateContent
 
-initialiseWith :: forall a b. Ord a => (a -> b) -> Set a -> Map a b
-initialiseWith f = foldMap (\x -> Map.singleton x $ f x)
+initializeWith :: forall a b. Ord a => (a -> b) -> Set a -> Map a b
+initializeWith f = foldMap (\x -> Map.singleton x $ f x)
 
-initialiseTemplateContent :: Placeholders -> TemplateContent
-initialiseTemplateContent ( Placeholders
+initializeTemplateContent :: Placeholders -> TemplateContent
+initializeTemplateContent ( Placeholders
     { slotPlaceholderIds, valuePlaceholderIds }
 ) =
   TemplateContent
-    { slotContent: initialiseWith (const zero) slotPlaceholderIds
-    , valueContent: initialiseWith (const zero) valuePlaceholderIds
+    { slotContent: initializeWith (const zero) slotPlaceholderIds
+    , valueContent: initializeWith (const zero) valuePlaceholderIds
     }
 
 updateTemplateContent :: Placeholders -> TemplateContent -> TemplateContent
 updateTemplateContent ( Placeholders { slotPlaceholderIds, valuePlaceholderIds }
 ) (TemplateContent { slotContent, valueContent }) =
   TemplateContent
-    { slotContent: initialiseWith (\x -> fromMaybe zero $ Map.lookup x slotContent) slotPlaceholderIds
-    , valueContent: initialiseWith (\x -> fromMaybe zero $ Map.lookup x valueContent) valuePlaceholderIds
+    { slotContent: initializeWith (\x -> fromMaybe zero $ Map.lookup x slotContent) slotPlaceholderIds
+    , valueContent: initializeWith (\x -> fromMaybe zero $ Map.lookup x valueContent) valuePlaceholderIds
     }
 
 class Template a b where

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -38,7 +38,7 @@ import Marlowe.Semantics (Rational(..), Slot(..), emptyState, evalValue, makeEnv
 import Marlowe.Semantics as S
 import Monaco (TextEdit)
 import Pretty (showPrettyMoney, showPrettyParty, showPrettyToken)
-import StaticAnalysis.Reachability (initialisePrefixMap, stepPrefixMap)
+import StaticAnalysis.Reachability (initializePrefixMap, stepPrefixMap)
 import StaticAnalysis.Types (ContractPath, ContractPathStep(..), PrefixMap)
 import Text.Pretty (hasArgs, pretty)
 
@@ -193,7 +193,7 @@ emptyEnvironment unreachablePathList =
     , letBindings: mempty
     , maxTimeout: mempty
     , isReachable: true
-    , unreachablePaths: Just $ initialisePrefixMap unreachablePathList
+    , unreachablePaths: Just $ initializePrefixMap unreachablePathList
     }
 
 -- Generic wrapper for stepPrefixMap. It steps the results of reachability analysis to see

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -25,7 +25,7 @@ panelContents state StaticAnalysisView =
   section
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
-    [ analysisResultPane state
+    [ analysisResultPane SetIntegerTemplateParam state
     , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
     , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -29,7 +29,7 @@ panelContents state StaticAnalysisView =
     , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
     , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
-    , clearButton (not noneAskedAnalysis) "Clear" ClearAnalysisResults
+    , clearButton (nothingLoading && not noneAskedAnalysis) "Clear" ClearAnalysisResults
     ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
@@ -40,7 +40,9 @@ panelContents state StaticAnalysisView =
 
   noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isNoneAsked
 
-  enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not contractHasErrors state
+  nothingLoading = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis
+
+  enabled' = nothingLoading && not contractHasErrors state
 
 panelContents state MarloweWarningsView =
   section

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -17,7 +17,7 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _showErrorDetail, contractHasErrors)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton)
-import StaticAnalysis.Types (_analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
 
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
@@ -31,11 +31,11 @@ panelContents state StaticAnalysisView =
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
     ]
   where
-  loadingWarningAnalysis = state ^. _analysisState <<< to isStaticLoading
+  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
 
-  loadingReachability = state ^. _analysisState <<< to isReachabilityLoading
+  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<< to isReachabilityLoading
 
-  loadingCloseAnalysis = state ^. _analysisState <<< to isCloseAnalysisLoading
+  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
   enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not contractHasErrors state
 

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -16,8 +16,8 @@ import Halogen.HTML (ClassName(..), HTML, a, div, li, pre, section, text, ul_)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _showErrorDetail, contractHasErrors)
-import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton)
-import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
+import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
 
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
@@ -29,6 +29,7 @@ panelContents state StaticAnalysisView =
     , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
     , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
     , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
+    , clearButton (not noneAskedAnalysis) "Clear" ClearAnalysisResults
     ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
@@ -36,6 +37,8 @@ panelContents state StaticAnalysisView =
   loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<< to isReachabilityLoading
 
   loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
+
+  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isNoneAsked
 
   enabled' = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis && not contractHasErrors state
 

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -26,10 +26,10 @@ panelContents state StaticAnalysisView =
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
     [ analysisResultPane SetIntegerTemplateParam state
-    , analyzeButton loadingWarningAnalysis enabled' "Analyse for warnings" AnalyseContract
-    , analyzeButton loadingReachability enabled' "Analyse reachability" AnalyseReachabilityContract
-    , analyzeButton loadingCloseAnalysis enabled' "Analyse for refunds on Close" AnalyseContractForCloseRefund
-    , clearButton (nothingLoading && not noneAskedAnalysis) "Clear" ClearAnalysisResults
+    , analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
+    , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
+    , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
+    , clearButton clearEnabled "Clear" ClearAnalysisResults
     ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
@@ -42,7 +42,9 @@ panelContents state StaticAnalysisView =
 
   nothingLoading = not loadingWarningAnalysis && not loadingReachability && not loadingCloseAnalysis
 
-  enabled' = nothingLoading && not contractHasErrors state
+  clearEnabled = nothingLoading && not noneAskedAnalysis
+
+  analysisEnabled = nothingLoading && not contractHasErrors state
 
 panelContents state MarloweWarningsView =
   section

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -18,6 +18,7 @@ import Data.Either (Either(..), hush)
 import Data.Foldable (for_, traverse_)
 import Data.Lens (assign, modifying, preview, set, use)
 import Data.Lens.Index (ix)
+import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (codePointFromChar)
 import Data.String as String
@@ -31,7 +32,7 @@ import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
-import Marlowe.Extended (Contract, getPlaceholderIds, updateTemplateContent)
+import Marlowe.Extended (Contract, getPlaceholderIds, typeToLens, updateTemplateContent)
 import Marlowe.Holes (fromTerm)
 import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
@@ -115,6 +116,9 @@ handleAction (InitMarloweProject contents) = do
   liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey contents
 
 handleAction (SelectHole hole) = assign _selectedHole hole
+
+handleAction (SetIntegerTemplateParam templateType key value) = do
+  modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 
 handleAction AnalyseContract = runAnalysis $ analyseContract
 

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -165,13 +165,10 @@ lintText text = do
     (Tuple markerData additionalContext) = Linter.markers unreachableContracts parsedContract
   markers <- query _marloweEditorPageSlot unit (Monaco.SetModelMarkers markerData identity)
   traverse_ editorSetMarkers markers
-  for_ parsedContract
-    ( \contractHoles ->
-        for_ ((fromTerm contractHoles) :: Maybe Contract)
-          ( \contract ->
-              modifying (_analysisState <<< _templateContent) $ updateTemplateContent $ getPlaceholderIds contract
-          )
-    ) -- We set the templates here so that we don't have to parse twice
+  for_ parsedContract \contractHoles ->
+    for_ ((fromTerm contractHoles) :: Maybe Contract) \contract ->
+      modifying (_analysisState <<< _templateContent) $ updateTemplateContent $ getPlaceholderIds contract
+  -- We set the templates here so that we don't have to parse twice
   {-
     There are three different Monaco objects that require the linting information:
       * Markers

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -44,7 +44,7 @@ import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
 import StaticAnalysis.Reachability (analyseReachability, getUnreachableContracts)
 import StaticAnalysis.StaticTools (analyseContract)
-import StaticAnalysis.Types (_analysisExecutionState, _analysisState, _templateContent)
+import StaticAnalysis.Types (AnalysisExecutionState(..), _analysisExecutionState, _analysisState, _templateContent)
 import StaticData (marloweBufferLocalStorageKey)
 import StaticData as StaticData
 import Text.Pretty (pretty)
@@ -117,14 +117,15 @@ handleAction (InitMarloweProject contents) = do
 
 handleAction (SelectHole hole) = assign _selectedHole hole
 
-handleAction (SetIntegerTemplateParam templateType key value) = do
-  modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
+handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 
 handleAction AnalyseContract = runAnalysis $ analyseContract
 
 handleAction AnalyseReachabilityContract = runAnalysis $ analyseReachability
 
 handleAction AnalyseContractForCloseRefund = runAnalysis $ analyseClose
+
+handleAction ClearAnalysisResults = assign (_analysisState <<< _analysisExecutionState) NoneAsked
 
 handleAction Save = pure unit
 

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -31,19 +31,19 @@ import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
+import Marlowe.Extended (Contract)
 import Marlowe.Holes (fromTerm)
 import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import Marlowe.Extended (Contract)
 import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _selectedHole, _showErrorDetail)
 import Monaco (IMarker, isError, isWarning)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
 import StaticAnalysis.Reachability (analyseReachability, getUnreachableContracts)
 import StaticAnalysis.StaticTools (analyseContract)
-import StaticAnalysis.Types (_analysisState)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState)
 import StaticData (marloweBufferLocalStorageKey)
 import StaticData as StaticData
 import Text.Pretty (pretty)
@@ -148,11 +148,11 @@ lintText ::
   String ->
   HalogenM State Action ChildSlots Void m Unit
 lintText text = do
-  analysisState <- use _analysisState
+  analysisExecutionState <- use (_analysisState <<< _analysisExecutionState)
   let
     parsedContract = parseContract text
 
-    unreachableContracts = getUnreachableContracts analysisState
+    unreachableContracts = getUnreachableContracts analysisExecutionState
 
     (Tuple markerData additionalContext) = Linter.markers unreachableContracts parsedContract
   markers <- query _marloweEditorPageSlot unit (Monaco.SetModelMarkers markerData identity)

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -125,7 +125,10 @@ handleAction AnalyseReachabilityContract = runAnalysis $ analyseReachability
 
 handleAction AnalyseContractForCloseRefund = runAnalysis $ analyseClose
 
-handleAction ClearAnalysisResults = assign (_analysisState <<< _analysisExecutionState) NoneAsked
+handleAction ClearAnalysisResults = do
+  assign (_analysisState <<< _analysisExecutionState) NoneAsked
+  mContents <- editorGetValue
+  for_ mContents \contents -> lintText contents
 
 handleAction Save = pure unit
 

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -6,6 +6,7 @@ import Analytics as A
 import BottomPanel.Types as BottomPanel
 import Data.Array (filter)
 import Data.Array as Array
+import Data.BigInteger (BigInteger)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', to, view, (^.))
@@ -15,6 +16,7 @@ import Data.String (Pattern(..), contains)
 import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
+import Marlowe.Extended (IntegerTemplateType)
 import Monaco (IMarker)
 import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
 import Text.Parsing.StringParser (Pos)
@@ -35,6 +37,7 @@ data Action
   | ViewAsBlockly
   | InitMarloweProject String
   | SelectHole (Maybe String)
+  | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
@@ -58,6 +61,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent ViewAsBlockly = Just $ defaultEvent "ViewAsBlockly"
   toEvent (InitMarloweProject _) = Just $ defaultEvent "InitMarloweProject"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
+  toEvent (SetIntegerTemplateParam _ _ _) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -41,6 +41,7 @@ data Action
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
+  | ClearAnalysisResults
   | Save
 
 defaultEvent :: String -> Event
@@ -65,6 +66,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"
+  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent Save = Just $ defaultEvent "Save"
 
 data BottomPanelView

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -18,7 +18,7 @@ import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Marlowe.Extended (IntegerTemplateType)
 import Monaco (IMarker)
-import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, initAnalysisState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
 
@@ -115,10 +115,7 @@ initialState =
   , bottomPanelState: BottomPanel.initialState StaticAnalysisView
   , showErrorDetail: false
   , selectedHole: Nothing
-  , analysisState:
-      { templateContent: mempty
-      , analysisExecutionState: NoneAsked
-      }
+  , analysisState: initAnalysisState
   , editorErrors: mempty
   , editorWarnings: mempty
   }

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -16,7 +16,7 @@ import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Monaco (IMarker)
-import StaticAnalysis.Types (AnalysisState(..))
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
 
@@ -109,7 +109,10 @@ initialState =
   , bottomPanelState: BottomPanel.initialState StaticAnalysisView
   , showErrorDetail: false
   , selectedHole: Nothing
-  , analysisState: NoneAsked
+  , analysisState:
+      { templateContent: mempty
+      , analysisExecutionState: NoneAsked
+      }
   , editorErrors: mempty
   , editorWarnings: mempty
   }

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -41,7 +41,7 @@ import Halogen.Monaco (Query(..)) as Monaco
 import LocalStorage as LocalStorage
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe as Server
-import Marlowe.Extended (fillTemplate, toCore)
+import Marlowe.Extended (fillTemplate, toCore, typeToLens)
 import Marlowe.Extended as EM
 import Marlowe.Holes (fromTerm)
 import Marlowe.Monaco as MM
@@ -84,6 +84,10 @@ handleAction Init = do
 
 handleAction (SetInitialSlot initialSlot) = do
   assign (_currentMarloweState <<< _executionState <<< _SimulationNotStarted <<< _initialSlot) initialSlot
+  setOraclePrice
+
+handleAction (SetIntegerTemplateParam templateType key value) = do
+  modifying (_currentMarloweState <<< _executionState <<< _SimulationNotStarted <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
   setOraclePrice
 
 handleAction StartSimulation =

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -27,7 +27,7 @@ import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Help (HelpContext(..))
-import Marlowe.Extended (IntegerTemplateType, TemplateContent, getPlaceholderIds, initialiseTemplateContent)
+import Marlowe.Extended (IntegerTemplateType, TemplateContent, getPlaceholderIds, initializeTemplateContent)
 import Marlowe.Extended as EM
 import Marlowe.Holes (Holes)
 import Marlowe.Semantics (AccountId, Assets, Bound, ChoiceId, ChosenNum, Contract, Input, Party(..), Payment, Slot, SlotInterval, Token, TransactionError, TransactionInput, TransactionWarning, aesonCompatibleOptions, emptyState)
@@ -229,7 +229,7 @@ simulationNotStartedWithSlot slot mContract =
   SimulationNotStarted
     { initialSlot: slot
     , extendedContract: mContract
-    , templateContent: maybe mempty (initialiseTemplateContent <<< getPlaceholderIds) mContract
+    , templateContent: maybe mempty (initializeTemplateContent <<< getPlaceholderIds) mContract
     }
 
 simulationNotStarted :: Maybe EM.Contract -> ExecutionState

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -20,13 +20,14 @@ import Data.List.NonEmpty as NEL
 import Data.List.Types (NonEmptyList)
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype)
 import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Help (HelpContext(..))
+import Marlowe.Extended (TemplateContent, getPlaceholderIds, initialiseTemplateContent)
 import Marlowe.Extended as EM
 import Marlowe.Holes (Holes)
 import Marlowe.Semantics (AccountId, Assets, Bound, ChoiceId, ChosenNum, Contract, Input, Party(..), Payment, Slot, SlotInterval, Token, TransactionError, TransactionInput, TransactionWarning, aesonCompatibleOptions, emptyState)
@@ -175,6 +176,7 @@ _payments = _log <<< to (mapMaybe f)
 type InitialConditionsRecord
   = { initialSlot :: Slot
     , extendedContract :: Maybe EM.Contract
+    , templateContent :: TemplateContent
     }
 
 _initialSlot :: forall s a. Lens' { initialSlot :: a | s } a
@@ -182,6 +184,9 @@ _initialSlot = prop (SProxy :: SProxy "initialSlot")
 
 _extendedContract :: forall s a. Lens' { extendedContract :: a | s } a
 _extendedContract = prop (SProxy :: SProxy "extendedContract")
+
+_templateContent :: forall s a. Lens' { templateContent :: a | s } a
+_templateContent = prop (SProxy :: SProxy "templateContent")
 
 data ExecutionState
   = SimulationRunning ExecutionStateRecord
@@ -224,6 +229,7 @@ simulationNotStartedWithSlot slot mContract =
   SimulationNotStarted
     { initialSlot: slot
     , extendedContract: mContract
+    , templateContent: maybe mempty (initialiseTemplateContent <<< getPlaceholderIds) mContract
     }
 
 simulationNotStarted :: Maybe EM.Contract -> ExecutionState

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -27,7 +27,7 @@ import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Help (HelpContext(..))
-import Marlowe.Extended (TemplateContent, getPlaceholderIds, initialiseTemplateContent)
+import Marlowe.Extended (IntegerTemplateType, TemplateContent, getPlaceholderIds, initialiseTemplateContent)
 import Marlowe.Extended as EM
 import Marlowe.Holes (Holes)
 import Marlowe.Semantics (AccountId, Assets, Bound, ChoiceId, ChosenNum, Contract, Input, Party(..), Payment, Slot, SlotInterval, Token, TransactionError, TransactionInput, TransactionWarning, aesonCompatibleOptions, emptyState)
@@ -315,6 +315,7 @@ data Action
   = Init
   -- marlowe actions
   | SetInitialSlot Slot
+  | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | StartSimulation
   | MoveSlot Slot
   | SetSlot Slot
@@ -335,6 +336,7 @@ defaultEvent s = A.defaultEvent $ "Simulation." <> s
 instance isEventAction :: IsEvent Action where
   toEvent Init = Just $ defaultEvent "Init"
   toEvent (SetInitialSlot _) = Just $ defaultEvent "SetInitialSlot"
+  toEvent (SetIntegerTemplateParam templateType key value) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent StartSimulation = Just $ defaultEvent "StartSimulation"
   toEvent (MoveSlot _) = Just $ defaultEvent "MoveSlot"
   toEvent (SetSlot _) = Just $ defaultEvent "SetSlot"

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -33,7 +33,7 @@ import Monaco (Editor)
 import Monaco as Monaco
 import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
-import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId, BottomPanelView(..), ExecutionState(..), MarloweEvent(..), State, InitialConditionsRecord, _SimulationRunning, _bottomPanelState, _currentContract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _showRightPanel, _slot, _transactionError, _transactionWarnings, otherActionsParty)
+import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId, BottomPanelView(..), ExecutionState(..), InitialConditionsRecord, MarloweEvent(..), State, _SimulationRunning, _bottomPanelState, _currentContract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _showRightPanel, _slot, _transactionError, _transactionWarnings, otherActionsParty)
 import Simulator (hasHistory, inFuture)
 
 render ::
@@ -232,8 +232,8 @@ startSimulationWidget { initialSlot, templateContent } =
             ]
         , div [ classes [] ]
             [ ul [ class_ (ClassName "templates") ]
-                ( integerTemplateParameters SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
-                    <> integerTemplateParameters ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+                ( integerTemplateParameters SetIntegerTemplateParam SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
+                    <> integerTemplateParameters SetIntegerTemplateParam ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
                 )
             ]
         , div [ classes [ ClassName "transaction-btns", flex, justifyCenter ] ]
@@ -245,8 +245,8 @@ startSimulationWidget { initialSlot, templateContent } =
             ]
         ]
 
-integerTemplateParameters :: forall p. IntegerTemplateType -> String -> String -> Map String BigInteger -> Array (HTML p Action)
-integerTemplateParameters typeName title prefix content =
+integerTemplateParameters :: forall action p. (IntegerTemplateType -> String -> BigInteger -> action) -> IntegerTemplateType -> String -> String -> Map String BigInteger -> Array (HTML p action)
+integerTemplateParameters actionGen typeName title prefix content =
   [ li_
       if Map.isEmpty content then
         []
@@ -258,7 +258,7 @@ integerTemplateParameters typeName title prefix content =
                           [ text (prefix <> " ")
                           , strong_ [ text key ]
                           , text ":"
-                          , marloweActionInput (SetIntegerTemplateParam typeName key) value
+                          , marloweActionInput (actionGen typeName key) value
                           ]
                       )
                     )
@@ -467,7 +467,7 @@ inputItem state person (MoveToSlot slot) =
 
   boundsError = "The slot must be more than the current slot " <> (state ^. (_currentMarloweState <<< _executionState <<< _SimulationRunning <<< _slot <<< to show))
 
-marloweActionInput :: forall p a. Show a => (BigInteger -> Action) -> a -> HTML p Action
+marloweActionInput :: forall p a action. Show a => (BigInteger -> action) -> a -> HTML p action
 marloweActionInput f current =
   input
     [ type_ InputNumber

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -19,7 +19,7 @@ import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..))
 import Pretty (showPrettyToken)
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
-import StaticAnalysis.Types (AnalysisState(..), MultiStageAnalysisData(..), _analysisState)
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, MultiStageAnalysisData(..), _analysisExecutionState, _analysisState)
 import Types (WarningAnalysisError(..))
 
 analyzeButton ::
@@ -35,7 +35,7 @@ analyzeButton isLoading isEnabled name action =
 analysisResultPane :: forall action p state. { analysisState :: AnalysisState | state } -> HTML p action
 analysisResultPane state =
   let
-    result = state ^. _analysisState
+    result = state ^. (_analysisState <<< _analysisExecutionState)
 
     explanation = div [ classes [ ClassName "padded-explanation" ] ]
   in

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -4,22 +4,26 @@ module StaticAnalysis.BottomPanel
   ) where
 
 import Prelude hiding (div)
+import Data.BigInteger (BigInteger)
 import Data.Foldable (foldMap)
 import Data.Lens ((^.))
 import Data.List (List, null, toUnfoldable)
 import Data.List as List
 import Data.List.NonEmpty (toList)
 import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
 import Halogen.Classes (spaceBottom, spaceRight, spaceTop, spanText)
 import Halogen.HTML (ClassName(..), HTML, b_, br_, button, div, h2, h3, li_, ol, span_, text, ul)
 import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (classes, enabled)
+import Halogen.HTML.Properties (class_, classes, enabled)
+import Marlowe.Extended (IntegerTemplateType(..))
 import Marlowe.Semantics (ChoiceId(..), Input(..), Payee(..), Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..))
 import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..))
 import Pretty (showPrettyToken)
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
-import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, MultiStageAnalysisData(..), _analysisExecutionState, _analysisState)
+import SimulationPage.View (integerTemplateParameters)
+import StaticAnalysis.Types (AnalysisExecutionState(..), AnalysisState, MultiStageAnalysisData(..), _analysisExecutionState, _analysisState, _templateContent)
 import Types (WarningAnalysisError(..))
 
 analyzeButton ::
@@ -32,9 +36,11 @@ analyzeButton isLoading isEnabled name action =
     ]
     [ text (if isLoading then "Analysing..." else name) ]
 
-analysisResultPane :: forall action p state. { analysisState :: AnalysisState | state } -> HTML p action
-analysisResultPane state =
+analysisResultPane :: forall action p state. (IntegerTemplateType -> String -> BigInteger -> action) -> { analysisState :: AnalysisState | state } -> HTML p action
+analysisResultPane actionGen state =
   let
+    templateContent = state ^. (_analysisState <<< _templateContent)
+
     result = state ^. (_analysisState <<< _analysisExecutionState)
 
     explanation = div [ classes [ ClassName "padded-explanation" ] ]
@@ -43,6 +49,10 @@ analysisResultPane state =
       NoneAsked ->
         explanation
           [ text ""
+          , ul [ class_ (ClassName "templates") ]
+              ( integerTemplateParameters actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
+                  <> integerTemplateParameters actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+              )
           ]
       WarningAnalysis staticSubResult -> case staticSubResult of
         NotAsked ->

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -1,6 +1,7 @@
 module StaticAnalysis.BottomPanel
   ( analysisResultPane
   , analyzeButton
+  , clearButton
   ) where
 
 import Prelude hiding (div)
@@ -35,6 +36,16 @@ analyzeButton isLoading isEnabled name action =
     , classes [ spaceTop, spaceBottom, spaceRight ]
     ]
     [ text (if isLoading then "Analysing..." else name) ]
+
+clearButton ::
+  forall p action. Boolean -> String -> action -> HTML p action
+clearButton isEnabled name action =
+  button
+    [ onClick $ const $ Just $ action
+    , enabled isEnabled
+    , classes [ spaceTop, spaceBottom, spaceRight ]
+    ]
+    [ text name ]
 
 analysisResultPane :: forall action p state. (IntegerTemplateType -> String -> BigInteger -> action) -> { analysisState :: AnalysisState | state } -> HTML p action
 analysisResultPane actionGen state =

--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -2,7 +2,7 @@ module StaticAnalysis.Reachability
   ( analyseReachability
   , areContractAndStateTheOnesAnalysed
   , getUnreachableContracts
-  , initialisePrefixMap
+  , initializePrefixMap
   , startReachabilityAnalysis
   , stepPrefixMap
   ) where
@@ -94,8 +94,8 @@ areContractAndStateTheOnesAnalysed (ReachabilityAnalysis (AnalysisFoundCounterEx
 areContractAndStateTheOnesAnalysed _ _ _ = false
 
 -- It groups the contract paths by their head, discards empty contract paths
-initialisePrefixMap :: List ContractPath -> PrefixMap
-initialisePrefixMap unreachablePathList = fromFoldableWith union $ map (\x -> (head x /\ singleton x)) $ catMaybes $ map fromList unreachablePathList
+initializePrefixMap :: List ContractPath -> PrefixMap
+initializePrefixMap unreachablePathList = fromFoldableWith union $ map (\x -> (head x /\ singleton x)) $ catMaybes $ map fromList unreachablePathList
 
 -- Returns Nothing when the path is unreachable according to one of the paths, otherwise it returns the updated PrefixMap for the subpath
 stepPrefixMap :: forall a. CMS.State a Unit -> PrefixMap -> ContractPathStep -> CMS.State a (Maybe PrefixMap)
@@ -108,5 +108,5 @@ stepPrefixMap markUnreachable prefixMap contractPath = case lookup contractPath 
         markUnreachable
         pure Nothing
       else
-        pure $ Just $ unionWith union (initialisePrefixMap tails) mempty
+        pure $ Just $ unionWith union (initializePrefixMap tails) mempty
   Nothing -> pure (Just mempty)

--- a/marlowe-playground-client/src/StaticAnalysis/Types.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Types.purs
@@ -30,6 +30,12 @@ _templateContent = prop (SProxy :: SProxy "templateContent")
 _analysisExecutionState :: forall s a. Lens' { analysisExecutionState :: a | s } a
 _analysisExecutionState = prop (SProxy :: SProxy "analysisExecutionState")
 
+initAnalysisState :: AnalysisState
+initAnalysisState =
+  { templateContent: mempty
+  , analysisExecutionState: NoneAsked
+  }
+
 data AnalysisExecutionState
   = NoneAsked
   | WarningAnalysis (WarningAnalysisData Result)

--- a/marlowe-playground-client/src/StaticAnalysis/Types.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Types.purs
@@ -58,6 +58,11 @@ isCloseAnalysisLoading (CloseAnalysis AnalysisNotStarted) = true
 
 isCloseAnalysisLoading _ = false
 
+isNoneAsked :: AnalysisExecutionState -> Boolean
+isNoneAsked NoneAsked = true
+
+isNoneAsked _ = false
+
 -------------------------------------------------------------------------------
 data MultiStageAnalysisData
   = AnalysisNotStarted

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -493,3 +493,26 @@ button.minus-btn:hover {
   margin-bottom: 0.5rem;
 }
 
+.templates li {
+  margin: 1.5rem 0;
+}
+
+.templates h6 {
+  margin: 0 0 1rem 0;
+}
+
+.templates em {
+  display: inline-block;
+}
+
+.template-fields {
+  margin: 0.5rem 1.5rem;
+}
+
+.template-fields * {
+  word-break: break-all;
+}
+
+.template-fields > input {
+  margin-left: 1rem;
+}


### PR DESCRIPTION
This PR adds the instantiation mechanism to the UI, both to the Marlowe Editor's static analysis (before analysis) and the Simulation (before starting simulation).

It was necessary to add a "Clear" button for Marlowe Editor's static analysis, because otherwise you can only set the parameters onces. You can still do that, but if you add new parameters you need to `Clear` and instantiate the new ones. This also allows the user to clear the results from reachability analysis without starting a new analysis.

For Haskell and JavaScript, we are going to need an initialisation phase, with Marlowe we can get away with having the template instantiation update automatically with the contract.

![instantiation](https://user-images.githubusercontent.com/638102/108005844-bfc39700-6ff1-11eb-98dd-7bc8000afa70.gif)

Example contract with parameters:
```haskell
When [Case (Deposit (Role "alice") (Role "alice") (Token "" "") (ConstantParam "amount")) (When [Case (Choice (ChoiceId "choice" (Role "alice")) [Bound 0 1]) (When [Case (Choice (ChoiceId "choice" (Role "bob")) [Bound 0 1]) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (ChoiceValue (ChoiceId "choice" (Role "bob")))) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (Constant 0)) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) Close) (When [Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 1 1]) Close , Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 0 0]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close)] (SlotParam "arbitrageTimeout") Close))] (SlotParam "bobTimeout") (When [Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 1 1]) Close , Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 0 0]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close)] (SlotParam "arbitrageTimeout") Close))] (SlotParam "aliceTimeout") (When [Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 1 1]) Close , Case (Choice (ChoiceId "choice" (Role "carol")) [Bound 0 0]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close)] (SlotParam "arbitrageTimeout") Close))] (SlotParam "depositSlot") Close
```

Deployed to: https://pablo.marlowe.iohkdev.io/

First idea that comes to mind is that maybe we should show the templates in chronological order (from root to leaf), but that is not so trivial at all and it doesn't add any functionality. So I think we can maybe add a low priority ticket for that, or rather think of a different way of parametrising slots. In the meanwhile, we can just parametrise with names like "01 - Initial timeout", "02 - Alices deposit" :)

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
