### PR TITLE
Script to spin up a webserver for the docs

### DIFF
--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -46,7 +46,7 @@ let
       };
     };
 in
-pkgs.recurseIntoAttrs {
+pkgs.recurseIntoAttrs rec {
   papers = pkgs.recurseIntoAttrs {
     system-f-in-agda = import ../papers/system-f-in-agda { inherit buildLatexDoc; };
     eutxo = import ../papers/eutxo { inherit buildLatexDoc; };
@@ -72,4 +72,6 @@ pkgs.recurseIntoAttrs {
     combined-haddock = plutus.plutus-haddock-combined;
     pythonPackages = pkgs.python3Packages;
   };
+
+  serve-docs = plutus.serveDir { path = site; scriptName = "serve-docs"; port = 8002; };
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -80,6 +80,7 @@ let
   updateClientDeps = pkgs.callPackage ./update-client-deps {
     inherit purs psc-package spago spago2nix;
   };
+  serveDir = pkgs.callPackage ./serve-dir { };
 
   #
   # sphinx python packages
@@ -185,7 +186,7 @@ in
   inherit nix-pre-commit-hooks;
   inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios;
   inherit purty purty-pre-commit purs spago spago2nix;
-  inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps;
+  inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps serveDir;
   inherit iohkNix set-git-rev web-ghc;
   inherit easyPS plutus-haddock-combined;
   inherit agdaWithStdlib;

--- a/nix/pkgs/serve-dir/default.nix
+++ b/nix/pkgs/serve-dir/default.nix
@@ -1,0 +1,6 @@
+{ writeShellScriptBin, python3 }:
+{ path, port, scriptName }:
+writeShellScriptBin "${scriptName}" ''
+  cd ${path} && \
+  ${python3}/bin/python3 -m http.server ${toString port}
+''

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@
 , enableHaskellProfiling ? false
 }:
 let
-  inherit (packages) pkgs plutus plutus-playground marlowe-playground plutus-pab marlowe-dashboard deployment;
+  inherit (packages) pkgs plutus plutus-playground marlowe-playground plutus-pab marlowe-dashboard deployment docs;
   inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt;
   inherit (plutus) haskell agdaPackages stylish-haskell sphinxcontrib-haddock nix-pre-commit-hooks;
   inherit (plutus) agdaWithStdlib;
@@ -83,6 +83,7 @@ let
     updateClientDeps
     updateMetadataSamples
     deployment.getCreds
+    docs.serve-docs
   ]);
 
 in


### PR DESCRIPTION
Specifically so we can view the haddocks (and make use of the search
capability).

Related to SCP-1900.

@gilligan Adding you as a reviewer so you can let me know if I've done this nix stuff in a nice way ... :) Very happy to change/receive some suggestions on how to do it better.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge