### PR TITLE
Drop waiting for GitHub status

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -52,4 +52,4 @@ ssh-add -l
 # starting deployment
 # -----------------------------------------------------------------------------
 
-cd deployment && nix-shell --argstr rev "$BUILDKITE_COMMIT" -A "$DEPLOY_ENV" --run "wait-github-status && deploy"
+cd deployment && nix-shell --argstr rev "$BUILDKITE_COMMIT" -A "$DEPLOY_ENV" --run "deploy"


### PR DESCRIPTION
Do not wait for GitHub ci status before starting the deployment. This
means that some builds are most likely going to occur which ideally
should not happen.

Ideally hydra should invoke the buildkite pipeline. Since this isn't
currently possible the next best thing was to have buildkite wait for
hydra to complete the build.

The hydra API does not provide any straight forward way to do so. The
workaround to that in turn was to poll the GitHub CI status. Sadly this
simply isn't a reliable alternative:

- Sometimes hydra evaluation will fail and the failed job will be queued
again. Hydra will thus succeeed eventually but buildkite will have
aborted with the first failure and won't have been invoked when hydra
tries a second time.

- Sometimes PRs are merged in closed succession and hydra just skips
a commit. Buildkite will still have been triggered forever and will wait
till the end of the universe for all staus checks to report.

-----------

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
