### PR TITLE
[Builtins] [Refactoring] Removed 'DynamicPart'

### DIFF
--- a/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
@@ -103,11 +103,11 @@ insertBuiltin fun =
         BuiltinMeaning sch meta _ ->
            case typeSchemeResult sch of
                AsKnownType ->
-                   insertDenotation $ Denotation fun (Builtin ()) (meta ()) sch
+                   insertDenotation $ Denotation fun (Builtin ()) meta sch
 
 -- Builtins that may fail are commented out, because we cannot handle them right now.
 -- Look for "UNDEFINED BEHAVIOR" in "PlutusCore.Generators.Internal.Dependent".
--- | A 'DenotationContext' that consists of 'TypedStaticBuiltin's.
+-- | A 'DenotationContext' that consists of 'DefaultFun's.
 typedBuiltins
     :: DenotationContext (Term TyName Name DefaultUni DefaultFun ())
 typedBuiltins

--- a/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
@@ -118,109 +118,108 @@ nonZeroArg _ _ 0 = EvaluationFailure
 nonZeroArg f x y = EvaluationSuccess $ f x y
 
 defBuiltinsRuntime :: HasConstantIn DefaultUni term => BuiltinsRuntime DefaultFun term
-defBuiltinsRuntime = toBuiltinsRuntime () defaultCostModel
+defBuiltinsRuntime = toBuiltinsRuntime defaultCostModel
 
 instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni DefaultFun where
-    type DynamicPart uni DefaultFun = ()
     type CostingPart uni DefaultFun = CostModel
     toBuiltinMeaning AddInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((+) @Integer)
             (runCostingFunTwoArguments . paramAddInteger)
     toBuiltinMeaning SubtractInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((-) @Integer)
             (runCostingFunTwoArguments . paramSubtractInteger)
     toBuiltinMeaning MultiplyInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((*) @Integer)
             (runCostingFunTwoArguments . paramMultiplyInteger)
     toBuiltinMeaning DivideInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (nonZeroArg div)
             (runCostingFunTwoArguments . paramDivideInteger)
     toBuiltinMeaning QuotientInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (nonZeroArg quot)
             (runCostingFunTwoArguments . paramQuotientInteger)
     toBuiltinMeaning RemainderInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (nonZeroArg rem)
             (runCostingFunTwoArguments . paramRemainderInteger)
     toBuiltinMeaning ModInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (nonZeroArg mod)
             (runCostingFunTwoArguments . paramModInteger)
     toBuiltinMeaning LessThanInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((<) @Integer)
             (runCostingFunTwoArguments . paramLessThanInteger)
     toBuiltinMeaning LessThanEqInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((<=) @Integer)
             (runCostingFunTwoArguments . paramLessThanEqInteger)
     toBuiltinMeaning GreaterThanInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((>) @Integer)
             (runCostingFunTwoArguments . paramGreaterThanInteger)
     toBuiltinMeaning GreaterThanEqInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((>=) @Integer)
             (runCostingFunTwoArguments . paramGreaterThanEqInteger)
     toBuiltinMeaning EqInteger =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((==) @Integer)
             (runCostingFunTwoArguments . paramEqInteger)
     toBuiltinMeaning Concatenate =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             BS.append
             (runCostingFunTwoArguments . paramConcatenate)
     toBuiltinMeaning TakeByteString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             BS.take
             (runCostingFunTwoArguments . paramTakeByteString)
     toBuiltinMeaning DropByteString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             BS.drop
             (runCostingFunTwoArguments . paramDropByteString)
     toBuiltinMeaning SHA2 =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             Hash.sha2
             (runCostingFunOneArgument . paramSHA2)
     toBuiltinMeaning SHA3 =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             Hash.sha3
             (runCostingFunOneArgument . paramSHA3)
     toBuiltinMeaning VerifySignature =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (verifySignature @EvaluationResult)
             (runCostingFunThreeArguments . paramVerifySignature)
     toBuiltinMeaning EqByteString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((==) @BS.ByteString)
             (runCostingFunTwoArguments . paramEqByteString)
     toBuiltinMeaning LtByteString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((<) @BS.ByteString)
             (runCostingFunTwoArguments . paramLtByteString)
     toBuiltinMeaning GtByteString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((>) @BS.ByteString)
             (runCostingFunTwoArguments . paramGtByteString)
     toBuiltinMeaning IfThenElse =
