### PR TITLE
Work on landing pages a bit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,19 +1,32 @@
-= https://github.com/input-output-hk/plutus[Plutus Platform]
+= https://github.com/input-output-hk/plutus[The Plutus Platform and Marlowe]
 :email: plutus@iohk.io
 :author: Input Output HK Limited
 :toc: left
 :reproducible:
 
-The Plutus Platform enables you to:
+The Plutus Platform is an application development platform for developing distributed applications using the Cardano blockchain; and Marlowe is a platform specifically for financial products, built on top of Plutus.
+For more information about the projects, see https://docs.cardano.org/projects/plutus/en/latest/[the documentation].
 
-* Work with Plutus Core, the smart contract language embedded in the Cardano ledger.
-* Write Haskell programs that create and use embedded Plutus Core programs using Plutus Tx.
-* Write smart contract executables which can be distributed for use with the Plutus
-Smart Contract Backend.
+This repository contains:
 
-You are free to copy, modify, and distribute the Plutus Platform with
-under the terms of the Apache 2.0 license. See the link:./LICENSE[LICENSE]
-and link:./NOTICE[NOTICE] files for details.
+* Plutus Platform
+  * The implementation, specification, and mechanized metatheory of Plutus Core, the scripting language embedded in the Cardano ledger.
+  * Plutus Tx, the compiler from Haskell to Plutus Core.
+  * Libraries which implement the Plutus Application Framework, a framework for writing applications that work with Cardano.
+  * A selection of end-to-end usecases written with the Plutus Application Framework
+  * The Plutus Playground, a web-based playground for learning and writing basic Plutus Applications.
+* Marlowe
+  * The implementation of the Marlowe domain-specific language.
+  * Tools for working with Marlowe, including static analysis.
+  * A selection of examples using Marlowe, including a number based on the ACTUS financial standard.
+  * The Marlowe Playground, a web-based playground for learning and writing Marlowe Applications.
+
+[IMPORTANT]
+====
+The rest of this README is focussed on people who want to develop or contribute to the Platform.
+
+For people who want to *use* the Platform, please consult https://docs.cardano.org/projects/plutus/en/latest/[the documentation].
+====
 
 [[cache-warning]]
 [IMPORTANT]
@@ -27,15 +40,15 @@ If you find yourself building GHC, STOP and fix the cache.
 
 == How to use the project
 
-This section contains brief information about how to use this project. For development
-work see <<how-to-develop>> for more information.
+This section contains brief information about how to use this project.
+For development work see <<how-to-develop>> for more information.
 
 [[prerequisites]]
 === Prerequisites
 
-The Haskell libraries in the Plutus Platform can be built in a number of ways. The prerequisites depend
-on how you want to build the libraries. The other artifacts (docs etc.) are most easily built with Nix,
-so we recommend installing it regardless.
+The Haskell libraries in the Plutus Platform can be built in a number of ways.
+The prerequisites depend on how you want to build the libraries.
+The other artifacts (docs etc.) are most easily built with Nix, so we recommend installing it regardless.
 
 ==== Nix
 
@@ -54,38 +67,29 @@ If you use Nix, these tools are provided for you via `shell.nix`, and you do *no
 * If you want to build our Haskell packages with https://haskellstack.org/[`stack`], then install it.
 * If you want to build our Agda code, then install https://github.com/agda/agda[Agda] and the https://github.com/agda/agda-stdlib[standard library].
 
-=== How to get started using the platform
-
-The https://github.com/input-output-hk/plutus-starter[`plutus-starter`] repository contains a starter setup.
-
 === How to build the Haskell packages and other artifacts
 
 [[building-with-nix]]
 ==== How to build Haskell packages and other artifacts with Nix
 
-Run `nix build -f default.nix plutus.haskell.packages.plutus-core.components.library`
-from the root to build the Plutus Core library.
+Run `nix build -f default.nix plutus.haskell.packages.plutus-core.components.library` from the root to build the Plutus Core library.
 
-See <<nix-build-attributes>> to find out
-what other attributes you can build.
+See <<nix-build-attributes>> to find out what other attributes you can build.
 
 ==== How to build Haskell packages with `cabal`
 
-Run `cabal build plutus-core` from the root to build the
-Plutus Core library.
+Run `cabal build plutus-core` from the root to build the Plutus Core library.
 
 NOTE: you must have R installed for this to work. https://cran.r-project.org/[R Installation]
 
-See the link:./cabal.project[cabal project file] to see the other
-projects that you can build with `cabal`.
+See the link:./cabal.project[cabal project file] to see the other projects that you can build with `cabal`.
 
 ==== How to build the Haskell packages with `stack`
 
-Run `stack build plutus-core` from the root to build the
-Plutus Core library. The `stack` build is less well supported than the `cabal` build, we do not promise that it will work.
+Run `stack build plutus-core` from the root to build the Plutus Core library.
+The `stack` build is less well supported than the `cabal` build, we do not promise that it will work.
 
-See the link:./stack.yaml[stack project file] to see the other
-projects that you can build with stack.
+See the link:./stack.yaml[stack project file] to see the other projects that you can build with stack.
 
 === How to get the most recent documentation PDFs from CI
 
@@ -105,35 +109,16 @@ projects that you can build with stack.
 
 == Where to go next
 
-=== Where to find tutorials
-
-The link:./doc[doc] folder contains the documentation site.
-
-To build a full HTML version of the site that you can view locally, build the `docs.site` attribute xref:building-with-nix[using Nix].
-
-The online version of the tutorial can be found https://docs.cardano.org/projects/plutus/en/latest/index.html[here]
-
 === How to submit an issue
 
-User issues can be filed in the 
-https://github.com/input-output-hk/plutus/issues[GitHub Issue tracker].
+User issues can be filed in the https://github.com/input-output-hk/plutus/issues[GitHub Issue tracker].
 
 However, note that this is pre-release software, so we will not usually be providing support.
-
-=== How to communicate with us
-
-We’re active on the https://forum.cardano.org/[Cardano
-forum]. Tag your post with the `plutus` tag so we’ll see it.
-
-Use the Github issue tracker for bugs and feature requests, but keep
-other discussions to the forum.
 
 [[how-to-develop]]
 === How to develop and contribute to the project
 
-See link:CONTRIBUTING{outfilesuffix}[CONTRIBUTING], which describes our processes in more
-detail including development environments;
-and link:ARCHITECTURE{outfilesuffix}[ARCHITECTURE], which describes the structure of the repository.
+See link:CONTRIBUTING{outfilesuffix}[CONTRIBUTING], which describes our processes in more detail including development environments; and link:ARCHITECTURE{outfilesuffix}[ARCHITECTURE], which describes the structure of the repository.
 
 [[nix-advice]]
 == Nix
