### PR TITLE
Teach updateMaterialized to update the tool shas as well

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -89,6 +89,8 @@ But the CI will tell you if you've failed to do so.
 
 You can regenerate the files by running `updateMaterialized` (provided by `nix-shell`) from the repository root.
 
+This will also update the `plan-256` shas for the extra Haskell tools, if you have a problem iwth that.
+
 === How to add a new Haskell package
 
 You need to do a few things when adding a new package, in the following order:
@@ -136,6 +138,8 @@ The Nix code which builds our packages also cares about the index state.
 The set of index states which it knows about is controlled by `hackage.nix`, which is a Nix representation of Hackage.
 This therefore needs to be newer than the index state.
 You can update it xref:update-nix-pins[with `niv`].
+
+You will need to update the xref:update-generated[package set] after this to reflect the new build plan that Cabal will pick.
 
 == Working conventions
 

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -24,7 +24,7 @@ let
 
   # { index-state, project, projectPackages, packages, extraPackages }
   haskell = pkgs.callPackage ./haskell {
-    inherit gitignore-nix;
+    inherit gitignore-nix sources;
     inherit agdaWithStdlib checkMaterialization enableHaskellProfiling;
     # This ensures that the utility scripts produced in here will run on the current system, not
     # the build system, so we can run e.g. the darwin ones on linux

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -26,6 +26,9 @@ let
   haskell = pkgs.callPackage ./haskell {
     inherit gitignore-nix;
     inherit agdaWithStdlib checkMaterialization enableHaskellProfiling;
+    # This ensures that the utility scripts produced in here will run on the current system, not
+    # the build system, so we can run e.g. the darwin ones on linux
+    inherit (pkgs.evalPackages) writeShellScript;
   };
 
   #
@@ -81,6 +84,10 @@ let
 
     # Update the linux files (will do for all unixes atm).
     $(nix-build default.nix -A plutus.haskell.project.plan-nix.passthru.updateMaterialized --argstr system x86_64-linux)
+
+    # This updates the sha files for the extra packages
+    $(nix-build default.nix -A plutus.haskell.extraPackages.updateAllShaFiles --argstr system x86_64-linux)
+    $(nix-build default.nix -A plutus.haskell.extraPackages.updateAllShaFiles --argstr system x86_64-darwin)
   '';
   updateMetadataSamples = pkgs.callPackage ./update-metadata-samples { };
   updateClientDeps = pkgs.callPackage ./update-client-deps {

--- a/nix/pkgs/haskell/agda.sha
+++ b/nix/pkgs/haskell/agda.sha
@@ -1,0 +1,1 @@
+0w6cra4ynqprbv83qbc8bsnnzly9sv3ry99jfskls4cr47l3gjks

--- a/nix/pkgs/haskell/cabal-install.sha
+++ b/nix/pkgs/haskell/cabal-install.sha
@@ -1,0 +1,1 @@
+0z0ir8kcs9b8f0d72rx5xkq7w1m9s76i3h84lbk0bdh3l4kqld8r

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -1,6 +1,5 @@
 { lib
-, fetchFromGitHub
-, fetchFromGitLab
+, sources
 , agdaWithStdlib
 , stdenv
 , haskell-nix
@@ -55,7 +54,7 @@ let
   projectPackagesAllHaddock = haskell-nix.haskellLib.selectProjectPackages projectAllHaddock.hsPkgs;
 
   extraPackages = import ./extra.nix {
-    inherit stdenv lib haskell-nix fetchFromGitHub fetchFromGitLab buildPackages writeShellScript;
+    inherit stdenv lib haskell-nix sources buildPackages writeShellScript;
     inherit index-state checkMaterialization compiler-nix-name;
   };
 

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -5,6 +5,7 @@
 , stdenv
 , haskell-nix
 , buildPackages
+, writeShellScript
 , checkMaterialization
 , gitignore-nix
 , R
@@ -54,7 +55,7 @@ let
   projectPackagesAllHaddock = haskell-nix.haskellLib.selectProjectPackages projectAllHaddock.hsPkgs;
 
   extraPackages = import ./extra.nix {
-    inherit stdenv lib haskell-nix fetchFromGitHub fetchFromGitLab buildPackages;
+    inherit stdenv lib haskell-nix fetchFromGitHub fetchFromGitLab buildPackages writeShellScript;
     inherit index-state checkMaterialization compiler-nix-name;
   };
 

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -7,8 +7,7 @@
 { stdenv
 , lib
 , haskell-nix
-, fetchFromGitHub
-, fetchFromGitLab
+, sources
 , index-state
 , compiler-nix-name
 , checkMaterialization
@@ -74,12 +73,7 @@ let
   # See https://github.com/input-output-hk/nix-tools/issues/97
   hlsShaFile = if stdenv.isLinux then ./hls-linux.sha else ./hls-darwin.sha;
   hlsProject = haskell-nix.cabalProject' {
-    src = fetchFromGitHub {
-      owner = "haskell";
-      repo = "haskell-language-server";
-      rev = "1.1.0";
-      sha256 = "0kviq3kinm3i0qm4r26rdnlkwbs1s3r1rqiqdry517rgkgnjpcp5";
-    };
+    src = sources.haskell-language-server;
     inherit compiler-nix-name index-state checkMaterialization;
     plan-sha256 = lib.removeSuffix "\n" (builtins.readFile hlsShaFile);
     modules = [{

--- a/nix/pkgs/haskell/hlint.sha
+++ b/nix/pkgs/haskell/hlint.sha
@@ -1,0 +1,1 @@
+138zligphj3ndvjzb2hhb40jjji83m3brnqs2maysblplwcsm4gr

--- a/nix/pkgs/haskell/hls-darwin.sha
+++ b/nix/pkgs/haskell/hls-darwin.sha
@@ -1,0 +1,1 @@
+0w6bwrysl0ni87k6qjsssv64h1hcg5czv6ml5czsl6rw8id0i9cj

--- a/nix/pkgs/haskell/hls-linux.sha
+++ b/nix/pkgs/haskell/hls-linux.sha
@@ -1,0 +1,1 @@
+0q6m14y4fbk75z5mm92ylyzbfjla885fyibq4cxcd6gsn445ai51

--- a/nix/pkgs/haskell/stylish-haskell.sha
+++ b/nix/pkgs/haskell/stylish-haskell.sha
@@ -1,0 +1,1 @@
+1pgmscvz7jx5lx22pqbx6vw43mjd1a7sjj81i988bqw5ab4iq264

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -37,6 +37,19 @@
         "url": "https://github.com/input-output-hk/hackage.nix/archive/c63c196d3f72ed29840b0ac7605eeb4408c1bc6c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "haskell-language-server": {
+        "branch": "master",
+        "builtin": false,
+        "description": "Successor of ghcide & haskell-ide-engine. One IDE to rule them all.",
+        "homepage": "",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "1.1.0",
+        "sha256": "0kviq3kinm3i0qm4r26rdnlkwbs1s3r1rqiqdry517rgkgnjpcp5",
+        "type": "tarball",
+        "url": "https://github.com/haskell/haskell-language-server/archive/1.1.0.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",


### PR DESCRIPTION
This has been bugging me for ages. Now it's completely mechanical and rolled into `updateMaterialized`. Much better!

While I was at it, I made the HLS source a niv source, so it should now be updatable by doing `niv update` followed by `updateMaterialized`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
