### PR TITLE
SCP-2158: use the new CBOR tags that we have proposed

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-tx.nix
@@ -35,6 +35,7 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -75,6 +75,7 @@ library
     build-depends:
         base >=4.9 && <5,
         bytestring -any,
+        cborg -any,
         deepseq -any,
         template-haskell >=2.13.0.0,
         th-abstraction -any,

--- a/plutus-tx/src/PlutusTx/Data.hs
+++ b/plutus-tx/src/PlutusTx/Data.hs
@@ -2,14 +2,19 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE MultiWayIf         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ViewPatterns       #-}
 
 module PlutusTx.Data (Data (..)) where
 
-import           Codec.Serialise           (Serialise)
+import qualified Codec.CBOR.Term           as CBOR
+import           Codec.Serialise           (Serialise (..))
 import           Control.DeepSeq           (NFData)
+import           Control.Monad.Except
+import           Data.Bifunctor            (bimap)
 import qualified Data.ByteString           as BS
+import qualified Data.ByteString.Lazy      as BSL
 import           Data.Text.Prettyprint.Doc
 import           GHC.Generics
 import           Prelude
@@ -27,7 +32,7 @@ data Data =
     | I Integer
     | B BS.ByteString
     deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (Serialise, NFData)
+    deriving anyclass (NFData)
 
 instance Pretty Data where
     pretty = \case
@@ -36,3 +41,79 @@ instance Pretty Data where
         List ds     -> brackets (sep (punctuate comma (fmap pretty ds)))
         I i         -> pretty i
         B b         -> viaShow b
+
+{- Note [Encoding via Term]
+We want to write a custom encoder/decoder for Data (i.e. not use the Generic version), but actually
+doing this is a pain. So instead we go via the CBOR 'Term' representation, which lets us process a
+more structured representation, which is a lot easier.
+-}
+
+instance Serialise Data where
+    -- See Note [Encoding via Term]
+    encode = CBOR.encodeTerm . toTerm
+    decode = do
+        t <- CBOR.decodeTerm
+        case fromTerm t of
+            Right d -> pure d
+            Left e  -> fail e
+
+{- Note [CBOR alternative tags]
+We've proposed to add additional tags to the CBOR standard to cover (essentially) sum types.
+This is exactly what we need to encode the 'Constr' constructor of 'Data' in an unambiguous way.
+
+The tags aren't *quite* accepted yet, but they're clearly going to accept so we might as well
+start using them.
+
+The scheme is:
+- Alternatives 0-6 -> tags 121-127
+- Alternatives 7-127 -> tags 1280-1400
+- Any alternatives, including those that don't fit in the above -> tag 102 followed by an integer for the actual alternative.
+-}
+
+-- | Turn Data into a CBOR Term.
+toTerm :: Data -> CBOR.Term
+toTerm = \case
+    -- See Note [CBOR alternative tags]
+    Constr i ds | 0 <= i && i < 7   -> CBOR.TTagged (fromIntegral (121 + i)) (CBOR.TList $ fmap toTerm ds)
+    Constr i ds | 7 <= i && i < 128 -> CBOR.TTagged (fromIntegral (1280 + (i - 7))) (CBOR.TList $ fmap toTerm ds)
+    Constr i ds | otherwise         -> CBOR.TTagged 102 (CBOR.TList $ CBOR.TInteger i : fmap toTerm ds)
+    Map es                          -> CBOR.TMap (fmap (bimap toTerm toTerm) es)
+    List ds                         -> CBOR.TList $ fmap toTerm ds
+    I i                             -> CBOR.TInteger i
+    B b                             -> CBOR.TBytes b
+
+{- Note [Definite and indefinite forms of CBOR]
+CBOR is annoying and you can have both definite (with a fixed length) and indefinite lists, maps, etc.
+
+So we have to be careful to handle both cases when decoding. When encoding we simply don't make
+the indefinite kinds.
+-}
+
+-- | Turn a CBOR Term into Data if possible.
+fromTerm :: CBOR.Term -> Either String Data
+fromTerm = \case
+    -- See Note [CBOR alternative tags]
+    CBOR.TTagged t (CBOR.TList ds)
+        | 121  <= t && t < 128                -> Constr (fromIntegral t - 121) <$> traverse fromTerm ds
+    CBOR.TTagged t (CBOR.TList ds)
+        | 1280 <= t && t < 1401               -> Constr ((fromIntegral t - 1280) + 7) <$> traverse fromTerm ds
+    CBOR.TTagged t (CBOR.TList (i:ds))
+        | t == 102, Just actualTag <- asInt i -> Constr actualTag <$> traverse fromTerm ds
+    CBOR.TTagged _ _                          -> throwError "Couldn't interpret tag as constructor tag"
+    -- See Note [Definite and indefinite forms of CBOR]
+    CBOR.TMap es                              -> Map <$> traverse (\(t1, t2) -> (,) <$> fromTerm t1 <*> fromTerm t2) es
+    CBOR.TMapI es                             -> Map <$> traverse (\(t1, t2) -> (,) <$> fromTerm t1 <*> fromTerm t2) es
+    CBOR.TList l                              -> List <$> traverse fromTerm l
+    CBOR.TListI l                             -> List <$> traverse fromTerm l
+    CBOR.TInteger i                           -> pure $ I i
+    CBOR.TInt i                               -> pure $ I $ fromIntegral i
+    CBOR.TBytes b                             -> pure $ B b
+    CBOR.TBytesI b                            -> pure $ B $ BSL.toStrict b
+    _                                         -> throwError "Unsupported kind of CBOR"
+
+-- See Note [Definite and indefinite forms of CBOR]
+-- | View a CBOR Term as an Integer if possible.
+asInt :: CBOR.Term -> Maybe Integer
+asInt (CBOR.TInteger i) = Just i
+asInt (CBOR.TInt i)     = Just $ fromIntegral i
+asInt _                 = Nothing

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,7 +19,7 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",10)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx d11f7cd7e2e931e126928b3d841ba2dc60269fb3c49263657af71b57c89cf575:
+                Tx af0f5853f7c80869f947beb7061e8fa42ea771ab687487a7bcab68f23460314d:
                   {inputs:
                   outputs:
                     - Value (Map [(,Map [("",10)])]) addressed to
@@ -32,7 +32,7 @@ Slot 1: W2: Balancing an unbalanced transaction:
                   data:
                     "9\247\DC3\208\166D%?\EOTR\148!\185\245\ESC\155\b\151\157\b)YY\196\243\153\SO\230\ETB\245\DC3\159"}
               Requires signatures:
-Slot 1: W2: TxSubmit: 3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
+Slot 1: W2: TxSubmit: 01ac510eadab9f19208d3ae99156eafa82d4f56a5f04c7f1a237db254a1cf15a
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
@@ -41,7 +41,7 @@ Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",1)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx 4648c86cdf2c3490343fd15c77cb00a100629beb0d4ddca2566791066e7aa283:
+                Tx ac9e30ee5f7ff9f51d4ee081598db47c33c0bec8b846dc68c6e59ab6d8b3c334:
                   {inputs:
                   outputs:
                     - Value (Map [(,Map [("",10)])]) addressed to
@@ -54,10 +54,10 @@ Slot 1: W3: Balancing an unbalanced transaction:
                   data:
                     "\218\192s\224\DC2;\222\165\157\217\179\189\169\207`7\246:\202\130b}z\188\213\196\172)\221t\NUL>"}
               Requires signatures:
