### PR TITLE
SCP-2132: Configurable slot 0

### DIFF
--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -29,6 +29,10 @@ let
       mscSocketPath = "/tmp/node-server.sock";
       mscSlotLength = 5;
       mscRandomTxInterval = 20000000;
+      mscSlotConfig = {
+        scZeroSlotTime = "2020-07-29T21:44:51Z"; #Wednesday, July 29, 2020 21:44:51 - shelley launch time
+        scSlotLength = 1;
+      };
       mscKeptBlocks = 100000;
       mscBlockReaper = {
         brcInterval = 6000000;

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
@@ -113,6 +113,7 @@
           (hsPkgs."lobemo-backend-ekg" or (errorHandler.buildDepError "lobemo-backend-ekg"))
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
           ];
         buildable = true;
         modules = [
@@ -347,6 +348,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
             ];
           buildable = true;
           hsSourceDirs = [ "tx-inject" ];

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -80,7 +80,7 @@ import           Data.Text.Prettyprint.Doc               (defaultLayoutOptions, 
 import           Data.Text.Prettyprint.Doc.Render.String (renderString)
 import           Plutus.Trace.Scheduler                  (EmSystemCall, ThreadId, exit, runThreads)
 import           System.IO                               (Handle, hPutStrLn, stdout)
-import           Wallet.Emulator.Chain                   (ChainControlEffect, ChainEffect)
+import           Wallet.Emulator.Chain                   (ChainControlEffect)
 import qualified Wallet.Emulator.Chain                   as ChainState
 import           Wallet.Emulator.MultiAgent              (EmulatorEvent, EmulatorEvent' (..), EmulatorState (..),
                                                           MultiAgentControlEffect, MultiAgentEffect, _eteEmulatorTime,
@@ -165,7 +165,6 @@ interpretEmulatorTrace :: forall effs a.
     ( Member MultiAgentEffect effs
     , Member MultiAgentControlEffect effs
     , Member (Error EmulatorRuntimeError) effs
-    , Member ChainEffect effs
     , Member ChainControlEffect effs
     , Member (LogMsg EmulatorEvent') effs
     , Member (State EmulatorState) effs

--- a/plutus-contract/src/Plutus/Trace/Playground.hs
+++ b/plutus-contract/src/Plutus/Trace/Playground.hs
@@ -54,7 +54,7 @@ import           Plutus.Trace.Emulator.Types                (ContractConstraints
 import           Plutus.Trace.Scheduler                     (EmSystemCall, ThreadId, exit, runThreads)
 import           Streaming                                  (Stream)
 import           Streaming.Prelude                          (Of)
-import           Wallet.Emulator.Chain                      (ChainControlEffect, ChainEffect)
+import           Wallet.Emulator.Chain                      (ChainControlEffect)
 import           Wallet.Emulator.MultiAgent                 (EmulatorEvent, EmulatorEvent' (..), EmulatorState,
                                                              MultiAgentControlEffect, MultiAgentEffect, schedulerEvent)
 import           Wallet.Emulator.Stream                     (EmulatorConfig (..), EmulatorErr (..), initialChainState,
@@ -138,7 +138,6 @@ interpretPlaygroundTrace :: forall w s e effs a.
     ( Member MultiAgentEffect effs
     , Member MultiAgentControlEffect effs
     , Member (Error EmulatorRuntimeError) effs
-    , Member ChainEffect effs
     , Member ChainControlEffect effs
     , Member (LogMsg EmulatorEvent') effs
     , HasBlockchainActions s

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions.txt
@@ -1,15 +1,15 @@
-Slot 00001: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
-Slot 00001: SlotAdd Slot 1
+Slot 00000: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
+Slot 00000: SlotAdd Slot 1
 Slot 00001: W1: TxSubmit: b88eef8f6e6ecc1005a17b2f80fa8173e108457bb861ebf287a882f2517374a1
-Slot 00002: TxnValidate b88eef8f6e6ecc1005a17b2f80fa8173e108457bb861ebf287a882f2517374a1
-Slot 00002: SlotAdd Slot 2
+Slot 00001: TxnValidate b88eef8f6e6ecc1005a17b2f80fa8173e108457bb861ebf287a882f2517374a1
+Slot 00001: SlotAdd Slot 2
 Slot 00002: W2: TxSubmit: 3c2b8dffba39e446e7f0920c9fa0684addedd68a09f5a538b0617606386b01e1
-Slot 00003: TxnValidate 3c2b8dffba39e446e7f0920c9fa0684addedd68a09f5a538b0617606386b01e1
-Slot 00003: SlotAdd Slot 3
+Slot 00002: TxnValidate 3c2b8dffba39e446e7f0920c9fa0684addedd68a09f5a538b0617606386b01e1
+Slot 00002: SlotAdd Slot 3
 Slot 00003: W3: TxSubmit: 9b9bbd27ffb2c5ad5c742f2829de9db2b5c025dc3918652450a82c06519bc28c
-Slot 00004: TxnValidate 9b9bbd27ffb2c5ad5c742f2829de9db2b5c025dc3918652450a82c06519bc28c
-Slot 00004: SlotAdd Slot 4
-Slot 00005: SlotAdd Slot 5
+Slot 00003: TxnValidate 9b9bbd27ffb2c5ad5c742f2829de9db2b5c025dc3918652450a82c06519bc28c
+Slot 00003: SlotAdd Slot 4
+Slot 00004: SlotAdd Slot 5
 Final balances
 Wallet 1: 
     {, ""}: 99999990

--- a/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - pubKeyTransactions2.txt
@@ -1,18 +1,18 @@
-Slot 00001: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
-Slot 00001: SlotAdd Slot 1
+Slot 00000: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
+Slot 00000: SlotAdd Slot 1
 Slot 00001: W1: TxSubmit: a7f674beb0b2b728d80cdf60ad2945556d0a91add3a0209ac60bc411871da826
-Slot 00002: TxnValidate a7f674beb0b2b728d80cdf60ad2945556d0a91add3a0209ac60bc411871da826
-Slot 00002: SlotAdd Slot 2
+Slot 00001: TxnValidate a7f674beb0b2b728d80cdf60ad2945556d0a91add3a0209ac60bc411871da826
+Slot 00001: SlotAdd Slot 2
 Slot 00002: W2: TxSubmit: 4fa93f6f251ef383a974ba52920cf85850c28ff33a9550fee88d92b3f8a9d81a
-Slot 00003: TxnValidate 4fa93f6f251ef383a974ba52920cf85850c28ff33a9550fee88d92b3f8a9d81a
-Slot 00003: SlotAdd Slot 3
+Slot 00002: TxnValidate 4fa93f6f251ef383a974ba52920cf85850c28ff33a9550fee88d92b3f8a9d81a
+Slot 00002: SlotAdd Slot 3
 Slot 00003: W3: TxSubmit: 087caad8d00f3b1201171cffcda723fc5079380828f39c63f3dc3e5a48b71752
-Slot 00004: TxnValidate 087caad8d00f3b1201171cffcda723fc5079380828f39c63f3dc3e5a48b71752
-Slot 00004: SlotAdd Slot 4
+Slot 00003: TxnValidate 087caad8d00f3b1201171cffcda723fc5079380828f39c63f3dc3e5a48b71752
+Slot 00003: SlotAdd Slot 4
 Slot 00004: W1: TxSubmit: 9933fe032fd1ede9744b248db221103a29e83f24ebb8274e8df19ff70b2ae541
-Slot 00005: TxnValidate 9933fe032fd1ede9744b248db221103a29e83f24ebb8274e8df19ff70b2ae541
-Slot 00005: SlotAdd Slot 5
-Slot 00006: SlotAdd Slot 6
+Slot 00004: TxnValidate 9933fe032fd1ede9744b248db221103a29e83f24ebb8274e8df19ff70b2ae541
+Slot 00004: SlotAdd Slot 5
+Slot 00005: SlotAdd Slot 6
 Final balances
 Wallet 1: 
     {, ""}: 99999980

--- a/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
+++ b/plutus-contract/test/Spec/golden/traceOutput - wait1.txt
@@ -1,7 +1,7 @@
-Slot 00001: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
-Slot 00001: SlotAdd Slot 1
-Slot 00002: SlotAdd Slot 2
-Slot 00003: SlotAdd Slot 3
+Slot 00000: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
+Slot 00000: SlotAdd Slot 1
+Slot 00001: SlotAdd Slot 2
+Slot 00002: SlotAdd Slot 3
 Final balances
 Wallet 1: 
     {, ""}: 100000000

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -29,6 +29,9 @@
     mscSocketPath: /tmp/node-server.sock
     mscSlotLength: 5
     mscRandomTxInterval: 20000000
+    mscSlotConfig:
+      scZeroSlotTime: "2020-07-29T21:44:51Z" #Wednesday, July 29, 2020 21:44:51 - shelley launch time
+      scSlotLength: 1
     mscKeptBlocks: 100000
     mscBlockReaper:
       brcInterval: 6000000

--- a/plutus-pab/app/Cli.hs
+++ b/plutus-pab/app/Cli.hs
@@ -121,6 +121,7 @@ runCliCommand trace _ Config {..} serviceAvailability MockWallet =
         (toWalletLog trace)
         walletServerConfig
         (mscSocketPath nodeServerConfig)
+        (mscSlotConfig nodeServerConfig)
         (ChainIndex.ciBaseUrl chainIndexConfig)
         serviceAvailability
 
@@ -168,6 +169,7 @@ runCliCommand t _ Config {nodeServerConfig, chainIndexConfig} serviceAvailabilit
         (toChainIndexLog t)
         chainIndexConfig
         (mscSocketPath nodeServerConfig)
+        (mscSlotConfig nodeServerConfig)
         serviceAvailability
 
 -- Install a contract

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -195,7 +195,8 @@ library
         lobemo-backend-ekg -any,
         exceptions -any,
         data-default -any,
-        time-units -any
+        time-units -any,
+        time -any
 
 executable plutus-pab
     main-is: Main.hs
@@ -408,4 +409,5 @@ executable tx-inject
         stm -any,
         text -any,
         time-units -any,
-        yaml -any
+        yaml -any,
+        data-default -any

--- a/plutus-pab/plutus-pab.yaml
+++ b/plutus-pab/plutus-pab.yaml
@@ -14,7 +14,10 @@ walletServerConfig:
 nodeServerConfig:
   mscBaseUrl: http://localhost:9082
   mscSocketPath: ./node-server.sock
-  mscSlotLength: 1
+  mscKeptBlocks: 100
+  mscSlotConfig:
+    scZeroSlotTime: "2020-07-29T21:44:51Z" #Wednesday, July 29, 2020 21:44:51 - shelley launch time
+    scSlotLength: 1
   # mscRandomTxInterval: 20
   mscBlockReaper:
     brcInterval: 600

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -17,6 +17,9 @@ nodeServerConfig:
   mscSlotLength: 5
   mscKeptBlocks: 100
   mscRandomTxInterval: 20
+  mscSlotConfig:
+    scZeroSlotTime: "2020-07-29T21:44:51Z" #Wednesday, July 29, 2020 21:44:51 - shelley launch time
+    scSlotLength: 1
   mscBlockReaper:
     brcInterval: 600
     brcBlocksToKeep: 100

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -24,6 +24,7 @@ import qualified Wallet.Effects                  as WalletEffects
 
 import           Cardano.ChainIndex.ChainIndex   (confirmedBlocks, healthcheck, processIndexEffects, startWatching,
                                                   syncState, watchedAddresses)
+import           Cardano.Node.Types              (SlotConfig)
 import           Control.Monad.IO.Class          (MonadIO (..))
 import           Data.Function                   ((&))
 import           Data.Proxy                      (Proxy (Proxy))
@@ -49,12 +50,12 @@ app trace stateVar =
         (liftIO . processIndexEffects trace stateVar)
         (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
 
-main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> Availability -> IO ()
-main trace ChainIndexConfig{ciBaseUrl} socketPath availability = runLogEffects trace $ do
+main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> SlotConfig -> Availability -> IO ()
+main trace ChainIndexConfig{ciBaseUrl} socketPath slotConfig availability = runLogEffects trace $ do
     mVarState <- liftIO $ newMVar initialAppState
 
     logInfo StartingNodeClientThread
-    _ <- liftIO $ runClientNode socketPath $ updateChainState mVarState
+    _ <- liftIO $ runClientNode socketPath slotConfig $ updateChainState mVarState
 
     logInfo $ StartingChainIndex servicePort
     liftIO $ Warp.runSettings warpSettings $ app trace mVarState

--- a/plutus-pab/src/Cardano/Node/Client.hs
+++ b/plutus-pab/src/Cardano/Node/Client.hs
@@ -64,5 +64,4 @@ handleNodeClientClient e = do
     case e of
         PublishTx tx  ->
             liftIO $ Client.queueTx clientHandler tx
-        GetClientSlot ->
-            liftIO $ Client.getCurrentSlot clientHandler
+        GetClientSlot -> liftIO $ Client.getCurrentSlot clientHandler

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -128,13 +128,15 @@ transactionGenerator trace interval clientHandler stateVar =
 -- | Calls 'addBlock' at the start of every slot, causing pending transactions
 --   to be validated and added to the chain.
 slotCoordinator ::
-    Second
- -> Server.ServerHandler
- -> IO a
-slotCoordinator slotLength serverHandler =
+    SlotConfig
+    -> Server.ServerHandler
+    -> IO a
+slotCoordinator sc@SlotConfig{scSlotLength} serverHandler = do
     forever $ do
         void $ Server.processBlock serverHandler
-        liftIO $ threadDelay $ fromIntegral $ toMicroseconds slotLength
+        newSlot <- currentSlot sc
+        void $ Server.modifySlot (const newSlot) serverHandler
+        liftIO $ threadDelay $ fromIntegral $ toMicroseconds scSlotLength
 
 -- | Discards old blocks according to the 'BlockReaperConfig'. (avoids memory
 --   leak)

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TemplateHaskell   #-}
@@ -38,6 +39,11 @@ module Cardano.Node.Types
     , MockServerConfig (..)
     , BlockReaperConfig (..)
 
+    -- ** Slot / timing
+    , SlotConfig(..)
+    , slotNumber
+    , currentSlot
+
     -- * newtype wrappers
     , NodeUrl (..)
     )
@@ -47,7 +53,9 @@ import           Control.Lens                   (makeLenses, view)
 import           Control.Monad.Freer.TH         (makeEffect)
 import           Data.Aeson                     (FromJSON, ToJSON)
 import qualified Data.Map                       as Map
-import           Data.Text.Prettyprint.Doc      (Pretty (..), pretty, (<+>))
+import           Data.Text.Prettyprint.Doc      (Pretty (..), pretty, viaShow, (<+>))
+import           Data.Time.Clock                (UTCTime)
+import qualified Data.Time.Format.ISO8601       as F
 import           Data.Time.Units                (Second)
 import           Data.Time.Units.Extra          ()
 import           GHC.Generics                   (Generic)
@@ -57,6 +65,7 @@ import           Servant.Client                 (BaseUrl)
 import           Cardano.BM.Data.Tracer         (ToObject (..))
 import           Cardano.BM.Data.Tracer.Extras  (Tagged (..), mkObjectStr)
 import qualified Cardano.Protocol.Socket.Client as Client
+import           Cardano.Protocol.Socket.Type   (SlotConfig (..), currentSlot, slotNumber)
 import           Control.Monad.Freer.Extras.Log (LogMessage, LogMsg (..))
 import           Control.Monad.Freer.Reader     (Reader)
 import           Control.Monad.Freer.State      (State)
@@ -70,6 +79,24 @@ import           Plutus.PAB.Arbitrary           ()
 
 -- Configuration ------------------------------------------------------------------------------------------------------
 
+{- Note [Slot numbers in mock node]
+
+The mock node has an internal clock that generates new slots in a regular
+interval. Slots are identified by consecutive integers. What should the
+initial slot number be? We can either set it to 0, so that the slot number
+is the number of intervals that have passed since the process was started.
+Or we can define an initial timestamp, so that the slot number is the number
+of intervals since that timestamp.
+
+The first option of counting from 0 is useful for integration tests where we
+want the test outcome to be independent of when the test was run. This approach
+is used in the PAB simulator.
+The second option, counting from a timestamp, is more realistic and it is
+useful for frontends that need to convert the slot number back to a timestamp.
+We use this approach for the "proper" pab executable.
+
+-}
+
 newtype NodeUrl = NodeUrl BaseUrl
     deriving (Show, Eq) via BaseUrl
 
@@ -78,8 +105,6 @@ data MockServerConfig =
     MockServerConfig
         { mscBaseUrl          :: BaseUrl
         -- ^ base url of the service
-        , mscSlotLength       :: Second
-        -- ^ Duration of one slot
         , mscRandomTxInterval :: Maybe Second
         -- ^ Time between two randomly generated transactions
         , mscBlockReaper      :: Maybe BlockReaperConfig
@@ -90,6 +115,8 @@ data MockServerConfig =
         -- ^ Path to the socket used to communicate with the server.
         , mscKeptBlocks       :: Integer
         -- ^ The number of blocks to keep for replaying to a newly connected clients
+        , mscSlotConfig       :: SlotConfig
+        -- ^ Beginning of slot 0.
         }
     deriving (Show, Eq, Generic, FromJSON)
 
@@ -107,7 +134,7 @@ data BlockReaperConfig =
 -- | Top-level logging data type for structural logging
 -- inside the Mock Node server.
 data MockServerLogMsg =
-    StartingSlotCoordination
+    StartingSlotCoordination UTCTime Second
     | NoRandomTxGeneration
     | StartingRandomTx
     | KeepingOldBlocks
@@ -125,7 +152,10 @@ instance Pretty MockServerLogMsg where
         KeepingOldBlocks          -> "Not starting block reaper thread (old blocks will be retained in-memory forever"
         RemovingOldBlocks         -> "Starting block reaper thread (old blocks will be removed)"
         StartingMockServer p      -> "Starting Mock Node Server on port " <+> pretty p
-        StartingSlotCoordination  -> "Starting slot coordination thread"
+        StartingSlotCoordination initialSlotTime slotLength  ->
+            "Starting slot coordination thread."
+            <+> "Initial slot time:" <+> pretty (F.iso8601Show initialSlotTime)
+            <+> "Slot length:" <+> viaShow slotLength
         ProcessingChainEvent e    -> "Processing chain event " <+> pretty e
         BlockOperation e          -> "Block operation " <+> pretty e
         CreatingRandomTransaction -> "Generating a random transaction"
@@ -137,7 +167,7 @@ instance ToObject MockServerLogMsg where
         KeepingOldBlocks          ->  mkObjectStr "Not starting block reaper thread (old blocks will be retained in-memory forever" ()
         RemovingOldBlocks         ->  mkObjectStr "Starting block reaper thread (old blocks will be removed)" ()
         StartingMockServer p      ->  mkObjectStr "Starting Mock Node Server on port " (Tagged @"port" p)
-        StartingSlotCoordination  ->  mkObjectStr "" ()
+        StartingSlotCoordination i l  -> mkObjectStr "Starting slot coordination thread" (Tagged @"initial-slot-time" (F.iso8601Show  i), Tagged @"slot-length" l)
         ProcessingChainEvent e    ->  mkObjectStr "Processing chain event" (Tagged @"event" e)
         BlockOperation e          ->  mkObjectStr "Block operation" (Tagged @"event" e)
         CreatingRandomTransaction ->  mkObjectStr "Creating random transaction" ()

--- a/plutus-pab/src/Cardano/Protocol/Socket/Type.hs
+++ b/plutus-pab/src/Cardano/Protocol/Socket/Type.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -15,7 +16,13 @@ import           Data.Aeson                                         (FromJSON, T
 import qualified Data.ByteArray                                     as BA
 import qualified Data.ByteString                                    as BS
 import qualified Data.ByteString.Lazy                               as BSL
+import           Data.Default                                       (Default (..))
 import           Data.Text.Prettyprint.Doc                          (Pretty)
+import           Data.Time.Calendar                                 (fromGregorian)
+import           Data.Time.Clock                                    (UTCTime (..), diffUTCTime, getCurrentTime,
+                                                                     nominalDiffTimeToSeconds, secondsToNominalDiffTime)
+import           Data.Time.Units                                    (Second)
+import           Data.Time.Units.Extra                              ()
 
 import           GHC.Generics
 import           NoThunks.Class                                     (NoThunks)
@@ -31,7 +38,7 @@ import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Codec as TxSubmiss
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Type  as TxSubmission
 import           Ouroboros.Network.Util.ShowProxy
 
-import           Ledger                                             (Block, Tx (..), TxId (..))
+import           Ledger                                             (Block, Slot (..), Tx (..), TxId (..))
 import           Ledger.Bytes                                       (LedgerBytes (..))
 
 -- | Tip of the block chain type (used by node protocols).
@@ -113,3 +120,29 @@ codecTxSubmission =
     TxSubmission.codecLocalTxSubmission
       CBOR.encode CBOR.decode
       CBOR.encode CBOR.decode
+
+data SlotConfig =
+    SlotConfig
+        { scSlotLength   :: Second -- ^ Length of 1 slot
+        , scZeroSlotTime :: UTCTime -- ^ Beginning of the first slot
+        }
+    deriving (Show, Eq, Generic, FromJSON)
+
+instance Default SlotConfig where
+  def =
+    let shelleyLaunchDate =
+          let ninePm = 21 * 60 * 60
+              fourtyFourMinutes = 44 * 60
+          in UTCTime (fromGregorian 2020 07 29) (ninePm + fourtyFourMinutes + 51)
+    in SlotConfig{ scSlotLength = 1, scZeroSlotTime = shelleyLaunchDate }
+
+-- | Convert a timestamp to a slot number
+slotNumber :: SlotConfig -> UTCTime -> Slot
+slotNumber SlotConfig{scSlotLength, scZeroSlotTime} currentTime =
+    let timePassed = currentTime `diffUTCTime` scZeroSlotTime
+        slotsPassed = timePassed / (secondsToNominalDiffTime $ fromIntegral scSlotLength)
+    in Slot $ round $ nominalDiffTimeToSeconds slotsPassed
+
+-- | Get the current slot number
+currentSlot :: SlotConfig -> IO Slot
+currentSlot sc = slotNumber sc <$> getCurrentTime

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -20,6 +20,7 @@ import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), Insta
                                                        emptyBlockchainEnv)
 import qualified Plutus.PAB.Core.ContractInstance.STM as S
 
+import           Cardano.Node.Types                   (SlotConfig)
 import           Control.Concurrent                   (forkIO)
 import           Control.Concurrent.STM               (STM)
 import qualified Control.Concurrent.STM               as STM
@@ -36,11 +37,12 @@ import qualified Wallet.Emulator.ChainIndex.Index     as Index
 --   env.
 startNodeClient ::
   FilePath -- ^ Socket to connect to node
+  -> SlotConfig -- ^ Slot config used by the node
   -> InstancesState
   -> IO BlockchainEnv
-startNodeClient socket instancesState =  do
+startNodeClient socket slotConfig instancesState =  do
     env <- STM.atomically emptyBlockchainEnv
-    _ <- Client.runClientNode socket (\block -> STM.atomically . processBlock env block)
+    _ <- Client.runClientNode socket slotConfig (\block -> STM.atomically . processBlock env block)
     _ <- forkIO (clientEnvLoop env instancesState)
     pure env
 

--- a/plutus-pab/tx-inject/Main.hs
+++ b/plutus-pab/tx-inject/Main.hs
@@ -19,6 +19,7 @@ import           Control.Lens                   hiding (ix)
 import           Control.Monad                  (forever)
 import           Control.Monad.IO.Class         (liftIO)
 import           Control.RateLimit              (rateLimitExecution)
+import           Data.Default                   (Default (..))
 import qualified Data.Map                       as Map
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
@@ -185,7 +186,7 @@ initializeInterruptHandler stats = do
 initializeClient :: Config -> IO ClientHandler
 initializeClient cfg = do
     let serverSocket = mscSocketPath $ nodeServerConfig cfg
-    runClientNode serverSocket (\_ _ -> pure ())
+    runClientNode serverSocket def (\_ _ -> pure ())
 
 main :: IO ()
 main = do

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -1,4 +1,4 @@
-Slot 1: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
+Slot 0: TxnValidate af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
 Slot 1: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
           Contract instance started
 Slot 1: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
@@ -71,9 +71,9 @@ Slot 1: W4: Balancing an unbalanced transaction:
                     "\237\209\195sr\247R\201z\236\b\130E/\172\172\ETB\164\253\175F\230\FS\ETX?J\246x\164\a\155\205"}
               Requires signatures:
 Slot 1: W4: TxSubmit: 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
-Slot 2: TxnValidate 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
-Slot 2: TxnValidate 2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
-Slot 2: TxnValidate 3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
+Slot 1: TxnValidate 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
+Slot 1: TxnValidate 2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
+Slot 1: TxnValidate 3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
@@ -97,4 +97,4 @@ Slot 20: W1: Balancing an unbalanced transaction:
 Slot 20: W1: TxSubmit: 87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 21: TxnValidate 87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62
+Slot 20: TxnValidate 87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62


### PR DESCRIPTION
* Add a config field `mscZeroSlotTime` to the mock node's configuration. The mock node will start its slot count from that date.
* Separate `ModifySlot` from `AddBlock` in `ChainIndexControlEffect`. We need this so that we can change the slot number independently.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
