### PR TITLE
Update PAB ports & demo doc

### DIFF
--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -3,12 +3,12 @@
 { name
 , db-file ? "/tmp/pab-core.db"
 , client
-, webserver-port ? "8080"
-, walletserver-port ? "8081"
-, nodeserver-port ? "8082"
-, chain-index-port ? "8083"
-, signing-process-port ? "8084"
-, metadata-server-port ? "8085"
+, webserver-port ? "9080"
+, walletserver-port ? "9081"
+, nodeserver-port ? "9082"
+, chain-index-port ? "9083"
+, signing-process-port ? "9084"
+, metadata-server-port ? "9085"
 , wallet ? "1"
 }: pkgs.writeText "pab.yaml" ''
   dbConfig:

--- a/plutus-pab-client/webpack.config.js
+++ b/plutus-pab-client/webpack.config.js
@@ -32,10 +32,10 @@ module.exports = {
         https: true,
         proxy: {
             "/api": {
-                target: 'http://localhost:8080'
+                target: 'http://localhost:9080'
             },
             "/ws": {
-                target: 'ws://localhost:8080',
+                target: 'ws://localhost:9080',
                 ws: true,
                 onError(err) {
                   console.log('Error with the WebSocket:', err);

--- a/plutus-pab/README.md
+++ b/plutus-pab/README.md
@@ -33,7 +33,7 @@ to be started in order to access the web frontend. The required steps are descri
 First we build the startup scripts:
 
 ```
-$ nix-build ../default.nix plutus-pab.demo-scripts
+$ nix-build ../default.nix -A plutus-pab.demo-scripts
 ```
 
 Next we start all required servers and install several contracts:

--- a/plutus-pab/README.md
+++ b/plutus-pab/README.md
@@ -57,8 +57,8 @@ $ npm start
 
 The client is now running at https://localhost:8009 -- See [pab-demo-scripts.nix](https://github.com/input-output-hk/plutus/blob/pab-readme/plutus-pab-client/pab-demo-scripts.nix) for details on the service invcation and contract installation.
 
-**Note**: By default the frontend will forward requests to `localhost:8080` - the first PAB instance. Connecting to the second
-instance currently requires changing the proxy config in [webpack.config.js](https://github.com/input-output-hk/plutus/blob/master/plutus-pab-client/webpack.config.js#L33-L41). The second instance runs on port 8086 so the linked section in the config file would have to be
+**Note**: By default the frontend will forward requests to `localhost:9080` - the first PAB instance. Connecting to the second
+instance currently requires changing the proxy config in [webpack.config.js](https://github.com/input-output-hk/plutus/blob/master/plutus-pab-client/webpack.config.js#L33-L41). The second instance runs on port 9086 so the linked section in the config file would have to be
 updated accordingly.
 
 ## PAB Components


### PR DESCRIPTION
To reflect the demo scripts changes in 63493b4cb7c7ea53eee4825e200caef60cc4f55a.

I'm not sure if these changes make sense, or users are supposed to tweak their own demo scripts.
But the current `plutus-pab` README instructions aren't working and I think we should do something about it.

<!--
Here are some checklists you may like to use. Use your judgment.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
