### PR TITLE
SCP-1903: Remove runStderrLog

### DIFF
--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -41,16 +41,15 @@ import           Control.Monad.Freer.Log                         (logError)
 import           Control.Monad.IO.Class                          (liftIO)
 import           Control.Monad.Logger                            (runStdoutLoggingT)
 import qualified Data.Aeson                                      as JSON
-import           Data.Bifunctor                                  (Bifunctor (..))
 import qualified Data.ByteString.Lazy.Char8                      as BS8
 import           Data.Foldable                                   (for_, traverse_)
-import           Data.Functor.Contravariant                      (Contravariant (..))
 import qualified Data.Map                                        as Map
 import qualified Data.Set                                        as Set
 import qualified Data.Text                                       as Text
 import           GHC.Generics                                    (Generic)
 import           Plutus.PAB.MonadLoggerBridge                    (TraceLoggerT (..))
-import           Plutus.PAB.Monitoring                           (defaultConfig, handleLogMsgTrace, loadConfig)
+import           Plutus.PAB.Monitoring                           (convertLog, defaultConfig, handleLogMsgTrace,
+                                                                  loadConfig)
 
 import           Data.Text.Prettyprint.Doc                       (Pretty (..), pretty)
 import           Data.Time.Units                                 (toMicroseconds)
@@ -573,9 +572,6 @@ main = do
             exitWith (ExitFailure 1)
         Right _ -> exitSuccess
 
--- Convert tracer structured log data
-convertLog :: (a -> b) -> Trace m b -> Trace m a
-convertLog f = contramap (second (fmap f))
 
 toPABMsg :: Trace m AppMsg -> Trace m PABLogMsg
 toPABMsg = convertLog PABMsg

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -21,14 +21,12 @@ import           Control.Monad                   (forever, unless, void)
 import           Control.Monad.Freer             hiding (run)
 import           Control.Monad.Freer.Extra.Log
 import           Control.Monad.Freer.Extra.State (assign, use)
-import           Control.Monad.Freer.Log         (renderLogMessages)
 import           Control.Monad.Freer.State
 import qualified Control.Monad.Freer.State       as Eff
 import           Control.Monad.IO.Class          (MonadIO (..))
 import           Data.Foldable                   (fold, traverse_)
 import           Data.Function                   ((&))
 import           Data.Proxy                      (Proxy (Proxy))
-import           Data.Text                       (Text)
 import           Data.Time.Units                 (Second, toMicroseconds)
 import           Ledger.Blockchain               (Block)
 import           Network.HTTP.Client             (defaultManagerSettings, newManager)
@@ -45,7 +43,7 @@ import qualified Cardano.Node.Follower           as NodeFollower
 import           Control.Concurrent.Availability (Availability, available)
 import           Ledger.Address                  (Address)
 import           Ledger.AddressMap               (AddressMap)
-import           Plutus.PAB.Monitoring           (runLogEffects)
+import           Plutus.PAB.Monitoring           (convertLog, handleLogMsgTrace, runLogEffects)
 import           Wallet.Effects                  (ChainIndexEffect)
 import qualified Wallet.Effects                  as WalletEffects
 import           Wallet.Emulator.ChainIndex      (ChainIndexControlEffect, ChainIndexEvent, ChainIndexState)
