### PR TITLE
Avoid crashing when the FE can’t connect to the web socket

### DIFF
--- a/marlowe-dashboard-client/webpack.config.js
+++ b/marlowe-dashboard-client/webpack.config.js
@@ -34,7 +34,10 @@ module.exports = {
             },
             "/ws": {
                 target: 'ws://localhost:8080',
-                ws: true
+                ws: true,
+                onError(err) {
+                  console.log('Error with the WebSocket:', err);
+                }
             }
         }
     },

--- a/plutus-pab-client/webpack.config.js
+++ b/plutus-pab-client/webpack.config.js
@@ -36,7 +36,10 @@ module.exports = {
             },
             "/ws": {
                 target: 'ws://localhost:8080',
-                ws: true
+                ws: true,
+                onError(err) {
+                  console.log('Error with the WebSocket:', err);
+                }
             }
         }
     },


### PR DESCRIPTION
This PR fixes the dashboard client webpack configuration so that it doesn't crash if it has a problem with the web socket.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
