### PR TITLE
Hrajchert/small refactor

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -25,6 +25,7 @@ import Data.String as String
 import Data.String.Extra (capitalize)
 import Data.Tuple (Tuple(..), fst, uncurry)
 import Data.Tuple.Nested ((/\))
+import Halogen.Extra (lifeCycleEvent)
 import Halogen.HTML (HTML, a, button, div, div_, h1, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
@@ -57,7 +58,10 @@ contractDetailsCard currentSlot state =
     --       first and last card can be scrolled to the center
     paddingElement = [ div [ classNames [ "flex-shrink-0", "-ml-3", "w-carousel-padding-element" ] ] [] ]
   in
-    div [ classNames [ "flex", "flex-col", "items-center", "pt-5", "h-full" ] ]
+    div
+      [ classNames [ "flex", "flex-col", "items-center", "pt-5", "h-full" ]
+      , lifeCycleEvent { onInit: Just CarouselOpened, onFinilize: Just CarouselClosed }
+      ]
       [ h1 [ classNames [ "text-xl", "font-semibold" ] ] [ text metadata.contractName ]
       , h2 [ classNames [ "mb-5", "text-xs", "uppercase" ] ] [ text $ contractTypeName metadata.contractType ]
       -- NOTE: The card is allowed to grow in an h-full container and the navigation buttons are absolute positioned

--- a/marlowe-dashboard-client/src/Pickup/State.purs
+++ b/marlowe-dashboard-client/src/Pickup/State.purs
@@ -103,9 +103,9 @@ handleAction PickupWallet = do
   liftEffect $ setItem walletLibraryLocalStorageKey $ encodeJSON walletLibrary
   callMainFrameAction $ MainFrame.EnterPlayState walletLibrary walletDetails
 
-handleAction ClearLocalStorage = do
-  liftEffect $ removeItem walletLibraryLocalStorageKey
-  liftEffect $ removeItem walletDetailsLocalStorageKey
-  window_ <- liftEffect window
-  location_ <- liftEffect $ location window_
-  liftEffect $ reload location_
+handleAction ClearLocalStorage =
+  liftEffect do
+    removeItem walletLibraryLocalStorageKey
+    removeItem walletDetailsLocalStorageKey
+    location_ <- location =<< window
+    reload location_

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -198,7 +198,6 @@ handleAction (ContractHomeAction contractHomeAction) = case contractHomeAction o
     walletDetails <- use _walletDetails
     toContractHome $ ContractHome.handleAction a
     handleAction $ OpenCard ContractCard
-    toContract $ Contract.handleAction walletDetails Contract.CarouselOpened
   _ -> toContractHome $ ContractHome.handleAction contractHomeAction
 
 handleAction (ContractAction contractAction) = do


### PR DESCRIPTION
This PR  changes the lifecycle hack to detect when we Open/Close a carousel from using a visibility subscription to using the native Core.ref.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
