### PR TITLE
Avoid our Agda depending on GHC from nixpkgs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,7 +37,7 @@ benchmarks: true
 package eventful-sql-common
   ghc-options: -XDerivingStrategies -XStandaloneDeriving -XUndecidableInstances -XDataKinds -XFlexibleInstances
 
-allow-newer: 
+allow-newer:
            -- Has a commit to allow newer aeson, not on Hackage yet
            monoidal-containers:aeson
            -- Pins to an old version of Template Haskell, unclear if/when it will be updated
@@ -50,6 +50,10 @@ allow-newer:
 constraints:
   -- aws-lambda-haskell-runtime-wai doesn't compile with newer versions
   aws-lambda-haskell-runtime <= 3.0.3
+
+-- See the note on nix/pkgs/default.nix:agdaPackages for why this is here.
+-- (NOTE this will change to ieee754 in newer versions of nixpkgs).
+extra-packages: ieee, filemanip
 
 -- Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
 source-repository-package
@@ -89,7 +93,7 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-prelude
   tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
   subdir:
-    cardano-prelude 
+    cardano-prelude
     cardano-prelude-test
 
 source-repository-package

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -49,6 +49,12 @@ let
   #
   # So we stitch one together here. It doesn't *seem* to need the library interface files,
   # but it seems like they should be there so I added them too.
+  #
+  # Furthermore, the agda builder uses a `ghcWithPackages` that has to have ieee754 available.
+  # We'd like it to use the same GHC as we have, if nothing else just to avoid depending on
+  # another GHC from nixpkgs! Sadly, this one is harder to override, and we just hack
+  # it into pkgs.haskellPackages in a fragile way. Annoyingly, this also means we have to ensure
+  # we have a few extra packages that it uses in our Haskell package set.
   agdaPackages =
     let
       frankenAgda = (pkgs.symlinkJoin {
@@ -59,8 +65,9 @@ let
           haskellNixAgda.components.library
         ];
       }) // { version = haskellNixAgda.identifier.version; };
+      frankenPkgs = pkgs // { haskellPackages = pkgs.haskellPackages // { ghcWithPackages = haskell.project.ghcWithPackages; }; };
     in
-    pkgs.agdaPackages.override { Agda = frankenAgda; };
+    pkgs.agdaPackages.override { Agda = frankenAgda; pkgs = frankenPkgs; };
 
   agdaWithStdlib = agdaPackages.agda.withPackages [ agdaPackages.standard-library ];
 

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -148,6 +148,10 @@ let
           inline-r.package.ghcOptions = "-XStandaloneKindSignatures";
 
           eventful-sql-common.package.ghcOptions = "-XDerivingStrategies -XStandaloneDeriving -XUndecidableInstances -XDataKinds -XFlexibleInstances -XMultiParamTypeClasses";
+
+          # Honestly not sure why we need this, it has a mysterious unused dependency on "m"
+          # This will go away when we upgrade nixpkgs and things use ieee754 anyway.
+          ieee.components.library.libs = lib.mkForce [ ];
         };
       }
     ] ++ lib.optional enableHaskellProfiling {

--- a/nix/pkgs/haskell/materialized-unix/default.nix
+++ b/nix/pkgs/haskell/materialized-unix/default.nix
@@ -21,6 +21,8 @@
         "barbies".revision = (((hackage."barbies")."2.0.2.0").revisions).default;
         "row-types".revision = (((hackage."row-types")."0.4.0.0").revisions).default;
         "io-streams-haproxy".revision = (((hackage."io-streams-haproxy")."1.0.1.0").revisions).default;
+        "ieee".revision = (((hackage."ieee")."0.7").revisions).default;
+        "ieee".flags.big_endian = false;
         "wai-websockets".revision = (((hackage."wai-websockets")."3.0.1.2").revisions).default;
         "wai-websockets".flags.example = true;
         "cookie".revision = (((hackage."cookie")."0.4.5").revisions).default;
@@ -449,6 +451,7 @@
         "prometheus".revision = (((hackage."prometheus")."2.2.2").revisions).default;
         "rate-limit".revision = (((hackage."rate-limit")."1.4.2").revisions).default;
         "type-equality".revision = (((hackage."type-equality")."1").revisions).default;
+        "filemanip".revision = (((hackage."filemanip")."0.3.6.3").revisions).default;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.1").revisions).default;
         "optics-extra".revision = (((hackage."optics-extra")."0.3").revisions).default;
         "freer-simple".revision = (((hackage."freer-simple")."1.2.1.1").revisions).default;


### PR DESCRIPTION
We're trying to use the Agda nixpkgs infrastructure with our own GHC. I
hadn't done quite enough overriding, so a reference to the nixpkgs GHC
was still sneaking in there!

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
