### PR TITLE
Testing: run only single vm test

### DIFF
--- a/nix/tests/vm.nix
+++ b/nix/tests/vm.nix
@@ -12,10 +12,10 @@ let
   testing = import (pkgs.path + "/nixos/lib/testing-python.nix") { system = builtins.currentSystem; };
   makeTest = testing.makeTest;
   tests = pkgs.recurseIntoAttrs {
-    plutus-playground-server = pkgs.callPackage ./vm-tests/plutus-playground.nix { inherit makeTest plutus-playground; };
-    marlowe-playground-server = pkgs.callPackage ./vm-tests/marlowe-playground.nix { inherit makeTest marlowe-playground; };
-    web-ghc = pkgs.callPackage ./vm-tests/web-ghc.nix { inherit makeTest web-ghc; };
-    pab = pkgs.callPackage ./vm-tests/pab.nix { inherit makeTest plutus-pab marlowe-dashboard; };
+    #plutus-playground-server = pkgs.callPackage ./vm-tests/plutus-playground.nix { inherit makeTest plutus-playground; };
+    #marlowe-playground-server = pkgs.callPackage ./vm-tests/marlowe-playground.nix { inherit makeTest marlowe-playground; };
+    #web-ghc = pkgs.callPackage ./vm-tests/web-ghc.nix { inherit makeTest web-ghc; };
+    #pab = pkgs.callPackage ./vm-tests/pab.nix { inherit makeTest plutus-pab marlowe-dashboard; };
     all = pkgs.callPackage ./vm-tests/all.nix { inherit makeTest plutus-playground marlowe-playground marlowe-dashboard web-ghc marlowe-app plutus-pab vmCompileTests; };
   };
 in


### PR DESCRIPTION
While the tests work reliably locally they keep on failing on hydra.
This limits the vm tests to a single one to see if this makes any
difference in the stability.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge