### PR TITLE
SCP-2085 - Write hack to identify templates from instances of contracts

### DIFF
--- a/marlowe-playground-client/test/Main.purs
+++ b/marlowe-playground-client/test/Main.purs
@@ -7,6 +7,7 @@ import Marlowe.BlocklyTests as BlocklyTests
 import Marlowe.ContractTests as ContractTests
 import Marlowe.LintTests as LintTests
 import Marlowe.ParserTests as ParserTests
+import Marlowe.DeinstantiatorTests as DeinstantiatorTests
 import Test.Unit.Main (runTest)
 
 foreign import forDeps :: Effect Unit
@@ -19,3 +20,4 @@ main =
     ContractTests.all
     BlocklyTests.all
     LintTests.all
+    DeinstantiatorTests.all

--- a/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
+++ b/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
@@ -6,6 +6,9 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
 import Data.Tuple.Nested ((/\))
 import Examples.PureScript.Escrow as Escrow
+import Examples.PureScript.EscrowWithCollateral as EscrowWithCollateral
+import Examples.PureScript.CouponBondGuaranteed as CouponBondGuaranteed
+import Examples.PureScript.ZeroCouponBond as ZeroCouponBond
 import Marlowe.Deinstantiate (findTemplate)
 import Marlowe.Extended (TemplateContent(..), fillTemplate, toCore)
 import Marlowe.Semantics (Contract)
@@ -39,4 +42,71 @@ all =
             )
       assertFalse "Could not instantiate Escrow contract" (mFilledEscrow == Nothing)
       equal (Just Escrow.contractTemplate) (maybe Nothing findTemplate mFilledEscrow)
-      pure unit
+    test "Escrow with collateral" do
+      let
+        mFilledEscrowWithCollateral :: Maybe Contract
+        mFilledEscrowWithCollateral =
+          toCore
+            ( fillTemplate
+                ( TemplateContent
+                    { slotContent:
+                        Map.fromFoldable
+                          [ "Collateral deposit by seller timeout" /\ fromInt 10
+                          , "Deposit of collateral by buyer timeout" /\ fromInt 50
+                          , "Deposit of price by buyer timeout" /\ fromInt 100
+                          , "Dispute by buyer timeout" /\ fromInt 1000
+                          , "Seller's response timeout" /\ fromInt 2000
+                          ]
+                    , valueContent:
+                        Map.fromFoldable
+                          [ "Collateral amount" /\ fromInt 500
+                          , "Price" /\ fromInt 500
+                          ]
+                    }
+                )
+                EscrowWithCollateral.contractTemplate.extendedContract
+            )
+      assertFalse "Could not instantiate Escrow with collateral contract" (mFilledEscrowWithCollateral == Nothing)
+      equal (Just EscrowWithCollateral.contractTemplate) (maybe Nothing findTemplate mFilledEscrowWithCollateral)
+    test "Zero Coupon Bond" do
+      let
+        mFilledZeroCouponBond :: Maybe Contract
+        mFilledZeroCouponBond =
+          toCore
+            ( fillTemplate
+                ( TemplateContent
+                    { slotContent:
+                        Map.fromFoldable
+                          [ "Initial exchange deadline" /\ fromInt 10
+                          , "Maturity exchange deadline" /\ fromInt 20
+                          ]
+                    , valueContent:
+                        Map.fromFoldable
+                          [ "Discounted price" /\ fromInt 50
+                          , "Notional" /\ fromInt 100
+                          ]
+                    }
+                )
+                ZeroCouponBond.contractTemplate.extendedContract
+            )
+      assertFalse "Could not instantiate Zero Coupon Bond contract" (mFilledZeroCouponBond == Nothing)
+      equal (Just ZeroCouponBond.contractTemplate) (maybe Nothing findTemplate mFilledZeroCouponBond)
+    test "Coupon Bond Guaranteed" do
+      let
+        mFilledCouponBondGuaranteed :: Maybe Contract
+        mFilledCouponBondGuaranteed =
+          toCore
+            ( fillTemplate
+                ( TemplateContent
+                    { slotContent: mempty
+                    , valueContent:
+                        Map.fromFoldable
+                          [ "Interest instalment" /\ fromInt 10
+                          , "Principal" /\ fromInt 1000
+                          ]
+                    }
+                )
+                CouponBondGuaranteed.contractTemplate.extendedContract
+            )
+      assertFalse "Could not instantiate Coupon Bond Guaranteed contract" (mFilledCouponBondGuaranteed == Nothing)
+      equal (Just CouponBondGuaranteed.contractTemplate) (maybe Nothing findTemplate mFilledCouponBondGuaranteed)

--- a/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
+++ b/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
@@ -1,0 +1,42 @@
+module Marlowe.DeinstantiatorTests where
+
+import Prelude
+import Data.BigInteger (fromInt)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), maybe)
+import Data.Tuple.Nested ((/\))
+import Examples.PureScript.Escrow as Escrow
+import Marlowe.Deinstantiate (findTemplate)
+import Marlowe.Extended (TemplateContent(..), fillTemplate, toCore)
+import Marlowe.Semantics (Contract)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert (assertFalse, equal)
+
+all :: TestSuite
+all =
+  suite "Deinstantiator Tests" do
+    test "Escrow" do
+      let
+        mFilledEscrow :: Maybe Contract
+        mFilledEscrow =
+          toCore
+            ( fillTemplate
+                ( TemplateContent
+                    { slotContent:
+                        Map.fromFoldable
+                          [ "Buyer's deposit timeout" /\ fromInt 10
+                          , "Buyer's dispute timeout" /\ fromInt 50
+                          , "Seller's response timeout" /\ fromInt 100
+                          , "Timeout for arbitrage" /\ fromInt 1000
+                          ]
+                    , valueContent:
+                        Map.fromFoldable
+                          [ "Price" /\ fromInt 450
+                          ]
+                    }
+                )
+                Escrow.contractTemplate.extendedContract
+            )
+      assertFalse "Could not instantiate Escrow contract" (mFilledEscrow == Nothing)
+      equal (Just Escrow.contractTemplate) (maybe Nothing findTemplate mFilledEscrow)
+      pure unit

