### PR TITLE
SCP-2009 towards successful EC reduction implies successful CC execution for types

### DIFF
--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -12,7 +12,7 @@ module Type.CC where
 ```
 open import Type
 open import Type.RenamingSubstitution
-open import Type.ReductionC hiding (step)
+open import Type.ReductionCI hiding (step)
 
 open import Data.Product
 ```
@@ -128,15 +128,13 @@ step** : {s : State K J}{s' : State K I}{s'' : State K I'}
 step** base q = q
 step** (step* x p) q = step* x (step** p q)
 
-variable J' : Kind
+variable J' K' : Kind
 
 subst-step* : {s : State K J}{s' : State K J'}{s'' : State K I}
         → _≡_ {A = Σ Kind (State K)} (J , s) (J' , s')
         → s' -→s s''
         → s -→s s''
 subst-step* refl q = q
-
-variable K' : Kind
 
 helper·-lem : ∀(E : EvalCtx K J)(E' : EvalCtx K' I) B {A' : ∅ ⊢⋆ K' ⇒ J}(V : Value⋆ A') → 
    helper V (dissect (extendEvalCtx E (-· B))) ≡ (K' , extendEvalCtx E (V ·-) ▻ B)
@@ -210,32 +208,32 @@ lem62 A .(μ A₁ B₁) E (μl E' B₁) (~μl .A A₁ .B₁ .E' x) = step*
   refl
   (lem62 A _ (extendEvalCtx E (μ- B₁)) E' x)
 
-{-
-lem1 : (A : ∅ ⊢⋆ J)(B : ∅ ⊢⋆ K)(E : EvalCtx K J)
-       (A' : ∅ ⊢⋆ J)(B' : ∅ ⊢⋆ K)(E' : EvalCtx K J)
-  → B ~ E ⟦ A ⟧ → B' ~ E' ⟦ A' ⟧ → B —→⋆ B' -> (E ▻ A) -→s (E' ▻ A')
-lem1 A B E A' B' E' p q r = {!!}
 
-lem1' : (A : ∅ ⊢⋆ J)(B : ∅ ⊢⋆ K)(E : EvalCtx K J)
-       (B' : ∅ ⊢⋆ K) → B ~ E ⟦ A ⟧ → B —→⋆ B' →
-       Σ (∅ ⊢⋆ J) λ A' → Σ (EvalCtx K J) λ E' →  B' ~ E' ⟦ A' ⟧ ×(E ▻ A) -→s (E' ▻ A')
-lem1' A B E B' p (contextRule E₁ q x x₁) = {!lem1 !}
-lem1' A .(ƛ _ · _) E .(sub (sub-cons ` _) _) p (β-ƛ x) = -, -, -, {!!}
+-- there are varous ways the E' can be related to E,
+-- it coud be the same, it could be shorter, it could be an extension
+-- but it is related in some way
 
+lem1 : (M : ∅ ⊢⋆ J)(B B' : ∅ ⊢⋆ K)(E : EvalCtx K J)
+  → B ~ E ⟦ M ⟧ → B —→⋆ B'
+  → Σ Kind λ J' → Σ (∅ ⊢⋆ J') λ N → Σ (EvalCtx K J') λ E'
+  → B' ~ E' ⟦ N ⟧ × (E ▻ M) -→s (E' ▻ N)
+  × Σ (∅ ⊢⋆ J') λ L →  (B ~ E' ⟦ L ⟧) × (L —→⋆ N)
+lem1 M B B' E p q = {!lem62!}
 
 unwind : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J) → A' ~ E ⟦ A ⟧ → (V : Value⋆ A') → (E ▻ A) -→s ([] ◅ V)
 unwind = {!!}
 
 -- thm2 follows from this stronger theorem
+
 thm1 : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → A' ~ E ⟦ A ⟧ → (B : ∅ ⊢⋆ K)(V : Value⋆ B) → A' —↠⋆ B -> (E ▻ A) -→s ([] ◅ V)
 thm1 A A' E p .A' V refl—↠⋆ = unwind A A' E p V
-thm1 A A' E p B V (trans—↠⋆ {B = B'} x q) =
+thm1 A A' E p B V (trans—↠⋆ {B = B'} x q) = let J' , N , E' , p' , p'' , L , X , Y = lem1 A A' B' E p x in step** p'' (thm1 A' B' E' p' B V q)
+{-
   let A' , E' , p' , p'' = lem1' A A' E B' p x in
     step** p'' (thm1 A' B' E' p' _ _ q)
-
+-}
 -- this is the result we want
 thm2 : (A B : ∅ ⊢⋆ K)(V : Value⋆ B) → A —↠⋆ B -> ([] ▻ A) -→s ([] ◅ V)
 thm2 A B V p = thm1 A A [] (~[] A) B V p
--}
 ```

--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -209,65 +209,32 @@ lem62 A .(μ A₁ B₁) E (μl E' B₁) (~μl .A A₁ .B₁ .E' x) = step*
   (lem62 A _ (extendEvalCtx E (μ- B₁)) E' x)
 
 
--- there are varous ways the E' can be related to E,
--- it coud be the same, it could be shorter, it could be an extension
--- but it is related in some way
-
+{-
 lem1 : (M : ∅ ⊢⋆ J)(B B' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → B ~ E ⟦ M ⟧ → B —→⋆ B'
   → Σ Kind λ J' → Σ (∅ ⊢⋆ J') λ N → Σ (EvalCtx K J') λ E'
   → B' ~ E' ⟦ N ⟧ × (E ▻ M) -→s (E' ▻ N)
   × Σ (∅ ⊢⋆ J') λ L →  (B ~ E' ⟦ L ⟧) × (L —→⋆ N)
-lem1 M B B' E p q = {!!} 
+-}
 
+{-
 unwind : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J) → A' ~ E ⟦ A ⟧ → (V : Value⋆ A') → (E ▻ A) -→s ([] ◅ V)
-unwind = {!!}
+-}
 
 -- thm2 follows from this stronger theorem
 
 
-
+{-
 thm1 : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → A' ~ E ⟦ A ⟧ → (B : ∅ ⊢⋆ K)(V : Value⋆ B) → A' —↠⋆ B -> (E ▻ A) -→s ([] ◅ V)
 thm1 A A' E p .A' V refl—↠⋆ = unwind A A' E p V
 thm1 A A' E p B V (trans—↠⋆ {B = B'} q r) with lemma51 B'
 ... | inj₂ (J , E' , I , L , N , VL , VN , X) = {!!}
--- ^ this means that B' is not a value (xor might be useful) and we have
--- a factoring of the term, with a place where beta should happen next
--- so what's next
--- lem62 is probably not used directly here, instead it is used in
--- the unnamed lemma
--- claims:
--- at least one step means, there exists an L...
--- there are only 4 cases
-
 ... | inj₁ V' with v-refl B' B V' r
--- ^ this means that r must be refl
 ... | refl , refl = step** {!!} (unwind {!!} {!!} {!!} {!!} V)
--- ^ so possibly we can unwind again...
 
-
-
-
-{-
-with lemma51 B'
-... | inj₁ V' = {!!}
--- ^ this means that r must be refl
--- ^ so possibly we can unwind again...
--- and we've already hit a value so we can probably generate the []<| V.
-... | inj₂ (J , E' , I , L , N , VL , VN , X) = {!lem62!}
--- ^ this means that we didn't hit a value (xor might be useful) and we have
--- a factoring of the term, with a place where beta should happen next
--- so what's next
--}
-{-
-let J' , N , E' , p' , p'' , L , X , Y = lem1 A A' B' E p x in step** p'' (thm1 A' B' E' p' B V q)
--}
-{-
-  let A' , E' , p' , p'' = lem1' A A' E B' p x in
-    step** p'' (thm1 A' B' E' p' _ _ q)
--}
 -- this is the result we want
 thm2 : (A B : ∅ ⊢⋆ K)(V : Value⋆ B) → A —↠⋆ B -> ([] ▻ A) -→s ([] ◅ V)
 thm2 A B V p = thm1 A A [] (~[] A) B V p
+-}
 ```

--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -218,17 +218,51 @@ lem1 : (M : ∅ ⊢⋆ J)(B B' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → Σ Kind λ J' → Σ (∅ ⊢⋆ J') λ N → Σ (EvalCtx K J') λ E'
   → B' ~ E' ⟦ N ⟧ × (E ▻ M) -→s (E' ▻ N)
   × Σ (∅ ⊢⋆ J') λ L →  (B ~ E' ⟦ L ⟧) × (L —→⋆ N)
-lem1 M B B' E p q = {!lem62!}
+lem1 M B B' E p q = {!!} 
 
 unwind : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J) → A' ~ E ⟦ A ⟧ → (V : Value⋆ A') → (E ▻ A) -→s ([] ◅ V)
 unwind = {!!}
 
 -- thm2 follows from this stronger theorem
 
+
+
 thm1 : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → A' ~ E ⟦ A ⟧ → (B : ∅ ⊢⋆ K)(V : Value⋆ B) → A' —↠⋆ B -> (E ▻ A) -→s ([] ◅ V)
 thm1 A A' E p .A' V refl—↠⋆ = unwind A A' E p V
-thm1 A A' E p B V (trans—↠⋆ {B = B'} x q) = let J' , N , E' , p' , p'' , L , X , Y = lem1 A A' B' E p x in step** p'' (thm1 A' B' E' p' B V q)
+thm1 A A' E p B V (trans—↠⋆ {B = B'} q r) with lemma51 B'
+... | inj₂ (J , E' , I , L , N , VL , VN , X) = {!!}
+-- ^ this means that B' is not a value (xor might be useful) and we have
+-- a factoring of the term, with a place where beta should happen next
+-- so what's next
+-- lem62 is probably not used directly here, instead it is used in
+-- the unnamed lemma
+-- claims:
+-- at least one step means, there exists an L...
+-- there are only 4 cases
+
+... | inj₁ V' with v-refl B' B V' r
+-- ^ this means that r must be refl
+... | refl , refl = step** {!!} (unwind {!!} {!!} {!!} {!!} V)
+-- ^ so possibly we can unwind again...
+
+
+
+
+{-
+with lemma51 B'
+... | inj₁ V' = {!!}
+-- ^ this means that r must be refl
+-- ^ so possibly we can unwind again...
+-- and we've already hit a value so we can probably generate the []<| V.
+... | inj₂ (J , E' , I , L , N , VL , VN , X) = {!lem62!}
+-- ^ this means that we didn't hit a value (xor might be useful) and we have
+-- a factoring of the term, with a place where beta should happen next
+-- so what's next
+-}
+{-
+let J' , N , E' , p' , p'' , L , X , Y = lem1 A A' B' E p x in step** p'' (thm1 A' B' E' p' B V q)
+-}
 {-
   let A' , E' , p' , p'' = lem1' A A' E B' p x in
     step** p'' (thm1 A' B' E' p' _ _ q)

--- a/plutus-metatheory/src/Type/ReductionC.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionC.lagda.md
@@ -681,79 +681,11 @@ uniqueness : (A : ∅ ⊢⋆ K)
            → (B : ∅ ⊢⋆ J)(B' : ∅ ⊢⋆ J')
            → (E : EvalCtx K J)(E' : EvalCtx K J')
            → A ≡ closeEvalCtx E B
-           → A ≡ closeEvalCtx E' B'
+           → A ≡ closeEvalCtx E' B'           
+           → Σ (J ≡ J') λ p → subst (EvalCtx K) p E ≡ E' × subst (∅ ⊢⋆_) p B ≡ -}
            
-           → Σ (J ≡ J') λ p → subst (EvalCtx K) p E ≡ E' × subst (∅ ⊢⋆_) p B ≡ B'
-uniqueness = {!!}
--}
 {-
 det : (p : A —→E B)(q : A —→E B') → B ≡ B'
-det (contextRule [] p refl refl) C@(contextRule _ _ _ _) = det p C
-det C@(contextRule (_ ·r _) _ _ _) (contextRule [] q refl refl) = det C q
-det (contextRule (V ·r E) {A = B}{A' = B'} p x x') (contextRule (V' ·r E') {A = C}{A' = C'} q x'' x''')
-  with closeEvalCtx E B
-  | inspect (closeEvalCtx E) B
-  | closeEvalCtx E B'
-  | inspect (closeEvalCtx E) B'
-  | closeEvalCtx E' C
-  | inspect (closeEvalCtx E') C
-  | closeEvalCtx E' C'
-  | inspect (closeEvalCtx E') C'
-det (contextRule (V ·r E) p refl refl) (contextRule (V' ·r E') q refl refl)
-  | r
-  | blah x
-  | r'
-  | blah x'
-  | .r
-  | blah x''
-  | r'''
-  | blah x''' = cong
-    (_ ·_)
-    (det (contextRule E p (sym x) (sym x'))
-         (contextRule E' q (sym x'') (sym x''')))
-det (contextRule (x₄ ·r E) p x x₁) (contextRule (E₁ l· x₅) q x₂ x₃) = {!!}
-det (contextRule (x₄ ·r E) p x x₁) (contextRule (x₅ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (x₄ ·r E) p x x₁) (contextRule (E₁ l⇒ x₅) q x₂ x₃) = {!!}
-det (contextRule (x₄ ·r E) p x x₁) (contextRule (μr x₅ E₁) q x₂ x₃) = {!!}
-det (contextRule (x₄ ·r E) p x x₁) (contextRule (μl E₁ B) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule [] q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (x₅ ·r E₁) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (E₁ l· x₅) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (x₅ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (E₁ l⇒ x₅) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (μr x₅ E₁) q x₂ x₃) = {!!}
-det (contextRule (E l· x₄) p x x₁) (contextRule (μl E₁ B) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule [] q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (x₅ ·r E₁) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (E₁ l· x₅) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (x₅ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (E₁ l⇒ x₅) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (μr x₅ E₁) q x₂ x₃) = {!!}
-det (contextRule (x₄ ⇒r E) p x x₁) (contextRule (μl E₁ B) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule [] q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (x₅ ·r E₁) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (E₁ l· x₅) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (x₅ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (E₁ l⇒ x₅) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (μr x₅ E₁) q x₂ x₃) = {!!}
-det (contextRule (E l⇒ x₄) p x x₁) (contextRule (μl E₁ B) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule [] q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (x₅ ·r E₁) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (E₁ l· x₅) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (x₅ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (E₁ l⇒ x₅) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (μr x₅ E₁) q x₂ x₃) = {!!}
-det (contextRule (μr x₄ E) p x x₁) (contextRule (μl E₁ B) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule [] q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (x₄ ·r E₁) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (E₁ l· x₄) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (x₄ ⇒r E₁) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (E₁ l⇒ x₄) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (μr x₄ E₁) q x₂ x₃) = {!!}
-det (contextRule (μl E B) p x x₁) (contextRule (μl E₁ B₁) q x₂ x₃) = {!!}
-det (contextRule E p x x₁) (β-ƛ x₂) = {!!}
-det (β-ƛ x) (contextRule E q x₁ x₂) = {!!}
-det (β-ƛ x) (β-ƛ x₁) = {!!}
 -}
 ```
 

--- a/plutus-metatheory/src/Type/ReductionCI.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionCI.lagda.md
@@ -595,13 +595,3 @@ v-refl :  (A B : ∅ ⊢⋆ K)(V : Value⋆ A)(r : A —↠⋆ B)
 v-refl A .A V refl—↠⋆       = refl , refl
 v-refl A B V (trans—↠⋆ p q) = ⊥-elim (notboth A (V , _ , p)) 
 ```
-```
-variable J' : Kind
-
-one-step : (A B : ∅ ⊢⋆ K)(r : A —→⋆ B)
-         → (E : EvalCtx K J)(A' : ∅ ⊢⋆ J) → A ~ E ⟦ A' ⟧
-         → (E' : EvalCtx K J')(B' : ∅ ⊢⋆ J') → B ~ E' ⟦ B' ⟧
-         → Σ (∅ ⊢⋆ J') λ A'' → A'' —→⋆ B' → A ~ E' ⟦ A'' ⟧
-one-step A B (contextRule E₁ r x x₁) E A' p E' B' q = {!!}
-one-step .(ƛ _ · _) .(sub (sub-cons ` _) _) (β-ƛ x) E A' p E' B' q = {!!}
-```

--- a/plutus-metatheory/src/Type/ReductionCI.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionCI.lagda.md
@@ -150,8 +150,15 @@ close-comp (μl E B) E' A = cong (λ E → μ E B) (close-comp E E' A)
 
 open import Data.Sum
 
+-- Lemma 5.1 from the book
 -- existence
-existence : (M : ∅ ⊢⋆ K)
+
+-- I haven't proved uniqueness yet..
+
+-- might we need uniqueness of just E the other stuff too (certainly
+-- they are unique but are they needed?)
+
+lemma51 : (M : ∅ ⊢⋆ K)
   → Value⋆ M
   ⊎ Σ Kind λ J →
     Σ (EvalCtx K J) λ E →
@@ -161,30 +168,31 @@ existence : (M : ∅ ⊢⋆ K)
       Value⋆ L
     × Value⋆ N
     × M ≡ closeEvalCtx E (L · N)
-existence (Π M)    = inj₁ (V-Π M)
-existence (M ⇒ M') with existence M
+lemma51 (Π M)    = inj₁ (V-Π M)
+lemma51 (M ⇒ M') with lemma51 M
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , E l⇒ M' , I , L , N , VL , VN , cong (_⇒ M') p)
-... | inj₁ VM with existence M'
+... | inj₁ VM with lemma51 M'
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , VM ⇒r E , I , L , N , VL , VN , cong (M ⇒_) p)
 ... | inj₁ VM' = inj₁ (VM V-⇒ VM')
-existence (ƛ M)    = inj₁ (V-ƛ M)
-existence (M · M') with existence M
+lemma51 (ƛ M)    = inj₁ (V-ƛ M)
+lemma51 (M · M') with lemma51 M
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , E l· M' , I , L , N , VL , VN , cong (_· M') p)
-... | inj₁ VM with existence M'
+... | inj₁ VM with lemma51 M'
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , VM ·r E , I , L , N , VL , VN , cong (M ·_) p)
 ... | inj₁ VM' = inj₂ (_ , [] , _ , M , M' , VM , VM' , refl)
-existence (μ M M')  with existence M
+lemma51 (μ M M')  with lemma51 M
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , μl E M' , I , L , N , VL , VN , cong (λ M → μ M M') p)
-... | inj₁ VM with existence M'
+... | inj₁ VM with lemma51 M'
 ... | inj₂ (J , E , I , L , N , VL , VN , p) =
   inj₂ (J , μr VM E , I , L , N , VL , VN , cong (μ M) p)
 ... | inj₁ VM' = inj₁ (V-μ VM VM')
-existence (con c)  = inj₁ (V-con c)
+lemma51 (con c)  = inj₁ (V-con c)
+
 
 -- an inductive version of the graph of closeEvalCtx
 data _~_⟦_⟧ : ∅ ⊢⋆ K → EvalCtx K J → ∅ ⊢⋆ J → Set where
@@ -579,4 +587,21 @@ det (β-ƛ x) (contextRule [] q (~[] .(ƛ _ · _)) (~[] _)) = det (β-ƛ x) q
 det (β-ƛ x) (contextRule (x₃ ·r E) q (~·r _ .x₃ _ .E x₁) (~·r _ .x₃ B .E x₂)) = ⊥-elim (notboth _ (lem0 _ _ _ x₁ x , _ , q))
 det (β-ƛ x) (contextRule (E l· x₃) q (~l· _ .(ƛ _) .x₃ _ x₁) (~l· _ A .x₃ _ x₂)) = ⊥-elim (notboth _ (lem0 _ _ _ x₁ (V-ƛ _) , _ , q))
 det (β-ƛ x) (β-ƛ x₁) = refl
+```
+
+```
+v-refl :  (A B : ∅ ⊢⋆ K)(V : Value⋆ A)(r : A —↠⋆ B)
+  → Σ (A ≡ B) λ p → subst (_—↠⋆ _)p r ≡ refl—↠⋆
+v-refl A .A V refl—↠⋆       = refl , refl
+v-refl A B V (trans—↠⋆ p q) = ⊥-elim (notboth A (V , _ , p)) 
+```
+```
+variable J' : Kind
+
+one-step : (A B : ∅ ⊢⋆ K)(r : A —→⋆ B)
+         → (E : EvalCtx K J)(A' : ∅ ⊢⋆ J) → A ~ E ⟦ A' ⟧
+         → (E' : EvalCtx K J')(B' : ∅ ⊢⋆ J') → B ~ E' ⟦ B' ⟧
+         → Σ (∅ ⊢⋆ J') λ A'' → A'' —→⋆ B' → A ~ E' ⟦ A'' ⟧
+one-step A B (contextRule E₁ r x x₁) E A' p E' B' q = {!!}
+one-step .(ƛ _ · _) .(sub (sub-cons ` _) _) (β-ƛ x) E A' p E' B' q = {!!}
 ```

--- a/plutus-metatheory/src/Type/ReductionCI.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionCI.lagda.md
@@ -148,6 +148,44 @@ close-comp (E l⇒ B) E' A = cong (_⇒ B) (close-comp E E' A)
 close-comp (μr V E) E' A = cong (μ (discharge V)) (close-comp E E' A)
 close-comp (μl E B) E' A = cong (λ E → μ E B) (close-comp E E' A)
 
+open import Data.Sum
+
+-- existence
+existence : (M : ∅ ⊢⋆ K)
+  → Value⋆ M
+  ⊎ Σ Kind λ J →
+    Σ (EvalCtx K J) λ E →
+    Σ Kind λ I → 
+    Σ (∅ ⊢⋆ I ⇒ J)  λ L →
+    Σ (∅ ⊢⋆ I)      λ N →
+      Value⋆ L
+    × Value⋆ N
+    × M ≡ closeEvalCtx E (L · N)
+existence (Π M)    = inj₁ (V-Π M)
+existence (M ⇒ M') with existence M
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , E l⇒ M' , I , L , N , VL , VN , cong (_⇒ M') p)
+... | inj₁ VM with existence M'
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , VM ⇒r E , I , L , N , VL , VN , cong (M ⇒_) p)
+... | inj₁ VM' = inj₁ (VM V-⇒ VM')
+existence (ƛ M)    = inj₁ (V-ƛ M)
+existence (M · M') with existence M
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , E l· M' , I , L , N , VL , VN , cong (_· M') p)
+... | inj₁ VM with existence M'
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , VM ·r E , I , L , N , VL , VN , cong (M ·_) p)
+... | inj₁ VM' = inj₂ (_ , [] , _ , M , M' , VM , VM' , refl)
+existence (μ M M')  with existence M
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , μl E M' , I , L , N , VL , VN , cong (λ M → μ M M') p)
+... | inj₁ VM with existence M'
+... | inj₂ (J , E , I , L , N , VL , VN , p) =
+  inj₂ (J , μr VM E , I , L , N , VL , VN , cong (μ M) p)
+... | inj₁ VM' = inj₁ (V-μ VM VM')
+existence (con c)  = inj₁ (V-con c)
+
 -- an inductive version of the graph of closeEvalCtx
 data _~_⟦_⟧ : ∅ ⊢⋆ K → EvalCtx K J → ∅ ⊢⋆ J → Set where
   ~[] : (P : ∅ ⊢⋆ K) → P ~ [] ⟦ P ⟧


### PR DESCRIPTION
some properties:
- [X] for any term `M` either it's a value already or it can be factored into an evaluation context `E` that contains an application of a value to a value in it somewhere: `M = E [ V V' ]`
- [x] that factoring is unique (mu case postulated)


Refactoring:
- [X] EC reduction relation is not inductive anymore: it is of the form:
```
M -> M'
-----------------
E [ M ] ~> E [ M']
```
where `->` is a relation containing only beta reduction on types.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
