### PR TITLE
SCP-2210 and SCP-2211 - Catch exception that caused subscriptions to fail

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -18,11 +18,11 @@ exports.getElementById_ = function (id) {
 
 exports.createWorkspace_ = function (blockly, workspaceDiv, config) {
 
-  /* Disable disabling blocks */
-  blockly.ContextMenuRegistry.registry.unregister('blockDisable');
-
   /* Disable comments */
-  blockly.ContextMenuRegistry.registry.unregister('blockComment');
+  try { blockly.ContextMenuRegistry.registry.unregister('blockComment'); } catch(err) { }
+
+  /* Disable disabling blocks */
+  try { blockly.ContextMenuRegistry.registry.unregister('blockDisable'); } catch(err) { }
 
   /* Register extensions */
   /* Silently clean if already registered */
@@ -66,6 +66,7 @@ exports.createWorkspace_ = function (blockly, workspaceDiv, config) {
   /* Inject workspace */
   var workspace = blockly.inject(workspaceDiv, config);
   blockly.svgResize(workspace);
+  
   return workspace;
 };
 


### PR DESCRIPTION
The instructions that unregistered the context menus in blockly caused an exception that prevented subscriptions from succeeding (which resulted in JS disabled bits being editable, and buttons not refreshing). This PR wraps it in a `try ... catch` so that this doesn't have side-effects

Deployed to: https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
