### PR TITLE
SCP-2147: Keep all logs in ResumableState

### DIFF
--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -53,7 +53,7 @@ import           Plutus.Contract.Schema               (Event (..), Handlers (..)
 import           Plutus.Contract.Trace                (handleBlockchainQueries)
 import           Plutus.Contract.Trace.RequestHandler (RequestHandler (..), RequestHandlerLogMsg, tryHandler,
                                                        wrapHandler)
-import           Plutus.Contract.Types                (ResumableResult (..), logs, requests, resumableResult)
+import           Plutus.Contract.Types                (ResumableResult (..), lastLogs, requests, resumableResult)
 import           Plutus.Trace.Emulator.Types          (ContractConstraints, ContractHandle (..),
                                                        ContractInstanceLog (..), ContractInstanceMsg (..),
                                                        ContractInstanceState (..), ContractInstanceStateInternal (..),
@@ -347,5 +347,5 @@ logNewMessages :: forall w s e effs.
     )
     => Eff effs ()
 logNewMessages = do
-    newContractLogs <- gets @(ContractInstanceStateInternal w s e ()) (view (resumableResult . logs) . cisiSuspState)
+    newContractLogs <- gets @(ContractInstanceStateInternal w s e ()) (view lastLogs . cisiSuspState)
     traverse_ (send . LMessage . fmap ContractLog) newContractLogs


### PR DESCRIPTION
* `ResumableState` should keep all the log messages, not just the most recent ones. Otherwise we will never see them in the web API.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
