### PR TITLE
freer-extras: drop Changelog reference from cabal

### DIFF
--- a/freer-extras/freer-extras.cabal
+++ b/freer-extras/freer-extras.cabal
@@ -9,7 +9,6 @@ license-file:        LICENSE
 author:              Tobias Pflug
 maintainer:          tobias.pflug@iohk.io
 build-type:          Simple
-extra-source-files:  CHANGELOG.md
 
 source-repository head
     type: git

--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/freer-extras.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/freer-extras.nix
@@ -26,7 +26,7 @@
       licenseFiles = [ "LICENSE" ];
       dataDir = "";
       dataFiles = [];
-      extraSrcFiles = [ "CHANGELOG.md" ];
+      extraSrcFiles = [];
       extraTmpFiles = [];
       extraDocFiles = [];
       };

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/freer-extras.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/freer-extras.nix
@@ -26,7 +26,7 @@
       licenseFiles = [ "LICENSE" ];
       dataDir = "";
       dataFiles = [];
-      extraSrcFiles = [ "CHANGELOG.md" ];
+      extraSrcFiles = [];
       extraTmpFiles = [];
       extraDocFiles = [];
       };


### PR DESCRIPTION
```
Warning: File listed in freer-extras/freer-extras.cabal file does not exist: CHANGELOG.md
```

----

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge