### PR TITLE
Fixing some CSS in the playgrounds.

### DIFF
--- a/marlowe-playground-client/src/BottomPanel/View.purs
+++ b/marlowe-playground-client/src/BottomPanel/View.purs
@@ -1,11 +1,10 @@
 module BottomPanel.View (render) where
 
 import Prelude hiding (div)
-import Bootstrap (hidden)
 import BottomPanel.Types (Action(..), State, _panelView, _showBottomPanel)
 import Data.Lens (to, (^.))
 import Data.Maybe (Maybe(..))
-import Halogen.Classes (accentBorderTop, borderSeparator, boxShadowInverted, closeDrawerArrowIcon, collapsed, flex, flexCol, flexShrink0, fontBold, fullHeight, justifyBetween, minH0, minimizeIcon, paddingX, scroll, smallPaddingRight, smallPaddingTop, smallPaddingY, spaceX, textInactive, textSecondary)
+import Halogen.Classes (accentBorderTop, borderSeparator, boxShadowInverted, closeDrawerArrowIcon, collapsed, flex, flexCol, flexShrink0, fontBold, fullHeight, hidden, justifyBetween, minH0, minimizeIcon, paddingX, scroll, smallPaddingRight, smallPaddingTop, smallPaddingY, spaceX, textInactive, textSecondary)
 import Halogen.HTML (ClassName, HTML, a, div, img, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (alt, classes, src)

--- a/marlowe-playground-client/src/ConfirmUnsavedNavigation/View.purs
+++ b/marlowe-playground-client/src/ConfirmUnsavedNavigation/View.purs
@@ -2,12 +2,11 @@ module ConfirmUnsavedNavigation.View where
 
 import Prelude hiding (div)
 import Halogen.HTML (ClassName(..), ComponentHTML, button, div, div_, p_, text)
-import Bootstrap (btnSecondary, btn)
 import ConfirmUnsavedNavigation.Types as CN
 import Data.Lens ((^.))
 import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
-import Halogen.Classes (modalContent, spaceRight, uppercase)
+import Halogen.Classes (btn, btnSecondary, modalContent, spaceRight, uppercase)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (classes)
 import MainFrame.Types (Action(..), ChildSlots, State, _projectName)

--- a/marlowe-playground-client/src/Halogen/Classes.purs
+++ b/marlowe-playground-client/src/Halogen/Classes.purs
@@ -1,6 +1,7 @@
 module Halogen.Classes where
 
 import Prelude hiding (div)
+
 import Data.Lens (Getter', to)
 import Halogen (ClassName(..))
 import Halogen.HTML (HTML, IProp, div, span, text)
@@ -181,7 +182,7 @@ minusBtn :: ClassName
 minusBtn = ClassName "minus-btn"
 
 btn :: ClassName
-btn = ClassName "button"
+btn = ClassName "btn"
 
 btnSecondary :: ClassName
 btnSecondary = ClassName "btn-secondary"
@@ -444,3 +445,6 @@ overflowXScroll = ClassName "overflow-x-scroll"
 
 boxShadowInverted :: ClassName
 boxShadowInverted = ClassName "box-shadow-inverted"
+
+hidden :: ClassName
+hidden = ClassName "hidden"

--- a/marlowe-playground-client/src/Halogen/Classes.purs
+++ b/marlowe-playground-client/src/Halogen/Classes.purs
@@ -1,7 +1,6 @@
 module Halogen.Classes where
 
 import Prelude hiding (div)
-
 import Data.Lens (Getter', to)
 import Halogen (ClassName(..))
 import Halogen.HTML (HTML, IProp, div, span, text)

--- a/web-common/src/Bootstrap.purs
+++ b/web-common/src/Bootstrap.purs
@@ -515,7 +515,7 @@ navLink :: ClassName
 navLink = ClassName "nav-link"
 
 hidden :: ClassName
-hidden = ClassName "hidden"
+hidden = ClassName "d-none"
 
 -- | A third of the screen, assuming a reasonable screen
 -- size. Collapses sensibly as the size goes down to iPhone.


### PR DESCRIPTION
The Plutus playground view depended on Bootstrap's `d-none` class, which was changed to `hidden` for the Marlowe playground. This fix changes it back, and removes the Marlowe playground's dependency on the `web-commom/Bootstrap` module.