### PR TITLE
Updating documentation, as in many cases /etc/nix/nix.conf is not pre…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,7 +150,7 @@ not have this set up properly.
 
 To set up the cache:
 
-. On non-NixOS, edit `/etc/nix/nix.conf` and add the following lines:
+. On non-NixOS, edit `/etc/nix/nix.conf` or create `/home/{your_user}/.config/nix.conf` and add the following lines:
 +
 ----
 substituters        = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/


### PR DESCRIPTION
After fighting with long build times under MacOS, CentOS 7 and Ubuntu, I found myself digging through the nix documentation to resolve this.

After running the default Nix Install Script found [here](https://nixos.org/download.html), I found that it does NOT create an **/etc/nix/** folder at all.

As a result build times have been horrible.
The workaround is described in nix's official documentation [here](https://nixos.org/manual/nix/unstable/command-ref/conf-file.html).

Full Details ([Source](https://nixos.org/manual/nix/unstable/command-ref/conf-file.html)):

The system-wide configuration file sysconfdir/nix/nix.conf (i.e. /etc/nix/nix.conf on most systems), or $NIX_CONF_DIR/nix.conf if NIX_CONF_DIR is set. Values loaded in this file are not forwarded to the Nix daemon. The client assumes that the daemon has already loaded them.

If NIX_USER_CONF_FILES is set, then each path separated by : will be loaded in reverse order.

Otherwise it will look for nix/nix.conf files in XDG_CONFIG_DIRS and XDG_CONFIG_HOME. If these are unset, it will look in $HOME/.config/nix.conf.

Please consider reviewing the README, as per the PR.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
