### PR TITLE
SCP-2153: Fix wait action not working

### DIFF
--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -63,7 +63,6 @@ import           Ledger.Constraints.OffChain          (UnbalancedTx)
 import qualified Ledger.Constraints.OffChain          as Constraints
 import           Ledger.Constraints.TxConstraints     (InputConstraint (..), OutputConstraint (..))
 import           Ledger.Crypto                        (pubKeyHash)
-import qualified Ledger.Interval                      as Interval
 import           Ledger.Tx                            as Tx
 import qualified Ledger.Typed.Scripts                 as Scripts
 import           Ledger.Typed.Tx                      (TypedScriptTxOut (..))
@@ -224,7 +223,8 @@ waitForUpdateUntil StateMachineClient{scInstance, scChooser} timeoutSlot = do
     let addr = Scripts.scriptAddress $ validatorInstance scInstance
     let go sl = do
             txns <- acrTxns <$> addressChangeRequest AddressChangeRequest
-                { acreqSlotRange = Interval.singleton sl
+                { acreqSlotRangeFrom = sl
+                , acreqSlotRangeTo = sl
                 , acreqAddress = addr
                 }
             if null txns && sl < timeoutSlot

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
@@ -32,7 +32,7 @@ import           Wallet.Effects                   (ChainIndexEffect (..))
 import           Wallet.Emulator.ChainIndex.Index (ChainIndex, ChainIndexItem (..))
 import qualified Wallet.Emulator.ChainIndex.Index as Index
 import           Wallet.Emulator.NodeClient       (ChainClientNotification (..))
-import           Wallet.Types                     (AddressChangeRequest (..), AddressChangeResponse (..))
+import           Wallet.Types                     (AddressChangeRequest (..), AddressChangeResponse (..), slotRange)
 
 import           Ledger.Address                   (Address)
 import           Ledger.AddressMap                (AddressMap)
@@ -110,12 +110,12 @@ handleChainIndex = interpret $ \case
     ConfirmedBlocks -> gets _idxConfirmedBlocks
     TransactionConfirmed txid ->
         Map.member txid <$> gets _idxConfirmedTransactions
-    AddressChanged r@AddressChangeRequest{acreqSlotRange, acreqAddress} -> do
+    AddressChanged r@AddressChangeRequest{acreqAddress} -> do
         idx <- gets _idxIdx
-        let itms = Index.transactionsAt idx acreqSlotRange acreqAddress
+        let itms = Index.transactionsAt idx (slotRange r) acreqAddress
         logDebug $ HandlingAddressChangeRequest r itms
         pure $ AddressChangeResponse
             { acrAddress=acreqAddress
-            , acrSlotRange=acreqSlotRange
+            , acrSlotRange=slotRange r
             , acrTxns = fmap ciTx itms
             }

--- a/plutus-contract/src/Wallet/Types.hs
+++ b/plutus-contract/src/Wallet/Types.hs
@@ -17,6 +17,8 @@ module Wallet.Types(
     , Payment(..)
     , emptyPayment
     , AddressChangeRequest(..)
+    , targetSlot
+    , slotRange
     , AddressChangeResponse(..)
     -- * Error types
     , MatchingError(..)
@@ -47,7 +49,7 @@ import qualified Data.UUID.V4                     as UUID
 import           GHC.Generics                     (Generic)
 import qualified Language.Haskell.TH.Syntax       as TH
 
-import           Ledger                           (Address, SlotRange, Tx, TxIn, TxOut, txId)
+import           Ledger                           (Address, Slot, SlotRange, Tx, TxIn, TxOut, interval, txId)
 import           Ledger.Constraints.OffChain      (MkTxError)
 import           Plutus.Contract.Checkpoint       (AsCheckpointError (..), CheckpointError)
 import           Wallet.Emulator.Error            (WalletAPIError)
@@ -213,15 +215,25 @@ instance Pretty AddressChangeResponse where
 --   outputs at a specific address in a slot range.
 data AddressChangeRequest =
     AddressChangeRequest
-        { acreqSlotRange :: SlotRange -- ^ The slot range
-        , acreqAddress   :: Address -- ^ The address
+        { acreqSlotRangeFrom :: Slot
+        , acreqSlotRangeTo   :: Slot
+        , acreqAddress       :: Address -- ^ The address
         }
         deriving stock (Eq, Generic, Show, Ord)
         deriving anyclass (ToJSON, FromJSON)
 
+-- | The earliest slot in which we can respond to an 'AddressChangeRequest'.
+targetSlot :: AddressChangeRequest -> Slot
+targetSlot = succ . acreqSlotRangeTo
+
+-- | The slot range for this request
+slotRange :: AddressChangeRequest -> SlotRange
+slotRange AddressChangeRequest{acreqSlotRangeFrom, acreqSlotRangeTo} =
+    interval acreqSlotRangeFrom acreqSlotRangeTo
+
 instance Pretty AddressChangeRequest where
-    pretty AddressChangeRequest{acreqSlotRange, acreqAddress} =
+    pretty AddressChangeRequest{acreqSlotRangeFrom, acreqSlotRangeTo, acreqAddress} =
         hang 2 $ vsep
-            [ "Slot range:" <+> pretty acreqSlotRange
+            [ "From " <+> pretty acreqSlotRangeFrom <+> "to" <+> pretty acreqSlotRangeTo
             , "Address:" <+> pretty acreqAddress
             ]

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -139,7 +139,7 @@ instance (Arbitrary k, Arbitrary v) => Arbitrary (AssocMap.Map k v) where
     arbitrary = AssocMap.fromList <$> arbitrary
 
 instance Arbitrary AddressChangeRequest where
-    arbitrary =  AddressChangeRequest <$> arbitrary <*> arbitrary
+    arbitrary =  AddressChangeRequest <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary ContractPABRequest where
     arbitrary =

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -39,7 +39,6 @@ import           Control.Monad.Freer.Error                        (Error)
 import           Control.Monad.Freer.Extras.Log                   (LogMessage, LogMsg, LogObserve, logDebug, logInfo)
 import           Control.Monad.Freer.Reader                       (Reader, ask, runReader)
 import           Control.Monad.IO.Class                           (MonadIO (liftIO))
-import           Data.Maybe                                       (fromMaybe)
 import           Data.Proxy                                       (Proxy (..))
 import qualified Data.Text                                        as Text
 
@@ -56,11 +55,8 @@ import           Plutus.PAB.Core.ContractInstance.RequestHandlers (ContractInsta
 
 import           Wallet.Effects                                   (ChainIndexEffect, ContractRuntimeEffect,
                                                                    WalletEffect)
-import qualified Wallet.Effects
 import           Wallet.Emulator.LogMessages                      (TxBalanceMsg)
-import           Wallet.Types                                     (targetSlot)
 
-import qualified Debug.Trace                                      as Trace
 import           Plutus.Contract                                  (AddressChangeRequest (..))
 import           Plutus.PAB.Core.ContractInstance.STM             (Activity (Done), BlockchainEnv (..),
                                                                    InstanceState (..), InstancesState,

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/STM.hs
@@ -45,7 +45,7 @@ import           Control.Applicative                      (Alternative (..))
 import           Control.Concurrent.STM                   (STM, TMVar, TVar)
 import qualified Control.Concurrent.STM                   as STM
 import           Control.Lens                             (view)
-import           Control.Monad                            (guard, void)
+import           Control.Monad                            (guard)
 import           Data.Aeson                               (Value)
 import           Data.Foldable                            (fold)
 import           Data.Map                                 (Map)
@@ -55,15 +55,12 @@ import qualified Data.Set                                 as Set
 import           Ledger                                   (Address, Slot, TxId, txOutTxOut, txOutValue)
 import           Ledger.AddressMap                        (AddressMap)
 import qualified Ledger.AddressMap                        as AM
-import           Ledger.Interval
 import qualified Ledger.Value                             as Value
 import           Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed (..))
 import           Plutus.Contract.Effects.ExposeEndpoint   (ActiveEndpoint (..), EndpointValue (..))
 import           Plutus.Contract.Resumable                (IterationID, Request (..), RequestID)
 import           Wallet.Emulator.ChainIndex.Index         (ChainIndex)
-import qualified Wallet.Emulator.ChainIndex.Index         as Index
-import           Wallet.Types                             (AddressChangeRequest (..), AddressChangeResponse (..),
-                                                           ContractInstanceId, EndpointDescription,
+import           Wallet.Types                             (ContractInstanceId, EndpointDescription,
                                                            NotificationError (..))
 
 {- Note [Contract instance thread model]

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract/ContractTest.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract/ContractTest.hs
@@ -37,6 +37,7 @@ import           Plutus.Contract                             (BlockchainActions)
 import           Plutus.Contract.Effects.RPC                 (RPCClient)
 import qualified Plutus.Contracts.Currency                   as Contracts.Currency
 import qualified Plutus.Contracts.GameStateMachine           as Contracts.GameStateMachine
+import qualified Plutus.Contracts.PingPong                   as Contracts.PingPong
 import qualified Plutus.Contracts.RPC                        as Contracts.RPC
 import           Plutus.PAB.Effects.Contract                 (ContractEffect (..))
 import           Plutus.PAB.Effects.Contract.Builtin         (Builtin, SomeBuiltin (..))
@@ -47,7 +48,7 @@ import           Plutus.PAB.Monitoring.PABLogMsg             (PABMultiAgentMsg)
 import           Plutus.PAB.Types                            (PABError (..))
 import           Schema                                      (FormSchema)
 
-data TestContracts = GameStateMachine | Currency | AtomicSwap | PayToWallet | RPCClient | RPCServer
+data TestContracts = GameStateMachine | Currency | AtomicSwap | PayToWallet | RPCClient | RPCServer | PingPong
     deriving (Eq, Ord, Show, Generic)
     deriving anyclass (FromJSON, ToJSON)
 
@@ -71,6 +72,7 @@ getSchema = \case
     PayToWallet      -> Builtin.endpointsToSchemas @(Contracts.PayToWallet.PayToWalletSchema .\\ BlockchainActions)
     RPCClient        -> adderSchema
     RPCServer        -> adderSchema
+    PingPong         -> Builtin.endpointsToSchemas @(Contracts.PingPong.PingPongSchema .\\ BlockchainActions)
     where
         adderSchema = Builtin.endpointsToSchemas @(Contracts.RPC.AdderSchema .\\ (BlockchainActions .\/ RPCClient Contracts.RPC.Adder))
 
@@ -82,6 +84,7 @@ getContract = \case
     PayToWallet      -> SomeBuiltin payToWallet
     RPCClient        -> SomeBuiltin rpcClient
     RPCServer        -> SomeBuiltin rpcServer
+    PingPong         -> SomeBuiltin pingPong
     where
         game = Contracts.GameStateMachine.contract
         currency = Contracts.Currency.forgeCurrency
@@ -89,4 +92,4 @@ getContract = \case
         payToWallet = Contracts.PayToWallet.payToWallet
         rpcClient =  Contracts.RPC.callAdder
         rpcServer = Contracts.RPC.respondAdder
-
+        pingPong = Contracts.PingPong.combined

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -328,7 +328,7 @@ activateContract = Core.activateContract
 
 -- | Call a named endpoint on a contract instance
 callEndpointOnInstance :: forall a t. (JSON.ToJSON a) => ContractInstanceId -> String -> a -> Simulation t (Maybe NotificationError)
-callEndpointOnInstance = Core.callEndpointOnInstance
+callEndpointOnInstance = Core.callEndpointOnInstance'
 
 -- | Log some output to the console
 logString :: forall t effs. Member (LogMsg (PABMultiAgentMsg t)) effs => String -> Eff effs ()

--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -277,7 +277,8 @@ waitForChange AuctionParams{apEndTime} client lastHighestBid = do
                                            -- I don't have the time to look into that atm though :(
             AddressChangeResponse{acrTxns} <- addressChangeRequest
                 AddressChangeRequest
-                { acreqSlotRange = Interval.singleton targetSlot
+                { acreqSlotRangeFrom = targetSlot
+                , acreqSlotRangeTo = targetSlot
                 , acreqAddress = address
                 }
             case acrTxns of

--- a/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
@@ -25,27 +25,29 @@ module Plutus.Contracts.PingPong(
     runPong,
     initialise,
     runStop,
-    runWaitForUpdate
+    runWaitForUpdate,
+    combined
     ) where
 
 import           Control.Lens
-import           Control.Monad                (void)
+import           Control.Monad                (forever, void)
 import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Monoid                  (Last (..))
 import           GHC.Generics                 (Generic)
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Constraints           (TxConstraints)
 import qualified Ledger.Typed.Scripts         as Scripts
-import           Ledger.Typed.Tx              (tyTxOutData)
+import           Ledger.Typed.Tx              (TypedScriptTxOut (..))
 import qualified PlutusTx                     as PlutusTx
 import           PlutusTx.Prelude             hiding (Applicative (..), check)
 
+import           Plutus.Contract
 import           Plutus.Contract.StateMachine (AsSMContractError (..), OnChainState, State (..), Void)
 import qualified Plutus.Contract.StateMachine as SM
-
-import           Plutus.Contract
+import qualified Prelude                      as Haskell
 
 data PingPongState = Pinged | Ponged | Stopped
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq PingPongState where
@@ -111,13 +113,14 @@ machineInstance = SM.StateMachineInstance machine scriptInstance
 client :: SM.StateMachineClient PingPongState Input
 client = SM.mkStateMachineClient machineInstance
 
-initialise :: Contract () PingPongSchema PingPongError PingPongState
+initialise :: forall w. Contract w PingPongSchema PingPongError PingPongState
 initialise = endpoint @"initialise" >> SM.runInitialise client Pinged (Ada.lovelaceValueOf 1)
 
 run ::
+    forall w.
     PingPongState
-    -> Contract () PingPongSchema PingPongError ()
-    -> Contract () PingPongSchema PingPongError ()
+    -> Contract w PingPongSchema PingPongError ()
+    -> Contract w PingPongSchema PingPongError ()
 run expectedState action = do
     let extractState = tyTxOutData . fst
         go Nothing = throwError StoppedUnexpectedly
@@ -128,17 +131,34 @@ run expectedState action = do
     let datum = fmap fst maybeState
     go datum
 
-runPing :: Contract () PingPongSchema PingPongError ()
-runPing = run Ponged (endpoint @"ping" >> void (SM.runStep client Ping))
+runPing :: forall w. Contract w PingPongSchema PingPongError ()
+runPing = run Ponged ping
 
-runPong :: Contract () PingPongSchema PingPongError ()
-runPong = run Pinged (endpoint @"pong" >> void (SM.runStep client Pong))
+ping :: forall w. Contract w PingPongSchema PingPongError ()
+ping = endpoint @"ping" >> void (SM.runStep client Ping)
 
-runStop :: Contract () PingPongSchema PingPongError ()
+runPong :: forall w. Contract w PingPongSchema PingPongError ()
+runPong = run Pinged pong
+
+pong :: forall w. Contract w PingPongSchema PingPongError ()
+pong = endpoint @"pong" >> void (SM.runStep client Pong)
+
+runStop :: forall w. Contract w PingPongSchema PingPongError ()
 runStop = endpoint @"stop" >> void (SM.runStep client Stop)
 
-runWaitForUpdate :: Contract () PingPongSchema PingPongError (Maybe (OnChainState PingPongState Input))
+runWaitForUpdate :: forall w. Contract w PingPongSchema PingPongError (Maybe (OnChainState PingPongState Input))
 runWaitForUpdate = SM.waitForUpdate client
+
+combined :: Contract (Last PingPongState) PingPongSchema PingPongError ()
+combined = forever (void initialise `select` ping `select` pong `select` runStop `select` wait) where
+    wait = do
+        _ <- endpoint @"wait"
+        newState <- runWaitForUpdate
+        case newState of
+            Nothing -> logWarn @String "runWaitForUpdate: Nothing"
+            Just (TypedScriptTxOut{tyTxOutData=s}, _) -> do
+                logInfo $ "new state: " <> show s
+                tell (Last $ Just s)
 
 PlutusTx.unstableMakeIsData ''PingPongState
 PlutusTx.makeLift ''PingPongState


### PR DESCRIPTION
The core of the problem was a discrepancy between emulator and PAB: In the emulator we retry all the request handlers whenever something changes, but in the PAB we don't (deliberately - to avoid polling).
The handler for `addressChangeRequest` just failed when the request was for a future slot. In the emulator this doesn't matter, because the handler is going to be retried, but in the PAB it just fails. Therefore I changed `addressChangeRequest` to wait until the slot that we're asking for has passed.
In the course of this, I changed the interval type in `AddressChangeRequest` to be definite on both ends. Otherwise we don't know how long to wait for.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
