### PR TITLE
Marlowe redo wallet workflow

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -31,7 +31,7 @@ contractsScreen contractStatus =
         [ span
             [ classNames [ "mr-0.5" ] ]
             [ text "New" ]
-        , Icon.libraryAdd
+        , Icon.add
         ]
     ]
 

--- a/marlowe-dashboard-client/src/Icons.purs
+++ b/marlowe-dashboard-client/src/Icons.purs
@@ -1,19 +1,12 @@
 -- TODO: replace web-common Icons module with this one
 module Material.Icons
   ( add
-  , addCircle
   , close
   , contacts
-  , help
+  , contracts
   , home
-  , image
-  , libraryAdd
   , menu
-  , navigateBefore
-  , navigateNext
-  , notifications
-  , personAdd
-  , search
+  , rightArrow
   , wallet
   ) where
 
@@ -22,50 +15,29 @@ import Halogen.HTML (ClassName(ClassName), HTML, span, text)
 import Halogen.HTML.Properties (class_)
 
 icon :: forall p i. String -> HTML p i
-icon str = span [ class_ $ ClassName "material-icons" ] [ text str ]
+icon str = span [ class_ $ ClassName "material-icons round" ] [ text str ]
 
 -----
 add :: forall p i. HTML p i
 add = icon "add"
 
-addCircle :: forall p i. HTML p i
-addCircle = icon "add_circle"
-
 close :: forall p i. HTML p i
 close = icon "close"
 
 contacts :: forall p i. HTML p i
-contacts = icon "contacts"
+contacts = icon "person"
 
-help :: forall p i. HTML p i
-help = icon "help"
+contracts :: forall p i. HTML p i
+contracts = icon "history_edu"
 
 home :: forall p i. HTML p i
 home = icon "home"
 
-image :: forall p i. HTML p i
-image = icon "image"
-
-libraryAdd :: forall p i. HTML p i
-libraryAdd = icon "library_add"
-
 menu :: forall p i. HTML p i
-menu = icon "menu"
+menu = icon "short_text"
 
-navigateBefore :: forall p i. HTML p i
-navigateBefore = icon "navigate_before"
-
-navigateNext :: forall p i. HTML p i
-navigateNext = icon "navigate_next"
-
-notifications :: forall p i. HTML p i
-notifications = icon "notifications_none"
-
-personAdd :: forall p i. HTML p i
-personAdd = icon "person_add"
-
-search :: forall p i. HTML p i
-search = icon "search"
+rightArrow :: forall p i. HTML p i
+rightArrow = icon "navigate_next"
 
 wallet :: forall p i. HTML p i
-wallet = icon "account_balance_wallet"
+wallet = icon "layers"

--- a/marlowe-dashboard-client/src/MainFrame/Lenses.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Lenses.purs
@@ -1,6 +1,7 @@
 module MainFrame.Lenses
   ( _wallets
-  , _newWalletNicknameKey
+  , _newWalletDetails
+  , _newWalletPubKey
   , _templates
   , _subState
   , _webSocketStatus
@@ -16,17 +17,23 @@ import Data.Lens (Lens', Traversal')
 import Data.Lens.Prism.Either (_Left, _Right)
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
+import Network.RemoteData (RemoteData)
 import MainFrame.Types (State, WebSocketStatus)
 import Marlowe.Extended (ContractTemplate)
+import Marlowe.Semantics (PubKey)
 import Play.Types (State) as Play
 import Pickup.Types (State) as Pickup
-import WalletData.Types (WalletLibrary, WalletNicknameKey)
+import Servant.PureScript.Ajax (AjaxError)
+import WalletData.Types (WalletDetails, WalletLibrary)
 
 _wallets :: Lens' State WalletLibrary
 _wallets = prop (SProxy :: SProxy "wallets")
 
-_newWalletNicknameKey :: Lens' State WalletNicknameKey
-_newWalletNicknameKey = prop (SProxy :: SProxy "newWalletNicknameKey")
+_newWalletDetails :: Lens' State WalletDetails
+_newWalletDetails = prop (SProxy :: SProxy "newWalletDetails")
+
+_newWalletPubKey :: Lens' State (RemoteData AjaxError PubKey)
+_newWalletPubKey = prop (SProxy :: SProxy "newWalletPubKey")
 
 _templates :: Lens' State (Array ContractTemplate)
 _templates = prop (SProxy :: SProxy "templates")

--- a/marlowe-dashboard-client/src/MainFrame/Lenses.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Lenses.purs
@@ -1,7 +1,8 @@
 module MainFrame.Lenses
   ( _wallets
-  , _newWalletDetails
-  , _newWalletPubKey
+  , _newWalletNickname
+  , _newWalletContractId
+  , _remoteDataPubKey
   , _templates
   , _subState
   , _webSocketStatus
@@ -17,23 +18,26 @@ import Data.Lens (Lens', Traversal')
 import Data.Lens.Prism.Either (_Left, _Right)
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
-import Network.RemoteData (RemoteData)
 import MainFrame.Types (State, WebSocketStatus)
 import Marlowe.Extended (ContractTemplate)
 import Marlowe.Semantics (PubKey)
-import Play.Types (State) as Play
+import Network.RemoteData (RemoteData)
 import Pickup.Types (State) as Pickup
+import Play.Types (State) as Play
 import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Types (WalletDetails, WalletLibrary)
+import WalletData.Types (Nickname, WalletLibrary)
 
 _wallets :: Lens' State WalletLibrary
 _wallets = prop (SProxy :: SProxy "wallets")
 
-_newWalletDetails :: Lens' State WalletDetails
-_newWalletDetails = prop (SProxy :: SProxy "newWalletDetails")
+_newWalletNickname :: Lens' State Nickname
+_newWalletNickname = prop (SProxy :: SProxy "newWalletNickname")
 
-_newWalletPubKey :: Lens' State (RemoteData AjaxError PubKey)
-_newWalletPubKey = prop (SProxy :: SProxy "newWalletPubKey")
+_newWalletContractId :: Lens' State String
+_newWalletContractId = prop (SProxy :: SProxy "newWalletContractId")
+
+_remoteDataPubKey :: Lens' State (RemoteData AjaxError PubKey)
+_remoteDataPubKey = prop (SProxy :: SProxy "remoteDataPubKey")
 
 _templates :: Lens' State (Array ContractTemplate)
 _templates = prop (SProxy :: SProxy "templates")

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -120,7 +120,7 @@ handleAction AddNewWallet = do
     $ \walletDetails ->
         when (not $ member newWalletNickname oldWallets) do
           modify_
-            $ (over _wallets) (insert newWalletNickname walletDetails)
+            $ over _wallets (insert newWalletNickname walletDetails)
             <<< set _newWalletNickname mempty
             <<< set _newWalletContractId mempty
             <<< set _remoteDataPubKey NotAsked
@@ -176,6 +176,7 @@ handleAction (PickupAction pickupAction) = Pickup.handleAction pickupAction
 handleAction (PlayAction Play.PutdownWallet) = do
   assign _subState $ Left Pickup.initialState
   liftEffect $ removeItem walletDetailsLocalStorageKey
+
 handleAction (PlayAction (Play.SetNewWalletNickname nickname)) = handleAction $ SetNewWalletNickname nickname
 
 handleAction (PlayAction (Play.SetNewWalletContractId contractId)) = handleAction $ SetNewWalletContractId contractId
@@ -190,6 +191,3 @@ mkNewWallet :: Nickname -> String -> RemoteData AjaxError PubKey -> Maybe Wallet
 mkNewWallet nickname contractId remoteDataPubKey = case remoteDataPubKey of
   Success pubKey -> Just { nickname, contractId, pubKey, balance: Nothing }
   _ -> Nothing
-
-defaultWalletDetails :: WalletDetails
-defaultWalletDetails = { nickname: mempty, contractId: mempty, pubKey: mempty, balance: Nothing }

--- a/marlowe-dashboard-client/src/MainFrame/Types.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Types.purs
@@ -15,11 +15,11 @@ import Data.Maybe (Maybe(..))
 import Marlowe.Extended (ContractTemplate)
 import Marlowe.Semantics (PubKey)
 import Network.RemoteData (RemoteData)
+import Pickup.Types (Action, State) as Pickup
 import Play.Types (Action, State) as Play
 import Plutus.PAB.Webserver.Types (StreamToClient, StreamToServer)
-import Pickup.Types (Action, State) as Pickup
 import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Types (Nickname, WalletDetails, WalletLibrary)
+import WalletData.Types (Nickname, WalletLibrary)
 import Web.Socket.Event.CloseEvent (CloseEvent, reason) as WS
 import WebSocket.Support (FromSocket) as WS
 
@@ -29,8 +29,9 @@ import WebSocket.Support (FromSocket) as WS
 -- for when you have picked up a wallet, and can do all of the things.
 type State
   = { wallets :: WalletLibrary
-    , newWalletDetails :: WalletDetails
-    , newWalletPubKey :: RemoteData AjaxError PubKey
+    , newWalletNickname :: Nickname
+    , newWalletContractId :: String
+    , remoteDataPubKey :: RemoteData AjaxError PubKey
     , templates :: Array ContractTemplate
     , webSocketStatus :: WebSocketStatus
     , subState :: Either Pickup.State Play.State
@@ -62,10 +63,9 @@ data Msg
 ------------------------------------------------------------
 data Action
   = Init
-  | AddWallet WalletDetails
   | SetNewWalletNickname Nickname
   | SetNewWalletContractId String
-  | FetchNewWalletPubKey
+  | AddNewWallet
   | PickupAction Pickup.Action
   | PlayAction Play.Action
 
@@ -73,9 +73,8 @@ data Action
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
   toEvent Init = Just $ defaultEvent "Init"
-  toEvent (AddWallet _) = Just $ defaultEvent "AddWallet"
   toEvent (SetNewWalletNickname _) = Nothing
   toEvent (SetNewWalletContractId _) = Nothing
-  toEvent (FetchNewWalletPubKey) = Nothing
+  toEvent AddNewWallet = Just $ defaultEvent "AddNewWallet"
   toEvent (PickupAction pickupAction) = toEvent pickupAction
   toEvent (PlayAction playAction) = toEvent playAction

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -5,7 +5,7 @@ import Data.Either (Either(..))
 import Data.Lens (view)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
-import MainFrame.Lenses (_newWalletNicknameKey, _templates, _subState, _wallets)
+import MainFrame.Lenses (_newWalletDetails, _newWalletPubKey, _templates, _subState, _wallets)
 import MainFrame.Types (Action(..), ChildSlots, State)
 import Pickup.View (renderPickupState)
 import Play.View (renderPlayState)
@@ -15,10 +15,12 @@ render state =
   let
     wallets = view _wallets state
 
-    newWalletNicknameKey = view _newWalletNicknameKey state
+    newWalletDetails = view _newWalletDetails state
+
+    newWalletPubKey = view _newWalletPubKey state
 
     templates = view _templates state
   in
     case view _subState state of
-      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletNicknameKey pickupState
-      Right playState -> PlayAction <$> renderPlayState wallets newWalletNicknameKey templates playState
+      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletDetails newWalletPubKey pickupState
+      Right playState -> PlayAction <$> renderPlayState wallets newWalletDetails newWalletPubKey templates playState

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -5,7 +5,7 @@ import Data.Either (Either(..))
 import Data.Lens (view)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
-import MainFrame.Lenses (_newWalletDetails, _newWalletPubKey, _templates, _subState, _wallets)
+import MainFrame.Lenses (_newWalletContractId, _newWalletNickname, _remoteDataPubKey, _templates, _subState, _wallets)
 import MainFrame.Types (Action(..), ChildSlots, State)
 import Pickup.View (renderPickupState)
 import Play.View (renderPlayState)
@@ -15,12 +15,14 @@ render state =
   let
     wallets = view _wallets state
 
-    newWalletDetails = view _newWalletDetails state
+    newWalletNickname = view _newWalletNickname state
 
-    newWalletPubKey = view _newWalletPubKey state
+    newWalletContractId = view _newWalletContractId state
+
+    remoteDataPubKey = view _remoteDataPubKey state
 
     templates = view _templates state
   in
     case view _subState state of
-      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletDetails newWalletPubKey pickupState
-      Right playState -> PlayAction <$> renderPlayState wallets newWalletDetails newWalletPubKey templates playState
+      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletNickname newWalletContractId remoteDataPubKey pickupState
+      Right playState -> PlayAction <$> renderPlayState wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState

--- a/marlowe-dashboard-client/src/Pickup/State.purs
+++ b/marlowe-dashboard-client/src/Pickup/State.purs
@@ -10,16 +10,13 @@ import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM)
-import MainFrame.Lenses (_card, _pickupState, _screen)
+import MainFrame.Lenses (_card, _pickupState)
 import MainFrame.Types (ChildSlots, Msg)
 import MainFrame.Types (Action, State) as MainFrame
-import Pickup.Types (Action(..), Screen(..), State)
+import Pickup.Types (Action(..), State)
 
 initialState :: State
-initialState =
-  { screen: GDPRScreen
-  , card: Nothing
-  }
+initialState = { card: Nothing }
 
 -- Some actions are handled in `MainFrame.State` because they involve
 -- modifications of that state. See Note [State].
@@ -28,8 +25,6 @@ handleAction ::
   MonadAff m =>
   MonadAsk Env m =>
   Action -> HalogenM MainFrame.State MainFrame.Action ChildSlots Msg m Unit
-handleAction (SetScreen screen) = assign (_pickupState <<< _screen) screen
-
 handleAction (SetCard card) = assign (_pickupState <<< _card) card
 
 -- all other actions are handled in `MainFrame.State`

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -1,6 +1,5 @@
 module Pickup.Types
   ( State
-  , Screen(..)
   , Card(..)
   , Action(..)
   ) where
@@ -8,44 +7,34 @@ module Pickup.Types
 import Prelude
 import Analytics (class IsEvent, defaultEvent)
 import Data.Maybe (Maybe(..))
-import Marlowe.Semantics (PubKey)
-import WalletData.Types (WalletNicknameKey)
+import WalletData.Types (Nickname, WalletDetails)
 
 type State
-  = { screen :: Screen
-    , card :: Maybe Card
+  = { card :: Maybe Card
     }
-
--- there's only one pickup screen at the moment, but we might need more, and
--- in any case it seems clearer to specify it explicitly
-data Screen
-  = GDPRScreen
-  | GenerateWalletScreen
-
-derive instance eqScreen :: Eq Screen
 
 data Card
   = PickupNewWalletCard
-  | PickupWalletCard WalletNicknameKey
+  | PickupWalletCard Nickname
 
 derive instance eqCard :: Eq Card
 
 data Action
-  = SetScreen Screen
-  | SetCard (Maybe Card)
+  = SetCard (Maybe Card)
   | GenerateNewWallet
   | LookupWallet String
-  | SetNewWalletNickname String
+  | SetNewWalletNickname Nickname
+  | SetNewWalletContractId String
   | PickupNewWallet
-  | PickupWallet PubKey
+  | PickupWallet WalletDetails
 
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
-  toEvent (SetScreen _) = Just $ defaultEvent "SetPickupScreen"
   toEvent (SetCard _) = Just $ defaultEvent "SetPickupCard"
   toEvent GenerateNewWallet = Just $ defaultEvent "GenerateNewWallet"
   toEvent (LookupWallet _) = Nothing
-  toEvent (SetNewWalletNickname _) = Just $ defaultEvent "SetNewWalletNickname"
+  toEvent (SetNewWalletNickname _) = Nothing
+  toEvent (SetNewWalletContractId _) = Nothing
   toEvent PickupNewWallet = Just $ defaultEvent "PickupNewWallet"
   toEvent (PickupWallet _) = Just $ defaultEvent "PickupWallet"

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -15,7 +15,7 @@ type State
 
 data Card
   = PickupNewWalletCard
-  | PickupWalletCard Nickname
+  | PickupWalletCard WalletDetails
 
 derive instance eqCard :: Eq Card
 
@@ -36,5 +36,5 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (LookupWallet _) = Nothing
   toEvent (SetNewWalletNickname _) = Nothing
   toEvent (SetNewWalletContractId _) = Nothing
-  toEvent PickupNewWallet = Just $ defaultEvent "PickupNewWallet"
+  toEvent PickupNewWallet = Just $ defaultEvent "PickupWallet"
   toEvent (PickupWallet _) = Just $ defaultEvent "PickupWallet"

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -6,37 +6,38 @@ import Css as Css
 import Data.Foldable (foldMap)
 import Data.Lens (view)
 import Data.Maybe (Maybe(..), isJust, isNothing)
-import Halogen.HTML (HTML, a, button, div, div_, footer, h1, header, hr_, input, label, main, p, span_, text)
+import Halogen.HTML (HTML, a, button, div, div_, footer, h1, header, hr_, input, label, main, p, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), disabled, for, href, id_, list, placeholder, readOnly, type_, value)
-import MainFrame.Lenses (_card, _screen)
+import MainFrame.Lenses (_card)
+import Marlowe.Semantics (PubKey)
 import Material.Icons as Icon
-import Pickup.Types (Action(..), Card(..), Screen(..), State)
+import Network.RemoteData (RemoteData)
+import Pickup.Types (Action(..), Card(..), State)
 import Prim.TypeError (class Warn, Text)
-import WalletData.Lenses (_key, _nickname)
-import WalletData.Types (WalletLibrary, WalletNicknameKey)
-import WalletData.Validation (nicknameError)
+import Servant.PureScript.Ajax (AjaxError)
+import WalletData.Lenses (_contractId, _nickname)
+import WalletData.Types (WalletDetails, WalletLibrary)
+import WalletData.Validation (contractIdError, nicknameError)
 import WalletData.View (nicknamesDataList)
 
-renderPickupState :: forall p. WalletLibrary -> WalletNicknameKey -> State -> HTML p Action
-renderPickupState wallets newWalletNicknameKey pickupState =
+renderPickupState :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> State -> HTML p Action
+renderPickupState wallets newWalletDetails newWalletPubKey pickupState =
   let
-    screen = view _screen pickupState
-
     card = view _card pickupState
   in
     div
       [ classNames [ "grid", "h-full" ] ]
       [ main
           [ classNames [ "relative" ] ]
-          [ renderPickupCard card newWalletNicknameKey wallets
-          , renderPickupScreen wallets screen
+          [ renderPickupCard wallets newWalletDetails newWalletPubKey card
+          , renderPickupScreen wallets
           ]
       ]
 
 ------------------------------------------------------------
-renderPickupCard :: forall p. Maybe Card -> WalletNicknameKey -> WalletLibrary -> HTML p Action
-renderPickupCard pickupCard newWalletNicknameKey wallets =
+renderPickupCard :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> Maybe Card -> HTML p Action
+renderPickupCard wallets newWalletDetails newWalletPubKey pickupCard =
   div
     [ classNames $ Css.cardWrapper $ isNothing pickupCard ]
     [ div
@@ -51,19 +52,21 @@ renderPickupCard pickupCard newWalletNicknameKey wallets =
             ]
         , div
             [ classNames [ "px-1", "pb-1" ] ] case pickupCard of
-            Just card -> [ pickupWalletCard card newWalletNicknameKey wallets ]
+            Just card -> [ pickupWalletCard wallets newWalletDetails newWalletPubKey card ]
             Nothing -> []
         ]
     ]
 
-pickupWalletCard :: forall p. Card -> WalletNicknameKey -> WalletLibrary -> HTML p Action
-pickupWalletCard card newWalletNicknameKey wallets =
+pickupWalletCard :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> Card -> HTML p Action
+pickupWalletCard wallets newWalletDetails newWalletPubKey card =
   let
-    nickname = view _nickname newWalletNicknameKey
+    nickname = view _nickname newWalletDetails
 
-    key = view _key newWalletNicknameKey
+    contractId = view _contractId newWalletDetails
 
     mNicknameError = nicknameError nickname wallets
+
+    mContractIdError = contractIdError contractId newWalletPubKey wallets
   in
     div_
       [ p
@@ -104,12 +107,12 @@ pickupWalletCard card newWalletNicknameKey wallets =
               [ classNames Css.nestedLabel
               , for "newWalletKey"
               ]
-              [ text "Public key" ]
+              [ text "Wallet ID" ]
           , input
               [ type_ InputText
               , classNames $ Css.input false
               , id_ "newWalletKey"
-              , value key
+              , value contractId
               , readOnly true
               ]
           ]
@@ -124,56 +127,30 @@ pickupWalletCard card newWalletNicknameKey wallets =
               [ classNames $ Css.primaryButton <> [ "flex-1" ]
               , disabled
                   $ case card of
-                      PickupNewWalletCard -> isJust mNicknameError
-                      PickupWalletCard _ -> false
+                      PickupNewWalletCard -> isJust mNicknameError || isJust mContractIdError
+                      PickupWalletCard _ -> isJust mContractIdError
               , onClick_
                   $ case card of
                       PickupNewWalletCard -> PickupNewWallet
-                      PickupWalletCard _ -> PickupWallet key
+                      PickupWalletCard _ -> PickupWallet nickname
               ]
               [ text "Pickup" ]
           ]
       ]
 
 ------------------------------------------------------------
-renderPickupScreen :: forall p. WalletLibrary -> Screen -> HTML p Action
-renderPickupScreen wallets screen =
+renderPickupScreen :: forall p. Warn (Text "We need to add the Marlowe links.") => WalletLibrary -> HTML p Action
+renderPickupScreen wallets =
   div
     [ classNames [ "absolute", "top-0", "bottom-0", "left-0", "right-0", "overflow-auto", "z-0", "flex", "flex-col", "justify-between" ] ]
     [ header
         [ classNames [ "flex" ] ]
-        [ link Icon.navigateBefore "Back to marlowe.io" "" ]
-    , case screen of
-        GDPRScreen -> gdprScreen
-        GenerateWalletScreen -> pickupWalletScreen wallets
+        [ link "marlowe.io" "" ]
+    , pickupWalletScreen wallets
     , footer
         [ classNames [ "flex" ] ]
-        [ link Icon.navigateNext "Docs" ""
-        , link Icon.navigateNext "Library" ""
-        ]
-    ]
-
-gdprScreen :: forall p. Warn (Text "We need to add the GDPR text.") => HTML p Action
-gdprScreen =
-  main
-    [ classNames [ "p-1", "w-22", "mx-auto", "text-center" ] ]
-    [ p
-        [ classNames [ "mb-1" ] ]
-        [ text "Welcome to" ]
-    , h1
-        [ classNames [ "text-2xl", "font-bold", "mb-1" ] ]
-        [ text "Marlowe" ]
-    , p
-        [ classNames [ "mb-1" ] ]
-        [ text "GDPR text - Tiramisu toffee gingerbread lemon drops jelly cake lemon drops" ]
-    , button
-        [ classNames $ Css.primaryButton <> [ "w-12", "mx-auto", "justify-between" ]
-        , onClick_ $ SetScreen GenerateWalletScreen
-        ]
-        [ span_
-            [ text "I Agree" ]
-        , span_
-            [ Icon.navigateNext ]
+        [ link "Docs" ""
+        , link "Marketplace" ""
         ]
     ]
 
@@ -207,10 +184,10 @@ pickupWalletScreen wallets =
     , nicknamesDataList wallets
     ]
 
-link :: forall p a. HTML p a -> String -> String -> HTML p a
-link icon label url =
+link :: forall p a. String -> String -> HTML p a
+link label url =
   a
     [ classNames [ "flex", "items-center", "p-0.5" ]
     , href url
     ]
-    [ icon, text label ]
+    [ text label ]

--- a/marlowe-dashboard-client/src/Play/Lenses.purs
+++ b/marlowe-dashboard-client/src/Play/Lenses.purs
@@ -1,5 +1,5 @@
 module Play.Lenses
-  ( _wallet
+  ( _walletDetails
   , _menuOpen
   , _templateState
   , _contractState
@@ -9,12 +9,12 @@ import Contract.Types (State) as Contract
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
-import Marlowe.Semantics (PubKey)
+import WalletData.Types (WalletDetails)
 import Play.Types (State)
 import Template.Types (State) as Template
 
-_wallet :: Lens' State PubKey
-_wallet = prop (SProxy :: SProxy "wallet")
+_walletDetails :: Lens' State WalletDetails
+_walletDetails = prop (SProxy :: SProxy "walletDetails")
 
 _menuOpen :: Lens' State Boolean
 _menuOpen = prop (SProxy :: SProxy "menuOpen")

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -23,16 +23,16 @@ import MainFrame.Types (Action(..), State) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
 import Marlowe.Execution (_contract)
 import Marlowe.Extended (fillTemplate, toCore)
-import Marlowe.Semantics (PubKey)
 import Play.Lenses (_contractState, _menuOpen, _templateState)
 import Play.Types (Action(..), Card(..), ContractStatus(..), Screen(..), State)
 import Template.Lenses (_extendedContract, _template, _templateContent)
 import Template.State (defaultState, handleAction, mkInitialState) as Template
 import Template.Types (Action(..), Screen(..)) as Template
+import WalletData.Types (WalletDetails)
 
-mkInitialState :: PubKey -> State
-mkInitialState pubKeyHash =
-  { wallet: pubKeyHash
+mkInitialState :: WalletDetails -> State
+mkInitialState walletDetails =
+  { walletDetails: walletDetails
   , menuOpen: false
   , screen: ContractsScreen Running
   , card: Nothing

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -31,7 +31,7 @@ derive instance eqScreen :: Eq Screen
 
 data Card
   = CreateWalletCard
-  | ViewWalletCard Nickname String
+  | ViewWalletCard WalletDetails
   | PutdownWalletCard
   | TemplateLibraryCard
   | NewContractForRoleCard

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -50,7 +50,7 @@ data Action
   = PutdownWallet
   | SetNewWalletNickname Nickname
   | SetNewWalletContractId String
-  | AddWallet WalletDetails
+  | AddNewWallet
   | ToggleMenu
   | SetScreen Screen
   | SetCard (Maybe Card)
@@ -64,7 +64,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent PutdownWallet = Just $ defaultEvent "PutdownWallet"
   toEvent (SetNewWalletNickname _) = Just $ defaultEvent "SetNewWalletNickname"
   toEvent (SetNewWalletContractId _) = Just $ defaultEvent "SetNewWalletContractId"
-  toEvent (AddWallet _) = Just $ defaultEvent "AddWallet"
+  toEvent AddNewWallet = Just $ defaultEvent "AddNewWallet"
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
   toEvent (SetScreen _) = Just $ defaultEvent "SetScreen"
   toEvent (SetCard _) = Just $ defaultEvent "SetCard"

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -10,12 +10,11 @@ import Prelude
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Contract.Types (Action, State) as Contract
 import Data.Maybe (Maybe(..))
-import Marlowe.Semantics (PubKey)
+import WalletData.Types (Nickname, WalletDetails)
 import Template.Types (Action, Screen, State) as Template
-import WalletData.Types (WalletDetails, WalletNicknameKey)
 
 type State
-  = { wallet :: PubKey
+  = { walletDetails :: WalletDetails
     , menuOpen :: Boolean
     , screen :: Screen
     , card :: Maybe Card
@@ -32,7 +31,7 @@ derive instance eqScreen :: Eq Screen
 
 data Card
   = CreateWalletCard
-  | ViewWalletCard WalletNicknameKey WalletDetails
+  | ViewWalletCard Nickname String
   | PutdownWalletCard
   | TemplateLibraryCard
   | NewContractForRoleCard
@@ -49,9 +48,9 @@ derive instance eqContractStatus :: Eq ContractStatus
 
 data Action
   = PutdownWallet
-  | SetNewWalletNickname String
-  | SetNewWalletKey PubKey
-  | AddNewWallet
+  | SetNewWalletNickname Nickname
+  | SetNewWalletContractId String
+  | AddWallet WalletDetails
   | ToggleMenu
   | SetScreen Screen
   | SetCard (Maybe Card)
@@ -64,8 +63,8 @@ data Action
 instance actionIsEvent :: IsEvent Action where
   toEvent PutdownWallet = Just $ defaultEvent "PutdownWallet"
   toEvent (SetNewWalletNickname _) = Just $ defaultEvent "SetNewWalletNickname"
-  toEvent (SetNewWalletKey _) = Just $ defaultEvent "SetNewWalletKey"
-  toEvent AddNewWallet = Just $ defaultEvent "AddNewWallet"
+  toEvent (SetNewWalletContractId _) = Just $ defaultEvent "SetNewWalletContractId"
+  toEvent (AddWallet _) = Just $ defaultEvent "AddWallet"
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
   toEvent (SetScreen _) = Just $ defaultEvent "SetScreen"
   toEvent (SetCard _) = Just $ defaultEvent "SetCard"

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -27,8 +27,8 @@ import WalletData.Lenses (_nickname)
 import WalletData.Types (Nickname, WalletDetails, WalletLibrary)
 import WalletData.View (newWalletCard, walletDetailsCard, putdownWalletCard, walletLibraryScreen)
 
-renderPlayState :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> Array Template -> State -> HTML p Action
-renderPlayState wallets newWalletDetails newWalletPubKey templates playState =
+renderPlayState :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> State -> HTML p Action
+renderPlayState wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState =
   let
     walletNickname = view (_walletDetails <<< _nickname) playState
 
@@ -37,7 +37,7 @@ renderPlayState wallets newWalletDetails newWalletPubKey templates playState =
     div
       [ classNames [ "grid", "h-full", "grid-rows-main" ] ]
       [ renderHeader walletNickname menuOpen
-      , renderMain wallets newWalletDetails newWalletPubKey templates playState
+      , renderMain wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState
       , renderFooter
       ]
 
@@ -76,8 +76,8 @@ renderHeader walletNickname menuOpen =
       ]
 
 ------------------------------------------------------------
-renderMain :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> Array Template -> State -> HTML p Action
-renderMain wallets newWalletDetails newWalletPubKey templates playState =
+renderMain :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> State -> HTML p Action
+renderMain wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState =
   let
     walletDetails = view _walletDetails playState
 
@@ -94,7 +94,7 @@ renderMain wallets newWalletDetails newWalletPubKey templates playState =
     main
       [ classNames [ "relative" ] ]
       [ renderMobileMenu menuOpen
-      , renderCards wallets newWalletDetails newWalletPubKey templates walletDetails card contractState
+      , renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates walletDetails card contractState
       , renderScreen wallets screen templateState
       ]
 
@@ -113,8 +113,8 @@ renderMobileMenu menuOpen =
         iohkLinks
     ]
 
-renderCards :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> Array Template -> WalletDetails -> Maybe Card -> Contract.State -> HTML p Action
-renderCards wallets newWalletDetails newWalletPubKey templates walletDetails card contractState =
+renderCards :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> WalletDetails -> Maybe Card -> Contract.State -> HTML p Action
+renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates walletDetails card contractState =
   div
     [ classNames $ Css.cardWrapper $ isNothing card ]
     [ div
@@ -130,7 +130,7 @@ renderCards wallets newWalletDetails newWalletPubKey templates walletDetails car
         , div
             [ classNames [ "px-1", "pb-1" ] ]
             $ (flip foldMap card) \cardType -> case cardType of
-                CreateWalletCard -> [ newWalletCard wallets newWalletDetails newWalletPubKey ]
+                CreateWalletCard -> [ newWalletCard wallets newWalletNickname newWalletContractId remoteDataPubKey ]
                 ViewWalletCard nickname contractId -> [ walletDetailsCard nickname contractId ]
                 PutdownWalletCard -> [ putdownWalletCard walletDetails ]
                 TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard templates ]

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -114,7 +114,7 @@ renderMobileMenu menuOpen =
     ]
 
 renderCards :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> WalletDetails -> Maybe Card -> Contract.State -> HTML p Action
-renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates walletDetails card contractState =
+renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates currentWalletDetails card contractState =
   div
     [ classNames $ Css.cardWrapper $ isNothing card ]
     [ div
@@ -131,8 +131,8 @@ renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templ
             [ classNames [ "px-1", "pb-1" ] ]
             $ (flip foldMap card) \cardType -> case cardType of
                 CreateWalletCard -> [ newWalletCard wallets newWalletNickname newWalletContractId remoteDataPubKey ]
-                ViewWalletCard nickname contractId -> [ walletDetailsCard nickname contractId ]
-                PutdownWalletCard -> [ putdownWalletCard walletDetails ]
+                ViewWalletCard walletDetails -> [ walletDetailsCard walletDetails ]
+                PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
                 TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard templates ]
                 NewContractForRoleCard -> []
                 ContractSetupConfirmationCard -> [ TemplateAction <$> contractSetupConfirmationCard ]

--- a/marlowe-dashboard-client/src/StaticData.purs
+++ b/marlowe-dashboard-client/src/StaticData.purs
@@ -1,12 +1,12 @@
 module StaticData
-  ( walletsLocalStorageKey
-  , walletLocalStorageKey
+  ( walletLibraryLocalStorageKey
+  , walletDetailsLocalStorageKey
   ) where
 
 import LocalStorage (Key(..))
 
-walletsLocalStorageKey :: Key
-walletsLocalStorageKey = Key "wallets"
+walletLibraryLocalStorageKey :: Key
+walletLibraryLocalStorageKey = Key "walletLibrary"
 
-walletLocalStorageKey :: Key
-walletLocalStorageKey = Key "wallet"
+walletDetailsLocalStorageKey :: Key
+walletDetailsLocalStorageKey = Key "walletDetails"

--- a/marlowe-dashboard-client/src/Template/Validation.purs
+++ b/marlowe-dashboard-client/src/Template/Validation.purs
@@ -15,9 +15,7 @@ module Template.Validation
 import Prelude
 import Data.BigInteger (BigInteger)
 import Data.Map (Map, isEmpty, mapMaybe, member)
-import Data.Map.Extra (mapIndex)
 import Data.Maybe (Maybe(..))
-import Data.Tuple (fst)
 import WalletData.Types (WalletLibrary)
 
 data RoleError
@@ -41,8 +39,8 @@ instance showParameterError :: Show ParameterError where
 roleError :: String -> WalletLibrary -> Maybe RoleError
 roleError "" _ = Just EmptyNickname
 
-roleError nickname wallets =
-  if member nickname $ mapIndex fst wallets then
+roleError nickname library =
+  if member nickname library then
     Nothing
   else
     Just NonExistentNickname

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -250,7 +250,7 @@ templateLibraryCard templates =
               , onClick_ $ SetTemplate template
               ]
               [ span_ [ text "Setup" ]
-              , span_ [ Icon.navigateNext ]
+              , span_ [ Icon.rightArrow ]
               ]
           ]
       , p_

--- a/marlowe-dashboard-client/src/WalletData/Lenses.purs
+++ b/marlowe-dashboard-client/src/WalletData/Lenses.purs
@@ -1,21 +1,26 @@
 module WalletData.Lenses
   ( _nickname
-  , _key
-  , _userHasPickedUp
+  , _contractId
+  , _balance
+  , _pubKey
   ) where
 
 import Data.Lens (Lens')
-import Data.Lens.Lens.Tuple (_1, _2)
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
-import Marlowe.Semantics (PubKey)
-import WalletData.Types (WalletDetails, WalletNicknameKey)
+import Marlowe.Semantics (Assets, PubKey)
+import Network.RemoteData (RemoteData)
+import Servant.PureScript.Ajax (AjaxError)
+import WalletData.Types (Nickname, WalletDetails)
 
-_nickname :: Lens' WalletNicknameKey String
-_nickname = _1
+_nickname :: Lens' WalletDetails Nickname
+_nickname = prop (SProxy :: SProxy "nickname")
 
-_key :: Lens' WalletNicknameKey PubKey
-_key = _2
+_pubKey :: Lens' WalletDetails PubKey
+_pubKey = prop (SProxy :: SProxy "pubKey")
 
-_userHasPickedUp :: Lens' WalletDetails Boolean
-_userHasPickedUp = prop (SProxy :: SProxy "userHasPickedUp")
+_contractId :: forall r. Lens' { contractId :: String | r } String
+_contractId = prop (SProxy :: SProxy "contractId")
+
+_balance :: Lens' WalletDetails (RemoteData AjaxError (Array Assets))
+_balance = prop (SProxy :: SProxy "balance")

--- a/marlowe-dashboard-client/src/WalletData/Lenses.purs
+++ b/marlowe-dashboard-client/src/WalletData/Lenses.purs
@@ -7,10 +7,9 @@ module WalletData.Lenses
 
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
+import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
 import Marlowe.Semantics (Assets, PubKey)
-import Network.RemoteData (RemoteData)
-import Servant.PureScript.Ajax (AjaxError)
 import WalletData.Types (Nickname, WalletDetails)
 
 _nickname :: Lens' WalletDetails Nickname
@@ -22,5 +21,5 @@ _pubKey = prop (SProxy :: SProxy "pubKey")
 _contractId :: forall r. Lens' { contractId :: String | r } String
 _contractId = prop (SProxy :: SProxy "contractId")
 
-_balance :: Lens' WalletDetails (RemoteData AjaxError (Array Assets))
+_balance :: Lens' WalletDetails (Maybe (Array Assets))
 _balance = prop (SProxy :: SProxy "balance")

--- a/marlowe-dashboard-client/src/WalletData/Types.purs
+++ b/marlowe-dashboard-client/src/WalletData/Types.purs
@@ -5,9 +5,8 @@ module WalletData.Types
   ) where
 
 import Data.Map (Map)
+import Data.Maybe (Maybe)
 import Marlowe.Semantics (Assets, PubKey)
-import Network.RemoteData (RemoteData)
-import Servant.PureScript.Ajax (AjaxError)
 
 type WalletLibrary
   = Map Nickname WalletDetails
@@ -19,5 +18,5 @@ type WalletDetails
   = { nickname :: Nickname
     , contractId :: String
     , pubKey :: PubKey
-    , balance :: RemoteData AjaxError (Array Assets)
+    , balance :: Maybe (Array Assets)
     }

--- a/marlowe-dashboard-client/src/WalletData/Types.purs
+++ b/marlowe-dashboard-client/src/WalletData/Types.purs
@@ -1,20 +1,23 @@
 module WalletData.Types
   ( WalletLibrary
-  , WalletNicknameKey
+  , Nickname
   , WalletDetails
   ) where
 
-import Data.Tuple (Tuple)
 import Data.Map (Map)
-import Marlowe.Semantics (PubKey)
+import Marlowe.Semantics (Assets, PubKey)
+import Network.RemoteData (RemoteData)
+import Servant.PureScript.Ajax (AjaxError)
 
 type WalletLibrary
-  = Map WalletNicknameKey WalletDetails
+  = Map Nickname WalletDetails
 
--- make the nickname (string) the first key so we get alphabetical ordering for free
-type WalletNicknameKey
-  = Tuple String PubKey
+type Nickname
+  = String
 
 type WalletDetails
-  = { userHasPickedUp :: Boolean
+  = { nickname :: Nickname
+    , contractId :: String
+    , pubKey :: PubKey
+    , balance :: RemoteData AjaxError (Array Assets)
     }

--- a/marlowe-dashboard-client/src/WalletData/Validation.purs
+++ b/marlowe-dashboard-client/src/WalletData/Validation.purs
@@ -52,9 +52,7 @@ contractIdError "" _ _ = Just EmptyContractId
 contractIdError contractId pubKey library =
   if not $ isEmpty $ filter (\walletDetails -> walletDetails.contractId == contractId) library then
     Just DuplicateContractId
-  else
-    case pubKey of
-      Success _ -> Nothing
-      Failure _ -> Just NonexistentContractId
-      _ -> Just UnconfirmedContractId
-
+  else case pubKey of
+    Success _ -> Nothing
+    Failure _ -> Just NonexistentContractId
+    _ -> Just UnconfirmedContractId

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -12,30 +12,31 @@ import Css as Css
 import Data.Foldable (foldMap)
 import Data.Lens (view)
 import Data.Map (isEmpty, toUnfoldable)
-import Data.Map.Extra (findIndex)
 import Data.Maybe (Maybe(..), isJust)
 import Data.String (null)
-import Data.Tuple (Tuple(..), fst, snd)
+import Data.Tuple (Tuple(..))
 import Halogen.HTML (HTML, button, datalist, div, div_, h2, h3, input, label, li, option, p, p_, span, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), disabled, id_, placeholder, readOnly, type_, value)
 import Marlowe.Semantics (PubKey)
 import Material.Icons as Icon
+import Network.RemoteData (RemoteData)
 import Play.Types (Action(..), Card(..))
-import WalletData.Lenses (_key, _nickname)
-import WalletData.Types (WalletDetails, WalletLibrary, WalletNicknameKey)
-import WalletData.Validation (keyError, nicknameError)
+import Servant.PureScript.Ajax (AjaxError)
+import WalletData.Lenses (_contractId, _nickname)
+import WalletData.Types (Nickname, WalletDetails, WalletLibrary)
+import WalletData.Validation (contractIdError, nicknameError)
 
-newWalletCard :: forall p. WalletNicknameKey -> WalletLibrary -> HTML p Action
-newWalletCard newWalletNicknameKey wallets =
+newWalletCard :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> HTML p Action
+newWalletCard library newWalletDetails newWalletPubKey =
   let
-    nickname = view _nickname newWalletNicknameKey
+    nickname = view _nickname newWalletDetails
 
-    key = view _key newWalletNicknameKey
+    contractId = view _contractId newWalletDetails
 
-    mNicknameError = nicknameError nickname wallets
+    mNicknameError = nicknameError nickname library
 
-    mKeyError = keyError key wallets
+    mContractIdError = contractIdError contractId newWalletPubKey library
   in
     div
       [ classNames [ "flex", "flex-col" ] ]
@@ -46,7 +47,7 @@ newWalletCard newWalletNicknameKey wallets =
           [ classNames $ [ "mb-1" ] <> (applyWhen (not null nickname) Css.hasNestedLabel) ]
           [ label
               [ classNames $ Css.nestedLabel <> hideWhen (null nickname) ]
-              [ text "Nickname:" ]
+              [ text "Nickname" ]
           , input
               [ type_ InputText
               , classNames $ Css.input $ isJust mNicknameError
@@ -59,20 +60,20 @@ newWalletCard newWalletNicknameKey wallets =
               [ text $ foldMap show mNicknameError ]
           ]
       , div
-          [ classNames $ [ "mb-1" ] <> (applyWhen (not null key) Css.hasNestedLabel) ]
+          [ classNames $ [ "mb-1" ] <> (applyWhen (not null contractId) Css.hasNestedLabel) ]
           [ label
-              [ classNames $ Css.nestedLabel <> hideWhen (null key) ]
-              [ text "Public key:" ]
+              [ classNames $ Css.nestedLabel <> hideWhen (null contractId) ]
+              [ text "Wallet ID" ]
           , input
               [ type_ InputText
-              , classNames $ Css.input $ isJust mKeyError
-              , placeholder "Public key"
-              , value key
-              , onValueInput_ SetNewWalletKey
+              , classNames $ Css.input $ isJust mContractIdError
+              , placeholder "Wallet ID"
+              , value contractId
+              , onValueInput_ SetNewWalletContractId
               ]
           , div
               [ classNames Css.inputError ]
-              [ text $ foldMap show mKeyError ]
+              [ text $ foldMap show mContractIdError ]
           ]
       , div
           [ classNames [ "flex" ] ]
@@ -83,90 +84,78 @@ newWalletCard newWalletNicknameKey wallets =
               [ text "Cancel" ]
           , button
               [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , disabled $ isJust mKeyError || isJust mNicknameError
+              , disabled $ isJust mNicknameError || isJust mContractIdError
               , onClick_ AddNewWallet
               ]
               [ text "Save" ]
           ]
       ]
 
-walletDetailsCard :: forall p a. WalletNicknameKey -> WalletDetails -> HTML p a
-walletDetailsCard walletNicknameKey walletDetails =
-  let
-    nickname = view _nickname walletNicknameKey
+walletDetailsCard :: forall p a. Nickname -> String -> HTML p a
+walletDetailsCard nickname contractId =
+  div_
+    [ h3
+        [ classNames [ "font-bold", "mb-1" ] ]
+        [ text $ "Wallet " <> nickname ]
+    , div
+        [ classNames Css.hasNestedLabel ]
+        [ label
+            [ classNames Css.nestedLabel ]
+            [ text "Wallet ID" ]
+        , input
+            [ type_ InputText
+            , classNames $ Css.input false <> [ "mb-1" ]
+            , value contractId
+            , readOnly true
+            ]
+        ]
+    ]
 
-    key = view _key walletNicknameKey
-  in
-    div_
-      [ h3
-          [ classNames [ "font-bold", "mb-1" ] ]
-          [ text $ "Wallet " <> nickname ]
-      , div
-          [ classNames Css.hasNestedLabel ]
-          [ label
-              [ classNames Css.nestedLabel ]
-              [ text "Public key" ]
-          , input
-              [ type_ InputText
-              , classNames $ Css.input false <> [ "mb-1" ]
-              , value key
-              , readOnly true
-              ]
-          ]
-      ]
-
-putdownWalletCard :: forall p. PubKey -> WalletLibrary -> HTML p Action
-putdownWalletCard pubKeyHash wallets =
-  let
-    mKey = findIndex (\key -> snd key == pubKeyHash) wallets
-
-    mNickname = map fst mKey
-
-    showNickname = foldMap (append " ") mNickname
-  in
-    div_
-      [ h3
-          [ classNames [ "font-bold", "mb-1" ] ]
-          [ text $ "Wallet" <> showNickname ]
-      , div
-          [ classNames Css.hasNestedLabel ]
-          [ label
-              [ classNames Css.nestedLabel ]
-              [ text "Public key" ]
-          , input
-              [ type_ InputText
-              , classNames $ Css.input false <> [ "mb-1" ]
-              , value pubKeyHash
-              , readOnly true
-              ]
-          ]
-      , div
-          [ classNames [ "flex" ] ]
-          [ button
-              [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-1" ]
-              , onClick_ $ SetCard Nothing
-              ]
-              [ text "Cancel" ]
-          , button
-              [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , onClick_ PutdownWallet
-              ]
-              [ text "Drop wallet" ]
-          ]
-      ]
+putdownWalletCard :: forall p. WalletDetails -> HTML p Action
+putdownWalletCard walletDetails =
+  div_
+    [ h3
+        [ classNames [ "font-bold", "mb-1" ] ]
+        [ text $ "Wallet " <> view _nickname walletDetails ]
+    , div
+        [ classNames Css.hasNestedLabel ]
+        [ label
+            [ classNames Css.nestedLabel ]
+            [ text "Wallet ID" ]
+        , input
+            [ type_ InputText
+            , classNames $ Css.input false <> [ "mb-1" ]
+            , value $ view _contractId walletDetails
+            , readOnly true
+            ]
+        ]
+    , div
+        [ classNames [ "flex" ] ]
+        [ button
+            [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-1" ]
+            , onClick_ $ SetCard Nothing
+            ]
+            [ text "Cancel" ]
+        , button
+            [ classNames $ Css.primaryButton <> [ "flex-1" ]
+            , onClick_ PutdownWallet
+            ]
+            [ text "Drop wallet" ]
+        ]
+    ]
 
 walletLibraryScreen :: forall p. WalletLibrary -> HTML p Action
-walletLibraryScreen wallets =
+walletLibraryScreen library =
   div_
     [ h2
         [ classNames [ "font-bold", "mb-1" ] ]
         [ text "Contacts" ]
-    , if isEmpty wallets then
+    , if isEmpty library then
         p_ [ text "You do not have any contacts." ]
       else
         ul_
           $ contactLi
-          <$> toUnfoldable wallets
+          <$> toUnfoldable library
     , button
         [ classNames Css.fixedPrimaryButton
         , onClick_ $ ToggleCard CreateWalletCard
@@ -174,22 +163,25 @@ walletLibraryScreen wallets =
         [ span
             [ classNames [ "mr-0.5" ] ]
             [ text "New contact" ]
-        , Icon.personAdd
+        , Icon.add
         ]
     ]
   where
-  contactLi (Tuple localWalletKey@(Tuple nickname key) localWallet) =
-    li
-      [ classNames [ "mt-1", "hover:cursor-pointer", "hover:text-green" ]
-      , onClick_ $ ToggleCard $ ViewWalletCard localWalletKey localWallet
-      ]
-      [ text nickname ]
+  contactLi (Tuple nickname walletDetails) =
+    let
+      contractId = view _contractId walletDetails
+    in
+      li
+        [ classNames [ "mt-1", "hover:cursor-pointer", "hover:text-green" ]
+        , onClick_ $ ToggleCard $ ViewWalletCard nickname contractId
+        ]
+        [ text nickname ]
 
 nicknamesDataList :: forall p a. WalletLibrary -> HTML p a
-nicknamesDataList wallets =
+nicknamesDataList library =
   datalist
     [ id_ "walletNicknames" ]
     $ walletOption
-    <$> toUnfoldable wallets
+    <$> toUnfoldable library
   where
-  walletOption (Tuple (Tuple nickname _) _) = option [ value nickname ] []
+  walletOption (Tuple nickname _) = option [ value nickname ] []

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -87,58 +87,68 @@ newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey =
           ]
       ]
 
-walletDetailsCard :: forall p a. Nickname -> String -> HTML p a
-walletDetailsCard nickname contractId =
-  div_
-    [ h3
-        [ classNames [ "font-bold", "mb-1" ] ]
-        [ text $ "Wallet " <> nickname ]
-    , div
-        [ classNames Css.hasNestedLabel ]
-        [ label
-            [ classNames Css.nestedLabel ]
-            [ text "Wallet ID" ]
-        , input
-            [ type_ InputText
-            , classNames $ Css.input false <> [ "mb-1" ]
-            , value contractId
-            , readOnly true
-            ]
-        ]
-    ]
+walletDetailsCard :: forall p a. WalletDetails -> HTML p a
+walletDetailsCard walletDetails =
+  let
+    nickname = view _nickname walletDetails
+
+    contractId = view _contractId walletDetails
+  in
+    div_
+      [ h3
+          [ classNames [ "font-bold", "mb-1" ] ]
+          [ text $ "Wallet " <> nickname ]
+      , div
+          [ classNames Css.hasNestedLabel ]
+          [ label
+              [ classNames Css.nestedLabel ]
+              [ text "Wallet ID" ]
+          , input
+              [ type_ InputText
+              , classNames $ Css.input false <> [ "mb-1" ]
+              , value contractId
+              , readOnly true
+              ]
+          ]
+      ]
 
 putdownWalletCard :: forall p. WalletDetails -> HTML p Action
 putdownWalletCard walletDetails =
-  div_
-    [ h3
-        [ classNames [ "font-bold", "mb-1" ] ]
-        [ text $ "Wallet " <> view _nickname walletDetails ]
-    , div
-        [ classNames Css.hasNestedLabel ]
-        [ label
-            [ classNames Css.nestedLabel ]
-            [ text "Wallet ID" ]
-        , input
-            [ type_ InputText
-            , classNames $ Css.input false <> [ "mb-1" ]
-            , value $ view _contractId walletDetails
-            , readOnly true
-            ]
-        ]
-    , div
-        [ classNames [ "flex" ] ]
-        [ button
-            [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-1" ]
-            , onClick_ $ SetCard Nothing
-            ]
-            [ text "Cancel" ]
-        , button
-            [ classNames $ Css.primaryButton <> [ "flex-1" ]
-            , onClick_ PutdownWallet
-            ]
-            [ text "Drop wallet" ]
-        ]
-    ]
+  let
+    nickname = view _nickname walletDetails
+
+    contractId = view _contractId walletDetails
+  in
+    div_
+      [ h3
+          [ classNames [ "font-bold", "mb-1" ] ]
+          [ text $ "Wallet " <> nickname ]
+      , div
+          [ classNames Css.hasNestedLabel ]
+          [ label
+              [ classNames Css.nestedLabel ]
+              [ text "Wallet ID" ]
+          , input
+              [ type_ InputText
+              , classNames $ Css.input false <> [ "mb-1" ]
+              , value contractId
+              , readOnly true
+              ]
+          ]
+      , div
+          [ classNames [ "flex" ] ]
+          [ button
+              [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-1" ]
+              , onClick_ $ SetCard Nothing
+              ]
+              [ text "Cancel" ]
+          , button
+              [ classNames $ Css.primaryButton <> [ "flex-1" ]
+              , onClick_ PutdownWallet
+              ]
+              [ text "Drop wallet" ]
+          ]
+      ]
 
 walletLibraryScreen :: forall p. WalletLibrary -> HTML p Action
 walletLibraryScreen library =
@@ -169,7 +179,7 @@ walletLibraryScreen library =
     in
       li
         [ classNames [ "mt-1", "hover:cursor-pointer", "hover:text-green" ]
-        , onClick_ $ ToggleCard $ ViewWalletCard nickname contractId
+        , onClick_ $ ToggleCard $ ViewWalletCard walletDetails
         ]
         [ text nickname ]
 

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -27,16 +27,12 @@ import WalletData.Lenses (_contractId, _nickname)
 import WalletData.Types (Nickname, WalletDetails, WalletLibrary)
 import WalletData.Validation (contractIdError, nicknameError)
 
-newWalletCard :: forall p. WalletLibrary -> WalletDetails -> RemoteData AjaxError PubKey -> HTML p Action
-newWalletCard library newWalletDetails newWalletPubKey =
+newWalletCard :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> HTML p Action
+newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey =
   let
-    nickname = view _nickname newWalletDetails
+    mNicknameError = nicknameError newWalletNickname library
 
-    contractId = view _contractId newWalletDetails
-
-    mNicknameError = nicknameError nickname library
-
-    mContractIdError = contractIdError contractId newWalletPubKey library
+    mContractIdError = contractIdError newWalletContractId remoteDataPubKey library
   in
     div
       [ classNames [ "flex", "flex-col" ] ]
@@ -44,15 +40,15 @@ newWalletCard library newWalletDetails newWalletPubKey =
           [ classNames [ "mb-1" ] ]
           [ text "Create new contact" ]
       , div
-          [ classNames $ [ "mb-1" ] <> (applyWhen (not null nickname) Css.hasNestedLabel) ]
+          [ classNames $ [ "mb-1" ] <> (applyWhen (not null newWalletNickname) Css.hasNestedLabel) ]
           [ label
-              [ classNames $ Css.nestedLabel <> hideWhen (null nickname) ]
+              [ classNames $ Css.nestedLabel <> hideWhen (null newWalletNickname) ]
               [ text "Nickname" ]
           , input
               [ type_ InputText
               , classNames $ Css.input $ isJust mNicknameError
               , placeholder "Nickname"
-              , value nickname
+              , value newWalletNickname
               , onValueInput_ SetNewWalletNickname
               ]
           , div
@@ -60,15 +56,15 @@ newWalletCard library newWalletDetails newWalletPubKey =
               [ text $ foldMap show mNicknameError ]
           ]
       , div
-          [ classNames $ [ "mb-1" ] <> (applyWhen (not null contractId) Css.hasNestedLabel) ]
+          [ classNames $ [ "mb-1" ] <> (applyWhen (not null newWalletContractId) Css.hasNestedLabel) ]
           [ label
-              [ classNames $ Css.nestedLabel <> hideWhen (null contractId) ]
+              [ classNames $ Css.nestedLabel <> hideWhen (null newWalletContractId) ]
               [ text "Wallet ID" ]
           , input
               [ type_ InputText
               , classNames $ Css.input $ isJust mContractIdError
               , placeholder "Wallet ID"
-              , value contractId
+              , value newWalletContractId
               , onValueInput_ SetNewWalletContractId
               ]
           , div
@@ -85,7 +81,7 @@ newWalletCard library newWalletDetails newWalletPubKey =
           , button
               [ classNames $ Css.primaryButton <> [ "flex-1" ]
               , disabled $ isJust mNicknameError || isJust mContractIdError
-              , onClick_ AddNewWallet
+              , onClick_ $ AddNewWallet
               ]
               [ text "Save" ]
           ]


### PR DESCRIPTION
The original plan was to identify wallets by their public key. But in discussions earlier this week we realised we were going to need a "wallet companion" contract running for each wallet (listening for changes to that wallet in advance of other contracts being started). The ID of this companion contract is what will primarily be used to identify wallets on the frontend, but we still need the public key as well. This PR changes the data model and the wallet generation/pickup workflow accordingly.

While I was at it, I removed the GDPR screen (since it's been confirmed we don't need this) and tidied up the icons based on the new designs.

