### PR TITLE
SCP-2098 - Connect metadata to contracts in the Haskell editor

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -17,7 +17,7 @@ import Data.Either (Either(..), hush)
 import Data.Foldable (for_)
 import Data.Lens (assign, modifying, use)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.String as String
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
@@ -25,12 +25,13 @@ import Examples.Haskell.Contracts (example) as HE
 import Halogen (HalogenM, liftEffect, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
-import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings)
+import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings, _metadataHintInfo)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult(..))
 import Language.Haskell.Monaco as HM
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe (postRunghc)
 import Marlowe.Extended (Contract, getPlaceholderIds, typeToLens, updateTemplateContent)
+import Marlowe.Extended.Metadata (MetadataHintInfo, getMetadataHintInfo)
 import Marlowe.Holes (fromTerm)
 import Marlowe.Parser (parseContract)
 import Monaco (IMarkerData, markerSeverity)
@@ -87,8 +88,13 @@ handleAction Compile = do
           let
             mContract :: Maybe Contract
             mContract = (fromTerm <=< hush <<< parseContract) interpretedResult.result
+
+            metadataHints :: MetadataHintInfo
+            metadataHints = maybe mempty getMetadataHintInfo mContract
           in
-            for_ mContract $ (modifying (_analysisState <<< _templateContent)) <<< updateTemplateContent <<< getPlaceholderIds
+            for_ mContract \contract -> do
+              modifying (_analysisState <<< _templateContent) $ updateTemplateContent $ getPlaceholderIds contract
+              assign _metadataHintInfo metadataHints
         _ -> pure unit
       let
         markers = case result of
@@ -104,11 +110,14 @@ handleAction (BottomPanelAction action) = do
 
 handleAction SendResultToSimulator = pure unit
 
-handleAction (InitHaskellProject contents) = do
+handleAction (InitHaskellProject metadataHints contents) = do
   editorSetValue contents
+  assign _metadataHintInfo metadataHints
   liftEffect $ SessionStorage.setItem haskellBufferLocalStorageKey contents
 
 handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
+
+handleAction (MetadataAction _) = pure unit
 
 handleAction AnalyseContract = analyze (WarningAnalysis Loading) $ analyseContract
 

--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -15,14 +15,14 @@ import Control.Monad.Reader (class MonadAsk, asks, runReaderT)
 import Data.Array (catMaybes)
 import Data.Either (Either(..), hush)
 import Data.Foldable (for_)
-import Data.Lens (assign, modifying, use)
+import Data.Lens (assign, modifying, over, set, use)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.String as String
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Examples.Haskell.Contracts (example) as HE
-import Halogen (HalogenM, liftEffect, query)
+import Halogen (HalogenM, liftEffect, modify_, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings, _metadataHintInfo)
@@ -92,9 +92,10 @@ handleAction Compile = do
             metadataHints :: MetadataHintInfo
             metadataHints = maybe mempty getMetadataHintInfo mContract
           in
-            for_ mContract \contract -> do
-              modifying (_analysisState <<< _templateContent) $ updateTemplateContent $ getPlaceholderIds contract
-              assign _metadataHintInfo metadataHints
+            for_ mContract \contract ->
+              modify_
+                $ over (_analysisState <<< _templateContent) (updateTemplateContent $ getPlaceholderIds contract)
+                <<< set _metadataHintInfo metadataHints
         _ -> pure unit
       let
         markers = case result of

--- a/marlowe-playground-client/src/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/HaskellEditor/View.purs
@@ -19,11 +19,12 @@ import Halogen.HTML.Events (onClick, onSelectedIndexChange)
 import Halogen.HTML.Properties (class_, classes, enabled)
 import Halogen.HTML.Properties as HTML
 import Halogen.Monaco (monacoComponent)
-import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings)
+import HaskellEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _haskellEditorKeybindings, _metadataHintInfo)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult(..))
 import Language.Haskell.Monaco as HM
 import MainFrame.Types (ChildSlots, _haskellEditorSlot)
 import Marlowe.Extended.Metadata (MetaData)
+import MetadataTab.View (metadataView)
 import Network.RemoteData (RemoteData(..), _Success)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
@@ -48,7 +49,8 @@ render metadata state =
     ]
   where
   panelTitles =
-    [ { title: "Generated code", view: GeneratedOutputView, classes: [] }
+    [ { title: "Metadata", view: MetadataView, classes: [] }
+    , { title: "Generated code", view: GeneratedOutputView, classes: [] }
     , { title: "Static Analysis", view: StaticAnalysisView, classes: [] }
     , { title: "Errors", view: ErrorsView, classes: [] }
     ]
@@ -177,6 +179,8 @@ panelContents state _ ErrorsView =
     Success (Left (TimeoutError error)) -> [ text error ]
     Success (Left (CompilationErrors errors)) -> map compilationErrorPane errors
     _ -> [ text "No errors" ]
+
+panelContents state metadata MetadataView = metadataView (state ^. _metadataHintInfo) metadata MetadataAction
 
 compilationErrorPane :: forall p. CompilationError -> HTML p Action
 compilationErrorPane (RawError error) = div_ [ text error ]

--- a/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
+++ b/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
@@ -3,7 +3,7 @@ module Marlowe.Extended.Metadata where
 import Prelude
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
-import Data.Map (Map)
+import Data.Map (Map, keys)
 import Data.Maybe (Maybe(..))
 import Data.Set (Set)
 import Data.Set as Set
@@ -89,3 +89,15 @@ getMetadataHintInfo contract =
     , valueParameters: placeholders.valuePlaceholderIds
     , choiceNames: getChoiceNames contract
     }
+
+getHintsFromMetadata :: MetaData -> MetadataHintInfo
+getHintsFromMetadata { roleDescriptions
+, slotParameterDescriptions
+, valueParameterDescriptions
+, choiceDescriptions
+} =
+  { roles: keys roleDescriptions
+  , slotParameters: keys slotParameterDescriptions
+  , valueParameters: keys valueParameterDescriptions
+  , choiceNames: keys choiceDescriptions
+  }


### PR DESCRIPTION
This PR adds the Metadata tab to the Haskell editor and adds the loading of metadata hints to Gists, Demos, and LocalStorage.

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
