### PR TITLE
SCP-2063 - Disable comments in Blockly

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -17,6 +17,10 @@ exports.getElementById_ = function (id) {
 };
 
 exports.createWorkspace_ = function (blockly, workspaceDiv, config) {
+
+  /* Disable comments */
+  blockly.ContextMenuRegistry.registry.unregister('blockComment');
+
   /* Register extensions */
   /* Silently clean if already registered */
   try { blockly.Extensions.register('timeout_validator', function () { }); } catch(err) { }


### PR DESCRIPTION
This PR disables the "Add comment" functionality of Blockly, since we are not using the comments. Ideally in the future we would like to include Blockly comments as Marlowe comments and re-enable this functionality.

Resolves #2897

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
