### PR TITLE
SCP-2052 - Remove killallz3 invocation from static analysis and add monitoring

### DIFF
--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -13,7 +13,7 @@ Now we will build and run the front end:
 ```bash
 cd marlowe-playground-client
 # Generate the purescript bridge files
-$(nix-build ../default.nix -A marlowe-playground.generate-purescript)
+$(nix-build ../default.nix -A marlowe-playground.generate-purescript)/bin/marlowe-playground-generate-purs
 # Download javascript dependencies
 npm install
 # Install purescript depdendencies

--- a/marlowe-playground-server/app/PSGenerator.hs
+++ b/marlowe-playground-server/app/PSGenerator.hs
@@ -149,6 +149,7 @@ myTypes =
     , mkSumType (Proxy @InterpreterError)
     , mkSumType (Proxy @Warning)
     , mkSumType (Proxy @(InterpreterResult A))
+    , (genericShow <*> mkSumType) (Proxy @MSRes.Response)
     , (genericShow <*> mkSumType) (Proxy @MSRes.Result)
     , mkSumType (Proxy @MSReq.Request)
     , mkSumType (Proxy @CT.ContractTerms)

--- a/marlowe-symbolic/marlowe-symbolic.cabal
+++ b/marlowe-symbolic/marlowe-symbolic.cabal
@@ -17,7 +17,9 @@ library
     default-language: Haskell2010
     build-depends:      aeson -any,
                         base >=4.9,
+                        clock,
                         deriving-aeson -any,
+                        formatting,
                         http-client,
                         http-client-tls,
                         marlowe,

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
@@ -46,10 +46,8 @@ makeResponse (Right res) =
 handlers :: Server API
 handlers Request {..} =
   liftIO $ do
-    _ <- system "killallz3"
     evRes <- warningsTraceCustom onlyAssertions contract (Just state)
     let resp = makeResponse (first show evRes)
-    _ <- system "killallz3"
     putStrLn $ BSU.toString $ JSON.encode resp
     pure resp
 
@@ -61,3 +59,4 @@ initializeContext = pure ()
 
 initializeApplication :: IO Application
 initializeApplication = pure app
+

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
@@ -11,12 +11,15 @@
 
 module Marlowe.Symbolic.Server where
 
+import           Control.Exception                     (evaluate)
 import           Control.Monad.IO.Class                (MonadIO, liftIO)
 import qualified Data.Aeson                            as JSON
 import           Data.Bifunctor                        (first)
 import           Data.ByteString.Lazy.UTF8             as BSU
 import           Data.Maybe                            (fromMaybe)
 import           Data.Proxy                            (Proxy (Proxy))
+import           Formatting                            (fprintLn, (%))
+import           Formatting.Clock                      (timeSpecs)
 import           Language.Marlowe                      (Contract, Slot (Slot), State, TransactionInput,
                                                         TransactionWarning)
 import           Language.Marlowe.Analysis.FSSemantics (warningsTraceCustom)
@@ -24,6 +27,7 @@ import           Marlowe.Symbolic.Types.Request        (Request (..))
 import           Marlowe.Symbolic.Types.Response       (Result (..))
 import           Servant                               (Application, Handler (Handler), JSON, Post, ReqBody, Server,
                                                         ServerError, hoistServer, serve, (:<|>) ((:<|>)), (:>))
+import           System.Clock                          (Clock (Monotonic), getTime)
 import           System.Process                        (system)
 import           Text.PrettyPrint.Leijen               (displayS, renderCompact)
 
@@ -46,10 +50,15 @@ makeResponse (Right res) =
 handlers :: Server API
 handlers Request {..} =
   liftIO $ do
+    start <- getTime Monotonic
     evRes <- warningsTraceCustom onlyAssertions contract (Just state)
+    evaluate evRes
+    end <- getTime Monotonic
     let resp = makeResponse (first show evRes)
     putStrLn $ BSU.toString $ JSON.encode resp
+    fprintLn ("Static analysis took " % timeSpecs) start end
     pure resp
+
 
 app :: Application
 app = serve (Proxy @API) handlers

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
@@ -17,3 +17,12 @@ data Result = Valid
 instance FromJSON Result
 instance ToJSON Result
 
+data Response = Response { result     :: Result
+                         , durationMs :: Integer
+                         }
+  deriving (Generic)
+
+instance FromJSON Response
+instance ToJSON Response
+
+

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe-symbolic.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe-symbolic.nix
@@ -35,7 +35,9 @@
         depends = [
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."clock" or (errorHandler.buildDepError "clock"))
           (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
+          (hsPkgs."formatting" or (errorHandler.buildDepError "formatting"))
           (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
           (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
           (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))

--- a/web-common/src/Analytics.purs
+++ b/web-common/src/Analytics.purs
@@ -37,6 +37,13 @@ type SegmentEvent
     , payload :: Object Foreign
     }
 
+type TimingEvent
+  = { category :: String
+    , variable :: String
+    , miliseconds :: Number
+    , label :: String
+    }
+
 defaultEvent :: String -> Event
 defaultEvent action =
   { action


### PR DESCRIPTION
This PR:
- Removes `killall` from the static analysis script.
- Measures time it takes to run static analysis and sends it to the analytics service.
- Updates instructions to generate purescript in the README.md

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [x] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [x] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [x] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [x] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
