### PR TITLE
SCP-1793 - Add metadata to Marlowe editor in Playground

### DIFF
--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -288,7 +288,7 @@ carryMetadataAction ::
   MonadAsk Env m =>
   ME.MetadataAction ->
   HalogenM State Action ChildSlots Void m Unit
-carryMetadataAction action =
+carryMetadataAction action = do
   modifying (_contractMetadata) case action of
     SetContractName name -> set _contractName name
     SetContractType typeName -> set _contractType typeName
@@ -301,6 +301,9 @@ carryMetadataAction action =
     DeleteValueParameterDescription valueParam -> over _valueParameterDescriptions $ Map.delete valueParam
     SetChoiceDescription choiceName description -> over _choiceDescriptions $ Map.insert choiceName description
     DeleteChoiceDescription choiceName -> over _choiceDescriptions $ Map.delete choiceName
+  metadata <- use _contractMetadata
+  assign (_hasUnsavedChanges) true
+  liftEffect $ SessionStorage.setItem metadataLocalStorageKey (encodeJSON (metadata :: MetaData))
 
 -- This handleAction can be called recursively, but because we use HOF to extend the functionality
 -- of the component, whenever we need to recurse we most likely be calling one of the extended functions

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -6,12 +6,13 @@ import BlocklyComponent.Types as Blockly
 import BlocklyEditor.State as BlocklyEditor
 import BlocklyEditor.Types (_marloweCode)
 import BlocklyEditor.Types as BE
+import BottomPanel.Types as BP
 import ConfirmUnsavedNavigation.Types (Action(..)) as ConfirmUnsavedNavigation
 import Control.Monad.Except (ExceptT(..), lift, runExcept, runExceptT)
 import Control.Monad.Maybe.Extra (hoistMaybe)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Monad.Reader (class MonadAsk, asks, runReaderT)
-import Control.Monad.State (modify, modify_)
+import Control.Monad.State (modify_)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), either, hush, note)
 import Data.Foldable (fold, for_)
@@ -52,8 +53,8 @@ import MainFrame.View (render)
 import Marlowe (getApiGistsByGistId)
 import Marlowe as Server
 import Marlowe.ActusBlockly as AMB
-import Marlowe.Gists (mkNewGist, playgroundFiles, PlaygroundFiles)
 import Marlowe.Extended (MetaData, _choiceDescriptions, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions, emptyContractMetadata)
+import Marlowe.Gists (mkNewGist, playgroundFiles, PlaygroundFiles)
 import MarloweEditor.State as MarloweEditor
 import MarloweEditor.Types (MetadataAction(..))
 import MarloweEditor.Types as ME
@@ -383,7 +384,7 @@ handleAction (MarloweEditorAction action) = do
         selectView BlocklyEditor
     ME.HandleEditorMessage (Monaco.TextChanged _) -> setUnsavedChangesForLanguage Marlowe true
     ME.InitMarloweProject _ -> setUnsavedChangesForLanguage Marlowe false
-    ME.MetadataAction action -> carryMetadataAction action
+    ME.BottomPanelAction (BP.PanelAction (ME.MetadataAction metadataAction)) -> carryMetadataAction metadataAction
     _ -> pure unit
 
 handleAction (BlocklyEditorAction action) = do

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -325,6 +325,7 @@ newtype Session
   { projectName :: String
   , gistId :: Maybe GistId
   , workflow :: Maybe Lang
+  , contractMetadata :: MetaData
   }
 
 derive instance newtypeSession :: Newtype Session _
@@ -343,11 +344,13 @@ stateToSession :: State -> Session
 stateToSession { projectName
 , gistId
 , workflow
+, contractMetadata
 } =
   Session
     { projectName
     , gistId
     , workflow
+    , contractMetadata
     }
 
 sessionToState :: Session -> State -> State
@@ -356,4 +359,5 @@ sessionToState (Session sessionData) defaultState =
     { projectName = sessionData.projectName
     , gistId = sessionData.gistId
     , workflow = sessionData.workflow
+    , contractMetadata = sessionData.contractMetadata
     }

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -3,6 +3,7 @@ module MainFrame.Types where
 import Prelude hiding (div)
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Auth (AuthStatus)
+import BlocklyComponent.Types as Blockly
 import BlocklyEditor.Types as BE
 import ConfirmUnsavedNavigation.Types as ConfirmUnsavedNavigation
 import Data.Either (Either)
@@ -11,20 +12,23 @@ import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', has, (^.))
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Demos.Types as Demos
+import Foreign.Class (class Decode, class Encode)
+import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
 import Gist (Gist, GistId)
 import Gists.Types (GistAction)
 import Halogen (ClassName)
 import Halogen as H
 import Halogen.ActusBlockly as AB
-import BlocklyComponent.Types as Blockly
 import Halogen.Classes (activeClass)
 import Halogen.Monaco (KeyBindings)
 import Halogen.Monaco as Monaco
 import HaskellEditor.Types as HE
 import JavascriptEditor.Types (CompilationState)
 import JavascriptEditor.Types as JS
+import Marlowe.Extended (MetaData)
 import MarloweEditor.Types as ME
 import Network.RemoteData (_Loading)
 import NewProject.Types as NewProject
@@ -37,9 +41,6 @@ import SimulationPage.Types as Simulation
 import Types (WebData)
 import WalletSimulation.Types as Wallet
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
-import Foreign.Class (class Decode, class Encode)
-import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
-import Data.Newtype (class Newtype)
 
 data ModalView
   = NewProject
@@ -190,6 +191,7 @@ type State
     , marloweEditorState :: ME.State
     , blocklyEditorState :: BE.State
     , simulationState :: Simulation.State
+    , contractMetadata :: MetaData
     , projects :: Projects.State
     , newProject :: NewProject.State
     , rename :: Rename.State
@@ -238,6 +240,9 @@ _javascriptState = prop (SProxy :: SProxy "javascriptState")
 
 _simulationState :: Lens' State Simulation.State
 _simulationState = prop (SProxy :: SProxy "simulationState")
+
+_contractMetadata :: Lens' State MetaData
+_contractMetadata = prop (SProxy :: SProxy "contractMetadata")
 
 _projects :: Lens' State Projects.State
 _projects = prop (SProxy :: SProxy "projects")

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -20,7 +20,7 @@ import HaskellEditor.View (otherActions, render) as HaskellEditor
 import Home as Home
 import Icons (Icon(..), icon)
 import JavascriptEditor.View as JSEditor
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _createGistResult, _hasUnsavedChanges, _haskellState, _javascriptState, _marloweEditorState, _projectName, _simulationState, _view, _walletSlot, hasGlobalLoading)
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _contractMetadata, _createGistResult, _hasUnsavedChanges, _haskellState, _javascriptState, _marloweEditorState, _projectName, _simulationState, _view, _walletSlot, hasGlobalLoading)
 import Marlowe.ActusBlockly as AMB
 import MarloweEditor.View as MarloweEditor
 import Modal.View (modal)
@@ -53,7 +53,7 @@ render state =
           [ section [ id_ "main-panel" ]
               [ tabContents HomePage [ Home.render state ]
               , tabContents Simulation [ renderSubmodule _simulationState SimulationAction Simulation.render state ]
-              , tabContents MarloweEditor [ renderSubmodule _marloweEditorState MarloweEditorAction MarloweEditor.render state ]
+              , tabContents MarloweEditor [ renderSubmodule _marloweEditorState MarloweEditorAction (MarloweEditor.render (state ^. _contractMetadata)) state ]
               , tabContents HaskellEditor [ renderSubmodule _haskellState HaskellAction HaskellEditor.render state ]
               , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction JSEditor.render state ]
               , tabContents BlocklyEditor [ renderSubmodule _blocklyEditorState BlocklyEditorAction BlocklyEditor.render state ]

--- a/marlowe-playground-client/src/Marlowe/Gists.purs
+++ b/marlowe-playground-client/src/Marlowe/Gists.purs
@@ -42,7 +42,7 @@ type PlaygroundFiles
     }
 
 toArray :: PlaygroundFiles -> Array NewGistFile
-toArray { playground, marlowe, haskell, blockly, javascript, actus } =
+toArray { playground, marlowe, haskell, blockly, javascript, actus, metadata } =
   [ mkNewGistFile filenames.playground playground
   ]
     <> catMaybes
@@ -51,6 +51,7 @@ toArray { playground, marlowe, haskell, blockly, javascript, actus } =
         , mkNewGistFile filenames.blockly <$> blockly
         , mkNewGistFile filenames.javascript <$> javascript
         , mkNewGistFile filenames.actus <<< unwrap <$> actus
+        , mkNewGistFile filenames.metadata <$> metadata
         ]
 
 filenames ::

--- a/marlowe-playground-client/src/Marlowe/Gists.purs
+++ b/marlowe-playground-client/src/Marlowe/Gists.purs
@@ -38,6 +38,7 @@ type PlaygroundFiles
     , blockly :: Maybe String
     , javascript :: Maybe String
     , actus :: Maybe XML
+    , metadata :: Maybe String
     }
 
 toArray :: PlaygroundFiles -> Array NewGistFile
@@ -59,6 +60,7 @@ filenames ::
   , blockly :: String
   , javascript :: String
   , actus :: String
+  , metadata :: String
   }
 filenames =
   { playground: "playground.marlowe.json"
@@ -67,6 +69,7 @@ filenames =
   , blockly: "blockly.xml"
   , javascript: "playground.js"
   , actus: "actus.xml"
+  , metadata: "metadata.json"
   }
 
 isPlaygroundGist :: Gist -> Boolean
@@ -80,6 +83,7 @@ playgroundFiles gist =
   , blockly: getFile filenames.blockly
   , javascript: getFile filenames.javascript
   , actus: wrap <$> getFile filenames.actus
+  , metadata: getFile filenames.metadata
   }
   where
   getFile name = view (gistFiles <<< ix name <<< gistFileContent) gist

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -14,7 +14,6 @@ import Data.Set (Set, toUnfoldable)
 import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple.Nested (type (/\), (/\))
-import Foreign.Generic (encodeJSON)
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, minW0, minusBtn, overflowXScroll, paddingRight, plusBtn, smallBtn, underline)
 import Halogen.HTML (ClassName(..), HTML, a, button, div, div_, em_, h6_, input, li_, ol_, option, pre_, section, section_, select, span, span_, text)
 import Halogen.HTML.Events (onClick, onValueChange)
@@ -47,7 +46,7 @@ metadataList metadataMap hintSet setAction deleteAction typeNameTitle typeNameSm
                               , onValueChange $ Just <<< MetadataAction <<< setAction key
                               ]
                           , button
-                              [ classes [ minusBtn, smallBtn, ClassName "align-top" ]
+                              [ classes [ if needed then plusBtn else minusBtn, smallBtn, ClassName "align-top" ]
                               , onClick $ const $ Just $ MetadataAction $ deleteAction key
                               ]
                               [ text "-" ]

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -12,20 +12,28 @@ import Data.String.Extra (unlines)
 import Data.Tuple.Nested ((/\))
 import Foreign.Generic (encodeJSON)
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, minW0, overflowXScroll, paddingRight, underline)
-import Halogen.HTML (HTML, a, div, div_, pre_, section, section_, span_, text)
-import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (class_, classes)
-import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _hasHoles, _showErrorDetail, contractHasErrors)
+import Halogen.HTML (ClassName(..), HTML, a, div, div_, input, pre_, section, section_, span_, text)
+import Halogen.HTML.Events (onClick, onValueChange)
+import Halogen.HTML.Properties (InputType(..), class_, classes, placeholder, type_, value)
 import Marlowe.Extended (MetaData)
-import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _metadataHintInfo, _showErrorDetail, contractHasErrors)
+import MarloweEditor.Types (Action(..), BottomPanelView(..), MetadataAction(..), State, _editorErrors, _editorWarnings, _hasHoles, _metadataHintInfo, _showErrorDetail, contractHasErrors)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
 
 panelContents :: forall p. State -> MetaData -> BottomPanelView -> HTML p Action
 panelContents state metadata MetadataView =
-  div_
-    [ div_ [ text (encodeJSON metadata) ]
+  div [ classes [ ClassName "padded-explanation" ] ]
+    [ div_
+        [ input
+            [ type_ InputText
+            , placeholder "Contract name"
+            , class_ $ ClassName "metadata-input"
+            , value $ metadata.contractName
+            , onValueChange $ Just <<< MetadataAction <<< SetContractName
+            ]
+        ]
+    , div_ [ text (encodeJSON metadata) ]
     , div_ [ text (show (state ^. _metadataHintInfo)) ]
     ]
 

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -10,17 +10,26 @@ import Data.Maybe (Maybe(..))
 import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple.Nested ((/\))
+import Foreign.Generic (encodeJSON)
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, minW0, overflowXScroll, paddingRight, underline)
 import Halogen.HTML (HTML, a, div, div_, pre_, section, section_, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _hasHoles, _showErrorDetail, contractHasErrors)
+import Marlowe.Extended (MetaData)
+import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _editorErrors, _editorWarnings, _metadataHintInfo, _showErrorDetail, contractHasErrors)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
 
-panelContents :: forall p. State -> BottomPanelView -> HTML p Action
-panelContents state StaticAnalysisView =
+panelContents :: forall p. State -> MetaData -> BottomPanelView -> HTML p Action
+panelContents state metadata MetadataView =
+  div_
+    [ div_ [ text (encodeJSON metadata) ]
+    , div_ [ text (show (state ^. _metadataHintInfo)) ]
+    ]
+
+panelContents state _ StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
     if (state ^. _hasHoles) then
       [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
@@ -49,7 +58,7 @@ panelContents state StaticAnalysisView =
 
   analysisEnabled = nothingLoading && not contractHasErrors state
 
-panelContents state MarloweWarningsView =
+panelContents state _ MarloweWarningsView =
   section_
     if Array.null warnings then
       [ pre_ [ text "No warnings" ] ]
@@ -74,7 +83,7 @@ panelContents state MarloweWarningsView =
         [ text $ show warning.startLineNumber ]
     ]
 
-panelContents state MarloweErrorsView =
+panelContents state _ MarloweErrorsView =
   section_
     if Array.null errors then
       [ pre_ [ text "No errors" ] ]

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -70,6 +70,11 @@ metadataList metadataMap hintSet setAction deleteAction typeNameTitle typeNameSm
 
   mergeMaps _ _ = Nothing
 
+  -- The value of the Map has the following meaning:
+  -- * Nothing means the entry is in the contract but not in the metadata
+  -- * Just (_ /\ false) means the entry is in the metadata but not in the contract
+  -- * Just (_ /\ true) means the entry is both in the contract and in the metadata
+  -- If it is nowhere we just don't store it in the map
   combinedMap :: Map String (Maybe (String /\ Boolean))
   combinedMap =
     Map.unionWith mergeMaps

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -120,6 +120,8 @@ handleAction (SelectHole hole) = assign _selectedHole hole
 
 handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< Extended.typeToLens templateType) (Map.insert key value)
 
+handleAction (MetadataAction _) = pure unit
+
 handleAction AnalyseContract = runAnalysis $ analyseContract
 
 handleAction AnalyseReachabilityContract = runAnalysis $ analyseReachability

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -15,17 +15,15 @@ import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Monad.Reader (class MonadAsk)
 import Data.Array as Array
 import Data.Either (Either(..), hush)
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (for_)
 import Data.Lens (assign, modifying, over, preview, set, use)
 import Data.Lens.Index (ix)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.String (Pattern(..), codePointFromChar, contains)
 import Data.String as String
 import Data.Tuple (Tuple(..))
-import Debug.Trace (spy)
 import Effect.Aff.Class (class MonadAff, liftAff)
-import Effect.Class (class MonadEffect)
 import Env (Env)
 import Examples.Marlowe.Contracts (example) as ME
 import Halogen (HalogenM, liftEffect, modify_, query)
@@ -33,15 +31,15 @@ import Halogen as H
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
-import Marlowe.Extended (TemplateContent(..))
+import Marlowe.Extended (MetadataHintInfo, TemplateContent, getMetadataHintInfo)
 import Marlowe.Extended as Extended
 import Marlowe.Holes as Holes
 import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import MarloweEditor.Types (Action(..), BottomPanelView, State, _hasHoles, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _selectedHole, _showErrorDetail)
-import Monaco (IMarker, IMarkerData, isError, isWarning)
+import MarloweEditor.Types (Action(..), BottomPanelView, State, _hasHoles, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
+import Monaco (isError, isWarning)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
 import SessionStorage as SessionStorage
@@ -188,22 +186,27 @@ processMarloweCode text = do
             in
               marker { message = trimmedMessage }
 
-    -- If we can get an Extended contract from the holes contract (basically if it has no holes)
-    -- then update the template content. If not, leave them as they are
-    maybeUpdateTemplateContent :: TemplateContent -> TemplateContent
-    maybeUpdateTemplateContent = case Holes.fromTerm =<< hush eParsedContract of
-      Just (contract :: Extended.Contract) -> Extended.updateTemplateContent $ Extended.getPlaceholderIds contract
-      Nothing -> identity
+    maybeContract :: Maybe Extended.Contract
+    maybeContract = Holes.fromTerm =<< hush eParsedContract
+
+    metadataInfo :: MetadataHintInfo
+    metadataInfo = maybe mempty getMetadataHintInfo maybeContract -- ToDo: Implement function that supports holes instead (SCP-2012)
 
     hasHoles =
       not $ Array.null
         $ Array.filter (contains (Pattern "hole") <<< _.message) warningMarkers
+
+    -- If we can get an Extended contract from the holes contract (basically if it has no holes)
+    -- then update the template content. If not, leave them as they are
+    maybeUpdateTemplateContent :: TemplateContent -> TemplateContent
+    maybeUpdateTemplateContent = maybe identity (Extended.updateTemplateContent <<< Extended.getPlaceholderIds) maybeContract
   void $ query _marloweEditorPageSlot unit $ H.request $ Monaco.SetModelMarkers markerData
   modify_
     ( set _editorWarnings warningMarkers
         <<< set _editorErrors errorMarkers
         <<< set _hasHoles hasHoles
         <<< over (_analysisState <<< _templateContent) maybeUpdateTemplateContent
+        <<< set _metadataHintInfo metadataInfo
     )
   {-
     There are three different Monaco objects that require the linting information:

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -188,11 +188,11 @@ processMarloweCode text = do
             in
               marker { message = trimmedMessage }
 
-    maybeContract :: Maybe Extended.Contract
-    maybeContract = Holes.fromTerm =<< hush eParsedContract
+    mContract :: Maybe Extended.Contract
+    mContract = Holes.fromTerm =<< hush eParsedContract
 
     metadataInfo :: MetadataHintInfo
-    metadataInfo = maybe mempty getMetadataHintInfo maybeContract -- ToDo: Implement function that supports holes instead (SCP-2012)
+    metadataInfo = maybe mempty getMetadataHintInfo mContract -- ToDo: Implement function that supports holes instead (SCP-2012)
 
     hasHoles =
       not $ Array.null
@@ -201,7 +201,7 @@ processMarloweCode text = do
     -- If we can get an Extended contract from the holes contract (basically if it has no holes)
     -- then update the template content. If not, leave them as they are
     maybeUpdateTemplateContent :: TemplateContent -> TemplateContent
-    maybeUpdateTemplateContent = maybe identity (Extended.updateTemplateContent <<< Extended.getPlaceholderIds) maybeContract
+    maybeUpdateTemplateContent = maybe identity (Extended.updateTemplateContent <<< Extended.getPlaceholderIds) mContract
   void $ query _marloweEditorPageSlot unit $ H.request $ Monaco.SetModelMarkers markerData
   modify_
     ( set _editorWarnings warningMarkers

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -11,14 +11,12 @@ import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', to, view)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
-import Data.Set (Set)
 import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
-import Marlowe.Extended (IntegerTemplateType, MetaData, MetadataHintInfo)
+import Marlowe.Extended (IntegerTemplateType, MetadataHintInfo)
 import Monaco (IMarkerData)
 import StaticAnalysis.Types (AnalysisState, initAnalysisState)
-import Plutus.V1.Ledger.Value as S
 import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
@@ -74,6 +72,7 @@ data BottomPanelView
   = StaticAnalysisView
   | MarloweErrorsView
   | MarloweWarningsView
+  | MetadataView
 
 derive instance eqBottomPanelView :: Eq BottomPanelView
 
@@ -121,7 +120,7 @@ _hasHoles = prop (SProxy :: SProxy "hasHoles")
 initialState :: State
 initialState =
   { keybindings: DefaultBindings
-  , bottomPanelState: BottomPanel.initialState StaticAnalysisView
+  , bottomPanelState: BottomPanel.initialState MetadataView
   , showErrorDetail: false
   , selectedHole: Nothing
   , metadataHintInfo: mempty

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -14,12 +14,41 @@ import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
-import Marlowe.Extended (IntegerTemplateType, MetadataHintInfo)
+import Marlowe.Extended (ContractType, IntegerTemplateType, MetadataHintInfo)
+import Marlowe.Semantics as S
 import Monaco (IMarkerData)
-import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
+
+class ShowConstructor a where
+  showConstructor :: a -> String
+
+data MetadataAction
+  = SetContractName String
+  | SetContractType ContractType
+  | SetContractDescription String
+  | SetRoleDescription S.TokenName String
+  | DeleteRoleDescription S.TokenName
+  | SetSlotParameterDescription String String
+  | DeleteSlotParameterDescription String
+  | SetValueParameterDescription String String
+  | DeleteValueParameterDescription String
+  | SetChoiceDescription String String
+  | DeleteChoiceDescription String
+
+instance metadataActionShowConstructor :: ShowConstructor MetadataAction where
+  showConstructor (SetContractName _) = "SetContractName"
+  showConstructor (SetContractType _) = "SetContractType"
+  showConstructor (SetContractDescription _) = "SetContractDescription"
+  showConstructor (SetRoleDescription _ _) = "SetRoleDescription"
+  showConstructor (DeleteRoleDescription _) = "DeleteRoleDescription"
+  showConstructor (SetSlotParameterDescription _ _) = "SetSlotParameterDescription"
+  showConstructor (DeleteSlotParameterDescription _) = "DeleteSlotParameterDescription"
+  showConstructor (SetValueParameterDescription _ _) = "SetValueParameterDescription"
+  showConstructor (DeleteValueParameterDescription _) = "DeleteValueParameterDescription"
+  showConstructor (SetChoiceDescription _ _) = "SetChoiceDescription"
+  showConstructor (DeleteChoiceDescription _) = "DeleteChoiceDescription"
 
 data Action
   = Init
@@ -36,6 +65,7 @@ data Action
   | ViewAsBlockly
   | InitMarloweProject String
   | SelectHole (Maybe String)
+  | MetadataAction MetadataAction
   | SetIntegerTemplateParam IntegerTemplateType String BigInteger
   | AnalyseContract
   | AnalyseReachabilityContract
@@ -61,6 +91,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent ViewAsBlockly = Just $ defaultEvent "ViewAsBlockly"
   toEvent (InitMarloweProject _) = Just $ defaultEvent "InitMarloweProject"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
+  toEvent (MetadataAction action) = Just $ (defaultEvent "MetadataAction") { label = Just $ showConstructor action }
   toEvent (SetIntegerTemplateParam _ _ _) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent AnalyseContract = Just $ defaultEvent "AnalyseContract"
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -11,11 +11,14 @@ import Data.Generic.Rep.Show (genericShow)
 import Data.Lens (Lens', to, view)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
+import Data.Set (Set)
 import Data.Symbol (SProxy(..))
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
-import Marlowe.Extended (IntegerTemplateType)
+import Marlowe.Extended (IntegerTemplateType, MetaData, MetadataHintInfo)
 import Monaco (IMarkerData)
+import StaticAnalysis.Types (AnalysisState, initAnalysisState)
+import Plutus.V1.Ledger.Value as S
 import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
@@ -84,6 +87,7 @@ type State
     , bottomPanelState :: BottomPanel.State BottomPanelView
     , showErrorDetail :: Boolean
     , selectedHole :: Maybe String
+    , metadataHintInfo :: MetadataHintInfo
     , analysisState :: AnalysisState
     , editorErrors :: Array IMarkerData
     , editorWarnings :: Array IMarkerData
@@ -98,6 +102,9 @@ _showErrorDetail = prop (SProxy :: SProxy "showErrorDetail")
 
 _selectedHole :: Lens' State (Maybe String)
 _selectedHole = prop (SProxy :: SProxy "selectedHole")
+
+_metadataHintInfo :: Lens' State MetadataHintInfo
+_metadataHintInfo = prop (SProxy :: SProxy "metadataHintInfo")
 
 _editorErrors :: forall s a. Lens' { editorErrors :: a | s } a
 _editorErrors = prop (SProxy :: SProxy "editorErrors")
@@ -117,6 +124,7 @@ initialState =
   , bottomPanelState: BottomPanel.initialState StaticAnalysisView
   , showErrorDetail: false
   , selectedHole: Nothing
+  , metadataHintInfo: mempty
   , analysisState: initAnalysisState
   , editorErrors: mempty
   , editorWarnings: mempty

--- a/marlowe-playground-client/src/MarloweEditor/View.purs
+++ b/marlowe-playground-client/src/MarloweEditor/View.purs
@@ -17,6 +17,7 @@ import Halogen.HTML.Properties (class_, classes, disabled, title)
 import Halogen.HTML.Properties as HTML
 import Halogen.Monaco (monacoComponent)
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
+import Marlowe.Extended (MetaData)
 import Marlowe.Monaco as MM
 import MarloweEditor.BottomPanel (panelContents)
 import MarloweEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, contractHasErrors, contractHasHoles)
@@ -25,9 +26,10 @@ import Prim.TypeError (class Warn, Text)
 render ::
   forall m.
   MonadAff m =>
+  MetaData ->
   State ->
   ComponentHTML Action ChildSlots m
-render state =
+render metadata state =
   div [ classes [ flex, flexCol, fullHeight, paddingX ] ]
     [ section [ classes [ minH0, flexGrow, overflowHidden ] ]
         [ marloweEditor state ]
@@ -41,7 +43,8 @@ render state =
     ]
   where
   panelTitles =
-    [ { title: "Static Analysis", view: StaticAnalysisView, classes: [] }
+    [ { title: "Metadata", view: MetadataView, classes: [] }
+    , { title: "Static Analysis", view: StaticAnalysisView, classes: [] }
     , { title: warningsTitle, view: MarloweWarningsView, classes: [] }
     , { title: errorsTitle, view: MarloweErrorsView, classes: [] }
     ]
@@ -52,7 +55,7 @@ render state =
 
   errorsTitle = withCount "Errors" $ state ^. _editorErrors
 
-  wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state panelView
+  wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state metadata panelView
 
 otherActions :: forall p. State -> HTML p Action
 otherActions state =

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -38,7 +38,6 @@ import Foreign.JSON (parseJSON)
 import Halogen (HalogenM, get, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Query(..)) as Monaco
-import SessionStorage as SessionStorage
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe as Server
 import Marlowe.Extended (fillTemplate, toCore, typeToLens)
@@ -51,6 +50,7 @@ import Marlowe.Semantics as S
 import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError, errorToString)
+import SessionStorage as SessionStorage
 import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId(..), BottomPanelView, ExecutionState(..), Parties(..), State, _SimulationNotStarted, _SimulationRunning, _bottomPanelState, _currentMarloweState, _executionState, _extendedContract, _helpContext, _initialSlot, _marloweState, _moveToAction, _possibleActions, _showRightPanel, _templateContent, emptyExecutionStateWithSlot, emptyMarloweState, mapPartiesActionInput)
 import Simulator (applyInput, inFuture, moveToSignificantSlot, moveToSlot, nextSignificantSlot, updateMarloweState, updatePossibleActions, updateStateP)
 import StaticData (simulatorBufferLocalStorageKey)
@@ -79,8 +79,8 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction Init = do
   editorSetTheme
-  mContents <- liftEffect $ SessionStorage.getItem simulatorBufferLocalStorageKey
-  handleAction $ LoadContract $ fromMaybe "" mContents
+  contents <- fromMaybe "" <$> (liftEffect $ SessionStorage.getItem simulatorBufferLocalStorageKey)
+  handleAction $ LoadContract contents
 
 handleAction (SetInitialSlot initialSlot) = do
   assign (_currentMarloweState <<< _executionState <<< _SimulationNotStarted <<< _initialSlot) initialSlot

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -27,7 +27,7 @@ import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Foreign.Generic (class Decode, class Encode, genericDecode, genericEncode)
 import Help (HelpContext(..))
-import Marlowe.Extended (IntegerTemplateType, TemplateContent, getPlaceholderIds, initializeTemplateContent)
+import Marlowe.Extended (IntegerTemplateType, TemplateContent, MetaData, getPlaceholderIds, initializeTemplateContent)
 import Marlowe.Extended as EM
 import Marlowe.Holes (Holes)
 import Marlowe.Semantics (AccountId, Assets, Bound, ChoiceId, ChosenNum, Contract, Input, Party(..), Payment, Slot, SlotInterval, Token, TransactionError, TransactionInput, TransactionWarning, aesonCompatibleOptions, emptyState)

--- a/marlowe-playground-client/src/StaticData.purs
+++ b/marlowe-playground-client/src/StaticData.purs
@@ -5,7 +5,6 @@ module StaticData
   , demoFilesJS
   , marloweBufferLocalStorageKey
   , simulatorBufferLocalStorageKey
-  , metadataLocalStorageKey
   , marloweContract
   , marloweContracts
   , gistIdLocalStorageKey
@@ -84,10 +83,6 @@ marloweBufferLocalStorageKey = LocalStorage.Key "MarloweBuffer"
 simulatorBufferLocalStorageKey ::
   LocalStorage.Key
 simulatorBufferLocalStorageKey = LocalStorage.Key "SimulationBuffer"
-
-metadataLocalStorageKey ::
-  LocalStorage.Key
-metadataLocalStorageKey = LocalStorage.Key "MarloweMetadata"
 
 gistIdLocalStorageKey ::
   LocalStorage.Key

--- a/marlowe-playground-client/src/StaticData.purs
+++ b/marlowe-playground-client/src/StaticData.purs
@@ -5,6 +5,7 @@ module StaticData
   , demoFilesJS
   , marloweBufferLocalStorageKey
   , simulatorBufferLocalStorageKey
+  , metadataLocalStorageKey
   , marloweContract
   , marloweContracts
   , gistIdLocalStorageKey
@@ -83,6 +84,10 @@ marloweBufferLocalStorageKey = LocalStorage.Key "MarloweBuffer"
 simulatorBufferLocalStorageKey ::
   LocalStorage.Key
 simulatorBufferLocalStorageKey = LocalStorage.Key "SimulationBuffer"
+
+metadataLocalStorageKey ::
+  LocalStorage.Key
+metadataLocalStorageKey = LocalStorage.Key "MarloweMetadata"
 
 gistIdLocalStorageKey ::
   LocalStorage.Key

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -231,3 +231,61 @@ button.minus-btn:hover {
 .template-fields > input {
   margin-left: 1rem;
 }
+
+.metadata-input {
+  margin-left: 1rem;
+  width: 50%;
+  display: inline;
+  padding: 0.3rem 0.5rem;
+  box-sizing: border-box;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 1px 0 1px rgba(0, 0, 0, .04);
+  border-radius: .3em;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: #fff;
+}
+
+.metadata-input::-ms-expand {
+  display: none;
+}
+
+.metadata-input:hover {
+  border-color: #888;
+}
+
+.metadata-input:focus {
+  border-color: #aaa;
+  box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
+  box-shadow: 0 0 0 3px -moz-mac-focusring;
+  color: #222;
+  outline: none;
+}
+
+.metadata-field-group {
+  margin: 0.5rem;
+}
+
+.metadata-field-group h6 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.metadata-field-group li {
+  margin-left: 1rem;
+}
+
+.metadata-field-group li::marker {
+  display: none;
+  content: " ";
+}
+
+.metadata-error {
+  color: var(--error-color);
+}
+
+.metadata-not-used {
+  margin-left: 1rem;
+}

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -60,6 +60,9 @@ data ContractType
 
 derive instance eqContractType :: Eq ContractType
 
+contractTypeArray :: Array ContractType
+contractTypeArray = [ Escrow, EscrowWithCollatoral, ZeroCouponBond, CouponBondGuaranteed, Swap, ContractForDifferences, Other ]
+
 contractTypeInitials :: ContractType -> String
 contractTypeInitials Escrow = "ES"
 
@@ -87,6 +90,8 @@ contractTypeName CouponBondGuaranteed = "Coupon Bond Guaranteed"
 contractTypeName Swap = "Swap"
 
 contractTypeName ContractForDifferences = "Contract for Differences"
+
+contractTypeName Other = "Other"
 
 initialsToContractType :: String -> ContractType
 initialsToContractType "ES" = Escrow
@@ -136,6 +141,18 @@ type MetadataHintInfo
     , valueParameters :: Set String
     , choiceNames :: Set String
     }
+
+_roles :: Lens' MetadataHintInfo (Set S.TokenName)
+_roles = prop (SProxy :: SProxy "roles")
+
+_slotParameters :: Lens' MetadataHintInfo (Set String)
+_slotParameters = prop (SProxy :: SProxy "slotParameters")
+
+_valueParameters :: Lens' MetadataHintInfo (Set String)
+_valueParameters = prop (SProxy :: SProxy "valueParameters")
+
+_choiceNames :: Lens' MetadataHintInfo (Set String)
+_choiceNames = prop (SProxy :: SProxy "choiceNames")
 
 getMetadataHintInfo :: Contract -> MetadataHintInfo
 getMetadataHintInfo contract =
@@ -743,13 +760,13 @@ instance fillableAction :: Fillable Action TemplateContent where
 
 instance actionHasChoices :: HasChoices Action where
   getChoiceNames (Deposit _ _ _ value) = getChoiceNames value
+  getChoiceNames (Choice choId _) = getChoiceNames choId
   getChoiceNames (Notify obs) = getChoiceNames obs
-  getChoiceNames _ = Set.empty
 
 instance actionHasParties :: HasParties Action where
   getParties (Deposit accId party _ value) = getParties accId <> getParties party <> getParties value
+  getParties (Choice _ _) = Set.empty
   getParties (Notify obs) = getParties obs
-  getParties _ = Set.empty
 
 data Payee
   = Account S.AccountId

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -38,6 +38,17 @@ type MetaData
     , choiceDescriptions :: Map String String
     }
 
+emptyContractMetadata :: MetaData
+emptyContractMetadata =
+  { contractType: Other
+  , contractName: ""
+  , contractDescription: ""
+  , roleDescriptions: mempty
+  , slotParameterDescriptions: mempty
+  , valueParameterDescriptions: mempty
+  , choiceDescriptions: mempty
+  }
+
 data ContractType
   = Escrow
   | EscrowWithCollatoral
@@ -45,6 +56,7 @@ data ContractType
   | CouponBondGuaranteed
   | Swap
   | ContractForDifferences
+  | Other
 
 derive instance eqContractType :: Eq ContractType
 
@@ -61,6 +73,8 @@ contractTypeInitials Swap = "S"
 
 contractTypeInitials ContractForDifferences = "CD"
 
+contractTypeInitials Other = "O"
+
 contractTypeName :: ContractType -> String
 contractTypeName Escrow = "Escrow"
 
@@ -73,6 +87,51 @@ contractTypeName CouponBondGuaranteed = "Coupon Bond Guaranteed"
 contractTypeName Swap = "Swap"
 
 contractTypeName ContractForDifferences = "Contract for Differences"
+
+initialsToContractType :: String -> ContractType
+initialsToContractType "ES" = Escrow
+
+initialsToContractType "EC" = EscrowWithCollatoral
+
+initialsToContractType "ZC" = ZeroCouponBond
+
+initialsToContractType "CB" = CouponBondGuaranteed
+
+initialsToContractType "S" = Swap
+
+initialsToContractType "CD" = ContractForDifferences
+
+initialsToContractType _ = Other
+
+instance encodeJsonContractType :: Encode ContractType where
+  encode = encode <<< contractTypeInitials
+
+instance decodeJsonContractType :: Decode ContractType where
+  decode ct = decode ct >>= pure <<< initialsToContractType
+
+type MetadataHintInfo
+  = { roles :: Set S.TokenName
+    , slotParameters :: Set String
+    , valueParameters :: Set String
+    , choiceNames :: Set String
+    }
+
+getMetadataHintInfo :: Contract -> MetadataHintInfo
+getMetadataHintInfo contract =
+  let
+    Placeholders placeholders = getPlaceholderIds contract
+  in
+    { roles:
+        Set.mapMaybe
+          ( case _ of
+              S.Role name -> Just name
+              _ -> Nothing
+          )
+          $ getParties contract
+    , slotParameters: placeholders.slotPlaceholderIds
+    , valueParameters: placeholders.valuePlaceholderIds
+    , choiceNames: getChoiceNames contract
+    }
 
 class ToCore a b where
   toCore :: a -> Maybe b
@@ -145,11 +204,20 @@ class Fillable a b where
 class HasParties a where
   getParties :: a -> Set S.Party
 
+class HasChoices a where
+  getChoiceNames :: a -> Set String
+
+instance arrayHasChoices :: HasChoices a => HasChoices (Array a) where
+  getChoiceNames = foldMap getChoiceNames
+
 instance arrayHasParties :: HasParties a => HasParties (Array a) where
   getParties = foldMap getParties
 
 instance sPartyHasParties :: HasParties S.Party where
   getParties party = Set.singleton party
+
+instance sChoiceIdHasChoices :: HasChoices S.ChoiceId where
+  getChoiceNames (S.ChoiceId choiceName _) = Set.singleton choiceName
 
 instance sChoiceIdHasParties :: HasParties S.ChoiceId where
   getParties (S.ChoiceId _ party) = getParties party
@@ -372,6 +440,21 @@ instance fillableValue :: Fillable Value TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
+instance valueHasChoices :: HasChoices Value where
+  getChoiceNames (AvailableMoney accId _) = Set.empty
+  getChoiceNames (Constant _) = Set.empty
+  getChoiceNames (ConstantParam _) = Set.empty
+  getChoiceNames (NegValue val) = getChoiceNames val
+  getChoiceNames (AddValue lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (SubValue lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (MulValue lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (Scale _ val) = getChoiceNames val
+  getChoiceNames (ChoiceValue choId) = getChoiceNames choId
+  getChoiceNames SlotIntervalStart = Set.empty
+  getChoiceNames SlotIntervalEnd = Set.empty
+  getChoiceNames (UseValue _) = Set.empty
+  getChoiceNames (Cond obs lhs rhs) = getChoiceNames obs <> getChoiceNames lhs <> getChoiceNames rhs
+
 instance valueHasParties :: HasParties Value where
   getParties (AvailableMoney accId _) = getParties accId
   getParties (Constant _) = Set.empty
@@ -540,6 +623,19 @@ instance fillableObservation :: Fillable Observation TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
+instance observationHasChoices :: HasChoices Observation where
+  getChoiceNames (AndObs lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (OrObs lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (NotObs v) = getChoiceNames v
+  getChoiceNames (ChoseSomething a) = getChoiceNames a
+  getChoiceNames (ValueGE lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (ValueGT lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (ValueLT lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (ValueLE lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames (ValueEQ lhs rhs) = getChoiceNames lhs <> getChoiceNames rhs
+  getChoiceNames TrueObs = Set.empty
+  getChoiceNames FalseObs = Set.empty
+
 instance observationHasParties :: HasParties Observation where
   getParties (AndObs lhs rhs) = getParties lhs <> getParties rhs
   getParties (OrObs lhs rhs) = getParties lhs <> getParties rhs
@@ -623,6 +719,11 @@ instance fillableAction :: Fillable Action TemplateContent where
     where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
+
+instance actionHasChoices :: HasChoices Action where
+  getChoiceNames (Deposit _ _ _ value) = getChoiceNames value
+  getChoiceNames (Notify obs) = getChoiceNames obs
+  getChoiceNames _ = Set.empty
 
 instance actionHasParties :: HasParties Action where
   getParties (Deposit accId party _ value) = getParties accId <> getParties party <> getParties value
@@ -709,6 +810,9 @@ instance fillableCase :: Fillable Case TemplateContent where
     where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
+
+instance caseHasChoices :: HasChoices Case where
+  getChoiceNames (Case action contract) = getChoiceNames action <> getChoiceNames contract
 
 instance caseHasParties :: HasParties Case where
   getParties (Case action contract) = getParties action <> getParties contract
@@ -827,7 +931,15 @@ instance fillableContract :: Fillable Contract TemplateContent where
     go :: forall a. (Fillable a TemplateContent) => a -> a
     go = fillTemplate placeholders
 
-instance contractHasParries :: HasParties Contract where
+instance contractHasChoices :: HasChoices Contract where
+  getChoiceNames Close = Set.empty
+  getChoiceNames (Pay accId payee _ val cont) = getChoiceNames val <> getChoiceNames cont
+  getChoiceNames (If obs cont1 cont2) = getChoiceNames obs <> getChoiceNames cont1 <> getChoiceNames cont2
+  getChoiceNames (When cases _ cont) = getChoiceNames cases <> getChoiceNames cont
+  getChoiceNames (Let _ val cont) = getChoiceNames val <> getChoiceNames cont
+  getChoiceNames (Assert obs cont) = getChoiceNames obs <> getChoiceNames cont
+
+instance contractHasParties :: HasParties Contract where
   getParties Close = Set.empty
   getParties (Pay accId payee _ val cont) = getParties accId <> getParties payee <> getParties val <> getParties cont
   getParties (If obs cont1 cont2) = getParties obs <> getParties cont1 <> getParties cont2

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -765,7 +765,7 @@ instance actionHasChoices :: HasChoices Action where
 
 instance actionHasParties :: HasParties Action where
   getParties (Deposit accId party _ value) = getParties accId <> getParties party <> getParties value
-  getParties (Choice _ _) = Set.empty
+  getParties (Choice choId _) = getParties choId
   getParties (Notify obs) = getParties obs
 
 data Payee

--- a/web-common-marlowe/src/Marlowe/Extended.purs
+++ b/web-common-marlowe/src/Marlowe/Extended.purs
@@ -109,6 +109,27 @@ instance encodeJsonContractType :: Encode ContractType where
 instance decodeJsonContractType :: Decode ContractType where
   decode ct = decode ct >>= pure <<< initialsToContractType
 
+_contractName :: Lens' MetaData String
+_contractName = prop (SProxy :: SProxy "contractName")
+
+_contractType :: Lens' MetaData ContractType
+_contractType = prop (SProxy :: SProxy "contractType")
+
+_contractDescription :: Lens' MetaData String
+_contractDescription = prop (SProxy :: SProxy "contractDescription")
+
+_roleDescriptions :: Lens' MetaData (Map S.TokenName String)
+_roleDescriptions = prop (SProxy :: SProxy "roleDescriptions")
+
+_slotParameterDescriptions :: Lens' MetaData (Map String String)
+_slotParameterDescriptions = prop (SProxy :: SProxy "slotParameterDescriptions")
+
+_valueParameterDescriptions :: Lens' MetaData (Map String String)
+_valueParameterDescriptions = prop (SProxy :: SProxy "valueParameterDescriptions")
+
+_choiceDescriptions :: Lens' MetaData (Map String String)
+_choiceDescriptions = prop (SProxy :: SProxy "choiceDescriptions")
+
 type MetadataHintInfo
   = { roles :: Set S.TokenName
     , slotParameters :: Set String


### PR DESCRIPTION
Adds a metadata editor to a bottom tab in the Marlowe editor, and it adds metadata to the global state and saves it when publishing gists and local storage. There are a couple of to-dos that I have written in the comments and I have assigned them new tickets.

Since meta-data is saved, we do not add and remove fields automatically, we have buttons for adding and removing fields, but we do hint to the fields that exist in the contract.

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
