### PR TITLE
SCP-1861 Marlowe Playground Client: Implement holes in blockly

### DIFF
--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -46,9 +46,6 @@ let
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = {
       shmish111.nearley-webpack-loader."939360f9d1bafa9019b6ff8739495c6c9101c4a1" = "1brx669dgsryakf7my00m25xdv7a02snbwzhzgc9ylmys4p8c10x";
-      # Note: for some unknown reason, it is necessary to add libxmljs to package.json even though it is a transitive dependency
-      # failure to do this meant that node_modules was being built without it there, even though it is in package-lock.json
-      znerol.libxmljs."0517e063347ea2532c9fdf38dc47878c628bf0ae" = "0g3kgwnqfr6v2xp1i7dfbm4z45inz1019ln06lfxl9mwxlc31wfg";
     };
   };
 

--- a/marlowe-playground-client/entry.js
+++ b/marlowe-playground-client/entry.js
@@ -2,7 +2,7 @@
 /*global global*/
 import '@fortawesome/fontawesome-free/css/all.css';
 import './static/css/main.scss';
-import 'node-blockly/browser';
+import 'blockly';
 
 import './grammar.ne';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';

--- a/marlowe-playground-client/package-lock.json
+++ b/marlowe-playground-client/package-lock.json
@@ -674,12 +674,6 @@
       "dev": true,
       "optional": true
     },
-    "bindings": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
-      "dev": true
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -3992,15 +3986,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "libxmljs": {
-      "version": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae",
-      "from": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae",
-      "dev": true,
-      "requires": {
-        "bindings": "~1.3.0",
-        "nan": "~2.14.0"
       }
     },
     "load-json-file": {

--- a/marlowe-playground-client/package-lock.json
+++ b/marlowe-playground-client/package-lock.json
@@ -677,7 +677,8 @@
     "bindings": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+      "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
@@ -686,6 +687,14 @@
       "dev": true,
       "requires": {
         "inherits": "~2.0.0"
+      }
+    },
+    "blockly": {
+      "version": "4.20201217.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-4.20201217.0.tgz",
+      "integrity": "sha512-kQjP0TydnMIkH8pbJ0qpC1bhqATijCwFMi1UFP3SjULWTR44JpHC4g8c2K+ATUexg9p5/nioslQDNL8dBi3nvw==",
+      "requires": {
+        "jsdom": "15.2.1"
       }
     },
     "bluebird": {
@@ -786,11 +795,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
-    },
-    "browser-request": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -1824,6 +1828,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
       "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
@@ -1832,12 +1837,14 @@
         "domelementtype": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+          "dev": true
         },
         "entities": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "dev": true
         }
       }
     },
@@ -1850,7 +1857,8 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
     },
     "domexception": {
       "version": "1.0.1",
@@ -1864,6 +1872,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -1872,6 +1881,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -2000,7 +2010,8 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "err-code": {
       "version": "1.1.2",
@@ -3278,6 +3289,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -3543,7 +3555,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -3984,6 +3997,7 @@
     "libxmljs": {
       "version": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae",
       "from": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae",
+      "dev": true,
       "requires": {
         "bindings": "~1.3.0",
         "nan": "~2.14.0"
@@ -4439,7 +4453,8 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4506,15 +4521,6 @@
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "node-blockly": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/node-blockly/-/node-blockly-1.2.8.tgz",
-      "integrity": "sha512-wvhHJ1nLzTy3yfZNluRrfQz4D+XARCz/AU7wAaRFAT8qVQ/7IguWY7Qjr5W7bk9DdnK9chf1KHDwpk9qkS4snA==",
-      "requires": {
-        "jsdom": "^15.1.1",
-        "xmlshim": "^0.2.6"
       }
     },
     "node-forge": {
@@ -4709,11 +4715,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -5647,6 +5648,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6804,6 +6806,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -7346,7 +7349,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -8429,21 +8433,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "whatwg-url-compat": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
-      "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
-      "requires": {
-        "tr46": "~0.0.1"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        }
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -8562,94 +8551,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
-    },
-    "xmlshim": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/xmlshim/-/xmlshim-0.2.7.tgz",
-      "integrity": "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==",
-      "requires": {
-        "jsdom": "^6.5.1",
-        "libxmljs": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
-        },
-        "acorn-globals": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-          "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
-          "requires": {
-            "acorn": "^2.1.0"
-          }
-        },
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-          "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-          "requires": {
-            "cssom": "0.3.x"
-          }
-        },
-        "jsdom": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-6.5.1.tgz",
-          "integrity": "sha1-tgZNanZRCBr0HVdu3Fa8UeABIsA=",
-          "requires": {
-            "acorn": "^2.4.0",
-            "acorn-globals": "^1.0.4",
-            "browser-request": ">= 0.3.1 < 0.4.0",
-            "cssom": ">= 0.3.0 < 0.4.0",
-            "cssstyle": ">= 0.2.29 < 0.3.0",
-            "escodegen": "^1.6.1",
-            "htmlparser2": ">= 3.7.3 < 4.0.0",
-            "nwmatcher": ">= 1.3.6 < 2.0.0",
-            "parse5": "^1.4.2",
-            "request": "^2.55.0",
-            "symbol-tree": ">= 3.1.0 < 4.0.0",
-            "tough-cookie": "^2.0.0",
-            "whatwg-url-compat": "~0.6.5",
-            "xml-name-validator": ">= 2.0.1 < 3.0.0",
-            "xmlhttprequest": ">= 1.6.0 < 2.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "parse5": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-          "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
-        }
-      }
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -34,7 +34,6 @@
     "css-loader": "^1.0.0",
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "^3.2.0",
-    "libxmljs": "github:znerol/libxmljs#0517e063347ea2532c9fdf38dc47878c628bf0ae",
     "monaco-editor-webpack-plugin": "^3.0.0",
     "nearley-webpack-loader": "github:shmish111/nearley-webpack-loader#939360f9d1bafa9019b6ff8739495c6c9101c4a1",
     "node-sass": "^4.12.0",

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.10.2",
     "bignumber": "^1.1.0",
+    "blockly": "^4.20201217.0",
     "bootstrap": "^4.3.1",
     "decimal.js": "^10.0.0",
     "json-bigint": "^1.0.0",
@@ -23,9 +24,8 @@
     "monaco-vim": "^0.1.7",
     "moo": "^0.5.1",
     "nearley": "^2.19.1",
-    "node-blockly": "^1.0.36",
-    "safe-eval": "^0.4.0",
     "popper.js": "^1.14.4",
+    "safe-eval": "^0.4.0",
     "xhr2": "^0.1.4"
   },
   "resolutions": {},

--- a/marlowe-playground-client/src/Blockly/Events.js
+++ b/marlowe-playground-client/src/Blockly/Events.js
@@ -11,7 +11,7 @@ exports._readProperty = function (nothing, just, property, event) {
     if (typeof event !== 'object') {
       return nothing;
     } else {
-      if (property in event && typeof event[property] !== 'undefined') {
+      if (property in event && typeof event[property] !== 'undefined' && event[property] !== null) {
         return just(event[property])
       } else {
         return nothing;

--- a/marlowe-playground-client/src/Blockly/Events.purs
+++ b/marlowe-playground-client/src/Blockly/Events.purs
@@ -6,11 +6,13 @@ module Blockly.Events
   , FinishLoadingEvent
   , MoveEvent
   , UIEvent
+  , SelectEvent
   , element
   , newParentId
   , oldParentId
   , oldInputName
   , newInputName
+  , newElementId
   ) where
 
 import Data.Function.Uncurried (Fn4, runFn4)
@@ -84,6 +86,16 @@ If needed these properties are also available for MoveEvent
   blockId	string	UUID of block. The block can be found with workspace.getBlockById(event.blockId)
   group	string	UUID of group. Some events are part of an indivisible group, such as inserting a statement in a stack.
 -}
+------------------------------------------------------------
+foreign import data SelectEvent :: Type
+
+instance hasEventSelectEvent :: HasEvent SelectEvent where
+  fromEvent :: Event -> Maybe SelectEvent
+  fromEvent = readBlocklyEventType "selected"
+
+newElementId :: SelectEvent -> Maybe String
+newElementId = readProperty "newElementId"
+
 ------------------------------------------------------------
 -- This function let us check if a blockly event is of the desired type. It was inspired by unsafeReadProtoTagged
 -- and the reason it's unsafe, it's because there could be other objects that have a property called `type` with

--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -4,7 +4,7 @@
 var JSONbig = require("json-bigint");
 
 exports.createBlocklyInstance_ = function () {
-  return require("node-blockly/browser");
+  return require("blockly");
 };
 exports.debugBlockly_ = function debugBlockly_ (name, state) {
   if (typeof window.blockly === 'undefined') {

--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -115,3 +115,12 @@ exports.centerOnBlock_ = function (workspace, blockId) {
 exports.hideChaff_ = function (blockly) {
   blockly.hideChaff();
 }
+
+exports.getBlockType_ = function (block) {
+  return block.type;
+}
+
+exports.updateToolbox_ = function (toolboxJson, workspace) {
+  workspace.updateToolbox(toolboxJson);
+}
+

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -241,10 +241,10 @@ data Arg
   | DummyLeft
   | DummyCentre
 
-argType :: Arg -> Maybe ({ name :: String, check :: String })
-argType (Value { name, check }) = Just $ { name, check }
+argType :: Arg -> Maybe { name :: String, check :: String }
+argType (Value { name, check }) = Just { name, check }
 
-argType (Statement { name, check }) = Just $ { name, check }
+argType (Statement { name, check }) = Just { name, check }
 
 argType _ = Nothing
 

--- a/marlowe-playground-client/src/Blockly/Toolbox.purs
+++ b/marlowe-playground-client/src/Blockly/Toolbox.purs
@@ -9,6 +9,7 @@ module Blockly.Toolbox
   , category
   , separator
   , leaf
+  , rename
   ) where
 
 import Prelude
@@ -97,6 +98,11 @@ data Category
   -- NOTE: Even if the documentation has the posibility to add a label, in practice the
   --       "label" type doesn't seem to be recognized.
   | Label String (Maybe String)
+
+rename :: String -> Category -> Category
+rename name (Category fields children) = Category (fields { name = name }) children
+
+rename _ category' = category'
 
 -- A category could also be one of these, but not worth to implement at the moment
 -- https://developers.google.com/blockly/guides/configure/web/toolbox#preset_blocks

--- a/marlowe-playground-client/src/Blockly/Toolbox.purs
+++ b/marlowe-playground-client/src/Blockly/Toolbox.purs
@@ -63,7 +63,7 @@ type CategoryFields
     , colour :: Maybe String
     , categorystyle :: Maybe String
     -- https://developers.google.com/blockly/guides/configure/web/toolbox#expanded
-    , expanded :: Boolean -- (default to false) (encoded as string)
+    , expanded :: Boolean
     -- Categories can also have this properties that we don't need to implement at the moment
     -- cssConfig :: Object String
     -- https://developers.google.com/blockly/guides/configure/web/toolbox#dynamic_categories
@@ -91,6 +91,9 @@ leaf _type = CategoryLeaf $ block _type
 separator :: Category
 separator = Separator Nothing
 
+-- A category could also be one of these, but not worth to implement at the moment
+-- https://developers.google.com/blockly/guides/configure/web/toolbox#preset_blocks
+-- https://developers.google.com/blockly/guides/configure/web/toolbox#buttons_and_labels
 data Category
   = Category CategoryFields (Array Category)
   | CategoryLeaf ToolboxBlock
@@ -104,9 +107,6 @@ rename name (Category fields children) = Category (fields { name = name }) child
 
 rename _ category' = category'
 
--- A category could also be one of these, but not worth to implement at the moment
--- https://developers.google.com/blockly/guides/configure/web/toolbox#preset_blocks
--- https://developers.google.com/blockly/guides/configure/web/toolbox#buttons_and_labels
 encodeCategory :: Category -> Json
 encodeCategory (Category fields children) =
   A.fromObject
@@ -119,6 +119,9 @@ encodeCategory (Category fields children) =
                 [ Tuple "toolboxitemid" <<< A.fromString <$> fields.toolboxitemid
                 , Tuple "colour" <<< A.fromString <$> fields.colour
                 , Tuple "categorystyle" <<< A.fromString <$> fields.categorystyle
+                -- Even if the expanded field is always present in our configuration (true/false)
+                -- we only encode it (as string) when is true, as Blockly expects the value to either
+                -- be present as a string, or not present at all.
                 , if fields.expanded then
                     Just $ Tuple "expanded" (A.fromString "true")
                   else

--- a/marlowe-playground-client/src/Blockly/Toolbox.purs
+++ b/marlowe-playground-client/src/Blockly/Toolbox.purs
@@ -1,0 +1,112 @@
+module Blockly.Toolbox
+  ( Toolbox(..)
+  , ToolboxBlock
+  , Category
+  , encodeToolbox
+  , block
+  , category
+  , leaf
+  ) where
+
+import Prelude
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Core as A
+import Data.Array (catMaybes)
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import Foreign.Object as Object
+
+data Toolbox
+  = FlyoutToolbox (Array ToolboxBlock)
+  | CategoryToolbox (Array Category)
+
+encodeToolbox :: Toolbox -> Json
+encodeToolbox (FlyoutToolbox xs) =
+  A.fromObject
+    ( Object.fromFoldable
+        [ Tuple "kind" (A.fromString "flyoutToolbox")
+        , Tuple "contents" (A.fromArray $ encodeBlock <$> xs)
+        ]
+    )
+
+encodeToolbox (CategoryToolbox xs) =
+  A.fromObject
+    ( Object.fromFoldable
+        [ Tuple "kind" (A.fromString "categoryToolbox")
+        , Tuple "contents" (A.fromArray $ encodeCategory <$> xs)
+        ]
+    )
+
+type ToolboxBlock
+  = { type :: String
+    }
+
+encodeBlock :: ToolboxBlock -> Json
+encodeBlock b =
+  A.fromObject
+    ( Object.fromFoldable
+        [ Tuple "kind" (A.fromString "block")
+        , Tuple "type" (A.fromString b.type)
+        ]
+    )
+
+block :: String -> ToolboxBlock
+block _type = { type: _type }
+
+type CategoryFields
+  = { name :: String
+    , toolboxitemid :: Maybe String
+    , colour :: Maybe String
+    , categorystyle :: Maybe String
+    -- https://developers.google.com/blockly/guides/configure/web/toolbox#expanded
+    , expanded :: Boolean -- (default to false) (encoded as string)
+    -- Categories can also have this properties that we don't need to implement at the moment
+    -- cssConfig :: Object String
+    -- https://developers.google.com/blockly/guides/configure/web/toolbox#dynamic_categories
+    -- custom :: Maybe String
+    }
+
+defaultCategoryFields :: CategoryFields
+defaultCategoryFields =
+  { name: ""
+  , toolboxitemid: Nothing
+  , colour: Nothing
+  , categorystyle: Nothing
+  , expanded: false
+  }
+
+category :: String -> String -> Array Category -> Category
+category name colour children =
+  Category
+    (defaultCategoryFields { name = name, colour = Just colour })
+    children
+
+leaf :: String -> Category
+leaf _type = CategoryLeaf $ block _type
+
+data Category
+  = Category CategoryFields (Array Category)
+  | CategoryLeaf ToolboxBlock
+
+-- A category could also be one of these, but not worth to implement at the moment
+-- https://developers.google.com/blockly/guides/configure/web/toolbox#preset_blocks
+-- https://developers.google.com/blockly/guides/configure/web/toolbox#separators
+-- https://developers.google.com/blockly/guides/configure/web/toolbox#buttons_and_labels
+encodeCategory :: Category -> Json
+encodeCategory (Category fields children) =
+  A.fromObject
+    ( Object.fromFoldable
+        ( [ Tuple "kind" (A.fromString "category")
+          , Tuple "name" (A.fromString fields.name)
+          , Tuple "contents" (A.fromArray $ encodeCategory <$> children)
+          , Tuple "expanded" (A.fromString $ show fields.expanded)
+          ]
+            <> catMaybes
+                [ Tuple "toolboxitemid" <<< A.fromString <$> fields.toolboxitemid
+                , Tuple "colour" <<< A.fromString <$> fields.colour
+                , Tuple "categorystyle" <<< A.fromString <$> fields.categorystyle
+                ]
+        )
+    )
+
+encodeCategory (CategoryLeaf b) = encodeBlock b

--- a/marlowe-playground-client/src/Blockly/Types.purs
+++ b/marlowe-playground-client/src/Blockly/Types.purs
@@ -1,7 +1,7 @@
 module Blockly.Types where
 
 import Prelude
-import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent, UIEvent, element)
+import Blockly.Events (ChangeEvent, CreateEvent, FinishLoadingEvent, MoveEvent, UIEvent, element, SelectEvent)
 import Data.Maybe (Maybe(..))
 
 foreign import data Blockly :: Type
@@ -22,6 +22,7 @@ data BlocklyEvent
   | Move MoveEvent
   | FinishLoading FinishLoadingEvent
   | UI UIEvent
+  | Select SelectEvent
 
 isDragStart :: BlocklyEvent -> Boolean
 isDragStart (UI event) = element event == (Just "dragStart")

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -171,7 +171,7 @@ handleAction (BlocklyEvent (BT.Select event)) = case newElementId event of
           blocklyState <- MaybeT $ use _blocklyState
           block <- MaybeT $ liftEffect $ getBlockById blocklyState.workspace blockId
           blockType <- MaybeT $ map pure $ liftEffect $ getBlockType block
-          MaybeT $ map pure $ raise $ BlockSelection $ Just $ { blockId, blockType }
+          MaybeT $ map pure $ raise $ BlockSelection $ Just { blockId, blockType }
 
 handleAction (BlocklyEvent event) = detectCodeChanges CodeChange event
 

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -3,6 +3,7 @@ module BlocklyComponent.Types where
 import Prelude hiding (div)
 import Blockly.Dom (Block)
 import Blockly.Internal (BlockDefinition, XML)
+import Blockly.Toolbox (Toolbox)
 import Blockly.Types as BT
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
@@ -45,7 +46,7 @@ data Query a
   | SelectWarning Warning a
 
 data Action
-  = Inject String (Array BlockDefinition)
+  = Inject String (Array BlockDefinition) Toolbox
   | SetData Unit
   | BlocklyEvent BT.BlocklyEvent
   | ResizeWorkspace

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -44,6 +44,7 @@ data Query a
   | LoadWorkspace XML a
   | GetBlockRepresentation (Block -> a)
   | SelectWarning Warning a
+  | SetToolbox Toolbox a
 
 data Action
   = Inject String (Array BlockDefinition) Toolbox
@@ -54,6 +55,7 @@ data Action
 
 data Message
   = CodeChange
+  | BlockSelection (Maybe ({ blockId :: String, blockType :: String }))
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -55,7 +55,7 @@ data Action
 
 data Message
   = CodeChange
-  | BlockSelection (Maybe ({ blockId :: String, blockType :: String }))
+  | BlockSelection (Maybe { blockId :: String, blockType :: String })
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -24,7 +24,7 @@ import Halogen (HalogenM, modify_, query)
 import Halogen as H
 import Halogen.Extra (mapSubmodule)
 import MainFrame.Types (ChildSlots, _blocklySlot)
-import Marlowe.Blockly (blockToContract)
+import Marlowe.Blockly as MB
 import Marlowe.Extended (TemplateContent)
 import Marlowe.Extended as EM
 import Marlowe.Holes as Holes
@@ -55,6 +55,14 @@ handleAction Init = do
   handleAction $ InitBlocklyProject $ fromMaybe ME.example mContents
 
 handleAction (HandleBlocklyMessage Blockly.CodeChange) = processBlocklyCode
+
+handleAction (HandleBlocklyMessage (Blockly.BlockSelection selection)) = case mBlockDefinition of
+  Nothing -> void $ query _blocklySlot unit $ H.tell (Blockly.SetToolbox MB.toolbox)
+  Just definition -> void $ query _blocklySlot unit $ H.tell (Blockly.SetToolbox $ MB.toolboxWithHoles definition)
+  where
+  mBlockDefinition = do
+    { blockType } <- selection
+    Map.lookup blockType MB.definitionsMap
 
 handleAction (InitBlocklyProject code) = do
   void $ query _blocklySlot unit $ H.tell (Blockly.SetCode code)
@@ -95,7 +103,7 @@ processBlocklyCode = do
   eContract <-
     runExceptT do
       block <- ExceptT <<< map (note "Blockly Workspace is empty") $ query _blocklySlot unit $ H.request Blockly.GetBlockRepresentation
-      except $ blockToContract block
+      except $ MB.blockToContract block
   case eContract of
     Left e ->
       modify_
@@ -138,7 +146,7 @@ runAnalysis doAnalyze =
     $ runMaybeT do
         block <- MaybeT $ query _blocklySlot unit $ H.request Blockly.GetBlockRepresentation
         -- FIXME: See if we can use runExceptT and show the error somewhere
-        contract <- MaybeT $ pure $ Holes.fromTerm =<< (hush $ blockToContract block)
+        contract <- MaybeT $ pure $ Holes.fromTerm =<< (hush $ MB.blockToContract block)
         lift do
           doAnalyze contract
           processBlocklyCode
@@ -147,5 +155,5 @@ editorGetValue :: forall state action msg m. HalogenM state action ChildSlots ms
 editorGetValue =
   runMaybeT do
     block <- MaybeT $ query _blocklySlot unit $ H.request Blockly.GetBlockRepresentation
-    contract <- hoistMaybe $ hush $ blockToContract block
+    contract <- hoistMaybe $ hush $ MB.blockToContract block
     pure $ show $ pretty $ contract

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -68,6 +68,8 @@ handleAction (InitBlocklyProject code) = do
   void $ query _blocklySlot unit $ H.tell (Blockly.SetCode code)
   liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey code
   processBlocklyCode
+  -- Reset the toolbox
+  void $ query _blocklySlot unit $ H.tell (Blockly.SetToolbox MB.toolbox)
 
 handleAction SendToSimulator = pure unit
 

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -1,7 +1,8 @@
 module BlocklyEditor.View where
 
 import Prelude hiding (div)
-import Blockly.Internal (block, blockType, category, colour, name, style, x, xml, y)
+import Blockly.Internal (block, blockType, style, x, xml, y)
+import Blockly.Toolbox (Toolbox(..), category, leaf)
 import BlocklyComponent.State as Blockly
 import BlocklyEditor.BottomPanel (panelContents)
 import BlocklyEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _hasHoles, _marloweCode, _warnings)
@@ -30,8 +31,7 @@ render state =
     [ section
         [ classes [ paddingX, minH0, overflowHidden, fullHeight ]
         ]
-        [ slot _blocklySlot unit (Blockly.blocklyComponent MB.rootBlockName MB.blockDefinitions) unit (Just <<< HandleBlocklyMessage)
-        , toolbox
+        [ slot _blocklySlot unit (Blockly.blocklyComponent MB.rootBlockName MB.blockDefinitions toolbox) unit (Just <<< HandleBlocklyMessage)
         , workspaceBlocks
         ]
     , section [ classes [ paddingX, maxH70p ] ]
@@ -54,21 +54,18 @@ render state =
 
   wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state panelView
 
-toolbox :: forall a b. HTML a b
+toolbox :: Toolbox
 toolbox =
-  xml [ id_ "blocklyToolbox", style "display:none" ]
-    [ category [ name "Contracts", colour MB.contractColour ] (map mkBlock MB.contractTypes)
-    , category [ name "Observations", colour MB.observationColour ] (map mkBlock MB.observationTypes)
-    , category [ name "Actions", colour MB.actionColour ] (map mkBlock MB.actionTypes)
-    , category [ name "Values", colour MB.valueColour ] (map mkBlock MB.valueTypes)
-    , category [ name "Payee", colour MB.payeeColour ] (map mkBlock MB.payeeTypes)
-    , category [ name "Party", colour MB.partyColour ] (map mkBlock MB.partyTypes)
-    , category [ name "Token", colour MB.tokenColour ] (map mkBlock MB.tokenTypes)
-    , category [ name "Bounds", colour MB.boundsColour ] (map mkBlock [ MB.BoundsType ])
+  CategoryToolbox
+    [ category "Contracts" MB.contractColour $ map (leaf <<< show) MB.contractTypes
+    , category "Observations" MB.observationColour $ map (leaf <<< show) MB.observationTypes
+    , category "Actions" MB.actionColour $ map (leaf <<< show) MB.actionTypes
+    , category "Values" MB.valueColour $ map (leaf <<< show) MB.valueTypes
+    , category "Payee" MB.payeeColour $ map (leaf <<< show) MB.payeeTypes
+    , category "Party" MB.partyColour $ map (leaf <<< show) MB.partyTypes
+    , category "Token" MB.tokenColour $ map (leaf <<< show) MB.tokenTypes
+    , category "Bounds" MB.boundsColour $ [ leaf $ show MB.BoundsType ]
     ]
-  where
-  mkBlock :: forall t. Show t => t -> _
-  mkBlock t = block [ blockType (show t) ] []
 
 workspaceBlocks :: forall a b. HTML a b
 workspaceBlocks =

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -2,7 +2,6 @@ module BlocklyEditor.View where
 
 import Prelude hiding (div)
 import Blockly.Internal (block, blockType, style, x, xml, y)
-import Blockly.Toolbox (Toolbox(..), category, leaf)
 import BlocklyComponent.State as Blockly
 import BlocklyEditor.BottomPanel (panelContents)
 import BlocklyEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _hasHoles, _marloweCode, _warnings)
@@ -31,7 +30,7 @@ render state =
     [ section
         [ classes [ paddingX, minH0, overflowHidden, fullHeight ]
         ]
-        [ slot _blocklySlot unit (Blockly.blocklyComponent MB.rootBlockName MB.blockDefinitions toolbox) unit (Just <<< HandleBlocklyMessage)
+        [ slot _blocklySlot unit (Blockly.blocklyComponent MB.rootBlockName MB.blockDefinitions MB.toolbox) unit (Just <<< HandleBlocklyMessage)
         , workspaceBlocks
         ]
     , section [ classes [ paddingX, maxH70p ] ]
@@ -53,19 +52,6 @@ render state =
   warningsTitle = withCount "Warnings" $ state ^. _warnings
 
   wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state panelView
-
-toolbox :: Toolbox
-toolbox =
-  CategoryToolbox
-    [ category "Contracts" MB.contractColour $ map (leaf <<< show) MB.contractTypes
-    , category "Observations" MB.observationColour $ map (leaf <<< show) MB.observationTypes
-    , category "Actions" MB.actionColour $ map (leaf <<< show) MB.actionTypes
-    , category "Values" MB.valueColour $ map (leaf <<< show) MB.valueTypes
-    , category "Payee" MB.payeeColour $ map (leaf <<< show) MB.payeeTypes
-    , category "Party" MB.partyColour $ map (leaf <<< show) MB.partyTypes
-    , category "Token" MB.tokenColour $ map (leaf <<< show) MB.tokenTypes
-    , category "Bounds" MB.boundsColour $ [ leaf $ show MB.BoundsType ]
-    ]
 
 workspaceBlocks :: forall a b. HTML a b
 workspaceBlocks =

--- a/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
+++ b/marlowe-playground-client/src/Halogen/BlocklyCommons.purs
@@ -41,13 +41,14 @@ blocklyEvents toAction workspace =
         let
           mEvent =
             -- Blockly can fire all of the following events https://developers.google.com/blockly/guides/configure/web/events
-            -- but at the moment we only care for the ones that may affect the unsaved changes.
+            -- but at the moment we only care for the following ones
             oneOf
               [ BT.Create <$> fromEvent event
               , BT.Move <$> fromEvent event
               , BT.Change <$> fromEvent event
               , BT.FinishLoading <$> fromEvent event
               , BT.UI <$> fromEvent event
+              , BT.Select <$> fromEvent event
               ]
         in
           for_ mEvent \ev -> EventSource.emit emitter (toAction ev)

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -58,8 +58,7 @@ render state =
               , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction JSEditor.render state ]
               , tabContents BlocklyEditor [ renderSubmodule _blocklyEditorState BlocklyEditorAction BlocklyEditor.render state ]
               , tabContents ActusBlocklyEditor
-                  [ slot _actusBlocklySlot unit (ActusBlockly.blockly AMB.rootBlockName AMB.blockDefinitions) unit (Just <<< HandleActusBlocklyMessage)
-                  , AMB.toolbox
+                  [ slot _actusBlocklySlot unit (ActusBlockly.blockly AMB.rootBlockName AMB.blockDefinitions AMB.toolbox) unit (Just <<< HandleActusBlocklyMessage)
                   , AMB.workspaceBlocks
                   ]
               , tabContents WalletEmulator

--- a/marlowe-playground-client/src/Marlowe/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Marlowe/ActusBlockly.purs
@@ -2,8 +2,9 @@ module Marlowe.ActusBlockly where
 
 import Prelude
 import Blockly.Generator (Generator, getFieldValue, getType, insertGeneratorFunction, mkGenerator, statementToCode)
-import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), block, blockType, category, colour, defaultBlockDefinition, name, style, x, xml, y)
-import Blockly.Types (Block, Blockly, BlocklyState)
+import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), block, blockType, defaultBlockDefinition, style, x, xml, y)
+import Blockly.Types (Block, Blockly)
+import Blockly.Toolbox (Toolbox(..), category, leaf)
 import Control.Alternative ((<|>))
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (lmap, rmap)
@@ -453,16 +454,13 @@ toDefinition (ActusPeriodType PeriodYearType) =
         }
         defaultBlockDefinition
 
-toolbox :: forall a b. HTML a b
+toolbox :: Toolbox
 toolbox =
-  xml [ id_ "actusBlocklyToolbox", style "display:none" ]
-    [ category [ name "Contracts", colour actusColour ] (map mkBlock actusContractTypes)
-    , category [ name "Values", colour valueColour ] (map mkBlock actusValueTypes)
-    , category [ name "Periods", colour periodColour ] (map mkBlock actusPeriodTypes)
+  CategoryToolbox
+    [ category "Contracts" actusColour $ map (leaf <<< show) actusContractTypes
+    , category "Values" valueColour $ map (leaf <<< show) actusValueTypes
+    , category "Periods" periodColour $ map (leaf <<< show) actusPeriodTypes
     ]
-  where
-  mkBlock :: forall t. Show t => t -> _
-  mkBlock t = block [ blockType (show t) ] []
 
 workspaceBlocks :: forall a b. HTML a b
 workspaceBlocks =

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -1032,7 +1032,7 @@ tokenCategory :: Category
 tokenCategory = category "Token" tokenColour $ map (leaf <<< show) tokenTypes
 
 boundsCategory :: Category
-boundsCategory = category "Bounds" boundsColour $ [ leaf $ show BoundsType ]
+boundsCategory = category "Bounds" boundsColour [ leaf $ show BoundsType ]
 
 -- This map ties a block definition "check" with a Category that can be displayed in the Toolbar
 -- as part of the Blockly holes functionality.
@@ -1040,15 +1040,15 @@ boundsCategory = category "Bounds" boundsColour $ [ leaf $ show BoundsType ]
 typeMap :: Map String Category
 typeMap =
   Map.fromFoldable
-    $ [ Tuple (show BaseContractType) contractsCategory
-      , Tuple "ActionType" actionsCategory
-      , Tuple "observation" observationsCategory
-      , Tuple "value" valueCategory
-      , Tuple "payee" payeeCategory
-      , Tuple "party" partyCategory
-      , Tuple "token" tokenCategory
-      , Tuple (show BoundsType) boundsCategory
-      ]
+    [ Tuple (show BaseContractType) contractsCategory
+    , Tuple "ActionType" actionsCategory
+    , Tuple "observation" observationsCategory
+    , Tuple "value" valueCategory
+    , Tuple "payee" payeeCategory
+    , Tuple "party" partyCategory
+    , Tuple "token" tokenCategory
+    , Tuple (show BoundsType) boundsCategory
+    ]
 
 defaultCategories :: Array Category
 defaultCategories =

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -9,9 +9,8 @@ import Control.Monad.Error.Class (catchError)
 import Control.Monad.Error.Extra (toMonadThrow)
 import Control.Monad.Except (class MonadError, throwError)
 import Control.Monad.Except.Trans (class MonadThrow)
-import Data.Array (filter, head, length, uncons)
+import Data.Array (filter, head, uncons)
 import Data.Array as Array
-import Data.Array.Partial as UnsafeArray
 import Data.Bifunctor (lmap)
 import Data.BigInteger (BigInteger)
 import Data.BigInteger as BigInteger

--- a/marlowe-playground-client/test/Blockly/Headless.js
+++ b/marlowe-playground-client/test/Blockly/Headless.js
@@ -2,7 +2,7 @@
 'use strict';
 
 exports.createBlocklyInstance_ = function() {
-    return require('node-blockly');
+    return require('blockly/blockly-node');
 }
 
 exports.createWorkspace_ = function(blockly) {


### PR DESCRIPTION
This PR implements blockly holes, which is a way to suggest to the user what blocks could fit into the selected block.

I had to upgrade blockly to the latest version (and while I was at it modify the source to the official one) as it was necessary for defining the Toolbox as JSON. Then I re-implement the toolbox from XML to Json and finally added the mechanism to modify the Toolbox with the hole information.

As a "weird" usability issue, the names of the toolbox categories correspond to the name of the holes rather than the name of the block. But trying to change that broke the CodeToBlocklyToCode quick check, as the names of the holes is tightly coupled to the block definition, and the quick check verifies that the names of the holes are preserved.

The code is deployed here: https://hernan.marlowe.iohkdev.io/

![Screen Shot 2021-03-02 at 12 12 51](https://user-images.githubusercontent.com/2634059/109669234-ae7d9d00-7b50-11eb-8fde-4b083ebf1847.png)
![Screen Shot 2021-03-02 at 12 13 03](https://user-images.githubusercontent.com/2634059/109669266-b4737e00-7b50-11eb-99dd-d868b45ed446.png)


Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
