### PR TITLE
Build deployments

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -59,7 +59,7 @@ let
         in
         filterAttrsOnlyRecursive (_: drv: isBuildable drv) {
           # build relevant top level attributes from default.nix
-          inherit (packages) docs tests plutus-playground marlowe-playground marlowe-dashboard plutus-pab;
+          inherit (packages) docs tests plutus-playground marlowe-playground marlowe-dashboard plutus-pab deployment;
           # The haskell.nix IFD roots for the Haskell project. We include these so they won't be GCd and will be in the
           # cache for users
           inherit (plutus.haskell.project) roots;

--- a/default.nix
+++ b/default.nix
@@ -91,9 +91,6 @@ rec {
 
   docs = import ./nix/docs.nix { inherit pkgs plutus; };
 
-  # Note: nix-build is not eager enough in evaluating `nix-build -A deployment` so 
-  # you need to specify a specific host. On hydra `pkgs.recurseIntoAttrs` solves
-  # this problem
   deployment = pkgs.recurseIntoAttrs (pkgs.callPackage ./deployment/morph {
     plutus = {
       plutus-docs = docs;

--- a/default.nix
+++ b/default.nix
@@ -91,6 +91,17 @@ rec {
 
   docs = import ./nix/docs.nix { inherit pkgs plutus; };
 
+  # Note: nix-build is not eager enough in evaluating `nix-build -A deployment` so 
+  # you need to specify a specific host. On hydra `pkgs.recurseIntoAttrs` solves
+  # this problem
+  deployment = pkgs.recurseIntoAttrs (pkgs.callPackage ./deployment/morph {
+    plutus = {
+      plutus-docs = docs;
+      inherit plutus-pab marlowe-app marlowe-companion-app
+        marlowe-dashboard marlowe-playground plutus-playground web-ghc;
+    };
+  });
+
   # This builds a vscode devcontainer that can be used with the plutus-starter project (or probably the plutus project itself).
   devcontainer = import ./nix/devcontainer/plutus-devcontainer.nix { inherit pkgs plutus; };
 }

--- a/deployment/morph/default.nix
+++ b/deployment/morph/default.nix
@@ -1,0 +1,33 @@
+{ pkgs, plutus }:
+let
+  # Dummy definition of what is usually read from
+  # the terraform local resource `machines.json`.
+  # The attributes in below are read in `machines.nix`
+  tfinfo = {
+    rootSshKeys = [ ];
+    marloweDashA.dns = "marlowe-dash-a";
+    marloweDashB.dns = "marlowe-dash-b";
+    playgroundsA.dns = "playgrounds-a";
+    playgroundsB.dns = "playgrounds-b";
+    webghcA.dns = "webghc-a";
+    webghcB.dns = "webghc-b";
+  };
+
+  # Fake `deployment` option definition so `pkgs.nixos` does not
+  # fail building the machines when it encounters the `deployment`.
+  fakeDeploymentOption = { lib, config, ... }: {
+    options.deployment = lib.mkOption {
+      type = lib.types.attrs;
+      description = "fake";
+    };
+  };
+
+  # Get a `buildMachine` function that wraps a `mkMachine` call with the fake deployment option
+  # in a `pkgs.nixos` call to build the machine outside of morph.
+  mkMachine = pkgs.callPackage ./mk-machine.nix { inherit plutus;inherit (tfinfo) rootSshKeys; extraImports = [ fakeDeploymentOption ]; };
+  buildMachine = { config, name }: pkgs.nixos (mkMachine { inherit config name; });
+in
+import ./machines.nix {
+  inherit pkgs tfinfo;
+  mkMachine = buildMachine;
+}

--- a/deployment/morph/default.nix
+++ b/deployment/morph/default.nix
@@ -29,7 +29,7 @@ let
   # Get a `buildMachine` function that wraps a `mkMachine` call with the fake deployment option
   # in a `pkgs.nixos` call to build the machine outside of morph.
   mkMachine = pkgs.callPackage ./mk-machine.nix { inherit plutus tfinfo; extraImports = [ fakeDeploymentOption ]; };
-  buildMachine = { config, name }: pkgs.nixos (mkMachine { inherit config name; });
+  buildMachine = { config, name }: (pkgs.nixos (mkMachine { inherit config name; })).toplevel;
 in
 import ./machines.nix {
   inherit pkgs tfinfo;

--- a/deployment/morph/default.nix
+++ b/deployment/morph/default.nix
@@ -30,8 +30,9 @@ let
   # in a `pkgs.nixos` call to build the machine outside of morph.
   mkMachine = pkgs.callPackage ./mk-machine.nix { inherit plutus tfinfo; extraImports = [ fakeDeploymentOption ]; };
   buildMachine = { config, name }: (pkgs.nixos (mkMachine { inherit config name; })).toplevel;
+  linuxOnly = x: if pkgs.stdenv.isDarwin then { } else x;
 in
-import ./machines.nix {
+linuxOnly (import ./machines.nix {
   inherit pkgs tfinfo;
   mkMachine = buildMachine;
-}
+})

--- a/deployment/morph/default.nix
+++ b/deployment/morph/default.nix
@@ -5,12 +5,16 @@ let
   # The attributes in below are read in `machines.nix`
   tfinfo = {
     rootSshKeys = [ ];
+    rev = "dev";
     marloweDashA.dns = "marlowe-dash-a";
     marloweDashB.dns = "marlowe-dash-b";
     playgroundsA.dns = "playgrounds-a";
     playgroundsB.dns = "playgrounds-b";
     webghcA.dns = "webghc-a";
     webghcB.dns = "webghc-b";
+    environment = "alpha";
+    plutusTld = "plutus.iohkdev.io";
+    marloweTld = "marlowe.iohkdev.io";
   };
 
   # Fake `deployment` option definition so `pkgs.nixos` does not
@@ -24,7 +28,7 @@ let
 
   # Get a `buildMachine` function that wraps a `mkMachine` call with the fake deployment option
   # in a `pkgs.nixos` call to build the machine outside of morph.
-  mkMachine = pkgs.callPackage ./mk-machine.nix { inherit plutus;inherit (tfinfo) rootSshKeys; extraImports = [ fakeDeploymentOption ]; };
+  mkMachine = pkgs.callPackage ./mk-machine.nix { inherit plutus tfinfo; extraImports = [ fakeDeploymentOption ]; };
   buildMachine = { config, name }: pkgs.nixos (mkMachine { inherit config name; });
 in
 import ./machines.nix {

--- a/deployment/morph/machines.nix
+++ b/deployment/morph/machines.nix
@@ -1,0 +1,39 @@
+{ pkgs, mkMachine, tfinfo }:
+{
+  # The network attribute allows to supply
+  # some settings to all deployments
+  network = {
+    description = "plutus network";
+    inherit pkgs;
+  };
+
+  "${tfinfo.marloweDashA.dns}" = mkMachine {
+    name = "marloweDashA";
+    config = ./machines/marlowe-dash.nix;
+  };
+
+  "${tfinfo.marloweDashB.dns}" = mkMachine {
+    name = "marloweDashB";
+    config = ./machines/marlowe-dash.nix;
+  };
+
+  "${tfinfo.playgroundsB.dns}" = mkMachine {
+    name = "playgroundsA";
+    config = ./machines/playground.nix;
+  };
+
+  "${tfinfo.playgroundsA.dns}" = mkMachine {
+    name = "playgroundsB";
+    config = ./machines/playground.nix;
+  };
+
+  "${tfinfo.webghcA.dns}" = mkMachine {
+    name = "webghcA";
+    config = ./machines/web-ghc.nix;
+  };
+
+  "${tfinfo.webghcB.dns}" = mkMachine {
+    name = "webghcB";
+    config = ./machines/web-ghc.nix;
+  };
+}

--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -1,6 +1,7 @@
 { pkgs, config, lib, ... }:
 {
   imports = [
+    ./std.nix
     ../../../nix/modules/pab.nix
   ];
 

--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, tfinfo, ... }:
 {
   imports = [
     ./std.nix

--- a/deployment/morph/machines/playground.nix
+++ b/deployment/morph/machines/playground.nix
@@ -5,6 +5,7 @@ in
 {
 
   imports = [
+    ./std.nix
     ../../../nix/modules/plutus-playground.nix
     ../../../nix/modules/marlowe-playground.nix
   ];

--- a/deployment/morph/machines/playground.nix
+++ b/deployment/morph/machines/playground.nix
@@ -1,7 +1,4 @@
-{ pkgs, config, lib, ... }:
-let
-  tfinfo = builtins.fromJSON (builtins.readFile ./../machines.json);
-in
+{ pkgs, config, lib, tfinfo, ... }:
 {
 
   imports = [

--- a/deployment/morph/machines/std.nix
+++ b/deployment/morph/machines/std.nix
@@ -1,8 +1,6 @@
 { config, lib, pkgs, ... }:
 {
 
-  imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
-
   ec2.hvm = true;
 
   nixpkgs.localSystem.system = "x86_64-linux";

--- a/deployment/morph/machines/std.nix
+++ b/deployment/morph/machines/std.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, tfinfo, ... }:
 {
 
   ec2.hvm = true;

--- a/deployment/morph/machines/web-ghc.nix
+++ b/deployment/morph/machines/web-ghc.nix
@@ -2,6 +2,7 @@
 {
 
   imports = [
+    ./std.nix
     ../../../nix/modules/web-ghc.nix
   ];
 

--- a/deployment/morph/machines/web-ghc.nix
+++ b/deployment/morph/machines/web-ghc.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, tfinfo, ... }:
 {
 
   imports = [

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -1,0 +1,32 @@
+{ pkgs, plutus, rootSshKeys, extraImports ? [ ] }:
+# mkMachine :: { config : Path, name : String } -> NixOS machine
+# Takes a machine specific configuration and a hostname to set and
+# applies generic settings:
+# - aws machine settings from ./profiles/std.nix
+# - configures root ssh keys for
+# - adds plutus specific packages through an overlay
+{ config, name }: {
+  imports = extraImports ++ [
+    config
+    ({ lib, config, ... }:
+      {
+        networking.hostName = name;
+        users.extraUsers.root.openssh.authorizedKeys.keys = rootSshKeys;
+        nixpkgs = {
+          inherit pkgs;
+          overlays = [
+            (self: super: {
+              plutus-pab = plutus.plutus-pab;
+              marlowe-app = plutus.marlowe-app;
+              marlowe-companion-app = plutus.marlowe-companion-app;
+              marlowe-dashboard = plutus.marlowe-dashboard;
+              marlowe-playground = plutus.marlowe-playground;
+              plutus-playground = plutus.plutus-playground;
+              web-ghc = plutus.web-ghc;
+              plutus-docs = plutus.docs;
+            })
+          ];
+        };
+      })
+  ];
+}

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -7,6 +7,7 @@
 # - adds plutus specific packages through an overlay
 { config, name }: {
   imports = extraImports ++ [
+    (pkgs.path + "/nixos/modules/virtualisation/amazon-image.nix")
     config
     ({ lib, config, ... }:
       {

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -1,4 +1,4 @@
-{ pkgs, plutus, rootSshKeys, extraImports ? [ ] }:
+{ pkgs, plutus, tfinfo, extraImports ? [ ] }:
 # mkMachine :: { config : Path, name : String } -> NixOS machine
 # Takes a machine specific configuration and a hostname to set and
 # applies generic settings:
@@ -7,12 +7,19 @@
 # - adds plutus specific packages through an overlay
 { config, name }: {
   imports = extraImports ++ [
+
     (pkgs.path + "/nixos/modules/virtualisation/amazon-image.nix")
+
     config
+
+    ({ config, ... }: {
+      config._module.args.tfinfo = tfinfo;
+    })
+
     ({ lib, config, ... }:
       {
         networking.hostName = name;
-        users.extraUsers.root.openssh.authorizedKeys.keys = rootSshKeys;
+        users.extraUsers.root.openssh.authorizedKeys.keys = tfinfo.rootSshKeys;
         nixpkgs = {
           inherit pkgs;
           overlays = [

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -31,7 +31,7 @@
               marlowe-playground = plutus.marlowe-playground;
               plutus-playground = plutus.plutus-playground;
               web-ghc = plutus.web-ghc;
-              plutus-docs = plutus.docs;
+              plutus-docs = plutus.plutus-docs;
             })
           ];
         };

--- a/deployment/morph/network.nix
+++ b/deployment/morph/network.nix
@@ -1,82 +1,12 @@
 let
   plutus = import ../../. { };
-
   pkgs = plutus.pkgs;
-
-  # tfinfo :: AttrSet
-  # Deployment information exported by terraform
   tfinfo = builtins.fromJSON (builtins.readFile ./machines.json);
-
-  # mkMachine :: { config : Path, name : String } -> NixOS machine
-  # Takes a machine specific configuration and a hostname to set and
-  # applies generic settings:
-  # - aws machine settings from ./profiles/std.nix
-  # - configures root ssh keys for
-  # - adds plutus specific packages through an overlay
-  mkMachine = { config, name }: {
-    imports = [
-      ./machines/std.nix
-      config
-      ({ lib, config, ... }:
-        {
-          networking.hostName = name;
-          users.extraUsers.root.openssh.authorizedKeys.keys = tfinfo.rootSshKeys;
-          nixpkgs = {
-            inherit pkgs;
-            overlays = [
-              (self: super: {
-                plutus-pab = plutus.plutus-pab;
-                marlowe-app = plutus.marlowe-app;
-                marlowe-companion-app = plutus.marlowe-companion-app;
-                marlowe-dashboard = plutus.marlowe-dashboard;
-                marlowe-playground = plutus.marlowe-playground;
-                plutus-playground = plutus.plutus-playground;
-                web-ghc = plutus.web-ghc;
-                plutus-docs = plutus.docs;
-              })
-            ];
-          };
-        })
-    ];
+  mkMachine = pkgs.callPackage ./mk-machine.nix {
+    inherit plutus;
+    inherit (tfinfo) rootSshKeys;
   };
-
 in
-{
-  # The network attribute allows to supply
-  # some settings to all deployments
-  network = {
-    description = "plutus network";
-    inherit pkgs;
-  };
-
-  "${tfinfo.marloweDashA.dns}" = mkMachine {
-    name = "marloweDashA";
-    config = ./machines/marlowe-dash.nix;
-  };
-
-  "${tfinfo.marloweDashB.dns}" = mkMachine {
-    name = "marloweDashB";
-    config = ./machines/marlowe-dash.nix;
-  };
-
-  "${tfinfo.playgroundsB.dns}" = mkMachine {
-    name = "playgroundsA";
-    config = ./machines/playground.nix;
-  };
-
-  "${tfinfo.playgroundsA.dns}" = mkMachine {
-    name = "playgroundsB";
-    config = ./machines/playground.nix;
-  };
-
-  "${tfinfo.webghcA.dns}" = mkMachine {
-    name = "webghcA";
-    config = ./machines/web-ghc.nix;
-  };
-
-  "${tfinfo.webghcB.dns}" = mkMachine {
-    name = "webghcB";
-    config = ./machines/web-ghc.nix;
-  };
-
+import ./machines.nix {
+  inherit pkgs mkMachine tfinfo;
 }

--- a/deployment/morph/network.nix
+++ b/deployment/morph/network.nix
@@ -3,8 +3,7 @@ let
   pkgs = plutus.pkgs;
   tfinfo = builtins.fromJSON (builtins.readFile ./machines.json);
   mkMachine = pkgs.callPackage ./mk-machine.nix {
-    inherit plutus;
-    inherit (tfinfo) rootSshKeys;
+    inherit plutus tfinfo;
   };
 in
 import ./machines.nix {


### PR DESCRIPTION
**Summary**
Build the deployment machines as part of the CI

**Details**
Previously all of the deployment processing was completely outside of the CI. While some nixos vm tests have already been added that at least verify the NixOS modules used in the configurations that we deploy, the actual machine derivations were never built. This PR adds `deployment/morph/default.nix` which builds all machines that are actually deployed.

---
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
