### PR TITLE
Modify AddressChangeRequest to use SlotRange

### DIFF
--- a/marlowe/test/Spec/Marlowe/AutoExecute.hs
+++ b/marlowe/test/Spec/Marlowe/AutoExecute.hs
@@ -104,7 +104,7 @@ autoexecZCBTest = checkPredicate "ZCB Auto Execute Contract"
     Trace.waitNSlots 1
 
     -- Now Alice should be able to retry and pay to Bob
-    void $ Trace.waitNSlots 1
+    void $ Trace.waitNSlots 2
 
 
 autoexecZCBTestAliceWalksAway :: TestTree

--- a/plutus-contract/src/Plutus/Contract/Effects/WatchAddress.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects/WatchAddress.hs
@@ -31,9 +31,9 @@ import           Data.Row
 import           Ledger                            (Address, Slot, Value)
 import           Ledger.AddressMap                 (AddressMap, UtxoMap)
 import qualified Ledger.AddressMap                 as AM
+import qualified Ledger.Interval                   as Interval
 import           Ledger.Tx                         (Tx, txOutTxOut, txOutValue)
 import qualified Ledger.Value                      as V
-
 import           Plutus.Contract.Effects.AwaitSlot (HasAwaitSlot, awaitSlot, currentSlot)
 import           Plutus.Contract.Effects.UtxoAt    (HasUtxoAt, utxoAt)
 import           Plutus.Contract.Request           (ContractRow, requestMaybe)
@@ -62,8 +62,8 @@ addressChangeRequest ::
     -> Contract w s e AddressChangeResponse
 addressChangeRequest rq =
     let check :: AddressChangeResponse -> Maybe AddressChangeResponse
-        check r@AddressChangeResponse{acrAddress, acrSlot}
-                | acrAddress == acreqAddress rq && acrSlot >= acreqSlot rq = Just r
+        check r@AddressChangeResponse{acrAddress, acrSlotRange}
+                | acrAddress == acreqAddress rq && acrSlotRange >= acreqSlotRange rq = Just r
                 | otherwise = Nothing
     in requestMaybe @w @AddressSymbol @_ @_ @s rq check
 
@@ -80,7 +80,11 @@ nextTransactionsAt ::
 nextTransactionsAt addr = do
     initial <- currentSlot
     let go sl = do
-            txns <- acrTxns <$> addressChangeRequest AddressChangeRequest{acreqSlot = sl, acreqAddress=addr}
+            txns <- acrTxns <$> addressChangeRequest AddressChangeRequest
+                { acreqSlotRange = Interval.singleton sl
+                , acreqAddress = addr
+                }
+
             if null txns
                 then go (succ sl)
                 else pure txns
@@ -147,7 +151,7 @@ events
     -> Tx
     -> Map Address (Event s)
 events sl utxo tx =
-    let mkEvent addr = AddressChangeResponse{acrAddress=addr,acrSlot=sl,acrTxns=[tx]}
+    let mkEvent addr = AddressChangeResponse{acrAddress=addr,acrSlotRange=Interval.singleton sl,acrTxns=[tx]}
     in Map.fromSet
         (Event . IsJust (Label @AddressSymbol) . mkEvent)
         (AM.addressesTouched utxo tx)

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -55,7 +55,6 @@ import           Data.Text                            (Text)
 import qualified Data.Text                            as Text
 import           Data.Void                            (Void, absurd)
 import           GHC.Generics                         (Generic)
-
 import           Ledger                               (Slot, Value)
 import qualified Ledger
 import           Ledger.AddressMap                    (UtxoMap)
@@ -64,6 +63,7 @@ import           Ledger.Constraints.OffChain          (UnbalancedTx)
 import qualified Ledger.Constraints.OffChain          as Constraints
 import           Ledger.Constraints.TxConstraints     (InputConstraint (..), OutputConstraint (..))
 import           Ledger.Crypto                        (pubKeyHash)
+import qualified Ledger.Interval                      as Interval
 import           Ledger.Tx                            as Tx
 import qualified Ledger.Typed.Scripts                 as Scripts
 import           Ledger.Typed.Tx                      (TypedScriptTxOut (..))
@@ -210,7 +210,10 @@ waitForUpdateUntil StateMachineClient{scInstance, scChooser} timeoutSlot = do
                 $ Map.filter ((==) addr . Tx.txOutAddress)
                 $ Tx.unspentOutputsTx t
     let go sl = do
-            txns <- acrTxns <$> addressChangeRequest AddressChangeRequest{acreqSlot = sl, acreqAddress=addr}
+            txns <- acrTxns <$> addressChangeRequest AddressChangeRequest
+                { acreqSlotRange = Interval.singleton sl
+                , acreqAddress = addr
+                }
             if null txns && sl < timeoutSlot
                 then go (succ sl)
                 else pure txns

--- a/plutus-contract/src/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace.hs
@@ -28,7 +28,7 @@ module Plutus.Contract.Trace
     -- * Running 'ContractTrace' actions
     -- * Constructing 'ContractTrace' actions
     , handleUtxoQueries
-    , handleNextTxAtQueries
+    , handleAddressChangedAtQueries
     -- * Handle blockchain events repeatedly
     , handleBlockchainQueries
     , handleSlotNotifications
@@ -147,7 +147,7 @@ handleBlockchainQueries =
     <> handleUtxoQueries
     <> handleTxConfirmedQueries
     <> handleOwnPubKeyQueries
-    <> handleNextTxAtQueries
+    <> handleAddressChangedAtQueries
     <> handleOwnInstanceIdQueries
     <> handleContractNotifications
     <> handleSlotNotifications
@@ -194,7 +194,7 @@ handleTxConfirmedQueries =
     >>> RequestHandler.handleTxConfirmedQueries
     >>^ AwaitTxConfirmed.event . unTxConfirmed
 
-handleNextTxAtQueries ::
+handleAddressChangedAtQueries ::
     ( HasWatchAddress s
     , Member (LogObserve (LogMessage Text)) effs
     , Member (LogMsg RequestHandlerLogMsg) effs
@@ -202,9 +202,9 @@ handleNextTxAtQueries ::
     , Member ChainIndexEffect effs
     )
     => RequestHandler effs (Handlers s) (Event s)
-handleNextTxAtQueries =
+handleAddressChangedAtQueries =
     maybeToHandler WatchAddress.watchAddressRequest
-    >>> RequestHandler.handleNextTxAtQueries
+    >>> RequestHandler.handleAddressChangedAtQueries
     >>^ WatchAddress.event
 
 handleOwnPubKeyQueries ::

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -43,6 +43,7 @@ import qualified Data.Map                                 as Map
 import           Data.Monoid                              (Alt (..), Ap (..))
 import           Data.Text                                (Text)
 import qualified Ledger.AddressMap                        as AM
+import           Ledger.Interval
 
 import           Plutus.Contract.Resumable                (Request (..), Response (..))
 
@@ -183,7 +184,9 @@ handleNextTxAtQueries ::
 handleNextTxAtQueries = RequestHandler $ \req ->
     surroundDebug @Text "handleNextTxAtQueries" $ do
         current <- Wallet.Effects.walletSlot
-        let target = acreqSlot req
+        let target = case acreqSlotRange req of
+                Interval _ (UpperBound (Finite s) in2) -> if in2 then succ s else s
+                Interval _ _                           -> pred current
         logDebug $ HandleNextTxAt current target
         -- If we ask the chain index for transactions that were confirmed in
         -- the current slot, we always get an empty list, because the chain

--- a/plutus-contract/src/Wallet/Effects.hs
+++ b/plutus-contract/src/Wallet/Effects.hs
@@ -33,7 +33,7 @@ module Wallet.Effects(
     , watchedAddresses
     , confirmedBlocks
     , transactionConfirmed
-    , nextTx
+    , addressChanged
     -- * Contract runtime
     , ContractRuntimeEffect(..)
     , sendNotification
@@ -70,7 +70,7 @@ data ChainIndexEffect r where
     ConfirmedBlocks :: ChainIndexEffect [[Tx]]
     -- TODO: In the future we should have degrees of confirmation
     TransactionConfirmed :: TxId -> ChainIndexEffect Bool
-    NextTx :: AddressChangeRequest -> ChainIndexEffect AddressChangeResponse
+    AddressChanged :: AddressChangeRequest -> ChainIndexEffect AddressChangeResponse
 makeEffect ''ChainIndexEffect
 
 {-| Interact with other contracts.

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
@@ -110,7 +110,7 @@ handleChainIndex = interpret $ \case
     ConfirmedBlocks -> gets _idxConfirmedBlocks
     TransactionConfirmed txid ->
         Map.member txid <$> gets _idxConfirmedTransactions
-    NextTx r@AddressChangeRequest{acreqSlotRange, acreqAddress} -> do
+    AddressChanged r@AddressChangeRequest{acreqSlotRange, acreqAddress} -> do
         idx <- gets _idxIdx
         let itms = Index.transactionsAt idx acreqSlotRange acreqAddress
         logDebug $ HandlingAddressChangeRequest r itms

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
@@ -110,12 +110,12 @@ handleChainIndex = interpret $ \case
     ConfirmedBlocks -> gets _idxConfirmedBlocks
     TransactionConfirmed txid ->
         Map.member txid <$> gets _idxConfirmedTransactions
-    NextTx r@AddressChangeRequest{acreqSlot, acreqAddress} -> do
+    NextTx r@AddressChangeRequest{acreqSlotRange, acreqAddress} -> do
         idx <- gets _idxIdx
-        let itms = Index.transactionsAt idx acreqSlot acreqAddress
+        let itms = Index.transactionsAt idx acreqSlotRange acreqAddress
         logDebug $ HandlingAddressChangeRequest r itms
         pure $ AddressChangeResponse
             { acrAddress=acreqAddress
-            , acrSlot=acreqSlot
+            , acrSlotRange=acreqSlotRange
             , acrTxns = fmap ciTx itms
             }

--- a/plutus-contract/src/Wallet/Emulator/LogMessages.hs
+++ b/plutus-contract/src/Wallet/Emulator/LogMessages.hs
@@ -14,14 +14,14 @@ import           Data.Text.Prettyprint.Doc   (Pretty (..), hang, viaShow, vsep, 
 import           GHC.Generics                (Generic)
 import           Ledger                      (Address)
 import           Ledger.Constraints.OffChain (UnbalancedTx)
-import           Ledger.Slot                 (Slot)
+import           Ledger.Slot                 (Slot, SlotRange)
 import           Ledger.Value                (Value)
 import           Wallet.Emulator.Error       (WalletAPIError)
 
 data RequestHandlerLogMsg =
     SlotNoficationTargetVsCurrent Slot Slot
     | StartWatchingContractAddresses
-    | HandleNextTxAt Slot Slot
+    | HandleAddressChangedAt Slot SlotRange
     | HandleTxFailed WalletAPIError
     | UtxoAtFailed Address
     deriving stock (Eq, Ord, Show, Generic)
@@ -33,9 +33,9 @@ instance Pretty RequestHandlerLogMsg where
             "target slot:" <+> pretty target <> "; current slot:" <+> pretty current
         StartWatchingContractAddresses -> "Start watching contract addresses"
         HandleTxFailed e -> "handleTx failed:" <+> viaShow e
-        HandleNextTxAt current target ->
-            "handle next tx at. Target:"
-                <+> pretty target
+        HandleAddressChangedAt current slotRange ->
+            "handle address changed at. Range:"
+                <+> pretty slotRange
                 <+> "Current:"
                 <+> pretty current
         UtxoAtFailed addr -> "UtxoAt failed:" <+> pretty addr

--- a/plutus-contract/src/Wallet/Types.hs
+++ b/plutus-contract/src/Wallet/Types.hs
@@ -47,7 +47,7 @@ import qualified Data.UUID.V4                     as UUID
 import           GHC.Generics                     (Generic)
 import qualified Language.Haskell.TH.Syntax       as TH
 
-import           Ledger                           (Address, Slot, Tx, TxIn, TxOut, txId)
+import           Ledger                           (Address, SlotRange, Tx, TxIn, TxOut, txId)
 import           Ledger.Constraints.OffChain      (MkTxError)
 import           Plutus.Contract.Checkpoint       (AsCheckpointError (..), CheckpointError)
 import           Wallet.Emulator.Error            (WalletAPIError)
@@ -191,37 +191,37 @@ emptyPayment :: Payment
 emptyPayment = Payment { paymentInputs = Set.empty, paymentChangeOutput = Nothing }
 
 -- | Information about transactions that spend or produce an output at
---   an address in a slot.
+--   an address in a slot range.
 data AddressChangeResponse =
     AddressChangeResponse
-        { acrAddress :: Address -- ^ The address
-        , acrSlot    :: Slot -- ^ The slot
-        , acrTxns    :: [Tx] -- ^ Transactions that were validated in the slot and spent or produced at least one output at the address.
+        { acrAddress   :: Address -- ^ The address
+        , acrSlotRange :: SlotRange -- ^ The slot range
+        , acrTxns      :: [Tx] -- ^ Transactions that were validated in the slot range and spent or produced at least one output at the address.
         }
         deriving stock (Eq, Generic, Show)
         deriving anyclass (ToJSON, FromJSON)
 
 instance Pretty AddressChangeResponse where
-    pretty AddressChangeResponse{acrAddress, acrTxns, acrSlot} =
+    pretty AddressChangeResponse{acrAddress, acrTxns, acrSlotRange} =
         hang 2 $ vsep
             [ "Address:" <+> pretty acrAddress
-            , "Slot:" <+> pretty acrSlot
+            , "Slot range:" <+> pretty acrSlotRange
             , "Tx IDs:" <+> pretty (txId <$> acrTxns)
             ]
 
 -- | Request for information about transactions that spend or produce
---   outputs at a specific address in a slot.
+--   outputs at a specific address in a slot range.
 data AddressChangeRequest =
     AddressChangeRequest
-        { acreqSlot    :: Slot -- ^ The slot
-        , acreqAddress :: Address -- ^ The address
+        { acreqSlotRange :: SlotRange -- ^ The slot range
+        , acreqAddress   :: Address -- ^ The address
         }
         deriving stock (Eq, Generic, Show, Ord)
         deriving anyclass (ToJSON, FromJSON)
 
 instance Pretty AddressChangeRequest where
-    pretty AddressChangeRequest{acreqSlot, acreqAddress} =
+    pretty AddressChangeRequest{acreqSlotRange, acreqAddress} =
         hang 2 $ vsep
-            [ "Slot:" <+> pretty acreqSlot
+            [ "Slot range:" <+> pretty acreqSlotRange
             , "Address:" <+> pretty acreqAddress
             ]

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -24,7 +24,7 @@ import           Codec.Serialise.Class     (Serialise)
 import           Control.DeepSeq           (NFData)
 import           Data.Aeson                (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import           Data.Hashable             (Hashable)
-import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
+import           Data.Text.Prettyprint.Doc (Pretty (pretty), comma, (<+>))
 import           GHC.Generics              (Generic)
 import qualified Prelude                   as Haskell
 
@@ -48,6 +48,9 @@ makeLift ''Slot
 
 instance Pretty Slot where
     pretty (Slot i) = "Slot" <+> pretty i
+
+instance Pretty (Interval Slot) where
+    pretty (Interval l h) = pretty l <+> comma <+> pretty h
 
 -- | An 'Interval' of 'Slot's.
 type SlotRange = Interval Slot

--- a/plutus-pab-client/src/View/Pretty.purs
+++ b/plutus-pab-client/src/View/Pretty.purs
@@ -104,9 +104,9 @@ instance prettyContractResponse :: Pretty ContractResponse where
       , nbsp
       , text $ show utxoAtAddress
       ]
-  pretty (NextTxAtResponse addressChangeResponse) =
+  pretty (AddressChangedAtResponse addressChangeResponse) =
     span_
-      [ text "NextTxAtResponse:"
+      [ text "AddressChangedAtResponse:"
       , nbsp
       , text $ show addressChangeResponse
       ]
@@ -160,9 +160,9 @@ instance prettyContractPABRequest :: Pretty ContractPABRequest where
       , nbsp
       , text $ show utxoAtAddress
       ]
-  pretty (NextTxAtRequest addressChangeRequest) =
+  pretty (AddressChangedAtRequest addressChangeRequest) =
     span_
-      [ text "NextTxAtRequest:"
+      [ text "AddressChangedAtRequest:"
       , nbsp
       , text $ show addressChangeRequest
       ]

--- a/plutus-pab/src/Cardano/ChainIndex/Client.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Client.hs
@@ -28,11 +28,11 @@ startWatching :: Address -> ClientM NoContent
 watchedAddresses :: ClientM AddressMap
 confirmedBlocks :: ClientM [Block]
 transactionConfirmed :: TxId -> ClientM Bool
-nextTx :: AddressChangeRequest -> ClientM AddressChangeResponse
-(healthCheck, startWatching, watchedAddresses, confirmedBlocks, transactionConfirmed, nextTx) =
-  (healthCheck_, startWatching_, watchedAddresses_, confirmedBlocks_, txConfirmed_, nextTx_)
+addressChanged :: AddressChangeRequest -> ClientM AddressChangeResponse
+(healthCheck, startWatching, watchedAddresses, confirmedBlocks, transactionConfirmed, addressChanged) =
+  (healthCheck_, startWatching_, watchedAddresses_, confirmedBlocks_, txConfirmed_, addressChanged_)
   where
-    healthCheck_ :<|> startWatching_ :<|> watchedAddresses_ :<|> confirmedBlocks_ :<|> txConfirmed_  :<|> nextTx_ =
+    healthCheck_ :<|> startWatching_ :<|> watchedAddresses_ :<|> confirmedBlocks_ :<|> txConfirmed_  :<|> addressChanged_ =
         client (Proxy @API)
 
 handleChainIndexClient ::
@@ -53,4 +53,4 @@ handleChainIndexClient event = do
         WatchedAddresses          -> runClient watchedAddresses
         ConfirmedBlocks           -> runClient confirmedBlocks
         TransactionConfirmed txid -> runClient (transactionConfirmed txid)
-        NextTx req                -> runClient (nextTx req)
+        AddressChanged req        -> runClient (addressChanged req)

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -47,7 +47,7 @@ app trace stateVar =
     hoistServer
         (Proxy @API)
         (liftIO . processIndexEffects trace stateVar)
-        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
+        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.addressChanged)
 
 main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> Availability -> IO ()
 main trace ChainIndexConfig{ciBaseUrl} socketPath availability = runLogEffects trace $ do

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -148,7 +148,7 @@ instance Arbitrary ContractPABRequest where
             , AwaitTxConfirmedRequest <$> arbitrary
             , UserEndpointRequest <$> arbitrary
             , UtxoAtRequest <$> arbitrary
-            , NextTxAtRequest <$> arbitrary
+            , AddressChangedAtRequest <$> arbitrary
             , pure $ OwnPubkeyRequest WaitingForPubKey
             -- TODO This would need an Arbitrary Tx instance: WriteTxRequest <$> arbitrary
             ]
@@ -179,7 +179,7 @@ instance Arbitrary WaitingForSlot where
 -- bad =
 --     [ WriteTxRequest <$> arbitrary
 --     , UtxoAtRequest <$> arbitrary
---     , NextTxAtRequest <$> arbitrary
+--     , AddressChangedAtRequest <$> arbitrary
 --     ]
 
 -- | Generate responses for mock requests. This function returns a

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -47,8 +47,9 @@ import           Plutus.Contract.Effects.ExposeEndpoint           (ActiveEndpoin
 import           Plutus.Contract.Resumable                        (Request (..), Response (..))
 import           Plutus.Contract.Trace.RequestHandler             (RequestHandler (..), RequestHandlerLogMsg, extract,
                                                                    maybeToHandler, tryHandler', wrapHandler)
-import           Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInstanceMsg (..), processInstanceRequests,
-                                                                   processNextTxAtRequests, processNotificationEffects,
+import           Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInstanceMsg (..),
+                                                                   processAddressChangedAtRequests,
+                                                                   processInstanceRequests, processNotificationEffects,
                                                                    processOwnPubkeyRequests, processTxConfirmedRequests,
                                                                    processUtxoAtRequests, processWriteTxRequests)
 
@@ -150,7 +151,7 @@ stmRequestHandler = fmap sequence (wrapHandler (fmap pure nonBlockingRequests) <
         <> processUtxoAtRequests @effs
         <> processWriteTxRequests @effs
         <> processTxConfirmedRequests @effs
-        <> processNextTxAtRequests @effs
+        <> processAddressChangedAtRequests @effs
         <> processInstanceRequests @effs
         <> processNotificationEffects @effs
 
@@ -244,7 +245,7 @@ updateState PartiallyDecodedResponse{observableState, hooks} = do
             case rqRequest r of
                 AwaitTxConfirmedRequest txid -> InstanceState.addTransaction txid state
                 UtxoAtRequest addr -> InstanceState.addAddress addr state
-                NextTxAtRequest AddressChangeRequest{acreqAddress} -> InstanceState.addAddress acreqAddress state
+                AddressChangedAtRequest AddressChangeRequest{acreqAddress} -> InstanceState.addAddress acreqAddress state
                 UserEndpointRequest endpoint -> InstanceState.addEndpoint (r { rqRequest = endpoint}) state
                 _ -> pure ()
         InstanceState.setObservableState observableState state

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
@@ -14,7 +14,7 @@ module Plutus.PAB.Core.ContractInstance.RequestHandlers(
     , processOwnPubkeyRequests
     , processUtxoAtRequests
     , processWriteTxRequests
-    , processNextTxAtRequests
+    , processAddressChangedAtRequests
     , processTxConfirmedRequests
     , processInstanceRequests
     , processNotificationEffects
@@ -83,7 +83,7 @@ processWriteTxRequests =
     >>> RequestHandler.handlePendingTransactions
     >>^ WriteTxResponse . either WriteTxFailed WriteTxSuccess
 
-processNextTxAtRequests ::
+processAddressChangedAtRequests ::
     forall effs.
     ( Member (LogObserve (LogMessage Text.Text)) effs
     , Member WalletEffect effs
@@ -91,10 +91,10 @@ processNextTxAtRequests ::
     , Member (LogMsg RequestHandlerLogMsg) effs
     )
     => RequestHandler effs ContractPABRequest ContractResponse
-processNextTxAtRequests =
-    maybeToHandler (extract Events.Contract._NextTxAtRequest)
-    >>> RequestHandler.handleNextTxAtQueries
-    >>^ NextTxAtResponse
+processAddressChangedAtRequests =
+    maybeToHandler (extract Events.Contract._AddressChangedAtRequest)
+    >>> RequestHandler.handleAddressChangedAtQueries
+    >>^ AddressChangedAtResponse
 
 processTxConfirmedRequests ::
     forall effs.

--- a/plutus-pab/src/Plutus/PAB/Events/Contract.hs
+++ b/plutus-pab/src/Plutus/PAB/Events/Contract.hs
@@ -22,7 +22,7 @@ module Plutus.PAB.Events.Contract(
   , _UserEndpointRequest
   , _OwnPubkeyRequest
   , _UtxoAtRequest
-  , _NextTxAtRequest
+  , _AddressChangedAtRequest
   , _WriteTxRequest
   , _OwnInstanceIdRequest
   , _SendNotificationRequest
@@ -32,7 +32,7 @@ module Plutus.PAB.Events.Contract(
   , _UserEndpointResponse
   , _OwnPubkeyResponse
   , _UtxoAtResponse
-  , _NextTxAtResponse
+  , _AddressChangedAtResponse
   , _WriteTxResponse
   , _OwnInstanceResponse
   , _NotificationResponse
@@ -56,7 +56,7 @@ import qualified Plutus.Contract.Effects.Instance         as Instance
 import qualified Plutus.Contract.Effects.Notify           as Notify
 import qualified Plutus.Contract.Effects.OwnPubKey        as OwnPubKey
 import qualified Plutus.Contract.Effects.UtxoAt           as UtxoAt
-import qualified Plutus.Contract.Effects.WatchAddress     as NextTxAt
+import qualified Plutus.Contract.Effects.WatchAddress     as AddressChangedAt
 import qualified Plutus.Contract.Effects.WriteTx          as W
 import qualified Plutus.Contract.Effects.WriteTx          as WriteTx
 import           Plutus.Contract.Resumable                (IterationID)
@@ -112,7 +112,7 @@ data ContractPABRequest =
   | UserEndpointRequest ActiveEndpoint -- ^ Expose a named endpoint to the user.
   | OwnPubkeyRequest OwnPubKeyRequest -- ^ Request a public key. It is expected that the wallet treats any outputs locked by this public key as part of its own funds.
   | UtxoAtRequest Address -- ^ Get the unspent transaction outputs at the address.
-  | NextTxAtRequest AddressChangeRequest -- ^ Wait for the next transaction that modifies the UTXO at the address and return it.
+  | AddressChangedAtRequest AddressChangeRequest -- ^ Wait for the next transaction that modifies the UTXO at the address and return it.
   | WriteTxRequest UnbalancedTx -- ^ Submit an unbalanced transaction to the PAB.
   | OwnInstanceIdRequest OwnIdRequest -- ^ Request the ID of the contract instance.
   | SendNotificationRequest Notification -- ^ Send a notification to another contract instance
@@ -131,7 +131,7 @@ instance FromJSON ContractHandlerRequest where
             "tx-confirmation" -> AwaitTxConfirmedRequest <$> v .: "value"
             "own-pubkey"      -> OwnPubkeyRequest <$> v .: "value"
             "utxo-at"         -> UtxoAtRequest <$> v.: "value"
-            "address"         -> NextTxAtRequest <$> v .: "value"
+            "address"         -> AddressChangedAtRequest <$> v .: "value"
             "tx"              -> WriteTxRequest <$> v .: "value"
             "own-instance-id" -> OwnInstanceIdRequest <$> v .: "value"
             "notify-instance" -> SendNotificationRequest <$> v .: "value"
@@ -144,7 +144,7 @@ instance Pretty ContractPABRequest where
         UserEndpointRequest t     -> "UserEndpoint:" <+> pretty t
         OwnPubkeyRequest r        -> "OwnPubKey:" <+> pretty r
         UtxoAtRequest a           -> "UtxoAt:" <+> pretty a
-        NextTxAtRequest a         -> "NextTxAt:" <+> pretty a
+        AddressChangedAtRequest a -> "AddressChangedAt:" <+> pretty a
         WriteTxRequest u          -> "WriteTx:" <+> pretty u
         OwnInstanceIdRequest r    -> "OwnInstanceId:" <+> pretty r
         SendNotificationRequest n -> "Notification:" <+> pretty n
@@ -155,7 +155,7 @@ data ContractResponse =
   | UserEndpointResponse EndpointDescription (EndpointValue Value)
   | OwnPubkeyResponse PubKey
   | UtxoAtResponse UtxoAtAddress
-  | NextTxAtResponse AddressChangeResponse
+  | AddressChangedAtResponse AddressChangeResponse
   | WriteTxResponse W.WriteTxResponse
   | OwnInstanceResponse ContractInstanceId
   | NotificationResponse (Maybe NotificationError)
@@ -164,15 +164,15 @@ data ContractResponse =
 
 instance Pretty ContractResponse where
     pretty = \case
-        AwaitSlotResponse s        -> "AwaitSlot:" <+> pretty s
-        UserEndpointResponse n r   -> "UserEndpoint:" <+> pretty n <+> pretty r
-        OwnPubkeyResponse pk       -> "OwnPubKey:" <+> pretty pk
-        UtxoAtResponse utxo        -> "UtxoAt:" <+> pretty utxo
-        NextTxAtResponse rsp       -> "NextTxAt:" <+> pretty rsp
-        WriteTxResponse w          -> "WriteTx:" <+> pretty w
-        AwaitTxConfirmedResponse w -> "AwaitTxConfirmed:" <+> pretty w
-        OwnInstanceResponse r      -> "OwnInstance:" <+> pretty r
-        NotificationResponse r     -> "Notification:" <+> pretty r
+        AwaitSlotResponse s          -> "AwaitSlot:" <+> pretty s
+        UserEndpointResponse n r     -> "UserEndpoint:" <+> pretty n <+> pretty r
+        OwnPubkeyResponse pk         -> "OwnPubKey:" <+> pretty pk
+        UtxoAtResponse utxo          -> "UtxoAt:" <+> pretty utxo
+        AddressChangedAtResponse rsp -> "AddressChangedAt:" <+> pretty rsp
+        WriteTxResponse w            -> "WriteTx:" <+> pretty w
+        AwaitTxConfirmedResponse w   -> "AwaitTxConfirmed:" <+> pretty w
+        OwnInstanceResponse r        -> "OwnInstance:" <+> pretty r
+        NotificationResponse r       -> "Notification:" <+> pretty r
 
 -- | 'ContractResponse' with a 'ToJSON' instance that is compatible with
 --   the 'FromJSON' instance of 'Plutus.Contract.Schema.Event'.
@@ -183,7 +183,7 @@ instance ToJSON ContractHandlersResponse where
         AwaitSlotResponse s  -> toJSON $ AwaitSlot.event @AwaitSlot.AwaitSlot s
         OwnPubkeyResponse pk -> toJSON $ OwnPubKey.event @OwnPubKey.OwnPubKey pk
         UtxoAtResponse utxo  -> toJSON $ UtxoAt.event @UtxoAt.UtxoAt utxo
-        NextTxAtResponse rsp -> toJSON $ NextTxAt.event @NextTxAt.WatchAddress rsp
+        AddressChangedAtResponse rsp -> toJSON $ AddressChangedAt.event @AddressChangedAt.WatchAddress rsp
         WriteTxResponse rsp -> toJSON $ WriteTx.event @WriteTx.WriteTx rsp
         AwaitTxConfirmedResponse (TxConfirmed rsp) -> toJSON $ AwaitTxConfirmed.event @AwaitTxConfirmed.TxConfirmation rsp
         OwnInstanceResponse r -> toJSON $ Instance.event @Instance.OwnId r

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -560,7 +560,7 @@ handleChainIndexEffect = runChainIndexEffects @t . \case
     WatchedAddresses          -> WalletEffects.watchedAddresses
     ConfirmedBlocks           -> WalletEffects.confirmedBlocks
     TransactionConfirmed txid -> WalletEffects.transactionConfirmed txid
-    NextTx r                  -> WalletEffects.nextTx r
+    AddressChanged r          -> WalletEffects.addressChanged r
 
 handleChainIndexControlEffect ::
     forall t effs.

--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -231,7 +231,11 @@ waitForChange AuctionParams{apEndTime} client lastHighestBid = do
                                            -- use succ.succ instead of just a single succ if we want 'addressChangeRequest'
                                            -- to wait for the next slot to begin.
                                            -- I don't have the time to look into that atm though :(
-            AddressChangeResponse{acrTxns} <- addressChangeRequest AddressChangeRequest{acreqSlot=targetSlot, acreqAddress = address}
+            AddressChangeResponse{acrTxns} <- addressChangeRequest
+                AddressChangeRequest
+                { acreqSlotRange = Interval.singleton targetSlot
+                , acreqAddress = address
+                }
             case acrTxns of
                 [] -> pure (NoChange lastHighestBid)
                 _  -> currentState client >>= pure . maybe (AuctionIsOver lastHighestBid) OtherBid


### PR DESCRIPTION
Modify `AddressChangeRequest` to use `SlotRange`. Now it returns all transactions that modify an address within the SlotRange. 
This modified `AddressChangeRequest` now can be used to get a history of a contract execution. This is needed for Marlowe Run contract execution in particular.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