@@ -56,24 +54,26 @@ import           Wallet.Emulator.NodeClient      (ChainClientNotification (Block
 -- The PAB chain index that keeps track of transaction data (UTXO set enriched
 -- with datums)
 
-app :: MVar AppState -> Application
-app stateVar =
+type ChainIndexTrace = Trace IO ChainIndexServerMsg
+
+app :: ChainIndexTrace -> MVar AppState -> Application
+app trace stateVar =
     serve (Proxy @API) $
     hoistServer
         (Proxy @API)
-        (processIndexEffects stateVar)
+        (liftIO . processIndexEffects trace stateVar)
         (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
 
-main :: Trace IO ChainIndexServerMsg -> ChainIndexConfig -> BaseUrl -> Availability -> IO ()
+main :: ChainIndexTrace -> ChainIndexConfig -> BaseUrl -> Availability -> IO ()
 main trace ChainIndexConfig{ciBaseUrl} nodeBaseUrl availability = runLogEffects trace $ do
     nodeClientEnv <- liftIO getNode
     mVarState <- liftIO $ newMVar initialAppState
 
     logInfo StartingNodeClientThread
-    void $ liftIO $ forkIO $ runLogEffects trace $ updateThread 10 mVarState nodeClientEnv
+    void $ liftIO $ forkIO $ runLogEffects trace $ updateThread trace 10 mVarState nodeClientEnv
 
     logInfo $ StartingChainIndex servicePort
-    liftIO $ Warp.runSettings warpSettings $ app mVarState
+    liftIO $ Warp.runSettings warpSettings $ app trace mVarState
         where
             isAvailable = available availability
             servicePort = baseUrlPort ciBaseUrl
@@ -119,14 +119,15 @@ updateThread ::
     ( LastMember IO effs
     , Member (LogMsg ChainIndexServerMsg) effs
     )
-    => Second
+    => ChainIndexTrace
+    -> Second
     -- ^ Interval between two queries for new blocks
     -> MVar AppState
     -- ^ State of the chain index
     -> ClientEnv
     -- ^ Servant client for the node API
     -> Eff effs ()
-updateThread updateInterval mv nodeClientEnv = do
+updateThread trace updateInterval mv nodeClientEnv = do
     logInfo ObtainingFollowerID
     followerID <-
         liftIO $
@@ -134,8 +135,8 @@ updateThread updateInterval mv nodeClientEnv = do
         either (error . show) pure
     logInfo $ ObtainedFollowerID followerID
     forever $ do
-        watching <- processIndexEffects mv WalletEffects.watchedAddresses
-        unless (watching == mempty) (fetchNewBlocks followerID nodeClientEnv mv)
+        watching <- processIndexEffects trace mv WalletEffects.watchedAddresses
+        unless (watching == mempty) (fetchNewBlocks trace followerID nodeClientEnv mv)
         liftIO $ threadDelay $ fromIntegral $ toMicroseconds updateInterval
 
 fetchNewBlocks ::
@@ -143,11 +144,12 @@ fetchNewBlocks ::
     ( LastMember IO effs
     , Member (LogMsg ChainIndexServerMsg) effs
     )
-    => FollowerID
+    => ChainIndexTrace
+    -> FollowerID
     -> ClientEnv
     -> MVar AppState
     -> Eff effs ()
-fetchNewBlocks followerID nodeClientEnv mv = do
+fetchNewBlocks trace followerID nodeClientEnv mv = do
     logInfo AskingNodeForNewBlocks
     newBlocks <-
         liftIO $
@@ -161,7 +163,7 @@ fetchNewBlocks followerID nodeClientEnv mv = do
         either (error . show) pure
     let notifications = BlockValidated <$> newBlocks
     traverse_
-        (processIndexEffects mv . ChainIndex.chainIndexNotify)
+        (processIndexEffects trace mv . ChainIndex.chainIndexNotify)
         (notifications ++ [SlotChanged curentSlot])
 
 type ChainIndexEffects m
@@ -169,23 +171,25 @@ type ChainIndexEffects m
         , ChainIndexEffect
         , State ChainIndexState
         , LogMsg ChainIndexEvent
-        , LogMsg Text
         , m
         ]
 
 processIndexEffects ::
     MonadIO m
-    => MVar AppState
+    => ChainIndexTrace
+    -> MVar AppState
     -> Eff (ChainIndexEffects IO) a
     -> m a
-processIndexEffects stateVar eff = do
-    AppState{_indexState, _indexEvents, _indexFollowerID} <- liftIO $ takeMVar stateVar
+processIndexEffects trace stateVar eff = do
+    AppState {_indexState, _indexEvents, _indexFollowerID} <- liftIO $ takeMVar stateVar
     (result, newState) <- liftIO
-                            $ runM
-                            $ runStderrLog
-                            $ interpret renderLogMessages
-                            $ Eff.runState _indexState
-                            $ ChainIndex.handleChainIndex
-                            $ ChainIndex.handleChainIndexControl eff
+        $ ChainIndex.handleChainIndexControl eff
+        & ChainIndex.handleChainIndex
+        & Eff.runState _indexState
+        & handleLogMsgTrace (toChainIndexServerMsg trace)
+        & runM
     liftIO $ putMVar stateVar AppState{_indexState=newState, _indexEvents=_indexEvents, _indexFollowerID=_indexFollowerID  }
     pure result
+        where
+            toChainIndexServerMsg :: Trace m ChainIndexServerMsg -> Trace m ChainIndexEvent
+            toChainIndexServerMsg = convertLog ChainEvent

--- a/plutus-pab/src/Cardano/ChainIndex/Types.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Types.hs
@@ -66,6 +66,7 @@ data ChainIndexServerMsg =
     | ReceivedBlocksTxns
         Int    -- ^ Blocks
         Int    -- ^ Transactions
+    | ChainEvent ChainIndexEvent
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -79,6 +80,7 @@ instance Pretty ChainIndexServerMsg where
         AskingNodeForCurrentSlot -> "Asking the node for the current slot"
         StartingNodeClientThread -> "Starting node client thread"
         StartingChainIndex port -> "Starting chain index on port: " <> pretty port
+        ChainEvent e -> "Processing chain index event: " <> pretty e
 
 instance ToObject ChainIndexServerMsg where
     toObject _ = \case
@@ -90,3 +92,4 @@ instance ToObject ChainIndexServerMsg where
       AskingNodeForCurrentSlot -> mkObjectStr "asking node for current slot" ()
       StartingNodeClientThread -> mkObjectStr "starting node client thread" ()
       StartingChainIndex p     -> mkObjectStr "starting chain index" (Tagged @"port" p)
+      ChainEvent e             -> mkObjectStr "processing chain event" (Tagged @"event" e)

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -14,7 +14,7 @@ import           Control.Lens                    (over, set, unto, view)
 import           Control.Monad                   (forever, unless, void)
 import           Control.Monad.Freer             (Eff, Member, interpret, reinterpret, runM, subsume)
 import           Control.Monad.Freer.Extras      (handleZoomedState)
-import           Control.Monad.Freer.Log         (LogMessage (..), handleLogWriter, mapLog, renderLogMessages)
+import           Control.Monad.Freer.Log         (LogMessage (..), handleLogWriter, mapLog)
 import           Control.Monad.Freer.Reader      (Reader)
 import qualified Control.Monad.Freer.Reader      as Eff
 import           Control.Monad.Freer.State       (State)
@@ -24,7 +24,6 @@ import           Control.Monad.IO.Class          (MonadIO, liftIO)
 import           Data.Foldable                   (traverse_)
 import           Data.Function                   ((&))
 import           Data.List                       (genericDrop)
-import           Data.Text                       (Text)
 import           Data.Time.Units                 (Second, toMicroseconds)
 import           Data.Time.Units.Extra           ()
 import           Servant                         (NoContent (NoContent))
@@ -41,7 +40,7 @@ import           Control.Monad.Freer.Extra.Log
 import           Ledger                          (Block, Slot (Slot), Tx)
 import           Ledger.Tx                       (outputs)
 import           Plutus.PAB.Arbitrary            ()
-import           Plutus.PAB.Monitoring           (runLogEffects)
+import           Plutus.PAB.Monitoring           (handleLogMsgTrace, runLogEffects)
 import qualified Wallet.Emulator                 as EM
 import           Wallet.Emulator.Chain           (ChainControlEffect, ChainEffect, ChainState)
 import qualified Wallet.Emulator.Chain           as Chain
@@ -103,7 +102,6 @@ type NodeServerEffects m
         , Reader Server.ServerHandler
         , State AppState
         , LogMsg MockServerLogMsg
-        , LogMsg Text
         , m]
 
 ------------------------------------------------------------
@@ -111,12 +109,13 @@ type NodeServerEffects m
 
 -- | Run all chain effects in the IO Monad
 runChainEffects ::
-    Server.ServerHandler
+ Trace IO MockServerLogMsg
+ -> Server.ServerHandler
  -> Client.ClientHandler
  -> MVar AppState
  -> Eff (NodeServerEffects IO) a
  -> IO ([LogMessage MockServerLogMsg], a)
-runChainEffects serverHandler clientHandler stateVar eff = do
+runChainEffects trace serverHandler clientHandler stateVar eff = do
     oldAppState <- liftIO $ takeMVar stateVar
     ((a, events), newState) <- liftIO
             $ processBlock eff
@@ -126,8 +125,7 @@ runChainEffects serverHandler clientHandler stateVar eff = do
             & mergeState
             & toWriter
             & runReaders oldAppState
-            & interpret renderLogMessages
-            & runStderrLog
+            & handleLogMsgTrace trace
             & runM
     liftIO $ putMVar stateVar newState
     pure (events, a)
@@ -154,7 +152,7 @@ processChainEffects ::
     -> Eff (NodeServerEffects IO) a
     -> IO a
 processChainEffects trace serverHandler clientHandler stateVar eff = do
-    (events, result) <- liftIO $ runChainEffects serverHandler clientHandler stateVar eff
+    (events, result) <- liftIO $ runChainEffects trace serverHandler clientHandler stateVar eff
     runLogEffects trace $ traverse_ (\(LogMessage _ chainEvent) -> logDebug chainEvent) events
     liftIO $
         modifyMVar_

--- a/plutus-pab/src/Cardano/Wallet/Types.hs
+++ b/plutus-pab/src/Cardano/Wallet/Types.hs
@@ -63,7 +63,7 @@ data Config =
     deriving anyclass (FromJSON, ToJSON)
 
 data WalletMsg = StartingWallet Port
-                  | ChainClientMsg Text
+               | ChainClientMsg Text
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 

--- a/plutus-pab/src/Cardano/Wallet/Types.hs
+++ b/plutus-pab/src/Cardano/Wallet/Types.hs
@@ -62,14 +62,17 @@ data Config =
     deriving (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)
 
-newtype WalletMsg = StartingWallet Port
+data WalletMsg = StartingWallet Port
+                  | ChainClientMsg Text
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Pretty WalletMsg where
     pretty = \case
         StartingWallet port -> "Starting wallet server on port " <+> pretty port
+        ChainClientMsg m    -> "Chain Client: " <+> pretty m
 
 instance ToObject WalletMsg where
     toObject _ = \case
         StartingWallet port -> mkObjectStr "Starting wallet server" (Tagged @"port" port)
+        ChainClientMsg m    -> mkObjectStr "Chain Client: " (Tagged @"msg" m)

--- a/plutus-pab/src/Control/Monad/Freer/Extra/Log.hs
+++ b/plutus-pab/src/Control/Monad/Freer/Extra/Log.hs
@@ -1,10 +1,6 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
 
 module Control.Monad.Freer.Extra.Log(
     -- $log
@@ -12,34 +8,7 @@ module Control.Monad.Freer.Extra.Log(
     , logDebug
     , logInfo
     , logWarn
-    , runStderrLog
     , handleWriterLog
     ) where
 
-import           Control.Monad.Freer     (Eff, LastMember, type (~>))
-import qualified Control.Monad.Freer     as Eff
-import           Control.Monad.Freer.Log (LogMessage (..), LogMsg (..), handleWriterLog, logDebug, logInfo, logWarn)
-import qualified Control.Monad.Freer.Log as Log
-import           Control.Monad.IO.Class  (MonadIO, liftIO)
-import           Control.Monad.Logger    (LogLevel (..), logWithoutLoc, runStderrLoggingT)
-import           Data.Text               (Text)
-
--- $log
--- A @freer-simple@ wrapper around @Control.Monad.Freer.Log.Log@
-
-runStderrLog :: forall effs m. (LastMember m effs, MonadIO m) => Eff (LogMsg Text ': effs) ~> Eff effs
-runStderrLog = Eff.interpretM $ \case
-    LMessage es -> logMessage es
-
-logMessage :: forall m. MonadIO m => LogMessage Text -> m ()
-logMessage LogMessage{_logLevel, _logMessageContent} =
-    let lvl = case _logLevel of
-            Log.Debug     -> LevelDebug
-            Log.Info      -> LevelInfo
-            Log.Notice    -> LevelInfo
-            Log.Warning   -> LevelWarn
-            Log.Error     -> LevelError
-            Log.Critical  -> LevelError
-            Log.Alert     -> LevelError
-            Log.Emergency -> LevelError
-    in liftIO $ runStderrLoggingT $ logWithoutLoc "" lvl _logMessageContent
+import           Control.Monad.Freer.Log (LogMsg (..), handleWriterLog, logDebug, logInfo, logWarn)

--- a/plutus-pab/src/Plutus/PAB/Monitoring.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring.hs
@@ -18,6 +18,7 @@ module Plutus.PAB.Monitoring(
   , loadConfig
   -- * Misc
   , toSeverity
+  , convertLog
   ) where
 
 import           Cardano.BM.Configuration       (setup)
@@ -158,3 +159,7 @@ handleObserveTrace config t =
   in L.handleObserve
       observeBefore
       observeAfter
+
+-- | Convert tracer structured log data
+convertLog :: (a -> b) -> Trace m b -> Trace m a
+convertLog f = contramap (second (fmap f))


### PR DESCRIPTION
runStderrLog should already have been replaced with handleLogMsgTrace
everywhere when switchign to the simple-freer based logging but some
occuoccurrences were still left.

This PR removes all of them and also drops `runStderrLog` itself since
it is now redundant.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge