### PR TITLE
Drop availability zone

### DIFF
--- a/deployment/morph/machines.nix
+++ b/deployment/morph/machines.nix
@@ -12,16 +12,6 @@
     config = ./machines/marlowe-dash.nix;
   };
 
-  "${tfinfo.marloweDashB.dns}" = mkMachine {
-    name = "marloweDashB";
-    config = ./machines/marlowe-dash.nix;
-  };
-
-  "${tfinfo.playgroundsB.dns}" = mkMachine {
-    name = "playgroundsA";
-    config = ./machines/playground.nix;
-  };
-
   "${tfinfo.playgroundsA.dns}" = mkMachine {
     name = "playgroundsB";
     config = ./machines/playground.nix;
@@ -29,11 +19,6 @@
 
   "${tfinfo.webghcA.dns}" = mkMachine {
     name = "webghcA";
-    config = ./machines/web-ghc.nix;
-  };
-
-  "${tfinfo.webghcB.dns}" = mkMachine {
-    name = "webghcB";
     config = ./machines/web-ghc.nix;
   };
 }

--- a/deployment/terraform/loadbalancing.tf
+++ b/deployment/terraform/loadbalancing.tf
@@ -236,12 +236,6 @@ resource "aws_alb_target_group_attachment" "marlowe_playground_a" {
   port             = local.marlowe_playground_port
 }
 
-resource "aws_alb_target_group_attachment" "marlowe_playground_b" {
-  target_group_arn = aws_alb_target_group.marlowe_playground.arn
-  target_id        = aws_instance.playgrounds_b.id
-  port             = local.marlowe_playground_port
-}
-
 resource "aws_route53_record" "marlowe_playground_alb" {
   zone_id = var.marlowe_public_zone
   name    = local.marlowe_domain_name
@@ -290,12 +284,6 @@ resource "aws_alb_listener_rule" "plutus_playground" {
 resource "aws_alb_target_group_attachment" "plutus_playground_a" {
   target_group_arn = aws_alb_target_group.plutus_playground.arn
   target_id        = aws_instance.playgrounds_a.id
-  port             = local.plutus_playground_port
-}
-
-resource "aws_alb_target_group_attachment" "plutus_playground_b" {
-  target_group_arn = aws_alb_target_group.plutus_playground.arn
-  target_id        = aws_instance.playgrounds_b.id
   port             = local.plutus_playground_port
 }
 

--- a/deployment/terraform/loadbalancing.tf
+++ b/deployment/terraform/loadbalancing.tf
@@ -146,12 +146,6 @@ resource "aws_alb_target_group_attachment" "webghc_a" {
   port             = "80"
 }
 
-resource "aws_alb_target_group_attachment" "webghc_b" {
-  target_group_arn = aws_alb_target_group.webghc.arn
-  target_id        = aws_instance.webghc_b.id
-  port             = "80"
-}
-
 ## ALB rule for marlowe-dashboard
 resource "aws_alb_target_group" "marlowe_dash" {
   # ALB is taking care of SSL termination so we listen to port 80 here

--- a/deployment/terraform/loadbalancing.tf
+++ b/deployment/terraform/loadbalancing.tf
@@ -185,12 +185,6 @@ resource "aws_alb_target_group_attachment" "marlowe_dash_a" {
   port             = local.pab_port
 }
 
-# resource "aws_alb_target_group_attachment" "marlowe_dash_b" {
-#   target_group_arn = aws_alb_target_group.marlowe_dash.arn
-#   target_id        = aws_instance.marlowe_dash_b.id
-#   port             = local.pab_port
-# }
-
 resource "aws_route53_record" "marlowe_dash_alb" {
   zone_id = var.marlowe_dash_public_zone
   name    = local.marlowe_dash_domain_name

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -6,12 +6,6 @@ locals {
     dns  = "webghc-a.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
   }
 
-  webghcB = {
-    name = "webghcB"
-    ip   = "${element(concat(aws_instance.webghc_b.*.private_ip, list("")), 0)}"
-    dns  = "webghc-b.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
-  }
-
   marloweDashA = {
     name = "marloweDashA"
     ip   = "${element(concat(aws_instance.marlowe_dash_a.*.private_ip, list("")), 0)}"
@@ -38,7 +32,6 @@ locals {
 
   machines = {
     webghcA      = "${local.webghcA}"
-    webghcB      = "${local.webghcB}"
     marloweDashA = "${local.marloweDashA}"
     marloweDashB = "${local.marloweDashB}"
     playgroundsA = "${local.playgroundsA}"

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -12,12 +12,6 @@ locals {
     dns  = "marlowe-dash-a.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
   }
 
-  marloweDashB = {
-    name = "marloweDashB"
-    ip   = "${element(concat(aws_instance.marlowe_dash_b.*.private_ip, list("")), 0)}"
-    dns  = "marlowe-dash-b.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
-  }
-
   playgroundsA = {
     name = "playgroundsA"
     ip   = "${element(concat(aws_instance.playgrounds_a.*.private_ip, list("")), 0)}"
@@ -33,7 +27,6 @@ locals {
   machines = {
     webghcA      = "${local.webghcA}"
     marloweDashA = "${local.marloweDashA}"
-    marloweDashB = "${local.marloweDashB}"
     playgroundsA = "${local.playgroundsA}"
     playgroundsB = "${local.playgroundsB}"
     rootSshKeys  = local.root_ssh_keys

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -18,17 +18,10 @@ locals {
     dns  = "playgrounds-a.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
   }
 
-  playgroundsB = {
-    name = "playgroundsB"
-    ip   = "${element(concat(aws_instance.playgrounds_b.*.private_ip, list("")), 0)}"
-    dns  = "playgrounds-b.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
-  }
-
   machines = {
     webghcA      = "${local.webghcA}"
     marloweDashA = "${local.marloweDashA}"
     playgroundsA = "${local.playgroundsA}"
-    playgroundsB = "${local.playgroundsB}"
     rootSshKeys  = local.root_ssh_keys
     awsRegion    = "${var.aws_region}"
     environment  = "${var.env}"

--- a/deployment/terraform/marlowe-dashboard.tf
+++ b/deployment/terraform/marlowe-dashboard.tf
@@ -71,33 +71,3 @@ resource "aws_route53_record" "marlowe_dash_internal_a" {
   ttl     = 300
   records = [aws_instance.marlowe_dash_a.private_ip]
 }
-
-resource "aws_instance" "marlowe_dash_b" {
-  ami = module.nixos_image.ami
-
-  instance_type = var.marlowe_dash_instance_type
-  subnet_id     = aws_subnet.private.*.id[1]
-  user_data     = data.template_file.marlowe_dash_user_data.rendered
-
-  vpc_security_group_ids = [
-    aws_security_group.marlowe_dash.id,
-  ]
-
-  root_block_device {
-    volume_size = "20"
-  }
-
-  tags = {
-    Name        = "${local.project}_${var.env}_marlowe_dash_b"
-    Project     = local.project
-    Environment = var.env
-  }
-}
-
-resource "aws_route53_record" "marlowe_dash_internal_b" {
-  zone_id = aws_route53_zone.plutus_private_zone.zone_id
-  type    = "A"
-  name    = "marlowe-dash-b.${aws_route53_zone.plutus_private_zone.name}"
-  ttl     = 300
-  records = [aws_instance.marlowe_dash_b.private_ip]
-}

--- a/deployment/terraform/playgrounds.tf
+++ b/deployment/terraform/playgrounds.tf
@@ -86,33 +86,3 @@ resource "aws_route53_record" "playgrounds_internal_a" {
   ttl     = 300
   records = [aws_instance.playgrounds_a.private_ip]
 }
-
-resource "aws_instance" "playgrounds_b" {
-  ami = module.nixos_image.ami
-
-  instance_type = var.playgrounds_instance_type
-  subnet_id     = aws_subnet.private.*.id[1]
-  user_data     = data.template_file.playgrounds_user_data.rendered
-
-  vpc_security_group_ids = [
-    aws_security_group.playgrounds.id,
-  ]
-
-  root_block_device {
-    volume_size = "20"
-  }
-
-  tags = {
-    Name        = "${local.project}_${var.env}_playgrounds_b"
-    Project     = local.project
-    Environment = var.env
-  }
-}
-
-resource "aws_route53_record" "playgrounds_internal_b" {
-  zone_id = aws_route53_zone.plutus_private_zone.zone_id
-  type    = "A"
-  name    = "playgrounds-b.${aws_route53_zone.plutus_private_zone.name}"
-  ttl     = 300
-  records = [aws_instance.playgrounds_b.private_ip]
-}

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -34,18 +34,6 @@ data "template_file" "ssh_config_section_playgrounds_a" {
   }
 }
 
-data "template_file" "ssh_config_section_playgrounds_b" {
-  template = file("${path.module}/templates/ssh-config")
-
-  vars = {
-    full_hostname    = "playgrounds-b.${aws_route53_zone.plutus_private_zone.name}"
-    short_hostname   = "playgrounds-b.${local.project}"
-    ip               = aws_instance.playgrounds_b.private_ip
-    bastion_hostname = aws_instance.bastion.*.public_ip[0]
-    user_name        = "root"
-  }
-}
-
 data "template_file" "ssh_config" {
   template = <<EOT
 $${webghc_a}
@@ -53,8 +41,6 @@ $${webghc_a}
 $${marlowe_dash_a}
 
 $${playgrounds_a}
-
-$${playgrounds_b}
 
 Host $${bastion_hostname}
   StrictHostKeyChecking no
@@ -64,7 +50,6 @@ EOT
     webghc_a         = data.template_file.ssh_config_section_webghc_a.rendered
     marlowe_dash_a   = data.template_file.ssh_config_section_marlowe_dash_a.rendered
     playgrounds_a    = data.template_file.ssh_config_section_playgrounds_a.rendered
-    playgrounds_b    = data.template_file.ssh_config_section_playgrounds_b.rendered
     bastion_hostname = aws_instance.bastion.*.public_ip[0]
   }
 }

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -10,17 +10,6 @@ data "template_file" "ssh_config_section_webghc_a" {
   }
 }
 
-data "template_file" "ssh_config_section_webghc_b" {
-  template = file("${path.module}/templates/ssh-config")
-
-  vars = {
-    full_hostname    = "webghc-b.${aws_route53_zone.plutus_private_zone.name}"
-    short_hostname   = "webghc-b.${local.project}"
-    ip               = aws_instance.webghc_b.private_ip
-    bastion_hostname = aws_instance.bastion.*.public_ip[0]
-    user_name        = "root"
-  }
-}
 data "template_file" "ssh_config_section_marlowe_dash_a" {
   template = file("${path.module}/templates/ssh-config")
 
@@ -72,8 +61,6 @@ data "template_file" "ssh_config" {
   template = <<EOT
 $${webghc_a}
 
-$${webghc_b}
-
 $${marlowe_dash_a}
 
 $${marlowe_dash_b}
@@ -88,7 +75,6 @@ EOT
 
   vars = {
     webghc_a         = data.template_file.ssh_config_section_webghc_a.rendered
-    webghc_b         = data.template_file.ssh_config_section_webghc_b.rendered
     marlowe_dash_a   = data.template_file.ssh_config_section_marlowe_dash_a.rendered
     marlowe_dash_b   = data.template_file.ssh_config_section_marlowe_dash_b.rendered
     playgrounds_a    = data.template_file.ssh_config_section_playgrounds_a.rendered

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -22,17 +22,6 @@ data "template_file" "ssh_config_section_marlowe_dash_a" {
   }
 }
 
-data "template_file" "ssh_config_section_marlowe_dash_b" {
-  template = file("${path.module}/templates/ssh-config")
-
-  vars = {
-    full_hostname    = "marlowe-dash-b.${aws_route53_zone.plutus_private_zone.name}"
-    short_hostname   = "marlowe-dash-b.${local.project}"
-    ip               = aws_instance.marlowe_dash_b.private_ip
-    bastion_hostname = aws_instance.bastion.*.public_ip[0]
-    user_name        = "root"
-  }
-}
 data "template_file" "ssh_config_section_playgrounds_a" {
   template = file("${path.module}/templates/ssh-config")
 
@@ -63,8 +52,6 @@ $${webghc_a}
 
 $${marlowe_dash_a}
 
-$${marlowe_dash_b}
-
 $${playgrounds_a}
 
 $${playgrounds_b}
@@ -76,7 +63,6 @@ EOT
   vars = {
     webghc_a         = data.template_file.ssh_config_section_webghc_a.rendered
     marlowe_dash_a   = data.template_file.ssh_config_section_marlowe_dash_a.rendered
-    marlowe_dash_b   = data.template_file.ssh_config_section_marlowe_dash_b.rendered
     playgrounds_a    = data.template_file.ssh_config_section_playgrounds_a.rendered
     playgrounds_b    = data.template_file.ssh_config_section_playgrounds_b.rendered
     bastion_hostname = aws_instance.bastion.*.public_ip[0]

--- a/deployment/terraform/webghc.tf
+++ b/deployment/terraform/webghc.tf
@@ -71,33 +71,3 @@ resource "aws_route53_record" "webghc_internal_a" {
   ttl     = 300
   records = [aws_instance.webghc_a.private_ip]
 }
-
-resource "aws_instance" "webghc_b" {
-  ami = module.nixos_image.ami
-
-  instance_type = var.webghc_instance_type
-  subnet_id     = aws_subnet.private.*.id[1]
-  user_data     = data.template_file.webghc_user_data.rendered
-
-  vpc_security_group_ids = [
-    aws_security_group.webghc.id,
-  ]
-
-  root_block_device {
-    volume_size = "20"
-  }
-
-  tags = {
-    Name        = "${local.project}_${var.env}_webghc_b"
-    Project     = local.project
-    Environment = var.env
-  }
-}
-
-resource "aws_route53_record" "webghc_internal_b" {
-  zone_id = aws_route53_zone.plutus_private_zone.zone_id
-  type    = "A"
-  name    = "webghc-b.${aws_route53_zone.plutus_private_zone.name}"
-  ttl     = 300
-  records = [aws_instance.webghc_b.private_ip]
-}


### PR DESCRIPTION
**Summary**
This PR drops the `_b` instances of all servers (webghc, marlowe-dash & playgrounds).

**Details**
The `_a` and `_b` instances of each server are part of the 2-availability-zone approach where each ec2 instance is deployed twice for the sake of a higher availability in case one zone becomes unreachable.

In practical terms this isn't currently helpful, desirable or necessary. There are no high-availability demands and the most likely scenario of complication would be too much load on PAB or web-ghc. Deploying to 2 availability zones does not help with that at all.

**NOTE**:
This does drop the deployment of machines to both availability zones. What this dosen't do is to drop the load balancer in general. This needs to happen as a follow-up

---------

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
