### PR TITLE
SCP-2012 - Get metadata hints from function that supports holes

### DIFF
--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -4,7 +4,7 @@
 
 Make sure you have a local backend server running first:
 ```bash
-$(nix-build -A marlowe-playground.server-invoker)/bin/marlowe-playground webserver
+$(nix-build -A marlowe-playground.server)/bin/marlowe-playground-server webserver
 ```
 
 Check the [backend documentation](../marlowe-playground-server/README.md) for more information on how to setup the Github OAuth application.

--- a/marlowe-playground-client/src/Marlowe/Monaco.purs
+++ b/marlowe-playground-client/src/Marlowe/Monaco.purs
@@ -73,7 +73,7 @@ settings setup =
   , tokensProvider: Just tokensProvider
   , hoverProvider: Just hoverProvider
   , completionItemProvider: Just completionItemProvider
-  , codeActionProvider: Just $ codeActionProvider { warnings: mempty, contract: Nothing }
+  , codeActionProvider: Just $ codeActionProvider { warnings: mempty, contract: Nothing, metadataHints: mempty }
   , documentFormattingEditProvider: Just documentFormattingEditProvider
   , refLabel
   , owner: "marloweEditor"

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -31,9 +31,9 @@ import Halogen as H
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
-import Marlowe.Extended.Metadata (MetadataHintInfo, getMetadataHintInfo)
 import Marlowe.Extended (TemplateContent)
 import Marlowe.Extended as Extended
+import Marlowe.Extended.Metadata (MetadataHintInfo)
 import Marlowe.Holes as Holes
 import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
@@ -162,6 +162,7 @@ processMarloweCode ::
   HalogenM State Action ChildSlots Void m Unit
 processMarloweCode text = do
   analysisExecutionState <- use (_analysisState <<< _analysisExecutionState)
+  oldMetadataInfo <- use _metadataHintInfo
   let
     eParsedContract = parseContract text
 
@@ -193,7 +194,7 @@ processMarloweCode text = do
     mContract = Holes.fromTerm =<< hush eParsedContract
 
     metadataInfo :: MetadataHintInfo
-    metadataInfo = maybe mempty getMetadataHintInfo mContract -- ToDo: Implement function that supports holes instead (SCP-2012)
+    metadataInfo = fromMaybe oldMetadataInfo additionalContext.metadataHints
 
     hasHoles =
       not $ Array.null


### PR DESCRIPTION
This PR changes the function that calculates the metadata needed (extracts metadata hints) to support holes.
- We reuse the linting function for efficiency and to avoid extra boilerplate
- Additionally, now we don't update the metadata hints unless the contract parses (because it is probably more useful to the user this way)
- Also updates the command for running the server in the `README.md` of `marlowe-playground-client`

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
