### PR TITLE
[plutus-core/exe] Remove small unnecessary code

### DIFF
--- a/plutus-core/exe/Main.hs
+++ b/plutus-core/exe/Main.hs
@@ -27,7 +27,7 @@ import qualified Language.UntypedPlutusCore.Evaluation.Machine.Cek  as Cek
 import           Codec.Serialise
 import           Control.DeepSeq                                    (NFData, rnf)
 import           Control.Monad
-import           Control.Monad.Trans.Except                         (runExceptT)
+import           Control.Monad.Trans.Except                         (runExcept, runExceptT)
 import           Data.Bifunctor                                     (second)
 import qualified Data.ByteString.Lazy                               as BSL
 import           Data.Foldable                                      (traverse_)
@@ -371,9 +371,8 @@ typedDeBruijnNotSupportedError =
 
 -- | Convert an untyped program to one where the 'name' type is de Bruijn indices.
 toDeBruijn :: UntypedProgram a -> IO (UntypedProgramDeBruijn a)
-toDeBruijn prog = do
-  r <- PLC.runQuoteT $ runExceptT @UPLC.FreeVariableError (UPLC.deBruijnProgram prog)
-  case r of
+toDeBruijn prog =
+  case runExcept @UPLC.FreeVariableError (UPLC.deBruijnProgram prog) of
     Left e  -> errorWithoutStackTrace $ show e
     Right p -> return $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) p
 


### PR DESCRIPTION
Removed an unnecessary call to `runQuote` when "debruij-ning" terms in the plc-exe.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
