### PR TITLE
plutus-pab: Monitoring module

### DIFF
--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-pab.nix
@@ -165,8 +165,11 @@
           "Plutus/PAB/Effects/MultiAgent"
           "Plutus/PAB/Effects/UUID"
           "Plutus/PAB/Instances"
-          "Plutus/PAB/MonadLoggerBridge"
-          "Plutus/PAB/Monitoring"
+          "Plutus/PAB/Monitoring/MonadLoggerBridge"
+          "Plutus/PAB/Monitoring/Monitoring"
+          "Plutus/PAB/Monitoring/PABLogMsg"
+          "Plutus/PAB/Monitoring/Config"
+          "Plutus/PAB/Monitoring/Util"
           "Plutus/PAB/Webserver/API"
           "Plutus/PAB/Webserver/Handler"
           "Plutus/PAB/Webserver/Server"
@@ -179,7 +182,6 @@
           "Plutus/PAB/Events/Wallet"
           "Plutus/PAB/ParseStringifiedJSON"
           "Plutus/PAB/Query"
-          "Plutus/PAB/PABLogMsg"
           "Plutus/PAB/Types"
           ];
         hsSourceDirs = [ "src" ];

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
@@ -165,8 +165,11 @@
           "Plutus/PAB/Effects/MultiAgent"
           "Plutus/PAB/Effects/UUID"
           "Plutus/PAB/Instances"
-          "Plutus/PAB/MonadLoggerBridge"
-          "Plutus/PAB/Monitoring"
+          "Plutus/PAB/Monitoring/MonadLoggerBridge"
+          "Plutus/PAB/Monitoring/Monitoring"
+          "Plutus/PAB/Monitoring/PABLogMsg"
+          "Plutus/PAB/Monitoring/Config"
+          "Plutus/PAB/Monitoring/Util"
           "Plutus/PAB/Webserver/API"
           "Plutus/PAB/Webserver/Handler"
           "Plutus/PAB/Webserver/Server"
@@ -179,7 +182,6 @@
           "Plutus/PAB/Events/Wallet"
           "Plutus/PAB/ParseStringifiedJSON"
           "Plutus/PAB/Query"
-          "Plutus/PAB/PABLogMsg"
           "Plutus/PAB/Types"
           ];
         hsSourceDirs = [ "src" ];

--- a/plutus-pab/app/Cli.hs
+++ b/plutus-pab/app/Cli.hs
@@ -21,7 +21,7 @@ module Cli (runCliCommand) where
 
 We use the 'iohk-monitoring' package to process the log messages that come
 out of the 'Control.Monad.Freer.Log' effects. We create a top-level 'Tracer'
-value that we pass to 'Plutus.PAB.Monitoring.handleLogMsgTrace', which
+value that we pass to 'Plutus.PAB.Monitoring.Monitoring.handleLogMsgTrace', which
 ultimately runs the trace actions in IO.
 
 This works well for our own code that uses the 'freer-simple' effects, but in
@@ -41,7 +41,7 @@ base monad of the 'AppBackend' effects stack.
 
 The 'MonadLogger' and 'MonadUnliftIO' constraints propagate up to the top level
 via 'Plutus.PAB.Effects.EventLog.handleEventLogSql'. Both instances are
-provided by 'Plutus.PAB.MonadLoggerBridge.TraceLoggerT', which translates
+provided by 'Plutus.PAB.Monitoring.MonadLoggerBridge.TraceLoggerT', which translates
 'MonadLogger' calls to 'Tracer' calls. This is why the base monad of the
 effects stack in 'runCliCommand' is 'TraceLoggerT IO' instead of just 'IO'.
 
@@ -76,24 +76,21 @@ import           Control.Monad.IO.Class                          (liftIO)
 import           Data.Foldable                                   (traverse_)
 import qualified Data.Map                                        as Map
 import qualified Data.Set                                        as Set
-import           Data.Text.Prettyprint.Doc                       (defaultLayoutOptions, layoutPretty)
+import           Data.Text.Prettyprint.Doc                       (Pretty (..), defaultLayoutOptions, layoutPretty,
+                                                                  pretty)
 import           Data.Text.Prettyprint.Doc.Render.Text           (renderStrict)
-import           Plutus.PAB.MonadLoggerBridge                    (TraceLoggerT (..))
-import           Plutus.PAB.Monitoring                           (convertLog, defaultConfig, handleLogMsgTrace)
 
 import           Cardano.Node.Types                              (MockServerConfig (..), NodeUrl (..))
-import           Data.Text.Prettyprint.Doc                       (Pretty (..), pretty)
 import           Data.Time.Units                                 (toMicroseconds)
 import           Language.Plutus.Contract.Effects.ExposeEndpoint (EndpointDescription (..))
 import qualified PSGenerator
-import           Plutus.PAB.App                                  (AppBackend, monadLoggerTracer, runApp)
+import           Plutus.PAB.App                                  (AppBackend, runApp)
 import qualified Plutus.PAB.App                                  as App
 import qualified Plutus.PAB.Core                                 as Core
 import qualified Plutus.PAB.Core.ContractInstance                as Instance
 import           Plutus.PAB.Events.Contract                      (ContractInstanceId (..))
