### PR TITLE
SCP-1648 Marlowe Playground Client: Fix blockly losing its state after refresh

### DIFF
--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -20,7 +20,6 @@ import Halogen.HTML (HTML)
 import Marlowe.Blockly (buildBlocks)
 import Marlowe.Holes (Term(..), Location(..))
 import Marlowe.Parser as Parser
-import Prim.TypeError (class Warn, Text)
 import Text.Extra as Text
 import Type.Proxy (Proxy(..))
 
@@ -104,7 +103,6 @@ handleQuery (GetBlockRepresentation next) = do
 
 handleAction ::
   forall m slots.
-  Warn (Text "SCP-1648 Fix blockly code being lost after refresh") =>
   MonadAff m =>
   Action ->
   HalogenM State Action slots Message m Unit

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -7,18 +7,21 @@ import BlocklyEditor.Types (Action(..), State, _errorMessage, _hasHoles, _marlow
 import Control.Monad.Except (ExceptT(..), except, runExceptT)
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
-import Data.Bifunctor (lmap)
 import Data.Either (Either(..), either, hush, note)
 import Data.Lens (set)
 import Data.List (List(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class (liftEffect)
+import Examples.Marlowe.Contracts (example) as ME
 import Halogen (HalogenM, modify_, query)
 import Halogen as H
 import MainFrame.Types (ChildSlots, _blocklySlot)
 import Marlowe.Blockly (blockToContract)
 import Marlowe.Linter as Linter
 import Marlowe.Parser as Parser
+import SessionStorage as SessionStorage
+import StaticData (marloweBufferLocalStorageKey)
 import Text.Pretty (pretty)
 
 handleAction ::
@@ -26,6 +29,10 @@ handleAction ::
   MonadAff m =>
   Action ->
   HalogenM State Action ChildSlots Void m Unit
+handleAction Init = do
+  mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
+  handleAction $ InitBlocklyProject $ fromMaybe ME.example mContents
+
 handleAction (HandleBlocklyMessage Blockly.CodeChange) = do
   eContract <-
     runExceptT do
@@ -37,20 +44,23 @@ handleAction (HandleBlocklyMessage Blockly.CodeChange) = do
         ( set _errorMessage (Just $ unexpected e)
             <<< set _marloweCode Nothing
         )
-    Right contract ->
+    Right contract -> do
       let
         hasHoles = Linter.hasHoles $ Linter.lint Nil contract
-      in
-        modify_
-          ( set _errorMessage Nothing
-              <<< set _marloweCode (Just $ show $ pretty contract)
-              <<< set _hasHoles hasHoles
-          )
+
+        prettyContract = show $ pretty contract
+      liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey prettyContract
+      modify_
+        ( set _errorMessage Nothing
+            <<< set _marloweCode (Just $ prettyContract)
+            <<< set _hasHoles hasHoles
+        )
   where
   unexpected s = "An unexpected error has occurred, please raise a support issue at https://github.com/input-output-hk/plutus/issues/new: " <> s
 
 handleAction (InitBlocklyProject code) = do
   void $ query _blocklySlot unit $ H.tell (Blockly.SetCode code)
+  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey code
   let
     hasHoles = either (const false) identity $ (Linter.hasHoles <<< Linter.lint Nil) <$> Parser.parseContract code
   modify_

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -1,7 +1,8 @@
 module BlocklyEditor.Types where
 
 import Prelude
-import Analytics (class IsEvent, defaultEvent)
+import Analytics (class IsEvent, Event)
+import Analytics as A
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
@@ -9,18 +10,23 @@ import Data.Symbol (SProxy(..))
 import BlocklyComponent.Types as Blockly
 
 data Action
-  = HandleBlocklyMessage Blockly.Message
+  = Init
+  | HandleBlocklyMessage Blockly.Message
   | InitBlocklyProject String
   | SendToSimulator
   | ViewAsMarlowe
   | Save
 
+defaultEvent :: String -> Event
+defaultEvent s = (A.defaultEvent $ "BlocklyEditor." <> s) { category = Just "Blockly" }
+
 instance blocklyActionIsEvent :: IsEvent Action where
-  toEvent (HandleBlocklyMessage _) = Just $ (defaultEvent "HandleBlocklyMessage") { category = Just "Blockly" }
-  toEvent (InitBlocklyProject _) = Just $ (defaultEvent "InitBlocklyProject") { category = Just "Blockly" }
-  toEvent SendToSimulator = Just $ (defaultEvent "SendToSimulator") { category = Just "Blockly" }
-  toEvent ViewAsMarlowe = Just $ (defaultEvent "ViewAsMarlowe") { category = Just "Blockly" }
-  toEvent Save = Just $ (defaultEvent "Save") { category = Just "Blockly" }
+  toEvent Init = Just $ defaultEvent "Init"
+  toEvent (HandleBlocklyMessage _) = Just $ defaultEvent "HandleBlocklyMessage"
+  toEvent (InitBlocklyProject _) = Just $ defaultEvent "InitBlocklyProject"
+  toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"
+  toEvent ViewAsMarlowe = Just $ defaultEvent "ViewAsMarlowe"
+  toEvent Save = Just $ defaultEvent "Save"
 
 type State
   = { errorMessage :: Maybe String

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -28,7 +28,7 @@ import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult(..))
 import Language.Haskell.Monaco as HM
-import LocalStorage as LocalStorage
+import SessionStorage as SessionStorage
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe (postRunghc)
 import Marlowe.Extended (Contract, typeToLens)
@@ -60,11 +60,11 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction Init = do
   editorSetTheme
-  mContents <- liftEffect $ LocalStorage.getItem haskellBufferLocalStorageKey
+  mContents <- liftEffect $ SessionStorage.getItem haskellBufferLocalStorageKey
   editorSetValue $ fromMaybe HE.example mContents
 
 handleAction (HandleEditorMessage (Monaco.TextChanged text)) = do
-  liftEffect $ LocalStorage.setItem haskellBufferLocalStorageKey text
+  liftEffect $ SessionStorage.setItem haskellBufferLocalStorageKey text
   assign _compilationResult NotAsked
 
 handleAction (ChangeKeyBindings bindings) = do
@@ -100,7 +100,7 @@ handleAction SendResultToSimulator = pure unit
 
 handleAction (InitHaskellProject contents) = do
   editorSetValue contents
-  liftEffect $ LocalStorage.setItem haskellBufferLocalStorageKey contents
+  liftEffect $ SessionStorage.setItem haskellBufferLocalStorageKey contents
 
 handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 

--- a/marlowe-playground-client/src/Main.purs
+++ b/marlowe-playground-client/src/Main.purs
@@ -50,18 +50,17 @@ main =
     void $ liftEffect
       $ matchesWith (Routing.parse Router.route) \old new -> do
           when (old /= Just new) $ launchAff_ $ driver.query (MainFrame.ChangeRoute new unit)
-    forkAff $ runProcess watchLocalStorageProcess
 
-watchLocalStorageProcess :: Process Aff Unit
-watchLocalStorageProcess = connect LocalStorage.listen watchLocalStorage
-
-watchLocalStorage ::
-  forall r.
-  Consumer RawStorageEvent Aff r
-watchLocalStorage =
-  consumer \event -> do
-    liftEffect $ log $ "Got Local Storage Event: " <> show event
-    pure Nothing
-
+-- FIXME: This was not doing anything... should we remove? add a comment for future use?
+-- forkAff $ runProcess watchLocalStorageProcess
+-- watchLocalStorageProcess :: Process Aff Unit
+-- watchLocalStorageProcess = connect LocalStorage.listen watchLocalStorage
+-- watchLocalStorage ::
+--   forall r.
+--   Consumer RawStorageEvent Aff r
+-- watchLocalStorage =
+--   consumer \event -> do
+--     liftEffect $ log $ "Got Local Storage Event: " <> show event
+--     pure Nothing
 onLoad :: Unit
 onLoad = unsafePerformEffect main

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -46,7 +46,6 @@ import JavascriptEditor.State as JavascriptEditor
 import JavascriptEditor.Types (Action(..), State, _ContractString, initialState) as JS
 import JavascriptEditor.Types (CompilationState(..))
 import Language.Haskell.Monaco as HM
-import LocalStorage as LocalStorage
 import LoginPopup (openLoginPopup, informParentAndClose)
 import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _blocklySlot, _createGistResult, _gistId, _hasUnsavedChanges, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _walletSlot, _workflow, sessionToState, stateToSession)
 import MainFrame.View (render)
@@ -299,6 +298,7 @@ handleAction Init = do
   toSimulation $ Simulation.handleAction ST.Init
   toHaskellEditor $ HaskellEditor.handleAction HE.Init
   toMarloweEditor $ MarloweEditor.handleAction ME.Init
+  toBlocklyEditor $ BlocklyEditor.handleAction BE.Init
   checkAuthStatus
   -- Load session data if available
   void
@@ -454,7 +454,7 @@ handleAction (NewProjectAction (NewProject.CreateProject lang)) = do
         <<< set _gistId Nothing
         <<< set _createGistResult NotAsked
     )
-  liftEffect $ LocalStorage.setItem gistIdLocalStorageKey mempty
+  liftEffect $ SessionStorage.setItem gistIdLocalStorageKey mempty
   -- We reset all editors and then initialize the selected language.
   toHaskellEditor $ HaskellEditor.handleAction $ HE.InitHaskellProject mempty
   toJavascriptEditor $ JavascriptEditor.handleAction $ JS.InitJavascriptProject mempty
@@ -531,7 +531,7 @@ handleAction (SaveAsAction action@SaveAs.SaveProject) = do
   res <- peruse (_createGistResult <<< _Success)
   case res of
     Just gist -> do
-      liftEffect $ LocalStorage.setItem gistIdLocalStorageKey (gist ^. (gistId <<< _GistId))
+      liftEffect $ SessionStorage.setItem gistIdLocalStorageKey (gist ^. (gistId <<< _GistId))
       modify_
         ( set _showModal Nothing
             <<< set (_saveAs <<< SaveAs._status) NotAsked

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -30,7 +30,7 @@ import Examples.Marlowe.Contracts (example) as ME
 import Halogen (HalogenM, liftEffect, modify_, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
-import LocalStorage as LocalStorage
+import SessionStorage as SessionStorage
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
 import Marlowe.Extended (Contract, getPlaceholderIds, typeToLens, updateTemplateContent)
 import Marlowe.Holes (fromTerm)
@@ -66,7 +66,7 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction Init = do
   editorSetTheme
-  mContents <- liftEffect $ LocalStorage.getItem marloweBufferLocalStorageKey
+  mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
   editorSetValue $ fromMaybe ME.example mContents
 
 handleAction (ChangeKeyBindings bindings) = do
@@ -75,7 +75,7 @@ handleAction (ChangeKeyBindings bindings) = do
 
 handleAction (HandleEditorMessage (Monaco.TextChanged text)) = do
   assign _selectedHole Nothing
-  liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey text
+  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey text
   lintText text
 
 handleAction (HandleDragEvent event) = liftEffect $ preventDefault event
@@ -95,7 +95,7 @@ handleAction (LoadScript key) = do
         Right pcon -> show $ pretty pcon
         Left _ -> contents
     editorSetValue prettyContents
-    liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey prettyContents
+    liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey prettyContents
 
 handleAction (SetEditorText contents) = editorSetValue contents
 
@@ -113,7 +113,7 @@ handleAction ViewAsBlockly = pure unit
 
 handleAction (InitMarloweProject contents) = do
   editorSetValue contents
-  liftEffect $ LocalStorage.setItem marloweBufferLocalStorageKey contents
+  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey contents
 
 handleAction (SelectHole hole) = assign _selectedHole hole
 

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -38,7 +38,7 @@ import Foreign.JSON (parseJSON)
 import Halogen (HalogenM, get, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Query(..)) as Monaco
-import LocalStorage as LocalStorage
+import SessionStorage as SessionStorage
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe as Server
 import Marlowe.Extended (fillTemplate, toCore, typeToLens)
@@ -79,7 +79,7 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction Init = do
   editorSetTheme
-  mContents <- liftEffect $ LocalStorage.getItem simulatorBufferLocalStorageKey
+  mContents <- liftEffect $ SessionStorage.getItem simulatorBufferLocalStorageKey
   handleAction $ LoadContract $ fromMaybe "" mContents
 
 handleAction (SetInitialSlot initialSlot) = do
@@ -140,7 +140,7 @@ handleAction Undo = do
   updateContractInEditor
 
 handleAction (LoadContract contents) = do
-  liftEffect $ LocalStorage.setItem simulatorBufferLocalStorageKey contents
+  liftEffect $ SessionStorage.setItem simulatorBufferLocalStorageKey contents
   let
     mExtendedContract = do
       termContract <- hush $ parseContract contents
@@ -278,6 +278,6 @@ updateContractInEditor = do
   editorSetValue
     ( case executionState of
         SimulationRunning runningState -> show $ genericPretty runningState.contract
-        SimulationNotStarted notStartedState -> maybe "No contract" (show <<< genericPretty) notStartedState.extendedContract -- This "No contract" should never happen if we get valid contracts from editors 
+        SimulationNotStarted notStartedState -> maybe "No contract" (show <<< genericPretty) notStartedState.extendedContract -- This "No contract" should never happen if we get valid contracts from editors
     )
   setOraclePrice


### PR DESCRIPTION
This PR solves a bug in where every time you refresh the browser in the blockly editor you lose the current contract.

It also changed the place where we store the contracts from local storage to session storage. This way we can have multiple tabs of the browser working on different contracts at the same time, without one disrupting another.

I've used the same key for Marlowe and Blockly editors as they should be interchangeable, and the session is stored as marlowe code, not XML nodes.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [X] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [X] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [X] Commits have useful messages
- [x] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
