### PR TITLE
Revert port change that seems to make CI fail

### DIFF
--- a/deployment/terraform/locals.tf
+++ b/deployment/terraform/locals.tf
@@ -15,7 +15,7 @@ locals {
   webghc_exporter_port    = 9091
   plutus_playground_port  = 8080
   marlowe_playground_port = 9080
-  pab_port                = 9080
+  pab_port                = 8080
 
   # SSH Keys
   ssh_keys = {


### PR DESCRIPTION
Revert one of the changes made by #2920, because it makes CI fail

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - ~Reviewer requested~
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- ~Someone approved it~
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
