### PR TITLE
SCP-1790 - Add "Extended Marlowe" types in Haskell language

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -104,39 +104,32 @@ handleAction (InitHaskellProject contents) = do
 
 handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
 
-handleAction AnalyseContract = compileAndAnalyze (WarningAnalysis Loading) $ analyseContract
+handleAction AnalyseContract = analyze (WarningAnalysis Loading) $ analyseContract
 
 handleAction AnalyseReachabilityContract =
-  compileAndAnalyze (ReachabilityAnalysis AnalysisNotStarted)
+  analyze (ReachabilityAnalysis AnalysisNotStarted)
     $ analyseReachability
 
 handleAction AnalyseContractForCloseRefund =
-  compileAndAnalyze (CloseAnalysis AnalysisNotStarted)
+  analyze (CloseAnalysis AnalysisNotStarted)
     $ analyseClose
 
--- This function runs a static analysis to the compiled code. It calls the compiler if
--- it wasn't runned before and it switches to the error panel if the compilation failed
-compileAndAnalyze ::
+-- This function runs a static analysis to the compiled code if it compiled successfully.
+analyze ::
   forall m.
   MonadAff m =>
   MonadAsk Env m =>
   AnalysisExecutionState ->
   (Contract -> HalogenM State Action ChildSlots Void m Unit) ->
   HalogenM State Action ChildSlots Void m Unit
-compileAndAnalyze initialAnalysisState doAnalyze = do
+analyze initialAnalysisState doAnalyze = do
   compilationResult <- use _compilationResult
   case compilationResult of
-    NotAsked -> do
-      -- The initial analysis state allow us to show an "Analysing..." indicator
-      assign (_analysisState <<< _analysisExecutionState) initialAnalysisState
-      handleAction Compile
-      compileAndAnalyze initialAnalysisState doAnalyze
     Success (Right (InterpreterResult interpretedResult)) ->
       let
         mContract = (fromTerm <=< hush <<< parseContract) interpretedResult.result
       in
         for_ mContract doAnalyze
-    Success (Left _) -> handleAction $ BottomPanelAction $ BottomPanel.ChangePanel ErrorsView
     _ -> pure unit
 
 runAjax ::

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -114,6 +114,8 @@ handleAction AnalyseContractForCloseRefund =
   analyze (CloseAnalysis AnalysisNotStarted)
     $ analyseClose
 
+handleAction ClearAnalysisResults = assign (_analysisState <<< _analysisExecutionState) NoneAsked
+
 -- This function runs a static analysis to the compiled code if it compiled successfully.
 analyze ::
   forall m.

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -34,6 +34,7 @@ data Action
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
+  | ClearAnalysisResults
 
 defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Haskell." <> s
@@ -50,6 +51,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent "AnalyseContractForCloseRefund"
+  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
 
 type State
   = { keybindings :: KeyBindings

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -25,8 +25,8 @@ import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..),
 import Language.Haskell.Monaco as HM
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Network.RemoteData (RemoteData(..))
-import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton)
-import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isReachabilityLoading, isStaticLoading)
+import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
+import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 
 render ::
   forall m.
@@ -150,6 +150,7 @@ panelContents state StaticAnalysisView =
       , analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
       , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
       , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
+      , clearButton clearEnabled "Clear" ClearAnalysisResults
       ]
         <> (if isCompiled then [] else [ div [ classes [ ClassName "choice-error" ] ] [ text "Haskell code needs to be compiled in order to run static analysis" ] ])
     )
@@ -160,9 +161,13 @@ panelContents state StaticAnalysisView =
 
   loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isCloseAnalysisLoading
 
+  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isNoneAsked
+
   anyAnalysisLoading = loadingWarningAnalysis || loadingReachability || loadingCloseAnalysis
 
   analysisEnabled = not anyAnalysisLoading && isCompiled
+
+  clearEnabled = not (anyAnalysisLoading || noneAskedAnalysis)
 
   isCompiled = case view _compilationResult state of
     Success (Right _) -> true

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -6,7 +6,7 @@ import BottomPanel.View (render) as BottomPanel
 import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Enum (toEnum, upFromIncluding)
