### PR TITLE
SCP-2041 - Buttons hover over "open example" window's title

### DIFF
--- a/marlowe-playground-client/static/css/modal.scss
+++ b/marlowe-playground-client/static/css/modal.scss
@@ -67,6 +67,7 @@ without doing it as an Effect in a mainframe action
     @extend .font-semibold;
     margin: 0;
   }
+  z-index: 2;
 }
 
 .modal-close {


### PR DESCRIPTION
Just changes the `z-index` of the header of the modal so that buttons don't hover over.

Before:
![before](https://user-images.githubusercontent.com/638102/114574324-10154900-9c71-11eb-8afc-42c44e14056e.png)

After:
![after](https://user-images.githubusercontent.com/638102/114574283-07bd0e00-9c71-11eb-89c7-6d49d3cbab78.png)


Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
