### PR TITLE
Implement curl/jq based wait-github-status

### DIFF
--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -24,12 +24,17 @@ let
         export DEPLOYMENT_ENV="${env}"
 
         SECRETS=$(${awscli}/bin/aws secretsmanager get-secret-value --secret env/${env} --query SecretString --output text --region ${region})
-        export TF_VAR_marlowe_github_client_id=$(echo $SECRETS | ${jq}/bin/jq ".marlowe.githubClientId")
-        export TF_VAR_marlowe_github_client_secret=$(echo $SECRETS | ${jq}/bin/jq ".marlowe.githubClientSecret")
-        export TF_VAR_marlowe_jwt_signature=$(echo $SECRETS | ${jq}/bin/jq ".marlowe.jwtSignature")
-        export TF_VAR_plutus_github_client_id=$(echo $SECRETS | ${jq}/bin/jq ".plutus.githubClientId")
-        export TF_VAR_plutus_github_client_secret=$(echo $SECRETS | ${jq}/bin/jq ".plutus.githubClientSecret")
-        export TF_VAR_plutus_jwt_signature=$(echo $SECRETS | ${jq}/bin/jq ".plutus.jwtSignature")
+        export TF_VAR_marlowe_github_client_id=$(echo $SECRETS | ${jq}/bin/jq --raw-output .marlowe.githubClientId)
+        export TF_VAR_marlowe_github_client_secret=$(echo $SECRETS | ${jq}/bin/jq --raw-output .marlowe.githubClientSecret)
+        export TF_VAR_marlowe_jwt_signature=$(echo $SECRETS | ${jq}/bin/jq --raw-output .marlowe.jwtSignature)
+        export TF_VAR_plutus_github_client_id=$(echo $SECRETS | ${jq}/bin/jq --raw-output .plutus.githubClientId)
+        export TF_VAR_plutus_github_client_secret=$(echo $SECRETS | ${jq}/bin/jq --raw-output .plutus.githubClientSecret)
+        export TF_VAR_plutus_jwt_signature=$(echo $SECRETS | ${jq}/bin/jq --raw-output .plutus.jwtSignature)
+
+        # In order to avoid problems with API rate-limiting when using `wait-github-status`
+        # we can specify an OAUTH application id and secret
+        export GITHUB_API_USER=$TF_VAR_plutus_github_client_id
+        export GITHUB_API_PW=$TF_VAR_plutus_github_client_secret
       '';
 
       # setupTerraform : Switch to `env` workspace (create it if neccessary)
@@ -67,39 +72,61 @@ let
       '';
 
       # wait-github-status: wait until the current commit has been processed by hydra
-      # - checks the github status in a loop with 30s breaks until it is is "success"
+      # - checks the github status in a loop with 60s breaks until it is is "success"
       #
-      # The `hub ci-status` calls do not seem to get rate limited. This was verified
-      # via `curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit`
+      # NOTE: this script depends on the GITHUB_API_USER and GITHUB_API_PW variables
+      # that are set above in `setupEnvSecrets` to avoid rate limiting problems.
       waitGitHubStatus = writeShellScriptBin "wait-github-status" ''
         set -eou pipefail
 
+        if [ -z $GITHUB_API_USER ] || [ -z $GITHUB_API_PW ]; then
+          echo "[wait-github-status]: GITHUB_API_USER and GITHUB_API_PW must be set! Exiting."
+          exit 1
+        fi
+
         echo "[wait-github-status]: waiting for commit to get processed by hydra"
+        GIT_COMMIT=$(git rev-parse HEAD)
+        GITHUB_API_URL=https://api.github.com/repos/input-output-hk/plutus/commits/"$GIT_COMMIT"/status
 
-        SLEEP_SECS=60
-        GH_STATUS=$(${hub}/bin/hub ci-status)
+        fetchCommitStatus() {
+            # Request the status from the GitHub API and build an object:
+            # { <context>, <status> }
+            # Note: the "buildkite/plutus" state gets filtered out otherwise we
+            # will be stuck in an infinite loop waiting for our own success.
+            curl --silent\
+             -u "$GITHUB_API_USER:$GITHUB_API_PW" \
+             -H "Accept: application/vnd.github.v3+json" \
+             "$GITHUB_API_URL" \
+                | ${jq}/bin/jq -c '.statuses | map(select(.context != "buildkite/plutus")) | map ({(.context): (.state)}) | add'
+        }
 
-        while [ $GH_STATUS != "success" ]; do
-         case "$GH_STATUS" in
-          failure|error|action_required|cancelled|timed_out)
-            echo "[wait-github-status]: $GH_STATUS"
-            exit 1
-            ;;
-          pending)
-            pritnf "."
-            sleep $SLEEP_SECS
-            GH_STATUS=$(${hub}/bin/hub ci-status)
-            continue
-            ;;
-          *)
-            echo "[wait-github-status]: Unexpected status $GH_STATUS"
-            exit 1
-            ;;
+        while true; do
+            GH_STATUS_MAP=$(fetchCommitStatus)
 
-         esac
+            # If any of the tests are in a failed state we can abort
+            if echo "$GH_STATUS_MAP" | ${jq}/bin/jq -c "values | .[]" | grep "failure\|error\|action_required\|cancelled\|timed_out" ; then
+                echo "[wait-github-status]: github reported a failure. Exiting"
+                exit 1
+            fi
+
+            # Check if all statuses have already been reported. If
+            # not we need to keep on waiting - hydra isn't ready.
+            ALL_CHECKS_PRESENT=$(echo "$GH_STATUS_MAP" | ${jq}/bin/jq 'has("ci/hydra-eval") and has("ci/hydra:Cardano:plutus:required") and has("ci/hydra-build:required")')
+            if ! [ "$ALL_CHECKS_PRESENT" = "true" ] ; then
+                echo "[wait-github-status]: waiting for all statuses to get reported ..."
+                sleep 60
+                continue
+            fi
+
+            # All relevant statuses have been reported and none of them are in a failed state.
+            # If all of them are "success" we are done. If not we have to keep on waiting.
+            # NOTE: A status is one of the failures captured above, "pending" or "success".
+            ALL_CHECKS_SUCCESS=$(echo "$GH_STATUS_MAP" | ${jq}/bin/jq  '[.[]] | all(. == "success")')
+            if [ "$ALL_CHECKS_SUCCESS" = "true" ] ; then
+                echo "[wait-github-status]: all statuses have been reported as successful"
+                exit 0
+            fi
         done
-        echo "[wait-github-status]: $GH_STATUS"
-        exit 0
       '';
 
       # deploy-nix: wrapper around executing `morph deploy`


### PR DESCRIPTION
Implement a bash script that polls the github commit status until all
relevant checks (excluding buildkite) are available and set to
"success".

The loop exits whenever any check has a non-success state. For
authentication the github app client id/secret is used which is already
made available as environment variable of the script.

------
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
