### PR TITLE
Sorting out PAB config.

### DIFF
--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -22,6 +22,8 @@
     chainIndexPort = 8083;
     signingProcessPort = 8084;
     metadataPort = 8085;
+    zeroSlotTime = "2020-06-07T21:44:51Z";
+    slotLength = 1;
   };
 
 }

--- a/marlowe-dashboard-client/plutus-pab.yaml
+++ b/marlowe-dashboard-client/plutus-pab.yaml
@@ -1,3 +1,9 @@
+# This file is provided here for development purposes only. In deployment,
+# settings are taken from `deployment/morph/machines/marlowe-dash.nix` (which
+# also determines which contracts are available). In most cases we use the
+# default settings - the main thing to watch out for is that the
+# `scZeroSlotTime` here coincides with the frontend code's assumptions about
+# the time of slot 0 (in `web-common-marlowe/src/Marlowe/Slot.purs`).
 dbConfig:
     dbConfigFile: pab-core.db
     dbConfigPoolSize: 20
@@ -16,6 +22,9 @@ nodeServerConfig:
   mscSocketPath: ./node-server.sock
   mscSlotLength: 1
   mscKeptBlocks: 100
+  mscSlotConfig:
+    scZeroSlotTime: "2020-06-07T21:44:51Z"
+    scSlotLength: 1
   # mscRandomTxInterval: 20 -- this creates random transactions on the blockchain
   mscBlockReaper:
     brcInterval: 600

--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -27,11 +27,10 @@ let
     nodeServerConfig = {
       mscBaseUrl = "http://localhost:${builtins.toString cfg.nodePort}";
       mscSocketPath = "/tmp/node-server.sock";
-      mscSlotLength = 5;
       mscRandomTxInterval = 20000000;
       mscSlotConfig = {
-        scZeroSlotTime = "2020-07-29T21:44:51Z"; #Wednesday, July 29, 2020 21:44:51 - shelley launch time
-        scSlotLength = 1;
+        scZeroSlotTime = cfg.zeroSlotTime;
+        scSlotLength = cfg.slotLength;
       };
       mscKeptBlocks = 100000;
       mscBlockReaper = {
@@ -106,7 +105,7 @@ in
       type = types.int;
       default = 1;
       description = ''
-        The default wallet to opreate on.
+        The default wallet to operate on.
       '';
     };
 
@@ -163,6 +162,22 @@ in
       default = [ ];
       description = ''
         List of paths to contracts that should be installed.
+      '';
+    };
+
+    zeroSlotTime = mkOption {
+      type = types.string;
+      default = "2020-07-29T21:44:51Z"; # Wednesday, July 29, 2020 21:44:51 - shelley launch time
+      description = ''
+        Time of slot 0. Setting this (together with the slot length) enables pure datetime-to-slot mappings.
+      '';
+    };
+
+    slotLength = mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        Length of a slot (in seconds).
       '';
     };
 

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -14,12 +14,11 @@ walletServerConfig:
 nodeServerConfig:
   mscBaseUrl: http://localhost:9082
   mscSocketPath: ./node-server.sock
-  mscSlotLength: 5
   mscKeptBlocks: 100
-  mscRandomTxInterval: 20
   mscSlotConfig:
     scZeroSlotTime: "2020-07-29T21:44:51Z" #Wednesday, July 29, 2020 21:44:51 - shelley launch time
     scSlotLength: 1
+  mscRandomTxInterval: 20
   mscBlockReaper:
     brcInterval: 600
     brcBlocksToKeep: 100


### PR DESCRIPTION
Following #3004, this adds the zero slot time config parameter to Marlowe Run in development and production.