-import Data.Lens (to, view, (^.))
+import Data.Lens (_Right, has, to, view, (^.))
 import Data.Maybe (Maybe(..))
 import Data.String (Pattern(..), split)
 import Data.String as String
@@ -24,7 +24,7 @@ import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanel
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult(..))
 import Language.Haskell.Monaco as HM
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
-import Network.RemoteData (RemoteData(..))
+import Network.RemoteData (RemoteData(..), _Success)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 
@@ -169,9 +169,7 @@ panelContents state StaticAnalysisView =
 
   clearEnabled = not (anyAnalysisLoading || noneAskedAnalysis)
 
-  isCompiled = case view _compilationResult state of
-    Success (Right _) -> true
-    _ -> false
+  isCompiled = has (_compilationResult <<< _Success <<< _Right) state
 
 panelContents state ErrorsView =
   section

--- a/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
+++ b/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CouponBondGuaranteed where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract
@@ -24,3 +24,4 @@ contract = When [Case (Deposit "investor" "guarantor" ada (Constant 1030))
             (Slot 10) Close))]
     (Slot 5) Close)]
     (Slot 5) Close
+

--- a/marlowe-playground-server/contracts/Escrow.hs
+++ b/marlowe-playground-server/contracts/Escrow.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Escrow where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract
@@ -90,15 +90,16 @@ carolChoice = choice "carol" both
 
 -- the values chosen in choices
 
-aliceChosen, bobChosen :: (Value Observation)
+aliceChosen, bobChosen :: Value
 
 aliceChosen = ChoiceValue (ChoiceId choiceName "alice")
 bobChosen   = ChoiceValue (ChoiceId choiceName "bob")
 
-defValue :: (Value Observation)
+defValue :: Value
 defValue = Constant 42
 
 -- Value under escrow
 
-price :: (Value Observation)
+price :: Value
 price = Constant 450
+

--- a/marlowe-playground-server/contracts/EscrowWithCollateral.hs
+++ b/marlowe-playground-server/contracts/EscrowWithCollateral.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module EscrowWithCollateral where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract
@@ -56,7 +56,7 @@ agreement =
 -- The contract to follow when Alice and Bob disagree
 destroyCollateral :: Contract
 destroyCollateral =
-    (Pay "alice" (Party "blackhole") ada aliceCollateral (Pay "bob" (Party "blackhole") ada bobCollateral Close))
+    Pay "alice" (Party "blackhole") ada aliceCollateral (Pay "bob" (Party "blackhole") ada bobCollateral Close)
 
 -- Names for choices
 pay,refund,both :: [Bound]
@@ -88,21 +88,21 @@ carolRefund = choice "carol" refund
 carolChoice = choice "carol" both
 
 -- the values chosen in choices
-aliceChosen, bobChosen :: (Value Observation)
+aliceChosen, bobChosen :: Value
 
 aliceChosen = ChoiceValue (ChoiceId choiceName "alice")
 bobChosen   = ChoiceValue (ChoiceId choiceName "bob")
 
-defValue :: (Value Observation)
+defValue :: Value
 defValue = Constant 42
 
 -- Value under escrow
-price :: (Value Observation)
+price :: Value
 price = Constant 450
 
-aliceCollateral :: (Value Observation)
+aliceCollateral :: Value
 aliceCollateral = Constant 4500
 
-bobCollateral :: (Value Observation)
+bobCollateral :: Value
 bobCollateral = Constant 4500
 

--- a/marlowe-playground-server/contracts/Example.hs
+++ b/marlowe-playground-server/contracts/Example.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Example where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/contracts/Option.hs
+++ b/marlowe-playground-server/contracts/Option.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Option where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/contracts/Swap.hs
+++ b/marlowe-playground-server/contracts/Swap.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Swap where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract
@@ -21,3 +21,4 @@ contract =
   where
     gracePeriod = Slot 5
     date1 = Slot 20
+

--- a/marlowe-playground-server/contracts/ZeroCouponBond.hs
+++ b/marlowe-playground-server/contracts/ZeroCouponBond.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 module ZeroCouponBond where
 
-import           Language.Marlowe
+import           Language.Marlowe.Extended
 
 main :: IO ()
 main = print . pretty $ contract
@@ -22,3 +22,4 @@ contract = When [ Case
     ]
     (Slot 10)
     Close
+

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -72,6 +72,7 @@ library
     freer-simple -any
   exposed-modules:
     Language.Marlowe
+    Language.Marlowe.Extended
     Language.Marlowe.Semantics
     Language.Marlowe.Client
     Language.Marlowe.Util

--- a/marlowe/src/Language/Marlowe/Extended.hs
+++ b/marlowe/src/Language/Marlowe/Extended.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
+
+{-| = Extended Marlowe: adds templating functionality to Marlowe language
+Extended Marlowe is not executable, it is translated to core Marlowe before
+execution, deployment, or analysis, through the process of instantiation.
+The purpose of Extended Marlowe is to allow Marlowe contracts to be reusable
+in different situations without cluttering the code that goes on-chain
+(core Marlowe).
+-}
+
+module Language.Marlowe.Extended ( module Language.Marlowe.Extended
+                                 , module Language.Marlowe.Pretty
+                                 , ada, adaSymbol, adaToken
+                                 , S.AccountId, S.Bound(..), S.ChoiceId(..)
+                                 , S.ChoiceName, S.ChosenNum, S.Party(..)
+                                 , S.SlotInterval, S.Token(..), S.ValueId(..)
+                                 ) where
+
+import           GHC.Generics
+import           Language.Marlowe.Pretty    (Pretty (..), pretty)
+import qualified Language.Marlowe.Semantics as S
+import           Language.Marlowe.Util      (ada)
+import           Ledger.Ada                 (adaSymbol, adaToken)
+import           Text.PrettyPrint.Leijen    (parens, text)
+
+
+data Timeout = SlotParam String
+             | Slot Integer
+  deriving stock (Show,Generic)
+
+instance Pretty Timeout where
+    prettyFragment (Slot n)         = prettyFragment n
+    prettyFragment sp@(SlotParam _) = parens $ text $ show sp
+
+instance Num Timeout where
+  (+) (Slot a) (Slot b) = Slot (a + b)
+  (+) _ _               = error "Tried to add with templates"
+  (-) (Slot a) (Slot b) = Slot (a - b)
+  (-) _ _               = error "Tried to subtract with templates"
+  (*) (Slot a) (Slot b) = Slot (a * b)
+  (*) _ _               = error "Tried to multiplate with templates"
+  abs (Slot a) = Slot (abs a)
+  abs _        = error "Tried to calculate absolute value of template"
+  signum (Slot a) = Slot (signum a)
+  signum _        = error "Tried to calculate signum of template"
+  fromInteger x = Slot x
+  negate (Slot x) = Slot (-x)
+  negate _        = error "Tried to negate a template"
+
+instance Pretty Rational where
+    prettyFragment = text . show
+
+data Value = AvailableMoney S.AccountId S.Token
+           | Constant Integer
+           | ConstantParam String
+           | NegValue Value
+           | AddValue Value Value
+           | SubValue Value Value
+           | MulValue Value Value
+           | Scale Rational Value
+           | ChoiceValue S.ChoiceId
+           | SlotIntervalStart
+           | SlotIntervalEnd
+           | UseValue S.ValueId
+           | Cond Observation Value Value
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)
+
+data Observation = AndObs Observation Observation
+                 | OrObs Observation Observation
+                 | NotObs Observation
+                 | ChoseSomething S.ChoiceId
+                 | ValueGE Value Value
+                 | ValueGT Value Value
+                 | ValueLT Value Value
+                 | ValueLE Value Value
+                 | ValueEQ Value Value
+                 | TrueObs
+                 | FalseObs
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)
+
+data Action = Deposit S.AccountId S.Party S.Token Value
+            | Choice S.ChoiceId [S.Bound]
+            | Notify Observation
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)
+
+data Payee = Account S.AccountId
+           | Party S.Party
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)
+
+data Case = Case Action Contract
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)
+
+data Contract = Close
+              | Pay S.AccountId Payee S.Token Value Contract
+              | If Observation Contract Contract
+              | When [Case] Timeout Contract
+              | Let S.ValueId Value Contract
+              | Assert Observation Contract
+  deriving stock (Show,Generic)
+  deriving anyclass (Pretty)