-Slot 1: W3: TxSubmit: 2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
+Slot 1: W3: TxSubmit: 1e4bb6ccf44cab04881fad815ee761e4fdcaf319c99a8f042be7a525f62ea3df
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx 92e4ec2faec589e104af51317653c4ddce679b8a22c3345515aeed2288cae0ca:
+                Tx f675cf5dac7d538e69cd99e3fd7d59c336830974729b0d1f90f2f99d10f97046:
                   {inputs:
                   outputs:
                     - Value (Map [(,Map [("",1)])]) addressed to
@@ -70,21 +70,21 @@ Slot 1: W4: Balancing an unbalanced transaction:
                   data:
                     "\237\209\195sr\247R\201z\236\b\130E/\172\172\ETB\164\253\175F\230\FS\ETX?J\246x\164\a\155\205"}
               Requires signatures:
-Slot 1: W4: TxSubmit: 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
-Slot 1: TxnValidate 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
-Slot 1: TxnValidate 2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
-Slot 1: TxnValidate 3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
+Slot 1: W4: TxSubmit: f387442ac1321aaa64464826eb64ed249ed27ba1631e51e41545e9bebcd1c310
+Slot 1: TxnValidate f387442ac1321aaa64464826eb64ed249ed27ba1631e51e41545e9bebcd1c310
+Slot 1: TxnValidate 1e4bb6ccf44cab04881fad815ee761e4fdcaf319c99a8f042be7a525f62ea3df
+Slot 1: TxnValidate 01ac510eadab9f19208d3ae99156eafa82d4f56a5f04c7f1a237db254a1cf15a
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 7c5957c59396a7cc7872284bda16237e35b8934a939ca1895ac04f552c1c309f:
+                 Tx 66e6db4103bd5184c514c075e2b63c8b49e007a95ec42773afa31012d1f9d395:
                    {inputs:
-                      - 2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247!1
+                      - 01ac510eadab9f19208d3ae99156eafa82d4f56a5f04c7f1a237db254a1cf15a!1
                         Redeemer: <>
-                      - 3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6!1
+                      - 1e4bb6ccf44cab04881fad815ee761e4fdcaf319c99a8f042be7a525f62ea3df!1
                         Redeemer: <>
-                      - 51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762!1
+                      - f387442ac1321aaa64464826eb64ed249ed27ba1631e51e41545e9bebcd1c310!1
                         Redeemer: <>
                    outputs:
                    forge: Value (Map [])
@@ -94,7 +94,7 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 20})) True, ivTo = UpperBound (Finite (Slot {getSlot = 30})) True}
                    data:}
                Requires signatures:
-Slot 20: W1: TxSubmit: 87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62
+Slot 20: W1: TxSubmit: b02dd70fea2ec17345354351372e5070be042b4e1131c808e48527cda2555bbe
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62
+Slot 20: TxnValidate b02dd70fea2ec17345354351372e5070be042b4e1131c808e48527cda2555bbe

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
+TxId:       f387442ac1321aaa64464826eb64ed249ed27ba1631e51e41545e9bebcd1c310
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840f8ac7148b1f06b3f77e4017305f225f23f14...
+              Signature: 5840b8207671ba781ee53a097107c8c6d4803c0b...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 4)
@@ -175,11 +175,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  1
 
 ==== Slot #1, Tx #1 ====
-TxId:       2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
+TxId:       1e4bb6ccf44cab04881fad815ee761e4fdcaf319c99a8f042be7a525f62ea3df
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584089842130b1d3a5c700351801557ce7957a31...
+              Signature: 58408f9c9ae2db10449f1d9707d36e58d2bbe5a0...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 3)
@@ -249,11 +249,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  11
 
 ==== Slot #1, Tx #2 ====
-TxId:       3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
+TxId:       01ac510eadab9f19208d3ae99156eafa82d4f56a5f04c7f1a237db254a1cf15a
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840cd96dd5223cddf8fe24e3d15d48a0a28d280...
+              Signature: 58401cc7a40abcfe6fe36e3190bbb402da8a0370...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -323,18 +323,18 @@ Balances Carried Forward:
     Ada:      Lovelace:  21
 
 ==== Slot #2, Tx #0 ====
