### PR TITLE
SCP-2025 - Even out the layout of the metadata form

### DIFF
--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -3,7 +3,7 @@ module MarloweEditor.BottomPanel
   ) where
 
 import Prelude hiding (div)
-import Data.Array (drop, head)
+import Data.Array (concat, concatMap, drop, head)
 import Data.Array as Array
 import Data.Lens (to, (^.))
 import Data.List (List)
@@ -15,56 +15,63 @@ import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple.Nested (type (/\), (/\))
 import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescriptionLocation, justifySelfEnd, minW0, minusBtn, overflowXScroll, paddingRight, plusBtn, smallBtn, underline)
-import Halogen.HTML (ClassName(..), HTML, a, button, div, div_, em_, h6_, input, li_, ol_, option, pre_, section, section_, select, span, span_, text)
+import Halogen.HTML (ClassName(..), HTML, a, button, div, div_, em_, h6_, input, option, pre_, section, section_, select, span_, text)
 import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), class_, classes, placeholder, selected, type_, value)
-import Marlowe.Extended.Metadata (MetaData, _choiceDescriptions, _choiceNames, _roleDescriptions, _roles, _slotParameterDescriptions, _slotParameters, _valueParameterDescriptions, _valueParameters)
 import Marlowe.Extended (contractTypeArray, contractTypeName, contractTypeInitials, initialsToContractType)
+import Marlowe.Extended.Metadata (MetaData, _choiceDescriptions, _choiceNames, _roleDescriptions, _roles, _slotParameterDescriptions, _slotParameters, _valueParameterDescriptions, _valueParameters)
 import MarloweEditor.Types (Action(..), BottomPanelView(..), MetadataAction(..), State, _editorErrors, _editorWarnings, _hasHoles, _metadataHintInfo, _showErrorDetail, contractHasErrors)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Parsing.StringParser.Basic (lines)
 
-metadataList :: forall p. Map String String -> Set String -> (String -> String -> MetadataAction) -> (String -> MetadataAction) -> String -> String -> HTML p Action
+metadataList :: forall p. Map String String -> Set String -> (String -> String -> MetadataAction) -> (String -> MetadataAction) -> String -> String -> Array (HTML p Action)
 metadataList metadataMap hintSet setAction deleteAction typeNameTitle typeNameSmall =
-  div [ class_ $ ClassName "metadata-field-group" ]
-    if Map.isEmpty combinedMap then
-      []
-    else
-      [ h6_ [ em_ [ text $ typeNameTitle <> " descriptions" ] ]
-      , ol_
-          $ map
-              ( \(key /\ val) ->
-                  li_
-                    ( case val of
-                        Just (desc /\ needed) ->
-                          [ text $ typeNameTitle <> " " <> show key <> ": "
-                          , input
+  if Map.isEmpty combinedMap then
+    []
+  else
+    [ div [ class_ $ ClassName "metadata-group-title" ]
+        [ h6_ [ em_ [ text $ typeNameTitle <> " descriptions" ] ] ]
+    ]
+      <> ( concatMap
+            ( \(key /\ val) ->
+                ( case val of
+                    Just (desc /\ needed) ->
+                      [ div [ class_ $ ClassName "metadata-prop-label" ]
+                          [ text $ typeNameTitle <> " " <> show key <> ": " ]
+                      , div [ class_ $ ClassName "metadata-prop-edit" ]
+                          [ input
                               [ type_ InputText
                               , placeholder $ "Description for " <> typeNameSmall <> " " <> show key
                               , class_ $ ClassName "metadata-input"
                               , value desc
                               , onValueChange $ Just <<< MetadataAction <<< setAction key
                               ]
-                          , button
+                          ]
+                      , div [ class_ $ ClassName "metadata-prop-delete" ]
+                          [ button
                               [ classes [ if needed then plusBtn else minusBtn, smallBtn, ClassName "align-top" ]
                               , onClick $ const $ Just $ MetadataAction $ deleteAction key
                               ]
                               [ text "-" ]
                           ]
-                            <> if needed then [] else [ span [ classes [ ClassName "metadata-error", ClassName "metadata-not-used" ] ] [ text "Not used" ] ]
-                        Nothing ->
-                          [ span [ class_ (ClassName "metadata-error") ] [ text $ typeNameTitle <> " " <> show key <> " description not defined" ]
-                          , button
-                              [ classes [ plusBtn, smallBtn, ClassName "align-top" ]
+                      ]
+                        <> if needed then [] else [ div [ classes [ ClassName "metadata-error", ClassName "metadata-prop-not-used" ] ] [ text "Not used" ] ]
+                    Nothing ->
+                      [ div [ classes [ ClassName "metadata-error", ClassName "metadata-prop-not-defined" ] ]
+                          [ text $ typeNameTitle <> " " <> show key <> " description not defined" ]
+                      , div [ class_ $ ClassName "metadata-prop-create" ]
+                          [ button
+                              [ classes [ minusBtn, smallBtn, ClassName "align-top" ]
                               , onClick $ const $ Just $ MetadataAction $ setAction key mempty
                               ]
                               [ text "+" ]
                           ]
-                    )
-              )
-          $ Map.toUnfoldable combinedMap
-      ]
+                      ]
+                )
+            )
+            $ Map.toUnfoldable combinedMap
+        )
   where
   mergeMaps :: (Maybe (String /\ Boolean)) -> (Maybe (String /\ Boolean)) -> (Maybe (String /\ Boolean))
   mergeMaps (Just (x /\ _)) _ = Just (x /\ true)
@@ -84,47 +91,55 @@ metadataList metadataMap hintSet setAction deleteAction typeNameTitle typeNameSm
 
 panelContents :: forall p. State -> MetaData -> BottomPanelView -> HTML p Action
 panelContents state metadata MetadataView =
-  div [ classes [ ClassName "padded-explanation" ] ]
-    [ div [ class_ $ ClassName "metadata-field-group" ]
-        [ text "Contract type: "
-        , select
-            [ class_ $ ClassName "metadata-input"
-            , onValueChange $ Just <<< MetadataAction <<< SetContractType <<< initialsToContractType
-            ] do
-            ct <- contractTypeArray
-            pure
-              $ option
-                  [ value $ contractTypeInitials ct
-                  , selected (ct == metadata.contractType)
+  div [ classes [ ClassName "metadata-form" ] ]
+    ( concat
+        [ [ div [ class_ $ ClassName "metadata-mainprop-label" ]
+              [ text "Contract type: " ]
+          , div [ class_ $ ClassName "metadata-mainprop-edit" ]
+              [ select
+                  [ class_ $ ClassName "metadata-input"
+                  , onValueChange $ Just <<< MetadataAction <<< SetContractType <<< initialsToContractType
+                  ] do
+                  ct <- contractTypeArray
+                  pure
+                    $ option
+                        [ value $ contractTypeInitials ct
+                        , selected (ct == metadata.contractType)
+                        ]
+                        [ text $ contractTypeName ct
+                        ]
+              ]
+          ]
+        , [ div [ class_ $ ClassName "metadata-mainprop-label" ]
+              [ text "Contract name: " ]
+          , div [ class_ $ ClassName "metadata-mainprop-edit" ]
+              [ input
+                  [ type_ InputText
+                  , placeholder "Contract name"
+                  , class_ $ ClassName "metadata-input"
+                  , value metadata.contractName
+                  , onValueChange $ Just <<< MetadataAction <<< SetContractName
                   ]
-                  [ text $ contractTypeName ct
+              ]
+          ]
+        , [ div [ class_ $ ClassName "metadata-mainprop-label" ]
+              [ text "Contract description: " ]
+          , div [ class_ $ ClassName "metadata-mainprop-edit" ]
+              [ input
+                  [ type_ InputText
+                  , placeholder "Contract description"
+                  , class_ $ ClassName "metadata-input"
+                  , value metadata.contractDescription
+                  , onValueChange $ Just <<< MetadataAction <<< SetContractDescription
                   ]
+              ]
+          ]
+        , generateMetadataList _roleDescriptions _roles SetRoleDescription DeleteRoleDescription "Role" "role"
+        , generateMetadataList _choiceDescriptions _choiceNames SetChoiceDescription DeleteChoiceDescription "Choice" "choice"
+        , generateMetadataList _slotParameterDescriptions _slotParameters SetSlotParameterDescription DeleteSlotParameterDescription "Slot parameter" "slot parameter"
+        , generateMetadataList _valueParameterDescriptions _valueParameters SetValueParameterDescription DeleteValueParameterDescription "Value parameter" "value parameter"
         ]
-    , div [ class_ $ ClassName "metadata-field-group" ]
-        [ text "Contract name: "
-        , input
-            [ type_ InputText
-            , placeholder "Contract name"
-            , class_ $ ClassName "metadata-input"
-            , value metadata.contractName
-            , onValueChange $ Just <<< MetadataAction <<< SetContractName
-            ]
-        ]
-    , div [ class_ $ ClassName "metadata-field-group" ]
-        [ text "Contract description: "
-        , input
-            [ type_ InputText
-            , placeholder "Contract description"
-            , class_ $ ClassName "metadata-input"
-            , value metadata.contractDescription
-            , onValueChange $ Just <<< MetadataAction <<< SetContractDescription
-            ]
-        ]
-    , generateMetadataList _roleDescriptions _roles SetRoleDescription DeleteRoleDescription "Role" "role"
-    , generateMetadataList _choiceDescriptions _choiceNames SetChoiceDescription DeleteChoiceDescription "Choice" "choice"
-    , generateMetadataList _slotParameterDescriptions _slotParameters SetSlotParameterDescription DeleteSlotParameterDescription "Slot parameter" "slot parameter"
-    , generateMetadataList _valueParameterDescriptions _valueParameters SetValueParameterDescription DeleteValueParameterDescription "Value parameter" "value parameter"
-    ]
+    )
   where
   generateMetadataList mapLens setLens = metadataList (metadata ^. mapLens) (state ^. (_metadataHintInfo <<< setLens))
 

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -279,10 +279,9 @@ button.minus-btn:hover {
   display: grid;
   grid-template-columns: auto 1fr auto auto;
   gap: 0.5rem 0px;
-  width: 100%;
+  width: clamp(calc(100% - 3rem), 75rem, 100%);
   box-sizing: border-box;
   align-items: center;
-  max-width: 75rem;
   margin: auto;
   padding: 1rem;
 }

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -233,8 +233,6 @@ button.minus-btn:hover {
 }
 
 .metadata-input {
-  margin-left: 1rem;
-  width: 50%;
   display: inline;
   padding: 0.3rem 0.5rem;
   box-sizing: border-box;
@@ -245,6 +243,7 @@ button.minus-btn:hover {
   -webkit-appearance: none;
   appearance: none;
   background-color: #fff;
+  width: 100%;
 }
 
 .metadata-input::-ms-expand {
@@ -263,23 +262,9 @@ button.minus-btn:hover {
   outline: none;
 }
 
-.metadata-field-group {
-  margin: 0.5rem;
-}
-
-.metadata-field-group h6 {
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
+.metadata-group-title h6 {
   font-weight: bold;
-}
-
-.metadata-field-group li {
-  margin-left: 1rem;
-}
-
-.metadata-field-group li::marker {
-  display: none;
-  content: " ";
+  margin: 0.5rem 0;
 }
 
 .metadata-error {
@@ -287,5 +272,27 @@ button.minus-btn:hover {
 }
 
 .metadata-not-used {
-  margin-left: 1rem;
+  row-gap: 1rem;
 }
+
+.metadata-form {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.5rem 0px;
+  width: 100%;
+  box-sizing: border-box;
+  align-items: center;
+  max-width: 75rem;
+  margin: auto;
+  padding: 1rem;
+}
+
+.metadata-mainprop-label { padding-right: 1rem; grid-column-start: 1; grid-column-end: 2; }
+.metadata-mainprop-edit { grid-column-start: 2; grid-column-end: 4; }
+.metadata-group-title { grid-column-start: 1; grid-column-end: 5; }
+.metadata-prop-label { padding: 0rem 1rem; grid-column-start: 1; grid-column-end: 2; }
+.metadata-prop-edit { grid-column-start: 2; grid-column-end: 3; }
+.metadata-prop-delete { grid-column-start: 3; grid-column-end: 4; }
+.metadata-prop-not-used { padding-left: 1rem; grid-column-start: 4; grid-column-end: 5; }
+.metadata-prop-not-defined { padding-left: 1rem; grid-column-start: 1; grid-column-end: 3; }
+.metadata-prop-create { grid-column-start: 3; grid-column-end: 4; }


### PR DESCRIPTION
This PR applies the CSS grid layout to the form for editing metadata, so that fields and buttons are aligned.

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
