### PR TITLE
marlowe-dashboard-client: provide contracts.json

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -65,10 +65,10 @@ rec {
 
   marlowe-dashboard = pkgs.recurseIntoAttrs rec {
     inherit (pkgs.callPackage ./marlowe-dashboard-client {
-      inherit plutus-pab;
+      inherit plutus-pab marlowe-app;
       inherit (plutus.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
       inherit webCommon webCommonMarlowe;
-    }) client server-invoker generated-purescript generate-purescript;
+    }) client server-invoker generated-purescript generate-purescript contractsJSON;
   };
 
   marlowe-marketplace = pkgs.recurseIntoAttrs rec {

--- a/marlowe-dashboard-client/.gitignore
+++ b/marlowe-dashboard-client/.gitignore
@@ -12,3 +12,6 @@ yarn.lock
 .psc-package2nix/
 .spago/
 .spago2nix/
+# contracts is a symlink provided via the nix build
+# and should be ignored
+contracts

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules, filterNpm, plutus-pab }:
+{ pkgs, gitignore-nix, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules, filterNpm, plutus-pab, marlowe-app }:
 let
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
@@ -8,6 +8,10 @@ let
     packageLockJson = ./package-lock.json;
     githubSourceHashMap = { };
   };
+
+  contractsJSON = pkgs.writeTextDir "contracts.json" (builtins.toJSON {
+    marlowe = "${marlowe-app}/bin/marlowe-app";
+  });
 
   client = buildPursPackage {
     inherit pkgs nodeModules;
@@ -20,6 +24,7 @@ let
       web-common = webCommon;
       web-common-marlowe = webCommonMarlowe;
       generated = plutus-pab.generated-purescript;
+      contracts = contractsJSON;
     };
     packages = pkgs.callPackage ./packages.nix { };
     spagoPackages = pkgs.callPackage ./spago-packages.nix { };
@@ -27,5 +32,5 @@ let
 in
 {
   inherit (plutus-pab) server-invoker generated-purescript generate-purescript start-backend;
-  inherit client;
+  inherit client contractsJSON;
 }

--- a/marlowe-dashboard-client/package.json
+++ b/marlowe-dashboard-client/package.json
@@ -12,7 +12,8 @@
     "test:watch": "spago test --no-psa --watch",
     "docs": "spago docs",
     "repl": "spago repl",
-    "start": "npm install && plutus-pab-generate-purs && npm run purs:compile && npm run webpack:server"
+    "start": "npm install && plutus-pab-generate-purs && npm run link-contracts && npm run purs:compile && npm run webpack:server",
+    "link-contracts": "nix-build ../default.nix -A marlowe-dashboard.contractsJSON -o contracts"
   },
   "dependencies": {
     "json-bigint": "^1.0.0"


### PR DESCRIPTION
Add an `extraSrcs` input that symlinks `contracts/contracts.json` into
the build. In order to get the same folder during development the
`package.json` provides a `link-contracts` script:

```
$ npm run link-contracts
```

The invocation of the above has also been added to the `start` script.

----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
