### PR TITLE
SCP-1973: use machine integers for costing

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -269,6 +269,7 @@
           "PlcTestUtils"
           "Crypto"
           "Data/Text/Prettyprint/Doc/Custom"
+          "Data/SatInt"
           ];
         hsSourceDirs = [
           "plutus-core/src"

--- a/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
+++ b/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
@@ -26,6 +26,7 @@ import qualified Data.Text.Encoding                        as T
 import           Data.Vector
 import           GHC.Generics
 
+import           Data.SatInt
 import           Foreign.R
 import           H.Prelude                                 (MonadR, Region, r)
 import           Language.R
@@ -294,7 +295,7 @@ dropByteString cpuModelR = do
 
 memoryUsageAsDouble :: ExMemoryUsage a => a -> Double
 memoryUsageAsDouble x =
-    let m = coerce $ memoryUsage x :: Integer
+    let m = coerce $ memoryUsage x :: SatInt
     in fromIntegral m
 
 sHA2 :: MonadR m => (SomeSEXP (Region m)) -> m (CostingFun ModelOneArgument)

--- a/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
+++ b/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
@@ -26,7 +26,6 @@ import qualified Data.Text.Encoding                        as T
 import           Data.Vector
 import           GHC.Generics
 
-import           Data.SatInt
 import           Foreign.R
 import           H.Prelude                                 (MonadR, Region, r)
 import           Language.R
@@ -295,7 +294,7 @@ dropByteString cpuModelR = do
 
 memoryUsageAsDouble :: ExMemoryUsage a => a -> Double
 memoryUsageAsDouble x =
-    let m = coerce $ memoryUsage x :: SatInt
+    let m = coerce $ memoryUsage x :: CostingInteger
     in fromIntegral m
 
 sHA2 :: MonadR m => (SomeSEXP (Region m)) -> m (CostingFun ModelOneArgument)

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -21,7 +21,6 @@ import           Control.Applicative
 import           Control.Monad.Morph
 import           CostModelCreation
 import           Data.Coerce
-import           Data.SatInt
 import           Hedgehog
 import qualified Hedgehog.Gen                              as Gen
 import           Hedgehog.Main
@@ -142,14 +141,14 @@ testPredictOne haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => SatInt -> m SatInt
+    predictR :: MonadR m => CostingInteger -> m CostingInteger
     predictR x =
       let
         xD = fromIntegral x :: Double
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs))[[1]]|]
-    predictH :: SatInt -> SatInt
+    predictH :: CostingInteger -> CostingInteger
     predictH x = coerce $ _exBudgetCPU $ runCostingFunOneArgument modelH (ExMemory x)
     sizeGen = do
       x <- Gen.integral (Range.exponential 0 5000)
@@ -166,7 +165,7 @@ testPredictTwo haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => SatInt -> SatInt -> m SatInt
+    predictR :: MonadR m => CostingInteger -> CostingInteger -> m CostingInteger
     predictR x y =
       let
         xD = fromIntegral x :: Double
@@ -174,7 +173,7 @@ testPredictTwo haskellModelFun modelFun = propertyR $ do
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
-    predictH :: SatInt -> SatInt -> SatInt
+    predictH :: CostingInteger -> CostingInteger -> CostingInteger
     predictH x y = coerce $ _exBudgetCPU $ runCostingFunTwoArguments modelH (ExMemory x) (ExMemory y)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)
@@ -192,7 +191,7 @@ testPredictThree haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => SatInt -> SatInt -> SatInt -> m SatInt
+    predictR :: MonadR m => CostingInteger -> CostingInteger -> CostingInteger -> m CostingInteger
     predictR x y _z =
       let
         xD = fromIntegral x :: Double
@@ -201,7 +200,7 @@ testPredictThree haskellModelFun modelFun = propertyR $ do
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
-    predictH :: SatInt -> SatInt -> SatInt -> SatInt
+    predictH :: CostingInteger -> CostingInteger -> CostingInteger -> CostingInteger
     predictH x y z = coerce $ _exBudgetCPU $ runCostingFunThreeArguments modelH (ExMemory x) (ExMemory y) (ExMemory z)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -21,6 +21,7 @@ import           Control.Applicative
 import           Control.Monad.Morph
 import           CostModelCreation
 import           Data.Coerce
+import           Data.SatInt
 import           Hedgehog
 import qualified Hedgehog.Gen                              as Gen
 import           Hedgehog.Main
@@ -141,14 +142,14 @@ testPredictOne haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => Integer -> m Integer
+    predictR :: MonadR m => SatInt -> m SatInt
     predictR x =
       let
-        xD = fromInteger x :: Double
+        xD = fromIntegral x :: Double
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs))[[1]]|]
-    predictH :: Integer -> Integer
+    predictH :: SatInt -> SatInt
     predictH x = coerce $ _exBudgetCPU $ runCostingFunOneArgument modelH (ExMemory x)
     sizeGen = do
       x <- Gen.integral (Range.exponential 0 5000)
@@ -165,15 +166,15 @@ testPredictTwo haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => Integer -> Integer -> m Integer
+    predictR :: MonadR m => SatInt -> SatInt -> m SatInt
     predictR x y =
       let
-        xD = fromInteger x :: Double
-        yD = fromInteger y :: Double
+        xD = fromIntegral x :: Double
+        yD = fromIntegral y :: Double
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
-    predictH :: Integer -> Integer -> Integer
+    predictH :: SatInt -> SatInt -> SatInt
     predictH x y = coerce $ _exBudgetCPU $ runCostingFunTwoArguments modelH (ExMemory x) (ExMemory y)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)
@@ -191,16 +192,16 @@ testPredictThree haskellModelFun modelFun = propertyR $ do
   modelR <- lift $ costModelsR
   modelH <- lift $ haskellModelFun $ modelFun modelR
   let
-    predictR :: MonadR m => Integer -> Integer -> Integer -> m Integer
+    predictR :: MonadR m => SatInt -> SatInt -> SatInt -> m SatInt
     predictR x y _z =
       let
-        xD = fromInteger x :: Double
-        yD = fromInteger y :: Double
+        xD = fromIntegral x :: Double
+        yD = fromIntegral y :: Double
         -- zD = fromInteger z :: Double
         model = modelFun modelR
       in
         (\t -> toCostUnit (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
-    predictH :: Integer -> Integer -> Integer -> Integer
+    predictH :: SatInt -> SatInt -> SatInt -> SatInt
     predictH x y z = coerce $ _exBudgetCPU $ runCostingFunThreeArguments modelH (ExMemory x) (ExMemory y) (ExMemory z)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)

--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -771,7 +771,7 @@ printBudgetStateTally (Cek.CekExTally costs) = do
               Nothing -> ExBudget 0 0
         allNodeTags = [Cek.BConst, Cek.BVar, Cek.BLamAbs, Cek.BApply, Cek.BDelay, Cek.BForce, Cek.BError, Cek.BBuiltin]
         totalComputeSteps = mconcat $ map get allNodeTags  -- Depends on the fact that we have a unit cost for each AST node type
-        budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) = printf "%10d  %10d" cpu mem :: String
+        budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) = printf "%10d  %10d" (toInteger cpu) (toInteger mem) :: String
         pbudget k = budgetToString $ get k
         f l e = case e of {(Cek.BBuiltinApp b, cost)  -> (b,cost):l; _ -> l}
         builtinsAndCosts = List.foldl f [] (H.toList costs)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -129,6 +129,7 @@ library
         PlcTestUtils
         Crypto
         Data.Text.Prettyprint.Doc.Custom
+        Data.SatInt
     build-tool-depends: alex:alex -any, happy:happy >=1.17.1
     hs-source-dirs:
         plutus-core/src

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -1,0 +1,296 @@
+{- |
+Adapted from 'Data.SafeInt' to perform saturating arithmetic (i.e. returning max or min bounds) instead of throwing on overflow.
+
+This is not quite as fast as using 'Int' or 'Int64' directly, but we need the safety.
+-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE MagicHash          #-}
+{-# LANGUAGE UnboxedTuples      #-}
+module Data.SatInt (SatInt(..), fromSat, toSat) where
+
+import           Control.DeepSeq (NFData)
+import           GHC.Base
+import           GHC.Num
+import           GHC.Real
+
+newtype SatInt = SI Int
+    deriving newtype NFData
+
+fromSat :: SatInt -> Int
+fromSat (SI x) = x
+
+toSat :: Int -> SatInt
+toSat = SI
+
+instance Show SatInt where
+  showsPrec p x = showsPrec p (fromSat x)
+
+instance Read SatInt where
+  readsPrec p xs = [ (toSat x, r) | (x, r) <- readsPrec p xs ]
+
+instance Eq SatInt where
+  SI x == SI y = eqInt x y
+  SI x /= SI y = neInt x y
+
+instance Ord SatInt where
+  SI x <  SI y = ltInt x y
+  SI x <= SI y = leInt x y
+  SI x >  SI y = gtInt x y
+  SI x >= SI y = geInt x y
+
+-- | In the `Num' instance, we plug in our own addition, multiplication
+-- and subtraction function that perform overflow-checking.
+instance Num SatInt where
+  (+)               = plusSI
+  (*)               = timesSI
+  (-)               = minusSI
+  negate (SI y)
+    | y == minBound = maxBound
+    | otherwise     = SI (negate y)
+  abs x
+    | x >= 0        = x
+    | otherwise     = negate x
+  signum (SI x)     = SI (signum x)
+  fromInteger x
+    | x > maxBoundInteger  = maxBound
+    | x < minBoundInteger  = minBound
+    | otherwise            = SI (fromInteger x)
+
+maxBoundInteger :: Integer
+maxBoundInteger = toInteger maxInt
+
+minBoundInteger :: Integer
+minBoundInteger = toInteger minInt
+
+instance Bounded SatInt where
+
+  minBound = SI minInt
+  maxBound = SI maxInt
+
+instance Enum SatInt where
+  succ (SI x) = SI (succ x)
+  pred (SI x) = SI (pred x)
+  toEnum                = SI
+  fromEnum              = fromSat
+
+  {-# INLINE enumFrom #-}
+  enumFrom (SI (I# x)) = eftInt x maxInt#
+      where !(I# maxInt#) = maxInt
+
+  {-# INLINE enumFromTo #-}
+  enumFromTo (SI (I# x)) (SI (I# y)) = eftInt x y
+
+  {-# INLINE enumFromThen #-}
+  enumFromThen (SI (I# x1)) (SI (I# x2)) = efdInt x1 x2
+
+  {-# INLINE enumFromThenTo #-}
+  enumFromThenTo (SI (I# x1)) (SI (I# x2)) (SI (I# y)) = efdtInt x1 x2 y
+
+-- The following code is copied/adapted from GHC.Enum.
+
+{-# RULES
+"eftInt"        [~1] forall x y. eftInt x y = build (\ c n -> eftIntFB c n x y)
+"eftIntList"    [1] eftIntFB  (:) [] = eftInt
+ #-}
+
+{-# NOINLINE [1] eftInt #-}
+eftInt :: Int# -> Int# -> [SatInt]
+-- [x1..x2]
+eftInt x0 y | isTrue# (x0 ># y) = []
+            | otherwise = go x0
+               where
+                 go x = SI (I# x) : if isTrue# (x ==# y) then [] else go (x +# 1#)
+
+{-# INLINE [0] eftIntFB #-}
+eftIntFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> r
+eftIntFB c n x0 y | isTrue# (x0 ># y) = n
+                  | otherwise = go x0
+                 where
+                   go x = SI (I# x) `c` if isTrue# (x ==# y) then n else go (x +# 1#)
+                        -- Watch out for y=maxBound; hence ==, not >
+        -- Be very careful not to have more than one "c"
+        -- so that when eftInfFB is inlined we can inline
+        -- whatever is bound to "c"
+
+{-# RULES
+"efdtInt"       [~1] forall x1 x2 y.
+                     efdtInt x1 x2 y = build (\ c n -> efdtIntFB c n x1 x2 y)
+"efdtIntUpList" [1]  efdtIntFB (:) [] = efdtInt
+ #-}
+
+efdInt :: Int# -> Int# -> [SatInt]
+-- [x1,x2..maxInt]
+efdInt x1 x2
+ | isTrue# (x2 >=# x1) = case maxInt of I# y -> efdtIntUp x1 x2 y
+ | otherwise = case minInt of I# y -> efdtIntDn x1 x2 y
+
+{-# NOINLINE [1] efdtInt #-}
+efdtInt :: Int# -> Int# -> Int# -> [SatInt]
+-- [x1,x2..y]
+efdtInt x1 x2 y
+ | isTrue# (x2 >=# x1) = efdtIntUp x1 x2 y
+ | otherwise = efdtIntDn x1 x2 y
+
+{-# INLINE [0] efdtIntFB #-}
+efdtIntFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
+efdtIntFB c n x1 x2 y
+ | isTrue# (x2 >=# x1) = efdtIntUpFB c n x1 x2 y
+ | otherwise  = efdtIntDnFB c n x1 x2 y
+
+-- Requires x2 >= x1
+efdtIntUp :: Int# -> Int# -> Int# -> [SatInt]
+efdtIntUp x1 x2 y    -- Be careful about overflow!
+ | isTrue# (y <# x2) = if isTrue# (y <# x1) then [] else [SI (I# x1)]
+ | otherwise = -- Common case: x1 <= x2 <= y
+               let !delta = x2 -# x1 -- >= 0
+                   !y' = y -# delta  -- x1 <= y' <= y; hence y' is representable
+
+                   -- Invariant: x <= y
+                   -- Note that: z <= y' => z + delta won't overflow
+                   -- so we are guaranteed not to overflow if/when we recurse
+                   go_up x | isTrue# (x ># y') = [SI (I# x)]
+                           | otherwise = SI (I# x) : go_up (x +# delta)
+               in SI (I# x1) : go_up x2
+
+-- Requires x2 >= x1
+efdtIntUpFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
+efdtIntUpFB c n x1 x2 y    -- Be careful about overflow!
+ | isTrue# (y <# x2) = if isTrue# (y <# x1) then n else SI (I# x1) `c` n
+ | otherwise = -- Common case: x1 <= x2 <= y
+               let !delta = x2 -# x1 -- >= 0
+                   !y' = y -# delta  -- x1 <= y' <= y; hence y' is representable
+
+                   -- Invariant: x <= y
+                   -- Note that: z <= y' => z + delta won't overflow
+                   -- so we are guaranteed not to overflow if/when we recurse
+                   go_up x | isTrue# (x ># y') = SI (I# x) `c` n
+                           | otherwise = SI (I# x) `c` go_up (x +# delta)
+               in SI (I# x1) `c` go_up x2
+
+-- Requires x2 <= x1
+efdtIntDn :: Int# -> Int# -> Int# -> [SatInt]
+efdtIntDn x1 x2 y    -- Be careful about underflow!
+ | isTrue# (y ># x2) = if isTrue# (y ># x1) then [] else [SI (I# x1)]
+ | otherwise = -- Common case: x1 >= x2 >= y
+               let !delta = x2 -# x1 -- <= 0
+                   !y' = y -# delta  -- y <= y' <= x1; hence y' is representable
+
+                   -- Invariant: x >= y
+                   -- Note that: z >= y' => z + delta won't underflow
+                   -- so we are guaranteed not to underflow if/when we recurse
+                   go_dn x | isTrue# (x <# y') = [SI (I# x)]
+                           | otherwise = SI (I# x) : go_dn (x +# delta)
+   in SI (I# x1) : go_dn x2
+
+
+-- Requires x2 <= x1
+efdtIntDnFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
+efdtIntDnFB c n x1 x2 y    -- Be careful about underflow!
+ | isTrue# (y ># x2) = if isTrue# (y ># x1) then n else SI (I# x1) `c` n
+ | otherwise = -- Common case: x1 >= x2 >= y
+               let !delta = x2 -# x1 -- <= 0
+                   !y' = y -# delta  -- y <= y' <= x1; hence y' is representable
+
+                   -- Invariant: x >= y
+                   -- Note that: z >= y' => z + delta won't underflow
+                   -- so we are guaranteed not to underflow if/when we recurse
+                   go_dn x | isTrue# (x <# y') = SI (I# x) `c` n
+                           | otherwise = SI (I# x) `c` go_dn (x +# delta)
+               in SI (I# x1) `c` go_dn x2
+
+-- The following code is copied/adapted from GHC.Real.
+
+instance Real SatInt where
+  toRational (SI x) = toInteger x % 1
+
+instance Integral SatInt where
+    toInteger (SI (I# i)) = smallInteger i
+
+    SI a `quot` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  = SI (a `quotInt` b)
+
+    SI a `rem` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  = SI (a `remInt` b)
+
+    SI a `div` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  = SI (a `divInt` b)
+
+    SI a `mod` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  = SI (a `modInt` b)
+
+    SI a `quotRem` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  =  a `quotRemSI` b
+
+    SI a `divMod` SI b
+     | b == 0                     = divZeroError
+     | a == minBound && b == (-1) = minBound
+     | otherwise                  =  a `divModSI` b
+
+quotRemSI :: Int -> Int -> (SatInt, SatInt)
+quotRemSI a@(I# _) b@(I# _) = (SI (a `quotInt` b), SI (a `remInt` b))
+
+divModSI ::  Int -> Int -> (SatInt, SatInt)
+divModSI x@(I# _) y@(I# _) = (SI (x `divInt` y), SI (x `modInt` y))
+
+plusSI :: SatInt -> SatInt -> SatInt
+plusSI (SI (I# x#)) (SI (I# y#)) =
+  case addIntC# x# y# of
+    (# r#, _ #) -> SI (I# r#)
+
+minusSI :: SatInt -> SatInt -> SatInt
+minusSI (SI (I# x#)) (SI (I# y#)) =
+  case subIntC# x# y# of
+    (# r#, _ #) -> SI (I# r#)
+
+timesSI :: SatInt -> SatInt -> SatInt
+timesSI (SI (I# x#)) (SI (I# y#)) =
+  case mulIntMayOflo# x# y# of
+    0# -> SI (I# (x# *# y#))
+    _  -> maxBound
+
+{-# RULES
+"fromIntegral/Int->SatInt"     fromIntegral = toSat
+"fromIntegral/SatInt->SatInt" fromIntegral = id :: SatInt -> SatInt
+  #-}
+
+-- Specialized versions of several functions. They're specialized for
+-- Int in the GHC base libraries. We try to get the same effect by
+-- including specialized code and adding a rewrite rule.
+
+sumSI :: [SatInt] -> SatInt
+sumSI     l       = sum' l 0
+  where
+    sum' []     a = a
+    sum' (x:xs) a = sum' xs (a + x)
+
+productSI :: [SatInt] -> SatInt
+productSI l       = prod l 1
+  where
+    prod []     a = a
+    prod (x:xs) a = prod xs (a*x)
+
+{-# RULES
+  "sum/SatInt"          sum = sumSI;
+  "product/SatInt"      product = productSI
+  #-}
+
+lcmSI :: SatInt -> SatInt -> SatInt
+lcmSI _      (SI 0) =  SI 0
+lcmSI (SI 0) _      =  SI 0
+lcmSI (SI x) (SI y) =  abs (SI (x `quot` (gcd x y)) * SI y)
+
+{-# RULES
+  "lcm/SatInt"          lcm = lcmSI;
+  "gcd/SatInt"          gcd = \ (SI a) (SI b) -> SI (gcd a b)
+  #-}

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -10,12 +10,13 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 module Data.SatInt (SatInt(..), fromSat, toSat) where
 
 import           Control.DeepSeq (NFData)
+import           Data.Bits
 import           GHC.Base
 import           GHC.Num
 import           GHC.Real
 
 newtype SatInt = SI Int
-    deriving newtype NFData
+    deriving newtype (NFData, Bits, FiniteBits)
 
 fromSat :: SatInt -> Int
 fromSat (SI x) = x

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -155,6 +155,7 @@ efdtIntUp x1 x2 y    -- Be careful about overflow!
                in SI (I# x1) : go_up x2
 
 -- Requires x2 >= x1
+{-# INLINE [0] efdtIntUpFB #-}
 efdtIntUpFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
 efdtIntUpFB c n x1 x2 y    -- Be careful about overflow!
  | isTrue# (y <# x2) = if isTrue# (y <# x1) then n else SI (I# x1) `c` n
@@ -186,6 +187,7 @@ efdtIntDn x1 x2 y    -- Be careful about underflow!
 
 
 -- Requires x2 <= x1
+{-# INLINE [0] efdtIntDnFB #-}
 efdtIntDnFB :: (SatInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
 efdtIntDnFB c n x1 x2 y    -- Be careful about underflow!
  | isTrue# (y ># x2) = if isTrue# (y ># x1) then n else SI (I# x1) `c` n

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -93,7 +93,6 @@ import           PlutusCore.Core
 import           PlutusCore.Name
 
 import           Control.Monad.Except
-import           Data.SatInt
 import           Data.Semigroup.Generic
 import           Data.Text.Prettyprint.Doc
 import           PlutusCore.Evaluation.Machine.ExMemory
@@ -154,11 +153,11 @@ isNegativeBudget (ExRestrictingBudget (ExBudget cpu mem)) = cpu < 0 || mem < 0
 
 -- | @(-)@ on 'ExCPU'.
 minusExCPU :: ExCPU -> ExCPU -> ExCPU
-minusExCPU = coerce $ (-) @SatInt
+minusExCPU = coerce $ (-) @CostingInteger
 
 -- | @(-)@ on 'ExMemory'.
 minusExMemory :: ExMemory -> ExMemory -> ExMemory
-minusExMemory = coerce $ (-) @SatInt
+minusExMemory = coerce $ (-) @CostingInteger
 
 -- | Subtract an 'ExBudget' from an 'ExRestrictingBudget'.
 minusExBudget :: ExRestrictingBudget -> ExBudget -> ExRestrictingBudget

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -93,6 +93,7 @@ import           PlutusCore.Core
 import           PlutusCore.Name
 
 import           Control.Monad.Except
+import           Data.SatInt
 import           Data.Semigroup.Generic
 import           Data.Text.Prettyprint.Doc
 import           PlutusCore.Evaluation.Machine.ExMemory
@@ -153,11 +154,11 @@ isNegativeBudget (ExRestrictingBudget (ExBudget cpu mem)) = cpu < 0 || mem < 0
 
 -- | @(-)@ on 'ExCPU'.
 minusExCPU :: ExCPU -> ExCPU -> ExCPU
-minusExCPU = coerce $ (-) @Integer
+minusExCPU = coerce $ (-) @SatInt
 
 -- | @(-)@ on 'ExMemory'.
 minusExMemory :: ExMemory -> ExMemory -> ExMemory
-minusExMemory = coerce $ (-) @Integer
+minusExMemory = coerce $ (-) @SatInt
 
 -- | Subtract an 'ExBudget' from an 'ExRestrictingBudget'.
 minusExBudget :: ExRestrictingBudget -> ExBudget -> ExRestrictingBudget

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgeting.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgeting.hs
@@ -49,6 +49,7 @@ import qualified Data.HashMap.Strict                    as HM
 import           Data.Hashable
 import qualified Data.Kind                              as Kind
 import qualified Data.Map                               as Map
+import           Data.SatInt
 import qualified Data.Scientific                        as S
 import qualified Data.Text                              as Text
 import           Deriving.Aeson
@@ -69,7 +70,7 @@ type CostModel = CostModelBase CostingFun
    `toCostUnit` is exported).
 -}
 
-toCostUnit :: Double -> Integer
+toCostUnit :: Double -> SatInt
 toCostUnit x = ceiling (10000 * x)
 
 -- | The main model which contains all data required to predict the cost of builtin functions. See Note [Creation of the Cost Model] for how this is generated. Calibrated for the CeK machine.
@@ -201,12 +202,12 @@ instance Default ModelOneArgument where
 runCostingFunOneArgument :: CostingFun ModelOneArgument -> ExMemory -> ExBudget
 runCostingFunOneArgument
     (CostingFun cpu mem) mem1 =
-        ExBudget (ExCPU (runOneArgumentModel cpu mem1)) (ExMemory (runOneArgumentModel mem mem1))
+        ExBudget (ExCPU $ runOneArgumentModel cpu mem1) (ExMemory $ runOneArgumentModel mem mem1)
 
-runOneArgumentModel :: ModelOneArgument -> ExMemory -> Integer
+runOneArgumentModel :: ModelOneArgument -> ExMemory -> SatInt
 runOneArgumentModel (ModelOneArgumentConstantCost c) _ = toCostUnit c
 runOneArgumentModel (ModelOneArgumentLinearCost (ModelLinearSize intercept slope _)) (ExMemory s) =
-    toCostUnit $ (fromInteger s) * slope + intercept
+    toCostUnit $ (fromIntegral s) * slope + intercept
 
 -- | s * (x + y) + I
 data ModelAddedSizes = ModelAddedSizes
@@ -292,33 +293,33 @@ runCostingFunTwoArguments :: CostingFun ModelTwoArguments -> ExMemory -> ExMemor
 runCostingFunTwoArguments (CostingFun cpu mem) mem1 mem2 =
     ExBudget (ExCPU (runTwoArgumentModel cpu mem1 mem2)) (ExMemory (runTwoArgumentModel mem mem1 mem2))
 
-runTwoArgumentModel :: ModelTwoArguments -> ExMemory -> ExMemory -> Integer
+runTwoArgumentModel :: ModelTwoArguments -> ExMemory -> ExMemory -> SatInt
 runTwoArgumentModel
     (ModelTwoArgumentsConstantCost c) _ _ = toCostUnit c
 runTwoArgumentModel
     (ModelTwoArgumentsAddedSizes (ModelAddedSizes intercept slope)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (fromInteger (size1 + size2)) * slope + intercept -- TODO is this even correct? If not, adjust the other implementations too.
+        toCostUnit $ (fromIntegral (size1 + size2)) * slope + intercept -- TODO is this even correct? If not, adjust the other implementations too.
 runTwoArgumentModel
     (ModelTwoArgumentsSubtractedSizes (ModelSubtractedSizes intercept slope minSize)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (max minSize (fromInteger (size1 - size2))) * slope + intercept
+        toCostUnit $ (max minSize (fromIntegral (size1 - size2))) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsMultipliedSizes (ModelMultipliedSizes intercept slope)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (fromInteger (size1 * size2)) * slope + intercept
+        toCostUnit $ (fromIntegral (size1 * size2)) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsMinSize (ModelMinSize intercept slope)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (fromInteger (min size1 size2)) * slope + intercept
+        toCostUnit $ (fromIntegral (min size1 size2)) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsMaxSize (ModelMaxSize intercept slope)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (fromInteger (max size1 size2)) * slope + intercept
+        toCostUnit $ (fromIntegral (max size1 size2)) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsSplitConstMulti (ModelSplitConst intercept slope)) (ExMemory size1) (ExMemory size2) =
-        toCostUnit $ (if (size1 > size2) then (fromInteger size1) * (fromInteger size2) else 0) * slope + intercept
+        toCostUnit $ (if (size1 > size2) then (fromIntegral size1) * (fromIntegral size2) else 0) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsLinearSize (ModelLinearSize intercept slope ModelOrientationX)) (ExMemory size1) (ExMemory _) =
-        toCostUnit $ (fromInteger size1) * slope + intercept
+        toCostUnit $ (fromIntegral size1) * slope + intercept
 runTwoArgumentModel
     (ModelTwoArgumentsLinearSize (ModelLinearSize intercept slope ModelOrientationY)) (ExMemory _) (ExMemory size2) =
-        toCostUnit $ (fromInteger size2) * slope + intercept
+        toCostUnit $ (fromIntegral size2) * slope + intercept
 
 data ModelThreeArguments =
     ModelThreeArgumentsConstantCost Double
@@ -330,10 +331,10 @@ data ModelThreeArguments =
 instance Default ModelThreeArguments where
     def = ModelThreeArgumentsConstantCost 1.0
 
-runThreeArgumentModel :: ModelThreeArguments -> ExMemory -> ExMemory -> ExMemory -> Integer
+runThreeArgumentModel :: ModelThreeArguments -> ExMemory -> ExMemory -> ExMemory -> SatInt
 runThreeArgumentModel (ModelThreeArgumentsConstantCost c) _ _ _ = toCostUnit c
 runThreeArgumentModel (ModelThreeArgumentsAddedSizes (ModelAddedSizes intercept slope)) (ExMemory size1) (ExMemory size2) (ExMemory size3) =
-    toCostUnit $ (fromInteger (size1 + size2 + size3)) * slope + intercept
+    toCostUnit $ (fromIntegral (size1 + size2 + size3)) * slope + intercept
 
 runCostingFunThreeArguments :: CostingFun ModelThreeArguments -> ExMemory -> ExMemory -> ExMemory -> ExBudget
 runCostingFunThreeArguments (CostingFun cpu mem) mem1 mem2 mem3 =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -23,6 +23,7 @@ import           PlutusPrelude
 import           Control.Monad.RWS.Strict
 import qualified Data.ByteString          as BS
 import           Data.Proxy
+import           Data.SatInt
 import qualified Data.Text                as T
 import           Foreign.Storable
 import           GHC.Generics
@@ -41,20 +42,58 @@ abstractly specifiable. It's an implementation detail.
 
 -}
 
--- | Counts size in machine words (64bit for the near future)
-newtype ExMemory = ExMemory Integer
-  deriving (Eq, Ord, Show)
-  deriving newtype (Num, Pretty, NFData)
-  deriving (Semigroup, Monoid) via (Sum Integer)
-deriving newtype instance PrettyDefaultBy config Integer => PrettyBy config ExMemory
+{- Note [Integer types for costing]
+We care about the speed of our integer operations for costing, this has a significant effect on speed.
+But we also need to care about overflow: the cost counters overflowing is a potential attack!
 
--- TODO: 'Integer's are not particularly fast. Should we use @Int64@?
--- | Counts CPU units - no fixed base, proportional.
-newtype ExCPU = ExCPU Integer
+We have a few choices here for what to do with an overflow:
+- Don't (this is what 'Integer' does, it's unbounded)
+- Wrap (this is what 'Int'/'Int64' and friends do)
+- Throw an overflow error (this is what 'Data.SafeInt' does)
+- Saturate (i.e. return max/min bound, this is what 'Data.SatInt does)
+
+In our case
+- Not overflowing would be nice, but 'Integer' is significantly slower than the other types.
+- Wrapping is quite dangerous, as it could lead to us getting attacked by someone wrapping
+their cost around to something that looks below the budget.
+- Throwing would be okay, but we'd have to worry about exception catching.
+- Saturating is actually quite nice: we care about whether `a op b < budget`. So long as `budget < maxBound`,
+  then `a op b < budget` will have the same truth value *regardless* of whether the operation overflows and saturates,
+  since saturating implies `a op b >= maxBound > budget`. Plus, it means we don't need to deal with
+  exceptions.
+
+So we use 'Data.SatInt', a variant of 'Data.SafeInt' that does saturating arithmetic.
+
+'SatInt' is quite fast, but not quite as fast as using 'Int64' directly (I don't know why that would be, apart from maybe
+just the overflow checks), but the wrapping behaviour of 'Int64' is unacceptable..
+
+One other wrinkle is that 'SatInt' is backed by an 'Int' (i.e. a machine integer with platform-dependent
+size), rather than an 'Int64' since the primops that we need are only available for 'Int' until GHC 9.2
+or so.
+
+This is okay, because we don't expect budgets to be anywhere near 'maxBound' for even Int32! So we're
+never going to need to worry about the possibility of saturating for 'Int32' but not for 'Int64' or something.
+-}
+
+-- | Counts size in machine words (64bit for the near future)
+newtype ExMemory = ExMemory SatInt
   deriving (Eq, Ord, Show)
-  deriving newtype (Num, Pretty, NFData)
-  deriving (Semigroup, Monoid) via (Sum Integer)
-deriving newtype instance PrettyDefaultBy config Integer => PrettyBy config ExCPU
+  deriving newtype (Num, NFData)
+  deriving (Semigroup, Monoid) via (Sum SatInt)
+instance Pretty ExMemory where
+    pretty (ExMemory i) = pretty (toInteger i)
+instance PrettyBy config ExMemory where
+    prettyBy _ m = pretty m
+
+-- | Counts CPU units - no fixed base, proportional.
+newtype ExCPU = ExCPU SatInt
+  deriving (Eq, Ord, Show)
+  deriving newtype (Num, NFData)
+  deriving (Semigroup, Monoid) via (Sum SatInt)
+instance Pretty ExCPU where
+    pretty (ExCPU i) = pretty (toInteger i)
+instance PrettyBy config ExCPU where
+    prettyBy _ m = pretty m
 
 -- Based on https://github.com/ekmett/semigroups/blob/master/src/Data/Semigroup/Generic.hs
 class GExMemoryUsage f where
@@ -103,6 +142,7 @@ deriving via (GenericExMemoryUsage (Term tyname name uni fun ann)) instance
     , Closed uni, uni `Everywhere` ExMemoryUsage, ExMemoryUsage fun
     ) => ExMemoryUsage (Term tyname name uni fun ann)
 deriving newtype instance ExMemoryUsage TyName
+deriving newtype instance ExMemoryUsage SatInt
 deriving newtype instance ExMemoryUsage ExMemory
 deriving newtype instance ExMemoryUsage Unique
 
@@ -119,10 +159,10 @@ instance ExMemoryUsage () where
   memoryUsage _ = 0 -- TODO or 1?
 
 instance ExMemoryUsage Integer where
-  memoryUsage i = ExMemory (1 + smallInteger (integerLog2# (abs i) `quotInt#` integerToInt 64)) -- assume 64bit size
+  memoryUsage i = ExMemory $ fromIntegral $ 1 + smallInteger (integerLog2# (abs i) `quotInt#` integerToInt 64) -- assume 64bit size
 
 instance ExMemoryUsage BS.ByteString where
-  memoryUsage bs = ExMemory $ (toInteger $ BS.length bs) `div` 8
+  memoryUsage bs = ExMemory $ fromIntegral $ (toInteger $ BS.length bs) `div` 8
 
 instance ExMemoryUsage T.Text where
   memoryUsage text = memoryUsage $ T.unpack text -- TODO not accurate, as Text uses UTF-16
@@ -137,4 +177,4 @@ instance ExMemoryUsage Bool where
   memoryUsage _ = 1
 
 instance ExMemoryUsage String where
-  memoryUsage string = ExMemory $ (toInteger $ sum $ fmap sizeOf string) `div` 8
+  memoryUsage string = ExMemory $ fromIntegral $ (sum $ fmap sizeOf string) `div` 8

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -1,9 +1,9 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -23,7 +23,6 @@ import           PlutusCore.Universe
 import           PlutusPrelude
 
 import           Control.Monad.RWS.Strict
-import           Data.Bits
 import qualified Data.ByteString          as BS
 import           Data.Proxy
 import           Data.SatInt
@@ -33,6 +32,8 @@ import           GHC.Generics
 import           GHC.Integer
 import           GHC.Integer.Logarithms
 import           GHC.Prim
+
+#include "MachDeps.h"
 
 {- Note [Memory Usage for Plutus]
 
@@ -72,7 +73,7 @@ just the overflow checks), but the wrapping behaviour of 'Int64' is unacceptable
 
 One other wrinkle is that 'SatInt' is backed by an 'Int' (i.e. a machine integer with platform-dependent
 size), rather than an 'Int64' since the primops that we need are only available for 'Int' until GHC 9.2
-or so.
+or so. So on 32bit platforms, we have much less header
 
 However we mostly care about 64bit platforms, so this isn't too much of a problem. The only one where it could be a problem
 is GHCJS, which does present as a 32bit platform. However, we won't care about *performance* on GHCJS, since
@@ -82,9 +83,14 @@ if we are not on a 64bit platform, then we can just fallback to the slower (but 
 -}
 
 -- See Note [Integer types for costing]
--- This relies on the fact that TH is run on the *target* platform, so even if we're e.g. cross-compiling to GHCJS
--- this will give the right answer.
-type CostingInteger = $(if finiteBitSize (0::SatInt) < 64 then [t|Integer|] else [t|SatInt|])
+type CostingInteger =
+#if WORD_SIZE_IN_BITS < 64
+    Integer
+#else
+    SatInt
+#endif
+
+-- $(if finiteBitSize (0::SatInt) < 64 then [t|Integer|] else [t|SatInt|])
 
 -- | Counts size in machine words (64bit for the near future)
 newtype ExMemory = ExMemory CostingInteger


### PR DESCRIPTION
Using machine integers rather than arbitrary-sized `Integer`s gives us a
decent speedup.

However, we do need to worry about overflow. It's hard to find an
existing type that has the semantics that we want. The closest is
`Data.SafeInt`, but this _throws_ on overflow. We could do with this,
but it's simpler for us to deal with _saturating_ arithmetic, since our
operations are always monotonic. Then we don't have to worry about
exceptions.

Consequently, this PR includes a copy of `Data.SafeInt` adapted to do
saturated arithmetic instead.

Overall, this is slower than just using `Int64`, but we need the
safety. I don't know why it's slower than `Int64`, though, apart from
the overflow checks.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