-import           Plutus.PAB.PABLogMsg                            (AppMsg (..), ChainIndexServerMsg,
-                                                                  ContractExeLogMsg (..), MetadataLogMessage,
-                                                                  MockServerLogMsg, PABLogMsg (..), SigningProcessMsg)
+import           Plutus.PAB.Monitoring.MonadLoggerBridge         (TraceLoggerT, monadLoggerTracer)
+import qualified Plutus.PAB.Monitoring.Monitoring                as LM
 import           Plutus.PAB.Types                                (Config (Config), ContractExe (..), PABError,
                                                                   RequestProcessingConfig (..), chainIndexConfig,
                                                                   metadataServerConfig, nodeServerConfig,
@@ -104,12 +101,12 @@ import qualified Plutus.PAB.Webserver.Server                     as PABServer
 -- | Interpret a 'Command' in 'Eff' using the provided tracer and configurations
 --
 runCliCommand ::
-    Trace IO AppMsg  -- ^ PAB Tracer logging instance
+    Trace IO LM.AppMsg  -- ^ PAB Tracer logging instance
     -> Configuration -- ^ Monitoring configuration
     -> Config        -- ^ PAB Configuration
     -> Availability  -- ^ Token for signaling service availability
     -> Command
-    -> Eff (LogMsg AppMsg ': AppBackend (TraceLoggerT IO)) ()
+    -> Eff (LogMsg LM.AppMsg ': AppBackend (TraceLoggerT IO)) ()
 
 -- Run database migration
 runCliCommand _ _ _ _ Migrate = raise App.migrate
@@ -157,7 +154,7 @@ runCliCommand trace logConfig config serviceAvailability (ForkCommands commands)
       putStrLn $ "Starting: " <> show subcommand
       -- see note [Use of iohk-monitoring in PAB]
       let trace' = monadLoggerTracer trace
-      asyncId <- async . void . runApp (toPABMsg trace) logConfig config . handleLogMsgTrace trace' . runCliCommand trace logConfig config serviceAvailability $ subcommand
+      asyncId <- async . void . runApp (toPABMsg trace) logConfig config . LM.handleLogMsgTrace trace' . runCliCommand trace logConfig config serviceAvailability $ subcommand
       putStrLn $ "Started: " <> show subcommand
       starting serviceAvailability
       pure asyncId
@@ -180,70 +177,70 @@ runCliCommand t _ Config {signingProcessConfig} serviceAvailability SigningProce
 
 -- Install a contract
 runCliCommand _ _ _ _ (InstallContract path) =
-    interpret (mapLog SCoreMsg)
+    interpret (mapLog LM.SCoreMsg)
     $ Core.installContract (ContractExe path)
 
 -- Activate a contract
 runCliCommand _ _ _ _ (ActivateContract path) =
     void
-    $ interpret (mapLog SContractInstanceMsg)
-    $ interpret (mapLog SCoreMsg)
+    $ interpret (mapLog LM.SContractInstanceMsg)
+    $ interpret (mapLog LM.SCoreMsg)
     $ Core.activateContract (ContractExe path)
 
 -- Get the state of a contract
 runCliCommand _ _ _ _ (ContractState uuid) =
-    interpret (mapLog SCoreMsg)
+    interpret (mapLog LM.SCoreMsg)
     $ Core.reportContractState @ContractExe (ContractInstanceId uuid)
 
 -- Get all installed contracts
 runCliCommand _ _ _ _ ReportInstalledContracts = do
-    logInfo InstalledContractsMsg
-    traverse_ (logInfo . InstalledContract . render . pretty) =<< Core.installedContracts @ContractExe
+    logInfo LM.InstalledContractsMsg
+    traverse_ (logInfo . LM.InstalledContract . render . pretty) =<< Core.installedContracts @ContractExe
         where
             render = renderStrict . layoutPretty defaultLayoutOptions
 
 -- Get all active contracts
 runCliCommand _ _ _ _ ReportActiveContracts = do
-    logInfo ActiveContractsMsg
+    logInfo LM.ActiveContractsMsg
     instances <- Map.toAscList <$> Core.activeContracts @ContractExe
-    traverse_ (\(e, s) -> logInfo $ ContractInstance e (Set.toList s)) instances
+    traverse_ (\(e, s) -> logInfo $ LM.ContractInstance e (Set.toList s)) instances
 
 -- Get transaction history
 runCliCommand _ _ _ _ ReportTxHistory = do
-    logInfo TransactionHistoryMsg
-    traverse_ (logInfo . TxHistoryItem) =<< Core.txHistory @ContractExe
+    logInfo LM.TransactionHistoryMsg
+    traverse_ (logInfo . LM.TxHistoryItem) =<< Core.txHistory @ContractExe
 
 -- Update a specific contract
 runCliCommand _ _ _ _ (UpdateContract uuid endpoint payload) =
     void
-    $ interpret (mapLog SContractInstanceMsg)
+    $ interpret (mapLog LM.SContractInstanceMsg)
     $ Instance.callContractEndpoint @ContractExe (ContractInstanceId uuid) (getEndpointDescription endpoint) payload
 
 -- Get history of a specific contract
 runCliCommand _ _ _ _ (ReportContractHistory uuid) = do
-    logInfo ContractHistoryMsg
+    logInfo LM.ContractHistoryMsg
     contracts <- Core.activeContractHistory @ContractExe (ContractInstanceId uuid)
     itraverse_ (\i -> logContract i) contracts
     where
-      logContract index contract = logInfo $ ContractHistoryItem index contract
+      logContract index contract = logInfo $ LM.ContractHistoryItem index contract
 
 -- DEPRECATED
 runCliCommand _ _ _ _ (ProcessContractInbox uuid) =
-    interpret (mapLog SContractInstanceMsg)
+    interpret (mapLog LM.SContractInstanceMsg)
     $ do
-        logInfo ProcessInboxMsg
+        logInfo LM.ProcessInboxMsg
         Core.processContractInbox @ContractExe (ContractInstanceId uuid)
 
 -- Run the process-outboxes command
 runCliCommand _ _ Config{requestProcessingConfig} _ ProcessAllContractOutboxes =
-    interpret (mapLog SContractInstanceMsg)
-    $ interpret (mapLog SContractExeLogMsg)
+    interpret (mapLog LM.SContractInstanceMsg)
+    $ interpret (mapLog LM.SContractExeLogMsg)
     $ do
         let RequestProcessingConfig{requestProcessingInterval} = requestProcessingConfig
-        logInfo $ ProcessAllOutboxesMsg requestProcessingInterval
+        logInfo $ LM.ProcessAllOutboxesMsg requestProcessingInterval
         forever $ do
             _ <- liftIO . threadDelay . fromIntegral $ toMicroseconds requestProcessingInterval
-            handleError @PABError (Core.processAllContractOutboxes @ContractExe Instance.defaultMaxIterations) (logError . ContractExePABError)
+            handleError @PABError (Core.processAllContractOutboxes @ContractExe Instance.defaultMaxIterations) (logError . LM.ContractExePABError)
 
 -- Generate PureScript bridge code
 runCliCommand _ _ _ _ PSGenerator {_outputDir} =
@@ -251,22 +248,22 @@ runCliCommand _ _ _ _ PSGenerator {_outputDir} =
 
 -- Get default logging configuration
 runCliCommand _ _ _ _ WriteDefaultConfig{_outputFile} =
-    liftIO $ defaultConfig >>= flip CM.exportConfiguration _outputFile
+    liftIO $ LM.defaultConfig >>= flip CM.exportConfiguration _outputFile
 
-toPABMsg :: Trace m AppMsg -> Trace m PABLogMsg
-toPABMsg = convertLog PABMsg
+toPABMsg :: Trace m LM.AppMsg -> Trace m LM.PABLogMsg
+toPABMsg = LM.convertLog LM.PABMsg
 
-toChainIndexLog :: Trace m AppMsg -> Trace m ChainIndexServerMsg
-toChainIndexLog = convertLog $ PABMsg . SChainIndexServerMsg
+toChainIndexLog :: Trace m LM.AppMsg -> Trace m LM.ChainIndexServerMsg
+toChainIndexLog = LM.convertLog $ LM.PABMsg . LM.SChainIndexServerMsg
 
-toSigningProcessLog :: Trace m AppMsg -> Trace m SigningProcessMsg
-toSigningProcessLog = convertLog $ PABMsg . SSigningProcessMsg
+toSigningProcessLog :: Trace m LM.AppMsg -> Trace m LM.SigningProcessMsg
+toSigningProcessLog = LM.convertLog $ LM.PABMsg . LM.SSigningProcessMsg
 
-toWalletLog :: Trace m AppMsg -> Trace m WalletMsg
-toWalletLog = convertLog $ PABMsg . SWalletMsg
+toWalletLog :: Trace m LM.AppMsg -> Trace m WalletMsg
+toWalletLog = LM.convertLog $ LM.PABMsg . LM.SWalletMsg
 
-toMetaDataLog :: Trace m AppMsg -> Trace m MetadataLogMessage
-toMetaDataLog = convertLog $ PABMsg . SMetaDataLogMsg
+toMetaDataLog :: Trace m LM.AppMsg -> Trace m LM.MetadataLogMessage
+toMetaDataLog = LM.convertLog $ LM.PABMsg . LM.SMetaDataLogMsg
 
-toMockNodeServerLog :: Trace m AppMsg -> Trace m MockServerLogMsg
-toMockNodeServerLog = convertLog $ PABMsg . SMockserverLogMsg
+toMockNodeServerLog :: Trace m LM.AppMsg -> Trace m LM.MockServerLogMsg
+toMockNodeServerLog = LM.convertLog $ LM.PABMsg . LM.SMockserverLogMsg

--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -15,22 +15,24 @@ module Main
 import           Cli
 import           CommandParser
 
-import qualified Cardano.BM.Backend.EKGView      as EKGView
-import qualified Cardano.BM.Configuration.Model  as CM
-import           Cardano.BM.Data.Trace           (Trace)
-import           Cardano.BM.Plugin               (loadPlugin)
-import           Cardano.BM.Setup                (setupTrace_)
-import           Control.Concurrent.Availability (newToken)
-import           Control.Monad                   (when)
-import           Control.Monad.IO.Class          (liftIO)
-import           Control.Monad.Logger            (logErrorN, runStdoutLoggingT)
-import           Data.Foldable                   (for_)
-import           Data.Text.Extras                (tshow)
-import           Data.Yaml                       (decodeFileThrow)
-import           Plutus.PAB.App                  (monadLoggerTracer, runApp)
-import           Plutus.PAB.Monitoring           (convertLog, defaultConfig, handleLogMsgTrace, loadConfig)
-import           Plutus.PAB.PABLogMsg            (AppMsg (..))
-import           System.Exit                     (ExitCode (ExitFailure), exitSuccess, exitWith)
+import qualified Cardano.BM.Backend.EKGView       as EKGView
+import qualified Cardano.BM.Configuration.Model   as CM
+import           Cardano.BM.Data.Trace            (Trace)
+import           Cardano.BM.Plugin                (loadPlugin)
+import           Cardano.BM.Setup                 (setupTrace_)
+import           Control.Concurrent.Availability  (newToken)
+import           Control.Monad                    (when)
+import           Control.Monad.IO.Class           (liftIO)
+import           Control.Monad.Logger             (logErrorN, runStdoutLoggingT)
+import           Data.Foldable                    (for_)
+import           Data.Text.Extras                 (tshow)
+import           Data.Yaml                        (decodeFileThrow)
+import           Plutus.PAB.App                   (runApp)
+import           Plutus.PAB.Monitoring.Config     (defaultConfig, loadConfig)
+import           Plutus.PAB.Monitoring.Monitoring (monadLoggerTracer)
+import           Plutus.PAB.Monitoring.PABLogMsg  (AppMsg (..))
+import           Plutus.PAB.Monitoring.Util       (convertLog, handleLogMsgTrace)
+import           System.Exit                      (ExitCode (ExitFailure), exitSuccess, exitWith)
 
 main :: IO ()
 main = do

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -96,8 +96,11 @@ library
         Plutus.PAB.Effects.MultiAgent
         Plutus.PAB.Effects.UUID
         Plutus.PAB.Instances
-        Plutus.PAB.MonadLoggerBridge
-        Plutus.PAB.Monitoring
+        Plutus.PAB.Monitoring.MonadLoggerBridge
+        Plutus.PAB.Monitoring.Monitoring
+        Plutus.PAB.Monitoring.PABLogMsg
+        Plutus.PAB.Monitoring.Config
+        Plutus.PAB.Monitoring.Util
         Plutus.PAB.Webserver.API
         Plutus.PAB.Webserver.Handler
         Plutus.PAB.Webserver.Server
@@ -110,7 +113,6 @@ library
         Plutus.PAB.Events.Wallet
         Plutus.PAB.ParseStringifiedJSON
         Plutus.PAB.Query
-        Plutus.PAB.PABLogMsg
         Plutus.PAB.Types
     other-modules:
         Servant.Extra

--- a/plutus-pab/src/Cardano/ChainIndex/ChainIndex.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/ChainIndex.hs
@@ -14,26 +14,26 @@ module Cardano.ChainIndex.ChainIndex
     , healthcheck
     ) where
 
-import           Cardano.BM.Data.Trace      (Trace)
-import           Control.Concurrent.MVar    (MVar, putMVar, takeMVar)
-import           Control.Monad.Freer        hiding (run)
-import qualified Control.Monad.Freer.State  as Eff
-import           Control.Monad.IO.Class     (MonadIO (..))
-import           Data.Foldable              (traverse_)
-import           Data.Function              ((&))
-import           Ledger.Blockchain          (Block)
-import           Ledger.Slot                (Slot)
-import           Servant                    (NoContent (NoContent))
+import           Cardano.BM.Data.Trace            (Trace)
+import           Control.Concurrent.MVar          (MVar, putMVar, takeMVar)
+import           Control.Monad.Freer              hiding (run)
+import qualified Control.Monad.Freer.State        as Eff
+import           Control.Monad.IO.Class           (MonadIO (..))
+import           Data.Foldable                    (traverse_)
+import           Data.Function                    ((&))
+import           Ledger.Blockchain                (Block)
+import           Ledger.Slot                      (Slot)
+import           Servant                          (NoContent (NoContent))
 
 import           Cardano.ChainIndex.Types
-import           Ledger.Address             (Address)
-import           Ledger.AddressMap          (AddressMap)
-import           Plutus.PAB.Monitoring      (convertLog, handleLogMsgTrace)
-import           Wallet.Effects             (ChainIndexEffect)
-import qualified Wallet.Effects             as WalletEffects
-import           Wallet.Emulator.ChainIndex (ChainIndexControlEffect, ChainIndexEvent)
-import qualified Wallet.Emulator.ChainIndex as ChainIndex
-import           Wallet.Emulator.NodeClient (ChainClientNotification (BlockValidated, SlotChanged))
+import           Ledger.Address                   (Address)
+import           Ledger.AddressMap                (AddressMap)
+import           Plutus.PAB.Monitoring.Monitoring (convertLog, handleLogMsgTrace)
+import           Wallet.Effects                   (ChainIndexEffect)
+import qualified Wallet.Effects                   as WalletEffects
+import           Wallet.Emulator.ChainIndex       (ChainIndexControlEffect, ChainIndexEvent)
+import qualified Wallet.Emulator.ChainIndex       as ChainIndex
+import           Wallet.Emulator.NodeClient       (ChainClientNotification (BlockValidated, SlotChanged))
 
 healthcheck :: Monad m => m NoContent
 healthcheck = pure NoContent

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -19,7 +19,7 @@ import           Control.Monad.Freer.Extras.Log
 import           Servant.Client                  (BaseUrl (baseUrlPort))
 
 import           Data.Coerce                     (coerce)
-import           Plutus.PAB.Monitoring           (runLogEffects)
+import           Plutus.PAB.Monitoring.Util      (runLogEffects)
 import qualified Wallet.Effects                  as WalletEffects
 
 import           Cardano.ChainIndex.ChainIndex

--- a/plutus-pab/src/Cardano/Metadata/Server.hs
+++ b/plutus-pab/src/Cardano/Metadata/Server.hs
@@ -12,29 +12,29 @@ module Cardano.Metadata.Server
     , handleMetadata
     ) where
 
-import           Control.Monad.Except            (ExceptT (ExceptT))
-import           Control.Monad.Freer             (Eff, Member, runM)
-import           Control.Monad.Freer.Error       (Error, runError)
-import           Control.Monad.IO.Class          (liftIO)
-import           Data.Bifunctor                  (first)
-import qualified Data.ByteString.Lazy.Char8      as BSL
-import           Data.Function                   ((&))
-import           Data.Proxy                      (Proxy (Proxy))
-import qualified Network.Wai.Handler.Warp        as Warp
-import           Servant                         (Application, Handler (Handler), ServerError, err404, err500, errBody,
-                                                  hoistServer, serve)
-import           Servant.API                     ((:<|>) ((:<|>)))
-import           Servant.Client                  (baseUrlPort)
+import           Control.Monad.Except             (ExceptT (ExceptT))
+import           Control.Monad.Freer              (Eff, Member, runM)
+import           Control.Monad.Freer.Error        (Error, runError)
+import           Control.Monad.IO.Class           (liftIO)
+import           Data.Bifunctor                   (first)
+import qualified Data.ByteString.Lazy.Char8       as BSL
+import           Data.Function                    ((&))
+import           Data.Proxy                       (Proxy (Proxy))
+import qualified Network.Wai.Handler.Warp         as Warp
+import           Servant                          (Application, Handler (Handler), ServerError, err404, err500, errBody,
+                                                   hoistServer, serve)
+import           Servant.API                      ((:<|>) ((:<|>)))
+import           Servant.Client                   (baseUrlPort)
 
 
-import           Cardano.BM.Data.Trace           (Trace)
-import           Cardano.Metadata.API            (API)
+import           Cardano.BM.Data.Trace            (Trace)
+import           Cardano.Metadata.API             (API)
 import           Cardano.Metadata.Mock
 import           Cardano.Metadata.Types
-import           Control.Concurrent.Availability (Availability, available)
-import           Control.Monad.Freer.Extras.Log  (LogMsg, handleLogTrace, logInfo)
-import           Data.Coerce                     (coerce)
-import           Plutus.PAB.Monitoring           (runLogEffects)
+import           Control.Concurrent.Availability  (Availability, available)
+import           Control.Monad.Freer.Extras.Log   (LogMsg, handleLogTrace, logInfo)
+import           Data.Coerce                      (coerce)
+import qualified Plutus.PAB.Monitoring.Monitoring as LM
 
 handler ::
        Member MetadataEffect effs
@@ -67,7 +67,7 @@ app = serve api apiServer
     apiServer = hoistServer api asHandler handler
 
 main :: Trace IO MetadataLogMessage -> MetadataConfig ->  Availability -> IO ()
-main trace MetadataConfig {mdBaseUrl} availability = runLogEffects trace $ do
+main trace MetadataConfig {mdBaseUrl} availability = LM.runLogEffects trace $ do
     logInfo $ StartingMetadataServer port
     liftIO $ Warp.runSettings warpSettings app
         where

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -33,7 +33,7 @@ import qualified Cardano.Protocol.Socket.Server    as Server
 import           Ledger                            (Block, Slot (..), Tx)
 import           Ledger.Tx                         (outputs)
 import           Plutus.PAB.Arbitrary              ()
-import           Plutus.PAB.Monitoring             (handleLogMsgTrace, runLogEffects)
+import qualified Plutus.PAB.Monitoring.Monitoring  as LM
 import qualified Wallet.Emulator                   as EM
 import           Wallet.Emulator.Chain             (ChainControlEffect, ChainEffect, ChainState)
 import qualified Wallet.Emulator.Chain             as Chain
@@ -84,7 +84,7 @@ runChainEffects trace serverHandler stateVar eff = do
             & mergeState
             & toWriter
             & runReaders oldAppState
-            & handleLogMsgTrace trace
+            & LM.handleLogMsgTrace trace
             & runM
     liftIO $ putMVar stateVar newState
     void $ Server.processBlocks serverHandler (newlyAddedBlocks oldAppState newState)
@@ -117,7 +117,7 @@ processChainEffects ::
     -> IO a
 processChainEffects trace serverHandler stateVar eff = do
     (events, result) <- liftIO $ runChainEffects trace serverHandler stateVar eff
-    runLogEffects trace $ traverse_ (\(LogMessage _ chainEvent) -> logDebug chainEvent) events
+    LM.runLogEffects trace $ traverse_ (\(LogMessage _ chainEvent) -> logDebug chainEvent) events
     liftIO $
         modifyMVar_
             stateVar

--- a/plutus-pab/src/Cardano/Node/Server.hs
+++ b/plutus-pab/src/Cardano/Node/Server.hs
@@ -7,24 +7,24 @@ module Cardano.Node.Server
     ( main
     ) where
 
-import           Control.Concurrent              (MVar, forkIO, newMVar)
-import           Control.Concurrent.Availability (Availability, available)
-import           Control.Monad                   (void)
-import           Control.Monad.Freer.Extras.Log  (logInfo)
-import           Control.Monad.IO.Class          (liftIO)
-import           Data.Function                   ((&))
-import           Data.Proxy                      (Proxy (Proxy))
-import qualified Network.Wai.Handler.Warp        as Warp
-import           Servant                         (Application, hoistServer, serve, (:<|>) ((:<|>)))
-import           Servant.Client                  (BaseUrl (baseUrlPort))
+import           Control.Concurrent               (MVar, forkIO, newMVar)
+import           Control.Concurrent.Availability  (Availability, available)
+import           Control.Monad                    (void)
+import           Control.Monad.Freer.Extras.Log   (logInfo)
+import           Control.Monad.IO.Class           (liftIO)
+import           Data.Function                    ((&))
+import           Data.Proxy                       (Proxy (Proxy))
+import qualified Network.Wai.Handler.Warp         as Warp
+import           Servant                          (Application, hoistServer, serve, (:<|>) ((:<|>)))
+import           Servant.Client                   (BaseUrl (baseUrlPort))
 
-import           Cardano.BM.Data.Trace           (Trace)
-import           Cardano.Node.API                (API)
+import           Cardano.BM.Data.Trace            (Trace)
+import           Cardano.Node.API                 (API)
 import           Cardano.Node.Mock
 import           Cardano.Node.Types
-import qualified Cardano.Protocol.Socket.Server  as Server
-import           Plutus.PAB.Arbitrary            ()
-import           Plutus.PAB.Monitoring           (runLogEffects)
+import qualified Cardano.Protocol.Socket.Server   as Server
+import           Plutus.PAB.Arbitrary             ()
+import qualified Plutus.PAB.Monitoring.Monitoring as LM
 
 app ::
     Trace IO MockServerLogMsg
@@ -51,7 +51,7 @@ main trace MockServerConfig { mscBaseUrl
                             , mscBlockReaper
                             , mscSlotLength
                             , mscInitialTxWallets
-                            , mscSocketPath} availability = runLogEffects trace $ do
+                            , mscSocketPath} availability = LM.runLogEffects trace $ do
 
     serverHandler <- liftIO $ Server.runServerNode mscSocketPath (_chainState $ initialAppState mscInitialTxWallets)
     serverState <- liftIO $ newMVar (initialAppState mscInitialTxWallets)

--- a/plutus-pab/src/Cardano/SigningProcess/Server.hs
+++ b/plutus-pab/src/Cardano/SigningProcess/Server.hs
@@ -12,28 +12,28 @@ module Cardano.SigningProcess.Server(
      main
     ) where
 
-import           Control.Concurrent.Availability (Availability, available)
-import           Control.Concurrent.MVar         (MVar, newMVar, putMVar, takeMVar)
+import           Control.Concurrent.Availability  (Availability, available)
+import           Control.Concurrent.MVar          (MVar, newMVar, putMVar, takeMVar)
 import           Control.Monad.Freer
-import qualified Control.Monad.Freer.Error       as Eff
+import qualified Control.Monad.Freer.Error        as Eff
 import           Control.Monad.Freer.Extras.Log
-import qualified Control.Monad.Freer.State       as Eff
-import           Control.Monad.IO.Class          (MonadIO (..))
-import           Data.Function                   ((&))
-import           Data.Proxy                      (Proxy (..))
-import qualified Network.Wai.Handler.Warp        as Warp
-import           Servant                         (Application, hoistServer, serve)
-import           Servant.Client                  (BaseUrl (baseUrlPort))
+import qualified Control.Monad.Freer.State        as Eff
+import           Control.Monad.IO.Class           (MonadIO (..))
+import           Data.Function                    ((&))
+import           Data.Proxy                       (Proxy (..))
+import qualified Network.Wai.Handler.Warp         as Warp
+import           Servant                          (Application, hoistServer, serve)
+import           Servant.Client                   (BaseUrl (baseUrlPort))
 
