### PR TITLE
deployment-shell: always recreate terraform bridge files

### DIFF
--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -77,6 +77,14 @@ let
         # reports it has nothing to do before we even attempt to deploy
         # any nix configuration.
 
+        # The local files (ssh configuration and dns/ip information on ec2
+        # instances) is part of the state so we have to create these before
+        # we check if the state is up to date
+        echo "[deploy-nix]: Creating terraform bridge files"
+        rm -rf ./plutus_playground.$DEPLOYMENT_ENV.conf
+        rm -rf ./machines.json
+        ${terraform}/bin/terraform apply -auto-approve -target=local_file.ssh_config -target=local_file.machines ./terraform/
+
         echo "[deploy-nix]: Checking if terraform state is up to date"
         if ! ${terraform}/bin/terraform plan --detailed-exitcode -compact-warnings ./terraform >/dev/null ; then
           echo "[deploy-nix]: terraform state is not up to date - Aborting"


### PR DESCRIPTION
Adjust the `deploy-nix` script to always re-create the "bridge files"
between terraform and morph.

The bridge files provide 2 things:

1. ssh configuration
2. per ec2 instance dns/ip information

Both provide information that `morph` cannot derive independently.
This commit chnages the script to always re-create these files before
performing the "is terraform state up to date" check. Without the files
`terraform plan` will report that there are 2 local files that have to
be created.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
