### PR TITLE
Revert "Revert port change that seems to make CI fail"

### DIFF
--- a/deployment/terraform/locals.tf
+++ b/deployment/terraform/locals.tf
@@ -15,7 +15,7 @@ locals {
   webghc_exporter_port    = 9091
   plutus_playground_port  = 8080
   marlowe_playground_port = 9080
-  pab_port                = 8080
+  pab_port                = 9080
 
   # SSH Keys
   ssh_keys = {


### PR DESCRIPTION
Reverts input-output-hk/plutus#2922.

After testing #2920, it seems the original change was in the right direction and the reason the CI failed was probably some other non-deterministic problem that just happened to occur at the same time