--- a/web-common-marlowe/src/Marlowe/Deinstantiate.purs
+++ b/web-common-marlowe/src/Marlowe/Deinstantiate.purs
@@ -1,0 +1,79 @@
+module Marlowe.Deinstantiate where
+
+import Prelude
+import Data.Array (filter, zipWith)
+import Data.BigInteger (BigInteger)
+import Data.Foldable (all)
+import Data.Generic.Rep (class Generic, Argument(..), Constructor(..), NoArguments, Product(..), Sum(..), from)
+import Data.Maybe (Maybe(..))
+import Data.Symbol (class IsSymbol)
+import Marlowe.Extended as EM
+import Marlowe.Extended.Template (ContractTemplate)
+import Marlowe.Market (contractTemplates)
+import Marlowe.Semantics as S
+
+class IsInstanceOf a b where
+  isInstance :: a -> b -> Boolean
+
+class GenericIsInstanceOf a b where
+  genericIsInstanceOf' :: a -> b -> Boolean
+
+instance genericIsInstanceOfSum :: (GenericIsInstanceOf a c, GenericIsInstanceOf b c) => GenericIsInstanceOf (Sum a b) c where
+  genericIsInstanceOf' (Inl a) c = genericIsInstanceOf' a c
+  genericIsInstanceOf' (Inr b) c = genericIsInstanceOf' b c
+else instance genericIsInstanceOfSum2 :: (GenericIsInstanceOf a b, GenericIsInstanceOf a c) => GenericIsInstanceOf a (Sum b c) where
+  genericIsInstanceOf' a (Inl b) = genericIsInstanceOf' a b
+  genericIsInstanceOf' a (Inr c) = genericIsInstanceOf' a c
+
+instance genericIsInstanceOfSlotParam :: (GenericIsInstanceOf a b) => GenericIsInstanceOf (Constructor "Constant" a) (Constructor "ConstantParam" b) where
+  genericIsInstanceOf' (Constructor a) (Constructor b) = true
+else instance genericIsInstanceOfEqConstructor :: (GenericIsInstanceOf a b, IsSymbol nameA) => GenericIsInstanceOf (Constructor nameA a) (Constructor nameA b) where
+  genericIsInstanceOf' (Constructor a) (Constructor b) = genericIsInstanceOf' a b
+else instance genericIsInstanceOfConstructor :: (IsSymbol nameA, IsSymbol nameB) => GenericIsInstanceOf (Constructor nameA a) (Constructor nameB b) where
+  genericIsInstanceOf' (Constructor a) (Constructor b) = false
+
+instance genericIsInstanceOfNoArguments :: GenericIsInstanceOf NoArguments NoArguments where
+  genericIsInstanceOf' _ _ = true
+else instance genericIsInstanceOfProduct :: (GenericIsInstanceOf a1 b1, GenericIsInstanceOf a2 b2) => GenericIsInstanceOf (Product a1 a2) (Product b1 b2) where
+  genericIsInstanceOf' (Product a1 a2) (Product b1 b2) = genericIsInstanceOf' a1 b1 && genericIsInstanceOf' a2 b2
+
+instance genericIsInstanceOfSame :: Eq a => GenericIsInstanceOf (Argument a) (Argument a) where
+  genericIsInstanceOf' (Argument a) (Argument b) = a == b
+else instance genericIsInstanceOfArguments :: IsInstanceOf a b => GenericIsInstanceOf (Argument a) (Argument b) where
+  genericIsInstanceOf' (Argument a) (Argument b) = isInstance a b
+
+genericIsInstanceOf :: forall a b repA repB. Generic a repA => Generic b repB => GenericIsInstanceOf repA repB => a -> b -> Boolean
+genericIsInstanceOf a b = genericIsInstanceOf' (from a) (from b)
+
+instance isInstanceOfPayee :: IsInstanceOf S.Payee EM.Payee where
+  isInstance a b = genericIsInstanceOf a b
+
+instance isInstanceOfBigIntegerString :: IsInstanceOf BigInteger String where
+  isInstance a b = false
+
+instance isInstanceOfValue :: IsInstanceOf S.Value EM.Value where
+  isInstance a b = genericIsInstanceOf a b
+
+instance isInstanceOfObservation :: IsInstanceOf S.Observation EM.Observation where
+  isInstance a b = genericIsInstanceOf a b
+
+instance isInstanceOfAction :: IsInstanceOf S.Action EM.Action where
+  isInstance a b = genericIsInstanceOf a b
+
+instance isInstanceOfCase :: IsInstanceOf S.Case EM.Case where
+  isInstance a b = genericIsInstanceOf a b
+
+instance isInstanceOfArrayOfCase :: IsInstanceOf (Array S.Case) (Array EM.Case) where
+  isInstance a b = all identity (zipWith isInstance a b)
+
+instance isInstanceOfSlotTimeout :: IsInstanceOf S.Slot EM.Timeout where
+  isInstance _ (EM.SlotParam _) = true
+  isInstance (S.Slot x) (EM.Slot y) = x == y
+
+instance isInstanceOfContract :: IsInstanceOf S.Contract EM.Contract where
+  isInstance a b = genericIsInstanceOf a b
+
+findTemplate :: S.Contract -> Maybe ContractTemplate
+findTemplate contract = case filter (\candidate -> isInstance contract candidate.extendedContract) contractTemplates of
+  [ template ] -> Just template
+  _ -> Nothing


### PR DESCRIPTION
Hack function that checks which example template matches with a given instance of a contract in core Marlowe. It checks each contract in the list and it returns Just if there is exactly one match.

Also a test that makes sure at least it works for escrow.

I used this opportunity to learn about Generics and it seems it worked :)

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
