### PR TITLE
SCP-1551 Marlowe Playground Client: fix blockly visual problems

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -112,3 +112,6 @@ exports.centerOnBlock_ = function (workspace, blockId) {
   workspace.centerOnBlock(blockId);
 }
 
+exports.hideChaff_ = function (blockly) {
+  blockly.hideChaff();
+}

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -109,6 +109,8 @@ foreign import select_ :: EffectFn1 Block Unit
 
 foreign import centerOnBlock_ :: EffectFn2 Workspace String Unit
 
+foreign import hideChaff_ :: EffectFn1 Blockly Unit
+
 newtype ElementId
   = ElementId String
 
@@ -201,6 +203,9 @@ select = runEffectFn1 select_
 
 centerOnBlock :: Workspace -> String -> Effect Unit
 centerOnBlock = runEffectFn2 centerOnBlock_
+
+hideChaff :: Blockly -> Effect Unit
+hideChaff = runEffectFn1 hideChaff_
 
 data Pair
   = Pair String String

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -161,13 +161,13 @@ resize :: Blockly -> Workspace -> Effect Unit
 resize = runEffectFn2 resizeBlockly_
 
 addBlockType :: Blockly -> BlockDefinition -> Effect Unit
-addBlockType blocklyRef (BlockDefinition fields) =
+addBlockType blockly (BlockDefinition fields) =
   let
     definition = JSON.write $ Record.delete type_ fields
 
     type' = fields.type
   in
-    runEffectFn3 addBlockType_ blocklyRef type' definition
+    runEffectFn3 addBlockType_ blockly type' definition
 
 addBlockTypes :: forall f. Foldable f => Blockly -> f BlockDefinition -> Effect Unit
 addBlockTypes blocklyState = traverse_ (addBlockType blocklyState)

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -1,11 +1,11 @@
-module BlocklyComponent.State where
+module BlocklyComponent.State (blocklyComponent) where
 
 import Prelude hiding (div)
 import Blockly.Dom (explainError, getDom)
 import Blockly.Generator (newBlock)
 import Blockly.Internal (BlockDefinition, ElementId(..), centerOnBlock, getBlockById, select)
 import Blockly.Internal as Blockly
-import BlocklyComponent.Types (Action(..), Message(..), Query(..), State, _blocklyEventSubscription, _blocklyState, _errorMessage, emptyState)
+import BlocklyComponent.Types (Action(..), Message(..), Query(..), State, _blocklyEventSubscription, _blocklyState, _errorMessage, blocklyRef, emptyState)
 import BlocklyComponent.View (render)
 import Control.Monad.Except (ExceptT(..), runExceptT, withExceptT)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
@@ -15,9 +15,10 @@ import Data.Maybe (Maybe(..))
 import Data.Traversable (for, for_)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Exception.Unsafe (unsafeThrow)
-import Halogen (Component, HalogenM, liftEffect, mkComponent, modify_)
+import Halogen (Component, HalogenM, getHTMLElementRef, liftEffect, mkComponent, modify_)
 import Halogen as H
 import Halogen.BlocklyCommons (blocklyEvents, runWithoutEventSubscription, detectCodeChanges)
+import Halogen.ElementResize (elementResize)
 import Halogen.HTML (HTML)
 import Marlowe.Blockly (buildBlocks)
 import Marlowe.Holes (Term(..), Location(..))
@@ -25,14 +26,16 @@ import Marlowe.Linter (_location)
 import Marlowe.Parser as Parser
 import Text.Extra as Text
 import Type.Proxy (Proxy(..))
+import Web.DOM.ResizeObserver (ResizeObserverBoxOptions(..))
+import Web.HTML.HTMLElement as HTMLElement
 
-blockly ::
+blocklyComponent ::
   forall m.
   MonadAff m =>
   String ->
   Array BlockDefinition ->
   Component HTML Query Unit Message m
