### PR TITLE
Replace raiseEndN's with general raiseEnd

### DIFF
--- a/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
+++ b/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
@@ -58,6 +58,10 @@ inserting effects at the *end* of the list is tricky.
 
 I have no idea what I'm doing, these are partially stolen from freer-simple/polysemy
 with a lot of hacking around.
+
+The first instance of CanWeakenEnd is for the case where the fixed list has length 1.
+The second instance is for cases where the fixed list has a length of 2 or more,
+hence the double cons in the types to prevent overlap with the first instance.
 -}
 class CanWeakenEnd as effs where
     weakenEnd :: Union as ~> Union effs

--- a/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
+++ b/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
@@ -1,56 +1,24 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE Rank2Types          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Rank2Types            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 module Control.Monad.Freer.Extras.Modify (
     -- * weaken functions
-    weakenEnd
-    , weakenEnd2
-    , weakenEnd3
-    , weakenEnd4
-    , weakenEnd5
-    , weakenEnd6
-    , weakenEnd7
-    , weakenEnd8
-    , weakenEnd9
-    , weakenEnd10
-    , weakenEnd11
-    , weakenEnd12
-    , weakenEnd13
-    , weakenEnd14
-    , weakenEnd15
-    , weakenEnd16
-    , weakenEnd17
-    , weakenEnd18
+    CanWeakenEnd(..)
     , weakenUnder
     , weakenUnderN
 
     -- * raise functions
     , raiseEnd
-    , raiseEnd2
-    , raiseEnd3
-    , raiseEnd4
-    , raiseEnd5
-    , raiseEnd6
-    , raiseEnd7
-    , raiseEnd8
-    , raiseEnd9
-    , raiseEnd10
-    , raiseEnd11
-    , raiseEnd12
-    , raiseEnd13
-    , raiseEnd14
-    , raiseEnd15
-    , raiseEnd16
-    , raiseEnd17
-    , raiseEnd18
     , raiseUnder
     , raiseUnder2
     , raiseUnderN
@@ -91,95 +59,14 @@ inserting effects at the *end* of the list is tricky.
 I have no idea what I'm doing, these are partially stolen from freer-simple/polysemy
 with a lot of hacking around.
 -}
-
-
-weakenEnd :: forall effs a . Union '[a] ~> Union (a ': effs)
-weakenEnd u = inj (extract u)
-
-weakenEnd2 :: forall effs a b . Union '[a, b] ~> Union (a ': b ': effs)
-weakenEnd2 u = case decomp u of
-    Left u' -> weaken $ weakenEnd u'
-    Right t -> inj t
-
-weakenEnd3 :: forall effs a b c . Union '[a, b, c] ~> Union (a ': b ': c ': effs)
-weakenEnd3 u = case decomp u of
-    Left u' -> weaken $ weakenEnd2 u'
-    Right t -> inj t
-
-weakenEnd4 :: forall effs a b c d. Union '[a, b, c, d] ~> Union (a ': b ': c ': d ': effs)
-weakenEnd4 u = case decomp u of
-    Left u' -> weaken $ weakenEnd3 u'
-    Right t -> inj t
-
-weakenEnd5 :: forall effs a b c d e. Union '[a, b, c, d, e] ~> Union (a ': b ': c ': d ': e ': effs)
-weakenEnd5 u = case decomp u of
-    Left u' -> weaken $ weakenEnd4 u'
-    Right t -> inj t
-
-weakenEnd6 :: forall effs a b c d e f. Union '[a, b, c, d, e, f] ~> Union (a ': b ': c ': d ': e ': f ': effs)
-weakenEnd6 u = case decomp u of
-    Left u' -> weaken $ weakenEnd5 u'
-    Right t -> inj t
-
-weakenEnd7 :: forall effs a b c d e f g. Union '[a, b, c, d, e, f, g] ~> Union (a ': b ': c ': d ': e ': f ': g ': effs)
-weakenEnd7 u = case decomp u of
-    Left u' -> weaken $ weakenEnd6 u'
-    Right t -> inj t
-
-weakenEnd8 :: forall effs a b c d e f g h. Union '[a, b, c, d, e, f, g, h] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': effs)
-weakenEnd8 u = case decomp u of
-    Left u' -> weaken $ weakenEnd7 u'
-    Right t -> inj t
-
-weakenEnd9 :: forall effs a b c d e f g h i. Union '[a, b, c, d, e, f, g, h, i] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': effs)
-weakenEnd9 u = case decomp u of
-    Left u' -> weaken $ weakenEnd8 u'
-    Right t -> inj t
-
-weakenEnd10 :: forall effs a b c d e f g h i j. Union '[a, b, c, d, e, f, g, h, i, j] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': effs)
-weakenEnd10 u = case decomp u of
-    Left u' -> weaken $ weakenEnd9 u'
-    Right t -> inj t
-
-weakenEnd11 :: forall effs a b c d e f g h i j k. Union '[a, b, c, d, e, f, g, h, i, j, k] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': effs)
-weakenEnd11 u = case decomp u of
-    Left u' -> weaken $ weakenEnd10 u'
-    Right t -> inj t
-
-weakenEnd12 :: forall effs a b c d e f g h i j k l. Union '[a, b, c, d, e, f, g, h, i, j, k, l] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': effs)
-weakenEnd12 u = case decomp u of
-    Left u' -> weaken $ weakenEnd11 u'
-    Right t -> inj t
-
-weakenEnd13 :: forall effs a b c d e f g h i j k l m. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': effs)
-weakenEnd13 u = case decomp u of
-    Left u' -> weaken $ weakenEnd12 u'
-    Right t -> inj t
-
-weakenEnd14 :: forall effs a b c d e f g h i j k l m n. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m, n] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': effs)
-weakenEnd14 u = case decomp u of
-    Left u' -> weaken $ weakenEnd13 u'
-    Right t -> inj t
-
-weakenEnd15 :: forall effs a b c d e f g h i j k l m n o. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': effs)
-weakenEnd15 u = case decomp u of
-    Left u' -> weaken $ weakenEnd14 u'
-    Right t -> inj t
-
-weakenEnd16 :: forall effs a b c d e f g h i j k l m n o p. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': effs)
-weakenEnd16 u = case decomp u of
-    Left u' -> weaken $ weakenEnd15 u'
-    Right t -> inj t
-
-weakenEnd17 :: forall effs a b c d e f g h i j k l m n o p q. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': q ': effs)
-weakenEnd17 u = case decomp u of
-    Left u' -> weaken $ weakenEnd16 u'
-    Right t -> inj t
-
-weakenEnd18 :: forall effs a b c d e f g h i j k l m n o p q r. Union '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r] ~> Union (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': q ': r ': effs)
-weakenEnd18 u = case decomp u of
-    Left u' -> weaken $ weakenEnd17 u'
-    Right t -> inj t
+class CanWeakenEnd as effs where
+    weakenEnd :: Union as ~> Union effs
+instance a ~ e => CanWeakenEnd '[a] (e ': effs) where
+    weakenEnd u = inj (extract u)
+instance (a ~ e, CanWeakenEnd (b ': as) (f ': effs)) => CanWeakenEnd (a ': b ': as) (e ': f ': effs) where
+    weakenEnd u = case decomp u of
+        Left u' -> weaken $ weakenEnd u'
+        Right t -> inj t
 
 weakenUnder :: forall effs a b . Union (a ': effs) ~> Union (a ': b ': effs)
 weakenUnder u = case decomp u of
@@ -191,113 +78,11 @@ weakenUnderN u = case decomp u of
     Left u' -> weaken $ weakens @effs' @effs u'
     Right t -> inj t
 
-raiseEnd :: forall effs a . Eff '[a] ~> Eff (a ': effs)
+raiseEnd :: forall effs as. CanWeakenEnd as effs => Eff as ~> Eff effs
 raiseEnd = loop where
     loop = \case
         Val a -> pure a
         E u q -> E (weakenEnd u) (tsingleton $ qComp q loop)
-
-raiseEnd2 :: forall effs a b . Eff '[a, b] ~> Eff (a ': b ': effs)
-raiseEnd2 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd2 u) (tsingleton $ qComp q loop)
-
-raiseEnd3 :: forall effs a b c . Eff '[a, b, c] ~> Eff (a ': b ': c ': effs)
-raiseEnd3 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd3 u) (tsingleton $ qComp q loop)
-
-raiseEnd4 :: forall effs a b c d. Eff '[a, b, c, d] ~> Eff (a ': b ': c ': d ': effs)
-raiseEnd4 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd4 u) (tsingleton $ qComp q loop)
-
-raiseEnd5 :: forall effs a b c d e. Eff '[a, b, c, d, e] ~> Eff (a ': b ': c ': d ': e ': effs)
-raiseEnd5 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd5 u) (tsingleton $ qComp q loop)
-
-raiseEnd6 :: forall effs a b c d e f. Eff '[a, b, c, d, e, f] ~> Eff (a ': b ': c ': d ': e ': f ': effs)
-raiseEnd6 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd6 u) (tsingleton $ qComp q loop)
-
-raiseEnd7 :: forall effs a b c d e f g. Eff '[a, b, c, d, e, f, g] ~> Eff (a ': b ': c ': d ': e ': f ': g ': effs)
-raiseEnd7 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd7 u) (tsingleton $ qComp q loop)
-
-raiseEnd8 :: forall effs a b c d e f g h. Eff '[a, b, c, d, e, f, g, h] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': effs)
-raiseEnd8 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd8 u) (tsingleton $ qComp q loop)
-
-raiseEnd9 :: forall effs a b c d e f g h i. Eff '[a, b, c, d, e, f, g, h, i] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': effs)
-raiseEnd9 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd9 u) (tsingleton $ qComp q loop)
-
-raiseEnd10 :: forall effs a b c d e f g h i j. Eff '[a, b, c, d, e, f, g, h, i, j] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': effs)
-raiseEnd10 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd10 u) (tsingleton $ qComp q loop)
-
-raiseEnd11 :: forall effs a b c d e f g h i j k. Eff '[a, b, c, d, e, f, g, h, i, j, k] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': effs)
-raiseEnd11 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd11 u) (tsingleton $ qComp q loop)
-
-raiseEnd12 :: forall effs a b c d e f g h i j k l. Eff '[a, b, c, d, e, f, g, h, i, j, k, l] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': effs)
-raiseEnd12 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd12 u) (tsingleton $ qComp q loop)
-
-raiseEnd13 :: forall effs a b c d e f g h i j k l m. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': effs)
-raiseEnd13 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd13 u) (tsingleton $ qComp q loop)
-
-raiseEnd14 :: forall effs a b c d e f g h i j k l m n. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m, n] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': effs)
-raiseEnd14 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd14 u) (tsingleton $ qComp q loop)
-
-raiseEnd15 :: forall effs a b c d e f g h i j k l m n o. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': effs)
-raiseEnd15 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd15 u) (tsingleton $ qComp q loop)
-
-raiseEnd16 :: forall effs a b c d e f g h i j k l m n o p. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': effs)
-raiseEnd16 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd16 u) (tsingleton $ qComp q loop)
-
-raiseEnd17 :: forall effs a b c d e f g h i j k l m n o p q. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': q ': effs)
-raiseEnd17 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd17 u) (tsingleton $ qComp q loop)
-
-raiseEnd18 :: forall effs a b c d e f g h i j k l m n o p q r. Eff '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r] ~> Eff (a ': b ': c ': d ': e ': f ': g ': h ': i ': j ': k ': l ': m ': n ': o ': p ': q ': r ': effs)
-raiseEnd18 = loop where
-    loop = \case
-        Val a -> pure a
-        E u q -> E (weakenEnd18 u) (tsingleton $ qComp q loop)
 
 raiseUnder :: forall effs a b . Eff (a ': effs) ~> Eff (a ': b ': effs)
 raiseUnder = loop where

--- a/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
+++ b/freer-extras/src/Control/Monad/Freer/Extras/Modify.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Control.Monad.Freer.Extras.Modify (
     -- * weaken functions
@@ -65,9 +66,9 @@ hence the double cons in the types to prevent overlap with the first instance.
 -}
 class CanWeakenEnd as effs where
     weakenEnd :: Union as ~> Union effs
-instance a ~ e => CanWeakenEnd '[a] (e ': effs) where
+instance effs ~ (a ': effs') => CanWeakenEnd '[a] effs where
     weakenEnd u = inj (extract u)
-instance (a ~ e, CanWeakenEnd (b ': as) (f ': effs)) => CanWeakenEnd (a ': b ': as) (e ': f ': effs) where
+instance (effs ~ (a ': effs'), CanWeakenEnd (b ': as) effs') => CanWeakenEnd (a ': b ': as) effs where
     weakenEnd u = case decomp u of
         Left u' -> weaken $ weakenEnd u'
         Right t -> inj t

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -63,7 +63,7 @@ import           Control.Monad.Freer
 import           Control.Monad.Freer.Coroutine           (Yield)
 import           Control.Monad.Freer.Error               (Error)
 import           Control.Monad.Freer.Extras.Log          (LogMessage (..), LogMsg (..), mapLog)
-import           Control.Monad.Freer.Extras.Modify       (raiseEnd5)
+import           Control.Monad.Freer.Extras.Modify       (raiseEnd)
 import           Control.Monad.Freer.Reader              (Reader)
 import           Control.Monad.Freer.State               (State, evalState)
 import qualified Data.Map                                as Map
@@ -121,7 +121,7 @@ handleEmulatorTrace action = do
             . interpret (handleEmulatorControl @_ @effs)
             . interpret (handleWaiting @_ @effs)
             . interpret (handleRunContract @_ @effs)
-            $ raiseEnd5 action
+            $ raiseEnd action
     void $ exit @effs @EmulatorMessage
 
 -- | Run a 'Trace Emulator', streaming the log messages as they arrive

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -36,7 +36,7 @@ import           Control.Monad.Freer.Coroutine                 (Yield)
 import           Control.Monad.Freer.Error                     (Error, throwError)
 import           Control.Monad.Freer.Extras.Log                (LogMessage, LogMsg (..), LogObserve, logDebug, logError,
                                                                 logInfo, logWarn, mapLog)
-import           Control.Monad.Freer.Extras.Modify             (raiseEnd10)
+import           Control.Monad.Freer.Extras.Modify             (raiseEnd)
 import           Control.Monad.Freer.Reader                    (Reader, ask, runReader)
 import           Control.Monad.Freer.State                     (State, evalState, get, gets, modify, put)
 import           Data.Aeson                                    (object)
@@ -293,7 +293,7 @@ respondToRequest :: forall w s e effs.
 respondToRequest f = do
     hks <- getHooks @w @s @e
     let hdl :: (Eff (Reader ContractInstanceId ': ContractRuntimeEffect ': EmulatedWalletEffects) (Maybe (Response (Event s)))) = tryHandler (wrapHandler f) hks
-        hdl' :: (Eff (ContractInstanceRequests effs) (Maybe (Response (Event s)))) = raiseEnd10 hdl
+        hdl' :: (Eff (ContractInstanceRequests effs) (Maybe (Response (Event s)))) = raiseEnd hdl
 
         response_ :: Eff effs (Maybe (Response (Event s))) =
                 subsume @(LogMsg T.Text)

--- a/plutus-contract/src/Plutus/Trace/Playground.hs
+++ b/plutus-contract/src/Plutus/Trace/Playground.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Freer                        (Eff, Member, interp
 import           Control.Monad.Freer.Coroutine              (Yield)
 import           Control.Monad.Freer.Error                  (Error)
 import           Control.Monad.Freer.Extras.Log             (LogMessage, LogMsg (..), mapLog)
-import           Control.Monad.Freer.Extras.Modify          (raiseEnd4)
+import           Control.Monad.Freer.Extras.Modify          (raiseEnd)
 import           Control.Monad.Freer.Reader                 (Reader)
 import           Control.Monad.Freer.State                  (State, evalState)
 import qualified Data.Aeson                                 as JSON
@@ -115,7 +115,7 @@ handlePlaygroundTrace contract action = do
             . interpret (handleWaiting @_ @effs)
             . subsume
             . interpret (handleRunContractPlayground @w @s @e @_ @effs contract)
-            $ raiseEnd4 action
+            $ raiseEnd action
     void $ exit @effs @EmulatorMessage
 
 -- | Run a 'Trace Playground', streaming the log messages as they arrive

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -22,7 +22,7 @@ import           Control.Monad
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error
 import           Control.Monad.Freer.Extras.Log    (LogMessage, LogMsg, LogObserve, handleObserveLog, mapLog)
-import           Control.Monad.Freer.Extras.Modify (handleZoomedState, raiseEnd5, raiseEnd8, writeIntoState)
+import           Control.Monad.Freer.Extras.Modify (handleZoomedState, raiseEnd, writeIntoState)
 import           Control.Monad.Freer.State
 import           Data.Aeson                        (FromJSON, ToJSON)
 import           Data.Map                          (Map)
@@ -316,7 +316,7 @@ handleMultiAgentControl = interpret $ \case
             p4 :: AReview EmulatorEvent' T.Text
             p4 =  walletEvent wallet . Wallet._GenericLog
         act
-            & raiseEnd5
+            & raiseEnd
             & NC.handleNodeControl
             & ChainIndex.handleChainIndexControl
             & Wallet.handleSigningProcessControl
@@ -354,7 +354,7 @@ handleMultiAgent = interpret $ \case
             p7 :: AReview EmulatorEvent' Notify.EmulatorNotifyLogMsg
             p7 = notificationEvent
         act
-            & raiseEnd8
+            & raiseEnd
             & Wallet.handleWallet
             & subsume
             & NC.handleNodeClient

--- a/plutus-contract/src/Wallet/Emulator/Stream.hs
+++ b/plutus-contract/src/Wallet/Emulator/Stream.hs
@@ -31,7 +31,7 @@ import           Control.Lens                           (filtered, makeLenses, p
 import           Control.Monad.Freer                    (Eff, Member, interpret, reinterpret, run, subsume, type (~>))
 import           Control.Monad.Freer.Coroutine          (Yield, yield)
 import           Control.Monad.Freer.Error              (Error, runError)
-import           Control.Monad.Freer.Extras             (raiseEnd7, wrapError)
+import           Control.Monad.Freer.Extras             (raiseEnd, wrapError)
 import           Control.Monad.Freer.Extras.Log         (LogLevel, LogMessage (..), LogMsg (..), logMessageContent,
                                                          mapMLog)
 import           Control.Monad.Freer.Extras.Stream      (runStream)
@@ -129,7 +129,7 @@ runTraceStream conf =
     . EM.processEmulated
     . subsume
     . subsume @(State EmulatorState)
-    . raiseEnd7
+    . raiseEnd
 
 data EmulatorConfig =
     EmulatorConfig

--- a/plutus-pab/src/Cardano/Wallet/Mock.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock.hs
@@ -83,7 +83,7 @@ handleMultiWallet = do
                 Just privateKey -> do
                     let walletState = WalletState privateKey emptyNodeClientState mempty (defaultSigningProcess wallet)
                     evalState walletState $ action
-                        & raiseEnd @(State WalletState ': effs)
+                        & raiseEnd
                         & Wallet.handleWallet
                 Nothing -> throwError $ WAPI.OtherError "Wallet not found"
         CreateWallet -> do

--- a/plutus-pab/src/Plutus/PAB/Effects/MultiAgent.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/MultiAgent.hs
@@ -40,7 +40,7 @@ import           Control.Monad.Freer                (Eff, Members, interpret, su
 import           Control.Monad.Freer.Error          (Error, handleError, throwError)
 import           Control.Monad.Freer.Extras.Log     (LogLevel (..), LogMessage, LogMsg, LogObserve, handleLogWriter,
                                                      handleObserveLog, logMessage)
-import           Control.Monad.Freer.Extras.Modify  (handleZoomedState, handleZoomedWriter, raiseEnd16, raiseEnd9)
+import           Control.Monad.Freer.Extras.Modify  (handleZoomedState, handleZoomedWriter, raiseEnd)
 import           Control.Monad.Freer.State          (State)
 import           Control.Monad.Freer.TH             (makeEffect)
 import           Control.Monad.Freer.Writer         (Writer)
@@ -200,7 +200,7 @@ handleMultiAgent = interpret $ \effect -> do
             p8 :: AReview [LogMessage PABMultiAgentMsg] (LogMessage ContractRuntimeMsg)
             p8 = _singleton . below _RuntimeLog
         action
-            & raiseEnd16
+            & raiseEnd
             & Wallet.handleWallet
             & interpret (handleContractRuntime @TestContracts)
             & handleContractTest
@@ -242,7 +242,7 @@ handleMultiAgent = interpret $ \effect -> do
             p6 :: AReview [LogMessage PABMultiAgentMsg] (LogMessage MetadataLogMessage)
             p6 = _singleton . below _MetadataLog
         action
-            & raiseEnd9
+            & raiseEnd
             & ChainIndex.handleChainIndexControl
             & handleMetadata
             -- & NF.handleNodeFollower


### PR DESCRIPTION
While going through the code, this bit jumped out and it was too tempting to try to improve it. This approach might very well already have been considered, so feel free to close this in that case.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge