### PR TITLE
buildkite deployment: apply terraform

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -52,4 +52,4 @@ ssh-add -l
 # starting deployment
 # -----------------------------------------------------------------------------
 
-cd deployment && nix-shell -A "$DEPLOY_ENV" --run "wait-github-status && deploy-nix"
+cd deployment && nix-shell --argstr rev "$BUILDKITE_COMMIT" -A "$DEPLOY_ENV" --run "wait-github-status && deploy"


### PR DESCRIPTION
**Summary**
Change the buildkite deploy script to always apply terraform changes
instead of bailing out when the terraform state is not up to date.

**Details**
Up until now the deploy script executed `deploy-nix` instead of
`deploy`. The former verifies that the terraform state is up to date and
no changes are necessary. This turned out to be less practical for a
staging scenario where we just want to apply whatever the current state
of master might be.

_Note_: As a drive-by fix this also passes the previously omitted `rev` switch providing the git commit which is going to be served from `/version`. 

-----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
