### PR TITLE
deployment/morph: specify ssh config

### DIFF
--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -166,16 +166,6 @@ let
         export GITHUB_CLIENT_SECRET="$(pass $DEPLOYMENT_ENV/marlowe/githubClientSecret)"
         EOL
 
-        # in order for morph to be able to access any of the machines
-        # at all we need to install an ssh configuration file.
-        # --------------------------------------------------------------
-        # NOTE: THIS WILL MODIFY FILES IN YOUR `~/.ssh/config` DIRECTORY
-        # --------------------------------------------------------------
-
-        echo "[deploy-nix]: Installing ssh configuration ..."
-        mkdir -p ~/.ssh/config.d
-        cp plutus_playground.$DEPLOYMENT_ENV.conf ~/.ssh/config.d/
-
         #
         # Note: there appears to be some timing issue with how morph executes
         # the health-checks. In order to circumvent this we split these steps in two
@@ -183,6 +173,8 @@ let
         # 2. health-checks only
         #
         echo "[deploy-nix]: Starting deployment ..."
+        export SSH_SKIP_HOST_KEY_CHECK=1
+        export SSH_CONFIG_FILE=./plutus_playground.$DEPLOYMENT_ENV.conf
         ${morph}/bin/morph deploy --skip-health-checks --upload-secrets ./morph/network.nix switch
         ${morph}/bin/morph check-health ./morph/network.nix
       '';

--- a/nix/overlays/nixpkgs-overrides.nix
+++ b/nix/overlays/nixpkgs-overrides.nix
@@ -1,3 +1,17 @@
 self: super: {
   z3 = super.callPackage ../pkgs/z3 { };
+
+  morph = super.morph.overrideAttrs (old: {
+    # See https://github.com/DBCDK/morph/pull/141
+    # Note that this patch does refelct the original content
+    # of the PR above since it was broken. 
+    patches = [ ../pkgs/morph/sshopts.patch ];
+    src = self.fetchFromGitHub {
+      owner = "DBCDK";
+      repo = "morph";
+      rev = "c048d6339f18613a1544bc62ff852cb4c6de1042";
+      sha256 = "0yb8prji2nqjsj1aiiqnbqaajbi5l17rg8k78ry7pl3a8sqa3h1x";
+    };
+  });
+
 }

--- a/nix/pkgs/morph/sshopts.patch
+++ b/nix/pkgs/morph/sshopts.patch
@@ -1,0 +1,27 @@
+diff --git a/nix/nix.go b/nix/nix.go
+index 6a9cfd5..39b0a34 100644
+--- a/nix/nix.go
++++ b/nix/nix.go
+@@ -350,6 +350,7 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
+ 
+ 	var userArg = ""
+ 	var keyArg = ""
++	var sshOpts = []string{}
+ 	var env = os.Environ()
+ 	if host.TargetUser != "" {
+ 		userArg = host.TargetUser + "@"
+@@ -360,7 +361,13 @@ func Push(ctx *ssh.SSHContext, host Host, paths ...string) (err error) {
+ 		keyArg = "?ssh-key=" + ctx.IdentityFile
+ 	}
+ 	if ctx.SkipHostKeyCheck {
+-		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
++		sshOpts = append(sshOpts, fmt.Sprintf("%s", "-o StrictHostkeyChecking=No -o UserKnownHostsFile=/dev/null"))
++	}
++	if ctx.ConfigFile != "" {
++		sshOpts = append(sshOpts, fmt.Sprintf("-F %s", ctx.ConfigFile))
++	}
++	if len(sshOpts) > 0 {
++		env = append(env, fmt.Sprintf("NIX_SSHOPTS=%s", strings.Join(sshOpts, " ")))
+ 	}
+ 
+ 	options := mkOptions(host)


### PR DESCRIPTION
Pass the ssh configuration file created by terraform to morph. This way
no modifications to the local ssh configuration are necessary.

NOTE: the latest released morph does allow passing in the ssh config
file but the feature is broken. That's why this change also includes
a patch to make this work.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge