### PR TITLE
SCP-2150 - Fix `Save` button in Marlowe Playground

### DIFF
--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -514,6 +514,8 @@ handleAction (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
     ( set _showModal Nothing
         <<< set _workflow (Just lang)
         <<< set _hasUnsavedChanges false
+        <<< set _gistId Nothing
+        <<< set _projectName metadata.contractName
         <<< set _contractMetadata metadata
     )
   selectView $ selectLanguageView lang

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -54,7 +54,7 @@ import Marlowe (getApiGistsByGistId)
 import Marlowe as Server
 import Marlowe.ActusBlockly as AMB
 import Marlowe.Extended.Metadata (emptyContractMetadata, getHintsFromMetadata)
-import Marlowe.Gists (mkNewGist, playgroundFiles, PlaygroundFiles)
+import Marlowe.Gists (PlaygroundFiles, mkNewGist, playgroundFiles)
 import MarloweEditor.State as MarloweEditor
 import MarloweEditor.Types as ME
 import MetadataTab.State (carryMetadataAction)
@@ -545,7 +545,7 @@ handleAction (SaveAsAction action@SaveAs.SaveProject) = do
         <<< set _projectName projectName
         <<< set (_saveAs <<< SaveAs._status) Loading
     )
-  handleGistAction PublishGist
+  handleGistAction PublishOrUpdateGist
   res <- peruse (_createGistResult <<< _Success)
   case res of
     Just gist -> do
@@ -669,15 +669,11 @@ checkAuthStatus = do
   assign _authStatus authResult
 
 ------------------------------------------------------------
-handleGistAction ::
+createFiles ::
   forall m.
-  Warn (Text "Check if the handler for LoadGist is being used") =>
-  Warn (Text "SCP-1591 Saving failure does not provide enough information") =>
   MonadAff m =>
-  MonadAsk Env m =>
-  GistAction -> HalogenM State Action ChildSlots Void m Unit
-handleGistAction PublishGist = do
-  description <- use _projectName
+  MonadAsk Env m => HalogenM State Action ChildSlots Void m PlaygroundFiles
+createFiles = do
   let
     pruneEmpty :: forall a. Eq a => Monoid a => Maybe a -> Maybe a
     pruneEmpty (Just v)
@@ -691,7 +687,7 @@ handleGistAction PublishGist = do
   workflow <- use _workflow
   let
     emptyFiles = (mempty :: PlaygroundFiles) { playground = playground, metadata = metadata }
-  files <- case workflow of
+  case workflow of
     Just Marlowe -> do
       marlowe <- pruneEmpty <$> MarloweEditor.editorGetValue
       pure $ emptyFiles { marlowe = marlowe }
@@ -708,6 +704,17 @@ handleGistAction PublishGist = do
       actus <- pruneEmpty <$> query _actusBlocklySlot unit (H.request ActusBlockly.GetWorkspace)
       pure $ emptyFiles { actus = actus }
     Nothing -> mempty
+
+handleGistAction ::
+  forall m.
+  Warn (Text "Check if the handler for LoadGist is being used") =>
+  Warn (Text "SCP-1591 Saving failure does not provide enough information") =>
+  MonadAff m =>
+  MonadAsk Env m =>
+  GistAction -> HalogenM State Action ChildSlots Void m Unit
+handleGistAction PublishOrUpdateGist = do
+  description <- use _projectName
+  files <- createFiles
   let
     newGist = mkNewGist description $ files
   void
@@ -826,7 +833,7 @@ handleConfirmUnsavedNavigationAction intendedAction modalAction = do
       -- refactor into a `Save (Maybe Action)` action. The handler for that should do
       -- this check and call the next action as a continuation
       if has (_authStatus <<< _Success <<< authStatusAuthRole <<< _GithubUser) state then do
-        fullHandleAction $ GistAction PublishGist
+        fullHandleAction $ GistAction PublishOrUpdateGist
         fullHandleAction intendedAction
       else
         fullHandleAction $ OpenModal $ GithubLogin $ ConfirmUnsavedNavigationAction intendedAction modalAction

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -726,7 +726,7 @@ handleGistAction PublishOrUpdateGist = do
           lift
             $ case mGist of
                 Nothing -> runAjax $ flip runReaderT settings $ Server.postApiGists newGist
-                Just gistId -> runAjax $ flip runReaderT settings $ Server.patchApiGistsByGistId newGist gistId
+                Just gistId -> runAjax $ flip runReaderT settings $ Server.postApiGistsByGistId newGist gistId
         assign _createGistResult newResult
         gistId <- hoistMaybe $ preview (_Success <<< gistId) newResult
         modify_

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -4,7 +4,7 @@ import Prelude hiding (div)
 import Auth (_GithubUser, authStatusAuthRole)
 import BlocklyEditor.View as BlocklyEditor
 import Data.Lens (has, to, (^.))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), isNothing)
 import Effect.Aff.Class (class MonadAff)
 import Gists.Types (GistAction(..))
 import Halogen (ComponentHTML)
@@ -20,7 +20,7 @@ import HaskellEditor.View (otherActions, render) as HaskellEditor
 import Home as Home
 import Icons (Icon(..), icon)
 import JavascriptEditor.View as JSEditor
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _contractMetadata, _createGistResult, _hasUnsavedChanges, _haskellState, _javascriptState, _marloweEditorState, _projectName, _simulationState, _view, _walletSlot, hasGlobalLoading)
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _contractMetadata, _createGistResult, _gistId, _hasUnsavedChanges, _haskellState, _javascriptState, _marloweEditorState, _projectName, _simulationState, _view, _walletSlot, hasGlobalLoading)
 import Marlowe.ActusBlockly as AMB
 import MarloweEditor.View as MarloweEditor
 import Modal.View (modal)
@@ -146,7 +146,7 @@ menuBar state =
       ]
     <> showInEditor
         [ menuButton (OpenModal RenameProject) "Rename"
-        , gistModal (GistAction PublishGist) "Save"
+        , gistModal (if isNothing $ state ^. _gistId then OpenModal SaveProjectAs else GistAction PublishOrUpdateGist) "Save"
         , gistModal (OpenModal SaveProjectAs) "Save As..."
         ]
   where

--- a/playground-common/src/Gist.hs
+++ b/playground-common/src/Gist.hs
@@ -37,7 +37,7 @@ import           Data.Proxy        (Proxy (Proxy))
 import           Data.Text         (Text)
 import qualified Data.Text         as T
 import           GHC.Generics      (Generic, Rep)
-import           Servant.API       (Capture, FromHttpApiData (parseQueryParam), Get, Header, JSON, Patch, Post, ReqBody,
+import           Servant.API       (Capture, FromHttpApiData (parseQueryParam), Get, Header, JSON, Post, ReqBody,
                                     ToHttpApiData (toQueryParam), (:<|>), (:>))
 import           Servant.Client    (ClientM, client)
 import qualified Servant.Extra
@@ -49,7 +49,7 @@ type GistAPI
      = Get '[ JSON] [Gist]
        :<|> ReqBody '[ JSON] NewGist :> Post '[ JSON] Gist
        :<|> Capture "GistId" GistId :> Get '[ JSON] Gist
-       :<|> Capture "GistId" GistId :> ReqBody '[ JSON] NewGist :> Patch '[ JSON] Gist
+       :<|> Capture "GistId" GistId :> ReqBody '[ JSON] NewGist :> Post '[ JSON] Gist
 
 apiClient ::
        Maybe (Token 'Github)
@@ -141,7 +141,7 @@ instance FromJSON Gist where
             _gistGitPushUrl <- o .: "git_push_url"
             _gistHtmlUrl <- o .: "html_url"
             _gistOwner <- o .: "owner"
-            _gistFiles <- (o .: "files")
+            _gistFiles <- o .: "files"
             _gistTruncated <- o .: "truncated"
             _gistCreatedAt <- o .: "created_at"
             _gistUpdatedAt <- o .: "updated_at"

--- a/plutus-playground-client/src/MainFrame/MonadApp.purs
+++ b/plutus-playground-client/src/MainFrame/MonadApp.purs
@@ -12,7 +12,7 @@ module MainFrame.MonadApp
   , getGistByGistId
   , postEvaluation
   , postGist
-  , patchGistByGistId
+  , postGistByGistId
   , postContract
   , resizeEditor
   , resizeBalancesChart
@@ -79,7 +79,7 @@ class
   getGistByGistId :: GistId -> m (WebData Gist)
   postEvaluation :: Evaluation -> m (WebData (Either PlaygroundError EvaluationResult))
   postGist :: NewGist -> m (WebData Gist)
-  patchGistByGistId :: NewGist -> GistId -> m (WebData Gist)
+  postGistByGistId :: NewGist -> GistId -> m (WebData Gist)
   postContract :: SourceCode -> m (WebData (Either InterpreterError (InterpreterResult CompilationResult)))
   resizeEditor :: m Unit
   resizeBalancesChart :: m Unit
@@ -145,7 +145,7 @@ instance monadAppHalogenApp ::
   getGistByGistId gistId = runAjax $ Server.getGistsByGistId gistId
   postEvaluation evaluation = runAjax $ Server.postEvaluate evaluation
   postGist newGist = runAjax $ Server.postGists newGist
-  patchGistByGistId newGist gistId = runAjax $ Server.patchGistsByGistId newGist gistId
+  postGistByGistId newGist gistId = runAjax $ Server.postGistsByGistId newGist gistId
   postContract source = runAjax $ Server.postContract source
   resizeEditor = wrap $ void $ H.query _editorSlot unit (Monaco.Resize unit)
   resizeBalancesChart = wrap $ void $ H.query _balancesChartSlot unit (Chartist.Resize unit)
@@ -171,7 +171,7 @@ instance monadAppState :: MonadApp m => MonadApp (StateT s m) where
   getGistByGistId gistId = lift $ getGistByGistId gistId
   postEvaluation evaluation = lift $ postEvaluation evaluation
   postGist newGist = lift $ postGist newGist
-  patchGistByGistId newGist gistId = lift $ patchGistByGistId newGist gistId
+  postGistByGistId newGist gistId = lift $ postGistByGistId newGist gistId
   postContract source = lift $ postContract source
   resizeEditor = lift resizeEditor
   resizeBalancesChart = lift resizeBalancesChart

--- a/plutus-playground-client/src/MainFrame/State.purs
+++ b/plutus-playground-client/src/MainFrame/State.purs
@@ -394,7 +394,7 @@ _details :: forall a. Traversal' (WebData (Either InterpreterError (InterpreterR
 _details = _Success <<< _Right <<< _InterpreterResult <<< _result
 
 handleGistAction :: forall m. MonadApp m => MonadState State m => GistAction -> m Unit
-handleGistAction PublishGist = do
+handleGistAction PublishOrUpdateGist = do
   void
     $ runMaybeT do
         mContents <- lift $ editorGetContents

--- a/plutus-playground-client/src/MainFrame/State.purs
+++ b/plutus-playground-client/src/MainFrame/State.purs
@@ -56,7 +56,7 @@ import Halogen.HTML (HTML)
 import Halogen.Query (HalogenM)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult, SourceCode(..), _InterpreterResult)
 import MainFrame.Lenses (_actionDrag, _authStatus, _blockchainVisualisationState, _compilationResult, _contractDemos, _createGistResult, _currentDemoName, _currentView, _demoFilesMenuVisible, _editorState, _evaluationResult, _functionSchema, _gistErrorPaneVisible, _gistUrl, _lastEvaluatedSimulation, _knownCurrencies, _result, _resultRollup, _simulationActions, _simulationId, _simulationWallets, _simulations, _successfulCompilationResult, _successfulEvaluationResult, getKnownCurrencies)
-import MainFrame.MonadApp (class MonadApp, editorGetContents, editorHandleAction, editorSetAnnotations, editorSetContents, getGistByGistId, getOauthStatus, patchGistByGistId, postContract, postEvaluation, postGist, preventDefault, resizeBalancesChart, resizeEditor, runHalogenApp, saveBuffer, scrollIntoView, setDataTransferData, setDropEffect)
+import MainFrame.MonadApp (class MonadApp, editorGetContents, editorHandleAction, editorSetAnnotations, editorSetContents, getGistByGistId, getOauthStatus, postGistByGistId, postContract, postEvaluation, postGist, preventDefault, resizeBalancesChart, resizeEditor, runHalogenApp, saveBuffer, scrollIntoView, setDataTransferData, setDropEffect)
 import MainFrame.Types (ChildSlots, DragAndDropEventType(..), HAction(..), Query, State(..), View(..), WalletEvent(..), WebData)
 import MainFrame.View (render)
 import Monaco (IMarkerData, markerSeverity)
@@ -406,7 +406,7 @@ handleGistAction PublishOrUpdateGist = do
           lift
             $ case preview (_Success <<< gistId) mGist of
                 Nothing -> postGist newGist
-                Just existingGistId -> patchGistByGistId newGist existingGistId
+                Just existingGistId -> postGistByGistId newGist existingGistId
         assign _createGistResult newResult
         gistId <- hoistMaybe $ preview (_Success <<< gistId <<< _GistId) newResult
         assign _gistUrl (Just gistId)

--- a/plutus-playground-client/src/MainFrame/Types.purs
+++ b/plutus-playground-client/src/MainFrame/Types.purs
@@ -167,7 +167,7 @@ instance actionIsEvent :: IsEvent HAction where
   toEvent CompileProgram = Just $ defaultEvent "CompileProgram"
   toEvent (HandleBalancesChartMessage _) = Nothing
   toEvent CheckAuthStatus = Nothing
-  toEvent (GistAction PublishGist) = Just $ (defaultEvent "Publish") { category = Just "Gist" }
+  toEvent (GistAction PublishOrUpdateGist) = Just $ (defaultEvent "Publish") { category = Just "Gist" }
   toEvent (GistAction (SetGistUrl _)) = Nothing
   toEvent (GistAction LoadGist) = Just $ (defaultEvent "LoadGist") { category = Just "Gist" }
   toEvent (GistAction (AjaxErrorPaneAction _)) = Nothing

--- a/plutus-playground-client/test/MainFrameTests.purs
+++ b/plutus-playground-client/test/MainFrameTests.purs
@@ -125,7 +125,7 @@ instance monadAppMockApp :: Monad m => MonadApp (MockApp m) where
       pure $ RemoteData.fromMaybe $ Map.lookup gistId gists
   postEvaluation evaluation = pure NotAsked
   postGist newGist = pure NotAsked
-  patchGistByGistId newGist gistId = pure NotAsked
+  postGistByGistId newGist gistId = pure NotAsked
   postContract sourceCode =
     MockApp do
       Tuple { compilationResult } _ <- get

--- a/web-common-playground/src/Gists/Types.purs
+++ b/web-common-playground/src/Gists/Types.purs
@@ -12,7 +12,7 @@ import Gist (GistId(..))
 import Prelude (bind, ($), (<$>))
 
 data GistAction
-  = PublishGist
+  = PublishOrUpdateGist
   | SetGistUrl String
   | LoadGist
   | AjaxErrorPaneAction AjaxErrorPaneAction

--- a/web-common-playground/src/Gists/View.purs
+++ b/web-common-playground/src/Gists/View.purs
@@ -116,7 +116,7 @@ gistControls { authStatus, createGistResult, gistErrorPaneVisible, gistUrl } =
       button
         [ idPublishGist
         , classes [ btn, btnSmall, btnSecondary ]
-        , onClick $ const $ Just PublishGist
+        , onClick $ const $ Just PublishOrUpdateGist
         ]
         [ text "Save" ]
     Loading ->
@@ -131,7 +131,7 @@ gistControls { authStatus, createGistResult, gistErrorPaneVisible, gistUrl } =
       button
         [ idPublishGist
         , classes [ btn, btnSmall, btnSecondary ]
-        , onClick $ const $ Just PublishGist
+        , onClick $ const $ Just PublishOrUpdateGist
         ]
         [ text "Save" ]
 


### PR DESCRIPTION
This PR:
 - Fixes the `Save` button in Marlowe Playground (it seems it didn't work because servant had some problem with `PATCH` requests, so I just replaced it with a `POST` request)
 - Makes sure that `gistId` is set to `Nothing` when loading a demo, otherwise it would have saved to to the most recently openeded gist
 - Renames `PublishGist` to `PublishOrUpdateGist` because the name was misleading (I realised it was meant to update half-way through implementing `UpdateGist`)
 - It changes behaviour of `Save` so that, if the gist wasn't saved before (`gistId = Nothing`) it behaves as `Save as...`.

Because the code for gists is shared with Plutus Playground, I had to rename some calls to generated functions in there too, but I imagine it had the same problem.

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
