### PR TITLE
Fix port in firewall to match PAB webserver

### DIFF
--- a/deployment/morph/configurations.nix
+++ b/deployment/morph/configurations.nix
@@ -17,7 +17,7 @@ let
     prometheus = 9090;
     nodeExporter = 9100;
     webGhcExporter = 9091;
-    pab-webserver = 8080;
+    pab-webserver = 9080;
     plutus-playground-webserver = 8080;
     marlowe-playground-webserver = 9080;
   };

--- a/deployment/terraform/locals.tf
+++ b/deployment/terraform/locals.tf
@@ -15,7 +15,7 @@ locals {
   webghc_exporter_port    = 9091
   plutus_playground_port  = 8080
   marlowe_playground_port = 9080
-  pab_port                = 8080
+  pab_port                = 9080
 
   # SSH Keys
   ssh_keys = {


### PR DESCRIPTION
In latest deployments I could not access the dashboard, and I think it was because this PR #2884 changed the port in the PAB webserver. So I have changed the port in the `morph` and `terraform` files.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - ~Reviewer requested~ (tiny fix)
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- ~Someone approved it~ (tiny fix)
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
