### PR TITLE
add the generation of the doc serve script to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -97,6 +97,7 @@ let
     updateMaterialized
     updateClientDeps
     updateMetadataSamples
+    docs.build-and-serve-docs
   ]);
 
 in


### PR DESCRIPTION
I think I just missed adding this at the time!

This time, it has no impact in the shell opening because, as discussed last time, now it just writes the shell script; the building happens when you run `build-and-serve-docs` from within the nix shell :)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
