### PR TITLE
Deployment fixes

### DIFF
--- a/deployment/morph/configurations.nix
+++ b/deployment/morph/configurations.nix
@@ -10,7 +10,7 @@ let
     then plutus.pkgs.lib.importJSON p
     else { rootSshKeys = [ ]; monitoringSshKeys = [ ]; };
   stdOverlays = [ ];
-  nixpkgsLocation = https://github.com/NixOS/nixpkgs/archive/5272327b81ed355bbed5659b8d303cf2979b6953.tar.gz;
+  nixpkgsLocation = (builtins.fromJSON (builtins.readFile ../../nix/sources.json)).nixpkgs.url;
   ports = {
     http = 80;
     ssh = 22;

--- a/deployment/morph/default-machine.nix
+++ b/deployment/morph/default-machine.nix
@@ -45,4 +45,8 @@
   users.extraUsers.root.openssh.authorizedKeys.keys = machines.rootSshKeys;
   services.fail2ban.enable = true;
 
+  # Allow `--substitute-on-destination` causing the target machine to fetch
+  # dependencies from the iohk binary cache instead of copying everything
+  # from the machine executing morph.
+  deployment.substituteOnDestination = true;
 }

--- a/deployment/terraform/templates/default_configuration.nix
+++ b/deployment/terraform/templates/default_configuration.nix
@@ -5,4 +5,16 @@
   services.fail2ban.enable = true;
   users.extraUsers.root.openssh.authorizedKeys.keys = [ ${root_ssh_keys} ];
 
+  # we need to configure the binary caches here otherwise the
+  # initial morph deployment cannot substitute anything causing
+  # everything to be uploaded from the deployer machine
+  nix = {
+    binaryCaches = [ https://hydra.iohk.io https://cache.nixos.org ];
+    requireSignedBinaryCaches = false;
+    trustedBinaryCaches = [ https://hydra.iohk.io ];
+    binaryCachePublicKeys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+  };
 }


### PR DESCRIPTION
These are some first *small* steps in improving parts of the deployment:

- Use nixpkgs pinned via `niv`: We don't want to use different nixpkgs versions so instead of hard-coding some nixpkgs url the deployments should use the nixpkgs version from `nix/sources.json`
- Enable path substitution for deployments (*)

(*) Unfortunately this doesn't really quite work yet. We are currently running into a bug with the deployment which is caused by Nix leaking file descriptors. As a result the target starts fetching binaries from cache.nixos.org and hydra.iohk.io until after some time file descriptors run out and there is an error - After that the fallback is that the deployment machine is scp'ing all store paths again. The problem is now being worked on but unfortunately all workarounds i tried failed and i could only solve this by reviewing and reducing closure sizes (we seem to be pushing a *lot*)

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
