### PR TITLE
Fix implementation of isEmpty and overlaps in Interval.hs

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
@@ -42,6 +42,7 @@
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
@@ -86,10 +87,13 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             ];
           buildable = true;
+          modules = [ "Spec/Interval" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];
           };

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -63,6 +63,7 @@ library
         cardano-crypto -any,
         flat -any,
         hashable -any,
+        hedgehog -any,
         plutus-core -any,
         memory -any,
         mtl -any,
@@ -83,8 +84,12 @@ test-suite plutus-ledger-api-test
     type: exitcode-stdio-1.0
     main-is: Spec.hs
     hs-source-dirs: test
+    other-modules:
+        Spec.Interval
     build-depends:
         base >=4.9 && <5,
         plutus-ledger-api -any,
+        hedgehog -any,
         tasty -any,
+        tasty-hedgehog -any,
         tasty-hunit -any

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
@@ -225,7 +225,7 @@ member a i = i `contains` singleton a
 -- | Check whether two intervals overlap, that is, whether there is a value that
 --   is a member of both intervals.
 overlaps :: Ord a => Interval a -> Interval a -> Bool
-overlaps l r = isEmpty (l `intersection` r)
+overlaps l r = not $ isEmpty (l `intersection` r)
 
 {-# INLINABLE intersection #-}
 -- | 'intersection a b' is the largest interval that is contained in 'a' and in
@@ -249,8 +249,8 @@ contains (Interval l1 h1) (Interval l2 h2) = l1 <= l2 && h2 <= h1
 -- | Check if an 'Interval' is empty.
 isEmpty :: Ord a => Interval a -> Bool
 isEmpty (Interval (LowerBound v1 in1) (UpperBound v2 in2)) = case v1 `compare` v2 of
-    LT -> True
-    GT -> False
+    LT -> False
+    GT -> True
     EQ -> not (in1 && in2)
 
 {-# INLINABLE before #-}

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -7,6 +7,7 @@ import           Data.Either
 import           Data.Maybe
 import           Plutus.V1.Ledger.Api
 import           Plutus.V1.Ledger.Examples
+import qualified Spec.Interval
 
 main :: IO ()
 main = defaultMain tests
@@ -25,4 +26,5 @@ tests :: TestTree
 tests = testGroup "plutus-ledger-api" [
     alwaysTrue
     , alwaysFalse
+    , Spec.Interval.tests
     ]

--- a/plutus-ledger-api/test/Spec/Interval.hs
+++ b/plutus-ledger-api/test/Spec/Interval.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+
+module Spec.Interval where
+
+import           Data.List                 (sort)
+import           Hedgehog                  (Property, forAll, property)
+import qualified Hedgehog
+import qualified Hedgehog.Gen              as Gen
+import qualified Hedgehog.Range            as Range
+import qualified Plutus.V1.Ledger.Interval as Interval
+import           Plutus.V1.Ledger.Slot
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.Hedgehog       (testProperty)
+
+alwaysIsNotEmpty :: TestTree
+alwaysIsNotEmpty =
+  testCase "always is not empty" $
+    assertBool "always" (not $ Interval.isEmpty (Interval.always :: Interval.Interval Slot))
+
+neverIsEmpty :: TestTree
+neverIsEmpty =
+  testCase "never is empty" $
+    assertBool "never" (Interval.isEmpty (Interval.never :: Interval.Interval Slot))
+
+intvlIsEmpty :: Property
+intvlIsEmpty = property $ do
+  (i1, i2) <- forAll $ (,) <$> Gen.integral (fromIntegral <$> Range.linearBounded @Int) <*> Gen.integral (fromIntegral <$> Range.linearBounded @Int)
+  let (from, to) = (min i1 i2, max i1 i2)
+      nonEmpty = Interval.interval (Slot from) (Slot to)
+      empty = Interval.interval (Slot to) (Slot from)
+  Hedgehog.assert $ from == to || Interval.isEmpty empty
+  Hedgehog.assert $ not $ Interval.isEmpty nonEmpty
+
+intvlIntersection :: Property
+intvlIntersection = property $ do
+  ints <- forAll $ traverse (const $ Gen.integral (fromIntegral <$> Range.linearBounded @Int)) [1..4 :: Integer]
+  let [i1, i2, i3, i4] = Slot <$> sort ints
+      outer = Interval.interval i1 i4
+      inner = Interval.interval i2 i3
+      intersec = outer `Interval.intersection` inner
+
+      lower = Interval.interval i1 i2
+      higher = Interval.interval i2 i3
+      common = Interval.interval i2 i2
+      intersec2 = lower `Interval.intersection` higher
+
+  Hedgehog.assert $ intersec == inner
+  Hedgehog.assert $ intersec2 == common
+
+intvlIntersectionWithAlwaysNever :: Property
+intvlIntersectionWithAlwaysNever = property $ do
+  (i1, i2) <- forAll $ (,) <$> Gen.integral (fromIntegral <$> Range.linearBounded @Int) <*> Gen.integral (fromIntegral <$> Range.linearBounded @Int)
+  let (from, to) = (min i1 i2, max i1 i2)
+      i = Interval.interval (Slot from) (Slot to)
+      e = Interval.interval (Slot to) (Slot from)
+
+  Hedgehog.assert $ Interval.never == i `Interval.intersection` Interval.never
+  Hedgehog.assert $ i == i `Interval.intersection` Interval.always
+  Hedgehog.assert $ e == e `Interval.intersection` i
+
+intvlOverlaps :: Property
+intvlOverlaps = property $ do
+  (i1, i2) <- forAll $ (,) <$> Gen.integral (fromIntegral <$> Range.linearBounded @Int) <*> Gen.integral (fromIntegral <$> Range.linearBounded @Int)
+  let (from, to) = (min i1 i2, max i1 i2)
+      i = Interval.interval (Slot from) (Slot to)
+
+  Hedgehog.assert $ i `Interval.overlaps` i
+  Hedgehog.assert $ Interval.always `Interval.overlaps` i
+  Hedgehog.assert $ not $ Interval.never `Interval.overlaps` i
+
+tests :: TestTree
+tests =
+  testGroup
+    "plutus-ledger-api-interval"
+    [ neverIsEmpty
+    , alwaysIsNotEmpty
+    , testProperty "interval intersection" intvlIntersection
+    , testProperty "interval intersection with always/never" intvlIntersectionWithAlwaysNever
+    , testProperty "interval isEmpty" intvlIsEmpty
+    , testProperty "interval overlaps" intvlOverlaps
+    ]


### PR DESCRIPTION
A fellow Plutus Pioneer Program student (BC Chuah) noticed an odd behavior of the `overlaps` function.

Upon further investigation, I noticed that both `overlaps` and `isEmpty` needed a change to work as expected.



Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
