### PR TITLE
marlowe-website: Fix css build

### DIFF
--- a/marlowe-website/default.nix
+++ b/marlowe-website/default.nix
@@ -3,6 +3,7 @@
 npmlock2nix.build {
   src = gitignore-nix.gitignoreSource ./.;
   installPhase = "cp -r public $out";
+  node_modules_mode = "copy";
 
   node_modules_attrs = {
     packageLockJson = ./package-lock.json;


### PR DESCRIPTION
Change the npmlock2nix build to copy node_modules.

The css tooling cannot deal with `node_modules` being a symlink so the
node_modules folder has to be copied instead.

-----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
