### PR TITLE
Kwxm/increase validation bm timelimit

### DIFF
--- a/plutus-benchmark/README.md
+++ b/plutus-benchmark/README.md
@@ -42,7 +42,7 @@ This directory contains two sets of benchmarks:
    * To run the benchmarks using stack, type a command like this
        * `stack bench plutus-benchmark:validation` (run all benchmarks)
        * `stack bench plutus-benchmark:validation --ba "crowdfunding/2 -L60"` (run the `crowdfunding/2`
-           benchmark with a time limit of 10 seconds)
+           benchmark with a time limit of 60 seconds)
 
    * The corresponding cabal commands are
        * `cabal bench plutus-benchmark:validation`
@@ -50,10 +50,9 @@ This directory contains two sets of benchmarks:
      or the `cabal run` equivalents (see the `nofib` section).
 
    * During benchmarking each validation script is run repeatedly up to a limit
-     of 520 seconds (Criterion's default; a single execution takes approximately
-     5-15 ms) to get statistically reasonable total number of executions.  It
-     takes about 10 minutes to run the entire suite (again, this will depend on
-     the hardware).
+     of 20 seconds (a single execution takes approximately 5-15 ms) to get
+     statistically reasonable total number of executions.  It takes about 10
+     minutes to run the entire suite (again, this will depend on the hardware).
 
 See also [nofib/README.md](./nofib/README.md) and [validation/README.md](./validation/README.md).
 

--- a/plutus-benchmark/README.md
+++ b/plutus-benchmark/README.md
@@ -41,7 +41,7 @@ This directory contains two sets of benchmarks:
 
    * To run the benchmarks using stack, type a command like this
        * `stack bench plutus-benchmark:validation` (run all benchmarks)
-       * `stack bench plutus-benchmark:validation --ba "crowdfunding/2 -L10"` (run the `crowdfunding/2`
+       * `stack bench plutus-benchmark:validation --ba "crowdfunding/2 -L60"` (run the `crowdfunding/2`
            benchmark with a time limit of 10 seconds)
 
    * The corresponding cabal commands are
@@ -50,12 +50,12 @@ This directory contains two sets of benchmarks:
      or the `cabal run` equivalents (see the `nofib` section).
 
    * During benchmarking each validation script is run repeatedly up to a limit
-     of 5 seconds (Criterion's default; a single execution takes approximately
+     of 520 seconds (Criterion's default; a single execution takes approximately
      5-15 ms) to get statistically reasonable total number of executions.  It
-     takes about 5 minutes to run the entire suite (again, this will depend on
+     takes about 10 minutes to run the entire suite (again, this will depend on
      the hardware).
 
-See also  [nofib/README.md](./nofib/README.md)  and [validation/README.md](./validation/README.md).
+See also [nofib/README.md](./nofib/README.md) and [validation/README.md](./validation/README.md).
 
 ### nofib-exe
 The `nofib-exe` program in `nofib/exe` allows you to run the `nofib` benchmarks from the command line and

--- a/plutus-benchmark/README.md
+++ b/plutus-benchmark/README.md
@@ -46,7 +46,7 @@ This directory contains two sets of benchmarks:
 
    * The corresponding cabal commands are
        * `cabal bench plutus-benchmark:validation`
-       * `cabal bench plutus-benchmark:validation --benchmark-options "crowdfunding/2 -L10"`
+       * `cabal bench plutus-benchmark:validation --benchmark-options "crowdfunding/2 -L60"`
      or the `cabal run` equivalents (see the `nofib` section).
 
    * During benchmarking each validation script is run repeatedly up to a limit
@@ -71,7 +71,7 @@ are interpreted relative to `plutus-benchmark` when running the benchmarks via
 stack or cabal): for example
 
 ```
-  stack bench plutus-benchmark:validation --ba "crowdfunding -L10 --output $PWD/crowdfunding-report.html"
+  stack bench plutus-benchmark:validation --ba "crowdfunding -L60 --output $PWD/crowdfunding-report.html"
 ```
 
 If using `cabal bench` you'll have to do something similar, but `cabal run` will write the output into

--- a/plutus-benchmark/nofib/bench/BenchPlc.hs
+++ b/plutus-benchmark/nofib/bench/BenchPlc.hs
@@ -65,5 +65,5 @@ benchKnights depth sz = benchCek $ Knights.mkKnightsTerm depth sz
 main :: IO ()
 main = do
   let runners = (benchClausify, benchKnights, benchPrime, benchQueens)
-  config <- Common.getConfig 60.0  -- Run each benchmark for at least one minute
+  config <- Common.getConfig 60.0  -- Run each benchmark for at least one minute.  Change this with -L or --timeout.
   defaultMainWith config $ Common.mkBenchMarks runners

--- a/plutus-benchmark/validation/Main.hs
+++ b/plutus-benchmark/validation/Main.hs
@@ -87,13 +87,14 @@ mkBgroup dirname bms = bgroup dirname (map (mkBM dirname) bms)
    `plutus-benchmark` directory by default.  The -o option can be used to change
    this, but an absolute path will probably be required (eg,
    "-o=$PWD/report.html") . -}
-getConfig :: IO Config
-getConfig = do
+getConfig :: Double -> IO Config
+getConfig limit = do
   templateDir <- getDataFileName "templates"
   let templateFile = templateDir </> "with-iterations" <.> "tpl" -- Include number of iterations in HTML report
   pure $ defaultConfig {
                 template = templateFile,
-                reportFile = Just "report.html"
+                reportFile = Just "report.html",
+                timeLimit = limit
               }
 
 {- See the README files in the data directories for the combinations of scripts.
@@ -101,7 +102,7 @@ getConfig = do
    `stack bench -- plutus-benchmark:validation --ba crowdfunding/2`. -}
 main :: IO ()
 main = do
-  config <- getConfig
+  config <- getConfig 20.0  -- Run each benchmark for at least 20 seconds.  Change this with -L or --timeout (longer is better).
   defaultMainWith config
        [ mkBgroup
          "crowdfunding"

--- a/plutus-benchmark/validation/data/make-validations
+++ b/plutus-benchmark/validation/data/make-validations
@@ -1,7 +1,7 @@
 #!/bin/bash
-cd crowdfunding          && make-validations
-cd ../future             && make-validations
-cd ../multisigSM         && make-validations
-cd ../vesting            && make-validations
-cd ../marlowe/trustfund  && make-validations
-cd ../zerocoupom         && make-validations
+cd crowdfunding          && ./make-validations
+cd ../future             && ./make-validations
+cd ../multisigSM         && ./make-validations
+cd ../vesting            && ./make-validations
+cd ../marlowe/trustfund  && ./make-validations
+cd ../zerocoupon         && ./make-validations


### PR DESCRIPTION
This increases the time limit for validation benchmark execution to 20 seconds per script  (from the default of 5 seconds), which should improve the accuracy of the results.  With this limit, the entire `validation` suite takes about 10 minutes on my laptop.  The limit for the `nofib` examples was already 60s and I haven't changed that.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
