### PR TITLE
Adding wireframe contract setup workflow.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Contract/State.purs
@@ -1,4 +1,9 @@
-module Contract.State where
+module Contract.State
+  ( defaultState
+  , mkInitialState
+  , handleQuery
+  , handleAction
+  ) where
 
 import Prelude
 import Contract.Types (Action(..), Query(..), Side(..), State, Tab(..), _confirmation, _executionState, _side, _step, _tab)
@@ -6,14 +11,16 @@ import Data.Lens (assign, modifying, use)
 import Data.Maybe (Maybe(..))
 import Data.Unfoldable as Unfoldable
 import Effect.Aff.Class (class MonadAff)
-import Halogen (HalogenM, raise)
-import MainFrame.Types (ChildSlots, Msg(..))
+import Halogen (HalogenM)
+import MainFrame.Types (ChildSlots, Msg)
 import Marlowe.Execution (NamedAction(..), _namedActions, _state, initExecution, merge, mkTx, nextState)
-import Marlowe.Semantics (Contract, Slot, _minSlot)
-import Plutus.PAB.Webserver.Types (StreamToServer(..))
+import Marlowe.Semantics (Contract(..), Slot, _minSlot)
 
-initialState :: Slot -> Contract -> State
-initialState slot contract =
+defaultState :: State
+defaultState = mkInitialState zero Close
+
+mkInitialState :: Slot -> Contract -> State
+mkInitialState slot contract =
   { tab: Tasks
   , executionState: initExecution slot contract
   , side: Overview

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -4,8 +4,7 @@ module Contract.View
   ) where
 
 import Prelude hiding (div)
-import Contract.Types (Action(..))
-import Css (classNames)
+import Contract.Types (Action(..), State)
 import Data.Foldable (foldr)
 import Data.Lens (view)
 import Data.Map (Map)
@@ -15,17 +14,16 @@ import Halogen.HTML (HTML, button, div, div_, h2_, text)
 import Halogen.HTML.Events (onClick)
 import MainFrame.Types (ContractStatus)
 import Marlowe.Execution (ExecutionStep, NamedAction(..))
-import Marlowe.Semantics (Accounts, ChoiceId(..), Contract, Input(..), Party, TransactionInput(..), _accounts)
+import Marlowe.Semantics (Accounts, ChoiceId(..), Input(..), Party, TransactionInput(..), _accounts)
 
 contractsScreen :: forall p. ContractStatus -> HTML p Action
 contractsScreen contractStatus =
-  div
-    [ classNames [ "p-1" ] ]
+  div_
     [ h2_
         [ text "Dashboard home" ]
     ]
 
-contractDetailsCard :: forall p. Contract -> HTML p Action
+contractDetailsCard :: forall p. State -> HTML p Action
 contractDetailsCard contractInstance =
   div_
     [ h2_

--- a/marlowe-dashboard-client/src/MainFrame/Lenses.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Lenses.purs
@@ -5,12 +5,13 @@ module MainFrame.Lenses
   , _subState
   , _pickupState
   , _walletState
-  , _contractState
   , _screen
   , _card
   , _wallet
   , _menuOpen
   , _webSocketStatus
+  , _templateState
+  , _contractState
   ) where
 
 import Prelude
@@ -22,7 +23,7 @@ import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
 import MainFrame.Types (PickupState, State, WalletState, WebSocketStatus)
 import Marlowe.Semantics (PubKey)
-import Template.Types (Template)
+import Template.Types (State, Template) as Template
 import WalletData.Types (WalletLibrary, WalletNicknameKey)
 
 _wallets :: Lens' State WalletLibrary
@@ -31,27 +32,21 @@ _wallets = prop (SProxy :: SProxy "wallets")
 _newWalletNicknameKey :: Lens' State WalletNicknameKey
 _newWalletNicknameKey = prop (SProxy :: SProxy "newWalletNicknameKey")
 
-_templates :: Lens' State (Array Template)
+_templates :: Lens' State (Array Template.Template)
 _templates = prop (SProxy :: SProxy "templates")
 
 _subState :: Lens' State (Either PickupState WalletState)
 _subState = prop (SProxy :: SProxy "subState")
 
--- This isn't a Traversal' in any meaningful sense (that I can see), but a Traversal'
--- is a Strong Choice Profunctor, so this is a neat type for the occasion.
--- Alternatively: forall a. Strong a => Choice a => Optic' a State PickupState
+_webSocketStatus :: Lens' State WebSocketStatus
+_webSocketStatus = prop (SProxy :: SProxy "webSocketStatus")
+
+------------------------------------------------------------
 _pickupState :: Traversal' State PickupState
 _pickupState = _subState <<< _Left
 
--- As above.
 _walletState :: Traversal' State WalletState
 _walletState = _subState <<< _Right
-
-_contractState :: Lens' State Contract.State
-_contractState = prop (SProxy :: SProxy "contractState")
-
-_webSocketStatus :: Lens' State WebSocketStatus
-_webSocketStatus = prop (SProxy :: SProxy "webSocketStatus")
 
 ------------------------------------------------------------
 _screen :: forall s b. Lens' { screen :: s | b } s
@@ -66,3 +61,9 @@ _wallet = prop (SProxy :: SProxy "wallet")
 
 _menuOpen :: Lens' WalletState Boolean
 _menuOpen = prop (SProxy :: SProxy "menuOpen")
+
+_templateState :: Lens' WalletState Template.State
+_templateState = prop (SProxy :: SProxy "templateState")
+
+_contractState :: Lens' WalletState Contract.State
+_contractState = prop (SProxy :: SProxy "contractState")

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -1,13 +1,12 @@
 module MainFrame.State (mkMainFrame) where
 
 import Prelude
-import Contract.State (handleAction, initialState) as Contract
-import Contract.Types (Action(..)) as Contract
+import Contract.State (handleAction, defaultState) as Contract
 import Contract.Types (_executionState)
 import Control.Monad.Except (runExcept)
 import Data.Either (Either(..))
 import Data.Foldable (for_)
-import Data.Lens (assign, modifying, over, set, use)
+import Data.Lens (Traversal', assign, modifying, over, set, use, view)
 import Data.Lens.Extra (peruse)
 import Data.Map (empty, insert, member)
 import Data.Map.Extra (findIndex)
@@ -17,17 +16,21 @@ import Effect.Aff.Class (class MonadAff)
 import Effect.Random (random)
 import Foreign.Generic (decodeJSON, encodeJSON)
 import Halogen (Component, HalogenM, liftEffect, mkComponent, mkEval, modify_)
-import Halogen.Extra (mapSubmodule)
+import Halogen.Extra (mapMaybeSubmodule)
 import Halogen.HTML (HTML)
 import LocalStorage (getItem, removeItem, setItem)
-import MainFrame.Lenses (_card, _contractState, _menuOpen, _newWalletNicknameKey, _pickupState, _screen, _subState, _templates, _walletState, _wallets, _webSocketStatus)
-import MainFrame.Types (Action(..), ChildSlots, ContractStatus(..), Msg, PickupCard(..), PickupScreen(..), PickupState, Query(..), Screen(..), State, WalletState, WebSocketStatus(..))
+import MainFrame.Lenses (_card, _contractState, _menuOpen, _newWalletNicknameKey, _pickupState, _screen, _templateState, _subState, _templates, _walletState, _wallets, _webSocketStatus)
+import MainFrame.Types (Action(..), Card(..), ChildSlots, ContractStatus(..), Msg, PickupCard(..), PickupScreen(..), PickupState, Query(..), Screen(..), State, WalletState, WebSocketStatus(..))
 import MainFrame.View (render)
 import Marlowe.Execution (_contract)
-import Marlowe.Semantics (Contract(..), PubKey)
+import Marlowe.Extended (fillTemplate, toCore)
+import Marlowe.Semantics (PubKey)
 import Plutus.PAB.Webserver.Types (StreamToClient(..))
 import StaticData (walletLocalStorageKey, walletsLocalStorageKey)
+import Template.Lenses (_extendedContract, _template, _templateContent)
 import Template.Library (templates)
+import Template.State (defaultState, handleAction, mkInitialState) as Template
+import Template.Types (ContractSetupScreen(..))
 import WalletData.Lenses (_key, _nickname)
 import WalletData.Types (WalletDetails)
 import WebSocket.Support as WS
@@ -53,7 +56,6 @@ initialState =
   , newWalletNicknameKey: mempty
   , templates: mempty
   , subState: Left initialPickupState
-  , contractState: Contract.initialState zero Close
   , webSocketStatus: WebSocketClosed Nothing
   }
 
@@ -69,6 +71,8 @@ mkWalletState pubKeyHash =
   , menuOpen: false
   , screen: ContractsScreen Running
   , card: Nothing
+  , templateState: Template.defaultState
+  , contractState: Contract.defaultState
   }
 
 defaultWalletDetails :: WalletDetails
@@ -177,10 +181,51 @@ handleAction AddNewWallet = do
     newWallets <- use _wallets
     liftEffect $ setItem walletsLocalStorageKey $ encodeJSON newWallets
 
--- contract actions
-handleAction (ContractAction contractAction) = do
-  case contractAction of
-    Contract.ClosePanel -> pure unit
-    action -> mapSubmodule _contractState ContractAction $ Contract.handleAction action
+-- template actions
+handleAction (SetTemplate template) = do
+  mCurrentTemplate <- peruse (_walletState <<< _templateState <<< _template)
+  case mCurrentTemplate of
+    Just currentTemplate
+      | currentTemplate == template -> pure unit
+    _ -> assign (_walletState <<< _templateState) $ Template.mkInitialState template
+  handleAction $ SetScreen $ ContractSetupScreen ContractRolesScreen
 
-handleAction (StartContract contract) = assign (_contractState <<< _executionState <<< _contract) contract
+handleAction (TemplateAction templateAction) = Template.handleAction templateAction
+
+-- contract actions
+handleAction StartContract = do
+  mTemplateState <- peruse (_walletState <<< _templateState)
+  for_ mTemplateState \templateState -> do
+    let
+      extendedContract = view (_template <<< _extendedContract) templateState
+    pure unit
+    let
+      templateContent = view _templateContent templateState
+    let
+      mContract = toCore $ fillTemplate templateContent extendedContract
+    for_ mContract \contract -> do
+      assign (_walletState <<< _contractState <<< _executionState <<< _contract) contract
+      handleAction $ SetScreen $ ContractsScreen Running
+      handleAction $ ToggleCard ContractCard
+
+handleAction (ContractAction contractAction) = handleSubAction (_walletState <<< _contractState) ContractAction Contract.defaultState (Contract.handleAction contractAction)
+
+-- there must be a nicer way to get the current state than by manually
+-- piecing together each of its properties, but I haven't found it :(
+handleSubAction ::
+  forall m state' action'.
+  MonadAff m =>
+  Traversal' State state' ->
+  (action' -> Action) ->
+  state' ->
+  HalogenM state' action' ChildSlots Msg m Unit ->
+  HalogenM State Action ChildSlots Msg m Unit
+handleSubAction traversal wrapper submoduleInitialState submoduleHandleAction = do
+  wallets <- use _wallets
+  newWalletNicknameKey <- use _newWalletNicknameKey
+  templates <- use _templates
+  subState <- use _subState
+  webSocketStatus <- use _webSocketStatus
+  let
+    state = { wallets, newWalletNicknameKey, templates, subState, webSocketStatus }
+  mapMaybeSubmodule state traversal wrapper submoduleInitialState submoduleHandleAction

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -1,0 +1,42 @@
+module Template.Lenses
+  ( _template
+  , _contractNickname
+  , _roleWallets
+  , _templateContent
+  , _name
+  , _type
+  , _description
+  , _extendedContract
+  ) where
+
+import Data.Lens (Lens')
+import Data.Lens.Record (prop)
+import Data.Map (Map)
+import Data.Symbol (SProxy(..))
+import Template.Types (State, Template)
+import Marlowe.Extended (Contract, TemplateContent)
+
+_template :: Lens' State Template
+_template = prop (SProxy :: SProxy "template")
+
+_contractNickname :: Lens' State String
+_contractNickname = prop (SProxy :: SProxy "contractNickname")
+
+_roleWallets :: Lens' State (Map String String)
+_roleWallets = prop (SProxy :: SProxy "roleWallets")
+
+_templateContent :: Lens' State TemplateContent
+_templateContent = prop (SProxy :: SProxy "templateContent")
+
+------------------------------------------------------------
+_name :: Lens' Template String
+_name = prop (SProxy :: SProxy "name")
+
+_type :: Lens' Template String
+_type = prop (SProxy :: SProxy "type_")
+
+_description :: Lens' Template String
+_description = prop (SProxy :: SProxy "description")
+
+_extendedContract :: Lens' Template Contract
+_extendedContract = prop (SProxy :: SProxy "extendedContract")

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -3,18 +3,23 @@ module Template.Lenses
   , _contractNickname
   , _roleWallets
   , _templateContent
-  , _name
-  , _type
-  , _description
+  , _metaData
   , _extendedContract
+  , _contractName
+  , _contractType
+  , _contractDescription
+  , _slotParameterDescriptions
+  , _valueParameterDescriptions
+  , _choiceDescriptions
   ) where
 
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Data.Map (Map)
 import Data.Symbol (SProxy(..))
-import Template.Types (State, Template)
+import Template.Types (MetaData, State, Template)
 import Marlowe.Extended (Contract, TemplateContent)
+import Marlowe.Semantics (TokenName)
 
 _template :: Lens' State Template
 _template = prop (SProxy :: SProxy "template")
@@ -29,14 +34,30 @@ _templateContent :: Lens' State TemplateContent
 _templateContent = prop (SProxy :: SProxy "templateContent")
 
 ------------------------------------------------------------
-_name :: Lens' Template String
-_name = prop (SProxy :: SProxy "name")
-
-_type :: Lens' Template String
-_type = prop (SProxy :: SProxy "type_")
-
-_description :: Lens' Template String
-_description = prop (SProxy :: SProxy "description")
+_metaData :: Lens' Template MetaData
+_metaData = prop (SProxy :: SProxy "metaData")
 
 _extendedContract :: Lens' Template Contract
 _extendedContract = prop (SProxy :: SProxy "extendedContract")
+
+------------------------------------------------------------
+_contractName :: Lens' MetaData String
+_contractName = prop (SProxy :: SProxy "contractName")
+
+_contractType :: Lens' MetaData String
+_contractType = prop (SProxy :: SProxy "contractType")
+
+_contractDescription :: Lens' MetaData String
+_contractDescription = prop (SProxy :: SProxy "contractDescription")
+
+_roleDescriptions :: Lens' MetaData (Map TokenName String)
+_roleDescriptions = prop (SProxy :: SProxy "roleDescriptions")
+
+_slotParameterDescriptions :: Lens' MetaData (Map String String)
+_slotParameterDescriptions = prop (SProxy :: SProxy "slotParameterDescriptions")
+
+_valueParameterDescriptions :: Lens' MetaData (Map String String)
+_valueParameterDescriptions = prop (SProxy :: SProxy "valueParameterDescriptions")
+
+_choiceDescriptions :: Lens' MetaData (Map String String)
+_choiceDescriptions = prop (SProxy :: SProxy "choiceDescriptions")

--- a/marlowe-dashboard-client/src/Template/Library.purs
+++ b/marlowe-dashboard-client/src/Template/Library.purs
@@ -1,51 +1,60 @@
-module Template.Library (templates) where
+module Template.Library
+  ( defaultTemplate
+  , templates
+  ) where
 
-import Marlowe.Extended (Contract(..))
+import Prelude
+import Marlowe.Extended (Action(..), Case(..), Contract(..), Observation(..), Payee(..), Timeout(..), Value(..))
+import Marlowe.Semantics (Bound(..), ChoiceId(..), Party(..), Token(..))
 import Template.Types (Template)
 
 -- we could potentially just hard code these here for now, but it would be
 -- better to fetch them from the library; in any case, I'm hard coding some
 -- approximations of what these might look like to help get the ball rolling
+defaultTemplate :: Template
+defaultTemplate =
+  { name: "Sample escrow contract 1"
+  , type_: "Escrow"
+  , description: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
+  , extendedContract: When [ Case (Deposit (Role "alice") (Role "alice") (Token "" "") (ConstantParam "amount")) (When [ Case (Choice (ChoiceId "choice" (Role "alice")) [ Bound zero one ]) (When [ Case (Choice (ChoiceId "choice" (Role "bob")) [ Bound zero one ]) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (ChoiceValue (ChoiceId "choice" (Role "bob")))) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (Constant zero)) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) Close) (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "bobTimeout") (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "aliceTimeout") (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "depositSlot") Close
+  }
+
 templates :: Array Template
 templates =
-  [ { name: "Sample escrow contract 1"
-    , type_: "Escrow"
-    , description: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
-    , contract: Close
-    }
+  [ defaultTemplate
   , { name: "Sample escrow contract 2"
     , type_: "Escrow"
     , description: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample zero coupon bond contract 1"
     , type_: "Zero Coupon Bond"
     , description: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample zero coupon bond contract 2"
     , type_: "Zero Coupon Bond"
     , description: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample coupon bond guaranteed contract 1"
     , type_: "Coupon Bond Guaranteed"
     , description: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample coupon bond guaranteed contract 2"
     , type_: "Coupon Bond Guaranteed"
     , description: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample swap contract 1"
     , type_: "Swap"
     , description: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
-    , contract: Close
+    , extendedContract: Close
     }
   , { name: "Sample swap contract 2"
     , type_: "Swap"
     , description: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
-    , contract: Close
+    , extendedContract: Close
     }
   ]

--- a/marlowe-dashboard-client/src/Template/Library.purs
+++ b/marlowe-dashboard-client/src/Template/Library.purs
@@ -4,6 +4,7 @@ module Template.Library
   ) where
 
 import Prelude
+import Data.Map (empty, insert, singleton)
 import Marlowe.Extended (Action(..), Case(..), Contract(..), Observation(..), Payee(..), Timeout(..), Value(..))
 import Marlowe.Semantics (Bound(..), ChoiceId(..), Party(..), Token(..))
 import Template.Types (Template)
@@ -13,48 +14,100 @@ import Template.Types (Template)
 -- approximations of what these might look like to help get the ball rolling
 defaultTemplate :: Template
 defaultTemplate =
-  { name: "Sample escrow contract 1"
-  , type_: "Escrow"
-  , description: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
+  { metaData:
+      { contractName: "Sample escrow contract 1"
+      , contractType: "Escrow"
+      , contractDescription: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
+      , roleDescriptions: insert "alice" "about the alice role" $ singleton "bob" "about the bob role"
+      , slotParameterDescriptions:
+          insert "aliceTimeout" "about the aliceTimeout"
+            $ insert "arbitrageTimeout" "about the arbitrageTimeout"
+            $ insert "bobTimeout" "about the bobTimeout"
+            $ singleton "depositSlot" "about the depositSlot"
+      , valueParameterDescriptions: singleton "amount" "about the amount"
+      , choiceDescriptions: singleton "choice" "about the choice"
+      }
   , extendedContract: When [ Case (Deposit (Role "alice") (Role "alice") (Token "" "") (ConstantParam "amount")) (When [ Case (Choice (ChoiceId "choice" (Role "alice")) [ Bound zero one ]) (When [ Case (Choice (ChoiceId "choice" (Role "bob")) [ Bound zero one ]) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (ChoiceValue (ChoiceId "choice" (Role "bob")))) (If (ValueEQ (ChoiceValue (ChoiceId "choice" (Role "alice"))) (Constant zero)) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) Close) (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "bobTimeout") (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "aliceTimeout") (When [ Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound one one ]) Close, Case (Choice (ChoiceId "choice" (Role "carol")) [ Bound zero zero ]) (Pay (Role "alice") (Party (Role "bob")) (Token "" "") (ConstantParam "amount") Close) ] (SlotParam "arbitrageTimeout") Close)) ] (SlotParam "depositSlot") Close
   }
 
 templates :: Array Template
 templates =
   [ defaultTemplate
-  , { name: "Sample escrow contract 2"
-    , type_: "Escrow"
-    , description: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
+  , { metaData:
+        { contractName: "Sample escrow contract 2"
+        , contractType: "Escrow"
+        , contractDescription: "Escrow is a financial arrangement where a third party holds and regulates payment of the funds required for two parties involved in a given transaction."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample zero coupon bond contract 1"
-    , type_: "Zero Coupon Bond"
-    , description: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
+  , { metaData:
+        { contractName: "Sample zero coupon bond contract 1"
+        , contractType: "Zero Coupon Bond"
+        , contractDescription: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample zero coupon bond contract 2"
-    , type_: "Zero Coupon Bond"
-    , description: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
+  , { metaData:
+        { contractName: "Sample zero coupon bond contract 2"
+        , contractType: "Zero Coupon Bond"
+        , contractDescription: "A zero-coupon bond is a debt security that does not pay interest but instead trades at a deep discount, rendering a profit at maturity, when the bond is redeemed for its full face value."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample coupon bond guaranteed contract 1"
-    , type_: "Coupon Bond Guaranteed"
-    , description: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
+  , { metaData:
+        { contractName: "Sample coupon bond guaranteed contract 1"
+        , contractType: "Coupon Bond Guaranteed"
+        , contractDescription: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample coupon bond guaranteed contract 2"
-    , type_: "Coupon Bond Guaranteed"
-    , description: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
+  , { metaData:
+        { contractName: "Sample coupon bond guaranteed contract 2"
+        , contractType: "Coupon Bond Guaranteed"
+        , contractDescription: "A guaranteed bond is a debt security that offers a secondary guarantee that interest and principal payments will be made by a third party, should the issuer default. It can be backed by a bond insurance company, a fund or group entity, a government authority, or the corporate parents of subsidiaries or joint ventures that are issuing bonds."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample swap contract 1"
-    , type_: "Swap"
-    , description: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
+  , { metaData:
+        { contractName: "Sample swap contract 1"
+        , contractType: "Swap"
+        , contractDescription: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
-  , { name: "Sample swap contract 2"
-    , type_: "Swap"
-    , description: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
+  , { metaData:
+        { contractName: "Sample swap contract 2"
+        , contractType: "Swap"
+        , contractDescription: "A swap is a derivative contract through which two parties exchange the cash flows or liabilities from two different financial instruments. Most swaps involve cash flows based on a notional principal amount such as a loan or bond, although the instrument can be almost anything. Usually, the principal does not change hands. Each cash flow comprises one leg of the swap. One cash flow is generally fixed, while the other is variable and based on a benchmark interest rate, floating currency exchange rate or index price."
+        , roleDescriptions: empty
+        , slotParameterDescriptions: empty
+        , valueParameterDescriptions: empty
+        , choiceDescriptions: empty
+        }
     , extendedContract: Close
     }
   ]

--- a/marlowe-dashboard-client/src/Template/State.purs
+++ b/marlowe-dashboard-client/src/Template/State.purs
@@ -1,0 +1,59 @@
+module Template.State
+  ( defaultState
+  , mkInitialState
+  , handleAction
+  ) where
+
+-- Note: There is no independent template state as such (just a property of
+-- the main state). This module simply includes some template-related helper
+-- functions for use in MainFrame.Sate, separated out to keep modules
+-- relatively small and easier to read.
+-- Maybe we could do the same for Contract.State...?
+import Prelude
+import Data.Lens (assign, modifying)
+import Data.Map (Map, insert, fromFoldable)
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set (delete, map) as Set
+import Data.Tuple (Tuple(..))
+import Effect.Aff.Class (class MonadAff)
+import Halogen (HalogenM)
+import MainFrame.Lenses (_templateState, _walletState)
+import MainFrame.Types (ChildSlots, Msg)
+import MainFrame.Types (Action, State) as MainFrame
+import Marlowe.Extended (Contract, getParties, getPlaceholderIds, initializeTemplateContent, typeToLens)
+import Marlowe.Semantics (Party(..))
+import Template.Lenses (_contractNickname, _roleWallets, _templateContent)
+import Template.Library (defaultTemplate)
+import Template.Types (Action(..), State, Template)
+
+defaultState :: State
+defaultState = mkInitialState defaultTemplate
+
+mkInitialState :: Template -> State
+mkInitialState template =
+  { template: template
+  , contractNickname: template.name
+  , roleWallets: mkRoleWallets template.extendedContract
+  , templateContent: initializeTemplateContent $ getPlaceholderIds template.extendedContract
+  }
+
+mkRoleWallets :: Contract -> Map String String
+mkRoleWallets contract = fromFoldable $ Set.map (\name -> Tuple name "") (getRoleNames contract)
+
+getRoleNames :: Contract -> Set String
+getRoleNames contract = Set.delete "" $ Set.map roleName (getParties contract)
+  where
+  roleName (PK pubKey) = ""
+
+  roleName (Role tokenName) = tokenName
+
+handleAction :: forall m. MonadAff m => Action -> HalogenM MainFrame.State MainFrame.Action ChildSlots Msg m Unit
+handleAction (SetContractNickname nickname) = assign (_walletState <<< _templateState <<< _contractNickname) nickname
+
+handleAction (SetRoleWallet roleName walletNickname) = modifying (_walletState <<< _templateState <<< _roleWallets) $ insert roleName walletNickname
+
+handleAction (SetParameter integerTemplateType key mValue) = do
+  let
+    value = fromMaybe zero mValue
+  modifying (_walletState <<< _templateState <<< _templateContent <<< typeToLens integerTemplateType) $ insert key value

--- a/marlowe-dashboard-client/src/Template/Types.purs
+++ b/marlowe-dashboard-client/src/Template/Types.purs
@@ -1,6 +1,7 @@
 module Template.Types
   ( State
   , Template
+  , MetaData
   , ContractSetupScreen(..)
   , Action(..)
   ) where
@@ -11,6 +12,7 @@ import Data.BigInteger (BigInteger)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))
 import Marlowe.Extended (Contract, IntegerTemplateType, TemplateContent)
+import Marlowe.Semantics (TokenName)
 
 type State
   = { template :: Template
@@ -20,10 +22,18 @@ type State
     }
 
 type Template
-  = { name :: String
-    , type_ :: String
-    , description :: String
+  = { metaData :: MetaData
     , extendedContract :: Contract
+    }
+
+type MetaData
+  = { contractName :: String
+    , contractType :: String
+    , contractDescription :: String
+    , roleDescriptions :: Map TokenName String
+    , slotParameterDescriptions :: Map String String
+    , valueParameterDescriptions :: Map String String
+    , choiceDescriptions :: Map String String
     }
 
 data ContractSetupScreen

--- a/marlowe-dashboard-client/src/Template/Types.purs
+++ b/marlowe-dashboard-client/src/Template/Types.purs
@@ -1,12 +1,46 @@
 module Template.Types
-  ( Template
+  ( State
+  , Template
+  , ContractSetupScreen(..)
+  , Action(..)
   ) where
 
-import Marlowe.Extended (Contract)
+import Prelude
+import Analytics (class IsEvent, defaultEvent)
+import Data.BigInteger (BigInteger)
+import Data.Map (Map)
+import Data.Maybe (Maybe(..))
+import Marlowe.Extended (Contract, IntegerTemplateType, TemplateContent)
+
+type State
+  = { template :: Template
+    , contractNickname :: String
+    , roleWallets :: Map String String
+    , templateContent :: TemplateContent
+    }
 
 type Template
   = { name :: String
     , type_ :: String
     , description :: String
-    , contract :: Contract
+    , extendedContract :: Contract
     }
+
+data ContractSetupScreen
+  = ContractRolesScreen
+  | ContractParametersScreen
+  | ContractReviewScreen
+
+derive instance eqContractSetupScreen :: Eq ContractSetupScreen
+
+data Action
+  = SetContractNickname String
+  | SetRoleWallet String String
+  | SetParameter IntegerTemplateType String (Maybe BigInteger)
+
+-- | Here we decide which top-level queries to track as GA events, and
+-- how to classify them.
+instance actionIsEvent :: IsEvent Action where
+  toEvent (SetContractNickname _) = Just $ defaultEvent "SetContractNickname"
+  toEvent (SetRoleWallet _ _) = Just $ defaultEvent "SetRoleWallet"
+  toEvent (SetParameter _ _ _) = Just $ defaultEvent "SetParameter"

--- a/marlowe-dashboard-client/src/Template/Validation.purs
+++ b/marlowe-dashboard-client/src/Template/Validation.purs
@@ -1,0 +1,63 @@
+module Template.Validation
+  ( RoleError(..)
+  , ParameterError(..)
+  , roleError
+  , slotError
+  , valueError
+  , roleWalletsAreValid
+  ) where
+
+-- General note: Validating number inputs is a pain. I cannot find a nice way
+-- of checking that number inputs are non-empty, or that they are integers (as
+-- opposed to rationals). It would almost be simpler to give all inputs a 
+-- type="text", and validate against the string input before converting it to
+-- a number. But then the HTML interface wouldn't be as user-friendly. :(
+
+import Prelude
+import Data.BigInteger (BigInteger)
+import Data.Map (Map, isEmpty, mapMaybe, member)
+import Data.Map.Extra (mapIndex)
+import Data.Maybe (Maybe(..))
+import Data.Tuple (fst)
+import WalletData.Types (WalletLibrary)
+
+data RoleError
+  = EmptyNickname
+  | NonExistentNickname
+
+derive instance eqRoleError :: Eq RoleError
+
+instance showRoleError :: Show RoleError where
+  show EmptyNickname = "Role nickname cannot be blank"
+  show NonExistentNickname = "Nickname not found in your wallet library"
+
+data ParameterError
+  = NonPositiveTimeout
+
+derive instance eqParameterError :: Eq ParameterError
+
+instance showParameterError :: Show ParameterError where
+  show NonPositiveTimeout = "Timeout must be positive"
+
+roleError :: String -> WalletLibrary -> Maybe RoleError
+roleError "" _ = Just EmptyNickname
+
+roleError nickname wallets =
+  if member nickname $ mapIndex fst wallets then
+    Nothing
+  else
+    Just NonExistentNickname
+
+slotError :: BigInteger -> Maybe ParameterError
+slotError timeout =
+  if timeout <= zero then
+    Just NonPositiveTimeout
+  else
+    Nothing
+
+-- placeholder in case we add value validation in the future
+valueError :: BigInteger -> Maybe ParameterError
+valueError _ = Nothing
+
+roleWalletsAreValid :: Map String String -> WalletLibrary -> Boolean
+roleWalletsAreValid roleWallets wallets = isEmpty $ mapMaybe (\value -> roleError value wallets) roleWallets

--- a/marlowe-dashboard-client/src/Template/Validation.purs
+++ b/marlowe-dashboard-client/src/Template/Validation.purs
@@ -12,7 +12,6 @@ module Template.Validation
 -- opposed to rationals). It would almost be simpler to give all inputs a 
 -- type="text", and validate against the string input before converting it to
 -- a number. But then the HTML interface wouldn't be as user-friendly. :(
-
 import Prelude
 import Data.BigInteger (BigInteger)
 import Data.Map (Map, isEmpty, mapMaybe, member)

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -1,15 +1,31 @@
 module Template.View
   ( templateLibraryCard
+  , contractSetupScreenHeader
   , contractSetupScreen
+  , contractSetupConfirmationCard
   ) where
 
-import Prelude hiding (div)
-import Css (classNames)
-import Data.Maybe (Maybe(..))
-import Halogen.HTML (HTML, button, div, div_, h2_, h3_, h4_, p_, text)
-import Halogen.HTML.Events (onClick)
-import MainFrame.Types (Action(..), Screen(..))
-import Template.Types (Template)
+import Prelude hiding (div, min)
+import Css (applyWhen, classNames, toggleWhen)
+import Data.BigInteger (fromString) as BigInteger
+import Data.Lens (view)
+import Data.Map (Map, lookup)
+import Data.Map (toUnfoldable) as Map
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Set (toUnfoldable) as Set
+import Data.Tuple.Nested ((/\))
+import Halogen.HTML (HTML, a, button, div, div_, h2_, h3_, h4_, input, label, li, p_, span, text, ul, ul_)
+import Halogen.HTML.Events (onClick, onValueInput)
+import Halogen.HTML.Properties (InputType(..), disabled, for, id_, list, min, placeholder, readOnly, type_, value)
+import MainFrame.Types (Action(..), Card(..), Screen(..))
+import Marlowe.Extended (Contract, IntegerTemplateType(..), TemplateContent, _slotContent, _valueContent, getParties)
+import Marlowe.Semantics (PubKey, Party(..))
+import Template.Lenses (_contractNickname, _extendedContract, _roleWallets, _template, _templateContent)
+import Template.Types (ContractSetupScreen(..), Template)
+import Template.Types (Action(..), State) as Template
+import Template.Validation (roleError, roleWalletsAreValid, slotError, valueError)
+import WalletData.Types (WalletLibrary)
+import WalletData.View (nicknamesDataList)
 
 templateLibraryCard :: forall p. Array Template -> HTML p Action
 templateLibraryCard templates =
@@ -32,13 +48,206 @@ templateBox template =
         [ text template.description ]
     , button
         [ classNames [ "bg-green", "text-white" ]
-        , onClick $ const $ Just $ SetScreen $ ContractSetupScreen template
+        , onClick $ const $ Just $ SetTemplate template
         ]
         [ text "Setup" ]
     ]
 
-contractSetupScreen :: forall p. Template -> HTML p Action
-contractSetupScreen template =
+contractSetupScreen :: forall p. WalletLibrary -> ContractSetupScreen -> Template.State -> HTML p Action
+contractSetupScreen wallets setupScreen state =
+  let
+    contractNickname = view _contractNickname state
+
+    extendedContract = view (_template <<< _extendedContract) state
+
+    roleWallets = view _roleWallets state
+
+    templateContent = view _templateContent state
+  in
+    div
+      []
+      [ contractSetupScreenHeader setupScreen contractNickname
+      , case setupScreen of
+          ContractRolesScreen -> contractRolesScreen wallets extendedContract roleWallets
+          ContractParametersScreen -> contractParametersScreen templateContent
+          ContractReviewScreen -> contractReviewScreen state
+      , div
+          [ classNames [ "absolute", "bottom-1", "left-1", "right-1", "flex", "items-center", "justify-between" ] ]
+          $ contractNavigationButtons setupScreen roleWallets wallets
+      ]
+
+contractSetupScreenHeader :: forall p. ContractSetupScreen -> String -> HTML p Action
+contractSetupScreenHeader setupScreen contractNickname =
+  div_
+    [ div
+        []
+        [ input
+            [ classNames [ "w-full", "text-center" ]
+            , type_ InputText
+            , placeholder "Contract name"
+            , value contractNickname
+            , onValueInput $ Just <<< TemplateAction <<< Template.SetContractNickname
+            ]
+        ]
+    , div
+        [ classNames [ "flex", "justify-between" ] ]
+        [ span
+            [ classNames $ screenClasses setupScreen ContractRolesScreen ]
+            [ text "Roles" ]
+        , span
+            [ classNames $ screenClasses setupScreen ContractParametersScreen ]
+            [ text "Parameters" ]
+        , span
+            [ classNames $ screenClasses setupScreen ContractReviewScreen ]
+            [ text "Review" ]
+        ]
+    ]
+  where
+  screenClasses currentScreen screen = [ "p-1" ] <> applyWhen (currentScreen == screen) "text-green"
+
+contractNavigationButtons :: forall p. ContractSetupScreen -> Map String String -> WalletLibrary -> Array (HTML p Action)
+contractNavigationButtons screen roleWallets wallets = case screen of
+  ContractRolesScreen ->
+    [ a
+        [ onClick $ const $ Just $ ToggleCard TemplateLibraryCard ]
+        [ text "< Library quick access" ]
+    , button
+        [ onClick $ const $ Just $ SetScreen $ ContractSetupScreen ContractParametersScreen
+        , disabled $ not $ roleWalletsAreValid roleWallets wallets
+        ]
+        [ text "Next >" ]
+    ]
+  ContractParametersScreen ->
+    [ a
+        [ onClick $ const $ Just $ SetScreen $ ContractSetupScreen ContractRolesScreen ]
+        [ text "< Roles" ]
+    , button
+        [ onClick $ const $ Just $ SetScreen $ ContractSetupScreen ContractReviewScreen ]
+        [ text "Next >" ]
+    ]
+  ContractReviewScreen ->
+    [ a
+        [ onClick $ const $ Just $ SetScreen $ ContractSetupScreen ContractParametersScreen ]
+        [ text "< Parameters" ]
+    , button
+        [ onClick $ const $ Just $ ToggleCard ContractSetupConfirmationCard ]
+        [ text "Pay and start >" ]
+    ]
+
+contractRolesScreen :: forall p. WalletLibrary -> Contract -> Map String PubKey -> HTML p Action
+contractRolesScreen wallets extendedContract roleWallets =
+  ul
+    [ classNames [ "mx-auto", "w-card" ] ]
+    $ map partyInput (Set.toUnfoldable $ getParties extendedContract)
+  where
+  partyInput (PK pubKey) =
+    li
+      [ classNames [ "mb-1" ] ]
+      [ label
+          [ classNames [ "block", "mb-0.5" ]
+          , for pubKey
+          ]
+          [ text "Wallet" ]
+      , input
+          [ classNames [ "w-full" ]
+          , id_ pubKey
+          , type_ InputText
+          , value pubKey
+          , readOnly true
+          ]
+      ]
+
+  partyInput (Role tokName) =
+    let
+      assigned = fromMaybe "" $ lookup tokName roleWallets
+
+      mRoleError = roleError assigned wallets
+    in
+      li
+        [ classNames [ "mb-1" ] ]
+        [ label
+            [ classNames [ "block", "mb-0.5" ]
+            , for tokName
+            ]
+            [ text tokName ]
+        , input
+            [ classNames $ [ "w-full" ] <> toggleWhen (mRoleError == Nothing) "border-green" "border-red"
+            , id_ tokName
+            , type_ InputText
+            , list "walletNicknames"
+            , onValueInput $ Just <<< TemplateAction <<< Template.SetRoleWallet tokName
+            , value assigned
+            ]
+        , div
+            [ classNames [ "mb-1", "text-red", "text-sm" ] ]
+            $ case mRoleError of
+                Just roleError -> [ text $ show roleError ]
+                Nothing -> []
+        , nicknamesDataList wallets
+        ]
+
+contractParametersScreen :: forall p. TemplateContent -> HTML p Action
+contractParametersScreen templateContent =
+  let
+    slotContent = view _slotContent templateContent
+
+    valueContent = view _valueContent templateContent
+  in
+    div
+      [ classNames [ "mx-auto", "w-card" ] ]
+      [ ul
+          [ classNames [ "mb-1" ] ]
+          $ map (parameterInput SlotContent) (Map.toUnfoldable slotContent)
+      , ul_
+          $ map (parameterInput ValueContent) (Map.toUnfoldable valueContent)
+      ]
+  where
+  parameterInput integerTemplateType (key /\ parameterValue) =
+    let
+      mParameterError = case integerTemplateType of
+        SlotContent -> slotError parameterValue
+        ValueContent -> valueError parameterValue
+    in
+      li
+        [ classNames [ "mb-1" ] ]
+        [ label
+            [ classNames [ "block", "mb-0.5" ] ]
+            [ text key ]
+        , input
+            [ classNames $ [ "w-full" ] <> toggleWhen (mParameterError == Nothing) "border-green" "border-red"
+            , type_ InputNumber
+            , min one
+            , onValueInput $ Just <<< TemplateAction <<< Template.SetParameter integerTemplateType key <<< BigInteger.fromString
+            , value $ show parameterValue
+            ]
+        , div
+            [ classNames [ "mb-1", "text-red", "text-sm" ] ]
+            $ case mParameterError of
+                Just parameterError -> [ text $ show parameterError ]
+                Nothing -> []
+        ]
+
+contractReviewScreen :: forall p. Template.State -> HTML p Action
+contractReviewScreen state =
   div
-    [ classNames [ "p-1" ] ]
-    [ text "Setup Contract" ]
+    [ classNames [ "mx-auto", "w-card", "bg-white", "p-1" ] ]
+    [ text "Summary information about the contract goes here." ]
+
+contractSetupConfirmationCard :: forall p. HTML p Action
+contractSetupConfirmationCard =
+  div_
+    [ p_ [ text "Are you sure?" ]
+    , div
+        [ classNames [ "flex" ] ]
+        [ button
+            [ classNames [ "flex-1", "mr-1" ]
+            , onClick $ const $ Just StartContract
+            ]
+            [ text "Pay and start" ]
+        , button
+            [ classNames [ "flex-1" ]
+            , onClick $ const $ Just $ ToggleCard ContractSetupConfirmationCard
+            ]
+            [ text "Cancel" ]
+        ]
+    ]

--- a/marlowe-dashboard-client/src/WalletData/Types.purs
+++ b/marlowe-dashboard-client/src/WalletData/Types.purs
@@ -1,11 +1,11 @@
 module WalletData.Types
   ( WalletLibrary
   , WalletNicknameKey
-  , WalletDetails(..)
+  , WalletDetails
   ) where
 
-import Data.Map (Map)
 import Data.Tuple (Tuple)
+import Data.Map (Map)
 import Marlowe.Semantics (PubKey)
 
 type WalletLibrary

--- a/marlowe-dashboard-client/src/WalletData/Validation.purs
+++ b/marlowe-dashboard-client/src/WalletData/Validation.purs
@@ -1,8 +1,8 @@
 module WalletData.Validation
-  ( KeyError(..)
-  , NicknameError(..)
-  , keyError
+  ( NicknameError(..)
+  , KeyError(..)
   , nicknameError
+  , keyError
   ) where
 
 import Prelude

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -1,5 +1,6 @@
 module WalletData.View
   ( pickupWalletScreen
+  , nicknamesDataList
   , pickupNewWalletCard
   , pickupLocalWalletCard
   , putdownWalletCard
@@ -15,7 +16,7 @@ import Data.Map (isEmpty, toUnfoldable)
 import Data.Map.Extra (findIndex)
 import Data.Maybe (Maybe(..), isJust)
 import Data.Tuple (Tuple(..), fst, snd)
-import Halogen.HTML (HTML, a, br_, button, datalist, div, footer, h2_, header, hr_, input, label, li, main, option, p, p_, span, text, ul)
+import Halogen.HTML (HTML, a, br_, button, datalist, div, div_, footer, h2_, header, hr_, input, label, li, main, option, p, p_, span, text, ul)
 import Halogen.HTML.Events (onClick, onValueInput)
 import Halogen.HTML.Properties (InputType(..), disabled, for, href, id_, list, placeholder, readOnly, type_, value)
 import MainFrame.Types (Action(..), Card(..))
@@ -52,13 +53,10 @@ pickupWalletScreen wallets =
         , input
             [ type_ InputText
             , id_ "existingWallet"
-            , list "existingNicknames"
+            , list "walletNicknames"
             , onValueInput $ Just <<< LookupWallet
             ]
-        , datalist
-            [ id_ "existingNicknames" ]
-            $ walletOption
-            <$> toUnfoldable wallets
+        , nicknamesDataList wallets
         ]
     , footer
         [ classNames [ "flex" ] ]
@@ -74,6 +72,13 @@ pickupWalletScreen wallets =
       ]
       [ icon, text label ]
 
+nicknamesDataList :: forall p a. WalletLibrary -> HTML p a
+nicknamesDataList wallets =
+  datalist
+    [ id_ "walletNicknames" ]
+    $ walletOption
+    <$> toUnfoldable wallets
+  where
   walletOption (Tuple (Tuple nickname _) _) = option [ value nickname ] []
 
 pickupNewWalletCard :: forall p. WalletNicknameKey -> WalletLibrary -> HTML p Action
@@ -182,8 +187,7 @@ putdownWalletCard pubKeyHash wallets =
 
 walletLibraryScreen :: forall p. WalletLibrary -> HTML p Action
 walletLibraryScreen wallets =
-  div
-    [ classNames [ "p-1" ] ]
+  div_
     [ h2_
         [ text "Contacts" ]
     , hr_

--- a/marlowe-dashboard-client/static/css/main.css
+++ b/marlowe-dashboard-client/static/css/main.css
@@ -23,6 +23,6 @@ button {
   @apply px-1 py-0.75 leading-none disabled:opacity-50 disabled:cursor-not-allowed bg-green text-white;
 }
 
-input[type="text"] {
+input[type="text"], input[type="number"] {
   @apply border p-0.5
 }

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -127,7 +127,7 @@ module.exports = {
     stroke: false,
     strokeWidth: false,
     tableLayout: false,
-    textAlign: false,
+    textAlign: true,
     textOpacity: false,
     textOverflow: false,
     fontStyle: false,

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -95,7 +95,7 @@ class HasParties a where
   getParties :: a -> Set S.Party
 
 instance arrayHasParties :: HasParties a => HasParties (Array a) where
-  getParties as = foldMap (\a -> getParties a) as
+  getParties = foldMap (\a -> getParties a)
 
 instance sPartyHasParties :: HasParties S.Party where
   getParties party = Set.singleton party
@@ -323,13 +323,18 @@ instance fillableValue :: Fillable Value TemplateContent where
 
 instance valueHasParties :: HasParties Value where
   getParties (AvailableMoney accId _) = getParties accId
+  getParties (Constant _) = Set.empty
+  getParties (ConstantParam _) = Set.empty
   getParties (NegValue val) = getParties val
   getParties (AddValue lhs rhs) = getParties lhs <> getParties rhs
   getParties (SubValue lhs rhs) = getParties lhs <> getParties rhs
+  getParties (MulValue lhs rhs) = getParties lhs <> getParties rhs
   getParties (Scale _ val) = getParties val
   getParties (ChoiceValue choId) = getParties choId
+  getParties SlotIntervalStart = Set.empty
+  getParties SlotIntervalEnd = Set.empty
+  getParties (UseValue _) = Set.empty
   getParties (Cond obs lhs rhs) = getParties obs <> getParties lhs <> getParties rhs
-  getParties _ = Set.empty
 
 data Observation
   = AndObs Observation Observation
@@ -494,7 +499,8 @@ instance observationHasParties :: HasParties Observation where
   getParties (ValueLT lhs rhs) = getParties lhs <> getParties rhs
   getParties (ValueLE lhs rhs) = getParties lhs <> getParties rhs
   getParties (ValueEQ lhs rhs) = getParties lhs <> getParties rhs
-  getParties _ = Set.empty
+  getParties TrueObs = Set.empty
+  getParties FalseObs = Set.empty
 
 data Action
   = Deposit S.AccountId S.Party S.Token Value

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -73,7 +73,7 @@ initializeTemplateContent ( Placeholders
     { slotPlaceholderIds, valuePlaceholderIds }
 ) =
   TemplateContent
-    { slotContent: initializeWith (const zero) slotPlaceholderIds
+    { slotContent: initializeWith (const one) slotPlaceholderIds
     , valueContent: initializeWith (const zero) valuePlaceholderIds
     }
 
@@ -81,7 +81,7 @@ updateTemplateContent :: Placeholders -> TemplateContent -> TemplateContent
 updateTemplateContent ( Placeholders { slotPlaceholderIds, valuePlaceholderIds }
 ) (TemplateContent { slotContent, valueContent }) =
   TemplateContent
-    { slotContent: initializeWith (\x -> fromMaybe zero $ Map.lookup x slotContent) slotPlaceholderIds
+    { slotContent: initializeWith (\x -> fromMaybe one $ Map.lookup x slotContent) slotPlaceholderIds
     , valueContent: initializeWith (\x -> fromMaybe zero $ Map.lookup x valueContent) valuePlaceholderIds
     }
 
@@ -90,6 +90,18 @@ class Template a b where
 
 class Fillable a b where
   fillTemplate :: b -> a -> a
+
+class HasParties a where
+  getParties :: a -> Set S.Party
+
+instance arrayHasParties :: HasParties a => HasParties (Array a) where
+  getParties as = foldMap (\a -> getParties a) as
+
+instance sPartyHasParties :: HasParties S.Party where
+  getParties party = Set.singleton party
+
+instance sChoiceIdHasParties :: HasParties S.ChoiceId where
+  getParties (S.ChoiceId _ party) = getParties party
 
 data Timeout
   = SlotParam String
@@ -309,6 +321,16 @@ instance fillableValue :: Fillable Value TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
+instance valueHasParties :: HasParties Value where
+  getParties (AvailableMoney accId _) = getParties accId
+  getParties (NegValue val) = getParties val
+  getParties (AddValue lhs rhs) = getParties lhs <> getParties rhs
+  getParties (SubValue lhs rhs) = getParties lhs <> getParties rhs
+  getParties (Scale _ val) = getParties val
+  getParties (ChoiceValue choId) = getParties choId
+  getParties (Cond obs lhs rhs) = getParties obs <> getParties lhs <> getParties rhs
+  getParties _ = Set.empty
+
 data Observation
   = AndObs Observation Observation
   | OrObs Observation Observation
@@ -462,6 +484,18 @@ instance fillableObservation :: Fillable Observation TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
+instance observationHasParties :: HasParties Observation where
+  getParties (AndObs lhs rhs) = getParties lhs <> getParties rhs
+  getParties (OrObs lhs rhs) = getParties lhs <> getParties rhs
+  getParties (NotObs v) = getParties v
+  getParties (ChoseSomething a) = getParties a
+  getParties (ValueGE lhs rhs) = getParties lhs <> getParties rhs
+  getParties (ValueGT lhs rhs) = getParties lhs <> getParties rhs
+  getParties (ValueLT lhs rhs) = getParties lhs <> getParties rhs
+  getParties (ValueLE lhs rhs) = getParties lhs <> getParties rhs
+  getParties (ValueEQ lhs rhs) = getParties lhs <> getParties rhs
+  getParties _ = Set.empty
+
 data Action
   = Deposit S.AccountId S.Party S.Token Value
   | Choice S.ChoiceId (Array S.Bound)
@@ -533,6 +567,11 @@ instance fillableAction :: Fillable Action TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
+instance actionHasParties :: HasParties Action where
+  getParties (Deposit accId party _ value) = getParties accId <> getParties party <> getParties value
+  getParties (Notify obs) = getParties obs
+  getParties _ = Set.empty
+
 data Payee
   = Account S.AccountId
   | Party S.Party
@@ -565,6 +604,10 @@ instance hasArgsPayee :: Args Payee where
 instance toCorePayee :: ToCore Payee S.Payee where
   toCore (Account accId) = Just $ S.Account accId
   toCore (Party roleName) = Just $ S.Party roleName
+
+instance payeeHasParties :: HasParties Payee where
+  getParties (Account accountId) = getParties accountId
+  getParties (Party party) = getParties party
 
 data Case
   = Case Action Contract
@@ -609,6 +652,9 @@ instance fillableCase :: Fillable Case TemplateContent where
     where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
+
+instance caseHasParties :: HasParties Case where
+  getParties (Case action contract) = getParties action <> getParties contract
 
 data Contract
   = Close
@@ -723,3 +769,11 @@ instance fillableContract :: Fillable Contract TemplateContent where
     where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
+
+instance contractHasParries :: HasParties Contract where
+  getParties Close = Set.empty
+  getParties (Pay accId payee _ val cont) = getParties accId <> getParties payee <> getParties val <> getParties cont
+  getParties (If obs cont1 cont2) = getParties obs <> getParties cont1 <> getParties cont2
+  getParties (When cases _ cont) = getParties cases <> getParties cont
+  getParties (Let _ val cont) = getParties val <> getParties cont
+  getParties (Assert obs cont) = getParties obs <> getParties cont

--- a/web-common/src/Halogen/Extra.purs
+++ b/web-common/src/Halogen/Extra.purs
@@ -7,7 +7,7 @@ import Data.Bifunctor (bimap)
 import Data.Foldable (for_)
 import Data.Lens (Lens', Traversal', preview, set, view)
 import Data.Lens.Extra (peruse)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (fromMaybe)
 import Data.Newtype (over)
 import Data.Tuple (Tuple(..))
 import Effect.Aff.Class (class MonadAff)
@@ -88,9 +88,7 @@ mapMaybeSubmodule state traversal wrapper submoduleDefaultState submoduleHandleA
   where
   subToMain submoduleState = set traversal submoduleState state
 
-  mainToSub mainState = case preview traversal mainState of
-    Just submoduleState -> submoduleState
-    _ -> submoduleDefaultState
+  mainToSub = fromMaybe submoduleDefaultState <<< preview traversal
 
 foreign import scrollIntoView_ :: EffectFn1 HTMLElement Unit
 

--- a/web-common/src/Halogen/Extra.purs
+++ b/web-common/src/Halogen/Extra.purs
@@ -5,20 +5,24 @@ import Control.Applicative.Free (hoistFreeAp)
 import Control.Monad.Free (hoistFree)
 import Data.Bifunctor (bimap)
 import Data.Foldable (for_)
-import Data.Lens (Lens', set, view)
+import Data.Lens (Lens', Traversal', preview, set, view)
+import Data.Lens.Extra (peruse)
+import Data.Maybe (Maybe(..))
 import Data.Newtype (over)
 import Data.Tuple (Tuple(..))
+import Effect.Aff.Class (class MonadAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Uncurried (EffectFn1, runEffectFn1)
 import Halogen (ComponentHTML, HalogenF(..), HalogenM(..), RefLabel, getHTMLElementRef)
 import Halogen.Query (HalogenM)
 import Halogen.Query.HalogenM (HalogenAp(..), mapAction)
+import Halogen.Query.HalogenM (imapState) as Halogen
 import Web.HTML.HTMLElement (HTMLElement)
 
--- | This is a version of imapState that uses a lens
+-- | This is a version of imapState that uses a lens.
 -- | With the official version it is easy to make a mistake and
--- | 'freeze' the old state and end up replacing and changes to
--- | the state that have happened asynchronously
+-- | 'freeze' the old state and end up replacing any changes to
+-- | the state that have happened asynchronously.
 imapState ::
   forall state state' action slots output m.
   Lens' state' state ->
@@ -63,6 +67,30 @@ renderSubmodule ::
   state ->
   ComponentHTML action slots m
 renderSubmodule lens wrapper renderer state = bimap (map wrapper) wrapper (renderer (view lens state))
+
+-- | This lets you map the state of a submodule that may not exist,
+-- | given an affine traversal into that optional substate. It's
+-- | an ugly solution, and it suffers from the same problem with
+-- | Halogen's `imapState` noted above. But for now, at least it works.
+mapMaybeSubmodule ::
+  forall m state state' action action' slots msg.
+  MonadAff m =>
+  state ->
+  Traversal' state state' ->
+  (action' -> action) ->
+  state' ->
+  HalogenM state' action' slots msg m Unit ->
+  HalogenM state action slots msg m Unit
+mapMaybeSubmodule state traversal wrapper submoduleDefaultState submoduleHandleAction = do
+  mSubmoduleState <- peruse traversal
+  for_ mSubmoduleState \submoduleState ->
+    (Halogen.imapState subToMain mainToSub <<< mapAction wrapper) $ submoduleHandleAction
+  where
+  subToMain submoduleState = set traversal submoduleState state
+
+  mainToSub mainState = case preview traversal mainState of
+    Just submoduleState -> submoduleState
+    _ -> submoduleDefaultState
 
 foreign import scrollIntoView_ :: EffectFn1 HTMLElement Unit
 


### PR DESCRIPTION
Work in progress, but this seems as good a moment as any to open a PR... A few comments:

- It's not possible yet, in the contract setup, to create a contact and immediately assign it to a role - that can wait for another PR. Otherwise, all the contract setup workflow is in place.
- Validation of number inputs is a pain. I had the same problem with the Plutus playground and never quite got to the bottom of it. But I think we've probably got enough validation here for the prototype.
- It looks as though there is a proper `Template.State` submodule, but there isn't. I've just separated out some template-related `MainFrame.State` code into a separate module for readability. Compare with `Contract.State`. Not sure which way is better. 🤷‍♂️ 

@palas, I've changed `Marlowe.Extended` slightly: added a `getParties` function and changed the default timeout value from zero to one.

UPDATE: While I was responding to Pablo's comments, I thought I might as well include the changes to template metadata as well. Sorry that makes this PR a bit larger.

Also I forgot to mention: Although we are not including contract drafts in the prototype, this PR does give you one draft for free. I.e. while you are setting up a contract you can go away and do something else - the roles and template parameters will still be around if you go back to setting up a contract from that same template later. (In concrete terms: the template state is only overwritten if you start setting up a _different_ template.)