### PR TITLE
SCP-2150 - Connect metadata to contracts in the JavaScript editor

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -98,7 +98,7 @@ initialState :: State
 initialState =
   { keybindings: DefaultBindings
   , compilationResult: NotAsked
-  , bottomPanelState: BottomPanel.initialState GeneratedOutputView
+  , bottomPanelState: BottomPanel.initialState MetadataView
   , metadataHintInfo: mempty
   , analysisState: initAnalysisState
   }

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -13,7 +13,7 @@ import Control.Monad.Maybe.Trans (runMaybeT)
 import Control.Monad.Reader (class MonadAsk)
 import Data.Array as Array
 import Data.Either (Either(..))
-import Data.Lens (assign, modifying, use, view)
+import Data.Lens (assign, modifying, over, set, use, view)
 import Data.List ((:))
 import Data.List as List
 import Data.Map as Map
@@ -24,20 +24,21 @@ import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect)
 import Env (Env)
 import Examples.JS.Contracts as JSE
-import Halogen (Component, HalogenM, gets, liftEffect, query)
+import Halogen (Component, HalogenM, gets, liftEffect, modify_, query)
 import Halogen.Extra (mapSubmodule)
 import Halogen.HTML (HTML)
 import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import Halogen.Monaco (Message, Query, monacoComponent)
-import JavascriptEditor.Types (Action(..), BottomPanelView(..), CompilationState(..), State, _bottomPanelState, _compilationResult, _decorationIds, _keybindings)
+import JavascriptEditor.Types (Action(..), BottomPanelView(..), CompilationState(..), State, _bottomPanelState, _compilationResult, _decorationIds, _keybindings, _metadataHintInfo)
 import Language.Javascript.Interpreter (InterpreterResult(..))
 import Language.Javascript.Interpreter as JSI
 import Language.Javascript.Monaco as JSM
-import SessionStorage as SessionStorage
 import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import Marlowe.Extended (Contract, getPlaceholderIds, typeToLens, updateTemplateContent)
+import Marlowe.Extended.Metadata (MetadataHintInfo, getMetadataHintInfo)
 import Monaco (IRange, getModel, isError, setValue)
 import Network.RemoteData (RemoteData(..))
+import SessionStorage as SessionStorage
 import StaticAnalysis.Reachability (analyseReachability)
 import StaticAnalysis.StaticTools (analyseContract)
 import StaticAnalysis.Types (AnalysisExecutionState(..), MultiStageAnalysisData(..), _analysisExecutionState, _analysisState, _templateContent)
@@ -125,7 +126,15 @@ handleAction Compile = do
           case res of
             Left err -> pure $ CompilationError err
             Right result -> do
-              modifying (_analysisState <<< _templateContent) $ updateTemplateContent $ getPlaceholderIds $ (unwrap result).result
+              let
+                contract :: Contract
+                contract = (unwrap result).result
+
+                metadataHints :: MetadataHintInfo
+                metadataHints = getMetadataHintInfo contract
+              modify_
+                $ over (_analysisState <<< _templateContent) (updateTemplateContent $ getPlaceholderIds contract)
+                <<< set _metadataHintInfo metadataHints
               pure $ CompiledSuccessfully result
   assign _compilationResult compilationResult
   case compilationResult of
@@ -141,11 +150,14 @@ handleAction (BottomPanelAction action) = do
 
 handleAction SendResultToSimulator = pure unit
 
-handleAction (InitJavascriptProject prunedContent) = do
+handleAction (InitJavascriptProject metadataHints prunedContent) = do
   editorSetValue prunedContent
+  assign _metadataHintInfo metadataHints
   liftEffect $ SessionStorage.setItem jsBufferLocalStorageKey prunedContent
 
 handleAction (SetIntegerTemplateParam templateType key value) = modifying (_analysisState <<< _templateContent <<< typeToLens templateType) (Map.insert key value)
+
+handleAction (MetadataAction _) = pure unit
 
 handleAction AnalyseContract = analyze (WarningAnalysis Loading) $ analyseContract
 

--- a/marlowe-playground-client/src/JavascriptEditor/View.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/View.purs
@@ -18,11 +18,12 @@ import Halogen.HTML.Events (onClick, onSelectedIndexChange)
 import Halogen.HTML.Properties (class_, classes, enabled, href)
 import Halogen.HTML.Properties as HTML
 import JavascriptEditor.State (mkEditor)
-import JavascriptEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _keybindings)
+import JavascriptEditor.Types (Action(..), BottomPanelView(..), State, _bottomPanelState, _compilationResult, _keybindings, _metadataHintInfo)
 import JavascriptEditor.Types as JS
 import Language.Javascript.Interpreter (CompilationError(..), InterpreterResult(..))
 import MainFrame.Types (ChildSlots, _jsEditorSlot)
 import Marlowe.Extended.Metadata (MetaData)
+import MetadataTab.View (metadataView)
 import StaticAnalysis.BottomPanel (analysisResultPane, analyzeButton, clearButton)
 import StaticAnalysis.Types (_analysisExecutionState, _analysisState, isCloseAnalysisLoading, isNoneAsked, isReachabilityLoading, isStaticLoading)
 import Text.Pretty (pretty)
@@ -47,7 +48,8 @@ render metadata state =
     ]
   where
   panelTitles =
-    [ { title: "Generated code", view: GeneratedOutputView, classes: [] }
+    [ { title: "Metadata", view: MetadataView, classes: [] }
+    , { title: "Generated code", view: GeneratedOutputView, classes: [] }
     , { title: "Static Analysis", view: StaticAnalysisView, classes: [] }
     , { title: "Errors", view: ErrorsView, classes: [] }
     ]
@@ -171,6 +173,8 @@ panelContents state _ ErrorsView =
   section_ case view _compilationResult state of
     JS.CompilationError err -> [ compilationErrorPane err ]
     _ -> [ text "No errors" ]
+
+panelContents state metadata MetadataView = metadataView (state ^. _metadataHintInfo) metadata MetadataAction
 
 compilationErrorPane :: forall p. CompilationError -> HTML p Action
 compilationErrorPane (RawError error) = div_ [ text "There was an error when running the JavaScript code:", code_ [ pre_ [ text $ error ] ] ]


### PR DESCRIPTION
This PR adds the Metadata tab to the JavaScript editor and adds the loading of metadata hints to Gists, Demos, and LocalStorage.

It also sets the Metadata as default both for JavaScript and for Haskell editor.

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
