### PR TITLE
Interchange -r and -R options in plc command

### DIFF
--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -216,19 +216,19 @@ exbudgetReader = do
     _     -> readerError badfmt
     where badfmt = "Invalid budget (expected eg 10000:50000)"
 
+restrictingbudgetEnormous :: Parser BudgetMode
+restrictingbudgetEnormous = flag' (Verbose enormousBudget)
+                            (  long "restricting-enormous"
+                            <> short 'r'
+                            <> help "Run the machine in restricting mode with an enormous budget" )
+
 restrictingbudget :: Parser BudgetMode
 restrictingbudget = Verbose . Restricting . ExRestrictingBudget
                     <$> option exbudgetReader
                             (  long "restricting"
-                            <> short 'r'
+                            <> short 'R'
                             <> metavar "ExCPU:ExMemory"
                             <> help "Run the machine in restricting mode with the given limits" )
-
-restrictingbudgetEnormous :: Parser BudgetMode
-restrictingbudgetEnormous = flag' (Verbose enormousBudget)
-                            (  long "restricting-enormous"
-                            <> short 'R'
-                            <> help "Run the machine in restricting mode with an enormous budget" )
 
 countingbudget :: Parser BudgetMode
 countingbudget = flag' (Verbose Counting)
@@ -244,8 +244,8 @@ tallyingbudget = flag' (Verbose Tallying)
 
 budgetmode :: Parser BudgetMode
 budgetmode = asum
-    [ restrictingbudget
-    , restrictingbudgetEnormous
+    [ restrictingbudgetEnormous
+    , restrictingbudget
     , countingbudget
     , tallyingbudget
     , pure Silent


### PR DESCRIPTION
Interchanging the `-r` and `-R` options in the plc command for consistency with `-x` and `-X` (default -> lower case).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
