### PR TITLE
Tweak the ledger interface for the cost model again

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -9,9 +9,8 @@ module Plutus.V1.Ledger.Api (
     -- * Validating scripts
     , validateScript
     -- * Cost model
-    , validateAndCreateCostModel
+    , validateCostModelParams
     , defaultCostModelParams
-    , CostModel
     , CostModelParams
     -- * Running scripts
     , evaluateScriptRestricting
@@ -73,6 +72,7 @@ import           Control.Monad.Writer
 import           Data.Bifunctor
 import           Data.ByteString.Short
 import           Data.Either
+import           Data.Maybe                                        (isJust)
 import qualified Data.Text                                         as Text
 import           Data.Text.Prettyprint.Doc
 import           Data.Tuple
@@ -92,7 +92,7 @@ import           PlutusCore.Constant                               (toBuiltinsRu
 import qualified PlutusCore.DeBruijn                               as PLC
 import           PlutusCore.Evaluation.Machine.ExBudget            (ExBudget (..))
 import qualified PlutusCore.Evaluation.Machine.ExBudget            as PLC
-import           PlutusCore.Evaluation.Machine.ExBudgeting         (CostModel, CostModelParams, applyModelParams)
+import           PlutusCore.Evaluation.Machine.ExBudgeting         (CostModelParams, applyModelParams)
 import           PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCostModel, defaultCostModelParams)
 import           PlutusCore.Evaluation.Machine.ExMemory            (ExCPU (..), ExMemory (..))
 import qualified PlutusCore.MkPlc                                  as PLC
@@ -126,8 +126,8 @@ anything, we're just going to create new versions.
 validateScript :: Script -> Bool
 validateScript = isRight . Flat.unflat @Scripts.Script . fromShort
 
-validateAndCreateCostModel :: CostModelParams -> Maybe CostModel
-validateAndCreateCostModel = applyModelParams defaultCostModel
+validateCostModelParams :: CostModelParams -> Bool
+validateCostModelParams = isJust . applyModelParams defaultCostModel
 
 data VerboseMode = Verbose | Quiet
     deriving (Eq)
@@ -143,7 +143,8 @@ data EvaluationError =
     | DeBruijnError PLC.FreeVariableError -- ^ An error in the pre-evaluation step of converting from de-Bruijn indices
     | CodecError Flat.DecodeException -- ^ A serialisation error
     | IncompatibleVersionError (PLC.Version ()) -- ^ An error indicating a version tag that we don't support
-    | CostModelParameterMismatch String -- ^ An error indicating that the cost model parameters didn't match what we expected
+    -- TODO: make this error more informative when we have more information about what went wrong
+    | CostModelParameterMismatch -- ^ An error indicating that the cost model parameters didn't match what we expected
     deriving stock (Show, Eq)
 
 instance Pretty EvaluationError where
@@ -151,7 +152,7 @@ instance Pretty EvaluationError where
     pretty (DeBruijnError e) = pretty e
     pretty (CodecError e) = viaShow e
     pretty (IncompatibleVersionError actual) = "This version of the Plutus Core interface does not support the version indicated by the AST:" <+> pretty actual
-    pretty (CostModelParameterMismatch e) = pretty e
+    pretty CostModelParameterMismatch = "Cost model parameters were not as we expected"
 
 -- | Shared helper for the evaluation functions, deserializes the 'Script' , applies it to its arguments, and un-deBruijn-ifies it.
 mkTermToEvaluate :: (MonadError EvaluationError m) => Script -> [Data] -> m (UPLC.Term UPLC.Name PLC.DefaultUni PLC.DefaultFun ())
@@ -171,13 +172,17 @@ mkTermToEvaluate bs args = do
 -- enough to evaluate any sensible program.
 evaluateScriptRestricting
     :: VerboseMode -- ^ Whether to produce log output
-    -> CostModel   -- ^ The cost model to use
+    -> CostModelParams -- ^ The cost model to use
     -> ExBudget    -- ^ The resource budget which must not be exceeded during evaluation
     -> Script      -- ^ The script to evaluate
     -> [Data]      -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ())
-evaluateScriptRestricting verbose model budget p args = swap $ runWriter @LogOutput $ runExceptT $ do
+evaluateScriptRestricting verbose params budget p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate p args
+    model <- case applyModelParams defaultCostModel params of
+        Just model -> pure model
+        Nothing    -> throwError CostModelParameterMismatch
+
     let (res, _, logs) =
             UPLC.runCek
                 (toBuiltinsRuntime model)
@@ -192,12 +197,16 @@ evaluateScriptRestricting verbose model budget p args = swap $ runWriter @LogOut
 -- to evaluate successfully.
 evaluateScriptCounting
     :: VerboseMode -- ^ Whether to produce log output
-    -> CostModel   -- ^ The cost model to use
+    -> CostModelParams -- ^ The cost model to use
     -> Script      -- ^ The script to evaluate
     -> [Data]      -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
-evaluateScriptCounting verbose model p args = swap $ runWriter @LogOutput $ runExceptT $ do
+evaluateScriptCounting verbose params p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate p args
+    model <- case applyModelParams defaultCostModel params of
+        Just model -> pure model
+        Nothing    -> throwError CostModelParameterMismatch
+
     let (res, UPLC.CountingSt final, logs) =
             UPLC.runCek
                 (toBuiltinsRuntime model)

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -13,12 +13,12 @@ main = defaultMain tests
 
 alwaysTrue :: TestTree
 alwaysTrue = testCase "always true script returns true" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust $ validateAndCreateCostModel =<< defaultCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
     in assertBool "succeeds" (isRight res)
 
 alwaysFalse :: TestTree
 alwaysFalse = testCase "always false script returns false" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust $ validateAndCreateCostModel =<< defaultCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
     in assertBool "fails" (isLeft res)
 
 tests :: TestTree


### PR DESCRIPTION
This puts the conversio of the `CostModelParams` into the `CostModel`
into our hot path again, but it's a pain for the ledger to maintain this
in the ledger state without a) a bunch of instances, b) us being on the
hook for not accidentally breaking them in future.

So the best path forward seems to be for us to process the paramters
when we get them, and work out a way to make that fast if it turns out
to be a problem.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