@@ -176,8 +161,7 @@ nix = {
 
 Nix on macOS can be a bit tricky. In particular, sandboxing is disabled by default, which can lead to strange failures.
 
-These days it should be safe to turn on sandboxing on macOS with a few exceptions. Consider setting the following Nix settings,
-in the same way as in xref:iohk-binary-cache[previous section]:
+These days it should be safe to turn on sandboxing on macOS with a few exceptions. Consider setting the following Nix settings, in the same way as in xref:iohk-binary-cache[previous section]:
 
 ----
 sandbox = true
@@ -188,12 +172,12 @@ extra-sandbox-paths = /System/Library/Frameworks /System/Library/PrivateFramewor
 [[nix-build-attributes]]
 === Which attributes to use to build different artifacts
 
-link:./default.nix[`default.nix`] defines a package set with attributes for all the
-artifacts you can build from this repository. These can be built
-using `nix build`. For example:
+link:./default.nix[`default.nix`] defines a package set with attributes for all the artifacts you can build from this repository.
+These can be built using `nix build`.
+For example:
 
 ----
-nix build -f default.nix plutus.haskell.packages.plutus-core
+nix build -f default.nix docs.papers.eutxo
 ----
 
 .Example attributes
@@ -201,7 +185,11 @@ nix build -f default.nix plutus.haskell.packages.plutus-core
 ** e.g. `plutus.haskell.packages.plutus-core.components.library`
 * Documents: defined inside `docs`
 ** e.g. `docs.plutus-core-spec`
-* Development scripts: defined inside `dev`
-** e.g. `dev.scripts.fixStylishHaskell`
 
 There are other attributes defined in link:./default.nix[`default.nix`].
+
+== Licensing
+
+You are free to copy, modify, and distribute the Plutus Platform with
+under the terms of the Apache 2.0 license. See the link:./LICENSE[LICENSE]
+and link:./NOTICE[NOTICE] files for details.

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 :reproducible:
 
 The Plutus Platform is an application development platform for developing distributed applications using the Cardano blockchain; and Marlowe is a platform specifically for financial products, built on top of Plutus.
-For more information about the projects, see https://docs.cardano.org/projects/plutus/en/latest/[the documentation].
+For more information about the projects, see the <<user-documentation>>.
 
 This repository contains:
 
@@ -25,7 +25,7 @@ This repository contains:
 ====
 The rest of this README is focussed on people who want to develop or contribute to the Platform.
 
-For people who want to *use* the Platform, please consult https://docs.cardano.org/projects/plutus/en/latest/[the documentation].
+For people who want to *use* the Platform, please consult the <<user-documentation>>.
 ====
 
 [[cache-warning]]
@@ -38,19 +38,67 @@ If you do not do this, you will end up building GHC, which takes several hours.
 If you find yourself building GHC, STOP and fix the cache.
 ====
 
-== How to use the project
+== Documentation
 
-This section contains brief information about how to use this project.
+=== User documentation
+
+The main documentation is located https://docs.cardano.org/projects/plutus/en/latest/[here].
+
+=== Talks
+
+- https://www.youtube.com/watch?v=MpWeg6Fg0t8[Functional Smart Contracts on Cardano]
+- https://www.youtube.com/watch?v=usMPt8KpBeI[The Plutus Platform]
+
+=== Specifications and design
+
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.plutus-report/latest/download-by-type/doc-pdf/plutus[Plutus Technical Report] (draft)
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.plutus-core-spec/latest/download-by-type/doc-pdf/plutus-core-specification[Plutus Core Specification]
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.extended-utxo-spec/latest/download-by-type/doc-pdf/extended-utxo-specification[Extended UTXO Model]
+
+=== Academic papers
+
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.unraveling-recursion/latest/download-by-type/doc-pdf/unraveling-recursion[Unraveling Recursion] (https://doi.org/10.1007/978-3-030-33636-3_15[published version])
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.system-f-in-agda/latest/download-by-type/doc-pdf/paper[System F in Agda] (https://doi.org/10.1007/978-3-030-33636-3_10[published version])
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.eutxo/latest/download-by-type/doc-pdf/eutxo[The Extended UTXO Model] (in press)
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.utxoma/latest/download-by-type/doc-pdf/utxoma[UTXOma: UTXO with Multi-Asset Support] (in press)
+- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.eutxoma/latest/download-by-type/doc-pdf/eutxoma[Native Custom Tokens in the Extended UTXO Model] (in press)
+
+== Working with the project
+
+=== How to submit an issue
+
+Issues can be filed in the https://github.com/input-output-hk/plutus/issues[GitHub Issue tracker].
+
+However, note that this is pre-release software, so we will not usually be providing support.
+
+[[how-to-develop]]
+=== How to develop and contribute to the project
+
+See link:CONTRIBUTING{outfilesuffix}[CONTRIBUTING], which describes our processes in more detail including development environments; and link:ARCHITECTURE{outfilesuffix}[ARCHITECTURE], which describes the structure of the repository.
+
+=== How to depend on the project from another Haskell project
+
+None of our libraries are on Hackage, unfortunately (many of our dependencies aren't either).
+So for the time being, you need to:
+
+. Add `plutus` as a `source-repository-package` to your `cabal.project`.
+. Copy the `source-repository-package` stanzas from our `cabal.project` to yours.
+. Copy additional stanzas from our `cabal.project` as you need, e.g. you may need some of the `allow-newer` stanzas.
+
+The https://github.com/input-output-hk/plutus-starter[plutus-starter] project provides an example.
+
+=== How to build the project's artifacts
+
+This section contains information about how to build the project's artifacts for independent usage.
 For development work see <<how-to-develop>> for more information.
 
 [[prerequisites]]
-=== Prerequisites
+==== Prerequisites
 
-The Haskell libraries in the Plutus Platform can be built in a number of ways.
-The prerequisites depend on how you want to build the libraries.
-The other artifacts (docs etc.) are most easily built with Nix, so we recommend installing it regardless.
+The Haskell libraries in the Plutus Platform are built with `cabal` and Nix.
+The other artifacts (docs etc.) are also most easily built with Nix.
 
-==== Nix
+===== Nix
 
 Install https://nixos.org/nix/[Nix] (recommended). following the instructions on the https://nixos.org/nix/[Nix website].
 
@@ -59,66 +107,32 @@ DO NOT IGNORE THIS.
 
 See <<nix-advice>> for further advice on using Nix.
 
-==== Non-Nix
+===== Non-Nix
 
+You can build some of the Haskell packages without Nix, but this is not recommended and we don't guarantee that these prerequisites are sufficient.
 If you use Nix, these tools are provided for you via `shell.nix`, and you do *not* need to install them yourself.
 
 * If you want to build our Haskell packages with https://www.haskell.org/cabal/[`cabal`], then install it.
 * If you want to build our Haskell packages with https://haskellstack.org/[`stack`], then install it.
 * If you want to build our Agda code, then install https://github.com/agda/agda[Agda] and the https://github.com/agda/agda-stdlib[standard library].
 
-=== How to build the Haskell packages and other artifacts
-
 [[building-with-nix]]
-==== How to build Haskell packages and other artifacts with Nix
+==== How to build the Haskell packages and other artifacts with Nix
 
 Run `nix build -f default.nix plutus.haskell.packages.plutus-core.components.library` from the root to build the Plutus Core library.
 
 See <<nix-build-attributes>> to find out what other attributes you can build.
 
-==== How to build Haskell packages with `cabal`
+==== How to build the Haskell packages with `cabal`
+
+The Haskell packages can be built directly with `cabal`.
+We do this during development (see <<how-to-develop>>).
+The best way is to do this is inside a `nix-shell`.
 
 Run `cabal build plutus-core` from the root to build the Plutus Core library.
 
-NOTE: you must have R installed for this to work. https://cran.r-project.org/[R Installation]
+See the link:./cabal.project[cabal project file] to see the other packages that you can build with `cabal`.
 
-See the link:./cabal.project[cabal project file] to see the other projects that you can build with `cabal`.
-
-==== How to build the Haskell packages with `stack`
-
-Run `stack build plutus-core` from the root to build the Plutus Core library.
-The `stack` build is less well supported than the `cabal` build, we do not promise that it will work.
-
-See the link:./stack.yaml[stack project file] to see the other projects that you can build with stack.
-
-=== How to get the most recent documentation PDFs from CI
-
-==== Specifications and design
-
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.plutus-report/latest/download-by-type/doc-pdf/plutus[Plutus Technical Report] (draft)
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.plutus-core-spec/latest/download-by-type/doc-pdf/plutus-core-specification[Plutus Core Specification]
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.extended-utxo-spec/latest/download-by-type/doc-pdf/extended-utxo-specification[Extended UTXO Model]
-
-==== Academic papers
-
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.unraveling-recursion/latest/download-by-type/doc-pdf/unraveling-recursion[Unraveling Recursion] (https://doi.org/10.1007/978-3-030-33636-3_15[published version])
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.system-f-in-agda/latest/download-by-type/doc-pdf/paper[System F in Agda] (https://doi.org/10.1007/978-3-030-33636-3_10[published version])
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.eutxo/latest/download-by-type/doc-pdf/eutxo[The Extended UTXO Model] (in press)
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.utxoma/latest/download-by-type/doc-pdf/utxoma[UTXOma: UTXO with Multi-Asset Support] (in press)
-- https://hydra.iohk.io/job/Cardano/plutus/linux.docs.papers.eutxoma/latest/download-by-type/doc-pdf/eutxoma[Native Custom Tokens in the Extended UTXO Model] (in press)
-
-== Where to go next
-
-=== How to submit an issue
-
-User issues can be filed in the https://github.com/input-output-hk/plutus/issues[GitHub Issue tracker].
-
-However, note that this is pre-release software, so we will not usually be providing support.
-
-[[how-to-develop]]
-=== How to develop and contribute to the project
-
-See link:CONTRIBUTING{outfilesuffix}[CONTRIBUTING], which describes our processes in more detail including development environments; and link:ARCHITECTURE{outfilesuffix}[ARCHITECTURE], which describes the structure of the repository.
 
 [[nix-advice]]
 == Nix

--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -7,7 +7,8 @@
   year = 2020,
   volume = "12063",
   publisher = "Springer",
-  series = "LNCS"
+  series = "LNCS",
+  note={Also available at https://github.com/input-output-hk/plutus}
 }
 
 @inproceedings{utxoma,
@@ -16,6 +17,7 @@
    year=2020,
    booktitle={International Symposium on Leveraging Applications of Formal Methods},
    organization={Springer},
+   note={Also available at https://github.com/input-output-hk/plutus}
 }
 
 @inproceedings{eutxoma,
@@ -24,7 +26,8 @@
   booktitle={International Symposium on Leveraging Applications of Formal Methods},
   pages={89--111},
   year={2020},
-  organization={Springer}
+  organization={Springer},
+  note={Also available at https://github.com/input-output-hk/plutus}
 }
 
 @techreport{chakravarty2020hydra,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,33 +1,12 @@
 The Plutus Platform and Marlowe
 ===============================
 
-The Plutus Platform is the smart contract platform of the Cardano blockchain.
-Plutus contracts consist of pieces that run on the blockchain (*on-chain* code) and pieces that run on a user’s machine (*off-chain* or *client* code).
-
-Both on-chain and off-chain code is written in Haskell, and Plutus smart contracts are Haskell programs.
-Off-chain code is compiled by GHC, the Haskell compiler, and on-chain code is compiled by the Plutus compiler.
+The Plutus Platform is an application development platform for the Cardano blockchain.
+To read more about the Platform, see :ref:`what_is_the_plutus_platform`.
+To get started using the Platform see :ref:`plutus_getting_started`.
 
 Marlowe is the flagship product built on top of the Plutus Platform, consisting of a domain-specific language for writing financial smart contracts.
-
-Smart contracts
----------------
-
-From the smart contract author’s perspective, the blockchain is a distributed bookkeeping system.
-It keeps track of who owns how much of a virtual resource (Bitcoin, Ada, etc.) and records when assets are transferred from one entity to another.
-The owners of digital assets are identified by their public keys, and they may be people or machines.
-
-Smart contracts are programs that control the transfer of resources on the blockchain.
-When two parties decide to enter a smart contract, they place some of their own assets under the control of an on-chain program which enforces the rules of the contract.
-Every time someone wants to take assets out of the contract, the program is run, and only if its output is positive are the assets released.
-
-On the Cardano blockchain, the on-chain programs are written in a language called *Plutus Core*.
-However, smart contract authors do not write Plutus Core directly.
-The Plutus Platform is a software development kit which enables smart contract authors to easily write smart contracts, including the logic that will eventually be run on the blockchain as Plutus Core.
-
-To write a smart contract using the Plutus Platform, you can code directly in the Plutus Playground.
-The Plutus Playground is a lightweight, web-based environment for exploratory Plutus development. Here you can easily write and simulate deployment of your contracts without the overhead of installing and maintaining a full development environment.
-
-You can also use a normal Haskell development environment on your computer to write Plutus programs. See the main `Plutus repository <https://github.com/input-output-hk/plutus>`_ for more information.
+To read more about Marlowe, see the :ref:`Marlowe tutorials<marlowe_tutorials>`.
 
 .. toctree::
    :caption: Explore Plutus
@@ -35,6 +14,7 @@ You can also use a normal Haskell development environment on your computer to wr
 
    plutus/explanations/index
    plutus/tutorials/index
+   plutus/howtos/index
    plutus/troubleshooting
 
 .. toctree::
@@ -48,14 +28,3 @@ You can also use a normal Haskell development environment on your computer to wr
    :maxdepth: 2
 
    reference/index
-
-References
-----------
-
-1. Haskell_ is the programming language for Plutus contracts.
-2. We also generate the developer documentation from our source code using Haddock_. You can also find this documentation in the Playground.
-3. If you want to talk to us directly, you can use the Cardano Forum_.
-
-.. _Haskell: http://haskell.org/
-.. _Haddock: https://www.haskell.org/haddock/index.html
-.. _Forum: http://forum.cardano.org/

--- a/doc/marlowe/tutorials/index.rst
+++ b/doc/marlowe/tutorials/index.rst
@@ -1,3 +1,5 @@
+.. _marlowe_tutorials:
+
 Tutorials
 =========
 

--- a/doc/plutus/howtos/getting-started.rst
+++ b/doc/plutus/howtos/getting-started.rst
@@ -1,0 +1,31 @@
+.. _plutus_getting_started:
+
+How to get started with the Plutus Platform
+===========================================
+
+We provide a template repository that you can use to get started quickly.
+For now, the only supported tooling setup is to use our provided VSCode devcontainer to get an environment with the correct tools set up.
+
+#. Install Docker using your operating system's package manager (or otherwise).
+#. Install VSCode using your operating system's package manager (or otherwise).
+
+    - Install the `Remote Development extension pack <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack>`_
+    - You do *not* need to install the Haskell extension, it will be enabled in the devcontainer. You may want it anyway in case you want to edit files locally.
+
+#. Get the docker image. For now, we need to build this with Nix.
+
+    - Clone `the main Plutus repository <https://github.com/input-output-hk/plutus>`_.
+    - Follow the instructions in the ``README`` to set yourself up to build artifacts with Nix (make sure to set up the binary cache!).
+    - Build and load the docker container: ``docker load < $(nix-build default.nix -A devcontainer)``.
+
+#. Clone `the template repository <https://github.com/input-output-hk/plutus-starter>`_ and open it in VSCode.
+
+    - It will ask if you want to open it in the container, say yes.
+
+#. Try building the example project from a VSCode terminal using ``cabal build`` .
+#. Try opening a Haskell file and experiment with the IDE features (it will take a little while to set up the first time).
+
+Further reading
+---------------
+
+This would be a good time to try one of the :ref:`tutorials <plutus_tutorials>`.

--- a/doc/plutus/howtos/index.rst
+++ b/doc/plutus/howtos/index.rst
@@ -1,0 +1,10 @@
+.. _plutus_howtos:
+
+How-to guides
+=============
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+
+   getting-started


### PR DESCRIPTION
- Remove some old content from the doc landing page, point to the new explainer pages.
- Add a getting started page (our first "how-to") that has some of the content from the `plutus-starter` README. I think it's better here, and I'm planning to make `plutus-starter` refer to the doc instead.
    - Maybe the "tutorial" content from there should also be moved into a tutorial in the main doc? WDYT @silky ?
- Remove some stuff from the main README and point into the doc, tidy up some prose.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
