### PR TITLE
Fix typo in with-iterations.tpl

### DIFF
--- a/plutus-benchmark/templates/with-iterations.tpl
+++ b/plutus-benchmark/templates/with-iterations.tpl
@@ -225,7 +225,7 @@
                : order === 'lex'          ? lexicalSort
                : order === 'colex'        ? reverseLexicalSort
                : order === 'duration'     ? durationSort
-               : order === 'rev-duration' ? durationSortreverseDurationSort
+               : order === 'rev-duration' ? reverseDurationSort
                : reportSort;
            var sortedReports = reports.filter(function(report) {
                return !state.hidden[report.groupNumber];

--- a/plutus-benchmark/templates/with-iterations.tpl
+++ b/plutus-benchmark/templates/with-iterations.tpl
@@ -11,11 +11,10 @@
        /* This is Criterion's `criterion.js` file modified to extend the HTML
           report with the total number of iterations and total time spent
           executing each benchmark.  The original `default.tpl` file includes
-          `criterion.js` using microstache via {{{js-criterion}}}.  That loads
-          files from a fixed location in the Criterion library using
+          `criterion.js` using microstache via \{\{\{js-criterion\}\}\}.  That
+          loads files from a fixed location in the Criterion library using
           `data-files`, so we can't use that to load a modified version.
-          Instead we have to include the entire script bodily.
-       */
+          Instead we have to include the entire script bodily.  */
 
        'use strict';
 


### PR DESCRIPTION
I seem to have accidentally pasted some spurious text into the `with-iterations.tpl` template file for the benchmarks.  This fixes that.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