-       toStaticBuiltinMeaning
+       makeBuiltinMeaning
             (\b x y -> if b then x else y)
             (runCostingFunThreeArguments . paramIfThenElse)
     toBuiltinMeaning CharToString =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (pure :: Char -> String)
             mempty  -- TODO: budget.
     toBuiltinMeaning Append =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             ((++) :: String -> String -> String)
             mempty  -- TODO: budget.
     toBuiltinMeaning Trace =
-        toStaticBuiltinMeaning
+        makeBuiltinMeaning
             (emit :: String -> Emitter ())
             mempty  -- TODO: budget.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -1,4 +1,4 @@
--- GHC doesn't like the definition of 'toDynamicBuiltinMeaning'.
+-- GHC doesn't like the definition of 'makeBuiltinMeaning'.
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 {-# LANGUAGE ConstraintKinds           #-}
@@ -37,7 +37,7 @@ import           Data.Type.Bool
 import           Data.Type.Equality
 import           GHC.TypeLits
 
--- | The meaning of a dynamic built-in function consists of its type represented as a 'TypeScheme',
+-- | The meaning of a built-in function consists of its type represented as a 'TypeScheme',
 -- its Haskell denotation and a costing function (both in uninstantiated form).
 --
 -- The 'TypeScheme' of a built-in function is used for
@@ -46,27 +46,15 @@ import           GHC.TypeLits
 -- 2. checking equality of the expected type of an argument of a builtin and the actual one
 --    during evaluation, so that we can avoid unsafe-coercing
 --
--- There exist two kinds of built-in functions:
---
--- 1. those whose denotation is known statically. E.g. the denotation of 'AddInteger' is @(+)@
--- 2. those whose denotation is computed at runtimefor. E.g. 'Trace' maps to a function whose
---    denotation is constructed in the 'IO' monad
---
--- Those functions that get their denotation at runtime make use of the @dyn@ parameter that
--- gets instantiated with a record containing interpretations for each of the "dynamic" built-in
--- functions. I.e. for each such function we simply extract its denotation from said record.
--- For "static" built-in function we ignore the @dyn@ record and construct the denotation
--- directly.
---
 -- A costing function for a built-in function is computed from a cost model for all built-in
 -- functions from a certain set, hence the @cost@ parameter.
-data BuiltinMeaning term dyn cost =
+data BuiltinMeaning term cost =
     forall args res. BuiltinMeaning
         (TypeScheme term args res)
-        (dyn -> FoldArgs args res)
+        (FoldArgs args res)
         (cost -> FoldArgsEx args)
 -- I tried making it @(forall term. HasConstantIn uni term => TypeScheme term args res)@ instead of
--- @TypeScheme term args res@, but 'toDynamicBuiltinMeaning' has to talk about
+-- @TypeScheme term args res@, but 'makeBuiltinMeaning' has to talk about
 -- @KnownPolytype binds term args res a@ (note the @term@), because instances of 'KnownMonotype'
 -- are constrained with @KnownType term arg@ and @KnownType term res@, and so the earliest we can
 -- generalize from @term@ to @UniOf term@ is in 'toBuiltinMeaning'.
@@ -93,39 +81,33 @@ newtype BuiltinsRuntime fun term = BuiltinsRuntime
     { unBuiltinRuntime :: Array fun (BuiltinRuntime term)
     }
 
--- | Instantiate a 'BuiltinMeaning' given denotations of dynamic built-in functions and
--- a cost model.
-toBuiltinRuntime :: dyn -> cost -> BuiltinMeaning term dyn cost -> BuiltinRuntime term
-toBuiltinRuntime dyn cost (BuiltinMeaning sch f exF) =
-    BuiltinRuntime sch (getArity sch) (f dyn) (exF cost)
+-- | Instantiate a 'BuiltinMeaning' given denotations of built-in functions and a cost model.
+toBuiltinRuntime :: cost -> BuiltinMeaning term cost -> BuiltinRuntime term
+toBuiltinRuntime cost (BuiltinMeaning sch f exF) =
+    BuiltinRuntime sch (getArity sch) f (exF cost)
 
 -- | A type class for \"each function from a set of built-in functions has a 'BuiltinMeaning'\".
 class (Bounded fun, Enum fun, Ix fun) => ToBuiltinMeaning uni fun where
-    -- | The @dyn@ part of 'BuiltinMeaning'.
-    type DynamicPart uni fun
-
     -- | The @cost@ part of 'BuiltinMeaning'.
     type CostingPart uni fun
 
     -- | Get the 'BuiltinMeaning' of a built-in function.
     toBuiltinMeaning
         :: HasConstantIn uni term
-        => fun -> BuiltinMeaning term (DynamicPart uni fun) (CostingPart uni fun)
+        => fun -> BuiltinMeaning term (CostingPart uni fun)
 
 -- | Get the type of a built-in function.
 typeOfBuiltinFunction :: ToBuiltinMeaning uni fun => fun -> Type TyName uni ()
 typeOfBuiltinFunction fun = case toBuiltinMeaning @_ @_ @(Term TyName Name _ _ ()) fun of
     BuiltinMeaning sch _ _ -> typeSchemeToType sch
 
--- | Calculate runtime info for all built-in functions given denotations of dynamic builtins
+-- | Calculate runtime info for all built-in functions given denotations of builtins
 -- and a cost model.
 toBuiltinsRuntime
-    :: ( dyn ~ DynamicPart uni fun, cost ~ CostingPart uni fun
-       , HasConstantIn uni term, ToBuiltinMeaning uni fun
-       )
-    => dyn -> cost -> BuiltinsRuntime fun term
-toBuiltinsRuntime dyn cost =
-    BuiltinsRuntime . tabulateArray $ toBuiltinRuntime dyn cost . toBuiltinMeaning
+    :: (cost ~ CostingPart uni fun, HasConstantIn uni term, ToBuiltinMeaning uni fun)
+    => cost -> BuiltinsRuntime fun term
+toBuiltinsRuntime cost =
+    BuiltinsRuntime . tabulateArray $ toBuiltinRuntime cost . toBuiltinMeaning
 
 -- | Look up the runtime info of a built-in function during evaluation.
 lookupBuiltin
@@ -319,30 +301,15 @@ instance {-# OVERLAPPING #-}
     ) => EnumerateFromTo i k term (a -> b)
 
 -- See Note [Automatic derivation of type schemes]
--- | Construct the meaning for a dynamic built-in function by automatically deriving its
--- 'TypeScheme', given
---
--- 1. a function that extracts the denotation of the builtin from the record with denotations
---    of dynamic builtins
--- 2. an uninstantiated costing function
-toDynamicBuiltinMeaning
-    :: forall a term dyn cost binds args res j.
-       ( args ~ GetArgs a, a ~ FoldArgs args res, binds ~ ToBinds (TypeScheme term args res)
-       , KnownPolytype binds term args res a, EnumerateFromTo 0 j term a
-       )
-    => (dyn -> a) -> (cost -> FoldArgsEx args) -> BuiltinMeaning term dyn cost
-toDynamicBuiltinMeaning = BuiltinMeaning (knownPolytype (Proxy @binds) :: TypeScheme term args res)
-
--- See Note [Automatic derivation of type schemes]
--- | Construct the meaning for a static built-in function by automatically deriving its
+-- | Construct the meaning for a built-in function by automatically deriving its
 -- 'TypeScheme', given
 --
 -- 1. the denotation of the builtin
 -- 2. an uninstantiated costing function
-toStaticBuiltinMeaning
-    :: forall a term dyn cost binds args res j.
+makeBuiltinMeaning
+    :: forall a term cost binds args res j.
        ( args ~ GetArgs a, a ~ FoldArgs args res, binds ~ ToBinds (TypeScheme term args res)
        , KnownPolytype binds term args res a, EnumerateFromTo 0 j term a
        )
-    => a -> (cost -> FoldArgsEx args) -> BuiltinMeaning term dyn cost
-toStaticBuiltinMeaning = toDynamicBuiltinMeaning . const
+    => a -> (cost -> FoldArgsEx args) -> BuiltinMeaning term cost
+makeBuiltinMeaning = BuiltinMeaning (knownPolytype (Proxy @binds) :: TypeScheme term args res)

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -366,7 +366,7 @@ applyEvaluate stack val@(VBuiltin bn arity0 arity tyargs args) arg = do
 applyEvaluate _ val _ =
     throwingWithCause _MachineError NonFunctionalApplicationMachineError $ Just $ ckValueToTerm val
 
--- | Apply a (static or dynamic) built-in function to some arguments
+-- | Apply a built-in function to some arguments
 applyBuiltin
     :: Ix fun
     => Context uni fun

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -59,13 +59,13 @@ This requires specialised encode/decode functions for each constructor
 that encodes a different number of possibilities. Here is a list of the
 tags and their used/available encoding possibilities.
 
-| Data type       | Function          | Used | Available |
-|-----------------|-------------------|------|-----------|
-| Static builtins | encodeBuiltin     | 22   | 32        |
-| Kinds           | encodeKind        | 2    | 2         |
-| Types           | encodeType        | 7    | 8         |
-| BuiltinNames    | encodeBuiltinName | 2    | 2         |
-| Terms           | encodeTerm        | 10   | 16        |
+| Data type        | Function          | Used | Available |
+|------------------|-------------------|------|-----------|
+| default builtins | encodeBuiltin     | 22   | 32        |
+| Kinds            | encodeKind        | 2    | 2         |
+| Types            | encodeType        | 7    | 8         |
+| BuiltinNames     | encodeBuiltinName | 2    | 2         |
+| Terms            | encodeTerm        | 10   | 16        |
 
 For format stability we are manually assigning the tag values to the
 constructors (and we do not use a generic algorithm that may change this order).

--- a/plutus-core/plutus-core/src/PlutusCore/Lexer.x
+++ b/plutus-core/plutus-core/src/PlutusCore/Lexer.x
@@ -150,7 +150,7 @@ tokens :-
     <kwd> delay          { mkKeyword KwDelay       `andBegin` 0 }
     <kwd> builtin        { mkKeyword KwBuiltin     `andBegin` builtin }
     -- ^ Switch the lexer into a mode where it's looking for a builtin id.
-    -- These are converted into Builtin names (possibly dynamic) in the parser.
+    -- These are converted into Builtin names in the parser.
     -- Outside this mode, all ids are parsed as Names.
     <kwd> con            { mkKeyword KwCon         `andBegin` conargs }
     -- ^ (con tyname) or (con tyname const)

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Internal.hs
@@ -28,7 +28,7 @@ type Parse = ExceptT (ParseError AlexPosn) Alex
 parseError :: Token AlexPosn -> Parse b
 parseError = throwError . Unexpected
 
---- Static built-in functions ---
+--- Parsing built-in functions ---
 
 parseBuiltinFunction :: (Bounded fun, Enum fun, Pretty fun) => T.Text -> Maybe fun
 parseBuiltinFunction name = find (\fun -> display fun == name) enumeration

--- a/plutus-core/plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications      #-}
 
 module Evaluation.ApplyBuiltinName
-    ( test_applyStaticBuiltin
+    ( test_applyDefaultBuiltin
     ) where
 
 import           PlutusCore
@@ -44,18 +44,17 @@ instance SpendBudget AppM DefaultFun () (Term TyName Name DefaultUni DefaultFun 
 test_applyBuiltinFunction :: DefaultFun -> TestTree
 test_applyBuiltinFunction fun =
     testProperty (show fun) . property $ case toBuiltinMeaning fun of
-        BuiltinMeaning sch toF toExF -> do
-            let f = toF ()
-                exF = toExF defaultCostModel
+        BuiltinMeaning sch f toExF -> do
+            let exF = toExF defaultCostModel
                 denot = Denotation fun (Builtin ()) f sch
                 getIterAppValue = runPlcT genTypedBuiltinDef $ genIterAppValue denot
             IterAppValue _ (IterApp _ args) res <- forAllNoShow getIterAppValue
             -- The calls to 'unAppM' are just to drive type inference.
             unAppM (applyTypeSchemed fun sch f exF args) === unAppM (makeKnown res)
 
-test_applyStaticBuiltin :: TestTree
-test_applyStaticBuiltin =
-    testGroup "applyStaticBuiltin"
+test_applyDefaultBuiltin :: TestTree
+test_applyDefaultBuiltin =
+    testGroup "applyDefaultBuiltin"
         [ test_applyBuiltinFunction AddInteger
         , test_applyBuiltinFunction SubtractInteger
         , test_applyBuiltinFunction MultiplyInteger

--- a/plutus-core/plutus-core/test/Evaluation/DynamicBuiltins/MakeRead.hs
+++ b/plutus-core/plutus-core/test/Evaluation/DynamicBuiltins/MakeRead.hs
@@ -70,7 +70,7 @@ test_stringRoundtrip =
 test_collectStrings :: TestTree
 test_collectStrings = testProperty "collectStrings" . property $ do
     strs <- forAll . Gen.list (Range.linear 0 10) $ Gen.string (Range.linear 0 20) Gen.unicode
-    let runtime = toBuiltinsRuntime () defaultCostModel
+    let runtime = toBuiltinsRuntime defaultCostModel
         step arg rest = mkIterApp () sequ
             [ Apply () (Builtin () Trace) $ mkConstant @String @DefaultUni () arg
             , rest

--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -1,6 +1,6 @@
 module Evaluation.Spec where
 
-import           Evaluation.ApplyBuiltinName (test_applyStaticBuiltin)
+import           Evaluation.ApplyBuiltinName (test_applyDefaultBuiltin)
 import           Evaluation.DynamicBuiltins  (test_dynamicBuiltins)
 import           Evaluation.Machines         (test_machines)
 
@@ -9,7 +9,7 @@ import           Test.Tasty
 test_evaluation :: TestTree
 test_evaluation =
     testGroup "evaluation"
-        [ test_applyStaticBuiltin
+        [ test_applyDefaultBuiltin
         , test_dynamicBuiltins
         , test_machines
         ]

--- a/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications      #-}
 
 module Evaluation.ApplyBuiltinName
-    ( test_applyStaticBuiltin
+    ( test_applyDefaultBuiltin
     ) where
 
 import           UntypedPlutusCore
@@ -58,16 +58,15 @@ instance SpendBudget AppM DefaultFun () (Term Name DefaultUni DefaultFun ()) whe
 test_applyBuiltinFunction :: DefaultFun -> TestTree
 test_applyBuiltinFunction fun =
     testProperty (show fun) . property $ case toBuiltinMeaning fun of
-        BuiltinMeaning sch toF toExF -> do
-            let f = toF ()
-                exF = toExF defaultCostModel
+        BuiltinMeaning sch f toExF -> do
+            let exF = toExF defaultCostModel
             withGenArgsRes sch f $ \args res ->
                 -- The calls to 'unAppM' are just to drive type inference.
                 unAppM (applyTypeSchemed fun sch f exF args) === unAppM (makeKnown res)
 
-test_applyStaticBuiltin :: TestTree
-test_applyStaticBuiltin =
-    testGroup "applyStaticBuiltin"
+test_applyDefaultBuiltin :: TestTree
+test_applyDefaultBuiltin =
+    testGroup "applyDefaultBuiltin"
         [ test_applyBuiltinFunction AddInteger
         , test_applyBuiltinFunction SubtractInteger
         , test_applyBuiltinFunction MultiplyInteger

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -131,7 +131,7 @@ test_budget
     $ concat
         [ folder defBuiltinsRuntime examples
         , folder defBuiltinsRuntime bunchOfFibs
-        , folder (toBuiltinsRuntime mempty ()) bunchOfIdNats
+        , folder (toBuiltinsRuntime ()) bunchOfIdNats
         , folder defBuiltinsRuntime bunchOfIfThenElseNats
         ]
   where

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           Evaluation.ApplyBuiltinName (test_applyStaticBuiltin)
+import           Evaluation.ApplyBuiltinName (test_applyDefaultBuiltin)
 import           Evaluation.Golden           (test_golden)
 import           Evaluation.Machines
 
@@ -8,7 +8,7 @@ import           Test.Tasty
 
 main :: IO ()
 main = defaultMain $ testGroup "Untyped Plutus Core"
-    [ test_applyStaticBuiltin
+    [ test_applyDefaultBuiltin
     , test_machines
     , test_memory
     , test_budget

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -177,7 +177,7 @@ evaluateScriptRestricting verbose costParams budget p args = swap $ runWriter @L
     model <- liftEither $ mkCostModel costParams
 
     let (res, _, logs) = UPLC.runCek
-          (PLC.toBuiltinsRuntime () model)
+          (PLC.toBuiltinsRuntime model)
           (UPLC.restricting $ PLC.ExRestrictingBudget budget)
           (verbose == Verbose)
          appliedTerm
@@ -197,7 +197,7 @@ evaluateScriptCounting verbose costParams p args = swap $ runWriter @LogOutput $
     model <- liftEither $ mkCostModel costParams
 
     let (res, UPLC.CountingSt final, logs) = UPLC.runCek
-          (PLC.toBuiltinsRuntime () model)
+          (PLC.toBuiltinsRuntime model)
           UPLC.counting
           (verbose == Verbose)
           appliedTerm


### PR DESCRIPTION
This removes the `DynamicPart` part of the meaning of a built-in function, since we no longer need this extensibility as we were only using it for tracing and now we handle tracing differently.