### PR TITLE
SCP-2206: Add a warning card for when cached wallet details are not found.

### DIFF
--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -2,7 +2,7 @@ module MainFrame.State (mkMainFrame, handleAction) where
 
 import Prelude
 import Bridge (toFront)
-import Capability.Marlowe (class ManageMarlowe, marloweFollowContract, marloweGetContracts, marloweGetRoleContracts)
+import Capability.Marlowe (class ManageMarlowe, marloweFollowContract, marloweLookupWalletDetails, marloweGetContracts, marloweGetRoleContracts)
 import Capability.Toast (class Toast, addToast)
 import Capability.Websocket (class MonadWebsocket, subscribeToContract, subscribeToWallet, unsubscribeFromContract, unsubscribeFromWallet)
 import Contract.Lenses (_marloweParams)
@@ -38,7 +38,7 @@ import Marlowe.PAB (ContractInstanceId, MarloweData, MarloweParams)
 import Marlowe.Slot (currentSlot)
 import Pickup.Lenses (_walletLibrary)
 import Pickup.State (handleAction, dummyState, mkInitialState) as Pickup
-import Pickup.Types (Action(..), State) as Pickup
+import Pickup.Types (Action(..), Card(..), State) as Pickup
 import Play.Lenses (_allContracts, _currentSlot, _walletDetails)
 import Play.State (dummyState, handleAction, mkInitialState) as Play
 import Play.Types (Action(..), State) as Play
@@ -175,7 +175,10 @@ handleAction Init = do
   mWalletDetailsJson <- liftEffect $ getItem walletDetailsLocalStorageKey
   for_ mWalletDetailsJson \json ->
     for_ (runExcept $ decodeJSON json) \walletDetails -> do
-      handleAction $ PickupAction $ Pickup.SetPickupWalletString $ view _walletNickname walletDetails
+      ajaxWalletDetails <- marloweLookupWalletDetails $ view _companionContractId walletDetails
+      case ajaxWalletDetails of
+        Left ajaxError -> handleAction $ PickupAction $ Pickup.OpenCard Pickup.LocalWalletMissingCard
+        Right _ -> handleAction $ PickupAction $ Pickup.SetPickupWalletString $ view _walletNickname walletDetails
 
 handleAction (EnterPickupState walletLibrary walletDetails followerContracts) = do
   unsubscribeFromWallet $ view (_walletInfo <<< _wallet) walletDetails

--- a/marlowe-dashboard-client/src/Pickup/State.purs
+++ b/marlowe-dashboard-client/src/Pickup/State.purs
@@ -19,17 +19,20 @@ import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Foreign.Generic (encodeJSON)
 import Halogen (HalogenM, liftEffect)
-import LocalStorage (setItem)
+import LocalStorage (setItem, removeItem)
 import MainFrame.Types (ChildSlots, Msg)
 import MainFrame.Types (Action(..)) as MainFrame
 import Pickup.Lenses (_card, _pickupWalletString, _walletDetails, _walletLibrary)
 import Pickup.Types (Action(..), Card(..), State)
-import StaticData (walletLibraryLocalStorageKey)
+import StaticData (walletLibraryLocalStorageKey, walletDetailsLocalStorageKey)
 import Toast.Types (ajaxErrorToast)
 import WalletData.Lenses (_companionContractId, _walletNickname)
 import WalletData.State (defaultWalletDetails)
 import WalletData.Types (WalletLibrary)
 import WalletData.Validation (parseContractInstanceId)
+import Web.HTML (window)
+import Web.HTML.Location (reload)
+import Web.HTML.Window (location)
 
 -- see note [dummyState] in MainFrame.State
 dummyState :: State
@@ -99,3 +102,10 @@ handleAction PickupWallet = do
   walletLibrary <- use _walletLibrary
   liftEffect $ setItem walletLibraryLocalStorageKey $ encodeJSON walletLibrary
   callMainFrameAction $ MainFrame.EnterPlayState walletLibrary walletDetails
+
+handleAction ClearLocalStorage = do
+  liftEffect $ removeItem walletLibraryLocalStorageKey
+  liftEffect $ removeItem walletDetailsLocalStorageKey
+  window_ <- liftEffect window
+  location_ <- liftEffect $ location window_
+  liftEffect $ reload location_

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -20,6 +20,7 @@ type State
 data Card
   = PickupNewWalletCard
   | PickupWalletCard
+  | LocalWalletMissingCard
 
 derive instance eqCard :: Eq Card
 
@@ -30,6 +31,7 @@ data Action
   | SetPickupWalletString String
   | SetWalletNickname WalletNickname
   | PickupWallet
+  | ClearLocalStorage
 
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
@@ -40,3 +42,4 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (SetPickupWalletString _) = Nothing
   toEvent (SetWalletNickname _) = Nothing
   toEvent PickupWallet = Just $ defaultEvent "PickupWallet"
+  toEvent ClearLocalStorage = Just $ defaultEvent "ClearLocalStorage"

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -8,11 +8,11 @@ import Data.Lens (view)
 import Data.Maybe (isJust, isNothing)
 import Data.Newtype (unwrap)
 import Data.UUID (toString) as UUID
-import Halogen.HTML (HTML, a, button, div, div_, footer, header, hr, img, input, label, main, p, text)
+import Halogen.HTML (HTML, a, button, div, div_, footer, header, hr, img, input, label, main, p, span_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), disabled, for, href, id_, list, placeholder, readOnly, src, type_, value)
 import Logo (marloweRunLogo)
-import Material.Icons (Icon(..), icon_)
+import Material.Icons (Icon(..), icon, icon_)
 import Pickup.Lenses (_card, _pickingUp, _pickupWalletString, _walletDetails, _walletLibrary)
 import Pickup.Types (Action(..), Card(..), State)
 import Prim.TypeError (class Warn, Text)
@@ -46,19 +46,13 @@ renderPickupCard state =
       [ classNames $ Css.overlay $ isNothing card ]
       [ div
           [ classNames $ Css.card $ isNothing card ]
-          [ a
-              [ classNames [ "absolute", "top-4", "right-4" ]
-              , onClick_ CloseCard
-              ]
-              [ icon_ Close ]
-          , div_
-              $ (flip foldMap card) \cardType -> case cardType of
-                  PickupNewWalletCard -> [ pickupNewWalletCard state ]
-                  PickupWalletCard -> [ pickupWalletCard state ]
-          ]
+          $ (flip foldMap card) \cardType -> case cardType of
+              PickupNewWalletCard -> pickupNewWalletCard state
+              PickupWalletCard -> pickupWalletCard state
+              LocalWalletMissingCard -> localWalletMissingCard
       ]
 
-pickupNewWalletCard :: forall p. State -> HTML p Action
+pickupNewWalletCard :: forall p. State -> Array (HTML p Action)
 pickupNewWalletCard state =
   let
     walletLibrary = view _walletLibrary state
@@ -73,61 +67,67 @@ pickupNewWalletCard state =
 
     mWalletNicknameError = walletNicknameError walletNickname walletLibrary
   in
-    div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
-      [ p
-          [ classNames [ "font-bold", "mb-4" ] ]
-          [ text $ "Demo wallet generated" ]
-      , div
-          [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
-          $ [ label
-                [ classNames $ Css.nestedLabel
-                , for "newWalletNickname"
-                ]
-                [ text "Nickname" ]
-            , input
-                $ [ type_ InputText
-                  , classNames $ (Css.input $ isJust mWalletNicknameError) <> [ "text-lg" ]
-                  , id_ "newWalletNickname"
-                  , placeholder "Nickname"
-                  , value walletNickname
-                  , onValueInput_ SetWalletNickname
+    [ a
+        [ classNames [ "absolute", "top-4", "right-4" ]
+        , onClick_ CloseCard
+        ]
+        [ icon_ Close ]
+    , div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
+        [ p
+            [ classNames [ "font-bold", "mb-4" ] ]
+            [ text $ "Demo wallet generated" ]
+        , div
+            [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
+            $ [ label
+                  [ classNames $ Css.nestedLabel
+                  , for "newWalletNickname"
                   ]
-            , div
-                [ classNames Css.inputError ]
-                [ text $ foldMap show mWalletNicknameError ]
+                  [ text "Nickname" ]
+              , input
+                  $ [ type_ InputText
+                    , classNames $ (Css.input $ isJust mWalletNicknameError) <> [ "text-lg" ]
+                    , id_ "newWalletNickname"
+                    , placeholder "Nickname"
+                    , value walletNickname
+                    , onValueInput_ SetWalletNickname
+                    ]
+              , div
+                  [ classNames Css.inputError ]
+                  [ text $ foldMap show mWalletNicknameError ]
+              ]
+        , div
+            [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
+            [ label
+                [ classNames Css.nestedLabel
+                , for "newWalletID"
+                ]
+                [ text "Wallet ID" ]
+            , input
+                [ type_ InputText
+                , classNames $ (Css.input false) <> [ "text-lg" ]
+                , id_ "newWalletID"
+                , value $ UUID.toString $ unwrap contractInstanceId
+                , readOnly true
+                ]
             ]
-      , div
-          [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
-          [ label
-              [ classNames Css.nestedLabel
-              , for "newWalletID"
-              ]
-              [ text "Wallet ID" ]
-          , input
-              [ type_ InputText
-              , classNames $ (Css.input false) <> [ "text-lg" ]
-              , id_ "newWalletID"
-              , value $ UUID.toString $ unwrap contractInstanceId
-              , readOnly true
-              ]
-          ]
-      , div
-          [ classNames [ "flex" ] ]
-          [ button
-              [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ CloseCard
-              ]
-              [ text "Cancel" ]
-          , button
-              [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , disabled $ isJust mWalletNicknameError || pickingUp
-              , onClick_ PickupWallet
-              ]
-              [ text if pickingUp then "Picking up... " else "Pickup" ]
-          ]
-      ]
+        , div
+            [ classNames [ "flex" ] ]
+            [ button
+                [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
+                , onClick_ CloseCard
+                ]
+                [ text "Cancel" ]
+            , button
+                [ classNames $ Css.primaryButton <> [ "flex-1" ]
+                , disabled $ isJust mWalletNicknameError || pickingUp
+                , onClick_ PickupWallet
+                ]
+                [ text if pickingUp then "Picking up... " else "Pickup" ]
+            ]
+        ]
+    ]
 
-pickupWalletCard :: forall p. State -> HTML p Action
+pickupWalletCard :: forall p. State -> Array (HTML p Action)
 pickupWalletCard state =
   let
     pickingUp = view _pickingUp state
@@ -138,55 +138,88 @@ pickupWalletCard state =
 
     companionContractId = view _companionContractId walletDetails
   in
-    div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
-      [ p
-          [ classNames [ "font-bold", "mb-4" ] ]
-          [ text $ "Play wallet " <> walletNickname ]
-      , div
-          [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
-          $ [ label
-                [ classNames $ Css.nestedLabel
-                , for "nickname"
-                ]
-                [ text "Nickname" ]
-            , input
-                $ [ type_ InputText
-                  , classNames $ Css.input false
-                  , id_ "nickname"
-                  , value walletNickname
-                  , readOnly true
+    [ a
+        [ classNames [ "absolute", "top-4", "right-4" ]
+        , onClick_ CloseCard
+        ]
+        [ icon_ Close ]
+    , div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
+        [ p
+            [ classNames [ "font-bold", "mb-4" ] ]
+            [ text $ "Play wallet " <> walletNickname ]
+        , div
+            [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
+            $ [ label
+                  [ classNames $ Css.nestedLabel
+                  , for "nickname"
                   ]
+                  [ text "Nickname" ]
+              , input
+                  $ [ type_ InputText
+                    , classNames $ Css.input false
+                    , id_ "nickname"
+                    , value walletNickname
+                    , readOnly true
+                    ]
+              ]
+        , div
+            [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
+            [ label
+                [ classNames Css.nestedLabel
+                , for "walletId"
+                ]
+                [ text "Wallet ID" ]
+            , input
+                [ type_ InputText
+                , classNames $ Css.input false
+                , id_ "walletId"
+                , value $ UUID.toString $ unwrap companionContractId
+                , readOnly true
+                ]
             ]
+        , div
+            [ classNames [ "flex" ] ]
+            [ button
+                [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
+                , onClick_ CloseCard
+                ]
+                [ text "Cancel" ]
+            , button
+                [ classNames $ Css.primaryButton <> [ "flex-1" ]
+                , onClick_ PickupWallet
+                , disabled pickingUp
+                ]
+                [ text if pickingUp then "Picking up... " else "Pickup" ]
+            ]
+        ]
+    ]
+
+localWalletMissingCard :: forall p. Array (HTML p Action)
+localWalletMissingCard =
+  [ a
+      [ classNames [ "absolute", "top-4", "right-4" ]
+      , onClick_ CloseCard
+      ]
+      [ icon_ Close ]
+  , div [ classNames [ "flex", "font-semibold", "px-5", "py-4", "bg-gray" ] ]
+      [ icon ErrorOutline [ "mr-2" ]
+      , span_ [ text "Wallet not found" ]
+      ]
+  , div
+      [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
+      [ p
+          [ classNames [ "mb-4" ] ]
+          [ text "A wallet that you have previously used is no longer available in our demo server. This is probably because the demo server has been updated. (Note that this demo is in continuous development, and data is not preserved between updates.) We recommend that you use the button below to clear your browser's cache for this site and start again." ]
       , div
-          [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
-          [ label
-              [ classNames Css.nestedLabel
-              , for "walletId"
-              ]
-              [ text "Wallet ID" ]
-          , input
-              [ type_ InputText
-              , classNames $ Css.input false
-              , id_ "walletId"
-              , value $ UUID.toString $ unwrap companionContractId
-              , readOnly true
-              ]
-          ]
-      , div
-          [ classNames [ "flex" ] ]
+          [ classNames [ "flex", "justify-center" ] ]
           [ button
-              [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ CloseCard
+              [ classNames Css.primaryButton
+              , onClick_ ClearLocalStorage
               ]
-              [ text "Cancel" ]
-          , button
-              [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , onClick_ PickupWallet
-              , disabled pickingUp
-              ]
-              [ text if pickingUp then "Picking up... " else "Pickup" ]
+              [ text "Clear Cache" ]
           ]
       ]
+  ]
 
 ------------------------------------------------------------
 renderPickupScreen :: forall p. Warn (Text "We need to add the Marlowe links.") => State -> HTML p Action


### PR DESCRIPTION
We are currently showing the pickup wallet card on page load if the user has a previously picked up wallet in their `localStorage`. But if the deployment has been updated, all data (including previously used wallets) will have disappeared. This PR changes it so that we first check whether the wallet still exists on the server - if it doesn't, we show a warning to the user inviting them to clear their browser's cache (because "cache" is likely a more familiar word - in fact, we clear the `localStorage`).

![localhost_8009_ (5)](https://user-images.githubusercontent.com/380759/116541962-6084db80-a8ec-11eb-9721-5ecda2241d21.png)