--- a/marlowe/src/Language/Marlowe/Pretty.hs
+++ b/marlowe/src/Language/Marlowe/Pretty.hs
@@ -78,8 +78,8 @@ instance (Pretty1 a, Pretty1 b) => Pretty1 (a :*: b) where
     pretty1 topLevel (f :*: g) = pretty1 topLevel f <> pretty1 topLevel g
     isNullary _ = False
 
-instance Pretty String where
-  prettyFragment = text
+instance {-# OVERLAPPING #-} Pretty [Char] where
+  prettyFragment = text . show
 
 instance Pretty Text where
   prettyFragment = text . show . Text.unpack

--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/marlowe.nix
@@ -60,6 +60,7 @@
         buildable = true;
         modules = [
           "Language/Marlowe"
+          "Language/Marlowe/Extended"
           "Language/Marlowe/Semantics"
           "Language/Marlowe/Client"
           "Language/Marlowe/Util"

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe.nix
@@ -60,6 +60,7 @@
         buildable = true;
         modules = [
           "Language/Marlowe"
+          "Language/Marlowe/Extended"
           "Language/Marlowe/Semantics"
           "Language/Marlowe/Client"
           "Language/Marlowe/Util"


### PR DESCRIPTION
This PR adds support to the Haskell tab for Extended Marlowe, in particular:
- Implements Haskell version of Extended Marlowe (Extended.hs)
- Disables analyse buttons when not compiled
- Adds "Clear" button to Static Analysis
- Updates template parameters on compilation
- Adapts Haskell examples to use Extended Marlowe (and other dependencies like PSGenerator)

Example:
```haskell
{-# LANGUAGE OverloadedStrings #-}
module Escrow where

import           Language.Marlowe.Extended

main :: IO ()
main = print . pretty $ contract


{- What does the vanilla contract look like?
  - if Alice and Bob choose
      - and agree: do it
      - and disagree: Carol decides
  - Carol also decides if timeout after one choice has been made;
  - refund if no choices are made.
-}

contract :: Contract

contract = When [Case (Deposit "alice" "alice" ada price) inner]
                (SlotParam "01 - Alice's deposit timeout")
                Close

inner :: Contract

inner =
  When [ Case aliceChoice
              (When [ Case bobChoice
                          (If (aliceChosen `ValueEQ` bobChosen)
                             agreement
                             arbitrate) ]
                    (SlotParam "03 - Bob's choice timeout")
                    arbitrate)
        ]
        (SlotParam "02 - Alice's choice timeout")
        arbitrate

-- The contract to follow when Alice and Bob have made the same choice.

agreement :: Contract
agreement =
  If
    (aliceChosen `ValueEQ` Constant 0)
    (Pay "alice" (Party "bob") ada price Close)
    Close

-- The contract to follow when Alice and Bob disagree, or if
-- Carol has to intervene after a single choice from Alice or Bob.

arbitrate :: Contract

arbitrate =
  When  [ Case carolRefund Close,
          Case carolPay (Pay "alice" (Party "bob") ada price Close) ]
        (SlotParam "04 - Carol's arbitrage timeout")
        Close

-- Names for choices

pay,refund,both :: [Bound]

pay    = [Bound 0 0]
refund = [Bound 1 1]
both   = [Bound 0 1]

-- helper function to build Actions

choiceName :: ChoiceName
choiceName = "choice"

choice :: Party -> [Bound] -> Action

choice party = Choice (ChoiceId choiceName party)

-- Name choices according to person making choice and choice made

alicePay, aliceRefund, aliceChoice, bobPay, bobRefund, bobChoice, carolPay, carolRefund, carolChoice :: Action

alicePay    = choice "alice" pay
aliceRefund = choice "alice" refund
aliceChoice = choice "alice" both

bobPay    = choice "bob" pay
bobRefund = choice "bob" refund
bobChoice = choice "bob" both

carolPay    = choice "carol" pay
carolRefund = choice "carol" refund
carolChoice = choice "carol" both

-- the values chosen in choices

aliceChosen, bobChosen :: Value

aliceChosen = ChoiceValue (ChoiceId choiceName "alice")
bobChosen   = ChoiceValue (ChoiceId choiceName "bob")

defValue :: Value
defValue = Constant 42

-- Value under escrow

price :: Value
price = ConstantParam "Amount on escrow"

```

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
