### PR TITLE
Fix diff type operator (.\\). Bump row-types to 1.0.1.0.

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/default.nix
+++ b/nix/pkgs/haskell/materialized-unix/default.nix
@@ -19,7 +19,7 @@
         "mtl-compat".flags.two-point-one = false;
         "mtl-compat".flags.two-point-two = false;
         "barbies".revision = (((hackage."barbies")."2.0.2.0").revisions).default;
-        "row-types".revision = (((hackage."row-types")."0.4.0.0").revisions).default;
+        "row-types".revision = (((hackage."row-types")."1.0.1.0").revisions).default;
         "io-streams-haproxy".revision = (((hackage."io-streams-haproxy")."1.0.1.0").revisions).default;
         "ieee".revision = (((hackage."ieee")."0.7").revisions).default;
         "ieee".flags.big_endian = false;

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -125,7 +125,7 @@ library
         transformers-base -any,
         monad-control -any,
         mmorph -any,
-        row-types < 1.0,
+        row-types >= 1.0.1.0,
         freer-simple -any,
         prettyprinter >=1.1.0.1,
         semigroups -any,

--- a/plutus-contract/src/Data/Row/Extras.hs
+++ b/plutus-contract/src/Data/Row/Extras.hs
@@ -26,7 +26,6 @@ import qualified Data.Row.Variants as Variants
 import           Data.Text         (Text)
 import qualified Data.Text         as Text
 import           GHC.TypeLits      hiding (Text)
-import qualified GHC.TypeLits      as TL
 
 newtype JsonVar s = JsonVar { unJsonVar :: Var s }
 

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -91,7 +91,7 @@ module Plutus.Contract(
     ) where
 
 import           Data.Aeson                               (ToJSON (toJSON))
-import           Data.Row                                 hiding (type (.\/))
+import           Data.Row
 
 import           Plutus.Contract.Effects.AwaitSlot        as AwaitSlot
 import           Plutus.Contract.Effects.AwaitTxConfirmed as AwaitTxConfirmed
@@ -103,7 +103,6 @@ import           Plutus.Contract.Effects.UtxoAt           as UtxoAt
 import           Plutus.Contract.Effects.WatchAddress     as WatchAddress
 import           Plutus.Contract.Effects.WriteTx
 
-import           Data.Row.Extras                          (type (.\/))
 import           Plutus.Contract.Request                  (ContractRow)
 import           Plutus.Contract.Typed.Tx                 as Tx
 import           Plutus.Contract.Types                    (AsCheckpointError (..), AsContractError (..),

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -49,6 +49,7 @@ type ContractRow s =
 request
   :: forall w l req resp s e.
     ( KnownSymbol l
+    , AllUniqueLabels (Output s)
     , HasType l resp (Input s)
     , HasType l req (Output s)
     , AsContractError e

--- a/plutus-contract/src/Plutus/Contract/Schema.hs
+++ b/plutus-contract/src/Plutus/Contract/Schema.hs
@@ -92,12 +92,13 @@ instance (Forall (Output s) Pretty) => Pretty (Handlers s) where
 initialise ::
   forall (s :: Row *) l a.
   ( KnownSymbol l
+  , AllUniqueLabels (Output s)
   , HasType l a (Output s)
   )
   => a
   -> Handlers s
 initialise a =
-  Handlers (Variants.unsafeMakeVar @(Output s) @l (Label @l) a)
+  Handlers (Variants.IsJust @l @(Output s) (Label @l) a)
 
 --  | Given a schema 's', 'Input s' is the 'Row' type of the inputs that
 --    contracts with this schema accept. See [Contract Schema]

--- a/plutus-pab/src/Plutus/PAB/ContractCLI.hs
+++ b/plutus-pab/src/Plutus/PAB/ContractCLI.hs
@@ -47,7 +47,8 @@ import qualified Data.ByteString.Char8             as BS8
 import qualified Data.ByteString.Lazy              as BSL
 import           Data.Foldable                     (traverse_)
 import           Data.Proxy                        (Proxy (..))
-import           Data.Row                          (AllUniqueLabels, Forall, type (.\\))
+import           Data.Row                          (AllUniqueLabels, Forall)
+import           Data.Row.Extras                   (type (.\\))
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
 import           Options.Applicative               (CommandFields, Mod, Parser, ParserResult, command, disambiguate,


### PR DESCRIPTION
Turned out `type (.\\)` is the reason of #3080. This PR replaces it with a working version. Also bumps the version of `row-types` to `1.0.1.0` with correct version of `type (.\/)`.

Tested against https://github.com/emiflake/plutus-3080-minimum-example.

----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
