### PR TITLE
SCP-2066 - Add validator and change default for PK and token hash in Blockly

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -28,6 +28,8 @@ exports.createWorkspace_ = function (blockly, workspaceDiv, config) {
   /* Silently clean if already registered */
   try { blockly.Extensions.register('timeout_validator', function () { }); } catch(err) { }
   blockly.Extensions.unregister('timeout_validator');
+  try { blockly.Extensions.register('hash_validator', function () { }); } catch(err) { }
+  blockly.Extensions.unregister('hash_validator');
 
   /* Timeout extension (advanced validation for the timeout field) */
   blockly.Extensions.register('timeout_validator',
@@ -61,6 +63,30 @@ exports.createWorkspace_ = function (blockly, workspaceDiv, config) {
           }
         }
       });
+    });
+
+  /* Hash extension (advanced validation for the hash fields) */
+  blockly.Extensions.register('hash_validator',
+    function () {
+      var thisBlock = this;
+
+      /* Validator for hash */
+      var hashValidator = function (input) {
+          var cleanedInput = input.replace(new RegExp('[^a-fA-F0-9]+', 'g'), '').toLowerCase();
+          if ((new RegExp('^([a-f0-9][a-f0-9])*$', 'g')).test(cleanedInput)) {
+            return cleanedInput;
+          } else {
+            return null;
+          }
+      };
+
+      ['currency_symbol', 'pubkey'].forEach(
+        function (fieldName) {
+          var field = thisBlock.getField(fieldName);
+          if (field != null) {
+            field.setValidator(hashValidator);
+          }
+        });
     });
 
   /* Inject workspace */

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -503,11 +503,12 @@ toDefinition blockType@(PartyType PKPartyType) =
         { type: show PKPartyType
         , message0: "Public Key %1"
         , args0:
-            [ Input { name: "pubkey", text: "pubkey", spellcheck: false }
+            [ Input { name: "pubkey", text: "0000000000000000000000000000000000000000000000000000000000000000", spellcheck: false }
             ]
         , colour: blockColour blockType
         , output: Just "party"
         , inputsInline: Just true
+        , extensions: [ "hash_validator" ]
         }
         defaultBlockDefinition
 
@@ -537,6 +538,7 @@ toDefinition blockType@(TokenType CustomTokenType) =
         , colour: blockColour blockType
         , output: Just "token"
         , inputsInline: Just true
+        , extensions: [ "hash_validator" ]
         }
         defaultBlockDefinition
 

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -194,7 +194,7 @@ getMarloweConstructors TokenType = Map.singleton "Token" $ ArgumentArray [ Defau
 
 getMarloweConstructors PartyType =
   Map.fromFoldable
-    [ (Tuple "PK" $ ArgumentArray [ DefaultString "pubKey" ])
+    [ (Tuple "PK" $ ArgumentArray [ DefaultString "0000000000000000000000000000000000000000000000000000000000000000" ])
     , (Tuple "Role" $ ArgumentArray [ DefaultString "token" ])
     ]
 

--- a/marlowe-playground-client/test/Blockly/Headless.js
+++ b/marlowe-playground-client/test/Blockly/Headless.js
@@ -11,6 +11,7 @@ exports.createWorkspace_ = function(blockly) {
 
 exports.initializeWorkspace_ = function(blockly, workspace) {
     try { blockly.Extensions.register('timeout_validator', function () { }); } catch(err) { }
+    try { blockly.Extensions.register('hash_validator', function () { }); } catch(err) { }
     var xmlText = '<xml id="workspaceBlocks" style="display:none"><block type="BaseContractType" x="13" y="187" id="root_contract"></block></xml>';
     var workspaceBlocks = blockly.Xml.textToDom(xmlText);
     blockly.Xml.domToWorkspace(workspaceBlocks, workspace);


### PR DESCRIPTION
This PR adds a validator and fixes the default values for PK and token currency symbols (so that they are/accept only valid hexadecimal sequences).

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