-blockly rootBlockName blockDefinitions =
+blocklyComponent rootBlockName blockDefinitions =
   mkComponent
     { initialState: const emptyState
     , render
@@ -51,12 +54,6 @@ handleQuery ::
   MonadAff m =>
   Query a ->
   HalogenM State Action slots Message m (Maybe a)
-handleQuery (Resize next) = do
-  mState <- use _blocklyState
-  for_ mState \{ blockly, workspace } ->
-    liftEffect $ Blockly.resize blockly workspace
-  pure $ Just next
-
 handleQuery (SetCode code next) = do
   mState <- use _blocklyState
   for_ mState \blocklyState -> do
@@ -138,6 +135,10 @@ handleAction (Inject rootBlockName blockDefinitions) = do
       Blockly.addBlockTypes state.blockly blockDefinitions
       Blockly.initializeWorkspace state.blockly state.workspace
       pure state
+  -- Subscribe to the resize events on the main section to resize blockly automatically
+  mElement <- getHTMLElementRef blocklyRef
+  for_ mElement $ H.subscribe <<< elementResize ContentBox (const ResizeWorkspace) <<< HTMLElement.toElement
+  -- Subscribe to blockly events
   eventSubscription <- H.subscribe $ blocklyEvents BlocklyEvent blocklyState.workspace
   modify_
     ( set _blocklyState (Just blocklyState)
@@ -147,3 +148,8 @@ handleAction (Inject rootBlockName blockDefinitions) = do
 handleAction (SetData _) = pure unit
 
 handleAction (BlocklyEvent event) = detectCodeChanges CodeChange event
+
+handleAction ResizeWorkspace = do
+  mState <- use _blocklyState
+  for_ mState \{ blockly, workspace } ->
+    liftEffect $ Blockly.resize blockly workspace

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -9,7 +9,7 @@ import Data.Lens.Record (prop)
 import Data.List (List)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
-import Halogen (SubscriptionId)
+import Halogen (RefLabel(..), SubscriptionId)
 import Marlowe.Linter (Warning)
 
 type State
@@ -37,8 +37,7 @@ emptyState =
   }
 
 data Query a
-  = Resize a
-  | SetCode String a
+  = SetCode String a
   | SetError String a
   | GetWorkspace (XML -> a)
   | LoadWorkspace XML a
@@ -49,6 +48,10 @@ data Action
   = Inject String (Array BlockDefinition)
   | SetData Unit
   | BlocklyEvent BT.BlocklyEvent
+  | ResizeWorkspace
 
 data Message
   = CodeChange
+
+blocklyRef :: RefLabel
+blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -49,6 +49,7 @@ data Action
   | SetData Unit
   | BlocklyEvent BT.BlocklyEvent
   | ResizeWorkspace
+  | VisibilityChanged Boolean
 
 data Message
   = CodeChange

--- a/marlowe-playground-client/src/BlocklyComponent/View.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/View.purs
@@ -1,14 +1,12 @@
-module BlocklyComponent.View where
+module BlocklyComponent.View (render) where
 
 import Prelude hiding (div)
+import BlocklyComponent.Types (blocklyRef)
 import Data.Maybe (Maybe(..))
-import Halogen (ClassName(..), RefLabel(..))
+import Halogen (ClassName(..))
 import Halogen.Classes (fullHeight, fullWidth)
 import Halogen.HTML (HTML, div, text)
 import Halogen.HTML.Properties (class_, classes, id_, ref)
-
-blocklyRef :: RefLabel
-blocklyRef = RefLabel "blockly"
 
 render :: forall r p action. { errorMessage :: Maybe String | r } -> HTML p action
 render state =

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -30,7 +30,6 @@ data Action
   | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | ClearAnalysisResults
   | SelectWarning Warning
-  | ResizeWorkspace
 
 defaultEvent :: String -> Event
 defaultEvent s = (A.defaultEvent $ "BlocklyEditor." <> s) { category = Just "Blockly" }
@@ -49,7 +48,6 @@ instance blocklyActionIsEvent :: IsEvent Action where
   toEvent (SetIntegerTemplateParam _ _ _) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent (SelectWarning _) = Just $ defaultEvent "SelectWarning"
-  toEvent ResizeWorkspace = Just $ defaultEvent "ResizeWorkspace"
 
 data BottomPanelView
   = StaticAnalysisView

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -28,10 +28,9 @@ render ::
 render state =
   div [ classes [ flex, flexCol, fullHeight ] ]
     [ section
-        [ id_ "blockly-editor-main-section"
-        , classes [ paddingX, minH0, overflowHidden, fullHeight ]
+        [ classes [ paddingX, minH0, overflowHidden, fullHeight ]
         ]
-        [ slot _blocklySlot unit (Blockly.blockly MB.rootBlockName MB.blockDefinitions) unit (Just <<< HandleBlocklyMessage)
+        [ slot _blocklySlot unit (Blockly.blocklyComponent MB.rootBlockName MB.blockDefinitions) unit (Just <<< HandleBlocklyMessage)
         , toolbox
         , workspaceBlocks
         ]

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -869,7 +869,7 @@ selectView view = do
     JSEditor -> do
       void $ query _jsEditorSlot unit (Monaco.Resize unit)
       void $ query _jsEditorSlot unit (Monaco.SetTheme HM.daylightTheme.name unit)
-    BlocklyEditor -> void $ query _blocklySlot unit (Blockly.Resize unit)
+    BlocklyEditor -> pure unit
     WalletEmulator -> pure unit
     ActusBlocklyEditor -> do
       void $ query _actusBlocklySlot unit (ActusBlockly.Resize unit)

--- a/marlowe-playground-client/static/css/modal.scss
+++ b/marlowe-playground-client/static/css/modal.scss
@@ -17,7 +17,7 @@ without doing it as an Effect in a mainframe action
   /* Stay in place */
   position: fixed;
   /* Sit on top */
-  z-index: 1;
+  z-index: 100; // Blockly toolbar has z-index of 70, so we need this be bigger than that
   left: 0;
   top: 0;
   /* Full width */

--- a/web-common/src/Halogen/ElementVisible.purs
+++ b/web-common/src/Halogen/ElementVisible.purs
@@ -1,0 +1,28 @@
+module Halogen.ElementVisible where
+
+import Prelude
+import Data.Array (head)
+import Data.Foldable (for_)
+import Effect.Aff.Class (class MonadAff)
+import Halogen.Query.EventSource (EventSource)
+import Halogen.Query.EventSource as EventSource
+import Web.DOM (Element)
+import Web.DOM.IntersectionObserver (intersectionObserver, observe, unobserve)
+
+-- This Halogen EventSource uses the IntersectionObserver to detect if an element is visible in the
+-- viewport.
+-- The `toAction` callback allows the subscriber to dispatch a particular action when the element is
+-- visible or not.
+elementVisible ::
+  forall m action.
+  MonadAff m =>
+  (Boolean -> action) ->
+  Element ->
+  EventSource m action
+elementVisible toAction element =
+  EventSource.effectEventSource \emitter -> do
+    observer <-
+      intersectionObserver \entries _ ->
+        for_ (head entries) \entry -> EventSource.emit emitter (toAction entry.isIntersecting)
+    observe element {} observer
+    pure $ EventSource.Finalizer $ unobserve element observer

--- a/web-common/src/Web/DOM/IntersectionObserver.js
+++ b/web-common/src/Web/DOM/IntersectionObserver.js
@@ -1,0 +1,33 @@
+"use strict";
+
+exports.intersectionObserver = function (cb) {
+  return function () {
+    return new IntersectionObserver(function (entries, observer) {
+      return cb(entries)(observer)();
+    });
+  };
+};
+
+exports._observe = function (element) {
+  return function (config) {
+    return function (observer) {
+      return function () {
+        return observer.observe(element, config);
+      };
+    };
+  };
+};
+
+exports.unobserve = function (element) {
+    return function (observer) {
+      return function () {
+        return observer.observe(element, config);
+      };
+    };
+};
+
+exports.disconnect = function (observer) {
+  return function () {
+    return observer.disconnect();
+  };
+};

--- a/web-common/src/Web/DOM/IntersectionObserver.purs
+++ b/web-common/src/Web/DOM/IntersectionObserver.purs
@@ -1,0 +1,62 @@
+-- This module provides FFI bindings for the Intersection Observer API.
+-- https://www.w3.org/TR/intersection-observer/#intersection-observer-interface
+-- TODO: Create a PR to make this a part of `purescript-web-dom`.
+-- NOTE: I'm not using the uncurried package as `web-dom` doesn't use it either.
+module Web.DOM.IntersectionObserver
+  ( IntersectionObserver
+  , IntersectionObserverEntry(..)
+  , intersectionObserver
+  , observe
+  , unobserve
+  , disconnect
+  ) where
+
+import Prelude
+import Effect (Effect)
+import Prim.Row (class Union)
+import Web.DOM (Element)
+import Web.HTML.HTMLElement (DOMRect)
+
+foreign import data IntersectionObserver :: Type
+
+type IntersectionObserverEntry
+  = { target :: Element
+    -- time :: DOMHighResTimeStamp
+    -- rootBounds :: Nullable DOMRect
+    , boundingClientRect :: DOMRect
+    , intersectionRect :: DOMRect
+    , isIntersecting :: Boolean
+    , intersectionRatio :: Number
+    }
+
+type IntersectionObserverInitFields
+  = ( {- NOTE: The spec says it can be a Element or Document. For the moment I choose
+               Element for simplicity, maybe it would be a good idea to add a wrapper data
+               ElementOrDocument
+      -} root :: Element
+    , rootMargin :: String
+    {- NOTE: The spec says it can be a double or array of double. For the moment I choose
+             only to manage a single Number for simplicity, maybe we would add a wrapper
+             constructor
+    -}
+    , threshold :: Number
+    )
+
+foreign import intersectionObserver ::
+  (Array IntersectionObserverEntry -> IntersectionObserver -> Effect Unit) ->
+  Effect IntersectionObserver
+
+foreign import _observe :: forall r. Element -> Record r -> IntersectionObserver -> Effect Unit
+
+observe ::
+  forall r rx.
+  Union r rx IntersectionObserverInitFields =>
+  Element ->
+  Record r ->
+  IntersectionObserver ->
+  Effect Unit
+observe = _observe
+
+foreign import unobserve :: Element -> IntersectionObserver -> Effect Unit
+
+foreign import disconnect :: IntersectionObserver -> Effect Unit

--- a/web-common/src/Web/DOM/ResizeObserver.purs
+++ b/web-common/src/Web/DOM/ResizeObserver.purs
@@ -1,4 +1,5 @@
 -- This module provides FFI bindings for the Resize Observer API.
+-- https://www.w3.org/TR/resize-observer/#api
 -- TODO: Create a PR to make this a part of `purescript-web-dom`.
 -- NOTE: I'm not using the uncurried package as `web-dom` doesn't use it either.
 module Web.DOM.ResizeObserver


### PR DESCRIPTION
This PR resolves 2 visual errors with Blockly. The first was that the toolbar had more visibility than the overlay, so you could click it when you had a modal.

**Blockly editor before**
![toolbar_issue](https://user-images.githubusercontent.com/2634059/109210339-727ebc80-778b-11eb-92c3-177616c527c3.png)

**Blockly editor now**
![overlay now](https://user-images.githubusercontent.com/2634059/109210479-a2c65b00-778b-11eb-98fa-e69e6353de8f.png)

The second problem happened when you were modifying a field and you switched views. A visual indicator was stuck on the screen. I used the IntersectionObserver to detect when the editor was no longer visible and called `blockly.hideChaff()`

<img width="407" alt="Screen Shot 2021-02-25 at 17 04 54" src="https://user-images.githubusercontent.com/2634059/109210714-f9339980-778b-11eb-9a8e-ee270525657e.png">

<img width="496" alt="Screen Shot 2021-02-25 at 17 05 01" src="https://user-images.githubusercontent.com/2634059/109210750-051f5b80-778c-11eb-973a-c6b82ffec9b5.png">

You can see the changes in https://hernan.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
