### PR TITLE
deployment: fix plutus-docs reference

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,9 +93,8 @@ rec {
 
   deployment = pkgs.recurseIntoAttrs (pkgs.callPackage ./deployment/morph {
     plutus = {
-      plutus-docs = docs;
       inherit plutus-pab marlowe-app marlowe-companion-app
-        marlowe-dashboard marlowe-playground plutus-playground web-ghc;
+        marlowe-dashboard marlowe-playground plutus-playground web-ghc docs;
     };
   });
 

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -31,7 +31,7 @@
               marlowe-playground = plutus.marlowe-playground;
               plutus-playground = plutus.plutus-playground;
               web-ghc = plutus.web-ghc;
-              plutus-docs = plutus.plutus-docs;
+              plutus-docs = plutus.docs;
             })
           ];
         };


### PR DESCRIPTION
Fix the `plutus-docs` reference which was correct for `deployment`
but broken for `morph build`: `plutus-docs <-> docs`


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge