### PR TITLE
SCP-2200 - Instantiate timeouts in all examples for the Dashboard

### DIFF
--- a/marlowe-dashboard-client/src/ContractHome/State.purs
+++ b/marlowe-dashboard-client/src/ContractHome/State.purs
@@ -100,7 +100,7 @@ filledContract1 (Slot currentSlot) =
         , (Role "Seller") /\ Nothing
         ]
 
-    mContract = toCore $ fillTemplate templateContent Escrow.extendedContract
+    mContract = toCore $ fillTemplate templateContent Escrow.fixedTimeoutContract
 
     contractInstanceId = fromMaybe (ContractInstanceId emptyUUID) $ parseContractInstanceId "09e83958-824d-4a9d-9fd3-2f57a4f211a1"
   in
@@ -167,7 +167,7 @@ filledContract2 (Slot currentSlot) = do
 
     nextState' :: Contract.State -> TransactionInput -> Contract.State
     nextState' state txInput = applyTx (Slot currentSlot) txInput state
-  contract <- toCore $ fillTemplate templateContent EscrowWithCollateral.extendedContract
+  contract <- toCore $ fillTemplate templateContent EscrowWithCollateral.fixedTimeoutContract
   initialState <- pure $ Contract.mkInitialState contractInstanceId zero EscrowWithCollateral.metaData participants (Just $ Role "Buyer") contract
   pure $ foldl nextState' initialState transactions
 
@@ -195,5 +195,5 @@ filledContract3 (Slot currentSlot) = do
         ]
 
     contractInstanceId = fromMaybe (ContractInstanceId emptyUUID) $ parseContractInstanceId "8242d217-6f7c-4a70-9b18-233a82d089aa"
-  contract <- toCore $ fillTemplate templateContent $ resolveRelativeTimes (Slot currentSlot) ZeroCouponBond.extendedContract
+  contract <- toCore $ fillTemplate templateContent $ resolveRelativeTimes (Slot currentSlot) ZeroCouponBond.fixedTimeoutContract
   pure $ Contract.mkInitialState contractInstanceId zero ZeroCouponBond.metaData participants (Just $ Role "Guarantor") contract

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -39,11 +39,11 @@ all :: TestSuite
 all =
   suite "Contract Tests" do
     test "Purescript and Haskell examples match" do
-      equal (Just Escrow.extendedContract) (contractToExtended Contracts.escrow)
-      equal (Just EscrowWithCollateral.extendedContract) (contractToExtended Contracts.escrowWithCollateral)
-      equal (Just ZeroCouponBond.extendedContract) (contractToExtended Contracts.zeroCouponBond)
+      equal (Just Escrow.fullExtendedContract) (contractToExtended Contracts.escrow)
+      equal (Just EscrowWithCollateral.fullExtendedContract) (contractToExtended Contracts.escrowWithCollateral)
+      equal (Just ZeroCouponBond.fullExtendedContract) (contractToExtended Contracts.zeroCouponBond)
       equal (Just CouponBondGuaranteed.extendedContract) (contractToExtended Contracts.couponBondGuaranteed)
-      equal (Just Swap.extendedContract) (contractToExtended Contracts.swap)
+      equal (Just Swap.fullExtendedContract) (contractToExtended Contracts.swap)
       equal (Just ContractForDifferences.extendedContract) (contractToExtended Contracts.contractForDifferences)
       equal (Just ContractForDifferencesWithOracle.extendedContract) (contractToExtended Contracts.contractForDifferencesWithOracle)
       pure unit

--- a/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
+++ b/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
@@ -27,10 +27,10 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Buyer's deposit timeout" /\ fromInt 10
-                          , "Buyer's dispute timeout" /\ fromInt 50
-                          , "Seller's response timeout" /\ fromInt 100
-                          , "Timeout for arbitrage" /\ fromInt 1000
+                          [ "Buyer's deposit timeout" /\ fromInt 60
+                          , "Buyer's dispute timeout" /\ fromInt 180
+                          , "Seller's response timeout" /\ fromInt 240
+                          , "Timeout for arbitrage" /\ fromInt 360
                           ]
                     , valueContent:
                         Map.fromFoldable
@@ -51,11 +51,11 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Collateral deposit by seller timeout" /\ fromInt 10
-                          , "Deposit of collateral by buyer timeout" /\ fromInt 50
-                          , "Deposit of price by buyer timeout" /\ fromInt 100
-                          , "Dispute by buyer timeout" /\ fromInt 1000
-                          , "Seller's response timeout" /\ fromInt 2000
+                          [ "Collateral deposit by seller timeout" /\ fromInt 60
+                          , "Deposit of collateral by buyer timeout" /\ fromInt 120
+                          , "Deposit of price by buyer timeout" /\ fromInt 180
+                          , "Dispute by buyer timeout" /\ fromInt 300
+                          , "Seller's response timeout" /\ fromInt 360
                           ]
                     , valueContent:
                         Map.fromFoldable
@@ -77,8 +77,8 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Initial exchange deadline" /\ fromInt 10
-                          , "Maturity exchange deadline" /\ fromInt 20
+                          [ "Initial exchange deadline" /\ fromInt 60
+                          , "Maturity exchange deadline" /\ fromInt 150
                           ]
                     , valueContent:
                         Map.fromFoldable

--- a/web-common-marlowe/src/Examples/PureScript/Escrow.purs
+++ b/web-common-marlowe/src/Examples/PureScript/Escrow.purs
@@ -1,20 +1,38 @@
 module Examples.PureScript.Escrow
   ( contractTemplate
+  , fullExtendedContract
   , metaData
-  , extendedContract
+  , fixedTimeoutContract
   ) where
 
 import Prelude
-import Data.BigInteger (BigInteger)
+import Data.BigInteger (BigInteger, fromInt)
+import Data.Map as Map
 import Data.Tuple.Nested (type (/\), (/\))
 import Examples.Metadata as Metadata
-import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), Timeout(..), Value(..))
+import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), TemplateContent(..), Timeout(..), Value(..), fillTemplate)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (Bound(..), ChoiceId(..), Party(..), Token(..), ChoiceName)
 
 contractTemplate :: ContractTemplate
-contractTemplate = { metaData, extendedContract }
+contractTemplate = { metaData, extendedContract: fixedTimeoutContract }
+
+fixedTimeoutContract :: Contract
+fixedTimeoutContract =
+  fillTemplate
+    ( TemplateContent
+        { slotContent:
+            Map.fromFoldable
+              [ "Buyer's deposit timeout" /\ fromInt 60
+              , "Buyer's dispute timeout" /\ fromInt 180
+              , "Seller's response timeout" /\ fromInt 240
+              , "Timeout for arbitrage" /\ fromInt 360
+              ]
+        , valueContent: Map.empty
+        }
+    )
+    fullExtendedContract
 
 metaData :: MetaData
 metaData = Metadata.escrow
@@ -76,8 +94,8 @@ sellerToBuyer = Pay seller (Account buyer) ada price
 paySeller :: Contract -> Contract
 paySeller = Pay buyer (Party seller) ada price
 
-extendedContract :: Contract
-extendedContract =
+fullExtendedContract :: Contract
+fullExtendedContract =
   deposit depositTimeout Close
     $ choices disputeTimeout buyer Close
         [ (zero /\ "Everything is alright" /\ Close)

--- a/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
+++ b/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
@@ -1,20 +1,39 @@
 module Examples.PureScript.EscrowWithCollateral
   ( contractTemplate
+  , fullExtendedContract
   , metaData
-  , extendedContract
+  , fixedTimeoutContract
   ) where
 
 import Prelude
-import Data.BigInteger (BigInteger)
+import Data.BigInteger (BigInteger, fromInt)
+import Data.Map as Map
 import Data.Tuple.Nested (type (/\), (/\))
 import Examples.Metadata as Metadata
-import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), Timeout(..), Value(..))
+import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), TemplateContent(..), Timeout(..), Value(..), fillTemplate)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (Bound(..), ChoiceId(..), Party(..), Token(..), ChoiceName)
 
 contractTemplate :: ContractTemplate
-contractTemplate = { metaData, extendedContract }
+contractTemplate = { metaData, extendedContract: fixedTimeoutContract }
+
+fixedTimeoutContract :: Contract
+fixedTimeoutContract =
+  fillTemplate
+    ( TemplateContent
+        { slotContent:
+            Map.fromFoldable
+              [ "Collateral deposit by seller timeout" /\ fromInt 60
+              , "Deposit of collateral by buyer timeout" /\ fromInt 120
+              , "Deposit of price by buyer timeout" /\ fromInt 180
+              , "Dispute by buyer timeout" /\ fromInt 300
+              , "Seller's response timeout" /\ fromInt 360
+              ]
+        , valueContent: Map.empty
+        }
+    )
+    fullExtendedContract
 
 metaData :: MetaData
 metaData = Metadata.escrowWithCollateral
@@ -91,8 +110,8 @@ choices timeout chooser timeoutContinuation list =
 sellerToBuyer :: Contract -> Contract
 sellerToBuyer = Pay seller (Account buyer) ada price
 
-extendedContract :: Contract
-extendedContract =
+fullExtendedContract :: Contract
+fullExtendedContract =
   depositCollateral seller sellerCollateralTimeout Close
     $ depositCollateral buyer buyerCollateralTimeout Close
     $ deposit depositTimeout Close

--- a/web-common-marlowe/src/Examples/PureScript/Swap.purs
+++ b/web-common-marlowe/src/Examples/PureScript/Swap.purs
@@ -1,19 +1,37 @@
 module Examples.PureScript.Swap
   ( contractTemplate
+  , fullExtendedContract
   , metaData
-  , extendedContract
+  , fixedTimeoutContract
   ) where
 
 import Prelude
 import Data.BigInteger (fromInt)
+import Data.Map as Map
+import Data.Tuple.Nested ((/\))
 import Examples.Metadata as Metadata
-import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), Timeout(..), Value(..))
+import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), TemplateContent(..), Timeout(..), Value(..), fillTemplate)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (Party(..), Token(..))
 
 contractTemplate :: ContractTemplate
-contractTemplate = { metaData, extendedContract }
+contractTemplate = { metaData, extendedContract: fixedTimeoutContract }
+
+fixedTimeoutContract :: Contract
+fixedTimeoutContract =
+  fillTemplate
+    ( TemplateContent
+        { slotContent:
+            Map.fromFoldable
+              [ "Timeout for Ada deposit" /\ fromInt 60
+              , "Timeout for dollar deposit" /\ fromInt 120
+              ]
+        , valueContent:
+            Map.empty
+        }
+    )
+    fullExtendedContract
 
 metaData :: MetaData
 metaData = Metadata.swap
@@ -74,8 +92,8 @@ makeDeposit src timeout timeoutContinuation continuation =
 makePayment :: SwapParty -> SwapParty -> Contract -> Contract
 makePayment src dest continuation = Pay src.party (Party $ dest.party) src.currency src.amount continuation
 
-extendedContract :: Contract
-extendedContract =
+fullExtendedContract :: Contract
+fullExtendedContract =
   makeDeposit adaProvider adaDepositTimeout Close
     $ makeDeposit dollarProvider dollarDepositTimeout Close
     $ makePayment adaProvider dollarProvider

--- a/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
@@ -1,18 +1,37 @@
 module Examples.PureScript.ZeroCouponBond
   ( contractTemplate
+  , fullExtendedContract
   , metaData
-  , extendedContract
+  , fixedTimeoutContract
   ) where
 
 import Prelude
+import Data.BigInteger (fromInt)
+import Data.Map as Map
+import Data.Tuple.Nested ((/\))
 import Examples.Metadata as Metadata
-import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), Timeout(..), Value(..))
+import Marlowe.Extended (Action(..), Case(..), Contract(..), Payee(..), TemplateContent(..), Timeout(..), Value(..), fillTemplate)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (Party(..), Token(..))
 
 contractTemplate :: ContractTemplate
-contractTemplate = { metaData, extendedContract }
+contractTemplate = { metaData, extendedContract: fixedTimeoutContract }
+
+fixedTimeoutContract :: Contract
+fixedTimeoutContract =
+  fillTemplate
+    ( TemplateContent
+        { slotContent:
+            Map.fromFoldable
+              [ "Initial exchange deadline" /\ fromInt 60
+              , "Maturity exchange deadline" /\ fromInt 150
+              ]
+        , valueContent:
+            Map.empty
+        }
+    )
+    fullExtendedContract
 
 metaData :: MetaData
 metaData = Metadata.zeroCouponBond
@@ -47,8 +66,8 @@ transfer timeout from to amount continuation =
     timeout
     Close
 
-extendedContract :: Contract
-extendedContract =
+fullExtendedContract :: Contract
+fullExtendedContract =
   transfer initialExchange investor issuer discountedPrice
     $ transfer maturityExchangeTimeout issuer investor notional
         Close


### PR DESCRIPTION
This PR instantiates the timeout parameters for the examples as seen by the dashboard. It keeps the fully parametrised versions both for the Marlowe Playground and for the future

Deployed to https://pablo.marlowe.iohkdev.io/ and https://pablo.marlowe-dash.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
