### PR TITLE
Turn the cost model tests into a benchmark

### DIFF
--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -92,12 +92,11 @@ let
             platforms = lib.platforms.linux;
           };
 
-          #  Temporarily removed due to CI problems
-          #          plutus-core.components.benchmarks.plutus-core-create-cost-model = {
-          #            build-tools = r-packages;
-          #            # Seems to be broken on darwin for some reason
-          #            platforms = lib.platforms.linux;
-          #          };
+          plutus-core.components.benchmarks.plutus-core-create-cost-model = {
+            build-tools = r-packages;
+            # Seems to be broken on darwin for some reason
+            platforms = lib.platforms.linux;
+          };
 
           marlowe-actus.components.exes.marlowe-shiny = {
             build-tools = r-packages;

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -86,7 +86,7 @@ let
           # Relies on cabal-doctest, just turn it off in the Nix build
           prettyprinter-configurable.components.tests.prettyprinter-configurable-doctest.buildable = lib.mkForce false;
 
-          plutus-core.components.tests.plutus-core-test-cost-model = {
+          plutus-core.components.benchmarks.plutus-core-test-cost-model = {
             build-tools = r-packages;
             # Seems to be broken on darwin for some reason
             platforms = lib.platforms.linux;

--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-core.nix
@@ -392,37 +392,6 @@
           hsSourceDirs = [ "untyped-plutus-core-test" ];
           mainPath = [ "Spec.hs" ];
           };
-        "plutus-core-test-cost-model" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."barbies" or (errorHandler.buildDepError "barbies"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
-            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
-            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."inline-r" or (errorHandler.buildDepError "inline-r"))
-            ];
-          buildable = true;
-          modules = [ "CostModelCreation" ];
-          hsSourceDirs = [ "test-cost-model" "cost-model-creation" ];
-          mainPath = [ "TestCostModels.hs" ];
-          };
         };
       benchmarks = {
         "plutus-core-bench" = {
@@ -488,6 +457,36 @@
           buildable = true;
           modules = [ "CostModelCreation" ];
           hsSourceDirs = [ "create-cost-model" "cost-model-creation" ];
+          };
+        "plutus-core-test-cost-model" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."barbies" or (errorHandler.buildDepError "barbies"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."inline-r" or (errorHandler.buildDepError "inline-r"))
+            ];
+          buildable = true;
+          modules = [ "CostModelCreation" ];
+          hsSourceDirs = [ "test-cost-model" "cost-model-creation" ];
           };
         };
       };

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -392,37 +392,6 @@
           hsSourceDirs = [ "untyped-plutus-core-test" ];
           mainPath = [ "Spec.hs" ];
           };
-        "plutus-core-test-cost-model" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."barbies" or (errorHandler.buildDepError "barbies"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
-            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
-            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
-            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
-            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
-            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
-            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."inline-r" or (errorHandler.buildDepError "inline-r"))
-            ];
-          buildable = true;
-          modules = [ "CostModelCreation" ];
-          hsSourceDirs = [ "test-cost-model" "cost-model-creation" ];
-          mainPath = [ "TestCostModels.hs" ];
-          };
         };
       benchmarks = {
         "plutus-core-bench" = {
@@ -488,6 +457,36 @@
           buildable = true;
           modules = [ "CostModelCreation" ];
           hsSourceDirs = [ "create-cost-model" "cost-model-creation" ];
+          };
+        "plutus-core-test-cost-model" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."barbies" or (errorHandler.buildDepError "barbies"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+            (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."inline-r" or (errorHandler.buildDepError "inline-r"))
+            ];
+          buildable = true;
+          modules = [ "CostModelCreation" ];
+          hsSourceDirs = [ "test-cost-model" "cost-model-creation" ];
           };
         };
       };

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -464,7 +464,9 @@ benchmark plutus-core-create-cost-model
     other-modules:
         CostModelCreation
 
-test-suite plutus-core-test-cost-model
+-- This test is problematic in CI: pretending that it's a benchmark will prevent
+-- it from being run automatically but will still allow us to run it manually.
+benchmark plutus-core-test-cost-model
     type: exitcode-stdio-1.0
     main-is: TestCostModels.hs
     hs-source-dirs: test-cost-model, cost-model-creation


### PR DESCRIPTION
We're having problems in CI due to timeouts during `plutus-core:plutus-core-cost-model-tests`.  This PR turns the test into a benchmark so that it doesn't get run in CI but we can still run it manually.  See SCP-1956.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
