### PR TITLE
scp-1862: Marlowe Dashboard Client - Implement past contract cards

### DIFF
--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -44,6 +44,7 @@ data Action
   | SelectTab Tab
   | AskConfirmation NamedAction
   | CancelConfirmation
+  | GoToStep Int
 
 instance actionIsEvent :: IsEvent Action where
   toEvent (ConfirmAction _) = Just $ defaultEvent "ConfirmAction"
@@ -51,3 +52,4 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (SelectTab _) = Just $ defaultEvent "SelectTab"
   toEvent (AskConfirmation _) = Just $ defaultEvent "AskConfirmation"
   toEvent CancelConfirmation = Just $ defaultEvent "CancelConfirmation"
+  toEvent (GoToStep _) = Just $ defaultEvent "GoToStep"

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -5,17 +5,18 @@ module Contract.View
 
 import Prelude hiding (div)
 import Contract.Lenses (_executionState, _mActiveUserParty, _metadata, _participants, _tab)
-import Contract.State (currentStep)
+import Contract.State (currentStep, isContractClosed)
 import Contract.Types (Action(..), State, Tab(..))
 import Css (applyWhen, classNames)
 import Css as Css
-import Data.Array (intercalate)
+import Data.Array (foldr, intercalate)
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NEA
 import Data.BigInteger (BigInteger, fromInt, fromString, toNumber)
 import Data.Foldable (foldMap)
 import Data.Formatter.Number (Formatter(..), format)
+import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lens ((^.))
 import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe, maybe')
@@ -28,22 +29,26 @@ import Data.Tuple.Nested ((/\))
 import Halogen.HTML (HTML, a, button, div, div_, h1, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, target, type_, value)
-import Marlowe.Execution (NamedAction(..), _contract, _namedActions, _state, getActionParticipant)
+import Marlowe.Execution (ExecutionStep, NamedAction(..), _contract, _namedActions, _state, _steps, getActionParticipant)
 import Marlowe.Extended (contractTypeName)
-import Marlowe.Semantics (Bound(..), ChoiceId(..), Input(..), Party(..), Token(..), _accounts, getEncompassBound)
+import Marlowe.Semantics (Bound(..), ChoiceId(..), Input(..), Party(..), SlotInterval, Token(..), TransactionInput(..), _accounts, getEncompassBound)
 import Material.Icons (Icon(..), icon)
 
 contractDetailsCard :: forall p. State -> HTML p Action
 contractDetailsCard state =
   let
     metadata = state ^. _metadata
+
+    pastStepsCards = mapWithIndex (renderPastStep state) (state ^. (_executionState <<< _steps))
+
+    currentStepCard = [ renderCurrentStep state ]
   in
     div [ classNames [ "flex", "flex-col", "items-center", "my-5" ] ]
       [ h1 [ classNames [ "text-xl", "font-semibold" ] ] [ text metadata.contractName ]
       -- FIXME: in zeplin the contractType is defined with color #283346, we need to define
       --        the color palette with russ.
       , h2 [ classNames [ "mb-2", "text-xs", "uppercase" ] ] [ text $ contractTypeName metadata.contractType ]
-      , div [ classNames [ "w-full", "px-5", "max-w-contract-card" ] ] [ renderCurrentStep state ]
+      , div [ classNames [ "flex", "w-full", "overflow-x-scroll", "mr-5" ] ] (pastStepsCards <> currentStepCard)
       ]
 
 actionConfirmationCard :: forall p. State -> NamedAction -> HTML p Action
@@ -73,7 +78,7 @@ actionConfirmationCard state namedAction =
 
     actionAmountItems = case namedAction of
       MakeDeposit _ _ token amount ->
-        [ detailItem [ text "Deposit amount:" ] [ currency token amount ] false
+        [ detailItem [ text "Deposit amount:" ] [ text $ currency token amount ] false
         , transactionFeeItem true
         ]
       MakeChoice _ _ (Just option) ->
@@ -83,8 +88,8 @@ actionConfirmationCard state namedAction =
       _ -> [ transactionFeeItem false ]
 
     totalToPay = case namedAction of
-      MakeDeposit _ _ token amount -> currency token amount
-      _ -> currency (Token "" "") (fromInt 0)
+      MakeDeposit _ _ token amount -> text $ currency token amount
+      _ -> text $ currency (Token "" "") (fromInt 0)
   in
     div_
       [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
@@ -138,11 +143,9 @@ actionConfirmationCard state namedAction =
           ]
       ]
 
-renderCurrentStep :: forall p. State -> HTML p Action
-renderCurrentStep state =
+renderContractCard :: forall p. State -> Array (HTML p Action) -> HTML p Action
+renderContractCard state cardBody =
   let
-    stepNumber = currentStep state
-
     currentTab = state ^. _tab
 
     -- FIXME: in zepplin the font size is 6px (I think the scale is wrong), but proportionally is half of
@@ -154,7 +157,7 @@ renderCurrentStep state =
             true -> [ "active" ]
             false -> []
   in
-    div [ classNames [ "rounded", "shadow-current-step", "overflow-hidden" ] ]
+    div [ classNames [ "rounded", "shadow-current-step", "overflow-hidden", "flex-grow", "ml-5", "max-w-contract-card", "min-w-contract-card" ] ]
       [ div [ classNames [ "flex", "overflow-hidden" ] ]
           [ a
               [ classNames (tabSelector $ currentTab == Tasks)
@@ -167,26 +170,177 @@ renderCurrentStep state =
               ]
               [ span_ $ [ text "Balances" ] ]
           ]
-      , div [ classNames [ "max-h-contract-card", "bg-white" ] ]
-          [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
-              [ span
-                  [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
-                  [ text $ "Step " <> show stepNumber ]
-              , span
-                  [ classNames [ "flex-grow", "rounded-lg", "bg-lightgray", "py-2", "flex", "items-center" ] ]
-                  [ icon Timer [ "pl-3" ]
-                  , span [ classNames [ "text-xs", "flex-grow", "text-center", "font-semibold" ] ]
-                      [ text "1hr 2mins left" ]
-                  ]
-              ]
-          , div [ classNames [ "h-contract-card", "overflow-y-scroll", "px-4" ] ]
-              [ if currentTab == Tasks then
-                  renderTasks state
-                else
-                  renderBalances state
-              ]
+      , div [ classNames [ "max-h-contract-card", "bg-white" ] ] cardBody
+      ]
+
+statusIndicator :: forall p a. Maybe Icon -> String -> Array String -> HTML p a
+statusIndicator mIcon status extraClasses =
+  div
+    [ classNames $ [ "flex-grow", "rounded-lg", "h-10", "flex", "items-center" ] <> extraClasses ]
+    $ Array.catMaybes
+        [ mIcon <#> \anIcon -> icon anIcon [ "pl-3" ]
+        , Just $ span [ classNames [ "text-xs", "flex-grow", "text-center", "font-semibold" ] ] [ text status ]
+        ]
+
+renderPastStep :: forall p. State -> Int -> ExecutionStep -> HTML p Action
+renderPastStep state stepNumber executionState =
+  let
+    -- FIXME: We need to make the tab independent.
+    currentTab = state ^. _tab
+
+    { timedOut } = executionState
+  in
+    renderContractCard state
+      [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
+          [ span
+              [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
+              [ text $ "Step " <> show (stepNumber + 1) ]
+          , if timedOut then
+              -- FIXME: The red used here corresponds to #de4c51, which is being used by border-red invalid inputs
+              --        but the zeplin had #e04b4c for this indicator. Check if it's fine or create a new red type
+              statusIndicator (Just Timer) "Timed out" [ "bg-red", "text-white" ]
+            else
+              statusIndicator (Just Done) "Completed" [ "bg-green", "text-white" ]
+          ]
+      , div [ classNames [ "h-contract-card", "overflow-y-scroll", "px-4" ] ]
+          [ case currentTab /\ timedOut of
+              Tasks /\ false -> renderPastActions state executionState
+              Tasks /\ true -> renderTimeout (stepNumber + 1)
+              Balances /\ _ -> renderBalances state
           ]
       ]
+
+type InputsByParty
+  = { inputs :: Array Input, interval :: SlotInterval, party :: Party }
+
+-- Normally we would expect that a TransactionInput has either no inputs or a single one
+-- but the types allows for them to be a list of different inputs, possibly made by different
+-- parties. If there are multiple inputs we group them by participant.
+groupTransactionInputByParticipant :: TransactionInput -> Array InputsByParty
+groupTransactionInputByParticipant (TransactionInput { inputs, interval }) =
+  Array.fromFoldable inputs
+    # Array.mapMaybe
+        ( \input -> getParty input <#> (\party -> { inputs: [ input ], party })
+        )
+    # Array.groupBy sameParty
+    # map mergeInputsFromSameParty
+  where
+  sameParty a b = a.party == b.party
+
+  mergeInputsFromSameParty ::
+    NonEmptyArray { inputs :: Array Input, party :: Party } ->
+    InputsByParty
+  mergeInputsFromSameParty nea =
+    foldr
+      (\elem accu -> accu { inputs = elem.inputs <> accu.inputs })
+      (NEA.head nea # \{ party } -> { inputs: [], party, interval })
+      nea
+
+renderPastActions :: forall p a. State -> ExecutionStep -> HTML p a
+renderPastActions state executionState =
+  let
+    actionsByParticipant = groupTransactionInputByParticipant executionState.txInput
+  in
+    div_
+      $ if Array.length actionsByParticipant == 0 then
+          -- TODO: See if we can reach this state and what text describes it better.
+          [ text "An empty transaction was made to advance this step" ]
+        else
+          renderPartyPastActions state <$> actionsByParticipant
+
+renderPartyPastActions :: forall p a. State -> InputsByParty -> HTML p a
+renderPartyPastActions state { inputs, interval, party } =
+  let
+    participantName = participantWithNickname state party
+
+    isActiveParticipant = (state ^. _mActiveUserParty) == Just party
+
+    fromDescription =
+      if isActiveParticipant then
+        "You"
+      else case party of
+        PK publicKey -> "Account " <> publicKey
+        Role roleName -> capitalize roleName
+
+    -- FIXME: Take this from interval
+    intervalDescrition = "on 10/03/2021 between 17:30 and 17:35"
+
+    renderPastAction = case _ of
+      IDeposit intoAccountOf by token value ->
+        let
+          toDescription =
+            if (state ^. _mActiveUserParty) == Just intoAccountOf then
+              "your"
+            else
+              if by == intoAccountOf then
+                "their"
+              else case intoAccountOf of
+                PK publicKey -> publicKey <> " public key"
+                Role roleName -> roleName <> "'s"
+        in
+          div [] [ text $ fromDescription <> " made a deposit of " <> currency token value <> " into " <> toDescription <> " account " <> intervalDescrition ]
+      IChoice (ChoiceId choiceIdKey _) chosenNum -> div [] [ text $ fromDescription <> " chose " <> show chosenNum <> " for " <> show choiceIdKey <> " " <> intervalDescrition ]
+      _ -> div_ []
+  in
+    div [ classNames [ "mt-4" ] ]
+      ( [ renderParty state party ] <> map renderPastAction inputs
+      )
+
+renderTimeout :: forall p a. Int -> HTML p a
+renderTimeout stepNumber =
+  div [ classNames [ "flex", "flex-col", "items-center", "h-full" ] ]
+    -- NOTE: we use pt-28 instead of making the parent justify-center because in the design it's not actually
+    --       centered and it has more space above than below.
+    [ icon Timer [ "pb-2", "pt-28", "text-red", "text-big-icon" ]
+    -- FIXME: Need to pass a Slot and convert it to the appropiate format
+    , span [ classNames [ "font-semibold", "text-center", "text-sm" ] ]
+        [ text $ "Step " <> show stepNumber <> " timed out on 03/10/2021 at 17:30" ]
+    ]
+
+renderCurrentStep :: forall p. State -> HTML p Action
+renderCurrentStep state =
+  let
+    stepNumber = currentStep state
+
+    currentTab = state ^. _tab
+
+    contractIsClosed = isContractClosed state
+  in
+    renderContractCard state
+      [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
+          [ span
+              [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
+              [ text $ "Step " <> show stepNumber ]
+          , if contractIsClosed then
+              -- FIXME: Check with russ. The original status indicator for contract closed
+              --        did not have an icon, but all other status indicator has. Check if
+              --        this is fine or if we should use a Maybe icon.
+              statusIndicator Nothing "Contract closed" [ "bg-lightgray" ]
+            else
+              statusIndicator (Just Timer) "1hr 2mins left" [ "bg-lightgray" ]
+          ]
+      , div [ classNames [ "h-contract-card", "overflow-y-scroll", "px-4" ] ]
+          [ case currentTab /\ contractIsClosed of
+              Tasks /\ false -> renderTasks state
+              Tasks /\ true -> renderContractClose
+              Balances /\ _ -> renderBalances state
+          ]
+      ]
+
+renderContractClose :: forall p a. HTML p a
+renderContractClose =
+  div [ classNames [ "flex", "flex-col", "items-center", "h-full" ] ]
+    -- NOTE: we use pt-28 instead of making the parent justify-center because in the design it's not actually
+    --       centered and it has more space above than below.
+    [ icon DoneWithCircle [ "pb-2", "pt-28", "text-green", "text-big-icon" ]
+    -- FIXME: Need to pass a Slot and convert it to the appropiate format
+    , div
+        [ classNames [ "text-center", "text-sm" ] ]
+        [ div [ classNames [ "font-semibold" ] ]
+            [ text "This contract is now closed" ]
+        , div_ [ text "There are no tasks to complete" ]
+        ]
+    ]
 
 -- This helper function expands actions that can be taken by anybody,
 -- then groups by participant and sorts it so that the owner starts first and the rest go
@@ -251,66 +405,106 @@ participantWithNickname state party =
       Role roleName /\ Just nickname -> roleName <> " (" <> nickname <> ")"
       Role roleName /\ Nothing -> roleName
 
+-- TODO: In zeplin all participants have a different color. We need to decide how are we going to assing
+--       colors to users. For now they all have purple
+renderParty :: forall p a. State -> Party -> HTML p a
+renderParty state party =
+  let
+    participantName = participantWithNickname state party
+  in
+    -- FIXME: mb-2 should not belong here
+    div [ classNames [ "text-xs", "flex", "mb-2" ] ]
+      [ div [ classNames [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white", "rounded-full", "w-5", "h-5", "text-center", "mr-1" ] ] [ text $ String.take 1 participantName ]
+      , div [ classNames [ "font-semibold" ] ] [ text participantName ]
+      ]
+
 renderPartyTasks :: forall p. State -> Party -> Array NamedAction -> HTML p Action
 renderPartyTasks state party actions =
   let
-    isActiveParticipant = (state ^. _mActiveUserParty) == Just party
-
     actionsSeparatedByOr =
       intercalate
         [ div [ classNames [ "font-semibold", "text-center", "my-2", "text-xs" ] ] [ text "OR" ]
         ]
-        (Array.singleton <<< renderAction state isActiveParticipant <$> actions)
-
-    participantName = participantWithNickname state party
+        (Array.singleton <<< renderAction state party <$> actions)
   in
     div [ classNames [ "mt-3" ] ]
-      ( [ div [ classNames [ "text-xs", "flex", "mb-2" ] ]
-            -- TODO: In zeplin all participants have a different color. We need to decide how are we going to assing
-            --       colors to users. For now they all have purple
-            [ div [ classNames [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white", "rounded-full", "w-5", "h-5", "text-center", "mr-1" ] ] [ text $ String.take 1 participantName ]
-            , div [ classNames [ "font-semibold" ] ] [ text participantName ]
-            ]
-        ]
-          <> actionsSeparatedByOr
-      )
+      ([ renderParty state party ] <> actionsSeparatedByOr)
 
-renderAction :: forall p. State -> Boolean -> NamedAction -> HTML p Action
-renderAction _ isActiveParticipant namedAction@(MakeDeposit intoAccountOf by token value) =
-  div_
-    [ shortDescription isActiveParticipant "chocolate pastry apple pie lemon drops apple pie halvah FIXME"
-    , button
-        -- FIXME: adapt to use button classes from Css module
-        [ classNames $ [ "flex", "justify-between", "px-6", "font-bold", "w-full", "py-4", "mt-2", "rounded-lg", "shadow" ]
-            <> if isActiveParticipant then
-                [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white" ]
-              else
-                [ "bg-gray", "text-black", "opacity-50", "cursor-default" ]
-        , enabled isActiveParticipant
-        , onClick_ $ AskConfirmation namedAction
-        ]
-        [ span_ [ text "Deposit:" ]
-        , span_ [ currency token value ]
-        ]
-    ]
+-- FIXME: This was added to allow anybody being able to do any actions for debug purposes...
+--        Remove once the PAB is connected
+debugMode :: Boolean
+debugMode = true
 
-renderAction state isActiveParticipant namedAction@(MakeChoice choiceId bounds mChosenNum) =
+-- The Party parameter represents who is taking the action
+renderAction :: forall p. State -> Party -> NamedAction -> HTML p Action
+renderAction state party namedAction@(MakeDeposit intoAccountOf by token value) =
   let
+    isActiveParticipant = (state ^. _mActiveUserParty) == Just party
+
+    fromDescription =
+      if isActiveParticipant then
+        "You make"
+      else case party of
+        PK publicKey -> "Account " <> publicKey <> " makes"
+        Role roleName -> capitalize roleName <> " makes"
+
+    toDescription =
+      if (state ^. _mActiveUserParty) == Just intoAccountOf then
+        "your"
+      else
+        if by == intoAccountOf then
+          "their"
+        else case intoAccountOf of
+          PK publicKey -> publicKey <> " public key"
+          Role roleName -> roleName <> "'s"
+
+    description = fromDescription <> " a deposit into " <> toDescription <> " account"
+  in
+    div_
+      [ shortDescription isActiveParticipant description
+      , button
+          -- FIXME: adapt to use button classes from Css module
+          [ classNames $ [ "flex", "justify-between", "px-6", "font-bold", "w-full", "py-4", "mt-2", "rounded-lg", "shadow" ]
+              <> if isActiveParticipant || debugMode then
+                  [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white" ]
+                else
+                  [ "bg-gray", "text-black", "opacity-50", "cursor-default" ]
+          , enabled $ isActiveParticipant || debugMode
+          , onClick_ $ AskConfirmation namedAction
+          ]
+          [ span_ [ text "Deposit:" ]
+          , span_ [ text $ currency token value ]
+          ]
+      ]
+
+renderAction state party namedAction@(MakeChoice choiceId bounds mChosenNum) =
+  let
+    isActiveParticipant = (state ^. _mActiveUserParty) == Just party
+
+    metadata = state ^. _metadata
+
     -- NOTE': We could eventually add an heuristic that if the difference between min and max is less
     --        than 10 elements, we could show a `select` instead of a input[number] and if the min==max
     --        we use a button that says "Choose `min`"
     Bound minBound maxBound = getEncompassBound bounds
 
+    ChoiceId choiceIdKey _ = choiceId
+
+    choiceDescription = case Map.lookup choiceIdKey metadata.choiceDescriptions of
+      Nothing -> div_ []
+      Just description -> shortDescription isActiveParticipant description
+
     isValid = maybe false (between minBound maxBound) mChosenNum
   in
     div_
-      [ shortDescription isActiveParticipant "chocolate pastry apple pie lemon drops apple pie halvah FIXME"
+      [ choiceDescription
       , div
           [ classNames [ "flex", "w-full", "shadow", "rounded-lg", "mt-2", "overflow-hidden", "focus-within:ring-1", "ring-black" ]
           ]
           [ input
               [ classNames [ "border-0", "py-4", "pl-4", "pr-1", "flex-grow", "focus:ring-0" ]
               , type_ InputNumber
+              , enabled $ isActiveParticipant || debugMode
               , maybe'
                   (\_ -> placeholder $ "Choose between " <> show minBound <> " and " <> show maxBound)
                   (value <<< show)
@@ -326,31 +520,35 @@ renderAction state isActiveParticipant namedAction@(MakeChoice choiceId bounds m
                           [ "bg-gray", "text-black", "opacity-50", "cursor-default" ]
                   )
               , onClick_ $ AskConfirmation namedAction
-              , enabled isValid
+              , enabled $ isValid && isActiveParticipant
               ]
               [ text "..." ]
           ]
       ]
 
-renderAction _ isActiveParticipant (MakeNotify _) = div [] [ text "FIXME: awaiting observation?" ]
+renderAction _ _ (MakeNotify _) = div [] [ text "FIXME: awaiting observation?" ]
 
-renderAction _ isActiveParticipant (Evaluate _) = div [] [ text "FIXME: what should we put here? Evaluate" ]
+renderAction _ _ (Evaluate _) = div [] [ text "FIXME: what should we put here? Evaluate" ]
 
-renderAction _ isActiveParticipant CloseContract =
-  div_
-    [ shortDescription isActiveParticipant "chocolate pastry apple pie lemon drops apple pie halvah FIXME"
-    , button
-        -- FIXME: adapt to use button classes from Css module
-        [ classNames $ [ "font-bold", "w-full", "py-4", "mt-2", "rounded-lg", "shadow" ]
-            <> if isActiveParticipant then
-                [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white" ]
-              else
-                [ "bg-gray", "text-black", "opacity-50", "cursor-default" ]
-        , enabled isActiveParticipant
-        , onClick_ $ AskConfirmation CloseContract
-        ]
-        [ text "Close contract" ]
-    ]
+renderAction state party CloseContract =
+  let
+    isActiveParticipant = (state ^. _mActiveUserParty) == Just party
+  in
+    div_
+      -- FIXME: revisit the text
+      [ shortDescription isActiveParticipant "The contract is still open and needs to be manually closed by any participant for the remainder of the balances to be distributed (charges may apply)"
+      , button
+          -- FIXME: adapt to use button classes from Css module
+          [ classNames $ [ "font-bold", "w-full", "py-4", "mt-2", "rounded-lg", "shadow" ]
+              <> if isActiveParticipant then
+                  [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white" ]
+                else
+                  [ "bg-gray", "text-black", "opacity-50", "cursor-default" ]
+          , enabled isActiveParticipant
+          , onClick_ $ AskConfirmation CloseContract
+          ]
+          [ text "Close contract" ]
+      ]
 
 currencyFormatter :: Formatter
 currencyFormatter =
@@ -365,14 +563,16 @@ currencyFormatter =
 formatBigInteger :: BigInteger -> String
 formatBigInteger = format currencyFormatter <<< toNumber
 
-currency :: forall p a. Token -> BigInteger -> HTML p a
+currency :: Token -> BigInteger -> String
 -- FIXME: value should be interpreted as lovelaces instead of ADA and we should
 --        display just the necesary amounts of digits
-currency (Token "" "") value = text ("₳ " <> formatBigInteger value)
+currency (Token "" "") value = "₳ " <> formatBigInteger value
 
-currency (Token symbol _) value = text (symbol <> " " <> formatBigInteger value)
+currency (Token "" "dollar") value = "$ " <> formatBigInteger value
 
-renderBalances :: forall p action. State -> HTML p action
+currency (Token _ name) value = formatBigInteger value <> " " <> name
+
+renderBalances :: forall p a. State -> HTML p a
 renderBalances state =
   let
     accounts :: Array (Tuple (Tuple Party Token) BigInteger)
@@ -393,13 +593,13 @@ renderBalances state =
               <#> ( \((party /\ token) /\ amount) ->
                     div [ classNames [ "flex", "justify-between", "py-3", "border-t" ] ]
                       [ span_ [ text $ participantWithNickname state party ]
-                      , span [ classNames [ "font-semibold" ] ] [ currency token amount ]
+                      , span [ classNames [ "font-semibold" ] ] [ text $ currency token amount ]
                       ]
                 )
           )
       )
 
-shortDescription :: forall p. Boolean -> String -> HTML p Action
+shortDescription :: forall p a. Boolean -> String -> HTML p a
 shortDescription isActiveParticipant description =
   div [ classNames ([ "text-xs" ] <> applyWhen (not isActiveParticipant) [ "opacity-50" ]) ]
     [ span [ classNames [ "font-semibold" ] ] [ text "Short description: " ]
@@ -412,58 +612,3 @@ getParty (IDeposit _ p _ _) = Just p
 getParty (IChoice (ChoiceId _ p) _) = Just p
 
 getParty _ = Nothing
-
-{-
-renderPastStep :: forall p. ExecutionStep -> HTML p Action
-renderPastStep { state, timedOut: true } =
-  let
-    balances = renderBalances state
-  in
-    text ""
-
-renderPastStep { txInput: TransactionInput { inputs }, state } =
-  let
-    balances = renderBalances state
-
-    f :: Input -> Map (Maybe Party) (Array Input) -> Map (Maybe Party) (Array Input)
-    f input acc = Map.insertWith append (getParty input) [ input ] acc
-
-    inputsMap = foldr f mempty inputs
-
-    tasks = renderCompletedTasks inputsMap
-  in
-    text ""
-
-renderCompletedTasks :: forall p. Map (Maybe Party) (Array Input) -> HTML p Action
-renderCompletedTasks inputsMap = text ""
-
-renderNamedAction :: forall p. NamedAction -> HTML p Action
-renderNamedAction (MakeDeposit accountId party token amount) =
-  let
-    input = IDeposit accountId party token amount
-  in
-    button [ onClick_ $ ChooseInput (Just input) ]
-      [ div [] [ text "deposit", text "some ada" ] ]
-
-renderNamedAction (MakeChoice choiceId bounds chosenNum) =
-  let
-    input = IChoice choiceId chosenNum
-  in
-    button [ onClick_ $ ChooseInput (Just input) ]
-      [ div [] [ text "deposit", text "some ada" ] ]
-
-renderNamedAction (MakeNotify observation) =
-  let
-    input = INotify
-  in
-    button [ onClick_ $ ChooseInput (Just input) ]
-      [ div [] [ text "deposit", text "some ada" ] ]
-
-renderNamedAction (Evaluate { payments, bindings }) =
-  button [ onClick_ $ ChooseInput Nothing ]
-    [ div [] [ text "deposit", text "some ada" ] ]
-
-renderNamedAction CloseContract =
-  button [ onClick_ $ ChooseInput Nothing ]
-    [ div [] [ text "deposit", text "some ada" ] ]
--}

--- a/marlowe-dashboard-client/src/Icons.purs
+++ b/marlowe-dashboard-client/src/Icons.purs
@@ -23,6 +23,7 @@ data Icon
   = Add
   | AddCircle
   | ArrowRight
+  | ArrowLeft
   | Close
   | Contacts
   | Done
@@ -44,6 +45,8 @@ content Add = "add"
 content AddCircle = "add_circle_outline"
 
 content ArrowRight = "east"
+
+content ArrowLeft = "west"
 
 content Close = "close"
 
@@ -79,6 +82,8 @@ iconClass Add = "add"
 iconClass AddCircle = "add-circle"
 
 iconClass ArrowRight = "arrow-right"
+
+iconClass ArrowLeft = "arrow-left"
 
 iconClass Close = "close"
 

--- a/marlowe-dashboard-client/src/Icons.purs
+++ b/marlowe-dashboard-client/src/Icons.purs
@@ -25,6 +25,8 @@ data Icon
   | ArrowRight
   | Close
   | Contacts
+  | Done
+  | DoneWithCircle
   | Help
   | Home
   | Menu
@@ -46,6 +48,10 @@ content ArrowRight = "east"
 content Close = "close"
 
 content Contacts = "people"
+
+content Done = "done"
+
+content DoneWithCircle = "task_alt"
 
 content Help = "help"
 
@@ -77,6 +83,10 @@ iconClass ArrowRight = "arrow-right"
 iconClass Close = "close"
 
 iconClass Contacts = "contacts"
+
+iconClass Done = "done"
+
+iconClass DoneWithCircle = "task-alt"
 
 iconClass Help = "help"
 

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -163,10 +163,10 @@ handleAction (ContractAction (Contract.AskConfirmation action)) = handleAction $
 -- FIXME: Once we have card stack this action should not be necesary
 handleAction (ContractAction (Contract.ConfirmAction action)) = do
   void $ toContract $ Contract.handleAction $ Contract.ConfirmAction action
-  handleAction $ ToggleCard $ ContractCard
+  handleAction $ ToggleCard ContractCard
 
--- FIXME: instead of SetCard I need to implement a card stack and pop the stack
-handleAction (ContractAction Contract.CancelConfirmation) = handleAction $ SetCard Nothing
+-- FIXME: instead of ToggleCard I need to implement a card stack and pop the stack
+handleAction (ContractAction Contract.CancelConfirmation) = handleAction $ ToggleCard ContractCard
 
 -- other contract  actions
 handleAction (ContractAction contractAction) = void $ toContract $ Contract.handleAction contractAction

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -5,11 +5,10 @@ import Contract.View (actionConfirmationCard, contractDetailsCard)
 import ContractHome.View (contractsScreen)
 import Css (applyWhen, classNames, hideWhen)
 import Css as Css
-import Data.Foldable (foldMap)
 import Data.Lens (preview, view)
 import Data.Maybe (Maybe(..), isNothing)
 import Data.String (take)
-import Halogen.HTML (HTML, a, div, div_, footer, header, img, main, nav, span, text)
+import Halogen.HTML (HTML, a, div, footer, header, img, main, nav, span, text)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (href, src)
 import Logo (marloweRunNavLogo, marloweRunNavLogoDark)
@@ -153,24 +152,23 @@ renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templ
       [ div
           [ classNames cardClasses ]
           $ closeButton
-          <> [ div_
-                $ (flip foldMap mCard) \cardType -> case cardType of
-                    -- TODO: Should this be renamed to CreateContactCard?
-                    CreateWalletCard mTokenName -> [ newWalletCard wallets newWalletNickname newWalletContractId remoteDataPubKey mTokenName ]
-                    ViewWalletCard walletDetails -> [ walletDetailsCard walletDetails ]
-                    PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
-                    TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard templates ]
-                    ContractSetupConfirmationCard -> [ TemplateAction <$> contractSetupConfirmationCard ]
-                    -- FIXME: We need to pattern match on the Maybe because the selectedContractState
-                    --        could be Nothing. We could add the state as part of the view, but is not ideal
-                    --        Will have to rethink how to deal with this once the overall state is more mature.
-                    ContractCard -> case mSelectedContractState of
-                      Just contractState -> [ ContractAction <$> contractDetailsCard contractState ]
-                      Nothing -> []
-                    ContractActionConfirmationCard action -> case mSelectedContractState of
-                      Just contractState -> [ ContractAction <$> actionConfirmationCard contractState action ]
-                      Nothing -> []
-            ]
+          <> case mCard of
+              -- TODO: Should this be renamed to CreateContactCard?
+              Just (CreateWalletCard mTokenName) -> [ newWalletCard wallets newWalletNickname newWalletContractId remoteDataPubKey mTokenName ]
+              Just (ViewWalletCard walletDetails) -> [ walletDetailsCard walletDetails ]
+              Just PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
+              Just TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard templates ]
+              Just ContractSetupConfirmationCard -> [ TemplateAction <$> contractSetupConfirmationCard ]
+              -- FIXME: We need to pattern match on the Maybe because the selectedContractState
+              --        could be Nothing. We could add the state as part of the view, but is not ideal
+              --        Will have to rethink how to deal with this once the overall state is more mature.
+              Just ContractCard -> case mSelectedContractState of
+                Just contractState -> [ ContractAction <$> contractDetailsCard contractState ]
+                Nothing -> []
+              Just (ContractActionConfirmationCard action) -> case mSelectedContractState of
+                Just contractState -> [ ContractAction <$> actionConfirmationCard contractState action ]
+                Nothing -> []
+              Nothing -> []
       ]
 
 renderScreen :: forall p. WalletLibrary -> Screen -> State -> HTML p Action

--- a/marlowe-dashboard-client/static/css/icons.css
+++ b/marlowe-dashboard-client/static/css/icons.css
@@ -2,10 +2,11 @@
 
 .material-icons-round {
   font-weight: inherit; /* override the default of normal that ships with google's css */
+  user-select: none; /* disable icons from being selected with the mouse */
 }
 
 .with-icon::after {
-  font-family: 'Material Icons Round';
+  font-family: "Material Icons Round";
   font-size: 24px;
   line-height: 1;
   white-space: nowrap;
@@ -14,61 +15,61 @@
 }
 
 .with-icon-add::after {
-  content: 'add';
+  content: "add";
 }
 
 .with-icon-add-circle::after {
-  content: 'add_circle_outline';
+  content: "add_circle_outline";
 }
 
 .with-icon-arrow-right::after {
-  content: 'east';
+  content: "east";
 }
 
 .with-icon-close::after {
-  content: 'close';
+  content: "close";
 }
 
 .with-icon-contacts::after {
-  content: 'people';
+  content: "people";
 }
 
 .with-icon-help::after {
-  content: 'help';
+  content: "help";
 }
 
 .with-icon-home::after {
-  content: 'home';
+  content: "home";
 }
 
 .with-icon-menu::after {
-  content: 'short_text';
+  content: "short_text";
 }
 
 .with-icon-next::after {
-  content: 'chevron_right';
+  content: "chevron_right";
 }
 
 .with-icon-pay::after {
-  content: 'credit_score';
+  content: "credit_score";
 }
 
 .with-icon-previous::after {
-  content: 'chevron_left';
+  content: "chevron_left";
 }
 
 .with-icon-roles::after {
-  content: 'person_pin_circle';
+  content: "person_pin_circle";
 }
 
 .with-icon-terms::after {
-  content: 'alarm_add';
+  content: "alarm_add";
 }
 
 .with-icon-timer::after {
-  content: 'timer';
+  content: "timer";
 }
 
 .with-icon-wallet::after {
-  content: 'account_balance_wallet';
+  content: "account_balance_wallet";
 }

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -28,7 +28,10 @@ module.exports = {
       xl: "24px",
       "2xl": "34px",
       "3xl": "46px",
-      "big-icon": "140px",
+      "big-icon": "100px",
+    },
+    scale: {
+      77: ".77",
     },
     borderRadius: {
       sm: "5px",
@@ -43,6 +46,7 @@ module.exports = {
         "0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05)",
       lg: "0 20px 25px -5px rgba(0,0,0,0.2), 0 10px 10px -5px rgba(0,0,0,0.04)",
       xl: "0 25px 50px -12px rgba(0,0,0,0.25)",
+      deep: "0 2.5px 5px 0 rgba(0, 0, 0, 0.22)",
     },
     extend: {
       gridTemplateRows: {
@@ -56,26 +60,22 @@ module.exports = {
         sm: "375px",
         md: "640px",
         lg: "768px",
-      },
-      borderWidth: {
-        half: "0.5px",
-      },
-      boxShadow: {
-        deep: "0 2.5px 5px 0 rgba(0, 0, 0, 0.22)",
-        "current-step": "0 25px 50px -12px rgb(0 0 0 / 25%)",
+        "contract-card": "264px",
       },
       height: {
-        "contract-card": "500px",
+        "contract-card": "467px",
+      },
+
+      borderWidth: {
+        half: "0.5px",
       },
       maxWidth: {
         sm: "375px",
         md: "640px",
         lg: "768px",
-        "contract-card": "360px",
       },
       minWidth: {
         button: "120px",
-        "contract-card": "300px",
       },
     },
   },
@@ -198,8 +198,9 @@ module.exports = {
     gridRowStart: false,
     gridRowEnd: false,
     transform: true,
-    transformOrigin: false,
-    scale: false,
+    // FIXME: See if we still use this after the contract run redesign
+    transformOrigin: true,
+    scale: true,
     rotate: false,
     translate: true,
     skew: false,

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -198,7 +198,6 @@ module.exports = {
     gridRowStart: false,
     gridRowEnd: false,
     transform: true,
-    // FIXME: See if we still use this after the contract run redesign
     transformOrigin: true,
     scale: true,
     rotate: false,

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -10,6 +10,7 @@ module.exports = {
       black: "#283346",
       lightgray: "#eeeeee",
       gray: "#dfdfdf",
+      green: "#00a551",
       darkgray: "#b7b7b7",
       overlay: "rgba(10,10,10,0.4)",
       white: "#ffffff",
@@ -27,6 +28,7 @@ module.exports = {
       xl: "24px",
       "2xl": "34px",
       "3xl": "46px",
+      "big-icon": "140px",
     },
     borderRadius: {
       sm: "5px",
@@ -73,6 +75,7 @@ module.exports = {
       },
       minWidth: {
         button: "120px",
+        "contract-card": "300px",
       },
     },
   },


### PR DESCRIPTION
This PR implements the layout for the timeout and close contract cards and the first version of the past step cards with the navigation buttons. It also changes the chose selector so that if it is a single option, it displays a button instead of an input field.

It is not possible to reach the timeout step as all times are hardcoded at the moment, but we can force a timeout to see how it looks like.

<img src="https://user-images.githubusercontent.com/2634059/112902159-1fff2b80-90bc-11eb-9c79-cb5c99ee6970.png" width="300">

The implementation differs from the design in a couple of points in order to make the deadline:
* In the design the mobile version has parts of the previous and next steps on the left and right of the selected step. For this version I've hidden those steps, and the only way to navigate is through the navigation buttons (no scrollbar)
* In the design of the desktop version, the selected step is always centered and you can use the scroll to navigate. The current version adds horizontal scrolling as the cards can get wider than the viewport, but the selected step is not centered and the scrolling does not modify the selected card.
* In the design the Tasks/Balance selector seems to be independent from card to card, currently the selector is global per contract.

### Middle step
There are 3 steps and we've selected the second one, so you can move back (<-) or forward (Next ->).

<img src="https://user-images.githubusercontent.com/2634059/112902210-33aa9200-90bc-11eb-8f21-f9f102511abe.png" width="300">

### Waiting step 
We are on a step waiting for user action. We can see the waiting indicator and you can either take the action or go back

<img src="https://user-images.githubusercontent.com/2634059/112902391-6f455c00-90bc-11eb-878f-7c5c98a48862.png" width="300">

### Completed
When completed the waiting indicator or next button disappears, and you can only go back

<img src="https://user-images.githubusercontent.com/2634059/112902469-8a17d080-90bc-11eb-9bca-f5a988819856.png" width="300">


### Multiple cards

In desktop you can see multiple cards at once (the selected one should be centered)
![multiple_steps](https://user-images.githubusercontent.com/2634059/112902626-c9deb800-90bc-11eb-9f5f-25746d25938b.png)


Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
