### PR TITLE
no-op: fix typos in technical documentation

### DIFF
--- a/plutus-report/ledger.tex
+++ b/plutus-report/ledger.tex
@@ -40,7 +40,7 @@ Hence the \gls{off-chain} needs to be able to inspect the \gls{datum} and interp
 
 This is primarily important for \gls{off-chain}.
 For example, when implementing \glspl{app} which are state machines, we will use the \glspl{datum} of outputs to store the on-chain \emph{state} of the machine.
-If the \gls{off-chain} wants to submit at transaction to advance such a state machine, it may need to read the current state from the chain (after all, the last transition might not have been performed by this agent).
+If the \gls{off-chain} wants to submit a transaction to advance such a state machine, it may need to read the current state from the chain (after all, the last transition might not have been performed by this agent).
 \end{requirement}
 
 \begin{requirement}[UTXO size]
@@ -191,7 +191,7 @@ Hence one could use a currency to track items in a game: different kinds of item
 
 Operations on \gls{value} are defined as if it were a finitely-supported function.
 
-The ledger rules do not need to change much in order to support this generalized the \gls{value}: the only change is that we need to use the appropriate sum operation on \gls{value} in e.g. the balancing rules.
+The ledger rules do not need to change much in order to support this generalized \gls{value}: the only change is that we need to use the appropriate sum operation on \gls{value} in e.g. the balancing rules.
 
 \subsubsection{\Glsentrytext{forging}}
 \label{sec:forging}

--- a/plutus-report/scripting.tex
+++ b/plutus-report/scripting.tex
@@ -42,8 +42,8 @@ Therefore we want as much certainty as we can get about what the code will do, o
 One part of reasoning about what our programming language does is to \emph{formalize} its semantics, so we can be sure that
 \begin{inparaenum}
   \item it has a sensible semantics, and
-  \item the implementation agrees with that semantics
-\end{inparaenum}.
+  \item the implementation agrees with that semantics.
+\end{inparaenum}
 \end{requirement}
 
 \begin{requirement}[Size]


### PR DESCRIPTION
This fixes a small typo in the ledger documentation.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
