### PR TITLE
Integrating Marlowe Run with the new PAB.

### DIFF
--- a/marlowe-dashboard-client/src/Bridge.purs
+++ b/marlowe-dashboard-client/src/Bridge.purs
@@ -1,0 +1,111 @@
+module Bridge
+  ( _bridge
+  , class Bridge
+  , toFront
+  , toBack
+  ) where
+
+import Prelude
+import Data.BigInteger (BigInteger)
+import Data.Json.JsonTuple (JsonTuple(..))
+import Data.Json.JsonUUID (JsonUUID(..))
+import Data.Lens (Iso', iso)
+import Data.Map (Map, fromFoldable, toUnfoldable) as Front
+import Data.Tuple (Tuple)
+import Data.Tuple.Nested ((/\))
+import Marlowe.Semantics (Assets(..), Slot(..)) as Front
+import Network.RemoteData (RemoteData)
+import Plutus.V1.Ledger.Crypto (PubKey(..)) as Back
+import Plutus.V1.Ledger.Slot (Slot(..)) as Back
+import Plutus.V1.Ledger.Value (CurrencySymbol(..), TokenName(..), Value(..)) as Back
+import PlutusTx.AssocMap (Map, fromTuples, toTuples) as Back
+import Servant.PureScript.Ajax (AjaxError)
+import Types (ContractInstanceId(..)) as Front
+import Wallet.Emulator.Wallet (Wallet(..)) as Back
+import Wallet.Types (ContractInstanceId(..)) as Back
+import Wallet.Types (Payment)
+import WalletData.Types (Wallet(..)) as Front
+
+-- | Servant.PureScript generates PureScript types from the Haskell codebase with JSON encode and decode instances
+--   that in principle enable easy communication between the (frontend) PureScript and (backend) Haskell code.
+--   **However**:
+--     - The Haskell code uses the newtype record shorthand a lot (e.g. newtype Slot = { getSlot: Integer }),
+--       which PureScript takes literally. Using these types directly in the PureScript code thus leads to a
+--       lot of tedious boilerplate.
+--     - The PureScript Marlowe.Semantics modules uses aliases in a handful of places where the Haskell code uses
+--       newtypes. I don't know why this is (it was before my time), and we should look into bringing things into
+--       closer alignment. But in the meantime, this module plasters over the cracks.
+--     - The Haskell code uses a custom `PlutusTx.AssocMap` where the PureScript code uses the standard `Data.Map`.
+--       This is because the Plutus core cannot compile the standard Haskell `Data.Map`.
+--
+-- TODO: Bring the PureScript Marlowe.Semantics types into closer alignment with their Haskell equivalents.
+--
+-- TODO: Some form of "bridge" module like this will probably always be wanted, even with the types in closer
+-- alignment. But it should be as general as possible and moved into a web-common directory.
+_bridge :: forall a b. Bridge a b => Iso' a b
+_bridge = iso toFront toBack
+
+class Bridge a b where
+  toFront :: a -> b
+  toBack :: b -> a
+
+instance webDataBridge :: (Bridge a b) => Bridge (RemoteData AjaxError a) (RemoteData AjaxError b) where
+  toFront = map toFront
+  toBack = map toBack
+
+instance tupleBridge :: (Bridge a c, Bridge b d) => Bridge (Tuple a b) (Tuple c d) where
+  toFront (a /\ b) = toFront a /\ toFront b
+  toBack (c /\ d) = toBack c /\ toBack d
+
+instance jsonTupleBridge :: (Bridge a c, Bridge b d) => Bridge (JsonTuple a b) (JsonTuple c d) where
+  toFront (JsonTuple tuple) = JsonTuple $ toFront tuple
+  toBack (JsonTuple tuple) = JsonTuple $ toBack tuple
+
+instance arrayBridge :: Bridge a b => Bridge (Array a) (Array b) where
+  toFront = map toFront
+  toBack = map toBack
+
+instance mapBridge :: (Ord a, Ord c, Bridge a c, Bridge b d) => Bridge (Back.Map a b) (Front.Map c d) where
+  toFront map = Front.fromFoldable $ toFront <$> Back.toTuples map
+  toBack map = Back.fromTuples $ toBack <$> Front.toUnfoldable map
+
+instance slotBridge :: Bridge Back.Slot Front.Slot where
+  toFront slot@(Back.Slot { getSlot }) = Front.Slot getSlot
+  toBack (Front.Slot slot) = Back.Slot { getSlot: slot }
+
+instance bigIntegerBridge :: Bridge BigInteger BigInteger where
+  toFront = identity
+  toBack = identity
+
+-- FIXME: Marlowe.Semantics.PubKey is currently just an alias for String
+instance pubKeyBridge :: Bridge Back.PubKey String where
+  toFront (Back.PubKey { getPubKey }) = getPubKey
+  toBack getPubKey = Back.PubKey { getPubKey }
+
+-- FIXME: the Haskell type is called 'Value' but the PureScript type is called 'Assets'
+instance valueBridge :: Bridge Back.Value Front.Assets where
+  toFront (Back.Value { getValue }) = Front.Assets $ toFront getValue
+  toBack (Front.Assets getValue) = Back.Value { getValue: toBack getValue }
+
+-- FIXME: Marlowe.Semantics.TokenName is currently just an alias for String
+instance tokenNameBridge :: Bridge Back.TokenName String where
+  toFront (Back.TokenName { unTokenName }) = unTokenName
+  toBack unTokenName = Back.TokenName { unTokenName }
+
+-- FIXME: Marlowe.Semantics.CurrencySymbol is currently just an alias for String
+instance currencySymbolBridge :: Bridge Back.CurrencySymbol String where
+  toFront (Back.CurrencySymbol { unCurrencySymbol }) = unCurrencySymbol
+  toBack unCurrencySymbol = Back.CurrencySymbol { unCurrencySymbol }
+
+instance walletBridge :: Bridge Back.Wallet Front.Wallet where
+  toFront (Back.Wallet { getWallet }) = Front.Wallet getWallet
+  toBack (Front.Wallet getWallet) = Back.Wallet { getWallet }
+
+instance contractInstanceIdBridge :: Bridge Back.ContractInstanceId Front.ContractInstanceId where
+  toFront (Back.ContractInstanceId { unContractInstanceId: JsonUUID uuid }) = Front.ContractInstanceId uuid
+  toBack (Front.ContractInstanceId uuid) = Back.ContractInstanceId { unContractInstanceId: JsonUUID uuid }
+
+-- NOTE: the `Payment` type defined in `Marlowe.Semantics` is for something different
+instance paymentBridge :: Bridge Payment Payment where
+  toFront = identity
+  toBack = identity

--- a/marlowe-dashboard-client/src/Capability/Ajax.purs
+++ b/marlowe-dashboard-client/src/Capability/Ajax.purs
@@ -1,0 +1,15 @@
+module Capability.Ajax (runAjax) where
+
+import Prelude
+import Control.Monad.Except (ExceptT, runExceptT)
+import Control.Monad.Reader (class MonadAsk, ReaderT)
+import Control.Monad.Reader.Extra (mapEnvReaderT)
+import Env (Env)
+import Network.RemoteData (fromEither)
+import Plutus.PAB.Webserver (SPParams_)
+import Servant.PureScript.Ajax (AjaxError)
+import Servant.PureScript.Settings (SPSettings_)
+import Types (WebData)
+
+runAjax :: forall a m. MonadAsk Env m => ExceptT AjaxError (ReaderT (SPSettings_ SPParams_) m) a -> m (WebData a)
+runAjax action = mapEnvReaderT _.ajaxSettings $ fromEither <$> runExceptT action

--- a/marlowe-dashboard-client/src/Capability/Contract.purs
+++ b/marlowe-dashboard-client/src/Capability/Contract.purs
@@ -1,0 +1,67 @@
+module Capability.Contract
+  ( class MonadContract
+  , activateContract
+  , getContractInstance
+  , invokeEndpoint
+  , getWalletContractInstances
+  , getAllContractInstances
+  , getContractDefinitions
+  ) where
+
+import Prelude
+import AppM (AppM)
+import Bridge (toFront)
+import Capability.Ajax (runAjax)
+import Control.Monad.Except (lift)
+import Data.Newtype (unwrap)
+import Data.RawJson (RawJson)
+import Data.UUID (toString) as UUID
+import Halogen (HalogenM)
+import MainFrame.Types (WebData)
+import Plutus.PAB.Effects.Contract.ContractExe (ContractExe)
+import Plutus.PAB.Webserver (getApiNewContractDefinitions, getApiNewContractInstanceByContractinstanceidStatus, getApiNewContractInstances, getApiNewContractInstancesWalletByWalletid, postApiNewContractActivate, postApiNewContractInstanceByContractinstanceidEndpointByEndpointname)
+import Plutus.PAB.Webserver.Types (ContractActivationArgs, ContractInstanceClientState, ContractSignatureResponse)
+import Types (ContractInstanceId)
+import WalletData.Types (Wallet)
+
+-- The PAB PSGenerator (using Servant.PureScript) automatically generates a PureScript module with
+-- functions for calling all PAB API endpoints. This `MonadContract` class wraps these up in a
+-- 'capability' monad (https://thomashoneyman.com/guides/real-world-halogen/push-effects-to-the-edges/)
+-- with some nicer names, and mapping the result to RemoteData.
+class
+  Monad m <= MonadContract m where
+  activateContract :: ContractActivationArgs ContractExe -> m (WebData ContractInstanceId)
+  getContractInstance :: ContractInstanceId -> m (WebData ContractInstanceClientState)
+  invokeEndpoint :: RawJson -> ContractInstanceId -> String -> m (WebData Unit)
+  getWalletContractInstances :: Wallet -> m (WebData (Array ContractInstanceClientState))
+  getAllContractInstances :: m (WebData (Array ContractInstanceClientState))
+  getContractDefinitions :: m (WebData (Array (ContractSignatureResponse ContractExe)))
+
+instance monadContractAppM :: MonadContract AppM where
+  activateContract contractActivationArgs =
+    runAjax
+      $ map toFront
+      $ postApiNewContractActivate contractActivationArgs
+  getContractInstance contractInstanceId =
+    runAjax
+      $ getApiNewContractInstanceByContractinstanceidStatus (UUID.toString $ unwrap contractInstanceId)
+  invokeEndpoint rawJson contractInstanceId endpointDescriptionString =
+    runAjax
+      $ postApiNewContractInstanceByContractinstanceidEndpointByEndpointname rawJson (UUID.toString $ unwrap contractInstanceId) endpointDescriptionString
+  getWalletContractInstances wallet =
+    runAjax
+      $ getApiNewContractInstancesWalletByWalletid (show $ unwrap wallet)
+  getAllContractInstances =
+    runAjax
+      $ getApiNewContractInstances
+  getContractDefinitions =
+    runAjax
+      $ getApiNewContractDefinitions
+
+instance monadContractHalogenM :: MonadContract m => MonadContract (HalogenM state action slots msg m) where
+  activateContract = lift <<< activateContract
+  getContractInstance = lift <<< getContractInstance
+  invokeEndpoint payload contractInstanceId endpointDescription = lift $ invokeEndpoint payload contractInstanceId endpointDescription
+  getWalletContractInstances = lift <<< getWalletContractInstances
+  getAllContractInstances = lift getAllContractInstances
+  getContractDefinitions = lift getContractDefinitions

--- a/marlowe-dashboard-client/src/Capability/ContractExe.js
+++ b/marlowe-dashboard-client/src/Capability/ContractExe.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const contracts = require('/contracts/contracts.json');
+
+exports.marloweContractPath_ = contracts.marlowe;
+
+//exports.walletCompanionContractPath_ = contracts.walletCompanion;
+exports.walletCompanionContractPath_ = "TODO: integrate the wallet companion contract"

--- a/marlowe-dashboard-client/src/Capability/ContractExe.purs
+++ b/marlowe-dashboard-client/src/Capability/ContractExe.purs
@@ -1,0 +1,16 @@
+module Capability.ContractExe
+  ( marloweContractExe
+  , walletCompanionContractExe
+  ) where
+
+import Plutus.PAB.Effects.Contract.ContractExe (ContractExe(..))
+
+foreign import marloweContractPath_ :: String
+
+foreign import walletCompanionContractPath_ :: String
+
+marloweContractExe :: ContractExe
+marloweContractExe = ContractExe { contractPath: marloweContractPath_ }
+
+walletCompanionContractExe :: ContractExe
+walletCompanionContractExe = ContractExe { contractPath: walletCompanionContractPath_ }

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -1,65 +1,78 @@
 module Capability.Marlowe
   ( class MonadMarlowe
-  , dummy
-  --, marloweCreateWalletCompanionContract
+  , marloweCreateWalletCompanionContract
   --, marloweCreateContract
-  --, marloweApplyInputs
-  --, marloweWait
-  --, marloweAuto
-  --, marloweRedeem
+  , marloweApplyInputs
+  , marloweWait
+  , marloweAuto
+  , marloweRedeem
   ) where
 
 import Prelude
-import AppM (AppM(..))
-import Capability.Ajax (runAjax)
-import Capability.Contract (class MonadContract)
+import AppM (AppM)
+import Bridge (toBack)
+import Capability.Contract (class MonadContract, activateContract, invokeEndpoint)
+import Capability.ContractExe (marloweContractExe, walletCompanionContractExe)
 import Control.Monad.Except (lift)
 import Data.Map (Map)
-import Data.RawJson (RawJson)
+import Data.RawJson (RawJson(..))
+import Data.Tuple.Nested ((/\))
+import Foreign.Generic (encode)
+import Foreign.JSON (unsafeStringify)
 import Halogen (HalogenM)
 import MainFrame.Types (WebData)
 import Marlowe.Semantics (Contract, Input, Party, Slot)
-import Network.RemoteData (RemoteData(..))
-import Plutus.PAB.Effects.Contract.ContractExe (ContractExe)
-import Plutus.PAB.Webserver (postApiNewContractActivate, getApiNewContractInstanceByContractinstanceidStatus, postApiNewContractInstanceByContractinstanceidEndpointByEndpointname, getApiNewContractInstances, getApiNewContractDefinitions)
-import Plutus.PAB.Webserver.Types (ContractActivationArgs, ContractInstanceClientState, ContractSignatureResponse)
-import Plutus.V1.Ledger.Crypto (PubKeyHash(..))
-import Plutus.V1.Ledger.Value (TokenName(..))
-import Wallet.Types (ContractInstanceId)
+import Plutus.PAB.Webserver.Types (ContractActivationArgs(..))
+import Plutus.V1.Ledger.Crypto (PubKeyHash)
+import Plutus.V1.Ledger.Value (TokenName)
+import Types (ContractInstanceId, MarloweParams)
+import WalletData.Types (Wallet)
 
 -- The `MonadMarlowe` class provides a window on the `MonadContract` class with function
 -- calls specific to the Marlowe Plutus contract.
 class
   MonadContract m <= MonadMarlowe m where
-  dummy :: m Unit
+  marloweCreateWalletCompanionContract :: Wallet -> m (WebData ContractInstanceId)
+  --marloweCreateContract :: Wallet -> Map TokenName PubKeyHash -> Contract -> m (WebData ContractInstanceId)
+  marloweApplyInputs :: ContractInstanceId -> MarloweParams -> Array Input -> m (WebData Unit)
+  marloweWait :: ContractInstanceId -> MarloweParams -> m (WebData Unit)
+  marloweAuto :: ContractInstanceId -> MarloweParams -> Party -> Slot -> m (WebData Unit)
+  marloweRedeem :: ContractInstanceId -> MarloweParams -> TokenName -> PubKeyHash -> m (WebData Unit)
 
---marloweCreateWalletCompanionContract :: Wallet -> m (WebData Unit)
---marloweCreateContract :: Wallet -> Map TokenName PubKeyHash -> Contract -> m (WebData ContractInstanceId)
---marloweApplyInputs :: ?MarloweParams -> Array Input -> m (WebData Unit)
---marloweWait :: ?MarloweParams -> m (WebData Unit)
---marloweAuto :: ?MarloweParams -> Party -> Slot -> m (WebData Unit)
---marloweRedeem :: ?MarloweParams -> TokenName -> PubKeyHash -> m (WebData Unit)
 instance monadMarloweAppM :: MonadMarlowe AppM where
-  dummy = AppM $ pure unit
+  marloweCreateWalletCompanionContract wallet = activateContract $ ContractActivationArgs { caID: marloweContractExe, caWallet: toBack wallet }
+  --marloweCreateContract wallet roles contract = do
+  --  webContractInstanceId <- activateContract $ ContractActivationArgs { caID: marloweContractExe, caWallet: toBack wallet }
+  --  case webContractInstanceId of
+  --    Success contractInstanceId ->
+  --      invokeEndpoint ?(encodeJSON wallet roles) contractInstanceId "create"
+  --      pure webContractInstanceId
+  --    _ -> pure $ Failure ""
+  marloweApplyInputs contractInstanceId params inputs =
+    let
+      rawJson = RawJson <<< unsafeStringify <<< encode $ (params /\ inputs)
+    in
+      invokeEndpoint rawJson contractInstanceId "apply-inputs"
+  marloweWait contractInstanceId params =
+    let
+      rawJson = RawJson <<< unsafeStringify <<< encode $ params
+    in
+      invokeEndpoint rawJson contractInstanceId "wait"
+  marloweAuto contractInstanceId params party slot =
+    let
+      rawJson = RawJson <<< unsafeStringify <<< encode $ (params /\ party /\ slot)
+    in
+      invokeEndpoint rawJson contractInstanceId "auto"
+  marloweRedeem contractInstanceId params tokenName pubKeyHash =
+    let
+      rawJson = RawJson <<< unsafeStringify <<< encode $ (params /\ tokenName /\ pubKeyHash)
+    in
+      invokeEndpoint rawJson contractInstanceId "redeem"
 
---marloweCreateWalletCompanionContract wallet = activateContract $ ContractActivationArgs { caID: WalletCompanion, caWallet: wallet }
---marloweCreateContract wallet roles contract = do
---  webContractInstanceId <- activateContract $ ContractActivationArgs { caID: MarloweApp, caWallet: wallet }
---  case webContractInstanceId of
---    Success contractInstanceId ->
---      invokeEndpoint ?(encodeJSON wallet roles) contractInstanceId "create"
---      pure webContractInstanceId
---    _ -> pure $ Failure ""
---marloweApplyInputs params inputs = invokeEndpoint ?(encodeJSON params inputs) ?contractInstanceId "apply-inputs"
---marloweWait params = invokeEndpoint ?(encodeJSON params) ?contractInstanceId "wait"
---marloweAuto params party slot = invokeEndpoint ?(encodeJSON params party slot) ?contractInstanceId "auto"
---marloweRedeem params tokenName pubKeyHash = invokeEndpoint ?(encodeJSON params tokenName pubKeyHash) ?contractInstanceId "wait"
 instance monadMarloweHalogenM :: MonadMarlowe m => MonadMarlowe (HalogenM state action slots msg m) where
-  dummy = lift dummy
-
---marloweCreateWalletCompanionContract = lift <<< marloweCreateWalletCompanionContract
---marloweCreateContract wallet roles contract = lift $ marloweCreateContract wallet roles contract
---marloweApplyInputs params inputs = lift $ marloweApplyInputs params inputs
---marloweWait = lift <<< marloweWait
---marloweAuto params party slot = lift $ marloweAuto params party slot
---marloweRedeem params tokenName pubKeyHash = lift $ marloweRedeem params tokenName pubKeyHash
+  marloweCreateWalletCompanionContract = lift <<< marloweCreateWalletCompanionContract
+  --marloweCreateContract wallet roles contract = lift $ marloweCreateContract wallet roles contract
+  marloweApplyInputs contractInstanceId params inputs = lift $ marloweApplyInputs contractInstanceId params inputs
+  marloweWait contractInstanceId params = lift $ marloweWait contractInstanceId params
+  marloweAuto contractInstanceId params party slot = lift $ marloweAuto contractInstanceId params party slot
+  marloweRedeem contractInstanceId params tokenName pubKeyHash = lift $ marloweRedeem contractInstanceId params tokenName pubKeyHash

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -1,0 +1,65 @@
+module Capability.Marlowe
+  ( class MonadMarlowe
+  , dummy
+  --, marloweCreateWalletCompanionContract
+  --, marloweCreateContract
+  --, marloweApplyInputs
+  --, marloweWait
+  --, marloweAuto
+  --, marloweRedeem
+  ) where
+
+import Prelude
+import AppM (AppM(..))
+import Capability.Ajax (runAjax)
+import Capability.Contract (class MonadContract)
+import Control.Monad.Except (lift)
+import Data.Map (Map)
+import Data.RawJson (RawJson)
+import Halogen (HalogenM)
+import MainFrame.Types (WebData)
+import Marlowe.Semantics (Contract, Input, Party, Slot)
+import Network.RemoteData (RemoteData(..))
+import Plutus.PAB.Effects.Contract.ContractExe (ContractExe)
+import Plutus.PAB.Webserver (postApiNewContractActivate, getApiNewContractInstanceByContractinstanceidStatus, postApiNewContractInstanceByContractinstanceidEndpointByEndpointname, getApiNewContractInstances, getApiNewContractDefinitions)
+import Plutus.PAB.Webserver.Types (ContractActivationArgs, ContractInstanceClientState, ContractSignatureResponse)
+import Plutus.V1.Ledger.Crypto (PubKeyHash(..))
+import Plutus.V1.Ledger.Value (TokenName(..))
+import Wallet.Types (ContractInstanceId)
+
+-- The `MonadMarlowe` class provides a window on the `MonadContract` class with function
+-- calls specific to the Marlowe Plutus contract.
+class
+  MonadContract m <= MonadMarlowe m where
+  dummy :: m Unit
+
+--marloweCreateWalletCompanionContract :: Wallet -> m (WebData Unit)
+--marloweCreateContract :: Wallet -> Map TokenName PubKeyHash -> Contract -> m (WebData ContractInstanceId)
+--marloweApplyInputs :: ?MarloweParams -> Array Input -> m (WebData Unit)
+--marloweWait :: ?MarloweParams -> m (WebData Unit)
+--marloweAuto :: ?MarloweParams -> Party -> Slot -> m (WebData Unit)
+--marloweRedeem :: ?MarloweParams -> TokenName -> PubKeyHash -> m (WebData Unit)
+instance monadMarloweAppM :: MonadMarlowe AppM where
+  dummy = AppM $ pure unit
+
+--marloweCreateWalletCompanionContract wallet = activateContract $ ContractActivationArgs { caID: WalletCompanion, caWallet: wallet }
+--marloweCreateContract wallet roles contract = do
+--  webContractInstanceId <- activateContract $ ContractActivationArgs { caID: MarloweApp, caWallet: wallet }
+--  case webContractInstanceId of
+--    Success contractInstanceId ->
+--      invokeEndpoint ?(encodeJSON wallet roles) contractInstanceId "create"
+--      pure webContractInstanceId
+--    _ -> pure $ Failure ""
+--marloweApplyInputs params inputs = invokeEndpoint ?(encodeJSON params inputs) ?contractInstanceId "apply-inputs"
+--marloweWait params = invokeEndpoint ?(encodeJSON params) ?contractInstanceId "wait"
+--marloweAuto params party slot = invokeEndpoint ?(encodeJSON params party slot) ?contractInstanceId "auto"
+--marloweRedeem params tokenName pubKeyHash = invokeEndpoint ?(encodeJSON params tokenName pubKeyHash) ?contractInstanceId "wait"
+instance monadMarloweHalogenM :: MonadMarlowe m => MonadMarlowe (HalogenM state action slots msg m) where
+  dummy = lift dummy
+
+--marloweCreateWalletCompanionContract = lift <<< marloweCreateWalletCompanionContract
+--marloweCreateContract wallet roles contract = lift $ marloweCreateContract wallet roles contract
+--marloweApplyInputs params inputs = lift $ marloweApplyInputs params inputs
+--marloweWait = lift <<< marloweWait
+--marloweAuto params party slot = lift $ marloweAuto params party slot
+--marloweRedeem params tokenName pubKeyHash = lift $ marloweRedeem params tokenName pubKeyHash

--- a/marlowe-dashboard-client/src/Capability/Wallet.purs
+++ b/marlowe-dashboard-client/src/Capability/Wallet.purs
@@ -1,0 +1,82 @@
+module Capability.Wallet
+  ( class MonadWallet
+  , createWallet
+  , submitWalletTransaction
+  , getWalletPubKey
+  , updateWalletPaymentWithChange
+  , getWalletSlot
+  , getWalletTransactions
+  , getWalletTotalFunds
+  , signTransaction
+  ) where
+
+import Prelude
+import AppM (AppM)
+import Bridge (toBack, toFront)
+import Capability.Ajax (runAjax)
+import Control.Monad.Except (lift)
+import Data.Json.JsonTuple (JsonTuple)
+import Data.Map (Map)
+import Data.Newtype (unwrap)
+import Halogen (HalogenM)
+import MainFrame.Types (WebData)
+import Marlowe.Semantics (Assets, PubKey, Slot)
+import Plutus.PAB.Webserver (getWalletByWalletIdOwnoutputs, getWalletByWalletIdOwnpublickey, getWalletByWalletIdTotalfunds, getWalletByWalletIdWalletslot, postWalletByWalletIdSign, postWalletByWalletIdSubmittxn, postWalletByWalletIdUpdatepaymentwithchange, postWalletCreate)
+import Plutus.V1.Ledger.Tx (Tx, TxOutRef, TxOutTx)
+import Wallet.Types (Payment)
+import WalletData.Types (Wallet)
+
+-- The PAB PSGenerator (using Servant.PureScript) automatically generates a PureScript module with
+-- functions for calling all Wallet API endpoints. This `MonadWallet` class wraps these up in a
+-- 'capability' monad (https://thomashoneyman.com/guides/real-world-halogen/push-effects-to-the-edges/)
+-- with some nicer names and type signatures, mapping the result to WebData.
+class
+  Monad m <= MonadWallet m where
+  createWallet :: m (WebData Wallet)
+  submitWalletTransaction :: Tx -> Wallet -> m (WebData Unit)
+  getWalletPubKey :: Wallet -> m (WebData PubKey)
+  updateWalletPaymentWithChange :: JsonTuple Assets Payment -> Wallet -> m (WebData Payment)
+  getWalletSlot :: Wallet -> m (WebData Slot)
+  getWalletTransactions :: Wallet -> m (WebData (Map TxOutRef TxOutTx))
+  getWalletTotalFunds :: Wallet -> m (WebData Assets)
+  signTransaction :: Tx -> Wallet -> m (WebData Tx)
+
+instance monadWalletAppM :: MonadWallet AppM where
+  createWallet =
+    runAjax
+      $ map toFront
+      $ postWalletCreate
+  submitWalletTransaction tx wallet =
+    runAjax
+      $ postWalletByWalletIdSubmittxn tx (show $ unwrap wallet)
+  getWalletPubKey wallet =
+    runAjax
+      $ map toFront
+      $ getWalletByWalletIdOwnpublickey (show $ unwrap wallet)
+  updateWalletPaymentWithChange valuePayment wallet =
+    runAjax
+      $ postWalletByWalletIdUpdatepaymentwithchange (toBack valuePayment) (show $ unwrap wallet)
+  getWalletSlot wallet =
+    runAjax
+      $ map toFront
+      $ getWalletByWalletIdWalletslot (show $ unwrap wallet)
+  getWalletTransactions wallet =
+    runAjax
+      $ getWalletByWalletIdOwnoutputs (show $ unwrap wallet)
+  getWalletTotalFunds wallet =
+    runAjax
+      $ map toFront
+      $ getWalletByWalletIdTotalfunds (show $ unwrap wallet)
+  signTransaction tx wallet =
+    runAjax
+      $ postWalletByWalletIdSign tx (show $ unwrap wallet)
+
+instance monadWalletHalogenM :: MonadWallet m => MonadWallet (HalogenM state action slots msg m) where
+  createWallet = lift createWallet
+  submitWalletTransaction tx wallet = lift $ submitWalletTransaction tx wallet
+  getWalletPubKey = lift <<< getWalletPubKey
+  updateWalletPaymentWithChange valuePayment wallet = lift $ updateWalletPaymentWithChange valuePayment wallet
+  getWalletSlot = lift <<< getWalletSlot
+  getWalletTransactions = lift <<< getWalletTransactions
+  getWalletTotalFunds = lift <<< getWalletTotalFunds
+  signTransaction tx wallet = lift $ signTransaction tx wallet

--- a/marlowe-dashboard-client/src/Capability/Websocket.purs
+++ b/marlowe-dashboard-client/src/Capability/Websocket.purs
@@ -1,0 +1,36 @@
+module Capability.Websocket
+  ( class MonadWebsocket
+  , subscribeToWallet
+  , unsubscribeFromWallet
+  , subscribeToContract
+  , unsubscribeFromContract
+  ) where
+
+import Prelude
+import AppM (AppM)
+import Bridge (toBack)
+import Data.Either (Either(..))
+import Halogen (HalogenM, raise)
+import MainFrame.Types (Msg(..))
+import Plutus.PAB.Webserver.Types (CombinedWSStreamToServer(..))
+import WalletData.Types (Wallet)
+import Types (ContractInstanceId)
+
+class
+  Monad m <= MonadWebsocket m where
+  subscribeToWallet :: Wallet -> m Unit
+  unsubscribeFromWallet :: Wallet -> m Unit
+  subscribeToContract :: ContractInstanceId -> m Unit
+  unsubscribeFromContract :: ContractInstanceId -> m Unit
+
+instance monadWebsocketAppM :: MonadWebsocket AppM where
+  subscribeToWallet wallet = pure unit
+  unsubscribeFromWallet wallet = pure unit
+  subscribeToContract contractInstanceId = pure unit
+  unsubscribeFromContract contractInstanceId = pure unit
+
+instance monadWebsocketHalogenM :: MonadWebsocket (HalogenM state action slots Msg m) where
+  subscribeToWallet wallet = raise $ SendWebSocketMessage $ Subscribe $ Right $ toBack wallet
+  unsubscribeFromWallet wallet = raise $ SendWebSocketMessage $ Unsubscribe $ Right $ toBack wallet
+  subscribeToContract contractInstanceId = raise $ SendWebSocketMessage $ Subscribe $ Left $ toBack contractInstanceId
+  unsubscribeFromContract contractInstanceId = raise $ SendWebSocketMessage $ Unsubscribe $ Left $ toBack contractInstanceId

--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -19,7 +19,7 @@ import Data.Symbol (SProxy(..))
 import Marlowe.Execution (ExecutionState, NamedAction)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics as Semantic
-import WalletData.Types (Nickname)
+import WalletData.Types (WalletNickname)
 
 _tab :: Lens' State Tab
 _tab = prop (SProxy :: SProxy "tab")
@@ -39,7 +39,7 @@ _selectedStep = prop (SProxy :: SProxy "selectedStep")
 _metadata :: Lens' State MetaData
 _metadata = prop (SProxy :: SProxy "metadata")
 
-_participants :: Lens' State (Map Semantic.Party (Maybe Nickname))
+_participants :: Lens' State (Map Semantic.Party (Maybe WalletNickname))
 _participants = prop (SProxy :: SProxy "participants")
 
 _mActiveUserParty :: Lens' State (Maybe Semantic.Party)

--- a/marlowe-dashboard-client/src/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Contract/State.purs
@@ -37,7 +37,7 @@ import Marlowe.Extended.Metadata (MetaData, emptyContractMetadata)
 import Marlowe.Semantics (Contract(..), Input(..), Slot, SlotInterval(..), Token(..), TransactionInput(..))
 import Marlowe.Semantics as Semantic
 import Marlowe.Slot (currentSlot)
-import WalletData.Types (Nickname)
+import WalletData.Types (WalletNickname)
 
 -- I don't like having to provide a default state for this component, but it is needed by the
 -- mapMaybeSubmodule in PlayState.
@@ -76,7 +76,7 @@ instantiateExtendedContract ::
   Extended.Contract ->
   TemplateContent ->
   MetaData ->
-  Map Semantic.Party (Maybe Nickname) ->
+  Map Semantic.Party (Maybe WalletNickname) ->
   Maybe Semantic.Party ->
   Maybe State
 instantiateExtendedContract contractId currentSlot extendedContract templateContent metadata participants mActiveUserParty =
@@ -92,7 +92,7 @@ mkInitialState ::
   String ->
   Slot ->
   MetaData ->
-  Map Semantic.Party (Maybe Nickname) ->
+  Map Semantic.Party (Maybe WalletNickname) ->
   Maybe Semantic.Party ->
   Contract ->
   State

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -8,7 +8,7 @@ import Marlowe.Execution (ExecutionState, NamedAction)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics (ChoiceId, ChosenNum, Slot, TransactionInput, Accounts)
 import Marlowe.Semantics as Semantic
-import WalletData.Types (Nickname)
+import WalletData.Types (WalletNickname)
 
 -- Represents a historical step in a contract's life.
 type PreviousStep
@@ -30,7 +30,7 @@ type State
     -- executionState has the current state and visually we can select any one of them.
     , selectedStep :: Int
     , metadata :: MetaData
-    , participants :: Map Semantic.Party (Maybe Nickname)
+    , participants :: Map Semantic.Party (Maybe WalletNickname)
     -- This field represents the logged-user party in the contract.
     -- If it's Nothing, then the logged-user is an observant of the contract. That could happen
     -- if the person who creates the contract does not put him/herself as a participant of the contract

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -80,7 +80,7 @@ hasNestedLabel :: Array String
 hasNestedLabel = [ "-mt-4" ]
 
 nestedLabel :: Array String
-nestedLabel = [ "relative", "left-2", "top-2.5", "px-1", "bg-white", "text-xs" ]
+nestedLabel = [ "relative", "left-2", "top-2.5", "px-1", "bg-white", "text-xs", "font-semibold" ]
 
 --- cards
 overlay :: Boolean -> Array String

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -47,11 +47,19 @@ main = do
   runHalogenAff do
     body <- awaitBody
     driver <- runUI mainFrame Init body
-    void $ forkAff $ runProcess watchLocalStorageProcess
-    wsManager :: WebSocketManager CombinedWSStreamToClient CombinedWSStreamToServer <- mkWebSocketManager
+    ---
     void
       $ forkAff
-      $ WS.runWebSocketManager (WS.URI "/ws") (\msg -> void $ driver.query $ ReceiveWebSocketMessage msg unit) wsManager
+      $ runProcess watchLocalStorageProcess -- do we need this?
+    ---
+    wsManager :: WebSocketManager CombinedWSStreamToClient CombinedWSStreamToServer <-
+      mkWebSocketManager
+    void
+      $ forkAff
+      $ WS.runWebSocketManager
+          (WS.URI "/ws")
+          (\msg -> void $ driver.query $ ReceiveWebSocketMessage msg unit)
+          wsManager
     driver.subscribe
       $ consumer
       $ case _ of

--- a/marlowe-dashboard-client/src/MainFrame/Lenses.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Lenses.purs
@@ -1,8 +1,6 @@
 module MainFrame.Lenses
   ( _wallets
-  , _newWalletNickname
-  , _newWalletContractId
-  , _remoteDataPubKey
+  , _newWalletDetails
   , _templates
   , _subState
   , _webSocketStatus
@@ -20,24 +18,15 @@ import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
 import MainFrame.Types (State, WebSocketStatus)
 import Marlowe.Extended.Template (ContractTemplate)
-import Marlowe.Semantics (PubKey)
-import Network.RemoteData (RemoteData)
 import Pickup.Types (State) as Pickup
 import Play.Types (State) as Play
-import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Types (Nickname, WalletLibrary)
+import WalletData.Types (WalletLibrary, NewWalletDetails)
 
 _wallets :: Lens' State WalletLibrary
 _wallets = prop (SProxy :: SProxy "wallets")
 
-_newWalletNickname :: Lens' State Nickname
-_newWalletNickname = prop (SProxy :: SProxy "newWalletNickname")
-
-_newWalletContractId :: Lens' State String
-_newWalletContractId = prop (SProxy :: SProxy "newWalletContractId")
-
-_remoteDataPubKey :: Lens' State (RemoteData AjaxError PubKey)
-_remoteDataPubKey = prop (SProxy :: SProxy "remoteDataPubKey")
+_newWalletDetails :: Lens' State NewWalletDetails
+_newWalletDetails = prop (SProxy :: SProxy "newWalletDetails")
 
 _templates :: Lens' State (Array ContractTemplate)
 _templates = prop (SProxy :: SProxy "templates")

--- a/marlowe-dashboard-client/src/MainFrame/Types.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Types.purs
@@ -1,10 +1,11 @@
 module MainFrame.Types
   ( State
+  , WebSocketStatus(..)
+  , WebData
   , ChildSlots
   , Query(..)
   , Msg(..)
   , Action(..)
-  , WebSocketStatus(..)
   ) where
 
 import Prelude
@@ -13,13 +14,12 @@ import Data.Either (Either)
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 import Marlowe.Extended.Template (ContractTemplate)
-import Marlowe.Semantics (PubKey)
 import Network.RemoteData (RemoteData)
 import Pickup.Types (Action, State) as Pickup
 import Play.Types (Action, State) as Play
 import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient, CombinedWSStreamToServer)
 import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Types (Nickname, WalletLibrary)
+import WalletData.Types (WalletLibrary, NewWalletDetails)
 import Web.Socket.Event.CloseEvent (CloseEvent, reason) as WS
 import WebSocket.Support (FromSocket) as WS
 
@@ -29,9 +29,7 @@ import WebSocket.Support (FromSocket) as WS
 -- for when you have picked up a wallet, and can do all of the things.
 type State
   = { wallets :: WalletLibrary
-    , newWalletNickname :: Nickname
-    , newWalletContractId :: String
-    , remoteDataPubKey :: RemoteData AjaxError PubKey
+    , newWalletDetails :: NewWalletDetails
     , templates :: Array ContractTemplate
     , webSocketStatus :: WebSocketStatus
     , subState :: Either Pickup.State Play.State
@@ -48,6 +46,9 @@ instance showWebSocketStatus :: Show WebSocketStatus where
   show (WebSocketClosed Nothing) = "WebSocketClosed"
   show (WebSocketClosed (Just closeEvent)) = "WebSocketClosed " <> WS.reason closeEvent
 
+type WebData
+  = RemoteData AjaxError
+
 ------------------------------------------------------------
 type ChildSlots
   = (
@@ -63,8 +64,8 @@ data Msg
 ------------------------------------------------------------
 data Action
   = Init
-  | SetNewWalletNickname Nickname
-  | SetNewWalletContractId String
+  | SetNewWalletNicknameString String
+  | SetNewWalletContractIdString String
   | AddNewWallet
   | PickupAction Pickup.Action
   | PlayAction Play.Action
@@ -73,8 +74,8 @@ data Action
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
   toEvent Init = Just $ defaultEvent "Init"
-  toEvent (SetNewWalletNickname _) = Nothing
-  toEvent (SetNewWalletContractId _) = Nothing
+  toEvent (SetNewWalletNicknameString _) = Nothing
+  toEvent (SetNewWalletContractIdString _) = Nothing
   toEvent AddNewWallet = Just $ defaultEvent "AddNewWallet"
   toEvent (PickupAction pickupAction) = toEvent pickupAction
   toEvent (PlayAction playAction) = toEvent playAction

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -5,7 +5,7 @@ import Data.Either (Either(..))
 import Data.Lens (view)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
-import MainFrame.Lenses (_newWalletContractId, _newWalletNickname, _remoteDataPubKey, _templates, _subState, _wallets)
+import MainFrame.Lenses (_newWalletDetails, _subState, _templates, _wallets)
 import MainFrame.Types (Action(..), ChildSlots, State)
 import Pickup.View (renderPickupState)
 import Play.View (renderPlayState)
@@ -15,14 +15,10 @@ render state =
   let
     wallets = view _wallets state
 
-    newWalletNickname = view _newWalletNickname state
-
-    newWalletContractId = view _newWalletContractId state
-
-    remoteDataPubKey = view _remoteDataPubKey state
+    newWalletDetails = view _newWalletDetails state
 
     templates = view _templates state
   in
     case view _subState state of
-      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletNickname newWalletContractId remoteDataPubKey pickupState
-      Right playState -> PlayAction <$> renderPlayState wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState
+      Left pickupState -> PickupAction <$> renderPickupState wallets newWalletDetails pickupState
+      Right playState -> PlayAction <$> renderPlayState wallets newWalletDetails templates playState

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -7,7 +7,7 @@ module Pickup.Types
 import Prelude
 import Analytics (class IsEvent, defaultEvent)
 import Data.Maybe (Maybe(..))
-import WalletData.Types (Nickname, WalletDetails)
+import WalletData.Types (WalletNickname, WalletDetails)
 
 type State
   = { card :: Maybe Card
@@ -23,7 +23,7 @@ data Action
   = SetCard (Maybe Card)
   | GenerateNewWallet
   | LookupWallet String
-  | SetNewWalletNickname Nickname
+  | SetNewWalletNickname WalletNickname
   | SetNewWalletContractId String
   | PickupNewWallet
   | PickupWallet WalletDetails

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -14,7 +14,6 @@ import Halogen.HTML.Properties (InputType(..), disabled, for, href, id_, list, p
 import Logo (marloweRunLogo)
 import MainFrame.Lenses (_card)
 import Material.Icons (Icon(..), icon_)
-import Network.RemoteData (RemoteData(..))
 import Pickup.Types (Action(..), Card(..), State)
 import Prim.TypeError (class Warn, Text)
 import WalletData.Lenses (_contractInstanceId, _contractInstanceIdString, _remoteDataPubKey, _remoteDataAssets, _remoteDataWallet, _walletNickname, _walletNicknameString)

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -14,7 +14,7 @@ import Data.Time.Duration (Minutes)
 import Marlowe.Execution (NamedAction)
 import Marlowe.Semantics (Slot)
 import Template.Types (Action, State) as Template
-import WalletData.Types (Nickname, WalletDetails)
+import WalletData.Types (WalletDetails, WalletNickname)
 
 type State
   = { walletDetails :: WalletDetails
@@ -47,7 +47,7 @@ derive instance eqCard :: Eq Card
 
 data Action
   = PutdownWallet
-  | SetNewWalletNickname Nickname
+  | SetNewWalletNickname WalletNickname
   | SetNewWalletContractId String
   | AddNewWallet (Maybe String)
   | ToggleMenu

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -20,23 +20,22 @@ import Network.RemoteData (RemoteData)
 import Play.Lenses (_contractsState, _currentSlot, _menuOpen, _selectedContract, _templateState, _walletDetails)
 import Play.Types (Action(..), Card(..), Screen(..), State)
 import Prim.TypeError (class Warn, Text)
-import Servant.PureScript.Ajax (AjaxError)
 import Template.View (contractSetupConfirmationCard, contractSetupScreen, templateLibraryCard)
-import WalletData.Lenses (_nickname)
-import WalletData.Types (Nickname, WalletLibrary)
+import WalletData.Lenses (_walletNickname)
+import WalletData.Types (NewWalletDetails, WalletLibrary)
 import WalletData.View (newWalletCard, walletDetailsCard, putdownWalletCard, walletLibraryScreen)
 
-renderPlayState :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> State -> HTML p Action
-renderPlayState wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState =
+renderPlayState :: forall p. WalletLibrary -> NewWalletDetails -> Array ContractTemplate -> State -> HTML p Action
+renderPlayState wallets newWalletDetails templates playState =
   let
-    walletNickname = view (_walletDetails <<< _nickname) playState
+    walletNickname = view (_walletDetails <<< _walletNickname) playState
 
     menuOpen = view _menuOpen playState
   in
     div
       [ classNames [ "grid", "h-full", "grid-rows-main" ] ]
       [ renderHeader walletNickname menuOpen
-      , renderMain wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState
+      , renderMain wallets newWalletDetails templates playState
       , renderFooter
       ]
 
@@ -90,8 +89,8 @@ renderHeader walletNickname menuOpen =
       ]
 
 ------------------------------------------------------------
-renderMain :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> State -> HTML p Action
-renderMain wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState =
+renderMain :: forall p. WalletLibrary -> NewWalletDetails -> Array ContractTemplate -> State -> HTML p Action
+renderMain wallets newWalletDetails templates playState =
   let
     menuOpen = view _menuOpen playState
 
@@ -100,7 +99,7 @@ renderMain wallets newWalletNickname newWalletContractId remoteDataPubKey templa
     main
       [ classNames [ "relative", "px-4", "md:px-5pc" ] ]
       [ renderMobileMenu menuOpen
-      , renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState
+      , renderCards wallets newWalletDetails templates playState
       , renderScreen wallets screen playState
       ]
 
@@ -116,8 +115,8 @@ renderMobileMenu menuOpen =
         iohkLinks
     ]
 
-renderCards :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Array ContractTemplate -> State -> HTML p Action
-renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templates playState =
+renderCards :: forall p. WalletLibrary -> NewWalletDetails -> Array ContractTemplate -> State -> HTML p Action
+renderCards wallets newWalletDetails templates playState =
   let
     currentWalletDetails = view _walletDetails playState
 
@@ -156,7 +155,7 @@ renderCards wallets newWalletNickname newWalletContractId remoteDataPubKey templ
           $ closeButton
           <> case mCard of
               -- TODO: Should this be renamed to CreateContactCard?
-              Just (CreateWalletCard mTokenName) -> [ newWalletCard wallets newWalletNickname newWalletContractId remoteDataPubKey mTokenName ]
+              Just (CreateWalletCard mTokenName) -> [ newWalletCard wallets newWalletDetails mTokenName ]
               Just (ViewWalletCard walletDetails) -> [ walletDetailsCard walletDetails ]
               Just PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
               Just TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard templates ]

--- a/marlowe-dashboard-client/src/Template/State.purs
+++ b/marlowe-dashboard-client/src/Template/State.purs
@@ -4,11 +4,7 @@ module Template.State
   , handleAction
   ) where
 
--- Note: There is no independent template state as such (just a property of
--- the main state). This module simply includes some template-related helper
--- functions for use in MainFrame.Sate, separated out to keep modules
--- relatively small and easier to read.
--- Maybe we could do the same for Contract.State...?
+-- TODO: Make this into a proper submodule.
 import Prelude
 import Control.Monad.Reader (class MonadAsk)
 import Data.Foldable (for_)

--- a/marlowe-dashboard-client/src/Types.purs
+++ b/marlowe-dashboard-client/src/Types.purs
@@ -2,6 +2,8 @@ module Types
   ( WebData
   , ContractInstanceId(..)
   , contractInstanceIdFromString
+  , MarloweParams
+  , ValidatorHash
   ) where
 
 -- this module is for miscellaneous types that don't belong anywhere else
@@ -13,6 +15,7 @@ import Data.Newtype (class Newtype)
 import Data.UUID (UUID, parseUUID)
 import Foreign.Class (class Encode, class Decode)
 import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
+import Marlowe.Semantics (CurrencySymbol)
 import Network.RemoteData (RemoteData)
 import Servant.PureScript.Ajax (AjaxError)
 
@@ -38,3 +41,26 @@ contractInstanceIdFromString :: String -> Maybe ContractInstanceId
 contractInstanceIdFromString contractInstanceIdString = case parseUUID contractInstanceIdString of
   Just uuid -> Just $ ContractInstanceId uuid
   _ -> Nothing
+
+-- TODO: check serialization of this type works with the backend
+newtype MarloweParams
+  = MarloweParams
+  { rolePayoutValidatorHash :: ValidatorHash
+  , rolesCurrency :: CurrencySymbol
+  }
+
+derive instance newtypeMarloweParams :: Newtype MarloweParams _
+
+derive instance eqMarloweParams :: Eq MarloweParams
+
+derive instance genericMarloweParams :: Generic MarloweParams _
+
+instance encodeMarloweParams :: Encode MarloweParams where
+  encode value = genericEncode defaultOptions value
+
+instance decodeMarloweParams :: Decode MarloweParams where
+  decode value = genericDecode defaultOptions value
+
+-- TODO: check serialization of this type works with the backend
+type ValidatorHash
+  = String

--- a/marlowe-dashboard-client/src/Types.purs
+++ b/marlowe-dashboard-client/src/Types.purs
@@ -1,0 +1,40 @@
+module Types
+  ( WebData
+  , ContractInstanceId(..)
+  , contractInstanceIdFromString
+  ) where
+
+-- this module is for miscellaneous types that don't belong anywhere else
+-- (or would lead to cyclic dependencies if put somewhere they might more naturall belong)
+import Prelude
+import Data.Generic.Rep (class Generic)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.UUID (UUID, parseUUID)
+import Foreign.Class (class Encode, class Decode)
+import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
+import Network.RemoteData (RemoteData)
+import Servant.PureScript.Ajax (AjaxError)
+
+type WebData
+  = RemoteData AjaxError
+
+newtype ContractInstanceId
+  = ContractInstanceId UUID
+
+derive instance newtypeContractInstanceId :: Newtype ContractInstanceId _
+
+derive instance eqContractInstanceId :: Eq ContractInstanceId
+
+derive instance genericContractInstanceId :: Generic ContractInstanceId _
+
+instance encodeContractInstanceId :: Encode ContractInstanceId where
+  encode value = genericEncode defaultOptions value
+
+instance decodeContractInstanceId :: Decode ContractInstanceId where
+  decode value = genericDecode defaultOptions value
+
+contractInstanceIdFromString :: String -> Maybe ContractInstanceId
+contractInstanceIdFromString contractInstanceIdString = case parseUUID contractInstanceIdString of
+  Just uuid -> Just $ ContractInstanceId uuid
+  _ -> Nothing

--- a/marlowe-dashboard-client/src/WalletData/Lenses.purs
+++ b/marlowe-dashboard-client/src/WalletData/Lenses.purs
@@ -1,25 +1,51 @@
 module WalletData.Lenses
-  ( _nickname
-  , _contractId
-  , _balance
+  ( _walletNicknameString
+  , _contractInstanceIdString
+  , _remoteDataWallet
+  , _remoteDataPubKey
+  , _remoteDataAssets
+  , _walletNickname
+  , _contractInstanceId
+  , _wallet
   , _pubKey
+  , _assets
   ) where
 
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
-import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
+import MainFrame.Types (WebData)
 import Marlowe.Semantics (Assets, PubKey)
-import WalletData.Types (Nickname, WalletDetails)
+import Types (ContractInstanceId)
+import WalletData.Types (NewWalletDetails, Wallet, WalletDetails, WalletNickname)
 
-_nickname :: Lens' WalletDetails Nickname
-_nickname = prop (SProxy :: SProxy "nickname")
+_walletNicknameString :: Lens' NewWalletDetails String
+_walletNicknameString = prop (SProxy :: SProxy "walletNicknameString")
+
+_contractInstanceIdString :: Lens' NewWalletDetails String
+_contractInstanceIdString = prop (SProxy :: SProxy "contractInstanceIdString")
+
+_remoteDataWallet :: Lens' NewWalletDetails (WebData Wallet)
+_remoteDataWallet = prop (SProxy :: SProxy "remoteDataWallet")
+
+_remoteDataPubKey :: Lens' NewWalletDetails (WebData PubKey)
+_remoteDataPubKey = prop (SProxy :: SProxy "remoteDataPubKey")
+
+_remoteDataAssets :: Lens' NewWalletDetails (WebData Assets)
+_remoteDataAssets = prop (SProxy :: SProxy "remoteDataAssets")
+
+------------------------------------------------------------
+_walletNickname :: Lens' WalletDetails WalletNickname
+_walletNickname = prop (SProxy :: SProxy "walletNickname")
+
+_contractInstanceId :: Lens' WalletDetails ContractInstanceId
+_contractInstanceId = prop (SProxy :: SProxy "contractInstanceId")
+
+_wallet :: Lens' WalletDetails Wallet
+_wallet = prop (SProxy :: SProxy "wallet")
 
 _pubKey :: Lens' WalletDetails PubKey
 _pubKey = prop (SProxy :: SProxy "pubKey")
 
-_contractId :: forall r. Lens' { contractId :: String | r } String
-_contractId = prop (SProxy :: SProxy "contractId")
-
-_balance :: Lens' WalletDetails (Maybe (Array Assets))
-_balance = prop (SProxy :: SProxy "balance")
+_assets :: Lens' WalletDetails Assets
+_assets = prop (SProxy :: SProxy "assets")

--- a/marlowe-dashboard-client/src/WalletData/Types.purs
+++ b/marlowe-dashboard-client/src/WalletData/Types.purs
@@ -1,22 +1,57 @@
 module WalletData.Types
   ( WalletLibrary
-  , Nickname
+  , WalletNickname
+  , NewWalletDetails
   , WalletDetails
+  , Wallet(..)
   ) where
 
+import Prelude
+import Data.BigInteger (BigInteger)
+import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
-import Data.Maybe (Maybe)
+import Data.Newtype (class Newtype)
+import Foreign.Class (class Encode, class Decode)
+import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
 import Marlowe.Semantics (Assets, PubKey)
+import Types (ContractInstanceId, WebData)
 
 type WalletLibrary
-  = Map Nickname WalletDetails
+  = Map WalletNickname WalletDetails
 
-type Nickname
+type WalletNickname
   = String
 
-type WalletDetails
-  = { nickname :: Nickname
-    , contractId :: String
-    , pubKey :: PubKey
-    , balance :: Maybe (Array Assets)
+-- this is the data we have when creating a new wallet
+type NewWalletDetails
+  = { walletNicknameString :: String
+    , contractInstanceIdString :: String
+    , remoteDataWallet :: WebData Wallet
+    , remoteDataPubKey :: WebData PubKey
+    , remoteDataAssets :: WebData Assets
     }
+
+-- this is the data we have for wallets that have been created
+-- (we know the contractInstanceId is valid and that contract instance exists)
+type WalletDetails
+  = { walletNickname :: WalletNickname
+    , contractInstanceId :: ContractInstanceId -- this is the ID of the wallet's companion contract instance
+    , wallet :: Wallet
+    , pubKey :: PubKey
+    , assets :: Assets
+    }
+
+newtype Wallet
+  = Wallet BigInteger
+
+derive instance newtypeWallet :: Newtype Wallet _
+
+derive instance eqWallet :: Eq Wallet
+
+derive instance genericWallet :: Generic Wallet _
+
+instance encodeWallet :: Encode Wallet where
+  encode value = genericEncode defaultOptions value
+
+instance decodeWallet :: Decode Wallet where
+  decode value = genericDecode defaultOptions value

--- a/marlowe-dashboard-client/src/WalletData/Validation.purs
+++ b/marlowe-dashboard-client/src/WalletData/Validation.purs
@@ -1,8 +1,8 @@
 module WalletData.Validation
-  ( NicknameError(..)
-  , ContractIdError(..)
-  , nicknameError
-  , contractIdError
+  ( WalletNicknameError(..)
+  , ContractInstanceIdError(..)
+  , walletNicknameError
+  , contractInstanceIdError
   ) where
 
 import Prelude
@@ -11,56 +11,66 @@ import Data.Char.Unicode (isAlphaNum)
 import Data.Map (isEmpty, filter, member)
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (toCharArray)
-import Marlowe.Semantics (PubKey)
+import Data.UUID (parseUUID)
+import MainFrame.Types (WebData)
+import Marlowe.Semantics (Assets, PubKey)
 import Network.RemoteData (RemoteData(..))
-import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Types (Nickname, WalletLibrary)
+import Types (ContractInstanceId(..))
+import WalletData.Types (Wallet, WalletNickname, WalletLibrary)
 
-data NicknameError
-  = EmptyNickname
-  | DuplicateNickname
-  | BadNickname
+data WalletNicknameError
+  = EmptyWalletNickname
+  | DuplicateWalletNickname
+  | BadWalletNickname
 
-derive instance eqNicknameError :: Eq NicknameError
+derive instance eqWalletNicknameError :: Eq WalletNicknameError
 
-instance showNicknameError :: Show NicknameError where
-  show EmptyNickname = "Nickname cannot be blank"
-  show DuplicateNickname = "Nickname is already in use in your contacts"
-  show BadNickname = "Nicknames can only contain letters and numbers"
+instance showWalletNicknameError :: Show WalletNicknameError where
+  show EmptyWalletNickname = "Nickname cannot be blank"
+  show DuplicateWalletNickname = "Nickname is already in use in your contacts"
+  show BadWalletNickname = "Nicknames can only contain letters and numbers"
 
-data ContractIdError
-  = EmptyContractId
-  | DuplicateContractId
-  | UnconfirmedContractId
-  | NonexistentContractId
+data ContractInstanceIdError
+  = EmptyContractInstanceId
+  | DuplicateContractInstanceId
+  | InvalidContractInstanceId
+  | UnconfirmedContractInstanceId
+  | NonexistentContractInstanceId
 
-derive instance eqKeyError :: Eq ContractIdError
+derive instance eqContractInstanceIdError :: Eq ContractInstanceIdError
 
-instance showContracyIdError :: Show ContractIdError where
-  show EmptyContractId = "Wallet ID cannot be blank"
-  show DuplicateContractId = "Wallet ID is already in your contacts"
-  show UnconfirmedContractId = "Looking up wallet ID..."
-  show NonexistentContractId = "Wallet ID not found"
+instance showContractInstanceIdError :: Show ContractInstanceIdError where
+  show EmptyContractInstanceId = "Wallet ID cannot be blank"
+  show DuplicateContractInstanceId = "Wallet ID is already in your contacts"
+  show InvalidContractInstanceId = "Wallet ID is not valid"
+  show UnconfirmedContractInstanceId = "Looking up wallet ID..."
+  show NonexistentContractInstanceId = "Wallet ID not found"
 
-nicknameError :: Nickname -> WalletLibrary -> Maybe NicknameError
-nicknameError "" _ = Just EmptyNickname
+walletNicknameError :: WalletNickname -> WalletLibrary -> Maybe WalletNicknameError
+walletNicknameError "" _ = Just EmptyWalletNickname
 
-nicknameError nickname library =
-  if member nickname library then
-    Just DuplicateNickname
+walletNicknameError walletNickname walletLibrary =
+  if member walletNickname walletLibrary then
+    Just DuplicateWalletNickname
   else
-    if any (\char -> not $ isAlphaNum char) $ toCharArray nickname then
-      Just BadNickname
+    if any (\char -> not $ isAlphaNum char) $ toCharArray walletNickname then
+      Just BadWalletNickname
     else
       Nothing
 
-contractIdError :: String -> RemoteData AjaxError PubKey -> WalletLibrary -> Maybe ContractIdError
-contractIdError "" _ _ = Just EmptyContractId
+contractInstanceIdError :: String -> WebData Wallet -> WebData PubKey -> WebData Assets -> WalletLibrary -> Maybe ContractInstanceIdError
+contractInstanceIdError "" _ _ _ _ = Just EmptyContractInstanceId
 
-contractIdError contractId pubKey library =
-  if not $ isEmpty $ filter (\walletDetails -> walletDetails.contractId == contractId) library then
-    Just DuplicateContractId
-  else case pubKey of
-    Success _ -> Nothing
-    Failure _ -> Just NonexistentContractId
-    _ -> Just UnconfirmedContractId
+contractInstanceIdError contractInstanceIdString remoteDataWallet remoteDataPubKey remoteDataAssets walletLibrary = case parseContractInstanceId contractInstanceIdString of
+  Nothing -> Just InvalidContractInstanceId
+  Just contractInstanceId
+    | not $ isEmpty $ filter (\walletDetails -> walletDetails.contractInstanceId == contractInstanceId) walletLibrary -> Just DuplicateContractInstanceId
+  _ -> case remoteDataWallet, remoteDataPubKey, remoteDataAssets of
+    Success _, Success _, Success _ -> Nothing
+    Failure _, _, _ -> Just NonexistentContractInstanceId
+    _, _, _ -> Just UnconfirmedContractInstanceId
+
+parseContractInstanceId :: String -> Maybe ContractInstanceId
+parseContractInstanceId contractInstanceIdString = case parseUUID contractInstanceIdString of
+  Just uuid -> Just $ ContractInstanceId uuid
+  Nothing -> Nothing

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -11,28 +11,37 @@ import Css (applyWhen, classNames, hideWhen)
 import Css as Css
 import Data.Foldable (foldMap)
 import Data.Lens (view)
-import Data.Map (isEmpty, toUnfoldable)
-import Data.Maybe (Maybe(..), isJust)
+import Data.Map (isEmpty, lookup, toUnfoldable)
+import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Newtype (unwrap)
 import Data.String (null)
 import Data.Tuple (Tuple(..))
-import Halogen.HTML (HTML, button, datalist, div, div_, h2, h3, input, label, li, option, p, p_, text, ul_)
+import Data.UUID (toString) as UUID
+import Halogen.HTML (HTML, button, datalist, div, h2, h3, h4, input, label, li, option, p, p_, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), disabled, id_, placeholder, readOnly, type_, value)
-import Marlowe.Semantics (PubKey)
 import Material.Icons (Icon(..))
-import Network.RemoteData (RemoteData)
 import Play.Types (Action(..), Card(..))
-import Servant.PureScript.Ajax (AjaxError)
-import WalletData.Lenses (_contractId, _nickname)
-import WalletData.Types (Nickname, WalletDetails, WalletLibrary)
-import WalletData.Validation (contractIdError, nicknameError)
+import WalletData.Lenses (_assets, _contractInstanceId, _contractInstanceIdString, _remoteDataPubKey, _remoteDataAssets, _remoteDataWallet, _walletNickname, _walletNicknameString)
+import WalletData.Types (NewWalletDetails, WalletDetails, WalletLibrary)
+import WalletData.Validation (contractInstanceIdError, walletNicknameError)
 
-newWalletCard :: forall p. WalletLibrary -> Nickname -> String -> RemoteData AjaxError PubKey -> Maybe String -> HTML p Action
-newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey mTokenName =
+newWalletCard :: forall p. WalletLibrary -> NewWalletDetails -> Maybe String -> HTML p Action
+newWalletCard library newWalletDetails mTokenName =
   let
-    mNicknameError = nicknameError newWalletNickname library
+    walletNicknameString = view _walletNicknameString newWalletDetails
 
-    mContractIdError = contractIdError newWalletContractId remoteDataPubKey library
+    contractInstanceIdString = view _contractInstanceIdString newWalletDetails
+
+    remoteDataWallet = view _remoteDataWallet newWalletDetails
+
+    remoteDataPubKey = view _remoteDataPubKey newWalletDetails
+
+    remoteDataAssets = view _remoteDataAssets newWalletDetails
+
+    mWalletNicknameError = walletNicknameError walletNicknameString library
+
+    mContractInstanceIdError = contractInstanceIdError contractInstanceIdString remoteDataWallet remoteDataPubKey remoteDataAssets library
   in
     div
       [ classNames [ "flex", "flex-col", "p-5", "pb-6", "md:pb-8" ] ]
@@ -40,36 +49,36 @@ newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey mTo
           [ classNames [ "font-semibold", "mb-4" ] ]
           [ text $ "Create new contact" <> foldMap (\tokenName -> " for role " <> show tokenName) mTokenName ]
       , div
-          [ classNames $ [ "mb-4" ] <> (applyWhen (not null newWalletNickname) Css.hasNestedLabel) ]
+          [ classNames $ [ "mb-4" ] <> (applyWhen (not null walletNicknameString) Css.hasNestedLabel) ]
           [ label
-              [ classNames $ Css.nestedLabel <> hideWhen (null newWalletNickname) ]
+              [ classNames $ Css.nestedLabel <> hideWhen (null walletNicknameString) ]
               [ text "Nickname" ]
           , input
               [ type_ InputText
-              , classNames $ Css.input $ isJust mNicknameError
+              , classNames $ Css.input $ isJust mWalletNicknameError
               , placeholder "Nickname"
-              , value newWalletNickname
+              , value walletNicknameString
               , onValueInput_ SetNewWalletNickname
               ]
           , div
               [ classNames Css.inputError ]
-              [ text $ foldMap show mNicknameError ]
+              [ text $ foldMap show mWalletNicknameError ]
           ]
       , div
-          [ classNames $ [ "mb-4" ] <> (applyWhen (not null newWalletContractId) Css.hasNestedLabel) ]
+          [ classNames $ [ "mb-4" ] <> (applyWhen (not null contractInstanceIdString) Css.hasNestedLabel) ]
           [ label
-              [ classNames $ Css.nestedLabel <> hideWhen (null newWalletContractId) ]
+              [ classNames $ Css.nestedLabel <> hideWhen (null contractInstanceIdString) ]
               [ text "Wallet ID" ]
           , input
               [ type_ InputText
-              , classNames $ Css.input $ isJust mContractIdError
+              , classNames $ Css.input $ isJust mContractInstanceIdError
               , placeholder "Wallet ID"
-              , value newWalletContractId
+              , value contractInstanceIdString
               , onValueInput_ SetNewWalletContractId
               ]
           , div
               [ classNames Css.inputError ]
-              [ text $ foldMap show mContractIdError ]
+              [ text $ foldMap show mContractInstanceIdError ]
           ]
       , div
           [ classNames [ "flex" ] ]
@@ -80,7 +89,7 @@ newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey mTo
               [ text "Cancel" ]
           , button
               [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , disabled $ isJust mNicknameError || isJust mContractIdError
+              , disabled $ isJust mWalletNicknameError || isJust mContractInstanceIdError
               , onClick_ $ AddNewWallet mTokenName
               ]
               [ text "Save" ]
@@ -90,14 +99,14 @@ newWalletCard library newWalletNickname newWalletContractId remoteDataPubKey mTo
 walletDetailsCard :: forall p a. WalletDetails -> HTML p a
 walletDetailsCard walletDetails =
   let
-    nickname = view _nickname walletDetails
+    walletNickname = view _walletNickname walletDetails
 
-    contractId = view _contractId walletDetails
+    contractInstanceId = view _contractInstanceId walletDetails
   in
     div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
       [ h3
           [ classNames [ "font-semibold", "mb-4" ] ]
-          [ text $ "Wallet " <> nickname ]
+          [ text $ "Wallet " <> walletNickname ]
       , div
           [ classNames Css.hasNestedLabel ]
           [ label
@@ -106,7 +115,7 @@ walletDetailsCard walletDetails =
           , input
               [ type_ InputText
               , classNames $ Css.input false <> [ "mb-4" ]
-              , value contractId
+              , value $ UUID.toString $ unwrap contractInstanceId
               , readOnly true
               ]
           ]
@@ -115,14 +124,18 @@ walletDetailsCard walletDetails =
 putdownWalletCard :: forall p. WalletDetails -> HTML p Action
 putdownWalletCard walletDetails =
   let
-    nickname = view _nickname walletDetails
+    walletNickname = view _walletNickname walletDetails
 
-    contractId = view _contractId walletDetails
+    contractInstanceId = view _contractInstanceId walletDetails
+
+    assets = view _assets walletDetails
+
+    ada = fromMaybe zero $ lookup "" =<< lookup "" (unwrap assets)
   in
     div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
       [ h3
           [ classNames [ "font-semibold", "mb-4" ] ]
-          [ text $ "Wallet " <> nickname ]
+          [ text $ "Wallet " <> walletNickname ]
       , div
           [ classNames Css.hasNestedLabel ]
           [ label
@@ -131,9 +144,18 @@ putdownWalletCard walletDetails =
           , input
               [ type_ InputText
               , classNames $ Css.input false <> [ "mb-4" ]
-              , value contractId
+              , value $ UUID.toString $ unwrap contractInstanceId
               , readOnly true
               ]
+          ]
+      , div
+          [ classNames [ "mb-4" ] ]
+          [ h4
+              [ classNames [ "font-semibold" ] ]
+              [ text "Balance:" ]
+          , p
+              [ classNames [ "text-2xl", "text-purple", "font-semibold" ] ]
+              [ text $ "₳ " <> show ada ]
           ]
       , div
           [ classNames [ "flex" ] ]
@@ -172,7 +194,7 @@ walletLibraryScreen library =
   where
   contactLi (Tuple nickname walletDetails) =
     let
-      contractId = view _contractId walletDetails
+      contractId = view _contractInstanceId walletDetails
     in
       li
         [ classNames [ "mt-4", "hover:cursor-pointer", "hover:text-green" ]

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
       lightpurple: "#8701fc",
       grayblue: "#f5f9fc",
       purple: "#4c41e5",
-      red: "#de4c51",
+      red: "#e04b4c",
     },
     fontSize: {
       xs: "12px",

--- a/marlowe-dashboard-client/webpack.config.js
+++ b/marlowe-dashboard-client/webpack.config.js
@@ -111,6 +111,7 @@ module.exports = {
             'node_modules'
         ],
         alias: {
+            contracts: path.resolve(__dirname, './contracts'),
             grammar: path.resolve(__dirname, './grammar.ne'),
             static: path.resolve(__dirname, './static'),
             src: path.resolve(__dirname, './src')

--- a/marlowe-dashboard-client/webpack.config.js
+++ b/marlowe-dashboard-client/webpack.config.js
@@ -32,6 +32,9 @@ module.exports = {
             "/api": {
                 target: 'http://localhost:9080'
             },
+            "/wallet": {
+                target: 'http://localhost:9080'
+            },
             "/ws": {
                 target: 'ws://localhost:9080',
                 ws: true,


### PR DESCRIPTION
This PR starts putting the framework in place for communicating with the new PAB and mock wallet server. Apart from some little tweaks here and there, the main changes are:

1. Added some Capability modules for interacting with the websocket and the APIs. I've started to sketch out a Marlowe capability with specific Marlowe interactions, but that's not ready yet.
2. Added a Bridge module for aligning the frontend and backend types. I haven't started on an instance for the Marlowe `Contract` yet, which may require a bit of work still...
3. Started to wire up wallet generation and pickup. You can now generate a wallet and pick it up, and you will get its pubkey and current balance, and subscribe to balance changes through the websocket. What's missing is creating a wallet companion contract (and getting its `ContractInstanceId`), because that contract hasn't been merged yet.