### PR TITLE
SCP-2123: Add a nicer interface to the cost model for the ledger

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -77,6 +77,7 @@
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."prettyprinter-configurable" or (errorHandler.buildDepError "prettyprinter-configurable"))
           (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
+          (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."semigroupoids" or (errorHandler.buildDepError "semigroupoids"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
@@ -90,6 +91,7 @@
           (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))
           (hsPkgs."th-utilities" or (errorHandler.buildDepError "th-utilities"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           ];
         build-tools = [
@@ -175,6 +177,7 @@
           "UntypedPlutusCore/Size"
           "UntypedPlutusCore/Subst"
           "UntypedPlutusCore/Transform/Simplify"
+          "Data/Aeson/Flatten"
           "Data/Aeson/THReader"
           "Data/Functor/Foldable/Monadic"
           "PlutusCore"

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
@@ -81,5 +81,18 @@
           ];
         hsSourceDirs = [ "src" ];
         };
+      tests = {
+        "plutus-ledger-api-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
       };
     } // rec { src = (pkgs.lib).mkDefault ../plutus-ledger-api; }

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -220,6 +220,7 @@ library
         UntypedPlutusCore.Subst
         UntypedPlutusCore.Transform.Simplify
 
+        Data.Aeson.Flatten
         Data.Aeson.THReader
         Data.Functor.Foldable.Monadic
     build-depends:
@@ -263,6 +264,7 @@ library
         prettyprinter >=1.1.0.1,
         prettyprinter-configurable -any,
         recursion-schemes -any,
+        scientific -any,
         semigroupoids -any,
         semigroups -any,
         serialise -any,
@@ -276,6 +278,7 @@ library
         th-lift-instances -any,
         th-utilities -any,
         transformers -any,
+        unordered-containers -any,
         witherable -any
 
 test-suite plutus-core-test

--- a/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
+++ b/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
@@ -1,0 +1,48 @@
+module Data.Aeson.Flatten
+    ( flattenObject
+    , unflattenObject
+    , mergeObject
+    , mergeValue
+    ) where
+
+import           Data.Aeson
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text           as Text
+
+-- | Turn a nested object into a "flat" object where the keys represent paths into the original object. The keys in the result
+-- will be the keys in the original path, separated by `sep`. The inverse of 'unflattenObject'.
+flattenObject :: Text.Text -> Object -> Object
+flattenObject sep = go Nothing
+    where
+        go :: Maybe Text.Text -> Object -> Object
+        go mprefix = HM.foldMapWithKey $ \k v ->
+            let newName = case mprefix of
+                    Just prefix -> prefix <> sep <> k
+                    Nothing     -> k
+            in case v of
+                Object o -> go (Just newName) o
+                leaf     -> HM.singleton newName leaf
+
+-- | Turn a "flat" object whose keys represent paths into an unflattened object. The keys in the result will be the get
+-- resulting path, separated by `sep`. The inverse of 'flattenObject'.
+unflattenObject :: Text.Text -> Object -> Object
+unflattenObject sep = HM.foldlWithKey (\acc k v -> mergeObject acc (mkPathObject k v)) mempty
+    where
+        mkPathObject :: Text.Text -> Value -> Object
+        mkPathObject k value =
+            let path = Text.splitOn sep k
+            in go path value
+            where
+                go :: [Text.Text] -> Value -> Object
+                go [] _        = error "empty path"
+                go [n] v       = HM.singleton n v
+                go (n:n':xs) v = HM.singleton n $ Object $ go (n':xs) v
+
+-- | Merge two objects, merging the values where both sides have an entry for a key rather than taking the first.
+mergeObject :: Object -> Object -> Object
+mergeObject = HM.unionWith mergeValue
+
+-- | Merge two values, merging the objects using 'mergeObject'. Can't merge anything else.
+mergeValue :: Value -> Value -> Value
+mergeValue (Object o1) (Object o2) = Object $ mergeObject o1 o2
+mergeValue _ _                     = error "can't merge"

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgeting.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgeting.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -27,6 +30,9 @@ module PlutusCore.Evaluation.Machine.ExBudgeting
     , runCostingFunThreeArguments
     , toCostUnit
     , Hashable
+    , CostModelParams
+    , extractModelParams
+    , applyModelParams
     )
 where
 
@@ -36,11 +42,17 @@ import           PlutusCore.Evaluation.Machine.ExBudget
 import           PlutusCore.Evaluation.Machine.ExMemory
 
 import           Barbies
+import           Data.Aeson
+import           Data.Aeson.Flatten
 import           Data.Default.Class
+import qualified Data.HashMap.Strict                    as HM
 import           Data.Hashable
 import qualified Data.Kind                              as Kind
+import qualified Data.Map                               as Map
+import qualified Data.Scientific                        as S
+import qualified Data.Text                              as Text
 import           Deriving.Aeson
-import           Language.Haskell.TH.Syntax             hiding (Name)
+import           Language.Haskell.TH.Syntax             hiding (Name, newName)
 
 type CostModel = CostModelBase CostingFun
 
@@ -90,6 +102,73 @@ data CostModelBase f =
 
 deriving via CustomJSON '[FieldLabelModifier (StripPrefix "param", CamelToSnake)] (CostModelBase CostingFun) instance ToJSON (CostModelBase CostingFun)
 deriving via CustomJSON '[FieldLabelModifier (StripPrefix "param", CamelToSnake)] (CostModelBase CostingFun) instance FromJSON (CostModelBase CostingFun)
+
+{- Note [Cost model parameters]
+We want to expose to the ledger some notion of the "cost model parameters". Intuitively, these should be all the numbers that appear in the cost model.
+
+However, there are quite a few quirks to deal with.
+
+1. CostModel is stuctured
+
+That is, it's a complex data structure and the numbers in question are often nested inside it.
+To deal with this quickly, we take the ugly approach of operating on the JSON representation of the model.
+We flatten this down into a simple key-value mapping (see 'flattenObject' and 'unflattenObject'), and then
+look only at the numbers.
+
+2. We use floats, not integers
+
+We'd really prefer to expose integers as our parameters - they're just better behaved, and really we'd like to use integers
+internally too for determinism reasons. So we pretend that we have integers by scaling up all our numbers by 1000 and taking
+the integral floor, at some loss of precision.
+
+Once we use integers internally this will be simpler.
+
+3. CostModel includes the *type* of the model, which isn't a parameter
+
+We can just strip the out, but in particular this means that the parameters are not enough to *construct* a model.
+So we punt and say that you can *update* a model by giving the parameters. So you can take the default model and then
+overwrite the parameters, which seems okay.
+
+This is also implemented in a horrible JSON-y way.
+
+4. The implementation is not nice
+
+Ugly JSON stuff and failure possibilities where there probably shouldn't be any.
+-}
+
+-- See Note [Cost model parameters]
+type CostModelParams = Map.Map Text.Text Integer
+
+-- See Note [Cost model parameters]
+-- | Extract the model parameters from a model.
+extractModelParams :: CostModel -> Maybe CostModelParams
+extractModelParams cm = case toJSON cm of
+    Object o ->
+        let
+            flattened = flattenObject "-" o
+            toScaledInteger :: S.Scientific -> Integer
+            toScaledInteger n = floor (n*1000)
+            scaledNumbers = HM.mapMaybe (\case { Number n -> Just $ toScaledInteger n; _ -> Nothing }) flattened
+            mapified = Map.fromList $ HM.toList scaledNumbers
+        in Just mapified
+    _ -> Nothing
+
+-- See Note [Cost model parameters]
+-- | Update a model by overwriting the parameters with the given ones.
+applyModelParams :: CostModel -> CostModelParams -> Maybe CostModel
+applyModelParams cm params = case toJSON cm of
+    Object o ->
+        let
+            hashmapified = HM.fromList $ Map.toList params
+            scaledNumbers = fmap (\n -> Number $ fromIntegral n / 1000) hashmapified
+            flattened = flattenObject "-" o
+            -- this is where the overwriting happens, this is left-biased
+            merged = HM.union scaledNumbers flattened
+            unflattened = unflattenObject "-" merged
+        in case fromJSON (Object unflattened) of
+            Success a -> Just a
+            Error _   -> Nothing
+    _ -> Nothing
 
 type AllArgumentModels (constraint :: Kind.Type -> Kind.Constraint) f = (constraint (f ModelOneArgument), constraint (f ModelTwoArguments), constraint (f ModelThreeArguments))
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -4,9 +4,14 @@ module PlutusCore.Evaluation.Machine.ExBudgetingDefaults where
 import           Data.Aeson.THReader
 import           PlutusCore.Evaluation.Machine.ExBudgeting
 
+-- | The default cost model.
 defaultCostModel :: CostModel
 defaultCostModel =
   $$(readJSONFromFile "cost-model/data/costModel.json")
+
+-- | The default cost model parameters.
+defaultCostModelParams :: Maybe CostModelParams
+defaultCostModelParams = extractModelParams defaultCostModel
 
 -- Use this one when you've changed the type of `CostModel` and you can't load the json.
 -- Then rerun

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -77,3 +77,14 @@ library
         newtype-generics -any,
         tagged -any,
         lens -any
+
+test-suite plutus-ledger-api-test
+    import: lang
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: test
+    build-depends:
+        base >=4.9 && <5,
+        plutus-ledger-api -any,
+        tasty -any,
+        tasty-hunit -any

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -8,6 +8,11 @@ module Plutus.V1.Ledger.Api (
     Script
     -- * Validating scripts
     , validateScript
+    -- * Cost model
+    , validateAndCreateCostModel
+    , defaultCostModelParams
+    , CostModel
+    , CostModelParams
     -- * Running scripts
     , evaluateScriptRestricting
     , evaluateScriptCounting
@@ -68,7 +73,7 @@ import           Control.Monad.Writer
 import           Data.Bifunctor
 import           Data.ByteString.Short
 import           Data.Either
-import qualified Data.Text                                 as Text
+import qualified Data.Text                                         as Text
 import           Data.Text.Prettyprint.Doc
 import           Data.Tuple
 import qualified Flat
@@ -79,22 +84,23 @@ import           Plutus.V1.Ledger.Credential
 import           Plutus.V1.Ledger.Crypto
 import           Plutus.V1.Ledger.DCert
 import           Plutus.V1.Ledger.Interval
-import           Plutus.V1.Ledger.Scripts                  hiding (Script)
-import qualified Plutus.V1.Ledger.Scripts                  as Scripts
+import           Plutus.V1.Ledger.Scripts                          hiding (Script)
+import qualified Plutus.V1.Ledger.Scripts                          as Scripts
 import           Plutus.V1.Ledger.Slot
-import qualified PlutusCore                                as PLC
-import           PlutusCore.Constant                       (toBuiltinsRuntime)
-import qualified PlutusCore.DeBruijn                       as PLC
-import           PlutusCore.Evaluation.Machine.ExBudget    (ExBudget (..))
-import qualified PlutusCore.Evaluation.Machine.ExBudget    as PLC
-import           PlutusCore.Evaluation.Machine.ExBudgeting (CostModel)
-import           PlutusCore.Evaluation.Machine.ExMemory    (ExCPU (..), ExMemory (..))
-import qualified PlutusCore.MkPlc                          as PLC
+import qualified PlutusCore                                        as PLC
+import           PlutusCore.Constant                               (toBuiltinsRuntime)
+import qualified PlutusCore.DeBruijn                               as PLC
+import           PlutusCore.Evaluation.Machine.ExBudget            (ExBudget (..))
+import qualified PlutusCore.Evaluation.Machine.ExBudget            as PLC
+import           PlutusCore.Evaluation.Machine.ExBudgeting         (CostModel, CostModelParams, applyModelParams)
+import           PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCostModel, defaultCostModelParams)
+import           PlutusCore.Evaluation.Machine.ExMemory            (ExCPU (..), ExMemory (..))
+import qualified PlutusCore.MkPlc                                  as PLC
 import           PlutusCore.Pretty
-import           PlutusTx                                  (Data (..), IsData (..))
-import qualified PlutusTx.Lift                             as PlutusTx
-import qualified UntypedPlutusCore                         as UPLC
-import qualified UntypedPlutusCore.Evaluation.Machine.Cek  as UPLC
+import           PlutusTx                                          (Data (..), IsData (..))
+import qualified PlutusTx.Lift                                     as PlutusTx
+import qualified UntypedPlutusCore                                 as UPLC
+import qualified UntypedPlutusCore.Evaluation.Machine.Cek          as UPLC
 
 plutusScriptEnvelopeType :: Text.Text
 plutusScriptEnvelopeType = "PlutusV1Script"
@@ -119,6 +125,9 @@ anything, we're just going to create new versions.
 -- implies that it is (almost certainly) an encoded script and cannot be interpreted as some other kind of encoded data.
 validateScript :: Script -> Bool
 validateScript = isRight . Flat.unflat @Scripts.Script . fromShort
+
+validateAndCreateCostModel :: CostModelParams -> Maybe CostModel
+validateAndCreateCostModel = applyModelParams defaultCostModel
 
 data VerboseMode = Verbose | Quiet
     deriving (Eq)

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -1,0 +1,28 @@
+module Main(main) where
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Data.Either
+import           Data.Maybe
+import           Plutus.V1.Ledger.Api
+import           Plutus.V1.Ledger.Examples
+
+main :: IO ()
+main = defaultMain tests
+
+alwaysTrue :: TestTree
+alwaysTrue = testCase "always true script returns true" $
+    let (_, res) = evaluateScriptCounting Quiet (fromJust $ validateAndCreateCostModel =<< defaultCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
+    in assertBool "succeeds" (isRight res)
+
+alwaysFalse :: TestTree
+alwaysFalse = testCase "always false script returns false" $
+    let (_, res) = evaluateScriptCounting Quiet (fromJust $ validateAndCreateCostModel =<< defaultCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
+    in assertBool "fails" (isLeft res)
+
+tests :: TestTree
+tests = testGroup "plutus-ledger-api" [
+    alwaysTrue
+    , alwaysFalse
+    ]


### PR DESCRIPTION
This gives the ledger an interface that looks like a bag of named
integer parameters.

The implementation is ugly. I wanted this to work today, so I went with
something cheap and unpleasant: it would be nice to have something more
principled, but the current version does work.

We may want to revisit any number of these things. We can get rid of
some ugliness once we also use integetrs internally. But also stuff
like: the set of keys is derived from our current JSONification, which
isn't ideal, it should be highly stable. However, apparently it's okay
if we change the keys a bit before the testnet, so we can come back to
this.

Finally, I added some actual tests that the example scripts work, which
is helpful!

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
