### PR TITLE
Adding in fine-grined Segment Event tracking.

### DIFF
--- a/plutus-playground-client/package-lock.json
+++ b/plutus-playground-client/package-lock.json
@@ -568,6 +568,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2215,6 +2224,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -6408,6 +6423,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -6748,6 +6764,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/web-common/src/Analytics.js
+++ b/web-common/src/Analytics.js
@@ -1,11 +1,21 @@
 /*eslint-env node*/
-/*global exports gtag*/
+/*global exports gtag, analytics*/
 'use strict';
 
 exports.trackEvent_ = function (action, category, label, value) {
-    gtag('event', action, {
-        'event_category': category,
-        'event_label': label,
-        'value': value
-    });
+    // Google Analytics, the default.
+    if (gtag) {
+        gtag('event', action, {
+            'event_category': category,
+            'event_label': label,
+            'value': value
+        });
+    };
+};
+
+exports.trackSegmentEvent_ = function (action, payload) {
+    // Segment.com.
+    if (analytics) {
+        analytics.track(action, payload);
+    };
 };

--- a/web-common/src/Analytics.purs
+++ b/web-common/src/Analytics.purs
@@ -1,6 +1,6 @@
 module Analytics
-  ( trackEvent
-  , Event
+  ( Event
+  , SegmentEvent
   , defaultEvent
   , class IsEvent
   , toEvent
@@ -9,19 +9,32 @@ module Analytics
 
 import Prelude
 import Data.Maybe (Maybe(..))
+import Data.Traversable (for_)
+import Data.Tuple.Nested ((/\))
 import Data.Undefinable (Undefinable, toUndefinable)
-import Data.Unit (Unit)
 import Effect (Effect)
-import Effect.Uncurried (EffectFn4, runEffectFn4)
+import Effect.Uncurried (EffectFn2, EffectFn4, runEffectFn2, runEffectFn4)
+import Foreign (Foreign, unsafeToForeign)
+import Foreign.NullOrUndefined (null)
+import Foreign.Object (Object)
+import Foreign.Object as Object
 
 foreign import trackEvent_ ::
   EffectFn4 String (Undefinable String) (Undefinable String) (Undefinable Number) Unit
+
+foreign import trackSegmentEvent_ ::
+  EffectFn2 String (Object Foreign) Unit
 
 type Event
   = { action :: String
     , category :: Maybe String
     , label :: Maybe String
     , value :: Maybe Number
+    }
+
+type SegmentEvent
+  = { action :: String
+    , payload :: Object Foreign
     }
 
 defaultEvent :: String -> Event
@@ -40,11 +53,47 @@ trackEvent { action, category, label, value } =
     (toUndefinable label)
     (toUndefinable value)
 
+trackSegmentEvent :: SegmentEvent -> Effect Unit
+trackSegmentEvent { action, payload } = runEffectFn2 trackSegmentEvent_ action payload
+
 class IsEvent a where
   toEvent :: a -> Maybe Event
 
+toSegmentEvent :: Event -> SegmentEvent
+toSegmentEvent { action, category, label, value } =
+  { action
+  , payload:
+      Object.fromFoldable
+        [ "category" /\ toForeign category
+        , "label" /\ toForeign label
+        , "value" /\ toForeign value
+        ]
+  }
+
 analyticsTracking :: forall a. IsEvent a => a -> Effect Unit
 analyticsTracking action = do
-  case toEvent action of
-    Nothing -> pure unit
-    Just event -> trackEvent event
+  for_ (toEvent action)
+    $ \event -> do
+        trackEvent event
+        trackSegmentEvent $ toSegmentEvent event
+
+------------------------------------------------------------
+-- This `IsForeign` code only exists because we need to use
+-- `unsafeToForeign`, but we want to limit it to types we know are safe.
+--
+-- As the docs say, "[unsafeToForeign] is considered unsafe as it's
+-- only intended to be used on primitive JavaScript types, rather than
+-- PureScript types." So it's safe as long as you use it on the right
+-- types.
+class IsForeign a where
+  toForeign :: a -> Foreign
+
+instance toForeignMaybe :: IsForeign a => IsForeign (Maybe a) where
+  toForeign Nothing = null
+  toForeign (Just x) = toForeign x
+
+instance toForeignString :: IsForeign String where
+  toForeign = unsafeToForeign
+
+instance toForeignNumber :: IsForeign Number where
+  toForeign = unsafeToForeign


### PR DESCRIPTION
I've taken the low-maintenance approach for this, by
keeping the way we track invididual events to Google Analytics, and then
massaging that data into Segment's shape.

An obvious alternative would be to have a second set of events (and
maybe even a second typeclass), which represents something more
bespoke, but keeping two descriptions of analytics events seems like
more of a maintenance problem than it's worth.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge