### PR TITLE
SCP-2103 Store contract history in Marlowe follower contract state

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,10 @@ rec {
     plutus-atomic-swap
     plutus-pay-to-wallet;
 
-  inherit (haskell.packages.marlowe.components.exes) marlowe-app marlowe-companion-app;
+  inherit (haskell.packages.marlowe.components.exes)
+    marlowe-app
+    marlowe-companion-app
+    marlowe-follow-app;
 
   webCommon = pkgs.callPackage ./web-common { inherit (plutus.lib) gitignore-nix; };
   webCommonPlutus = pkgs.callPackage ./web-common-plutus { inherit (plutus.lib) gitignore-nix; };
@@ -62,7 +65,7 @@ rec {
 
   marlowe-dashboard = pkgs.recurseIntoAttrs rec {
     inherit (pkgs.callPackage ./marlowe-dashboard-client {
-      inherit plutus-pab marlowe-app marlowe-companion-app;
+      inherit plutus-pab marlowe-app marlowe-companion-app marlowe-follow-app;
       inherit (plutus.lib) buildPursPackage buildNodeModules filterNpm gitignore-nix;
       inherit webCommon webCommonMarlowe;
     }) client server-invoker generated-purescript generate-purescript contractsJSON install-marlowe-contracts;
@@ -85,7 +88,8 @@ rec {
     inherit (plutus.lib) gitignore-nix;
     inherit (plutus) fixStylishHaskell fixPurty fixPngOptimization;
     inherit (pkgs) terraform;
-    inherit plutus-playground marlowe-playground marlowe-dashboard web-ghc plutus-pab marlowe-app marlowe-companion-app;
+    inherit plutus-playground marlowe-playground marlowe-dashboard web-ghc plutus-pab
+      marlowe-app marlowe-companion-app marlowe-follow-app;
     src = ./.;
   };
 
@@ -93,7 +97,7 @@ rec {
 
   deployment = pkgs.recurseIntoAttrs (pkgs.callPackage ./deployment/morph {
     plutus = {
-      inherit plutus-pab marlowe-app marlowe-companion-app
+      inherit plutus-pab marlowe-app marlowe-companion-app marlowe-follow-app
         marlowe-dashboard marlowe-playground plutus-playground web-ghc docs;
     };
   });

--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -12,7 +12,11 @@
   services.pab = {
     enable = true;
     pab-package = pkgs.plutus-pab.pab-exes.plutus-pab;
-    contracts = [ "${pkgs.marlowe-app}/bin/marlowe-app" "${pkgs.marlowe-companion-app}/bin/marlowe-companion-app" ];
+    contracts = [
+      "${pkgs.marlowe-app}/bin/marlowe-app"
+      "${pkgs.marlowe-companion-app}/bin/marlowe-companion-app"
+      "${pkgs.marlowe-follow-app}/bin/marlowe-follow-app"
+    ];
     staticContent = pkgs.marlowe-dashboard.client;
     dbFile = "/var/lib/pab/pab-core.db";
     defaultWallet = 1;

--- a/deployment/morph/mk-machine.nix
+++ b/deployment/morph/mk-machine.nix
@@ -27,6 +27,7 @@
               plutus-pab = plutus.plutus-pab;
               marlowe-app = plutus.marlowe-app;
               marlowe-companion-app = plutus.marlowe-companion-app;
+              marlowe-follow-app = plutus.marlowe-follow-app;
               marlowe-dashboard = plutus.marlowe-dashboard;
               marlowe-playground = plutus.marlowe-playground;
               plutus-playground = plutus.plutus-playground;

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, gitignore-nix, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules, filterNpm, plutus-pab, marlowe-app, marlowe-companion-app }:
+{ pkgs, gitignore-nix, webCommon, webCommonMarlowe, buildPursPackage, buildNodeModules, filterNpm, plutus-pab, marlowe-app, marlowe-companion-app, marlowe-follow-app }:
 let
   cleanSrc = gitignore-nix.gitignoreSource ./.;
 
@@ -12,6 +12,7 @@ let
   contractsJSON = pkgs.writeTextDir "contracts.json" (builtins.toJSON {
     marlowe = "${marlowe-app}/bin/marlowe-app";
     walletCompanion = "${marlowe-companion-app}/bin/marlowe-companion-app";
+    walletFollower = "${marlowe-follow-app}/bin/marlowe-follow-app";
   });
 
   client = buildPursPackage {
@@ -34,6 +35,7 @@ let
   install-marlowe-contracts = pkgs.writeShellScriptBin "install-marlowe-contracts" ''
     ${plutus-pab.server-invoker}/bin/plutus-pab contracts install --path ${marlowe-app}/bin/marlowe-app
     ${plutus-pab.server-invoker}/bin/plutus-pab contracts install --path ${marlowe-companion-app}/bin/marlowe-companion-app
+    ${plutus-pab.server-invoker}/bin/plutus-pab contracts install --path ${marlowe-follow-app}/bin/marlowe-follow-app
   '';
 in
 {

--- a/marlowe/follow/Main.hs
+++ b/marlowe/follow/Main.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE TypeApplications #-}
+module Main where
+
+import           Data.Bifunctor          (first)
+import           Data.Proxy              (Proxy (..))
+import           Data.Text.Extras        (tshow)
+import           Language.Marlowe.Client (MarloweFollowSchema, marloweFollowContract)
+import           Plutus.PAB.ContractCLI  (commandLineApp')
+
+main :: IO ()
+main =
+    commandLineApp'
+        (Proxy @MarloweFollowSchema) -- see note ['ToSchema' and Marlowe]
+        $ first tshow
+        $ marloweFollowContract
+
+{- Note ['ToSchema' and Marlowe]
+
+The PAB can automatically generate input forms for endpoints as long as their
+types have instances of the 'Schema.ToSchema' class.
+
+We can't derive instances of this class for union types such as
+'Language.Marlowe.Semantics.Party' (see SCP-1162). Unfortunately this makes the
+PAB UI unusable for most of the endpoints of the Marlowe contract.
+
+This doesn't mean that Marlowe can't run on the PAB. It just means that there
+is no schema for its endpoints, so we can't call them manually via the UI. We'd
+have to call them programmatically with a call to the PAB's API.
+
+-}

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -137,6 +137,16 @@ executable marlowe-companion-app
     plutus-contract -any,
     marlowe
 
+executable marlowe-follow-app
+  import: lang
+  main-is: Main.hs
+  hs-source-dirs: follow
+  build-depends:
+    base >= 4.9 && < 5,
+    plutus-pab -any,
+    plutus-contract -any,
+    marlowe
+
 -- | The PAB Specialised to the marlowe contract(s)
 executable marlowe-pab
   import: lang

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -29,6 +29,7 @@ import           Control.Monad.Error.Lens     (catching, throwing)
 import           Data.Aeson                   (FromJSON, ToJSON, parseJSON, toJSON)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import qualified Data.Text                    as T
 import           GHC.Generics                 (Generic)
@@ -36,10 +37,13 @@ import           Language.Marlowe.Semantics   hiding (Contract)
 import qualified Language.Marlowe.Semantics   as Marlowe
 import           Language.Marlowe.Util        (extractContractRoles)
 import           Ledger                       (CurrencySymbol, Datum (..), PubKeyHash, ScriptContext (..), Slot (..),
-                                               TokenName, TxOut (..), TxOutTx (..), ValidatorHash, mkValidatorScript,
-                                               pubKeyHash, txOutDatum, txOutValue, txOutputs, validatorHash, valueSpent)
+                                               TokenName, TxOut (..), TxOutTx (..), ValidatorHash, inScripts,
+                                               mkValidatorScript, pubKeyHash, txOutDatum, txOutValue, txOutputs,
+                                               validatorHash, valueSpent)
+import qualified Ledger
 import           Ledger.Ada                   (adaSymbol, adaValueOf)
 import           Ledger.Address               (pubKeyHashAddress, scriptHashAddress)
+import           Ledger.AddressMap            (outputsMapFromTxForAddress)
 import           Ledger.Constraints
 import qualified Ledger.Constraints           as Constraints
 import qualified Ledger.Interval              as Interval
@@ -49,7 +53,7 @@ import           Ledger.Typed.Tx              (TypedScriptTxOut (..), tyTxOutDat
 import qualified Ledger.Value                 as Val
 import           Plutus.Contract
 import           Plutus.Contract.StateMachine (AsSMContractError (..), StateMachine (..), StateMachineClient (..),
-                                               StateMachineInstance (..), Void, WaitingResult (..))
+                                               StateMachineInstance (..), Void, WaitingResult (..), getStates)
 import qualified Plutus.Contract.StateMachine as SM
 import qualified Plutus.Contracts.Currency    as Currency
 import qualified PlutusTx                     as PlutusTx
@@ -63,13 +67,15 @@ type MarloweSchema =
     BlockchainActions
         .\/ Endpoint "create" (AssocMap.Map Val.TokenName PubKeyHash, Marlowe.Contract)
         .\/ Endpoint "apply-inputs" (MarloweParams, Maybe SlotInterval, [Input])
-        .\/ Endpoint "wait" MarloweParams
         .\/ Endpoint "auto" (MarloweParams, Party, Slot)
         .\/ Endpoint "redeem" (MarloweParams, TokenName, PubKeyHash)
         .\/ Endpoint "close" ()
 
 
 type MarloweCompanionSchema = BlockchainActions
+type MarloweFollowSchema =
+        BlockchainActions
+            .\/ Endpoint "follow" MarloweParams
 
 
 data MarloweError =
@@ -106,11 +112,112 @@ data PartyAction
 
 type RoleOwners = AssocMap.Map Val.TokenName PubKeyHash
 
-type MarloweContractState = ()
+type MarloweContractState = [MarloweData]
 
+data ContractHistory
+        = None
+        | Created MarloweParams MarloweData
+        | Transition TransactionInput
+        | History MarloweParams MarloweData [TransactionInput]
+    deriving (Show,Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+instance Semigroup ContractHistory where
+    any <> None                                  = any
+    _ <> Created params md                       = History params md []
+    History params md inputs <> Transition input = History params md (inputs <> [input])
+    cur <> _                                     = cur
+
+instance Monoid ContractHistory where
+    mempty = None
+
+data ContractProgress = InProgress | Finished
+  deriving (Show,Eq)
+
+instance Semigroup ContractProgress where
+    _ <> Finished     = Finished
+    any <> InProgress = any
+
+instance Monoid ContractProgress where
+    mempty = InProgress
+
+
+marloweFollowContract :: Contract ContractHistory MarloweFollowSchema MarloweError ()
+marloweFollowContract = do
+    params <- endpoint @"follow"
+    slot <- currentSlot
+    logDebug @String "Getting contract history"
+    follow slot (Interval.to slot) params
+  where
+    follow slot slotRange params = do
+        let client@StateMachineClient{scInstance} = mkMarloweClient params
+        let inst = validatorInstance scInstance
+        let address = Scripts.scriptAddress inst
+        AddressChangeResponse{acrTxns} <- addressChangeRequest
+                AddressChangeRequest
+                { acreqSlotRange = slotRange
+                , acreqAddress = address
+                }
+        let go [] = pure InProgress
+            go (tx:rest) = do
+                res <- updateHistoryFromTx client params tx
+                case res of
+                    Finished   -> pure Finished
+                    InProgress -> go rest
+        res <- go acrTxns
+        case res of
+            Finished -> do
+                logDebug @String ("Contract finished " <> show params)
+                pure () -- close the contract
+            InProgress -> follow (succ slot) (Interval.singleton (succ slot)) params
+
+    updateHistoryFromTx StateMachineClient{scInstance, scChooser} params tx = do
+        let inst = validatorInstance scInstance
+        let address = Scripts.scriptAddress inst
+        let utxo = outputsMapFromTxForAddress address tx
+        let states = getStates scInstance utxo
+        case findInput inst tx of
+            -- if there's no TxIn for Marlowe contract that means
+            -- it's a contract creation transaction, and there is Marlowe TxOut
+            Nothing -> case scChooser states of
+                Left err    -> throwing _SMContractError err
+                Right (state, _) -> do
+                    let initialMarloweData = tyTxOutData state
+                    logDebug @String ("Contract created " <> show initialMarloweData)
+                    tell $ Created params initialMarloweData
+                    pure InProgress
+            -- There is TxIn with Marlowe contract, hence this is a state transition
+            Just (interval, inputs) -> do
+                let txInput = TransactionInput {
+                        txInterval = interval,
+                        txInputs = inputs }
+                logDebug @String ("Transition " <> show txInput)
+                tell $ Transition txInput
+                case states of
+                    -- when there is no Marlowe TxOut the contract is closed
+                    -- and we can close the follower contract
+                    [] -> pure Finished
+                    -- otherwise we continue following
+                    _  -> pure InProgress
+
+    findInput inst tx = do
+        let txIns = Set.toList (Ledger.txInputs tx)
+        let inputs = txIns >>= (maybeToList . inScripts)
+        let script = Scripts.validatorScript inst
+        -- find previous Marlowe contract
+        let marloweTxInputs = filter (\(validator, _, _) -> validator == script) inputs
+        case marloweTxInputs of
+            []                          -> Nothing
+            [(_, Ledger.Redeemer d, _)] -> PlutusTx.fromData d
+            _                           -> Nothing
+
+{-  This is a control contract.
+    It allows to create a contract, apply inputs, auto-execute a contract,
+    redeem role payouts, and close.
+ -}
 marlowePlutusContract :: Contract MarloweContractState MarloweSchema MarloweError ()
 marlowePlutusContract = do
-    create `select` apply `select` wait `select` auto `select` redeem `select` close
+    create `select` apply `select` auto `select` redeem `select` close
   where
     create = do
         (owners, contract) <- endpoint @"create"
@@ -126,10 +233,6 @@ marlowePlutusContract = do
         let lookups = Constraints.scriptInstanceLookups validatorInstance
         utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups tx)
         submitTxConfirmed utx
-        marlowePlutusContract
-    wait = do
-        params <- endpoint @"wait"
-        _ <- SM.waitForUpdate (mkMarloweClient params)
         marlowePlutusContract
     apply = do
         (params, slotInterval, inputs) <- endpoint @"apply-inputs"

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -94,8 +94,8 @@ zeroCouponBondTest :: TestTree
 zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250) "Zero Coupon Bond Contract"
     (assertNoFailedTransactions
     -- T..&&. emulatorLog (const False) ""
-    T..&&. assertNotDone marlowePlutusContract (Trace.walletInstanceTag alice) "contract should close"
-    T..&&. assertNotDone marlowePlutusContract (Trace.walletInstanceTag bob) "contract should close"
+    T..&&. assertDone marlowePlutusContract (Trace.walletInstanceTag alice) (const True) "contract should close"
+    T..&&. assertDone marlowePlutusContract (Trace.walletInstanceTag bob) (const True) "contract should close"
     T..&&. walletFundsChange alice (lovelaceValueOf (150))
     T..&&. walletFundsChange bob (lovelaceValueOf (-150))
     ) $ do
@@ -118,14 +118,14 @@ zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250
     Trace.callEndpoint @"create" aliceHdl (AssocMap.empty, zeroCouponBond)
     Trace.waitNSlots 2
 
-    Trace.callEndpoint @"wait" bobHdl (params)
-
-    Trace.callEndpoint @"apply-inputs" aliceHdl (params, [IDeposit alicePk alicePk ada 850])
+    Trace.callEndpoint @"apply-inputs" aliceHdl (params, Nothing, [IDeposit alicePk alicePk ada 850])
     Trace.waitNSlots 2
 
-    Trace.callEndpoint @"wait" aliceHdl (params)
+    Trace.callEndpoint @"apply-inputs" bobHdl (params, Nothing, [IDeposit alicePk bobPk ada 1000])
+    void $ Trace.waitNSlots 2
 
-    Trace.callEndpoint @"apply-inputs" bobHdl (params, [IDeposit alicePk bobPk ada 1000])
+    Trace.callEndpoint @"close" aliceHdl ()
+    Trace.callEndpoint @"close" bobHdl ()
     void $ Trace.waitNSlots 2
 
 
@@ -155,17 +155,13 @@ trustFundTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 200) "Tr
         [] -> pure ()
         (pms, _) : _ -> do
 
-            Trace.callEndpoint @"wait" bobHdl pms
-
-            Trace.callEndpoint @"apply-inputs" aliceHdl (pms,
+            Trace.callEndpoint @"apply-inputs" aliceHdl (pms, Nothing,
                 [ IChoice chId 256
                 , IDeposit "alice" "alice" ada 256
                 ])
             Trace.waitNSlots 17
 
-            Trace.callEndpoint @"wait" aliceHdl (pms)
-
-            Trace.callEndpoint @"apply-inputs" bobHdl (pms, [INotify])
+            Trace.callEndpoint @"apply-inputs" bobHdl (pms, Nothing, [INotify])
 
             Trace.waitNSlots 2
             Trace.callEndpoint @"redeem" bobHdl (pms, "bob", bobPkh)

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/marlowe.nix
@@ -96,6 +96,19 @@
             "Main.hs"
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) "") ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
           };
+        "marlowe-follow-app" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          hsSourceDirs = [ "follow" ];
+          mainPath = ([
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) "") ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
         "marlowe-pab" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -13,6 +13,7 @@
 , plutus-pab
 , marlowe-app
 , marlowe-companion-app
+, marlowe-follow-app
 , docs
 , vmCompileTests ? false
 }:
@@ -48,5 +49,9 @@ pkgs.recurseIntoAttrs {
     inherit (pkgs) terraform;
   };
 
-  vmTests = pkgs.callPackage ./vm.nix { inherit vmCompileTests plutus-playground marlowe-playground marlowe-dashboard web-ghc plutus-pab marlowe-app marlowe-companion-app docs; };
+  vmTests = pkgs.callPackage ./vm.nix {
+    inherit vmCompileTests plutus-playground marlowe-playground
+      marlowe-dashboard web-ghc plutus-pab
+      marlowe-app marlowe-companion-app marlowe-follow-app docs;
+  };
 }

--- a/nix/tests/vm-tests/all.nix
+++ b/nix/tests/vm-tests/all.nix
@@ -7,6 +7,7 @@
 , marlowe-dashboard
 , marlowe-app
 , marlowe-companion-app
+, marlowe-follow-app
 , web-ghc
 , vmCompileTests # when enabled the test tries to compile plutus/marlowe code on webghc
 }:
@@ -37,7 +38,11 @@ makeTest {
       services.pab = {
         enable = true;
         pab-package = plutus-pab.pab-exes.plutus-pab;
-        contracts = [ "${marlowe-app}/bin/marlowe-app" "${marlowe-companion-app}/bin/marlowe-companion-app" ];
+        contracts = [
+          "${marlowe-app}/bin/marlowe-app"
+          "${marlowe-companion-app}/bin/marlowe-companion-app"
+          "${marlowe-follow-app}/bin/marlowe-follow-app"
+        ];
         staticContent = marlowe-dashboard.client;
         dbFile = "/var/lib/pab/pab-core.db";
         defaultWallet = 1;

--- a/nix/tests/vm.nix
+++ b/nix/tests/vm.nix
@@ -6,6 +6,7 @@
 , plutus-pab
 , marlowe-app
 , marlowe-companion-app
+, marlowe-follow-app
 , docs
 , vmCompileTests
 }:
@@ -18,7 +19,7 @@ let
     marlowe-playground-server = pkgs.callPackage ./vm-tests/marlowe-playground.nix { inherit makeTest marlowe-playground; };
     web-ghc = pkgs.callPackage ./vm-tests/web-ghc.nix { inherit makeTest web-ghc; };
     pab = pkgs.callPackage ./vm-tests/pab.nix { inherit makeTest plutus-pab marlowe-dashboard; };
-    all = pkgs.callPackage ./vm-tests/all.nix { inherit makeTest plutus-playground marlowe-playground marlowe-dashboard web-ghc marlowe-app marlowe-companion-app plutus-pab docs vmCompileTests; };
+    all = pkgs.callPackage ./vm-tests/all.nix { inherit makeTest plutus-playground marlowe-playground marlowe-dashboard web-ghc marlowe-app marlowe-companion-app marlowe-follow-app plutus-pab docs vmCompileTests; };
   };
 in
 if isDarwin then { } else tests

--- a/plutus-ledger/src/Ledger/AddressMap.hs
+++ b/plutus-ledger/src/Ledger/AddressMap.hs
@@ -24,6 +24,7 @@ module Ledger.AddressMap(
     restrict,
     addressesTouched,
     outRefMap,
+    outputsMapFromTxForAddress,
     fromChain
     ) where
 
@@ -124,6 +125,12 @@ traverseWithKey ::
   -> AddressMap
   -> f AddressMap
 traverseWithKey f (AddressMap m) = AddressMap <$> Map.traverseWithKey f m
+
+outputsMapFromTxForAddress :: Address -> Tx -> Map TxOutRef TxOutTx
+outputsMapFromTxForAddress addr tx =
+    fmap (\txout -> TxOutTx{txOutTxTx=tx, txOutTxOut = txout})
+    $ Map.filter ((==) addr . txOutAddress)
+    $ unspentOutputsTx tx
 
 -- | Create an 'AddressMap' with the unspent outputs of a single transaction.
 fromTxOutputs :: Tx -> AddressMap

--- a/plutus-pab/plutus-pab.yaml
+++ b/plutus-pab/plutus-pab.yaml
@@ -22,6 +22,7 @@ nodeServerConfig:
   mscBlockReaper:
     brcInterval: 600
     brcBlocksToKeep: 100
+  mscKeptBlocks: 100
   mscInitialTxWallets:
     - getWallet: 1
     - getWallet: 2

--- a/plutus-pab/run-zcb.sh
+++ b/plutus-pab/run-zcb.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# Run in plutus/plutus-pab directory
+
+echo Marlowe ZeroCouponBond
+
+killall plutus-pab
+
+
+rm -rf pab-core.db* && \
+  cabal exec plutus-pab migrate && \
+  cabal exec plutus-pab contracts install -- --path /Users/nau/projects/iohk/plutus/dist-newstyle/build/x86_64-osx/ghc-8.10.2.20201118/marlowe-0.1.0.0/x/marlowe-app/build/marlowe-app/marlowe-app && \
+  cabal exec plutus-pab contracts install -- --path /Users/nau/projects/iohk/plutus/dist-newstyle/build/x86_64-osx/ghc-8.10.2.20201118/marlowe-0.1.0.0/x/marlowe-follow-app/build/marlowe-follow-app/marlowe-follow-app
+
+nohup cabal exec plutus-pab all-servers &> /dev/null 2>&1 &
+
+sleep 6
+
+echo Activate W1 contract
+echo
+
+instanceId1=$(curl -s -H "Content-Type: application/json" \
+  -d '{"caID": {"contractPath":"/Users/nau/projects/iohk/plutus/dist-newstyle/build/x86_64-osx/ghc-8.10.2.20201118/marlowe-0.1.0.0/x/marlowe-app/build/marlowe-app/marlowe-app"}, "caWallet": {"getWallet": 1}}' \
+  http://localhost:9080/api/new/contract/activate | jq -r '.unContractInstanceId')
+
+echo "Contract W1 $instanceId1"
+echo
+
+echo
+echo Activate W2 follow contract
+echo
+
+followId=$(curl -s -H "Content-Type: application/json" \
+  -d '{"caID": {"contractPath":"/Users/nau/projects/iohk/plutus/dist-newstyle/build/x86_64-osx/ghc-8.10.2.20201118/marlowe-0.1.0.0/x/marlowe-follow-app/build/marlowe-follow-app/marlowe-follow-app"}, "caWallet": {"getWallet": 1}}' \
+  http://localhost:9080/api/new/contract/activate | jq -r '.unContractInstanceId')
+
+sleep 3
+
+
+# set -o xtrace
+
+curl -s -H "Content-Type: application/json" -d '[[], {"timeout":300,"when":[{"then":{"to":{"party":{"pk_hash":"39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"}},"then":{"timeout":600,"when":[{"then":"close","case":{"deposits":1000,"party":{"pk_hash":"39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"},"of_token":{"currency_symbol":"","token_name":""},"into_account":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"}}}],"timeout_continuation":"close"},"token":{"currency_symbol":"","token_name":""},"from_account":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"},"pay":850},"case":{"deposits":850,"party":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"},"of_token":{"currency_symbol":"","token_name":""},"into_account":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"}}}],"timeout_continuation":"close"}]' \
+  "http://localhost:9080/api/new/contract/instance/${instanceId1}/endpoint/create"
+
+sleep 5
+
+echo
+echo Status
+echo
+
+curl -s "http://localhost:9080/api/new/contract/instance/${instanceId1}/status" | jq '.cicCurrentState.observableState'
+
+sleep 3
+
+echo
+echo "Contract W2 follow $followId"
+echo
+
+
+curl -s -H "Content-Type: application/json" -d '{"rolesCurrency":{"unCurrencySymbol":""},"rolePayoutValidatorHash":"edb912810cdc518e698a8b2da6b5d8e1d1ef2916396dde2fe6c0611f62bda3ff"}' \
+  "http://localhost:9080/api/new/contract/instance/${followId}/endpoint/follow"
+
+
+# exit
+
+echo
+echo Deposit W1 850
+echo
+
+curl -s -H "Content-Type: application/json" -d '[{"rolesCurrency":{"unCurrencySymbol":""},"rolePayoutValidatorHash":"edb912810cdc518e698a8b2da6b5d8e1d1ef2916396dde2fe6c0611f62bda3ff"},null,[{"that_deposits":850,"input_from_party":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"},"of_token":{"currency_symbol":"","token_name":""},"into_account":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"}}]]' \
+  "http://localhost:9080/api/new/contract/instance/${instanceId1}/endpoint/apply-inputs"
+
+sleep 5
+
+echo
+echo Status W1
+echo
+
+curl "http://localhost:9080/api/new/contract/instance/${instanceId1}/status" | jq '.cicCurrentState.observableState'
+
+echo
+echo Status W2 follow
+echo
+
+curl "http://localhost:9080/api/new/contract/instance/${followId}/status" # | jq '.cicCurrentState.observableState'
+echo "curl http://localhost:9080/api/new/contract/instance/${followId}/status"
+
+
+echo
+echo "W1 funds"
+echo
+
+curl http://localhost:9081/1/total-funds
+
+sleep 5
+
+echo
+echo Activate W2 contract
+echo
+
+instanceId3=$(curl -s -H "Content-Type: application/json" \
+  -d '{"caID": {"contractPath":"/Users/nau/projects/iohk/plutus/dist-newstyle/build/x86_64-osx/ghc-8.10.2.20201118/marlowe-0.1.0.0/x/marlowe-app/build/marlowe-app/marlowe-app"}, "caWallet": {"getWallet": 2}}' \
+  http://localhost:9080/api/new/contract/activate | jq -r '.unContractInstanceId')
+
+echo
+echo "Contract W2 $instanceId3"
+echo
+
+# slot=$(curl -s http://localhost:9081/1/wallet-slot | jq -r '.getSlot')
+
+sleep 5
+
+echo
+echo Status W2
+echo
+
+curl -s "http://localhost:9080/api/new/contract/instance/${instanceId3}/status" | jq '.cicCurrentState.observableState'
+
+sleep 5
+
+echo
+echo Deposit W2 1000
+echo
+
+curl -s -H "Content-Type: application/json" -d '[{"rolesCurrency":{"unCurrencySymbol":""},"rolePayoutValidatorHash":"edb912810cdc518e698a8b2da6b5d8e1d1ef2916396dde2fe6c0611f62bda3ff"}, null, [{"that_deposits":1000,"input_from_party":{"pk_hash":"39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"},"of_token":{"currency_symbol":"","token_name":""},"into_account":{"pk_hash":"21fe31dfa154a261626bf854046fd2271b7bed4b6abe45aa58877ef47f9721b9"}}]]' \
+  "http://localhost:9080/api/new/contract/instance/${instanceId3}/endpoint/apply-inputs"
+
+sleep 5
+
+echo
+echo Status W2 follow
+echo
+
+curl -s "http://localhost:9080/api/new/contract/instance/${followId}/status" | jq '.cicCurrentState.observableState'
+
+
+echo
+echo Status W2
+echo
+
+curl -s "http://localhost:9080/api/new/contract/instance/${instanceId3}/status" | jq '.cicCurrentState.observableState'
+
+echo
+echo
+echo "W2 funds"
+echo
+
+curl -s http://localhost:9081/2/total-funds
+
+sleep 5
+
+echo
+echo DONE
+
+echo
+echo "W1 funds"
+echo
+
+curl -s http://localhost:9081/1/total-funds
+
+echo
+echo
+echo "W2 funds"
+echo
+curl -s http://localhost:9081/2/total-funds
+echo


### PR DESCRIPTION
We add a new follower contract that tracks Marlowe contract execution history in form of `MarloweParams`, initial `MarloweData`, and a list of `TransactionInput`s
This is needed for Marlowe Run.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
