### PR TITLE
Add Slot to datetime converters

### DIFF
--- a/web-common-marlowe/src/Marlowe/Slot.purs
+++ b/web-common-marlowe/src/Marlowe/Slot.purs
@@ -1,0 +1,52 @@
+-- This module helps you work with slots and DateTimes. We only care about the current slot algorithm
+-- that was introduced when Shelley was launched in mid 2020. Since the launch, each slot number
+-- corresponds to a second.
+module Marlowe.Slot (slotToDateTime, dateTimeToSlot, currentSlot) where
+
+import Prelude
+import Data.BigInteger (fromInt)
+import Data.BigInteger as BigInteger
+import Data.DateTime (DateTime, adjust, diff)
+import Data.DateTime.Instant (instant, toDateTime)
+import Data.Int (round)
+import Data.Maybe (Maybe, fromJust)
+import Data.Newtype (unwrap)
+import Data.Time.Duration (Milliseconds(..), Seconds(..))
+import Effect (Effect)
+import Effect.Now (now)
+import Marlowe.Semantics (Slot(..))
+import Partial.Unsafe (unsafePartial)
+
+-- This was the slot number when shelley was released
+-- FIXME: check with Alex the exact number
+shelleyInitialSlot :: Slot
+shelleyInitialSlot = Slot $ fromInt 4492800
+
+-- This was the exact DateTime where shelley was released
+-- FIXME: check with Alex if the date and time are correct
+shelleyLaunchDate :: DateTime
+shelleyLaunchDate =
+  let
+    -- Wednesday, July 29, 2020 21:44:51 UTC expressed as unix epoch
+    epoch = Milliseconds 1596059091000.0
+  in
+    unsafePartial $ fromJust $ toDateTime <$> instant epoch
+
+slotToDateTime :: Slot -> Maybe DateTime
+slotToDateTime slot =
+  let
+    secondsDiff :: Seconds
+    secondsDiff = Seconds $ BigInteger.toNumber $ unwrap $ slot - shelleyInitialSlot
+  in
+    adjust secondsDiff shelleyLaunchDate
+
+dateTimeToSlot :: DateTime -> Slot
+dateTimeToSlot datetime =
+  let
+    secondsDiff :: Seconds
+    secondsDiff = diff datetime shelleyLaunchDate
+  in
+    shelleyInitialSlot + (Slot $ BigInteger.fromInt $ round $ unwrap secondsDiff)
+
+currentSlot :: Effect Slot
+currentSlot = dateTimeToSlot <<< toDateTime <$> now


### PR DESCRIPTION
This PR adds Slot to DateTime utilities to the marlowe web commons. 

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [X] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [X] Commits have useful messages
- [ ] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
