### PR TITLE
SCP-2015: Add docs prologue text and flag to build all docs ...

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -154,7 +154,7 @@ let
   plutus-haddock-combined =
     let
       haddock-combine = pkgs.callPackage ../lib/haddock-combine.nix {
-        ghc = haskell.project.pkg-set.config.ghc.package;
+        ghc = haskell.projectAllHaddock.pkg-set.config.ghc.package;
         inherit (sphinxcontrib-haddock) sphinxcontrib-haddock;
       };
     in

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -13,6 +13,9 @@
 , checkMaterialization
 , compiler-nix-name
 , enableHaskellProfiling
+  # Whether to set the `defer-plugin-errors` flag on those packages that need
+  # it. If set to true, we will also build the haddocks for those packages.
+, deferPluginErrors
 }:
 let
   r-packages = with rPackages; [ R tidyverse dplyr stringr MASS plotly shiny shinyjs purrr ];
@@ -53,10 +56,18 @@ let
       {
         reinstallableLibGhc = false;
         packages = {
-          # See https://github.com/input-output-hk/plutus/issues/1213
-          marlowe.doHaddock = false;
-          plutus-use-cases.doHaddock = false;
-          plutus-ledger.doHaddock = false;
+          # See https://github.com/input-output-hk/plutus/issues/1213 and
+          # https://github.com/input-output-hk/plutus/pull/2865.
+          marlowe.doHaddock = deferPluginErrors;
+          marlowe.flags.defer-plugin-errors = deferPluginErrors;
+
+          plutus-use-cases.doHaddock = deferPluginErrors;
+          plutus-use-cases.flags.defer-plugin-errors = deferPluginErrors;
+
+          plutus-ledger.doHaddock = deferPluginErrors;
+          plutus-ledger.flags.defer-plugin-errors = deferPluginErrors;
+
+          # Packages we just don't want docs for
           plutus-benchmark.doHaddock = false;
           # FIXME: Haddock mysteriously gives a spurious missing-home-modules warning
           plutus-tx-plugin.doHaddock = false;

--- a/nix/pkgs/plutus-haddock-combined/default.nix
+++ b/nix/pkgs/plutus-haddock-combined/default.nix
@@ -1,11 +1,25 @@
 { haddock-combine, haskell, haskell-nix, writeTextFile }:
 let
-  toHaddock = haskell-nix.haskellLib.collectComponents' "library" haskell.projectPackages;
+  toHaddock = haskell-nix.haskellLib.collectComponents' "library" haskell.projectPackagesAllHaddock;
 in
 haddock-combine {
   hspkgs = builtins.attrValues toHaddock;
   prologue = writeTextFile {
     name = "prologue";
-    text = "Combined documentation for all the public Plutus libraries.";
+    text = ''
+      = Combined documentation for all the public Plutus libraries
+
+      == Handy module entrypoints
+
+        * "PlutusTx": Compiling Haskell to PLC (Plutus Core; on-chain code).
+        * "PlutusTx.Prelude": Haskell prelude replacement compatible with PLC.
+        * "Plutus.Contract": Writing Plutus apps (off-chain code).
+        * "Ledger.Constraints": Constructing and validating Plutus
+           transactions. Built on "PlutusTx" and 
+           "Plutus.Contract".
+        * "Ledger.Typed.Scripts": A type-safe interface for spending and
+           producing script outputs. Built on "PlutusTx".
+        * "Plutus.Trace.Emulator": Testing Plutus contracts in the emulator.
+    '';
   };
 }


### PR DESCRIPTION
for which haddock would otherwise fail because "of the plugin".

We use set `defer-plugin-errors` for those packages.

@j-mueller @gilligan - Feel free to let me know if you have any refactoring suggestions.

~In particular, I think the name of the flag I've used is a bit confusing ...~

~Here's how to build the docs for these packages:~

~nix-build default.nix -A docs.site --arg deferPluginErrors true~

~I think if I was a bit better with my nix I wouldn't need to set this explicitly when building the `docs` target ... (note also: when you forget that flag, the links in the prologue for `Ledger....` are broken)~

Now the flag is set automatically when you build the docs (inside a nix shell):

```
build-and-serve-docs
```

Fixes SCP-2015

Screenshot:

![image](https://user-images.githubusercontent.com/129525/111599351-14f8f100-87c8-11eb-8d91-72cee2b56da0.png)


~So, before merging, my questions are:~

~- Are you happy with the prologue text? Anything else to add? (Of course, I simply added the links and no real supporting text; happy to have a chat about what should be added.)~
~- Should we change the name of this flag?~
~- How can I set the flag to always be true when building `docs` but not when building the packages themselves, say. (I think the answer is to not provide the pkgs in as an argument to docs; but I'm not totally certain; will take a look tomorrow.)~

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