-import           Cardano.BM.Data.Trace           (Trace)
-import           Cardano.SigningProcess.API      (API)
-import           Cardano.SigningProcess.Types    (SigningProcessConfig (..), SigningProcessEffects,
-                                                  SigningProcessMsg (..))
-import           Cardano.Wallet.Types            (WalletUrl (..))
-import           Data.Coerce                     (coerce)
-import           Plutus.PAB.Monitoring           (runLogEffects)
-import qualified Wallet.Effects                  as WE
-import           Wallet.Emulator.Wallet          (SigningProcess, defaultSigningProcess, handleSigningProcess)
+import           Cardano.BM.Data.Trace            (Trace)
+import           Cardano.SigningProcess.API       (API)
+import           Cardano.SigningProcess.Types     (SigningProcessConfig (..), SigningProcessEffects,
+                                                   SigningProcessMsg (..))
+import           Cardano.Wallet.Types             (WalletUrl (..))
+import           Data.Coerce                      (coerce)
+import qualified Plutus.PAB.Monitoring.Monitoring as LM
+import qualified Wallet.Effects                   as WE
+import           Wallet.Emulator.Wallet           (SigningProcess, defaultSigningProcess, handleSigningProcess)
 
 -- $ signingProcess
 -- The signing process that adds signatures to transactions.
@@ -52,7 +52,7 @@ app stateVar =
         (uncurry WE.addSignatures)
 
 main :: Trace IO SigningProcessMsg -> SigningProcessConfig -> Availability -> IO ()
-main trace SigningProcessConfig{spWallet, spBaseUrl} availability = runLogEffects trace $ do
+main trace SigningProcessConfig{spWallet, spBaseUrl} availability = LM.runLogEffects trace $ do
     stateVar <- liftIO $ newMVar (defaultSigningProcess spWallet)
     logInfo $ StartingSigningProcess servicePort
     liftIO $ Warp.runSettings warpSettings $ app stateVar

--- a/plutus-pab/src/Cardano/Wallet/Server.hs
+++ b/plutus-pab/src/Cardano/Wallet/Server.hs
@@ -11,35 +11,35 @@ module Cardano.Wallet.Server
     ( main
     ) where
 
-import           Control.Monad                   ((>=>))
-import           Control.Monad.Freer             (reinterpret, runM)
-import           Control.Monad.Freer.Error       (handleError)
-import           Control.Monad.Freer.Extras.Log  (logInfo)
-import           Control.Monad.IO.Class          (liftIO)
-import           Data.Function                   ((&))
-import           Data.Proxy                      (Proxy (Proxy))
-import           Network.HTTP.Client             (defaultManagerSettings, newManager)
-import qualified Network.Wai.Handler.Warp        as Warp
-import           Servant                         (Application, NoContent (..), hoistServer, serve, (:<|>) ((:<|>)))
-import           Servant.Client                  (BaseUrl (baseUrlPort), ClientEnv, ClientError, mkClientEnv)
+import           Control.Monad                    ((>=>))
+import           Control.Monad.Freer              (reinterpret, runM)
+import           Control.Monad.Freer.Error        (handleError)
+import           Control.Monad.Freer.Extras.Log   (logInfo)
+import           Control.Monad.IO.Class           (liftIO)
+import           Data.Function                    ((&))
+import           Data.Proxy                       (Proxy (Proxy))
+import           Network.HTTP.Client              (defaultManagerSettings, newManager)
+import qualified Network.Wai.Handler.Warp         as Warp
+import           Servant                          (Application, NoContent (..), hoistServer, serve, (:<|>) ((:<|>)))
+import           Servant.Client                   (BaseUrl (baseUrlPort), ClientEnv, ClientError, mkClientEnv)
 
 
-import           Cardano.BM.Data.Trace           (Trace)
-import qualified Cardano.ChainIndex.Client       as ChainIndexClient
-import           Cardano.ChainIndex.Types        (ChainIndexUrl (..))
-import           Cardano.Node.Types              (NodeUrl (..))
-import           Cardano.Wallet.API              (API)
+import           Cardano.BM.Data.Trace            (Trace)
+import qualified Cardano.ChainIndex.Client        as ChainIndexClient
+import           Cardano.ChainIndex.Types         (ChainIndexUrl (..))
+import           Cardano.Node.Types               (NodeUrl (..))
+import           Cardano.Wallet.API               (API)
 import           Cardano.Wallet.Mock
-import           Cardano.Wallet.Types            (Port (..), WalletConfig (..), WalletMsg (..), WalletUrl (..))
-import           Control.Concurrent.Availability (Availability, available)
-import           Control.Concurrent.MVar         (MVar, newMVar)
-import           Data.Coerce                     (coerce)
-import           Plutus.PAB.Arbitrary            ()
-import           Plutus.PAB.Monitoring           (runLogEffects)
-import           Wallet.Effects                  (ownOutputs, ownPubKey, startWatching, submitTxn,
-                                                  updatePaymentWithChange, walletSlot)
-import           Wallet.Emulator.Wallet          (WalletState, emptyWalletState)
-import qualified Wallet.Emulator.Wallet          as Wallet
+import           Cardano.Wallet.Types             (Port (..), WalletConfig (..), WalletMsg (..), WalletUrl (..))
+import           Control.Concurrent.Availability  (Availability, available)
+import           Control.Concurrent.MVar          (MVar, newMVar)
+import           Data.Coerce                      (coerce)
+import           Plutus.PAB.Arbitrary             ()
+import qualified Plutus.PAB.Monitoring.Monitoring as LM
+import           Wallet.Effects                   (ownOutputs, ownPubKey, startWatching, submitTxn,
+                                                   updatePaymentWithChange, walletSlot)
+import           Wallet.Emulator.Wallet           (WalletState, emptyWalletState)
+import qualified Wallet.Emulator.Wallet           as Wallet
 
 
 
@@ -54,7 +54,7 @@ app trace nodeClientEnv chainIndexEnv mVarState =
           walletSlot :<|> ownOutputs)
 
 main :: Trace IO WalletMsg -> WalletConfig -> NodeUrl -> ChainIndexUrl -> Availability -> IO ()
-main trace WalletConfig { baseUrl, wallet } (NodeUrl nodeUrl) (ChainIndexUrl chainUrl) availability = runLogEffects trace $ do
+main trace WalletConfig { baseUrl, wallet } (NodeUrl nodeUrl) (ChainIndexUrl chainUrl) availability = LM.runLogEffects trace $ do
     nodeClientEnv <- buildEnv nodeUrl defaultManagerSettings
     chainIndexEnv <- buildEnv chainUrl defaultManagerSettings
     mVarState <- liftIO $ newMVar state

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -17,59 +17,58 @@
 
 module Plutus.PAB.App where
 
-import qualified Cardano.BM.Configuration.Model     as CM
-import           Cardano.BM.Trace                   (Trace)
-import           Cardano.ChainIndex.Client          (handleChainIndexClient)
-import qualified Cardano.ChainIndex.Types           as ChainIndex
-import           Cardano.Metadata.Client            (handleMetadataClient)
-import           Cardano.Metadata.Types             (MetadataEffect)
-import qualified Cardano.Metadata.Types             as Metadata
-import           Cardano.Node.Client                (handleNodeClientClient, handleRandomTxClient)
-import           Cardano.Node.RandomTx              (GenRandomTx)
-import           Cardano.Node.Types                 (MockServerConfig (..))
-import qualified Cardano.SigningProcess.Client      as SigningProcessClient
-import qualified Cardano.SigningProcess.Types       as SigningProcess
-import qualified Cardano.Wallet.Client              as WalletClient
-import qualified Cardano.Wallet.Types               as Wallet
-import           Control.Monad.Catch                (MonadCatch)
+import qualified Cardano.BM.Configuration.Model          as CM
+import           Cardano.BM.Trace                        (Trace)
+import           Cardano.ChainIndex.Client               (handleChainIndexClient)
+import qualified Cardano.ChainIndex.Types                as ChainIndex
+import           Cardano.Metadata.Client                 (handleMetadataClient)
+import           Cardano.Metadata.Types                  (MetadataEffect)
+import qualified Cardano.Metadata.Types                  as Metadata
+import           Cardano.Node.Client                     (handleNodeClientClient, handleRandomTxClient)
+import           Cardano.Node.RandomTx                   (GenRandomTx)
+import           Cardano.Node.Types                      (MockServerConfig (..))
+import qualified Cardano.SigningProcess.Client           as SigningProcessClient
+import qualified Cardano.SigningProcess.Types            as SigningProcess
+import qualified Cardano.Wallet.Client                   as WalletClient
+import qualified Cardano.Wallet.Types                    as Wallet
+import           Control.Monad.Catch                     (MonadCatch)
 import           Control.Monad.Freer
-import           Control.Monad.Freer.Error          (Error, handleError, runError, throwError)
-import           Control.Monad.Freer.Extras.Log     (LogMessage, LogMsg, LogObserve, logDebug, logInfo, mapLog)
-import           Control.Monad.Freer.Reader         (Reader, asks, runReader)
-import           Control.Monad.Freer.WebSocket      (WebSocketEffect, handleWebSocket)
-import           Control.Monad.IO.Class             (MonadIO, liftIO)
-import           Control.Monad.IO.Unlift            (MonadUnliftIO)
-import           Control.Monad.Logger               (MonadLogger)
-import           Control.Tracer                     (natTracer)
-import           Data.Aeson                         (FromJSON, eitherDecode)
-import qualified Data.Aeson.Encode.Pretty           as JSON
-import           Data.Bifunctor                     (Bifunctor (..))
-import qualified Data.ByteString.Lazy.Char8         as BSL8
-import           Data.Coerce                        (coerce)
-import           Data.Functor.Contravariant         (Contravariant (..))
-import qualified Data.Text                          as Text
-import           Database.Persist.Sqlite            (runSqlPool)
-import           Eventful.Store.Sqlite              (initializeSqliteEventStore)
-import           Network.HTTP.Client                (managerModifyRequest, newManager, setRequestIgnoreStatus)
-import           Network.HTTP.Client.TLS            (tlsManagerSettings)
-import           Plutus.PAB.Core                    (Connection (Connection),
-                                                     ContractCommand (InitContract, UpdateContract), dbConnect)
-import           Plutus.PAB.Effects.Contract        (ContractEffect (..))
-import           Plutus.PAB.Effects.ContractRuntime (handleContractRuntime)
-import           Plutus.PAB.Effects.EventLog        (EventLogEffect (..), handleEventLogSql)
-import           Plutus.PAB.Effects.UUID            (UUIDEffect, handleUUIDEffect)
-import           Plutus.PAB.Events                  (ChainEvent)
-import           Plutus.PAB.MonadLoggerBridge       (TraceLoggerT (..))
-import           Plutus.PAB.Monitoring              (handleLogMsgTrace, handleObserveTrace)
-import           Plutus.PAB.PABLogMsg               (ContractExeLogMsg (..), PABLogMsg (..))
-import           Plutus.PAB.Types                   (Config (Config), ContractExe (..), PABError (..), chainIndexConfig,
-                                                     dbConfig, metadataServerConfig, nodeServerConfig,
-                                                     signingProcessConfig, walletServerConfig)
-import           Servant.Client                     (ClientEnv, ClientError, mkClientEnv)
-import           System.Exit                        (ExitCode (ExitFailure, ExitSuccess))
-import           System.Process                     (readProcessWithExitCode)
-import           Wallet.Effects                     (ChainIndexEffect, ContractRuntimeEffect, NodeClientEffect,
-                                                     SigningProcessEffect, WalletEffect)
+import           Control.Monad.Freer.Error               (Error, handleError, runError, throwError)
+import           Control.Monad.Freer.Extras.Log          (LogMessage, LogMsg, LogObserve, logDebug, logInfo, mapLog)
+import           Control.Monad.Freer.Reader              (Reader, asks, runReader)
+import           Control.Monad.Freer.WebSocket           (WebSocketEffect, handleWebSocket)
+import           Control.Monad.IO.Class                  (MonadIO, liftIO)
+import           Control.Monad.IO.Unlift                 (MonadUnliftIO)
+import           Control.Monad.Logger                    (MonadLogger)
+import           Data.Aeson                              (FromJSON, eitherDecode)
+import qualified Data.Aeson.Encode.Pretty                as JSON
+import           Data.Bifunctor                          (Bifunctor (..))
+import qualified Data.ByteString.Lazy.Char8              as BSL8
+import           Data.Coerce                             (coerce)
+import           Data.Functor.Contravariant              (Contravariant (..))
+import qualified Data.Text                               as Text
+import           Database.Persist.Sqlite                 (runSqlPool)
+import           Eventful.Store.Sqlite                   (initializeSqliteEventStore)
+import           Network.HTTP.Client                     (managerModifyRequest, newManager, setRequestIgnoreStatus)
+import           Network.HTTP.Client.TLS                 (tlsManagerSettings)
+import           Plutus.PAB.Core                         (Connection (Connection),
+                                                          ContractCommand (InitContract, UpdateContract), dbConnect)
+import           Plutus.PAB.Effects.Contract             (ContractEffect (..))
+import           Plutus.PAB.Effects.ContractRuntime      (handleContractRuntime)
+import           Plutus.PAB.Effects.EventLog             (EventLogEffect (..), handleEventLogSql)
+import           Plutus.PAB.Effects.UUID                 (UUIDEffect, handleUUIDEffect)
+import           Plutus.PAB.Events                       (ChainEvent)
+import           Plutus.PAB.Monitoring.MonadLoggerBridge (TraceLoggerT (..), monadLoggerTracer)
+import           Plutus.PAB.Monitoring.Monitoring        (handleLogMsgTrace, handleObserveTrace)
+import           Plutus.PAB.Monitoring.PABLogMsg         (ContractExeLogMsg (..), PABLogMsg (..))
+import           Plutus.PAB.Types                        (Config (Config), ContractExe (..), PABError (..),
+                                                          chainIndexConfig, dbConfig, metadataServerConfig,
+                                                          nodeServerConfig, signingProcessConfig, walletServerConfig)
+import           Servant.Client                          (ClientEnv, ClientError, mkClientEnv)
+import           System.Exit                             (ExitCode (ExitFailure, ExitSuccess))
+import           System.Process                          (readProcessWithExitCode)
+import           Wallet.Effects                          (ChainIndexEffect, ContractRuntimeEffect, NodeClientEffect,
+                                                          SigningProcessEffect, WalletEffect)
 
 
 ------------------------------------------------------------
@@ -257,6 +256,3 @@ migrate = interpret (mapLog SContractExeLogMsg) $ do
     liftIO
         $ flip runSqlPool connectionPool
         $ initializeSqliteEventStore sqlConfig connectionPool
-
-monadLoggerTracer :: Trace IO a -> Trace (TraceLoggerT IO) a
-monadLoggerTracer = natTracer (\x -> TraceLoggerT $ const  x)

--- a/plutus-pab/src/Plutus/PAB/Monitoring/Config.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring/Config.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Plutus.PAB.Monitoring.Config (
+      defaultConfig
+    , loadConfig
+    ) where
+
+import           Cardano.BM.Configuration       (setup)
+import qualified Cardano.BM.Configuration.Model as CM
+import           Cardano.BM.Data.BackendKind
+import           Cardano.BM.Data.Configuration  (Endpoint (..))
+import           Cardano.BM.Data.Output
+import           Cardano.BM.Data.Severity
+
+-- | A default 'CM.Configuration' that logs on 'Info' and above
+--   to stdout
+defaultConfig :: IO CM.Configuration
+defaultConfig = do
+  c <- CM.empty
+  CM.setMinSeverity c Info
+  CM.setSetupBackends c [ KatipBK
+                        , AggregationBK
+                        , MonitoringBK
+                        , EKGViewBK
+                        ]
+  CM.setDefaultBackends c [KatipBK, AggregationBK, EKGViewBK]
+  CM.setSetupScribes c [ ScribeDefinition {
+                          scName = "stdout"
+                        , scKind = StdoutSK
+                        , scFormat = ScText
+                        , scPrivacy = ScPublic
+                        , scRotation = Nothing
+                        , scMinSev = minBound
+                        , scMaxSev = maxBound
+                        }]
+  CM.setDefaultScribes c ["StdoutSK::stdout"]
+  CM.setEKGBindAddr c $ Just (Endpoint ("localhost", 12790))
+  pure c
+
+-- | Load a 'CM.Configuration' from a YAML file.
+loadConfig :: FilePath -> IO CM.Configuration
+loadConfig = setup

--- a/plutus-pab/src/Plutus/PAB/Monitoring/Monitoring.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring/Monitoring.hs
@@ -1,0 +1,18 @@
+module Plutus.PAB.Monitoring.Monitoring(
+    -- * IOHK Monitoring Library Configuration
+    module Plutus.PAB.Monitoring.Config
+
+    -- * Embedding MonadLogger with freer
+  , module Plutus.PAB.Monitoring.MonadLoggerBridge
+
+   -- * Structural Logging data types
+  , module Plutus.PAB.Monitoring.PABLogMsg
+
+   -- * Utility functions for running tracers
+  , module Plutus.PAB.Monitoring.Util
+  ) where
+
+import           Plutus.PAB.Monitoring.Config
+import           Plutus.PAB.Monitoring.MonadLoggerBridge
+import           Plutus.PAB.Monitoring.PABLogMsg
+import           Plutus.PAB.Monitoring.Util

--- a/plutus-pab/src/Plutus/PAB/Monitoring/PABLogMsg.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring/PABLogMsg.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeApplications  #-}
 
 -- | PAB Log messages and instances
