### PR TITLE
Slim down our Agda

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -47,8 +47,7 @@ let
   # - The 'agda-mode' executable
   # - A 'version' attribute
   #
-  # So we stitch one together here. It doesn't *seem* to need the library interface files,
-  # but it seems like they should be there so I added them too.
+  # So we stitch one together here.
   #
   # Furthermore, the agda builder uses a `ghcWithPackages` that has to have ieee754 available.
   # We'd like it to use the same GHC as we have, if nothing else just to avoid depending on
@@ -62,7 +61,6 @@ let
         paths = [
           haskellNixAgda.components.exes.agda
           haskellNixAgda.components.exes.agda-mode
-          haskellNixAgda.components.library
         ];
       }) // { version = haskellNixAgda.identifier.version; };
       frankenPkgs = pkgs // { haskellPackages = pkgs.haskellPackages // { ghcWithPackages = haskell.project.ghcWithPackages; }; };

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -33,14 +33,15 @@
       # - manually compile the executable (fortunately it has no extra dependencies!) and do the
       # compilation at the end of the library derivation.
       packages.Agda.package.buildType = lib.mkForce "Simple";
+      packages.Agda.components.library.enableSeparateDataOutput = lib.mkForce true;
       packages.Agda.components.library.postInstall = ''
         # Compile the executable using the package DB we've just made, which contains
         # the main Agda library
         ghc src/main/Main.hs -package-db=$out/package.conf.d -o agda
 
-        # Find all the files in $out (would be $data if we had a separate data output)
+        # Find all the files in $data
         shopt -s globstar
-        files=($out/**/*.agda)
+        files=($data/**/*.agda)
         for f in "''${files[@]}" ; do
           echo "Compiling $f"
           # This is what the custom setup calls in the end


### PR DESCRIPTION
It looks like we don't actually need the library interface files, the reference from the Agda executable is just fine.

This makes the devcontainer a bit smaller.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
