### PR TITLE
SCP-2043 - Open example doesn't refresh title nor size of code panel

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/HaskellEditor/State.purs
@@ -1,8 +1,6 @@
 module HaskellEditor.State
   ( handleAction
   , editorGetValue
-  -- TODO: This should probably be exposed by an action
-  , editorResize
   , editorSetTheme
   ) where
 
@@ -107,7 +105,6 @@ handleAction (BottomPanelAction (BottomPanel.PanelAction action)) = handleAction
 
 handleAction (BottomPanelAction action) = do
   toBottomPanel (BottomPanel.handleAction action)
-  editorResize
 
 handleAction SendResultToSimulator = pure unit
 
@@ -158,9 +155,6 @@ runAjax action = RemoteData.fromEither <$> runExceptT action
 
 editorSetTheme :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
 editorSetTheme = void $ query _haskellEditorSlot unit (Monaco.SetTheme HM.daylightTheme.name unit)
-
-editorResize :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
-editorResize = void $ query _haskellEditorSlot unit (Monaco.Resize unit)
 
 editorSetValue :: forall state action msg m. String -> HalogenM state action ChildSlots msg m Unit
 editorSetValue contents = void $ query _haskellEditorSlot unit (Monaco.SetText contents unit)

--- a/marlowe-playground-client/src/JavascriptEditor/State.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/State.purs
@@ -140,13 +140,11 @@ handleAction Compile = do
   case compilationResult of
     (CompilationError _) -> handleAction $ BottomPanelAction (BottomPanel.ChangePanel ErrorsView)
     _ -> pure unit
-  editorResize
 
 handleAction (BottomPanelAction (BottomPanel.PanelAction action)) = handleAction action
 
 handleAction (BottomPanelAction action) = do
   toBottomPanel (BottomPanel.handleAction action)
-  editorResize
 
 handleAction SendResultToSimulator = pure unit
 
@@ -184,9 +182,6 @@ analyze initialAnalysisState doAnalyze = do
   case compilationResult of
     CompiledSuccessfully (InterpreterResult interpretedResult) -> doAnalyze interpretedResult.result
     _ -> pure unit
-
-editorResize :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
-editorResize = void $ query _jsEditorSlot unit (Monaco.Resize unit)
 
 decorationHeader :: String
 decorationHeader =

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -892,16 +892,12 @@ selectView view = do
   case view of
     HomePage -> modify_ (set _workflow Nothing <<< set _hasUnsavedChanges false)
     Simulation -> do
-      Simulation.editorResize
       Simulation.editorSetTheme
     MarloweEditor -> do
-      MarloweEditor.editorResize
       MarloweEditor.editorSetTheme
     HaskellEditor -> do
-      HaskellEditor.editorResize
       HaskellEditor.editorSetTheme
     JSEditor -> do
-      void $ query _jsEditorSlot unit (Monaco.Resize unit)
       void $ query _jsEditorSlot unit (Monaco.SetTheme HM.daylightTheme.name unit)
     BlocklyEditor -> pure unit
     WalletEmulator -> pure unit

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -1,7 +1,6 @@
 module MarloweEditor.State
   ( handleAction
   , editorGetValue
-  , {- FIXME: this should be an action -} editorResize
   , editorSetTheme
   ) where
 
@@ -105,7 +104,6 @@ handleAction (BottomPanelAction (BottomPanel.PanelAction action)) = handleAction
 
 handleAction (BottomPanelAction action) = do
   toBottomPanel (BottomPanel.handleAction action)
-  editorResize
 
 handleAction (ShowErrorDetail val) = assign _showErrorDetail val
 
@@ -233,9 +231,6 @@ runAjax action = RemoteData.fromEither <$> runExceptT action
 
 editorSetTheme :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
 editorSetTheme = void $ query _marloweEditorPageSlot unit (Monaco.SetTheme MM.daylightTheme.name unit)
-
-editorResize :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
-editorResize = void $ query _marloweEditorPageSlot unit (Monaco.Resize unit)
 
 editorSetValue :: forall state action msg m. String -> HalogenM state action ChildSlots msg m Unit
 editorSetValue contents = void $ query _marloweEditorPageSlot unit (Monaco.SetText contents unit)

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -1,6 +1,5 @@
 module SimulationPage.State
   ( handleAction
-  , editorResize
   , editorSetTheme
   , editorGetValue
   , getCurrentContract
@@ -154,7 +153,6 @@ handleAction (BottomPanelAction (BottomPanel.PanelAction action)) = handleAction
 
 handleAction (BottomPanelAction action) = do
   toBottomPanel (BottomPanel.handleAction action)
-  editorResize
 
 handleAction (ChangeHelpContext help) = do
   assign _helpContext help
@@ -270,9 +268,6 @@ scrollHelpPanel =
 
 editorSetTheme :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
 editorSetTheme = void $ query _simulatorEditorSlot unit (Monaco.SetTheme MM.daylightTheme.name unit)
-
-editorResize :: forall state action msg m. HalogenM state action ChildSlots msg m Unit
-editorResize = void $ query _simulatorEditorSlot unit (Monaco.Resize unit)
 
 editorSetValue :: forall state action msg m. String -> HalogenM state action ChildSlots msg m Unit
 editorSetValue contents = void $ query _simulatorEditorSlot unit (Monaco.SetText contents unit)


### PR DESCRIPTION
This PR makes the trigger for resizing part of the Monaco component and gets rid of all the adhoc calls throughout

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
