### PR TITLE
SCP-2021 - Add metadata to simulator

### DIFF
--- a/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/BottomPanel.purs
@@ -11,17 +11,18 @@ import Halogen.Classes (flex, flexCol, fontBold, fullWidth, grid, gridColsDescri
 import Halogen.HTML (HTML, a, div, div_, pre_, section, section_, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
+import Marlowe.Extended.Metadata (MetaData)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 
-panelContents :: forall p. State -> BottomPanelView -> HTML p Action
-panelContents state StaticAnalysisView =
+panelContents :: forall p. State -> MetaData -> BottomPanelView -> HTML p Action
+panelContents state metadata StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
     if (state ^. _hasHoles) then
       [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
       ]
     else
-      [ analysisResultPane SetIntegerTemplateParam state
+      [ analysisResultPane metadata SetIntegerTemplateParam state
       , div [ classes [ paddingRight ] ]
           [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
           , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract
@@ -44,7 +45,7 @@ panelContents state StaticAnalysisView =
 
   analysisEnabled = nothingLoading
 
-panelContents state BlocklyWarningsView =
+panelContents state _ BlocklyWarningsView =
   section_
     if Array.null warnings then
       [ pre_ [ text "No warnings" ] ]

--- a/marlowe-playground-client/src/BlocklyEditor/View.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/View.purs
@@ -19,13 +19,15 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (classes, enabled, id_)
 import MainFrame.Types (ChildSlots, _blocklySlot)
 import Marlowe.Blockly as MB
+import Marlowe.Extended.Metadata (MetaData)
 
 render ::
   forall m.
   MonadAff m =>
+  MetaData ->
   State ->
   ComponentHTML Action ChildSlots m
-render state =
+render metadata state =
   div [ classes [ flex, flexCol, fullHeight ] ]
     [ section
         [ classes [ paddingX, minH0, overflowHidden, fullHeight ]
@@ -51,7 +53,7 @@ render state =
 
   warningsTitle = withCount "Warnings" $ state ^. _warnings
 
-  wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state panelView
+  wrapBottomPanelContents panelView = BottomPanel.PanelAction <$> panelContents state metadata panelView
 
 workspaceBlocks :: forall a b. HTML a b
 workspaceBlocks =

--- a/marlowe-playground-client/src/Halogen/Classes.purs
+++ b/marlowe-playground-client/src/Halogen/Classes.purs
@@ -250,6 +250,9 @@ disabled false = ClassName ""
 spanText :: forall p i. String -> HTML p i
 spanText s = span [] [ text s ]
 
+spanTextBreakWord :: forall p i. String -> HTML p i
+spanTextBreakWord s = span [ classes [ ClassName "break-word-span" ] ] [ text s ]
+
 sidebarComposer :: ClassName
 sidebarComposer = ClassName "sidebar-composer"
 

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -52,7 +52,7 @@ render state =
       , main []
           [ section [ id_ "main-panel" ]
               [ tabContents HomePage [ Home.render state ]
-              , tabContents Simulation [ renderSubmodule _simulationState SimulationAction Simulation.render state ]
+              , tabContents Simulation [ renderSubmodule _simulationState SimulationAction (Simulation.render (state ^. _contractMetadata)) state ]
               , tabContents MarloweEditor [ renderSubmodule _marloweEditorState MarloweEditorAction (MarloweEditor.render (state ^. _contractMetadata)) state ]
               , tabContents HaskellEditor [ renderSubmodule _haskellState HaskellAction HaskellEditor.render state ]
               , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction JSEditor.render state ]

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -54,9 +54,9 @@ render state =
               [ tabContents HomePage [ Home.render state ]
               , tabContents Simulation [ renderSubmodule _simulationState SimulationAction (Simulation.render (state ^. _contractMetadata)) state ]
               , tabContents MarloweEditor [ renderSubmodule _marloweEditorState MarloweEditorAction (MarloweEditor.render (state ^. _contractMetadata)) state ]
-              , tabContents HaskellEditor [ renderSubmodule _haskellState HaskellAction HaskellEditor.render state ]
-              , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction JSEditor.render state ]
-              , tabContents BlocklyEditor [ renderSubmodule _blocklyEditorState BlocklyEditorAction BlocklyEditor.render state ]
+              , tabContents HaskellEditor [ renderSubmodule _haskellState HaskellAction (HaskellEditor.render (state ^. _contractMetadata)) state ]
+              , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction (JSEditor.render (state ^. _contractMetadata)) state ]
+              , tabContents BlocklyEditor [ renderSubmodule _blocklyEditorState BlocklyEditorAction (BlocklyEditor.render (state ^. _contractMetadata)) state ]
               , tabContents ActusBlocklyEditor
                   [ slot _actusBlocklySlot unit (ActusBlockly.blockly AMB.rootBlockName AMB.blockDefinitions AMB.toolbox) unit (Just <<< HandleActusBlocklyMessage)
                   , AMB.workspaceBlocks

--- a/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/MarloweEditor/BottomPanel.purs
@@ -143,13 +143,13 @@ panelContents state metadata MetadataView =
   where
   generateMetadataList mapLens setLens = metadataList (metadata ^. mapLens) (state ^. (_metadataHintInfo <<< setLens))
 
-panelContents state _ StaticAnalysisView =
+panelContents state metadata StaticAnalysisView =
   section [ classes [ flex, flexCol ] ]
     if (state ^. _hasHoles) then
       [ div_ [ text "The contract needs to be complete (no holes) before doing static analysis." ]
       ]
     else
-      [ analysisResultPane SetIntegerTemplateParam state
+      [ analysisResultPane metadata SetIntegerTemplateParam state
       , div [ classes [ paddingRight ] ]
           [ analyzeButton loadingWarningAnalysis analysisEnabled "Analyse for warnings" AnalyseContract
           , analyzeButton loadingReachability analysisEnabled "Analyse reachability" AnalyseReachabilityContract

--- a/marlowe-playground-client/src/SimulationPage/BottomPanel.purs
+++ b/marlowe-playground-client/src/SimulationPage/BottomPanel.purs
@@ -14,12 +14,13 @@ import Halogen.Classes (first, rTable, rTable4cols, rTableCell, rTableEmptyRow)
 import Halogen.Classes as Classes
 import Halogen.HTML (HTML, div, text)
 import Halogen.HTML.Properties (class_, classes)
+import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics (ChoiceId(..), Party, Token, ValueId(..), _accounts, _boundValues, _choices)
 import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
 import SimulationPage.Types (Action, BottomPanelView(..), State, _SimulationNotStarted, _SimulationRunning, _executionState, _initialSlot, _marloweState, _slot, _state)
 
-panelContents :: forall p. State -> BottomPanelView -> HTML p Action
-panelContents state CurrentStateView =
+panelContents :: forall p. MetaData -> State -> BottomPanelView -> HTML p Action
+panelContents metadata state CurrentStateView =
   div [ classes [ rTable, rTable4cols ] ]
     ( tableRow
         { title: "Accounts"
@@ -51,7 +52,7 @@ panelContents state CurrentStateView =
     let
       (accounts :: Array (Tuple (Tuple Party Token) BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _state <<< _accounts <<< to Map.toUnfoldable)
 
-      asTuple (Tuple (Tuple accountOwner tok) value) = renderPrettyParty accountOwner /\ renderPrettyToken tok /\ text (showPrettyMoney value)
+      asTuple (Tuple (Tuple accountOwner tok) value) = renderPrettyParty metadata accountOwner /\ renderPrettyToken tok /\ text (showPrettyMoney value)
     in
       map asTuple accounts
 
@@ -59,7 +60,7 @@ panelContents state CurrentStateView =
     let
       (choices :: Array (Tuple ChoiceId BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _state <<< _choices <<< to Map.toUnfoldable)
 
-      asTuple (Tuple (ChoiceId choiceName choiceOwner) value) = text (show choiceName) /\ renderPrettyParty choiceOwner /\ text (showPrettyMoney value)
+      asTuple (Tuple (ChoiceId choiceName choiceOwner) value) = text (show choiceName) /\ renderPrettyParty metadata choiceOwner /\ text (showPrettyMoney value)
     in
       map asTuple choices
 

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -18,9 +18,9 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Halogen (RefLabel(..))
-import Halogen.Classes (aHorizontal, bold, btn, flex, flexCol, flexGrow, flexShrink0, fontBold, fullHeight, fullWidth, grid, gridColsDescriptionLocation, group, justifyBetween, justifyCenter, justifyEnd, maxH70p, minH0, noMargins, overflowHidden, overflowScroll, paddingX, plusBtn, smallBtn, smallSpaceBottom, spaceBottom, spaceLeft, spaceRight, spanText, textSecondaryColor, textXs, uppercase, w30p)
+import Halogen.Classes (aHorizontal, bold, btn, flex, flexCol, flexGrow, flexShrink0, fontBold, fullHeight, fullWidth, grid, gridColsDescriptionLocation, group, justifyBetween, justifyCenter, justifyEnd, maxH70p, minH0, noMargins, overflowHidden, overflowScroll, paddingX, plusBtn, smallBtn, smallSpaceBottom, spaceBottom, spaceLeft, spaceRight, spanText, spanTextBreakWord, textSecondaryColor, textXs, uppercase, w30p)
 import Halogen.Extra (renderSubmodule)
-import Halogen.HTML (ClassName(..), ComponentHTML, HTML, aside, b_, br_, button, div, div_, em_, h6, h6_, input, li, li_, p, p_, section, slot, span, span_, strong_, text, ul)
+import Halogen.HTML (ClassName(..), ComponentHTML, HTML, aside, b_, button, div, div_, em_, h6, h6_, input, li, li_, p, p_, section, slot, span, span_, strong_, text, ul)
 import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), class_, classes, disabled, placeholder, type_, value)
 import Halogen.Monaco (Settings, monacoComponent)
@@ -372,8 +372,8 @@ inputItem ::
   HTML p Action
 inputItem _ _ person (DepositInput accountId party token value) =
   div [ classes [ ClassName "action", aHorizontal ] ]
-    [ p_ (renderDeposit accountId party token value)
-    , div [ class_ (ClassName "align-center") ]
+    [ renderDeposit accountId party token value
+    , div [ class_ (ClassName "align-top") ]
         [ button
             [ classes [ plusBtn, smallBtn ]
             , onClick $ const $ Just
@@ -386,10 +386,9 @@ inputItem _ _ person (DepositInput accountId party token value) =
 inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwner) bounds chosenNum) =
   div
     [ classes [ ClassName "action", aHorizontal, ClassName "flex-nowrap" ] ]
-    ( [ div []
+    ( [ div [ classes [ ClassName "action-label" ] ]
           ( [ div [ class_ (ClassName "choice-input") ]
-                [ spanText "Choice "
-                , b_ [ spanText (show choiceName <> ": ") ]
+                [ span [ class_ (ClassName "break-word-span") ] [ text "Choice ", b_ [ text (show choiceName <> ": ") ] ]
                 , marloweActionInput (SetChoice choiceId) chosenNum
                 ]
             , div [ class_ (ClassName "choice-error") ] error
@@ -410,7 +409,7 @@ inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwn
   addButton =
     if inBounds chosenNum bounds then
       [ button
-          [ classes [ plusBtn, smallBtn, ClassName "align-center", ClassName "flex-noshrink" ]
+          [ classes [ plusBtn, smallBtn, ClassName "align-top", ClassName "flex-noshrink" ]
           , onClick $ const $ Just
               $ AddInput (IChoice (ChoiceId choiceName choiceOwner) chosenNum) bounds
           ]
@@ -434,7 +433,7 @@ inputItem _ _ person NotifyInput =
     [ classes [ ClassName "action", ClassName "choice-a", aHorizontal ] ]
     [ p_ [ text "Notify Contract" ]
     , button
-        [ classes [ plusBtn, smallBtn, ClassName "align-center" ]
+        [ classes [ plusBtn, smallBtn, ClassName "align-top" ]
         , onClick $ const $ Just
             $ AddInput INotify []
         ]
@@ -446,7 +445,7 @@ inputItem _ state person (MoveToSlot slot) =
     [ classes [ aHorizontal, ClassName "flex-nowrap" ] ]
     ( [ div [ classes [ ClassName "action" ] ]
           [ p [ class_ (ClassName "slot-input") ]
-              [ spanText "Move to slot "
+              [ spanTextBreakWord "Move to slot "
               , marloweActionInput (SetSlot <<< wrap) slot
               ]
           , p [ class_ (ClassName "choice-error") ] error
@@ -458,7 +457,7 @@ inputItem _ state person (MoveToSlot slot) =
   addButton =
     if inFuture state slot then
       [ button
-          [ classes [ plusBtn, smallBtn, ClassName "align-center", ClassName "flex-noshrink" ]
+          [ classes [ plusBtn, smallBtn, ClassName "align-top", ClassName "flex-noshrink" ]
           , onClick $ const $ Just $ MoveSlot slot
           ]
           [ text "+" ]
@@ -488,17 +487,18 @@ marloweActionInput f current =
           )
     ]
 
-renderDeposit :: forall p. AccountId -> Party -> Token -> BigInteger -> Array (HTML p Action)
+renderDeposit :: forall p. AccountId -> Party -> Token -> BigInteger -> HTML p Action
 renderDeposit accountOwner party tok money =
-  [ spanText "Deposit "
-  , b_ [ spanText (showPrettyMoney money) ]
-  , spanText " units of "
-  , b_ [ renderPrettyToken tok ]
-  , spanText " into account of "
-  , b_ [ renderPrettyParty accountOwner ]
-  , spanText " as "
-  , b_ [ renderPrettyParty party ]
-  ]
+  span [ classes [ ClassName "break-word-span" ] ]
+    [ text "Deposit "
+    , strong_ [ text (showPrettyMoney money) ]
+    , text " units of "
+    , strong_ [ renderPrettyToken tok ]
+    , text " into account of "
+    , strong_ [ renderPrettyParty accountOwner ]
+    , text " as "
+    , strong_ [ renderPrettyParty party ]
+    ]
 
 ------------------------------------------------------------
 logWidget ::

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -63,7 +63,7 @@ analysisResultPane metadata actionGen state =
           [ text ""
           , ul [ class_ (ClassName "templates") ]
               ( integerTemplateParameters metadata.slotParameterDescriptions actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
-                  <> integerTemplateParameters metadata.slotParameterDescriptions actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+                  <> integerTemplateParameters metadata.valueParameterDescriptions actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
               )
           ]
       WarningAnalysis staticSubResult -> case staticSubResult of

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -18,6 +18,7 @@ import Halogen.HTML (ClassName(..), HTML, b_, br_, button, div, h2, h3, li_, ol,
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, enabled)
 import Marlowe.Extended (IntegerTemplateType(..))
+import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics (ChoiceId(..), Input(..), Payee(..), Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..))
 import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..))
@@ -47,8 +48,8 @@ clearButton isEnabled name action =
     ]
     [ text name ]
 
-analysisResultPane :: forall action p state. (IntegerTemplateType -> String -> BigInteger -> action) -> { analysisState :: AnalysisState | state } -> HTML p action
-analysisResultPane actionGen state =
+analysisResultPane :: forall action p state. MetaData -> (IntegerTemplateType -> String -> BigInteger -> action) -> { analysisState :: AnalysisState | state } -> HTML p action
+analysisResultPane metadata actionGen state =
   let
     templateContent = state ^. (_analysisState <<< _templateContent)
 
@@ -61,8 +62,8 @@ analysisResultPane actionGen state =
         explanation
           [ text ""
           , ul [ class_ (ClassName "templates") ]
-              ( integerTemplateParameters actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
-                  <> integerTemplateParameters actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+              ( integerTemplateParameters metadata.slotParameterDescriptions actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
+                  <> integerTemplateParameters metadata.slotParameterDescriptions actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
               )
           ]
       WarningAnalysis staticSubResult -> case staticSubResult of

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -40,6 +40,7 @@ import Halogen.HTML.Properties (value) as HTML
 import Help (HelpContext(..), toHTML)
 import Marlowe.Extended (toCore)
 import Marlowe.Extended as EM
+import Marlowe.Extended.Metadata (emptyContractMetadata)
 import Marlowe.Holes (fromTerm, gatherContractData)
 import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Contract(..), Input(..), Party, Payment(..), PubKey, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
@@ -712,13 +713,13 @@ renderCurrentState state =
     , div [ class_ (ClassName "RTable-2-cells") ] [ text "TransactionNonPositiveDeposit" ]
     , div [ class_ (ClassName "RTable-4-cells") ]
         [ text $ "Party "
-        , renderPrettyParty party
+        , renderPrettyParty emptyContractMetadata party
         , text $ " is asked to deposit "
             <> showPrettyMoney amount
             <> " units of "
         , renderPrettyToken tok
         , text " into account of "
-        , renderPrettyParty owner
+        , renderPrettyParty emptyContractMetadata owner
         , text "."
         ]
     ]
@@ -735,7 +736,7 @@ renderCurrentState state =
               <> show owner
               <> " to "
           ]
-            <> renderPrettyPayee payee
+            <> renderPrettyPayee emptyContractMetadata payee
             <> [ text "." ]
         )
     ]
@@ -749,10 +750,10 @@ renderCurrentState state =
               <> " units of "
           , renderPrettyToken tok
           , text " from account of "
-          , renderPrettyParty owner
+          , renderPrettyParty emptyContractMetadata owner
           , text $ " to "
           ]
-            <> renderPrettyPayee payee
+            <> renderPrettyPayee emptyContractMetadata payee
             <> [ text $ "."
                   <> " but there is only "
                   <> showPrettyMoney amount
@@ -961,9 +962,9 @@ renderDeposit accountOwner party tok money =
   , spanText " units of "
   , b_ [ renderPrettyToken tok ]
   , spanText " into account of "
-  , b_ [ renderPrettyParty accountOwner ]
+  , b_ [ renderPrettyParty emptyContractMetadata accountOwner ]
   , spanText " as "
-  , b_ [ renderPrettyParty party ]
+  , b_ [ renderPrettyParty emptyContractMetadata party ]
   ]
 
 transactionComposer ::

--- a/marlowe-playground-client/static/css/main.scss
+++ b/marlowe-playground-client/static/css/main.scss
@@ -143,6 +143,12 @@ a:hover {
     flex-shrink: 0;
 }
 
+.break-word-span {
+  word-wrap: break-word;
+  min-width: 0;
+  line-height: normal;
+}
+
 .monaco-editor-container {
     height: 100%;
 }

--- a/marlowe-playground-client/static/css/main.scss
+++ b/marlowe-playground-client/static/css/main.scss
@@ -135,6 +135,14 @@ a:hover {
     flex-wrap: wrap;
 }
 
+.flex-nowrap {
+    flex-wrap: nowrap;
+}
+
+.flex-noshrink {
+    flex-shrink: 0;
+}
+
 .monaco-editor-container {
     height: 100%;
 }

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -217,8 +217,13 @@ button.minus-btn:hover {
   margin-bottom: 0.5rem;
 }
 
+.action-explanation {
+  margin-left: 1rem;
+}
+
 .action {
   padding-left: 1rem;
+  align-self: center;
 }
 
 .templates li {

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -28,6 +28,10 @@
   align-self: flex-start;
 }
 
+.align-center {
+  align-self: center;
+}
+
 button.plus-btn {
   padding: 0.25rem 0.5rem;
   margin-left: 0.5rem;
@@ -206,6 +210,15 @@ button.minus-btn:hover {
 .participants em {
   display: inline-block;
   margin-bottom: 0.5rem;
+}
+
+.action-group-explanation {
+  margin-left: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.action {
+  padding-left: 1rem;
 }
 
 .templates li {

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -62,6 +62,8 @@ button.minus-btn:hover {
 .choice-input {
   line-height: 1.4;
   flex: 1;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .transaction-btns {
@@ -212,17 +214,52 @@ button.minus-btn:hover {
   margin-bottom: 0.5rem;
 }
 
+.action-group {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .action-group-explanation {
   margin-left: 2rem;
   margin-bottom: 0.5rem;
+  line-height: normal;
+  min-width: 0;
+  flex-shrink: 1;
+  word-wrap: break-word;
 }
 
 .action-explanation {
   margin-left: 1rem;
+  margin-right: 1rem;
+  line-height: normal;
+  word-wrap: break-word;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.action-label {
+  min-width: 0;
+  flex-grow: 1;
 }
 
 .action {
   padding-left: 1rem;
+  align-self: center;
+  min-width: 0;
+  flex-grow: 1;
+  margin: 0.5rem 0;
+}
+
+.slot-input {
+  display: flex;
+  flex-wrap: wrap;
+  line-height: normal;
+}
+
+.action-input {
+  flex-grow: 1;
+  margin-left: 0.5rem;
+  min-width: 4rem;
   align-self: center;
 }
 

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -221,11 +221,11 @@ button.minus-btn:hover {
 
 .action-group-explanation {
   margin-left: 2rem;
-  margin-bottom: 0.5rem;
   line-height: normal;
   min-width: 0;
   flex-shrink: 1;
   word-wrap: break-word;
+  align-self: center;
 }
 
 .action-explanation {
@@ -276,11 +276,13 @@ button.minus-btn:hover {
 }
 
 .template-fields {
-  margin: 0.5rem 1.5rem;
+  margin: 0.5rem 0.5rem 0.5rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .template-fields * {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .template-fields > input {


### PR DESCRIPTION
This PR displays the metadata in the simulator and instantiation form:
- Adds explanation to the places where it is relevant
- Adds explanation to the hints (abbr) that already existed for roles
- Fixes several glitches in the CSS of the simulator (in order to make it more responsive)

![metadata-demo](https://user-images.githubusercontent.com/638102/112022292-13ae2800-8b2a-11eb-9619-988e17180849.gif)

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
