### PR TITLE
fix nix link in docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ Install https://nixos.org/nix/[Nix] (recommended). following the instructions on
 ====
 Even if you already have Nix installed, make sure to set up the xref:iohk-binary-cache[IOHK binary cache].
 ====
-See <<nix>> for further advice on using Nix.
+See <<nix-advice>> for further advice on using Nix.
 
 ==== Non-Nix
 
@@ -124,7 +124,7 @@ See link:CONTRIBUTING{outfilesuffix}[CONTRIBUTING], which describes our processe
 detail including development environments;
 and link:ARCHITECTURE{outfilesuffix}[ARCHITECTURE], which describes the structure of the repository.
 
-[[nix]]
+[[nix-advice]]
 == Nix
 
 [[iohk-binary-cache]]


### PR DESCRIPTION
The present link links to the _first_ nix title; i.e. the one you're reading! This makes it link to the intended spot.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