-TxId:       87b370c5e48f617b6cd8d595763c80ee966bf7586e9d56843713ad4c3266fb62
+TxId:       b02dd70fea2ec17345354351372e5070be042b4e1131c808e48527cda2555bbe
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584099a337bcf4fde278a7e3778a9e8597ca5edd...
+              Signature: 5840982d0db81e70422112fbff7175aa97108d13...
 Inputs:
   ---- Input 0 ----
   Destination:  Script: 95acd7ea52f13c014509d7372b8217b421231dc3bf2abfec4dcf7b7c5ec5ec37
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     2272d1950bca529345170ee4bd97c4f3535e84c8805727e83fa7949661cc9247
+    Tx:     01ac510eadab9f19208d3ae99156eafa82d4f56a5f04c7f1a237db254a1cf15a
     Output #1
     Script: 5924b60100003320033320020020033320020020...
 
@@ -343,7 +343,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     3d816e33bfe9db94f75245937d1e6b83b5bf1a7e8bb99d14bfcef45dfa47b6c6
+    Tx:     1e4bb6ccf44cab04881fad815ee761e4fdcaf319c99a8f042be7a525f62ea3df
     Output #1
     Script: 5924b60100003320033320020020033320020020...
 
@@ -352,7 +352,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     51721296e58bda2712d32621312b9684885ce804b84c2afba3ff9eb6f627c762
+    Tx:     f387442ac1321aaa64464826eb64ed249ed27ba1631e51e41545e9bebcd1c310
     Output #1
     Script: 5924b60100003320033320020020033320020020...
 

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       64b8585a3b44d6220210282943b4238c12979e21d71fda0614c25fa9824a8731
+TxId:       ac4f14c8279e8944df6b231184af8d00af658498d499003cd9fdc084ad5307a5
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58407c7541e00c3e20c2485ece36dec9907621ed...
+              Signature: 584090754133d8997c648c1415d1ca1ef63c510a...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
@@ -175,18 +175,18 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       f6a08f9f5ab5faa7abca8c4bd07fba04232ddd27a0555fd151f933f7655f583c
+TxId:       974bb853d1980af196353dfcd53d3be813ecfa67c9234ff8effa2231cbd9c423
 Fee:        Ada:      Lovelace:  10
 Forge:      8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584008ee8a1d5aa0e77a2d11bdf79335b249a44a...
+              Signature: 5840daa9944c0b3a7b82119aeb975bbedc24ec6b...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     64b8585a3b44d6220210282943b4238c12979e21d71fda0614c25fa9824a8731
+    Tx:     ac4f14c8279e8944df6b231184af8d00af658498d499003cd9fdc084ad5307a5
     Output #0
 
 
@@ -195,7 +195,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     64b8585a3b44d6220210282943b4238c12979e21d71fda0614c25fa9824a8731
+    Tx:     ac4f14c8279e8944df6b231184af8d00af658498d499003cd9fdc084ad5307a5
     Output #1
     Script: 593d250100003320033200200332002003332002...
 
@@ -266,11 +266,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       b1710a7e70edd32b2c0de29122297ea8d2b6052111cb7c2e2f8aec654ca03579
+TxId:       9e389a2d8f46e1c07886ec4da879a0717104bf063eba41cca8486b62a738ce31
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840eec705b6ae37de06310bdc8e86b991772a09...
+              Signature: 58408919ea2331e3fd71d073b9c91bdfc743a56c...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
@@ -278,7 +278,7 @@ Inputs:
     Ada:      Lovelace:  99999972
     8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  -
   Source:
-    Tx:     f6a08f9f5ab5faa7abca8c4bd07fba04232ddd27a0555fd151f933f7655f583c
+    Tx:     974bb853d1980af196353dfcd53d3be813ecfa67c9234ff8effa2231cbd9c423
     Output #0
 
 
@@ -288,7 +288,7 @@ Inputs:
     8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    1
     Ada:      -
   Source:
