### PR TITLE
Updating the Marlowe dashboard README and adding some useful PAB nix scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ pkgs/.stack
 **/.spago2nix/
 
 # Backend config files
+marlowe-dashboard-client/plutus-pab.yaml
 marlowe-playground-server/playground.yaml
 plutus-playground-server/playground.yaml
 plutus-pab/plutus-pab.yaml

--- a/default.nix
+++ b/default.nix
@@ -78,7 +78,6 @@ rec {
     }) client;
   };
 
-
   plutus-pab = pkgs.recurseIntoAttrs (pkgs.callPackage ./plutus-pab-client {
     inherit (plutus.lib) buildPursPackage buildNodeModules gitignore-nix filterNpm;
     inherit set-git-rev haskell webCommon webCommonPlutus;

--- a/marlowe-dashboard-client/README.md
+++ b/marlowe-dashboard-client/README.md
@@ -8,12 +8,19 @@ The Marlowe Dashboard is written in [PureScript](https://www.purescript.org/) an
 
 ### Starting the backend server
 
+The Marlowe Dashboard requires a running instance of the PAB to work. First you need to set up the database:
+
 ```bash
-$ marlowe-dashboard-server
+$ plutus-pab-migrate
 ```
 
-The `marlowe-dashboard-server` script is provided by the global [shell.nix](../shell.nix) and starts the server (If the command
-is not available make sure you are in a nix-shell session or that lorri is ready). For additional information on invoking the backend server please refer to its [README.md](https://github.com/input-output-hk/plutus/blob/master/marlowe-dashboard-server/README.md).
+Then start all the PAB servers:
+
+```bash
+$ plutus-pab-all-servers
+```
+
+The `plutus-pab-migrate` and `plutus-pab-all-servers` scripts are provided by the global [shell.nix](../shell.nix). (If the commands are not available make sure you are in a nix-shell session or that lorri is ready.) For additional information on invoking the PAB please refer to its [README.md](https://github.com/input-output-hk/plutus/blob/master/plutus-pab/README.md).
 
 ### Starting the frontend server
 

--- a/marlowe-dashboard-client/plutus-pab.yaml
+++ b/marlowe-dashboard-client/plutus-pab.yaml
@@ -3,16 +3,16 @@ dbConfig:
     dbConfigPoolSize: 20
 
 pabWebserverConfig:
-  baseUrl: http://localhost:8080
+  baseUrl: http://localhost:9080
   staticDir: plutus-pab-client/dist
 
 walletServerConfig:
-  baseUrl: http://localhost:8081
+  baseUrl: http://localhost:9081
   wallet:
     getWallet: 1
 
 nodeServerConfig:
-  mscBaseUrl: http://localhost:8082
+  mscBaseUrl: http://localhost:9082
   mscSocketPath: ./node-server.sock
   mscSlotLength: 5
   mscRandomTxInterval: 20
@@ -25,21 +25,21 @@ nodeServerConfig:
     - getWallet: 3
 
 chainIndexConfig:
-  ciBaseUrl: http://localhost:8083
+  ciBaseUrl: http://localhost:9083
   ciWatchedAddresses: []
 
 requestProcessingConfig:
   requestProcessingInterval: 1
 
 signingProcessConfig:
-  spBaseUrl: http://localhost:8084
+  spBaseUrl: http://localhost:9084
   spWallet:
     getWallet: 1
 
 metadataServerConfig:
-  mdBaseUrl: http://localhost:8085
+  mdBaseUrl: http://localhost:9085
 
 # Optional EKG Server Config
 # ----
 # monitoringConfig:
-#   monitoringPort: 8090
+#   monitoringPort: 9090

--- a/marlowe-dashboard-client/webpack.config.js
+++ b/marlowe-dashboard-client/webpack.config.js
@@ -30,10 +30,10 @@ module.exports = {
         https: true,
         proxy: {
             "/api": {
-                target: 'http://localhost:8080'
+                target: 'http://localhost:9080'
             },
             "/ws": {
-                target: 'ws://localhost:8080',
+                target: 'ws://localhost:9080',
                 ws: true,
                 onError(err) {
                   console.log('Error with the WebSocket:', err);

--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -17,17 +17,31 @@ let
   '';
 
   # For dev usage
+  migrate = pkgs.writeShellScriptBin "plutus-pab-migrate" ''
+    # There might be local modifications so only copy when missing
+    ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab migrate
+  '';
+
+  # For dev usage
   start-backend = pkgs.writeShellScriptBin "plutus-pab-server" ''
     export FRONTEND_URL=https://localhost:8009
     export WEBGHC_URL=http://localhost:8080
-    rm -rf ./generated
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab webserver
   '';
 
-  cleanSrc = gitignore-nix.gitignoreSource ./.;
+  # For dev usage
+  start-all-servers = pkgs.writeShellScriptBin "plutus-pab-all-servers" ''
+    export FRONTEND_URL=https://localhost:8009
+    export WEBGHC_URL=http://localhost:8080
+    # There might be local modifications so only copy when missing
+    ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab all-servers
+  '';
 
+  cleanSrc = gitignore-nix.gitignoreSource ./.;
 
   nodeModules = buildNodeModules {
     projectDir = filterNpm cleanSrc;
@@ -63,5 +77,5 @@ let
 
 in
 {
-  inherit client demo-scripts server-invoker generated-purescript generate-purescript start-backend mkConf pab-exes;
+  inherit client demo-scripts server-invoker generated-purescript generate-purescript migrate start-backend start-all-servers mkConf pab-exes;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -67,13 +67,14 @@ let
     haskell-language-server
     hie-bios
     hlint
-    marlowe-dashboard.generate-purescript
     marlowe-playground.generate-purescript
     marlowe-playground.start-backend
     plutus-playground.generate-purescript
     plutus-playground.start-backend
     plutus-pab.generate-purescript
+    plutus-pab.migrate
     plutus-pab.start-backend
+    plutus-pab.start-all-servers
     purs
     purty
     spago


### PR DESCRIPTION
This PR adds two new nix scripts to the PAB: one to migrate the database, and another to start all servers.

It also updates the Marlowe Dashboard README, with instructions to invoke these to get the backend up and running easily.