### PR TITLE
Kwxm/improve plc timing  (SCP-1872)

### DIFF
--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -657,7 +657,7 @@ formatTime t
     | t >= 1e3  = printf "%.3f ns" (t/1e3)
     | otherwise = printf "%f ps"   t
 
-{- Apply an evaluator to a program a number of times and report the mean execution
+{-| Apply an evaluator to a program a number of times and report the mean execution
 time.  The first measurement is often significantly larger than the rest
 (perhaps due to warm-up effects), and this can distort the mean.  To avoid this
 we measure the evaluation time (n+1) times and discard the first result. -}

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -665,7 +665,7 @@ timeEval :: NFData a => Integer -> (t -> a) -> t -> IO ()
 timeEval n evaluate prog =
     if n <= 0 then error "Error: the number of repetitions should be at least 1"
     else do
-      times <- tail <$> mapM (timeOnce evaluate) (replicate (fromIntegral (n+1)) prog)
+      times <- tail <$> for (replicate (fromIntegral (n+1)) prog) (timeOnce evaluate)
       let mean = (fromIntegral $ sum times) / (fromIntegral n) :: Double
           runs :: String = if n==1 then "run" else "runs"
       printf "Mean evaluation time (%d %s): %s\n" n runs (formatTime mean)

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -718,7 +718,7 @@ runEval (EvalOptions language inp ifmt evalMode printMode timingMode) =
                 PLC.EvaluationFailure   -> exitFailure
           handleTimingResults results =
               case nub results of
-                [PLC.EvaluationSuccess _] -> exitSuccess -- We don't want to see the results here
+                [PLC.EvaluationSuccess _] -> exitSuccess -- We don't want to see the result here
                 [PLC.EvaluationFailure]   -> exitFailure
                 _                         -> error "Timing evaluations returned inconsistent results"
 

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -723,7 +723,6 @@ runEval (EvalOptions language inp ifmt evalMode printMode timingMode) =
                 _                         -> error "Timing evaluations returned inconsistent results"
 
 
-
 ---------------- Driver ----------------
 
 main :: IO ()

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -667,8 +667,7 @@ timeEval n evaluate prog =
     else do
       times <- tail <$> mapM (timeOnce evaluate) (replicate (fromIntegral (n+1)) prog)
       let mean = (fromIntegral $ sum times) / (fromIntegral n) :: Double
-      _ <- mapM print times
-      let runs :: String = if n==1 then "run" else "runs"
+          runs :: String = if n==1 then "run" else "runs"
       printf "Mean evaluation time (%d %s): %s\n" n runs (formatTime mean)
     where timeOnce eval prg = do
              start <- performGC >> getCPUTime

--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -663,7 +663,7 @@ time.  The first measurement is often significantly larger than the rest
 we measure the evaluation time (n+1) times and discard the first result. -}
 timeEval :: NFData a => Integer -> (t -> a) -> t -> IO ()
 timeEval n evaluate prog =
-    if n <= 0then error "Error: the number of repetitions should be at least 1"
+    if n <= 0 then error "Error: the number of repetitions should be at least 1"
     else do
       times <- tail <$> mapM (timeOnce evaluate) (replicate (fromIntegral (n+1)) prog)
       let mean = (fromIntegral $ sum times) / (fromIntegral n) :: Double

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -397,7 +397,6 @@ executable plc
     build-depends:
         base <5,
         bytestring -any,
-        criterion-measurement -any,
         deepseq -any,
         flat -any,
         optparse-applicative -any,

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -397,6 +397,7 @@ executable plc
     build-depends:
         base <5,
         bytestring -any,
+        criterion-measurement -any,
         deepseq -any,
         flat -any,
         optparse-applicative -any,


### PR DESCRIPTION
This improves the timing feature in the plc command, so it should now be possible to quickly get reasonable benchmark times without having to set up lots of Criterion stuff.  You can now say `plc evaluate <prog> -X <N>` to run a program N times and see the mean execution time.  You can also use `-x` for 100 repetitions.

This turned out to be more difficult than I expected.  I had a version using `Criterion.Measurement.measure` (see the [documentation](http://hackage.haskell.org/package/criterion-measurement-0.1.2.0/docs/Criterion-Measurement.html)), which evaluates a function a given number of times and returns various statistics, including the total execution time.  However, this gives odd results.  It turns out that if you repeatedly execute a PLC program on the CEK machine the first evaluation can take significantly longer than subsequent ones (especially for programs which execute very quickly), perhaps because of warm-up effects.  You can see the effect of this in the attached PDFs, which show the time reported by `measure` for 1,2,3,... executions of a couple of programs (one just multiplies 88 by 44, the other is a crowfunding validator).  The reported average time starts off large and then drops asymptotically towards a stable value: this is because the atypically large first measurement drags the mean upwards, but the distortion decreases as large numbers of more typical measurements appear.  Criterion's `measure` function doesn't retain the individual times, so it's impossible to adjust it.  To overcome this I've written my own code which collects n+1 measurements and discards the first result (and if you look at the individual numbers you can see that the first one really is atypical).  This gives much more consistent results.    Possibly this isn't a sensible thing to do: in the real world the machine will be receiving a sequence of different validators to execute one after the other and maybe any warm-up effects won't have the opportunity to appear.

Here are the files mentioned above:
[mult.pdf](https://github.com/input-output-hk/plutus/files/5987883/mult.pdf)
[crowdfunding.pdf](https://github.com/input-output-hk/plutus/files/5987884/crowdfunding.pdf)


Next PR: adding an option to report budgeting information.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
