### PR TITLE
Kwxm/fix nofib exe output problem (SCP-1896)

### DIFF
--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -188,6 +188,8 @@ options = hsubparser
 
 evaluateWithCek :: UPLC.Term Name DefaultUni DefaultFun () -> EvaluationResult (UPLC.Term Name DefaultUni DefaultFun ())
 evaluateWithCek = unsafeEvaluateCekNoEmit defBuiltinsRuntime
+-- Careful! This uses the enormousBudget and that may not be enormous enough for
+-- some of the programs here.
 
 toDeBruijn :: UPLC.Program Name DefaultUni DefaultFun a -> IO (UPLC.Program UPLC.DeBruijn DefaultUni DefaultFun a)
 toDeBruijn prog = do
@@ -234,10 +236,7 @@ footerInfo = text "Every command takes the name of a program and a (possbily emp
 main :: IO ()
 main = do
   execParser (info (helper <*> options) (fullDesc <> progDesc description <> footerDoc (Just footerInfo))) >>= \case
-    RunPLC pa ->  print . PLC.prettyPlcClassicDebug <$>
-                  unsafeEvaluateCekNoEmit defBuiltinsRuntime $ getUnDBrTerm pa
-           -- Careful! This ^ uses the enormousBudget and that may not be
-           -- enormous enough for some of the programs here.
+    RunPLC pa ->  print . PLC.prettyPlcClassicDebug <$> evaluateWithCek . getUnDBrTerm $ pa
     RunHaskell pa ->
         case pa of
           Clausify formula        -> print $ Clausify.runClausify formula

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -188,8 +188,6 @@ options = hsubparser
 
 evaluateWithCek :: UPLC.Term Name DefaultUni DefaultFun () -> EvaluationResult (UPLC.Term Name DefaultUni DefaultFun ())
 evaluateWithCek = unsafeEvaluateCekNoEmit defBuiltinsRuntime
--- Careful! This uses the enormousBudget and that may not be enormous enough for
--- some of the programs here.
 
 toDeBruijn :: UPLC.Program Name DefaultUni DefaultFun a -> IO (UPLC.Program UPLC.DeBruijn DefaultUni DefaultFun a)
 toDeBruijn prog = do

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -196,15 +196,12 @@ toDeBruijn prog = do
     Left e  -> throw e
     Right p -> return $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) p
 
-data CborMode = Named | DeBruijn
+writeCBORnamed :: UPLC.Program Name DefaultUni DefaultFun () -> IO ()
+writeCBORnamed prog = BSL.putStr $ UPLC.serialiseOmittingUnits prog
 
-writeCBOR :: CborMode -> UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> IO ()
-writeCBOR cborMode prog =
-    case cborMode of
-      Named    -> case runExcept @UPLC.FreeVariableError $ PLC.runQuoteT $ UPLC.unDeBruijnProgram prog of
-          Left e  -> throw e
-          Right p -> BSL.putStr $ UPLC.serialiseOmittingUnits p
-      DeBruijn -> BSL.putStr $ UPLC.serialiseOmittingUnits $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) $ prog
+writeCBORdeBruijn ::UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> IO ()
+writeCBORdeBruijn  prog = BSL.putStr . UPLC.serialiseOmittingUnits $
+                      UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) $ prog
 
 description :: String
 description = "This program provides operations on a number of Plutus programs "
@@ -237,14 +234,10 @@ footerInfo = text "Every command takes the name of a program and a (possbily emp
 main :: IO ()
 main = do
   execParser (info (helper <*> options) (fullDesc <> progDesc description <> footerDoc (Just footerInfo))) >>= \case
-    RunPLC pa -> do
-        let
-            program :: UPLC.Term UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
-            program = getProgram pa
-            result = case runExcept @UPLC.FreeVariableError $ PLC.runQuoteT $ UPLC.unDeBruijnTerm program of
-                Left e  -> throw e
-                Right p -> unsafeEvaluateCek defBuiltinsRuntime p
-        print . PLC.prettyPlcClassicDebug $ result
+    RunPLC pa ->  print . PLC.prettyPlcClassicDebug <$>
+                  unsafeEvaluateCekNoEmit defBuiltinsRuntime $ getUnDBrTerm pa
+           -- Careful! This ^ uses the enormousBudget and that may not be
+           -- enormous enough for some of the programs here.
     RunHaskell pa ->
         case pa of
           Clausify formula        -> print $ Clausify.runClausify formula
