### PR TITLE
fix "cabal v2-run" commands in example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -41,7 +41,7 @@ an isolated environment where the packages and tools defined in that file are av
 
 Once the `nix-shell` environment has loaded, you can edit your project files
 with any Haskell editor you prefer, then in the `nix-shell` you can build your project with 
-`cabal v2-build` or compile and run your project's executable with `cabal v2-run`.
+`cabal v2-build` or compile and run your project's executable with `cabal v2-run example-exe`.
 
 ### Developing with Docker and VSCode
 
@@ -98,5 +98,5 @@ the container that is [bind mounted](https://docs.docker.com/storage/bind-mounts
 to your project's folder.
 
 Once inside the dev container, you can build your project with `cabal v2-build`
-or compile and run your project's executable with `cabal v2-run`. You can
+or compile and run your project's executable with `cabal v2-run example-exe`. You can
 also stop/restart/remove the container whenever.


### PR DESCRIPTION
Because there is "example-exe" and "example-test" the "cabal v2-run" command gives an error:
```
cabal: The run command is for running a single executable at once. The target
'' refers to the package example-0.1.0.0 which includes the executable
'example-exe' and the test suite 'example-test'.
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
