### PR TITLE
SCP-1900: Build combined doc-index.json

### DIFF
--- a/nix/lib/haddock-combine.nix
+++ b/nix/lib/haddock-combine.nix
@@ -1,4 +1,4 @@
-{ runCommand, lib, ghc, sphinxcontrib-haddock }:
+{ runCommand, lib, ghc, jq, sphinxcontrib-haddock }:
 { hspkgs # Haskell packages to make documentation for. Only those with a "doc" output will be used.
   # Note: we do not provide arbitrary additional Haddock options, as these would not be
   # applied consistently, since we're reusing the already built Haddock for the packages.
@@ -62,4 +62,17 @@ runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
     --quickjump \
     ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
     "''${interfaceOpts[@]}"
+
+  # Assemble a toplevel `doc-index.json` from package level ones.
+  shopt -s globstar
+  echo "[]" > "doc-index.json"
+  for file in $(ls **/doc-index.json); do
+    project=$(dirname $file);
+    ${jq}/bin/jq -s \
+      ".[0] + [.[1][] | (. + {link: (\"$project/\" + .link)}) ]" \
+      "doc-index.json" \
+      $file \
+      > /tmp/doc-index.json
+    mv /tmp/doc-index.json "doc-index.json"
+  done
 ''

--- a/nix/lib/haddock-combine.nix
+++ b/nix/lib/haddock-combine.nix
@@ -63,6 +63,7 @@ runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
     ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
     "''${interfaceOpts[@]}"
 
+  # Following: https://github.com/input-output-hk/ouroboros-network/blob/2068d091bc7dcd3f4538fb76f1b598f219d1e0c8/scripts/haddocs.sh#L87
   # Assemble a toplevel `doc-index.json` from package level ones.
   shopt -s globstar
   echo "[]" > "doc-index.json"


### PR DESCRIPTION
Following this example: https://github.com/input-output-hk/ouroboros-network/blob/2068d091bc7dcd3f4538fb76f1b598f219d1e0c8/scripts/haddocs.sh#L87 we add a step after the haddock generation to write a combined `doc-index.json` so that searching works! Note that for searching to work locally, you need to open the HTML files through a webserver (if we wanted to serve the docs via a webserver I can look into that, perhaps as a separate item?).

Fixes SCP-1900

I'm just assuming this will work when the docs get pushed; I'm hoping I can check this via one of the CI actions?

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
