### PR TITLE
Fix Interval comments on inclusivity of upper bound

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
@@ -185,8 +185,7 @@ instance Eq a => Eq (Interval a) where
 
 {-# INLINABLE interval #-}
 -- | @interval a b@ includes all values that are greater than or equal
---   to @a@ and smaller than @b@. Therefore it includes @a@ but not it
---   does not include @b@.
+--   to @a@, and less than or equal to @b@. Therefore it includes @a@ and @b@.
 interval :: a -> a -> Interval a
 interval s s' = Interval (lowerBound s) (upperBound s')
 
@@ -202,7 +201,7 @@ from s = Interval (lowerBound s) (UpperBound PosInf True)
 
 {-# INLINABLE to #-}
 -- | @to a@ is an 'Interval' that includes all values that are
---  smaller than @a@.
+--  less than or equal to @a@.
 to :: a -> Interval a
 to s = Interval (LowerBound NegInf True) (upperBound s)
 


### PR DESCRIPTION
Mentioned in [Plutus Pioneer Program - Lecture #3](https://www.youtube.com/watch?v=Lk1eIVm_ZTQ), timestamps [20:30](https://www.youtube.com/watch?v=Lk1eIVm_ZTQ&t=20m30s) and [21:15](https://www.youtube.com/watch?v=Lk1eIVm_ZTQ&t=21m15s).

Pre-submit checklist:
- Branch
    - :white_check_mark: Commit sequence broadly makes sense
    - :white_check_mark: Key commits have useful messages
    - :negative_squared_cross_mark: Relevant tickets are mentioned in commit messages
    - :negative_squared_cross_mark: Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - :white_check_mark: Self-reviewed the diff
    - :white_check_mark: Useful pull request description
    - :white_check_mark:  Reviewer requested: @michaelpj 😄 

Pre-merge checklist:
- [ ] Someone approved it
- :white_check_mark: Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
