### PR TITLE
deploy.sh: wait for github status

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -52,4 +52,4 @@ ssh-add -l
 # starting deployment
 # -----------------------------------------------------------------------------
 
-cd deployment && nix-shell -A "$DEPLOY_ENV" --run "deploy-nix"
+cd deployment && nix-shell -A "$DEPLOY_ENV" --run "wait-github-status && deploy-nix"


### PR DESCRIPTION
Wait for the github ci status on the commit to deploy to turn to
"success" before deploying.

The deployment process should itself not build deployment artifacts,
instead it should use what hydra as central CI and single source of
truth is providing.

The buildkite pipeline is triggered when PRs have been merged to
master. At this point however hydra hasn't yet processed the new
master branch. This commit adds `wait-github-status` which polls
the GitHub API using hub to wait until the commit to be deployed
has been processed:

GitHub merge -> Hydra -> GitHub ci status -> buildkite deploy

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
