### PR TITLE
Fix docs reference in playgrounds machine

### DIFF
--- a/deployment/morph/machines/playground.nix
+++ b/deployment/morph/machines/playground.nix
@@ -78,7 +78,7 @@ in
               '';
             };
             "^~ /doc/" = {
-              alias = "${pkgs.docs.site}/";
+              alias = "${pkgs.plutus-docs.site}/";
               extraConfig = ''
                 error_page 404 = @fallback;
               '';
@@ -109,7 +109,7 @@ in
               '';
             };
             "^~ /doc/" = {
-              alias = "${pkgs.docs.site}/";
+              alias = "${pkgs.plutus-docs.site}/";
               extraConfig = ''
                 error_page 404 = @fallback;
               '';

--- a/deployment/morph/network.nix
+++ b/deployment/morph/network.nix
@@ -32,6 +32,7 @@ let
                 marlowe-playground = plutus.marlowe-playground;
                 plutus-playground = plutus.plutus-playground;
                 web-ghc = plutus.web-ghc;
+                plutus-docs = plutus.docs;
               })
             ];
           };


### PR DESCRIPTION
Fix the reference to the documentation files in the playground nginx
configuration.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `nix-shell shell.nix --run updateMaterialized` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
    - [ ] `nix-shell shell.nix --run fix-stylish-haskell` to fix any formatting issues
- If you changed any Purescript files:
    - [ ] `nix-shell shell.nix --run fix-purty` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge