### PR TITLE
Don't build docs on shell entry; simple script to build and serve docs

### DIFF
--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -46,7 +46,7 @@ let
       };
     };
 in
-pkgs.recurseIntoAttrs rec {
+pkgs.recurseIntoAttrs {
   papers = pkgs.recurseIntoAttrs {
     system-f-in-agda = import ../papers/system-f-in-agda { inherit buildLatexDoc; };
     eutxo = import ../papers/eutxo { inherit buildLatexDoc; };
@@ -73,5 +73,8 @@ pkgs.recurseIntoAttrs rec {
     pythonPackages = pkgs.python3Packages;
   };
 
-  serve-docs = plutus.serveDir { path = site; scriptName = "serve-docs"; port = 8002; };
+  build-and-serve-docs = pkgs.writeShellScriptBin "build-and-serve-docs" ''
+    cd $(nix-build default.nix -A docs.site) && \
+    ${pkgs.python3}/bin/python3 -m http.server 8002
+  '';
 }

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -80,7 +80,6 @@ let
   updateClientDeps = pkgs.callPackage ./update-client-deps {
     inherit purs psc-package spago spago2nix;
   };
-  serveDir = pkgs.callPackage ./serve-dir { };
 
   #
   # sphinx python packages
@@ -186,7 +185,7 @@ in
   inherit nix-pre-commit-hooks;
   inherit haskell agdaPackages cabal-install stylish-haskell hlint haskell-language-server hie-bios;
   inherit purty purty-pre-commit purs spago spago2nix;
-  inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps serveDir;
+  inherit fixPurty fixStylishHaskell updateMaterialized updateMetadataSamples updateClientDeps;
   inherit iohkNix set-git-rev web-ghc;
   inherit easyPS plutus-haddock-combined;
   inherit agdaWithStdlib;

--- a/nix/pkgs/serve-dir/default.nix
+++ b/nix/pkgs/serve-dir/default.nix
@@ -1,6 +1,0 @@
-{ writeShellScriptBin, python3 }:
-{ path, port, scriptName }:
-writeShellScriptBin "${scriptName}" ''
-  cd ${path} && \
-  ${python3}/bin/python3 -m http.server ${toString port}
-''

--- a/shell.nix
+++ b/shell.nix
@@ -83,7 +83,7 @@ let
     updateClientDeps
     updateMetadataSamples
     deployment.getCreds
-    docs.serve-docs
+    docs.build-and-serve-docs
   ]);
 
 in


### PR DESCRIPTION
Simpler version of https://github.com/input-output-hk/plutus/pull/2858 that doesn't build the docs on shell entry anymore; just writes a script that both builds _and_ serves.

I just moved everything into docs to avoid over-complicating it.

Hope this makes sense :)


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