@@ -254,12 +247,13 @@ main = do
           Prime input             -> print $ Prime.runFixedPrimalityTest input
           Primetest n             -> if n<0 then P.error "Positive number expected"
                                      else print $ Prime.runPrimalityTest n
-    DumpPLC pa -> mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug $ getWrappedProgram pa
-               where unindent d = map (dropWhile isSpace) $ (lines . show $ d)
-    DumpCBORnamed pa   -> writeCBOR Named $ getWrappedProgram pa
-    DumpCBORdeBruijn pa-> writeCBOR DeBruijn $ getWrappedProgram pa
+    DumpPLC pa -> mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug . mkProg . getUnDBrTerm $ pa
+        where unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+    DumpCBORnamed pa   -> writeCBORnamed . mkProg . getUnDBrTerm $ pa
+    DumpCBORdeBruijn pa-> writeCBORdeBruijn . mkProg . getDBrTerm $ pa
     -- Write the output to stdout and let the user deal with redirecting it.
-    where getProgram =
+    where getDBrTerm :: ProgAndArgs -> UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ()
+          getDBrTerm =
               \case
                Clausify formula        -> Clausify.mkClausifyTerm formula
                Queens boardSize alg    -> Queens.mkQueensTerm boardSize alg
@@ -268,4 +262,12 @@ main = do
                Prime input             -> Prime.mkPrimalityBenchTerm input
                Primetest n             -> if n<0 then P.error "Positive number expected"
                                           else Prime.mkPrimalityTestTerm n
-          getWrappedProgram = UPLC.Program () (UPLC.Version () 1 0 0) . getProgram
+
+          getUnDBrTerm :: ProgAndArgs -> UPLC.Term Name DefaultUni DefaultFun ()
+          getUnDBrTerm pa =
+              case runExcept @UPLC.FreeVariableError . PLC.runQuoteT . UPLC.unDeBruijnTerm . getDBrTerm $ pa of
+                Left e  -> throw e
+                Right t -> t
+
+          mkProg :: UPLC.Term name uni fun () -> UPLC.Program name uni fun ()
+          mkProg = UPLC.Program () (UPLC.Version () 1 0 0)

--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -339,7 +339,7 @@ helpText :: String
 helpText =
        "This program provides a number of utilities for dealing with Plutus Core "
     ++ "programs, including typechecking, evaluation, and conversion between a "
-    ++ "number of differnt formats.  The program also provides a number of example "
+    ++ "number of different formats.  The program also provides a number of example "
     ++ "typed Plutus Core programs.  Some commands read or write Plutus Core abstract "
     ++ "syntax trees serialised in CBOR or Flat format: ASTs are always written with "
     ++ "unit annotations, and any CBOR/Flat-encoded AST supplied as input must also be "

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -25,6 +25,7 @@ import           PlutusPrelude
 import           UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 import           PlutusCore.Evaluation.Machine.ExBudget
+import           PlutusCore.Evaluation.Machine.ExMemory            (ExCPU (..), ExMemory (..))
 import           PlutusCore.Evaluation.Machine.Exception
 
 import           Control.Lens                                      (ifoldMap)
@@ -115,7 +116,8 @@ restricting = ExBudgetMode (CekBudgetSpender spend) . RestrictingSt where
 -- | When we want to just evaluate the program we use the 'Restricting' mode with an enormous
 -- budget, so that evaluation costs of on-chain budgeting are reflected accurately in benchmarks.
 enormousBudget :: ExRestrictingBudget
-enormousBudget = ExRestrictingBudget $ ExBudget (10^(10::Int)) (10^(10::Int))
+enormousBudget = ExRestrictingBudget $ ExBudget (ExCPU maxInt) (ExMemory maxInt)
+                 where maxInt = fromIntegral (maxBound::Int)
 
 -- | 'restricting' instantiated at 'enormousBudget'.
 restrictingEnormous :: ExBudgetMode RestrictingSt uni fun


### PR DESCRIPTION
The nofib-exe program has an option to compile its examples from Haskell and then output them as textual PLC.  This was producing programs that couldn't be executed, I think because I had failed to un-DeBruijnify them.  This should fix that, although I'm currently rather confused about all the possible formats.  I'll need to sleep on that before merging.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