-    Tx:     f6a08f9f5ab5faa7abca8c4bd07fba04232ddd27a0555fd151f933f7655f583c
+    Tx:     974bb853d1980af196353dfcd53d3be813ecfa67c9234ff8effa2231cbd9c423
     Output #1
 
 
@@ -354,13 +354,31 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       c703ae309531c1326d5873918a9ce6772a900ca78351779e7be60ceac02e9ea4
+TxId:       51ec942aea7cf280d8555e6a00ac80567467d2a3444d093c274e63a8494ac9e7
 Fee:        Ada:      Lovelace:  10
 Forge:      8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840a0f55b7866765861cecbcc498ff2a7121445...
+              Signature: 58401c22960bf13d742f718740f595654577df44...
 Inputs:
   ---- Input 0 ----
+  Destination:  Script: 9121626a5b036c130320c23eec5cec3d6ba2ea946a737dc804c03e210e4d6f06
+  Value:
+    Ada:      Lovelace:  8
+  Source:
+    Tx:     974bb853d1980af196353dfcd53d3be813ecfa67c9234ff8effa2231cbd9c423
+    Output #2
+    Script: 593d250100003320033200200332002003332002...
+
+  ---- Input 1 ----
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
+  Value:
+    8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    1
+  Source:
+    Tx:     9e389a2d8f46e1c07886ec4da879a0717104bf063eba41cca8486b62a738ce31
+    Output #0
+
+
+  ---- Input 2 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
@@ -369,31 +387,13 @@ Inputs:
     Output #1
 
 
-  ---- Input 1 ----
-  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
-  Value:
-    8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    1
-  Source:
-    Tx:     b1710a7e70edd32b2c0de29122297ea8d2b6052111cb7c2e2f8aec654ca03579
-    Output #0
-
-
-  ---- Input 2 ----
-  Destination:  Script: 9121626a5b036c130320c23eec5cec3d6ba2ea946a737dc804c03e210e4d6f06
-  Value:
-    Ada:      Lovelace:  8
-  Source:
-    Tx:     f6a08f9f5ab5faa7abca8c4bd07fba04232ddd27a0555fd151f933f7655f583c
-    Output #2
-    Script: 593d250100003320033200200332002003332002...
-
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99999993
     8a734493645271625fce446967cc928f97f25a0a02db9d3aee3cf11fbf5a9df8:  guess:    0
+    Ada:      Lovelace:  99999993
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       5f43760ba59ff7300f84b4f42db6c3d55c25ee64372267a29b8e2cdcfcd5eb0e
+TxId:       80d08047ad5c5c727794dda5d32a49ae584953cdd583d983e732162bb206eeb2
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840c892d37dfbf46faf948c76f8a9aaf3e9d63f...
+              Signature: 5840ee00a2707a70b70da571a16a5fe82980631e...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -175,18 +175,18 @@ Balances Carried Forward:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       0cb1a12d3c3a2d63a2faac71482551a0a935277eb0baa925ddace807249e925b
+TxId:       a168432b5ba8a0c9eeba8a1bb6f821db9d073ebb2cf9c2c846e848aa14f94295
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584052796d73459b28c63914d90bebabb37c9b42...
+              Signature: 5840f9bb359197a650177a53ffa63d5e763817c3...
 Inputs:
   ---- Input 0 ----
   Destination:  Script: 0e5d4a9feab58223921d169ea734bb1e8ff3ba22659b4bb1c2af0c6ccce5bd57
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     5f43760ba59ff7300f84b4f42db6c3d55c25ee64372267a29b8e2cdcfcd5eb0e
+    Tx:     80d08047ad5c5c727794dda5d32a49ae584953cdd583d983e732162bb206eeb2
     Output #1
     Script: 5926bb0100003320033320020020032003320020...
 


### PR DESCRIPTION
We've added a number of special tags for constructors to the CBOR
standard, which saves us some space and makes the encoding
non-ambiguous.

They are not *quite* accepted yet, but they nearly are, and it'll be a
lot easier to use them from the beginning than to change to using them
later, so this PR does it.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
