### PR TITLE
SCP-2151: PAB handles contract logs as part of its own logging

### DIFF
--- a/marlowe/pab/Main.hs
+++ b/marlowe/pab/Main.hs
@@ -13,6 +13,7 @@ module Main(main) where
 import           Control.Monad                       (void)
 import           Control.Monad.Freer                 (Eff, Member, interpret, type (~>))
 import           Control.Monad.Freer.Error           (Error)
+import           Control.Monad.Freer.Extras.Log      (LogMsg)
 import           Control.Monad.IO.Class              (MonadIO (..))
 import           Data.Aeson                          (FromJSON, ToJSON)
 import           Data.Text.Prettyprint.Doc           (Pretty (..), viaShow)
@@ -21,6 +22,7 @@ import qualified Language.Marlowe.Client             as Marlowe
 import           Plutus.PAB.Effects.Contract         (ContractEffect (..))
 import           Plutus.PAB.Effects.Contract.Builtin (Builtin, SomeBuiltin (..))
 import qualified Plutus.PAB.Effects.Contract.Builtin as Builtin
+import           Plutus.PAB.Monitoring.PABLogMsg     (PABMultiAgentMsg)
 import           Plutus.PAB.Simulator                (SimulatorEffectHandlers)
 import qualified Plutus.PAB.Simulator                as Simulator
 import           Plutus.PAB.Types                    (PABError (..))
@@ -51,6 +53,7 @@ instance Pretty Marlowe where
     pretty = viaShow
 handleMarloweContract ::
     ( Member (Error PABError) effs
+    , Member (LogMsg (PABMultiAgentMsg (Builtin Marlowe))) effs
     )
     => ContractEffect (Builtin Marlowe)
     ~> Eff effs

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -347,5 +347,5 @@ logNewMessages :: forall w s e effs.
     )
     => Eff effs ()
 logNewMessages = do
-    newContractLogs <- gets @(ContractInstanceStateInternal w s e ()) (view lastLogs . cisiSuspState)
+    newContractLogs <- gets @(ContractInstanceStateInternal w s e ()) (view (resumableResult . lastLogs) . cisiSuspState)
     traverse_ (send . LMessage . fmap ContractLog) newContractLogs

--- a/plutus-pab/app/Cli.hs
+++ b/plutus-pab/app/Cli.hs
@@ -255,7 +255,7 @@ runCliCommand _ _ _ _ StartSimulatorWebServer = do
 runCliCommand _ _ _ _ WriteDefaultConfig{_outputFile} =
     LM.defaultConfig >>= flip CM.exportConfiguration _outputFile
 
-toPABMsg :: Trace m (LM.AppMsg ContractExe) -> Trace m LM.PABLogMsg
+toPABMsg :: Trace m (LM.AppMsg ContractExe) -> Trace m (LM.PABLogMsg ContractExe)
 toPABMsg = LM.convertLog LM.PABMsg
 
 toChainIndexLog :: Trace m (LM.AppMsg ContractExe) -> Trace m LM.ChainIndexServerMsg

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
@@ -28,8 +28,10 @@ import           Control.Monad.Freer.Extras.Log          (LogMessage, LogMsg, Lo
 import           Control.Monad.Freer.Reader              (Reader)
 import           Data.Aeson                              (FromJSON, ToJSON)
 import qualified Data.Aeson                              as JSON
+import qualified Data.Aeson.Encode.Pretty                as JSON
+import qualified Data.ByteString.Lazy.Char8              as BSL8
 import qualified Data.Text                               as Text
-import           Data.Text.Prettyprint.Doc               (Pretty, parens, pretty, viaShow, (<+>))
+import           Data.Text.Prettyprint.Doc               (Pretty, colon, parens, pretty, viaShow, (<+>))
 import           GHC.Generics                            (Generic)
 import           Ledger.Tx                               (Tx, txId)
 import           Plutus.Contract.Effects.WriteTx         (WriteTxResponse (..))
@@ -139,6 +141,7 @@ data ContractInstanceMsg t =
     | InboxMessageMatchesIteration
     | InvokingContractUpdate
     | ObtainedNewState
+    | ContractLog ContractInstanceId JSON.Value
     | UpdatedContract ContractInstanceId IterationID
     | LookingUpContract (Contract.ContractDef t)
     | InitialisingContract (Contract.ContractDef t) ContractInstanceId
@@ -226,6 +229,8 @@ instance (ToJSON (Contract.ContractDef t)) => ToObject (ContractInstanceMsg t) w
                     _                -> Right ()
         NotificationFailed _ ->
             mkObjectStr "notification failed" ()
+        ContractLog i lg ->
+            mkObjectStr "contract log" (i, Tagged @"message" lg)
 
 instance Pretty (Contract.ContractDef t) => Pretty (ContractInstanceMsg t) where
     pretty = \case
@@ -254,3 +259,4 @@ instance Pretty (Contract.ContractDef t) => Pretty (ContractInstanceMsg t) where
         HandlingRequests i rqs -> "Handling" <+> pretty (length rqs) <+> "requests for" <+> pretty i
         BalancingTx msg -> pretty msg
         NotificationFailed e -> "Notification failed:" <+> pretty e
+        ContractLog i m -> pretty i <> colon <+> pretty (BSL8.unpack $ JSON.encodePretty m)

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract.hs
@@ -73,8 +73,8 @@ requests = hooks . serialisableState (Proxy @contract)
 -- | An effect for sending updates to contracts that implement @PABContract@
 data ContractEffect t r where
     ExportSchema   :: PABContract t => ContractDef t -> ContractEffect t [FunctionSchema FormSchema] -- ^ The schema of the contract
-    InitialState   :: PABContract t => ContractDef t -> ContractEffect t (State t) -- ^ The initial state of the contract's instance
-    UpdateContract :: PABContract t => ContractDef t -> State t -> Response ContractResponse -> ContractEffect t (State t) -- ^ Send an update to the contract and return the new state.
+    InitialState   :: PABContract t => ContractInstanceId -> ContractDef t -> ContractEffect t (State t) -- ^ The initial state of the contract's instance
+    UpdateContract :: PABContract t => ContractInstanceId -> ContractDef t -> State t -> Response ContractResponse -> ContractEffect t (State t) -- ^ Send an update to the contract and return the new state.
 
 -- | Get the schema of a contract given its definition.
 exportSchema ::
@@ -94,10 +94,11 @@ initialState ::
     ( Member (ContractEffect t) effs
     , PABContract t
     )
-    => ContractDef t
+    => ContractInstanceId
+    -> ContractDef t
     -> Eff effs (State t)
-initialState def =
-    let command :: ContractEffect t (State t) = InitialState def
+initialState i def =
+    let command :: ContractEffect t (State t) = InitialState i def
     in send command
 
 -- | Send an update to the contract and return the new state.
@@ -106,12 +107,13 @@ updateContract ::
     ( Member (ContractEffect t) effs
     , PABContract t
     )
-    => ContractDef t
+    => ContractInstanceId
+    -> ContractDef t
     -> State t
     -> Response ContractResponse
     -> Eff effs (State t)
-updateContract def state request =
-    let command :: ContractEffect t (State t) = UpdateContract def state request
+updateContract i def state request =
+    let command :: ContractEffect t (State t) = UpdateContract i def state request
     in send command
 
 -- | Storing and retrieving the state of a contract instance

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract/Builtin.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract/Builtin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveAnyClass      #-}
@@ -32,29 +33,35 @@ module Plutus.PAB.Effects.Contract.Builtin(
     ) where
 
 import           Control.Monad.Freer
-import           Control.Monad.Freer.Error               (Error, throwError)
-import           Data.Aeson                              (FromJSON, ToJSON, Value)
-import qualified Data.Aeson                              as JSON
-import qualified Data.Aeson.Types                        as JSON
+import           Control.Monad.Freer.Error                        (Error, throwError)
+import           Control.Monad.Freer.Extras.Log                   (LogMsg (..))
+import           Data.Aeson                                       (FromJSON, ToJSON, Value)
+import qualified Data.Aeson                                       as JSON
+import qualified Data.Aeson.Types                                 as JSON
+import           Data.Foldable                                    (traverse_)
 import           Data.Row
-import qualified Data.Text                               as Text
+import qualified Data.Text                                        as Text
 
-import           Plutus.PAB.Effects.Contract             (ContractEffect (..), PABContract (..))
-import           Plutus.PAB.Events.Contract              (ContractPABRequest)
-import qualified Plutus.PAB.Events.Contract              as C
-import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
-import qualified Plutus.PAB.Events.ContractInstanceState as C
-import           Plutus.PAB.Types                        (PABError (..))
+import           Plutus.Contract.Types                            (ResumableResult (..), SuspendedContract (..))
+import           Plutus.PAB.Effects.Contract                      (ContractEffect (..), PABContract (..))
+import           Plutus.PAB.Events.Contract                       (ContractPABRequest)
+import qualified Plutus.PAB.Events.Contract                       as C
+import           Plutus.PAB.Events.ContractInstanceState          (PartiallyDecodedResponse)
+import qualified Plutus.PAB.Events.ContractInstanceState          as C
+import           Plutus.PAB.Monitoring.PABLogMsg                  (PABMultiAgentMsg (..))
+import           Plutus.PAB.Types                                 (PABError (..))
 
-import           Playground.Schema                       (endpointsToSchemas)
-import           Playground.Types                        (FunctionSchema)
-import           Plutus.Contract                         (BlockchainActions, Contract)
-import           Plutus.Contract.Resumable               (Response)
-import           Plutus.Contract.Schema                  (Event, Handlers, Input, Output)
-import           Plutus.Contract.State                   (ContractResponse (..))
-import qualified Plutus.Contract.State                   as ContractState
-import qualified Plutus.Trace.Emulator.Types             as Emulator
-import           Schema                                  (FormSchema)
+import           Playground.Schema                                (endpointsToSchemas)
+import           Playground.Types                                 (FunctionSchema)
+import           Plutus.Contract                                  (BlockchainActions, Contract, ContractInstanceId)
+import           Plutus.Contract.Resumable                        (Response)
+import           Plutus.Contract.Schema                           (Event, Handlers, Input, Output)
+import           Plutus.Contract.State                            (ContractResponse (..))
+import qualified Plutus.Contract.State                            as ContractState
+import           Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInstanceMsg (ContractLog))
+import           Plutus.Trace.Emulator.Types                      (ContractInstanceStateInternal (..))
+import qualified Plutus.Trace.Emulator.Types                      as Emulator
+import           Schema                                           (FormSchema)
 
 -- | Contracts that are built into the PAB (ie. compiled with it) and receive
 --   an initial value of type 'a'.
@@ -91,15 +98,17 @@ instance PABContract (Builtin a) where
 --   @a@.
 handleBuiltin ::
     forall a effs.
-    Member (Error PABError) effs
+    ( Member (Error PABError) effs
+    , Member (LogMsg (PABMultiAgentMsg (Builtin a))) effs
+    )
     => (a -> [FunctionSchema FormSchema]) -- ^ The schema (construct with 'endpointsToSchemas'. Can also be an empty list)
     -> (a -> SomeBuiltin) -- ^ The actual contract
     -> ContractEffect (Builtin a)
     ~> Eff effs
 handleBuiltin mkSchema initialise = \case
-    InitialState c           -> case initialise c of SomeBuiltin c' -> initBuiltin c'
-    UpdateContract _ state p -> case state of SomeBuiltinState s -> updateBuiltin s p
-    ExportSchema a           -> pure $ mkSchema a
+    InitialState i c           -> case initialise c of SomeBuiltin c' -> initBuiltin i c'
+    UpdateContract i _ state p -> case state of SomeBuiltinState s -> updateBuiltin i s p
+    ExportSchema a             -> pure $ mkSchema a
 
 getResponse :: forall a. SomeBuiltinState a -> PartiallyDecodedResponse ContractPABRequest
 getResponse (SomeBuiltinState s) =
@@ -110,25 +119,44 @@ getResponse (SomeBuiltinState s) =
 
 initBuiltin ::
     forall effs a w schema error b.
-    ContractConstraints w schema error
-    => Contract w schema error b
+    ( ContractConstraints w schema error
+    , Member (LogMsg (PABMultiAgentMsg (Builtin a))) effs
+    )
+    => ContractInstanceId
+    -> Contract w schema error b
     -> Eff effs (SomeBuiltinState a)
-initBuiltin = pure . SomeBuiltinState . Emulator.emptyInstanceState
+initBuiltin i con = do
+    let initialState = Emulator.emptyInstanceState con
+    logNewMessages @a i initialState
+    pure $ SomeBuiltinState initialState
 
 updateBuiltin ::
     forall effs a w schema error b.
     ( ContractConstraints w schema error
     , Member (Error PABError) effs
+    , Member (LogMsg (PABMultiAgentMsg (Builtin a))) effs
     )
-    => Emulator.ContractInstanceStateInternal w schema error b
+    => ContractInstanceId
+    -> Emulator.ContractInstanceStateInternal w schema error b
     -> Response C.ContractResponse
     -> Eff effs (SomeBuiltinState a)
-updateBuiltin oldState event = do
+updateBuiltin i oldState event = do
     resp <- traverse toEvent event
     let newState = Emulator.addEventInstanceState resp oldState
     case newState of
-        Just k -> pure (SomeBuiltinState k)
+        Just k -> do
+            logNewMessages @a i k
+            pure (SomeBuiltinState k)
         _      -> throwError $ ContractCommandError 0 "failed to update contract"
+
+logNewMessages ::
+    forall b w s e a effs.
+    Member (LogMsg (PABMultiAgentMsg (Builtin b))) effs
+    => ContractInstanceId
+    -> ContractInstanceStateInternal w s e a
+    -> Eff effs ()
+logNewMessages i ContractInstanceStateInternal{cisiSuspState=SuspendedContract{_resumableResult=ResumableResult{_lastLogs}}} =
+    traverse_ (send @(LogMsg (PABMultiAgentMsg (Builtin b))) . LMessage . fmap (ContractInstanceLog . ContractLog i)) _lastLogs
 
 toEvent ::
     forall schema effs.
@@ -149,11 +177,12 @@ mkResponse ::
     )
     => ContractResponse w err (Event schema) (Handlers schema)
     -> PartiallyDecodedResponse ContractPABRequest
-mkResponse ContractResponse{newState, hooks, logs, observableState, err} =
+mkResponse ContractResponse{newState, hooks, logs, observableState, err, lastLogs} =
     C.PartiallyDecodedResponse
         { C.newState = fmap JSON.toJSON newState
         , C.hooks    = fmap (fmap (encodeRequest @schema)) hooks
         , C.logs     = logs
+        , C.lastLogs = lastLogs
         , C.observableState = JSON.toJSON observableState
         , C.err = fmap JSON.toJSON err
         }

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract/ContractTest.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract/ContractTest.hs
@@ -24,6 +24,7 @@ module Plutus.PAB.Effects.Contract.ContractTest(
 
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error                   (Error)
+import           Control.Monad.Freer.Extras.Log              (LogMsg)
 import           Data.Aeson                                  (FromJSON, ToJSON)
 import           Data.Bifunctor                              (Bifunctor (..))
 import           Data.Row
@@ -42,6 +43,7 @@ import           Plutus.PAB.Effects.Contract.Builtin         (Builtin, SomeBuilt
 import qualified Plutus.PAB.Effects.Contract.Builtin         as Builtin
 import qualified Plutus.PAB.Effects.ContractTest.AtomicSwap  as Contracts.AtomicSwap
 import qualified Plutus.PAB.Effects.ContractTest.PayToWallet as Contracts.PayToWallet
+import           Plutus.PAB.Monitoring.PABLogMsg             (PABMultiAgentMsg)
 import           Plutus.PAB.Types                            (PABError (..))
 import           Schema                                      (FormSchema)
 
@@ -55,6 +57,7 @@ instance Pretty TestContracts where
 -- | A mock/test handler for 'ContractEffect'. Uses 'Plutus.PAB.Effects.Contract.Builtin'.
 handleContractTest ::
     ( Member (Error PABError) effs
+    , Member (LogMsg (PABMultiAgentMsg (Builtin TestContracts))) effs
     )
     => ContractEffect (Builtin TestContracts)
     ~> Eff effs

--- a/plutus-pab/src/Plutus/PAB/Events/ContractInstanceState.hs
+++ b/plutus-pab/src/Plutus/PAB/Events/ContractInstanceState.hs
@@ -28,6 +28,7 @@ data PartiallyDecodedResponse v =
         { newState        :: Contract.State Value
         , hooks           :: [Contract.Request v]
         , logs            :: [LogMessage Value]
+        , lastLogs        :: [LogMessage Value] -- The log messages returned by the last step ('lastLogs' is a suffix of 'logs')
         , err             :: Maybe Value
         , observableState :: Value
         }
@@ -36,12 +37,12 @@ data PartiallyDecodedResponse v =
 
 
 toResp :: PartiallyDecodedResponse v -> Contract.ContractResponse Value Value Value v
-toResp PartiallyDecodedResponse{newState, hooks, logs, err, observableState} =
-    Contract.ContractResponse{Contract.newState = newState, Contract.hooks=hooks, Contract.logs=logs, Contract.err=err, Contract.observableState=observableState}
+toResp PartiallyDecodedResponse{newState, hooks, logs, err, observableState, lastLogs} =
+    Contract.ContractResponse{Contract.newState = newState, Contract.hooks=hooks, Contract.logs=logs, Contract.err=err, Contract.observableState=observableState, Contract.lastLogs=lastLogs}
 
 fromResp :: Contract.ContractResponse Value Value Value v -> PartiallyDecodedResponse v
-fromResp Contract.ContractResponse{Contract.newState, Contract.hooks, Contract.logs, Contract.err, Contract.observableState} =
-    PartiallyDecodedResponse{newState, hooks, logs, err, observableState}
+fromResp Contract.ContractResponse{Contract.newState, Contract.hooks, Contract.logs, Contract.err, Contract.observableState, Contract.lastLogs} =
+    PartiallyDecodedResponse{newState, hooks, logs, err, observableState, lastLogs}
 
 instance Pretty v => Pretty (PartiallyDecodedResponse v) where
     pretty PartiallyDecodedResponse {newState, hooks} =

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -176,6 +176,7 @@ initialState = do
 type SimulatorContractHandler t =
     forall effs.
         ( Member (Error PABError) effs
+        , Member (LogMsg (PABMultiAgentMsg t)) effs
         )
         => Eff (Contract.ContractEffect t ': effs)
         ~> Eff effs


### PR DESCRIPTION
* Log contract messages in the PAB's logging system (in addition to writing them into the contract state)
* This involved adding a `lastLogs` field with only the new messages, to avoid logging all the messages on every step
* Also had to shuffle some types around in `plutus-pab` to avoid cyclical imports

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
