### PR TITLE
SCP-1929 Marlowe Playground Client: dont do static analysis with holes

### DIFF
--- a/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
@@ -3,12 +3,13 @@ module BlocklyEditor.BottomPanel
   ) where
 
 import Prelude hiding (div)
-import BlocklyEditor.Types (Action(..), BottomPanelView(..), State, _warnings)
+
+import BlocklyEditor.Types (Action(..), BottomPanelView(..), State, _hasHoles, _warnings)
 import Data.Array as Array
 import Data.Lens (to, (^.))
 import Data.Maybe (Maybe(..))
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, paddingRight, underline)
-import Halogen.HTML (HTML, a, div, pre_, section, section_, span_, text)
+import Halogen.HTML (HTML, a, div, div_, pre_, section, section_, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
@@ -17,14 +18,18 @@ import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAna
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
 panelContents state StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
-    [ analysisResultPane SetIntegerTemplateParam state
-    , div [ classes [ paddingRight ] ]
-        [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
-        , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
-        , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
-        , clearButton clearEnabled "Clear" ClearAnalysisResults
-        ]
-    ]
+    if (state ^. _hasHoles ) then
+      [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
+      ]
+    else
+      [ analysisResultPane SetIntegerTemplateParam state
+      , div [ classes [ paddingRight ] ]
+          [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
+          , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
+          , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
+          , clearButton clearEnabled "Clear" ClearAnalysisResults
+          ]
+      ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
 

--- a/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
@@ -3,7 +3,6 @@ module BlocklyEditor.BottomPanel
   ) where
 
 import Prelude hiding (div)
-
 import BlocklyEditor.Types (Action(..), BottomPanelView(..), State, _hasHoles, _warnings)
 import Data.Array as Array
 import Data.Lens (to, (^.))
@@ -18,7 +17,7 @@ import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAna
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
 panelContents state StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
-    if (state ^. _hasHoles ) then
+    if (state ^. _hasHoles) then
       [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
       ]
     else

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -26,7 +26,7 @@ import Halogen.Extra (mapSubmodule)
 import MainFrame.Types (ChildSlots, _blocklySlot)
 import Marlowe.Blockly as MB
 import Marlowe.Extended (TemplateContent)
-import Marlowe.Extended as EM
+import Marlowe.Extended as Extended
 import Marlowe.Holes as Holes
 import Marlowe.Linter as Linter
 import SessionStorage as SessionStorage
@@ -83,7 +83,7 @@ handleAction (BottomPanelAction action) = toBottomPanel (BottomPanel.handleActio
 
 handleAction (SetIntegerTemplateParam templateType key value) =
   modifying
-    (_analysisState <<< _templateContent <<< EM.typeToLens templateType)
+    (_analysisState <<< _templateContent <<< Extended.typeToLens templateType)
     (Map.insert key value)
 
 handleAction AnalyseContract = runAnalysis $ analyseContract
@@ -125,7 +125,7 @@ processBlocklyCode = do
         -- then update the template content. If not, leave them as they are
         maybeUpdateTemplateContent :: TemplateContent -> TemplateContent
         maybeUpdateTemplateContent = case Holes.fromTerm holesContract of
-          Just (contract :: EM.Contract) -> EM.updateTemplateContent $ EM.getPlaceholderIds contract
+          Just (contract :: Extended.Contract) -> Extended.updateTemplateContent $ Extended.getPlaceholderIds contract
           Nothing -> identity
       liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey prettyContract
       modify_
@@ -141,7 +141,7 @@ processBlocklyCode = do
 runAnalysis ::
   forall m.
   MonadAff m =>
-  (EM.Contract -> HalogenM State Action ChildSlots Void m Unit) ->
+  (Extended.Contract -> HalogenM State Action ChildSlots Void m Unit) ->
   HalogenM State Action ChildSlots Void m Unit
 runAnalysis doAnalyze =
   void

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -3,7 +3,6 @@ module MarloweEditor.BottomPanel
   ) where
 
 import Prelude hiding (div)
-
 import Data.Array (drop, head)
 import Data.Array as Array
 import Data.Lens (to, (^.))
@@ -23,7 +22,7 @@ import Text.Parsing.StringParser.Basic (lines)
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
 panelContents state StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
-    if (state ^. _hasHoles ) then
+    if (state ^. _hasHoles) then
       [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
       ]
     else

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -3,6 +3,7 @@ module MarloweEditor.BottomPanel
   ) where
 
 import Prelude hiding (div)
+
 import Data.Array (drop, head)
 import Data.Array as Array
 import Data.Lens (to, (^.))
@@ -11,10 +12,10 @@ import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple.Nested ((/\))
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, minW0, overflowXScroll, paddingRight, underline)
-import Halogen.HTML (HTML, a, div, pre_, section, section_, span_, text)
+import Halogen.HTML (HTML, a, div, div_, pre_, section, section_, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
-import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _showErrorDetail, contractHasErrors)
+import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _hasHoles, _showErrorDetail, contractHasErrors)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
@@ -22,14 +23,18 @@ import Text.Parsing.StringParser.Basic (lines)
 panelContents :: forall p. State -> BottomPanelView -> HTML p Action
 panelContents state StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
-    [ analysisResultPane SetIntegerTemplateParam state
-    , div [ classes [ paddingRight ] ]
-        [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
-        , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
-        , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
-        , clearButton clearEnabled "Clear" ClearAnalysisResults
-        ]
-    ]
+    if (state ^. _hasHoles ) then
+      [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
+      ]
+    else
+      [ analysisResultPane SetIntegerTemplateParam state
+      , div [ classes [ paddingRight ] ]
+          [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
+          , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
+          , analyzeButton loadingCloseAnalysis analysisEnabled "Analyse for refunds on Close" AnalyseContractForCloseRefund
+          , clearButton clearEnabled "Clear" ClearAnalysisResults
+          ]
+      ]
   where
   loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to isStaticLoading
 


### PR DESCRIPTION
This PR Fixes a bug both in Marlowe and Blockly were you were able to select a static analysis for a contract with holes. Because the handleAction was using `for_` with Maybe's, the code didn't execute, but also didn't warn you about the problem.

Now it shows the following message:

<img width="1338" alt="Screen Shot 2021-03-03 at 16 00 44" src="https://user-images.githubusercontent.com/2634059/109857606-a188a880-7c39-11eb-8e2a-7087b69a2540.png">

I also took the opportunity to tidy up the processMarloweCode and editorSetMarkers

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [X] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