-module Plutus.PAB.PABLogMsg(
+module Plutus.PAB.Monitoring.PABLogMsg(
     PABLogMsg(..),
     ContractExeLogMsg(..),
     ChainIndexServerMsg,
@@ -18,34 +18,34 @@ module Plutus.PAB.PABLogMsg(
     AppMsg(..)
     ) where
 
-import           Data.Aeson                         (FromJSON, ToJSON, Value)
-import qualified Data.Aeson.Encode.Pretty           as JSON
-import qualified Data.ByteString.Lazy.Char8         as BSL8
-import           Data.String                        (IsString (..))
-import           Data.Text                          (Text)
-import           Data.Text.Prettyprint.Doc          (Pretty (..), colon, hang, viaShow, vsep, (<+>))
-import           Data.Time.Units                    (Second)
-import           GHC.Generics                       (Generic)
+import           Data.Aeson                              (FromJSON, ToJSON, Value)
+import qualified Data.Aeson.Encode.Pretty                as JSON
+import qualified Data.ByteString.Lazy.Char8              as BSL8
+import           Data.String                             (IsString (..))
+import           Data.Text                               (Text)
+import           Data.Text.Prettyprint.Doc               (Pretty (..), colon, hang, viaShow, vsep, (<+>))
+import           Data.Time.Units                         (Second)
+import           GHC.Generics                            (Generic)
 
-import           Cardano.BM.Data.Tracer             (ToObject (..), TracingVerbosity (..))
-import           Cardano.BM.Data.Tracer.Extras      (Tagged (..), mkObjectStr)
-import           Cardano.ChainIndex.Types           (ChainIndexServerMsg)
-import           Cardano.Metadata.Types             (MetadataLogMessage)
-import           Cardano.Node.Types                 (MockServerLogMsg)
-import           Cardano.SigningProcess.Types       (SigningProcessMsg)
-import           Cardano.Wallet.Types               (WalletMsg)
-import           Language.Plutus.Contract.State     (ContractRequest)
-import           Ledger.Tx                          (Tx)
-import           Plutus.PAB.Core                    (CoreMsg (..))
-import           Plutus.PAB.Core.ContractInstance   (ContractInstanceMsg (..))
-import           Plutus.PAB.Effects.ContractRuntime (ContractRuntimeMsg)
-import           Plutus.PAB.Events.Contract         (ContractInstanceId, ContractInstanceState)
-import           Plutus.PAB.Instances               ()
-import           Plutus.PAB.MonadLoggerBridge       (MonadLoggerMsg (..))
-import           Plutus.PAB.ParseStringifiedJSON    (UnStringifyJSONLog (..))
-import           Plutus.PAB.Types                   (ContractExe, PABError (..))
-import           Plutus.PAB.Webserver.Types         (WebSocketLogMsg)
-import           Wallet.Emulator.Wallet             (WalletEvent (..))
+import           Cardano.BM.Data.Tracer                  (ToObject (..), TracingVerbosity (..))
+import           Cardano.BM.Data.Tracer.Extras           (Tagged (..), mkObjectStr)
+import           Cardano.ChainIndex.Types                (ChainIndexServerMsg)
+import           Cardano.Metadata.Types                  (MetadataLogMessage)
+import           Cardano.Node.Types                      (MockServerLogMsg)
+import           Cardano.SigningProcess.Types            (SigningProcessMsg)
+import           Cardano.Wallet.Types                    (WalletMsg)
+import           Language.Plutus.Contract.State          (ContractRequest)
+import           Ledger.Tx                               (Tx)
+import           Plutus.PAB.Core                         (CoreMsg (..))
+import           Plutus.PAB.Core.ContractInstance        (ContractInstanceMsg (..))
+import           Plutus.PAB.Effects.ContractRuntime      (ContractRuntimeMsg)
+import           Plutus.PAB.Events.Contract              (ContractInstanceId, ContractInstanceState)
+import           Plutus.PAB.Instances                    ()
+import           Plutus.PAB.Monitoring.MonadLoggerBridge (MonadLoggerMsg (..))
+import           Plutus.PAB.ParseStringifiedJSON         (UnStringifyJSONLog (..))
+import           Plutus.PAB.Types                        (ContractExe, PABError (..))
+import           Plutus.PAB.Webserver.Types              (WebSocketLogMsg)
+import           Wallet.Emulator.Wallet                  (WalletEvent (..))
 
 data AppMsg =
     InstalledContractsMsg

--- a/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
@@ -47,7 +47,7 @@ import           Plutus.PAB.Effects.UUID                         (UUIDEffect)
 import           Plutus.PAB.Events                               (ChainEvent, ContractInstanceId (ContractInstanceId),
                                                                   ContractInstanceState (ContractInstanceState),
                                                                   csContractDefinition)
-import           Plutus.PAB.PABLogMsg                            (ContractExeLogMsg (..))
+import qualified Plutus.PAB.Monitoring.PABLogMsg                 as LM
 import           Plutus.PAB.ParseStringifiedJSON                 (UnStringifyJSONLog, parseStringifiedJSON)
 import qualified Plutus.PAB.Query                                as Query
 import           Plutus.PAB.Types
@@ -174,7 +174,7 @@ getContractInstanceState contractId = do
 invokeEndpoint ::
        forall t effs.
        ( Member (EventLogEffect (ChainEvent t)) effs
-       , Member (LogMsg ContractExeLogMsg) effs
+       , Member (LogMsg LM.ContractExeLogMsg) effs
        , Member (Error PABError) effs
        , Member (LogMsg (Instance.ContractInstanceMsg t)) effs
        , Pretty t
@@ -184,11 +184,11 @@ invokeEndpoint ::
     -> ContractInstanceId
     -> Eff effs (ContractInstanceState t)
 invokeEndpoint (EndpointDescription endpointDescription) payload contractId = do
-    logInfo $ InvokingEndpoint endpointDescription payload
+    logInfo $ LM.InvokingEndpoint endpointDescription payload
     newState :: [ChainEvent t] <-
         Instance.callContractEndpoint @t contractId endpointDescription payload
     logInfo $
-        EndpointInvocationResponse $
+        LM.EndpointInvocationResponse $
         fmap
             (renderStrict . layoutPretty defaultLayoutOptions . pretty)
             newState
@@ -208,7 +208,7 @@ handler ::
        , Member ChainIndexEffect effs
        , Member MetadataEffect effs
        , Member UUIDEffect effs
-       , Member (LogMsg ContractExeLogMsg) effs
+       , Member (LogMsg LM.ContractExeLogMsg) effs
        , Member (Error PABError) effs
        , Member (LogMsg UnStringifyJSONLog) effs
        , Member (LogMsg (Instance.ContractInstanceMsg ContractExe)) effs


### PR DESCRIPTION
Introduce better encapulsation for everything monitoring/logging related
under Plutus.PAB.Monitoring.

- Group some modules under `PAB.Monitoring`
- Move monadLoggerTracer to `Monitoring.MonadLoggerBridge`
- Use `LM` (*L*ogging and *M*onitoring) qualified imports
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
