### PR TITLE
Fix small compilation problem for PIR.Compiler.Error

### DIFF
--- a/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-musl/.plan.nix/plutus-core.nix
@@ -153,6 +153,7 @@
           "Language/PlutusIR/Compiler/Recursion"
           "Language/PlutusIR/Compiler/Types"
           "Language/PlutusIR/Compiler/Lower"
+          "Language/PlutusIR/Compiler/Error"
           "Language/PlutusIR/Normalize"
           "Language/PlutusIR/TypeCheck/Internal"
           "Language/UntypedPlutusCore/Core"

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -153,6 +153,7 @@
           "Language/PlutusIR/Compiler/Recursion"
           "Language/PlutusIR/Compiler/Types"
           "Language/PlutusIR/Compiler/Lower"
+          "Language/PlutusIR/Compiler/Error"
           "Language/PlutusIR/Normalize"
           "Language/PlutusIR/TypeCheck/Internal"
           "Language/UntypedPlutusCore/Core"

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -191,6 +191,7 @@ library
         Language.PlutusIR.Compiler.Recursion
         Language.PlutusIR.Compiler.Types
         Language.PlutusIR.Compiler.Lower
+        Language.PlutusIR.Compiler.Error
         Language.PlutusIR.Normalize
         Language.PlutusIR.TypeCheck.Internal
 

--- a/plutus-core/plutus-ir/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Compiler/Error.hs
@@ -24,20 +24,20 @@ data Error uni fun a = CompilationError a T.Text -- ^ A generic compilation erro
                deriving (Typeable)
 makeClassyPrisms ''Error
 
-instance PLC.AsTypeError (Error uni fun a) (PLC.Term PLC.TyName PLC.Name uni fun ()) uni a where
+instance PLC.AsTypeError (Error uni fun a) (PLC.Term PLC.TyName PLC.Name uni fun ()) uni fun a where
     _TypeError = _PLCError . PLC._TypeError
 
-instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty a) =>
+instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty fun, PP.Pretty a) =>
             Show (Error uni fun a) where
     show e = show $ PLC.prettyPlcClassicDebug e
 
-instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty a) =>
+instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty fun, PP.Pretty a) =>
             PLC.PrettyBy PLC.PrettyConfigPlc (Error uni fun a) where
     prettyBy config = \case
         CompilationError x e -> "Error during compilation:" <+> PP.pretty e <> "(" <> PP.pretty x <> ")"
         UnsupportedError x e -> "Unsupported construct:" <+> PP.pretty e <+> "(" <> PP.pretty x <> ")"
         PLCError e           -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
 
-instance ( PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty a
+instance ( PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty a, PP.Pretty fun
          , Typeable uni, Typeable fun, Typeable a
          ) => Exception (Error uni fun a)


### PR DESCRIPTION
PIR.Compiler.Error was missing from cabal so it was failing to compile all this time. Fix its compilation.

Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
