### PR TITLE
Add .direnv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ TAGS
 gh-pages
 .importify/
 .envrc
+.direnv/
 *.db
 *.db-shm
 *.db-wal


### PR DESCRIPTION
I use `direnv` with `use nix` in `.envrc` and this puts cached derivations in the `.direnv` directory.