### PR TITLE
SCP-2207: PAB wallet notifications

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
@@ -409,6 +409,7 @@
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             ];
           buildable = true;
           modules = [

--- a/plutus-contract/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-contract/src/Wallet/Emulator/Wallet.hs
@@ -87,6 +87,10 @@ walletAddress = pubKeyAddress . walletPubKey
 signWithWallet :: Wallet -> Tx -> Tx
 signWithWallet wlt = addSignature (walletPrivKey wlt)
 
+-- | Whether the wallet is one of the known emulated wallets
+isEmulatorWallet :: Wallet -> Bool
+isEmulatorWallet (Wallet i) = 0 <= i && i < fromIntegral (length Crypto.knownPrivateKeys)
+
 data WalletEvent =
     GenericLog T.Text
     | CheckpointLog CheckpointLogMsg

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -360,7 +360,8 @@ test-suite plutus-pab-test
         text -any,
         transformers -any,
         prettyprinter -any,
-        row-types -any
+        row-types -any,
+        plutus-tx -any
 
 executable prism-credential-manager
     import: lang

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -92,7 +92,7 @@ processBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} 
 
 processTx :: Slot -> (AddressMap, Map TxId TxStatus, ChainIndex) -> Tx -> (AddressMap, Map TxId TxStatus, ChainIndex)
 processTx currentSlot (addressMap, txStatusMap, chainIndex) tx = (addressMap', txStatusMap', chainIndex') where
-  addressMap' = AddressMap.updateAddresses tx addressMap
+  addressMap' = AddressMap.updateAllAddresses tx addressMap
   chainIndex' =
     let itm = ChainIndexItem{ciSlot = currentSlot, ciTx = tx, ciTxId = txId tx} in
     Index.insert addressMap' itm chainIndex

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -88,7 +88,6 @@ import           Data.Default                                   (Default (..))
 import           Data.Foldable                                  (fold, traverse_)
 import           Data.Map                                       (Map)
 import qualified Data.Map                                       as Map
-import           Data.Semigroup                                 (Max (..))
 import           Data.Set                                       (Set)
 import           Data.Text                                      (Text)
 import qualified Data.Text                                      as Text
@@ -716,8 +715,7 @@ addWallet = do
     (_, privateKey) <- MockWallet.newKeyPair
     liftIO $ STM.atomically $ do
         currentWallets <- STM.readTVar _agentStates
-        let newWalletId = maybe 0 (succ . getMax) $ foldMap (Just . Max . getWallet) $ Map.keysSet currentWallets
-            newWallet = Wallet newWalletId
+        let newWallet = MockWallet.privKeyWallet privateKey
             newWallets = currentWallets & at newWallet .~ Just (AgentState (Wallet.emptyWalletStateFromPrivateKey privateKey) mempty)
         STM.writeTVar _agentStates newWallets
         pure (newWallet, toPublicKey privateKey)

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -18,6 +18,7 @@ to one PAB, with its own view of the world, all acting on the same blockchain.
 -}
 module Plutus.PAB.Simulator(
     Simulation
+    , SimulatorState
     , runSimulation
     -- * Run with user-defined contracts
     , SimulatorContractHandler

--- a/plutus-pab/test/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab/test/Plutus/PAB/CoreSpec.hs
@@ -10,6 +10,7 @@
 module Plutus.PAB.CoreSpec
     ( tests
     , stopContractInstanceTest
+    , walletFundsChangeTest
     ) where
 
 import           Control.Lens                             ((&), (+~))
@@ -20,8 +21,9 @@ import           Control.Monad.Freer.Extras.Log           (LogMsg)
 import qualified Control.Monad.Freer.Extras.Log           as EmulatorLog
 import           Control.Monad.Freer.Extras.State         (use)
 import           Control.Monad.Freer.State                (State)
+import           Control.Monad.IO.Class                   (MonadIO (..))
 import qualified Data.Aeson                               as JSON
-import           Data.Foldable                            (fold)
+import           Data.Foldable                            (fold, traverse_)
 
 import qualified Data.Aeson.Types                         as JSON
 import           Data.Either                              (isRight)
@@ -35,11 +37,12 @@ import qualified Data.Text                                as Text
 import           Data.Text.Extras                         (tshow)
 import           Ledger                                   (pubKeyAddress)
 import           Ledger.Ada                               (adaSymbol, adaToken, lovelaceValueOf)
+import qualified Ledger.Ada                               as Ada
 import           Ledger.Value                             (valueOf)
 import           Plutus.Contracts.Currency                (OneShotCurrency, SimpleMPS (..))
 import qualified Plutus.Contracts.GameStateMachine        as Contracts.GameStateMachine
 import           Plutus.Contracts.PingPong                (PingPongState (..))
-import           Plutus.PAB.Core
+import           Plutus.PAB.Core                          as Core
 import           Plutus.PAB.Core.ContractInstance         (ContractInstanceMsg)
 import           Plutus.PAB.Db.Eventful.Command           ()
 import qualified Plutus.PAB.Db.Eventful.Query             as Query
@@ -52,10 +55,13 @@ import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedRespo
 import           Plutus.PAB.Simulator                     (Simulation, TxCounts (..))
 import qualified Plutus.PAB.Simulator                     as Simulator
 import           Plutus.PAB.Types                         (PABError (..), chainOverviewBlockchain, mkChainOverview)
+import qualified Plutus.PAB.Webserver.WebSocket           as WS
+import           PlutusTx.Monoid                          (Group (inv))
 import           Test.QuickCheck.Instances.UUID           ()
 import           Test.Tasty                               (TestTree, defaultMain, testGroup)
 import           Test.Tasty.HUnit                         (testCase)
 import           Wallet.API                               (WalletAPIError, ownPubKey)
+import qualified Wallet.API                               as WAPI
 import qualified Wallet.Emulator.Chain                    as Chain
 import           Wallet.Emulator.Wallet                   (Wallet (..))
 import           Wallet.Rollup                            (doAnnotateBlockchain)
@@ -100,6 +106,8 @@ executionTests =
         , rpcTest
         , testCase "wait for update" waitForUpdateTest
         , testCase "stop contract instance" stopContractInstanceTest
+        , testCase "can subscribe to slot updates" slotChangeTest
+        , testCase "can subscribe to wallet funds changes" walletFundsChangeTest
         ]
 
 waitForUpdateTest :: IO ()
@@ -130,6 +138,28 @@ stopContractInstanceTest = do
         _ <- Simulator.waitUntilFinished p1
         st <- Simulator.instanceActivity p1
         assertEqual "Instance should be 'Stopped'" st Simulator.Stopped
+
+slotChangeTest :: IO ()
+slotChangeTest = runScenario $ do
+    env <- Core.askBlockchainEnv @(Builtin TestContracts) @(Simulator.SimulatorState (Builtin TestContracts))
+    let stream = WS.slotChange env
+    ns <- liftIO (WS.readN 5 stream)
+    assertEqual "Should wait for five slots" 5 (length ns)
+
+walletFundsChangeTest :: IO ()
+walletFundsChangeTest = runScenario $ do
+    let payment = lovelaceValueOf 50
+        fee     = lovelaceValueOf 10
+
+    env <- Core.askBlockchainEnv @(Builtin TestContracts) @(Simulator.SimulatorState (Builtin TestContracts))
+    let stream = WS.walletFundsChange defaultWallet env
+    (initialValue, next) <- liftIO (WS.readOne stream)
+    (wllt, pk) <- Simulator.addWallet
+    _ <- Simulator.handleAgentThread defaultWallet $ WAPI.payToPublicKey WAPI.defaultSlotRange payment pk
+    nextStream <- case next of { Nothing -> throwError (OtherError "no next value"); Just a -> pure a; }
+    (finalValue, _) <- liftIO (WS.readOne nextStream)
+    let difference = initialValue <> inv finalValue
+    assertEqual "defaultWallet should make a payment" difference (payment <> fee)
 
 currencyTest :: TestTree
 currencyTest =


### PR DESCRIPTION
There were two issues preventing this from working properly

1. The `AddressMap` maintained by the PAB was not watching the addresses of newly created wallets
2. The conversion of `Wallet` to `Address` was assuming that it was dealing with one of the emulated wallets.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
