### PR TITLE
scp-1862 - Marlowe Dashboard Client - Improve contract semantics

### DIFF
--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -2,7 +2,6 @@ module Contract.Lenses
   ( _tab
   , _executionState
   , _contractId
-  , _confirmation
   , _selectedStep
   , _metadata
   , _participants
@@ -26,11 +25,8 @@ _tab = prop (SProxy :: SProxy "tab")
 _executionState :: Lens' State ExecutionState
 _executionState = prop (SProxy :: SProxy "executionState")
 
-_contractId :: Lens' State (Maybe String)
+_contractId :: Lens' State String
 _contractId = prop (SProxy :: SProxy "contractId")
-
-_confirmation :: Lens' State (Maybe Semantic.Input)
-_confirmation = prop (SProxy :: SProxy "confirmation")
 
 _selectedStep :: Lens' State Int
 _selectedStep = prop (SProxy :: SProxy "selectedStep")

--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -3,7 +3,7 @@ module Contract.Lenses
   , _executionState
   , _contractId
   , _confirmation
-  , _step
+  , _selectedStep
   , _metadata
   , _participants
   , _mActiveUserParty
@@ -32,8 +32,8 @@ _contractId = prop (SProxy :: SProxy "contractId")
 _confirmation :: Lens' State (Maybe Semantic.Input)
 _confirmation = prop (SProxy :: SProxy "confirmation")
 
-_step :: Lens' State Int
-_step = prop (SProxy :: SProxy "step")
+_selectedStep :: Lens' State Int
+_selectedStep = prop (SProxy :: SProxy "selectedStep")
 
 _metadata :: Lens' State MetaData
 _metadata = prop (SProxy :: SProxy "metadata")

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -6,15 +6,14 @@ import Data.Map (Map)
 import Data.Maybe (Maybe(..))
 import Marlowe.Execution (ExecutionState, NamedAction)
 import Marlowe.Extended.Metadata (MetaData)
-import Marlowe.Semantics (ChoiceId, ChosenNum, Input, Slot, TransactionInput)
+import Marlowe.Semantics (ChoiceId, ChosenNum, Slot, TransactionInput)
 import Marlowe.Semantics as Semantic
 import WalletData.Types (Nickname)
 
 type State
   = { tab :: Tab
     , executionState :: ExecutionState
-    , contractId :: Maybe String -- FIXME: what is a contract instance identified by
-    , confirmation :: Maybe Input
+    , contractId :: String -- FIXME: what is a contract instance identified by
     -- Which step of the execution state is selected. This index is 0 based and should be
     -- between [0, executionState.steps.length] (both sides inclusive). This is because the
     -- `steps` array represent the past steps and the executionState.state represents the
@@ -40,17 +39,15 @@ data Query a
   | ApplyTx TransactionInput a
 
 data Action
-  = ConfirmInput (Maybe Input)
+  = ConfirmAction NamedAction
   | ChangeChoice ChoiceId (Maybe ChosenNum)
-  | ChooseInput (Maybe Input)
   | SelectTab Tab
   | AskConfirmation NamedAction
   | CancelConfirmation
 
 instance actionIsEvent :: IsEvent Action where
-  toEvent (ConfirmInput _) = Just $ defaultEvent "ConfirmInput"
+  toEvent (ConfirmAction _) = Just $ defaultEvent "ConfirmAction"
   toEvent (ChangeChoice _ _) = Just $ defaultEvent "ChangeChoice"
-  toEvent (ChooseInput _) = Just $ defaultEvent "ChooseInput"
   toEvent (SelectTab _) = Just $ defaultEvent "SelectTab"
   toEvent (AskConfirmation _) = Just $ defaultEvent "AskConfirmation"
   toEvent CancelConfirmation = Just $ defaultEvent "CancelConfirmation"

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -15,7 +15,11 @@ type State
     , executionState :: ExecutionState
     , contractId :: Maybe String -- FIXME: what is a contract instance identified by
     , confirmation :: Maybe Input
-    , step :: Int
+    -- Which step of the execution state is selected. This index is 0 based and should be
+    -- between [0, executionState.steps.length] (both sides inclusive). This is because the
+    -- `steps` array represent the past steps and the executionState.state represents the
+    -- current state and visually we can select any one of them.
+    , selectedStep :: Int
     , metadata :: MetaData
     , participants :: Map Semantic.Party (Maybe Nickname)
     -- This field represents the logged-user party in the contract.

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -90,7 +90,7 @@ actionConfirmationCard state namedAction =
       [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
           [ span_ [ text "Demo wallet balance:" ]
           -- FIXME: remove placeholder with actual value
-          , span_ [ text "$223,456.78" ]
+          , span_ [ text "₳ 223,456.78" ]
           ]
       , div [ classNames [ "px-5", "pb-6", "pt-3", "md:pb-8" ] ]
           [ h2
@@ -115,8 +115,7 @@ actionConfirmationCard state namedAction =
                   [ text "Cancel" ]
               , button
                   [ classNames $ Css.primaryButton <> [ "flex-1" ]
-                  -- FIXME: Create an action that comunicates with the backend
-                  -- , onClick_ $ AskWalletConfirmation namedAction
+                  , onClick_ $ ConfirmAction namedAction
                   ]
                   [ text cta ]
               ]
@@ -367,6 +366,8 @@ formatBigInteger :: BigInteger -> String
 formatBigInteger = format currencyFormatter <<< toNumber
 
 currency :: forall p a. Token -> BigInteger -> HTML p a
+-- FIXME: value should be interpreted as lovelaces instead of ADA and we should
+--        display just the necesary amounts of digits
 currency (Token "" "") value = text ("₳ " <> formatBigInteger value)
 
 currency (Token symbol _) value = text (symbol <> " " <> formatBigInteger value)

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -4,7 +4,8 @@ module Contract.View
   ) where
 
 import Prelude hiding (div)
-import Contract.Lenses (_executionState, _mActiveUserParty, _metadata, _participants, _step, _tab)
+import Contract.Lenses (_executionState, _mActiveUserParty, _metadata, _participants, _tab)
+import Contract.State (currentStep)
 import Contract.Types (Action(..), State, Tab(..))
 import Css (applyWhen, classNames)
 import Css as Css
@@ -48,9 +49,7 @@ contractDetailsCard state =
 actionConfirmationCard :: forall p. State -> NamedAction -> HTML p Action
 actionConfirmationCard state namedAction =
   let
-    -- As programmers we use 0-indexed arrays and steps, but we number steps
-    -- starting from 1
-    stepNumber = state ^. _step + 1
+    stepNumber = currentStep state
 
     title = case namedAction of
       MakeDeposit _ _ _ _ -> "Deposit confirmation"
@@ -143,9 +142,7 @@ actionConfirmationCard state namedAction =
 renderCurrentStep :: forall p. State -> HTML p Action
 renderCurrentStep state =
   let
-    -- As programmers we use 0-indexed arrays and steps, but we number steps
-    -- starting from 1
-    stepNumber = state ^. _step + 1
+    stepNumber = currentStep state
 
     currentTab = state ^. _tab
 

--- a/marlowe-dashboard-client/src/ContractHome/Lenses.purs
+++ b/marlowe-dashboard-client/src/ContractHome/Lenses.purs
@@ -1,7 +1,7 @@
 module ContractHome.Lenses
   ( _status
   , _contracts
-  , _selectedContract
+  , _selectedContractIndex
   ) where
 
 import Contract.Types (State) as Contract
@@ -17,5 +17,5 @@ _status = prop (SProxy :: SProxy "status")
 _contracts :: Lens' State (Array Contract.State)
 _contracts = prop (SProxy :: SProxy "contracts")
 
-_selectedContract :: Lens' State (Maybe Contract.State)
-_selectedContract = prop (SProxy :: SProxy "selectedContract")
+_selectedContractIndex :: Lens' State (Maybe Int)
+_selectedContractIndex = prop (SProxy :: SProxy "selectedContractIndex")

--- a/marlowe-dashboard-client/src/ContractHome/State.purs
+++ b/marlowe-dashboard-client/src/ContractHome/State.purs
@@ -7,7 +7,7 @@ import Prelude
 import Contract.Lenses (_executionState)
 import Contract.State (mkInitialState) as Contract
 import Contract.Types (State) as Contract
-import ContractHome.Lenses (_selectedContract, _status)
+import ContractHome.Lenses (_selectedContractIndex, _status)
 import ContractHome.Types (ContractStatus(..), State, Action(..))
 import Data.Array (catMaybes)
 import Data.BigInteger (fromInt)
@@ -52,7 +52,7 @@ filledContract1 =
 
     mContract = toCore $ fillTemplate templateContent Contract1.extendedContract
   in
-    mContract <#> \contract -> Contract.mkInitialState zero contract Contract1.metaData participants (Just $ Role "Arbiter")
+    mContract <#> \contract -> Contract.mkInitialState "dummy contract 1" zero contract Contract1.metaData participants (Just $ Role "Arbiter")
 
 filledContract2 :: Maybe Contract.State
 filledContract2 = do
@@ -82,7 +82,7 @@ filledContract2 = do
     transactions =
       [ TransactionInput
           { interval:
-              (SlotInterval (Slot $ fromInt 40000) (Slot $ fromInt 40060))
+              (SlotInterval (Slot $ fromInt 0) (Slot $ fromInt 0))
           , inputs:
               List.singleton
                 $ IDeposit (Role "alice") (Role "alice") (Token "" "") (fromInt 1500)
@@ -92,7 +92,7 @@ filledContract2 = do
     nextState' :: Contract.State -> TransactionInput -> Contract.State
     nextState' state txInput = over _executionState (flip nextState $ txInput) state
   contract <- toCore $ fillTemplate templateContent Contract3.extendedContract
-  initialState <- pure $ Contract.mkInitialState zero contract Contract3.metaData participants (Just $ Role "alice")
+  initialState <- pure $ Contract.mkInitialState "dummy contract 2" zero contract Contract3.metaData participants (Just $ Role "alice")
   pure $ foldl nextState' initialState transactions
 
 defaultState :: State
@@ -100,7 +100,7 @@ defaultState =
   { status: Running
   , contracts: catMaybes [ filledContract1, filledContract2 ]
   -- , contracts: mempty
-  , selectedContract: Nothing
+  , selectedContractIndex: Nothing
   }
 
 handleAction ::
@@ -110,4 +110,4 @@ handleAction ToggleTemplateLibraryCard = pure unit -- handled in Play
 
 handleAction (SelectView view) = assign _status view
 
-handleAction (OpenContract contract) = assign _selectedContract $ Just contract
+handleAction (OpenContract ix) = assign _selectedContractIndex $ Just ix

--- a/marlowe-dashboard-client/src/ContractHome/State.purs
+++ b/marlowe-dashboard-client/src/ContractHome/State.purs
@@ -45,14 +45,14 @@ filledContract1 =
 
     participants =
       Map.fromFoldable
-        [ (Role "Arbiter") /\ Just "Alice user"
-        , (Role "Buyer") /\ Just "Bob user"
+        [ (Role "Arbiter") /\ Just "Alice"
+        , (Role "Buyer") /\ Just "Bob"
         , (Role "Seller") /\ Nothing
         ]
 
     mContract = toCore $ fillTemplate templateContent Contract1.extendedContract
   in
-    mContract <#> \contract -> Contract.mkInitialState "dummy contract 1" zero contract Contract1.metaData participants (Just $ Role "Arbiter")
+    mContract <#> \contract -> Contract.mkInitialState "dummy contract 1" zero contract Contract1.metaData participants (Just $ Role "Buyer")
 
 filledContract2 :: Maybe Contract.State
 filledContract2 = do
@@ -61,22 +61,20 @@ filledContract2 = do
       TemplateContent
         { slotContent:
             Map.fromFoldable
-              [ "aliceTimeout" /\ fromInt 10
-              , "arbitrageTimeout" /\ fromInt 12
-              , "bobTimeout" /\ fromInt 15
-              , "depositSlot" /\ fromInt 17
+              [ "Initial exchange deadline" /\ fromInt 10
+              , "Maturity exchange deadline" /\ fromInt 12
               ]
         , valueContent:
             Map.fromFoldable
-              [ "amount" /\ fromInt 1500
+              [ "Discounted price" /\ fromInt 1000
+              , "Notional" /\ fromInt 1500
               ]
         }
 
     participants =
       Map.fromFoldable
-        [ (Role "alice") /\ Just "Alice user"
-        , (Role "bob") /\ Just "Bob user"
-        , (Role "carol") /\ Nothing
+        [ (Role "Investor") /\ Just "Alice"
+        , (Role "Issuer") /\ Just "Bob"
         ]
 
     transactions =
@@ -85,7 +83,7 @@ filledContract2 = do
               (SlotInterval (Slot $ fromInt 0) (Slot $ fromInt 0))
           , inputs:
               List.singleton
-                $ IDeposit (Role "alice") (Role "alice") (Token "" "") (fromInt 1500)
+                $ IDeposit (Role "Investor") (Role "Investor") (Token "" "") (fromInt 1000)
           }
       ]
 

--- a/marlowe-dashboard-client/src/ContractHome/State.purs
+++ b/marlowe-dashboard-client/src/ContractHome/State.purs
@@ -4,21 +4,25 @@ module ContractHome.State
   ) where
 
 import Prelude
+import Contract.Lenses (_executionState)
 import Contract.State (mkInitialState) as Contract
 import Contract.Types (State) as Contract
 import ContractHome.Lenses (_selectedContract, _status)
 import ContractHome.Types (ContractStatus(..), State, Action(..))
 import Data.Array (catMaybes)
 import Data.BigInteger (fromInt)
-import Data.Lens (assign)
+import Data.Foldable (foldl)
+import Data.Lens (assign, over)
+import Data.List as List
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Halogen (HalogenM)
+import Marlowe.Execution (nextState)
 import Marlowe.Extended (TemplateContent(..), fillTemplate, toCore)
 import Marlowe.Market.Contract1 as Contract1
 import Marlowe.Market.Contract3 as Contract3
-import Marlowe.Semantics (Party(..))
+import Marlowe.Semantics (Input(..), Party(..), Slot(..), SlotInterval(..), Token(..), TransactionInput(..))
 
 -- FIXME: debug purposes only, delete later
 filledContract1 :: Maybe Contract.State
@@ -50,9 +54,8 @@ filledContract1 =
   in
     mContract <#> \contract -> Contract.mkInitialState zero contract Contract1.metaData participants (Just $ Role "Arbiter")
 
-{-
 filledContract2 :: Maybe Contract.State
-filledContract2 =
+filledContract2 = do
   let
     templateContent =
       TemplateContent
@@ -69,14 +72,33 @@ filledContract2 =
               ]
         }
 
-    mContract = toCore $ fillTemplate templateContent Contract3.extendedContract
-  in
-    mContract <#> \contract -> Contract.mkInitialState zero contract Contract3.metaData
--}
+    participants =
+      Map.fromFoldable
+        [ (Role "alice") /\ Just "Alice user"
+        , (Role "bob") /\ Just "Bob user"
+        , (Role "carol") /\ Nothing
+        ]
+
+    transactions =
+      [ TransactionInput
+          { interval:
+              (SlotInterval (Slot $ fromInt 40000) (Slot $ fromInt 40060))
+          , inputs:
+              List.singleton
+                $ IDeposit (Role "alice") (Role "alice") (Token "" "") (fromInt 1500)
+          }
+      ]
+
+    nextState' :: Contract.State -> TransactionInput -> Contract.State
+    nextState' state txInput = over _executionState (flip nextState $ txInput) state
+  contract <- toCore $ fillTemplate templateContent Contract3.extendedContract
+  initialState <- pure $ Contract.mkInitialState zero contract Contract3.metaData participants (Just $ Role "alice")
+  pure $ foldl nextState' initialState transactions
+
 defaultState :: State
 defaultState =
   { status: Running
-  , contracts: catMaybes [ filledContract1 ]
+  , contracts: catMaybes [ filledContract1, filledContract2 ]
   -- , contracts: mempty
   , selectedContract: Nothing
   }

--- a/marlowe-dashboard-client/src/ContractHome/Types.purs
+++ b/marlowe-dashboard-client/src/ContractHome/Types.purs
@@ -14,20 +14,20 @@ derive instance eqContractStatus :: Eq ContractStatus
 type State
   = { status :: ContractStatus
     -- FIXME: We are currently using an Array for holding all the contracts and a
-    --        Maybe Contract for seeing which one is selected. Eventually, this would probably
-    --        be a Map ContractId Contract.State and a Maybe ContractId. We need to see how
+    --        Maybe Int for seeing which one is selected. Eventually, this would probably
+    --        be a `Map ContractId Contract.State` and a `Maybe ContractId`. We need to see how
     --        we identify contracts between the FE and BE and also if the performance hit of having
     --        to split the map between running and completed is worth not having state duplication
     --        (Two arrays and a Map).
-    --        Also, the selectedContract might be better to add it in PlayState, rather than here
+    --        Also, we should check if this data belongs here or in PlayState
     , contracts :: Array (Contract.State)
-    , selectedContract :: Maybe (Contract.State)
+    , selectedContractIndex :: Maybe Int
     }
 
 data Action
   = ToggleTemplateLibraryCard
   | SelectView ContractStatus
-  | OpenContract (Contract.State)
+  | OpenContract Int
 
 instance actionIsEvent :: IsEvent Action where
   toEvent ToggleTemplateLibraryCard = Just $ defaultEvent "ToggleTemplateLibraryCard"

--- a/marlowe-dashboard-client/src/ContractHome/View.purs
+++ b/marlowe-dashboard-client/src/ContractHome/View.purs
@@ -1,7 +1,8 @@
 module ContractHome.View where
 
 import Prelude hiding (div)
-import Contract.Lenses (_metadata, _step)
+import Contract.Lenses (_metadata)
+import Contract.State (currentStep)
 import Contract.Types (State) as Contract
 import ContractHome.Lenses (_contracts, _status)
 import ContractHome.Types (Action(..), ContractStatus(..), State)
@@ -76,9 +77,7 @@ contractCard contractState =
 
     contractAcronym = contractTypeInitials metadata.contractType
 
-    -- As programmers we use 0-indexed arrays and steps, but we number steps
-    -- starting from 1
-    stepNumber = contractState ^. _step + 1
+    stepNumber = currentStep contractState
 
     -- FIXME: hardcoded time slot
     timeoutStr = "8hr 10m left"

--- a/marlowe-dashboard-client/src/ContractHome/View.purs
+++ b/marlowe-dashboard-client/src/ContractHome/View.purs
@@ -8,6 +8,7 @@ import ContractHome.Lenses (_contracts, _status)
 import ContractHome.Types (Action(..), ContractStatus(..), State)
 import Css (classNames)
 import Css as Css
+import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lens ((^.))
 import Halogen.HTML (HTML, a, div, h2, p_, span, text)
 import Halogen.HTML.Events.Extra (onClick_)
@@ -63,11 +64,10 @@ renderContractList state =
   in
     div
       [ classNames [ "space-y-4" ] ]
-      $ contractCard
-      <$> contracts
+      $ mapWithIndex contractCard contracts
 
-contractCard :: forall p. Contract.State -> HTML p Action
-contractCard contractState =
+contractCard :: forall p. Int -> Contract.State -> HTML p Action
+contractCard index contractState =
   let
     metadata = contractState ^. _metadata
 
@@ -86,7 +86,7 @@ contractCard contractState =
       -- NOTE: The overflow hidden helps fix a visual bug in which the background color eats away the border-radius
       [ classNames
           [ "cursor-pointer", "shadow", "bg-white", "rounded", "mx-auto", "md:w-96", "overflow-hidden" ]
-      , onClick_ $ OpenContract contractState
+      , onClick_ $ OpenContract index
       ]
       [ div [ classNames [ "flex", "px-4", "pt-4" ] ]
           [ span [ classNames [ "text-xl", "font-semibold" ] ] [ text contractAcronym ]

--- a/marlowe-dashboard-client/src/Marlowe/Execution.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution.purs
@@ -3,16 +3,15 @@ module Marlowe.Execution where
 import Prelude
 import Data.Array (fromFoldable)
 import Data.BigInteger (BigInteger, fromInt)
-import Data.Lens (Lens', has, only, to, view)
+import Data.Lens (Lens', view)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.List (List)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
-import Data.Ord (greaterThanOrEq)
 import Data.Symbol (SProxy(..))
-import Marlowe.Semantics (AccountId, Action(..), Bound(..), Case(..), ChoiceId(..), ChosenNum, Contract(..), Input, Observation, Party(..), Payment, Slot(..), SlotInterval(..), State, Timeout, Token(..), TransactionInput(..), TransactionOutput(..), ValueId, _boundValues, _minSlot, computeTransaction, emptyState, evalValue, makeEnvironment)
+import Marlowe.Semantics (AccountId, Action(..), Bound, Case(..), ChoiceId(..), ChosenNum, Contract(..), Input, Observation, Party, Payment, Slot(..), SlotInterval(..), State, Timeout, Token, TransactionInput(..), TransactionOutput(..), ValueId, _boundValues, _minSlot, computeTransaction, emptyState, evalValue, makeEnvironment)
 
 -- Represents a historical step in a contract's life and is what you see on a Step card that is in the past,
 -- that is the State as it was before it was executed and the TransactionInput that was applied.
@@ -63,18 +62,18 @@ initExecution currentSlot contract =
     state = emptyState currentSlot
 
     -- FIXME: We fake the namedActions for development until we fix the semantics
-    namedActions =
-      [ MakeDeposit (Role "into account") (Role "bob") (Token "" "") $ fromInt 200
-      , MakeDeposit (Role "into account") (Role "alice") (Token "" "") $ fromInt 1500
-      , MakeChoice (ChoiceId "choice id" (Role "alice"))
-          [ Bound (fromInt 0) (fromInt 3)
-          , Bound (fromInt 2) (fromInt 4)
-          , Bound (fromInt 6) (fromInt 8)
-          ]
-          Nothing
-      , CloseContract
-      ]
-  -- namedActions = extractNamedActions state contract
+    -- namedActions =
+    --   [ MakeDeposit (Role "into account") (Role "bob") (Token "" "") $ fromInt 200
+    --   , MakeDeposit (Role "into account") (Role "alice") (Token "" "") $ fromInt 1500
+    --   , MakeChoice (ChoiceId "choice id" (Role "alice"))
+    --       [ Bound (fromInt 0) (fromInt 3)
+    --       , Bound (fromInt 2) (fromInt 4)
+    --       , Bound (fromInt 6) (fromInt 8)
+    --       ]
+    --       Nothing
+    --   , CloseContract
+    --   ]
+    namedActions = extractNamedActions currentSlot state contract
   in
     { steps, state, contract, namedActions }
 
@@ -98,12 +97,26 @@ nextState { steps, state, contract } txInput =
   let
     currentSlot = view _minSlot state
 
+    TransactionInput { interval: SlotInterval minSlot maxSlot } = txInput
+
     { txOutState, txOutContract } = case computeTransaction txInput state contract of
       (TransactionOutput { txOutState, txOutContract }) -> { txOutState, txOutContract }
       -- We should not have contracts which cause errors in the dashboard so we will just ignore error cases for now
       (Error _) -> { txOutState: state, txOutContract: contract }
 
-    namedActions = extractNamedActions txOutState txOutContract
+    -- FIXME: Check with Pablo and/or alex:
+    --        To extract the possible actions a user can take I need to know if a Case has timeout. In the previous
+    --        version we were using the minSlot of the Semantic state, but after discussing with Alex we needed to
+    --        use "the current slot" instead.
+    --        This means that extractNamedActions now receives a slot to calculate the timeout. Inside `initExecution`
+    --        it makes total sense as we use the current slot of the system. But `nextState` can be used to re-create
+    --        a contract history from the TransactionInput. I had three possible values I could use:
+    --          * Add a Slot paramenter to nextState and make the caller to decide what's the "current slot"
+    --          * Use the minSlot of the TransactionInput slot interval
+    --          * Use the maxSlot of the TransactionInput slot interval
+    --        For now I'm using the maxSlot of the TransactionInput, asuming that if it didn't timeout by that time,
+    --        then it didn't timeout at all. But I need to confirm this decision and see what consequences it may bring.
+    namedActions = extractNamedActions maxSlot txOutState txOutContract
 
     timedOut = case hasTimeout contract of
       Just t -> t < currentSlot
@@ -145,14 +158,13 @@ getActionParticipant (MakeChoice (ChoiceId _ party) _ _) = Just party
 
 getActionParticipant _ = Nothing
 
-extractNamedActions :: State -> Contract -> Array NamedAction
-extractNamedActions _ Close = mempty
+extractNamedActions :: Slot -> State -> Contract -> Array NamedAction
+extractNamedActions _ _ Close = mempty
 
--- FIXME We need to provide the current slot instead of minSlot
 -- a When can only progress if it has timed out or has Cases
-extractNamedActions state (When cases timeout cont)
+extractNamedActions currentSlot state (When cases timeout cont)
   -- in the case of a timeout we need to provide an Evaluate action to all users to "manually" progress the contract
-  | has (_minSlot <<< to (greaterThanOrEq timeout) <<< only true) state =
+  | currentSlot > timeout =
     let
       minSlot = view _minSlot state
 
@@ -170,6 +182,14 @@ extractNamedActions state (When cases timeout cont)
             { payments: fromFoldable txOutPayments, bindings: bindings }
         _ -> mempty
     in
+      -- FIXME: Currently we don't have a way to display Evaluate so this can be dangerous.
+      --        We talked with Alex that when a contract timeouts there doesn't need to be
+      --        an explicity Evaluate, the next action will take care of that for us. If the
+      --        continuation of a contract is a Close, then we need to extract the `CloseContract`
+      --        so someone can pay to close the contract. If the continuation is a When, then we
+      --        need to extract the actions as below. In any case, I think that instead of using
+      --        `computeTransaction` and returning an Evaluate we should "advance" in the continuation
+      --        and recursively call extractNamedActions.
       [ Evaluate outputs ]
   -- if there are no cases then there is no action that any user can take to progress the contract
   | otherwise = cases <#> \(Case action _) -> toNamedAction action
@@ -191,4 +211,4 @@ extractNamedActions state (When cases timeout cont)
 -- In reality other situations should never occur as contracts always reduce to When or Close
 -- however someone could in theory publish a contract that starts with another Contract constructor
 -- and we would want to enable moving forward with Evaluate
-extractNamedActions _ _ = [ Evaluate mempty ]
+extractNamedActions _ _ _ = [ Evaluate mempty ]

--- a/marlowe-dashboard-client/src/Marlowe/Execution.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution.purs
@@ -49,6 +49,9 @@ _state = prop (SProxy :: SProxy "state")
 _contract :: Lens' ExecutionState Contract
 _contract = prop (SProxy :: SProxy "contract")
 
+_steps :: Lens' ExecutionState (Array ExecutionStep)
+_steps = prop (SProxy :: SProxy "steps")
+
 _namedActions :: Lens' ExecutionState (Array NamedAction)
 _namedActions = prop (SProxy :: SProxy "namedActions")
 

--- a/marlowe-dashboard-client/src/Play/Lenses.purs
+++ b/marlowe-dashboard-client/src/Play/Lenses.purs
@@ -4,11 +4,17 @@ module Play.Lenses
   , _currentSlot
   , _templateState
   , _contractsState
+  , _selectedContract
   ) where
 
+import Prelude
+import Contract.Types (State) as Contract
+import ContractHome.Lenses (_contracts, _selectedContractIndex)
 import ContractHome.Types (State) as ContractHome
-import Data.Lens (Lens')
+import Data.Array as Array
+import Data.Lens (Lens', Traversal', set, view, wander)
 import Data.Lens.Record (prop)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Symbol (SProxy(..))
 import Marlowe.Semantics (Slot)
 import Play.Types (State)
@@ -29,3 +35,18 @@ _templateState = prop (SProxy :: SProxy "templateState")
 
 _contractsState :: Lens' State ContractHome.State
 _contractsState = prop (SProxy :: SProxy "contractsState")
+
+_allContracts :: Lens' State (Array Contract.State)
+_allContracts = _contractsState <<< _contracts
+
+-- This traversal focus on a specific contract indexed by another property of the state
+_selectedContract :: Traversal' State Contract.State
+_selectedContract =
+  wander \f state -> case view (_contractsState <<< _selectedContractIndex) state of
+    Just ix
+      | Just contract <- Array.index (view _allContracts state) ix ->
+        let
+          updateContract contract' = fromMaybe (view _allContracts state) $ Array.updateAt ix contract' state.contractsState.contracts
+        in
+          (\contract' -> set _allContracts (updateContract contract') state) <$> f contract
+    _ -> pure state

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -52,7 +52,7 @@ toContract ::
   Functor m =>
   HalogenM Contract.State Contract.Action slots msg m Unit ->
   HalogenM MainFrame.State MainFrame.Action slots msg m Unit
-toContract = mapMaybeSubmodule (_playState <<< _selectedContract) (MainFrame.PlayAction <<< ContractAction) $ Contract.defaultState
+toContract = mapMaybeSubmodule (_playState <<< _selectedContract) (MainFrame.PlayAction <<< ContractAction) Contract.defaultState
 
 mkInitialState :: WalletDetails -> Minutes -> State
 mkInitialState walletDetails timezoneOffset =

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -2,12 +2,11 @@ module Play.View (renderPlayState) where
 
 import Prelude hiding (div)
 import Contract.View (actionConfirmationCard, contractDetailsCard)
-import ContractHome.Lenses (_selectedContract)
 import ContractHome.View (contractsScreen)
 import Css (applyWhen, classNames, hideWhen)
 import Css as Css
 import Data.Foldable (foldMap)
-import Data.Lens (view)
+import Data.Lens (preview, view)
 import Data.Maybe (Maybe(..), isNothing)
 import Data.String (take)
 import Halogen.HTML (HTML, a, div, div_, footer, header, img, main, nav, span, text)
@@ -19,7 +18,7 @@ import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (PubKey)
 import Material.Icons (Icon(..), icon_)
 import Network.RemoteData (RemoteData)
-import Play.Lenses (_contractsState, _currentSlot, _menuOpen, _templateState, _walletDetails)
+import Play.Lenses (_contractsState, _currentSlot, _menuOpen, _selectedContract, _templateState, _walletDetails)
 import Play.Types (Action(..), Card(..), Screen(..), State)
 import Prim.TypeError (class Warn, Text)
 import Servant.PureScript.Ajax (AjaxError)
@@ -125,7 +124,7 @@ renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templ
 
     mCard = view _card playState
 
-    mSelectedContractState = view (_contractsState <<< _selectedContract) playState
+    mSelectedContractState = preview _selectedContract playState
 
     cardClasses = case mCard of
       Just TemplateLibraryCard -> Css.largeCard false

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -351,7 +351,7 @@ contractSetupConfirmationCard =
         -- FIXME: remove placeholder with actual value
         , p
             [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
-            [ text "$123.456" ]
+            [ text "₳ 123.456" ]
         , div
             [ classNames [ "flex" ] ]
             [ button


### PR DESCRIPTION
This PR consists of three changes:
* It changes how we manage the current step of a contract. Before we were using a field in the Contract.State now we are counting the step history and renamed the field so that it indicates which step is the selected one (not using that info for the moment)
* It fixes a problem in the extractNamedAction that was using minSlot to calculate if a step had timeout (need review by @nau) 
* It adds a "hardcoded" way to advance the contract. We are not calling the PAB yet and we are assuming that the InputTransaction was processed successfully. In order to do this, I also needed to change the way we select contracts. We were using `selectedContract :: Maybe Contract`, but that was losing all changes when we deselected the contract.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [X] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
