### PR TITLE
SCP-2064 - Fix handling of undo stack for blockly

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -201,3 +201,13 @@ exports.updateToolbox_ = function (toolboxJson, workspace) {
 exports.clearUndoStack_ = function (workspace) {
   workspace.clearUndo();
 }
+
+exports.isWorkspaceEmpty_ = function (workspace) {
+  var topBlocks = workspace.getTopBlocks(false);
+  return ((topBlocks == null) || (topBlocks.length == 0));
+}
+
+exports.setGroup_ = function (blockly, isGroup) {
+  blockly.Events.setGroup(isGroup);
+}
+

--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -198,4 +198,6 @@ exports.updateToolbox_ = function (toolboxJson, workspace) {
   workspace.updateToolbox(toolboxJson);
 }
 
-
+exports.clearUndoStack_ = function (workspace) {
+  workspace.clearUndo();
+}

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -118,6 +118,10 @@ foreign import updateToolbox_ :: EffectFn2 Json Workspace Unit
 
 foreign import clearUndoStack_ :: EffectFn1 Workspace Unit
 
+foreign import isWorkspaceEmpty_ :: EffectFn1 Workspace Boolean
+
+foreign import setGroup_ :: EffectFn2 Blockly Boolean Unit
+
 newtype ElementId
   = ElementId String
 
@@ -221,6 +225,12 @@ updateToolbox toolbox = runEffectFn2 updateToolbox_ (encodeToolbox toolbox)
 
 clearUndoStack :: Workspace -> Effect Unit
 clearUndoStack = runEffectFn1 clearUndoStack_
+
+isWorkspaceEmpty :: Workspace -> Effect Boolean
+isWorkspaceEmpty = runEffectFn1 isWorkspaceEmpty_
+
+setGroup :: Blockly -> Boolean -> Effect Unit
+setGroup = runEffectFn2 setGroup_
 
 data Pair
   = Pair String String

--- a/marlowe-playground-client/src/Blockly/Internal.purs
+++ b/marlowe-playground-client/src/Blockly/Internal.purs
@@ -116,6 +116,8 @@ foreign import getBlockType_ :: EffectFn1 Block String
 
 foreign import updateToolbox_ :: EffectFn2 Json Workspace Unit
 
+foreign import clearUndoStack_ :: EffectFn1 Workspace Unit
+
 newtype ElementId
   = ElementId String
 
@@ -216,6 +218,9 @@ getBlockType = runEffectFn1 getBlockType_
 
 updateToolbox :: Toolbox -> Workspace -> Effect Unit
 updateToolbox toolbox = runEffectFn2 updateToolbox_ (encodeToolbox toolbox)
+
+clearUndoStack :: Workspace -> Effect Unit
+clearUndoStack = runEffectFn1 clearUndoStack_
 
 data Pair
   = Pair String String

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -59,7 +59,7 @@ handleQuery ::
   MonadAff m =>
   Query a ->
   HalogenM State Action slots Message m (Maybe a)
-handleQuery (SetCode code next) = do
+handleQuery (SetCode clearUndoStack code next) = do
   mState <- use _blocklyState
   for_ mState \blocklyState -> do
     let
@@ -70,7 +70,7 @@ handleQuery (SetCode code next) = do
           $ Parser.parseContract (Text.stripParens code)
     -- Create the blocks temporarily disabling the blockly events until they settle
     -- FIXME: check why buildBlocks requires we pass newBlock
-    runWithoutEventSubscription 100 BlocklyEvent $ buildBlocks newBlock blocklyState contract
+    runWithoutEventSubscription 100 BlocklyEvent $ buildBlocks clearUndoStack newBlock blocklyState contract
   assign _errorMessage Nothing
   pure $ Just next
 

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -38,7 +38,7 @@ emptyState =
   }
 
 data Query a
-  = SetCode String a
+  = SetCode Boolean String a
   | SetError String a
   | GetWorkspace (XML -> a)
   | LoadWorkspace XML a

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -52,7 +52,7 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction Init = do
   mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
-  handleAction $ InitBlocklyProject $ fromMaybe ME.example mContents
+  handleAction $ InitBlocklyProject true $ fromMaybe ME.example mContents
 
 handleAction (HandleBlocklyMessage Blockly.CodeChange) = processBlocklyCode
 
@@ -64,8 +64,8 @@ handleAction (HandleBlocklyMessage (Blockly.BlockSelection selection)) = case mB
     { blockType } <- selection
     Map.lookup blockType MB.definitionsMap
 
-handleAction (InitBlocklyProject code) = do
-  void $ query _blocklySlot unit $ H.tell (Blockly.SetCode code)
+handleAction (InitBlocklyProject clearUndoStack code) = do
+  void $ query _blocklySlot unit $ H.tell (Blockly.SetCode clearUndoStack code)
   liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey code
   processBlocklyCode
   -- Reset the toolbox

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -21,7 +21,7 @@ import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 data Action
   = Init
   | HandleBlocklyMessage Blockly.Message
-  | InitBlocklyProject String
+  | InitBlocklyProject Boolean String
   | SendToSimulator
   | ViewAsMarlowe
   | Save
@@ -40,7 +40,7 @@ defaultEvent s = (A.defaultEvent $ "BlocklyEditor." <> s) { category = Just "Blo
 instance blocklyActionIsEvent :: IsEvent Action where
   toEvent Init = Just $ defaultEvent "Init"
   toEvent (HandleBlocklyMessage _) = Just $ defaultEvent "HandleBlocklyMessage"
-  toEvent (InitBlocklyProject _) = Just $ defaultEvent "InitBlocklyProject"
+  toEvent (InitBlocklyProject _ _) = Just $ defaultEvent "InitBlocklyProject"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"
   toEvent ViewAsMarlowe = Just $ defaultEvent "ViewAsMarlowe"
   toEvent Save = Just $ defaultEvent "Save"

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -56,6 +56,7 @@ import Marlowe.ActusBlockly as AMB
 import Marlowe.Extended.Metadata (emptyContractMetadata, getHintsFromMetadata)
 import Marlowe.Gists (PlaygroundFiles, mkNewGist, playgroundFiles)
 import MarloweEditor.State as MarloweEditor
+import MarloweEditor.Types (_comesFromBlockly)
 import MarloweEditor.Types as ME
 import MetadataTab.State (carryMetadataAction)
 import Network.RemoteData (RemoteData(..), _Success)
@@ -359,9 +360,10 @@ handleAction (MarloweEditorAction action) = do
       for_ mContents \contents ->
         sendToSimulation contents
     ME.ViewAsBlockly -> do
+      comesFromBlockly <- use (_marloweEditorState <<< _comesFromBlockly)
       mSource <- MarloweEditor.editorGetValue
       for_ mSource \source -> do
-        void $ toBlocklyEditor $ BlocklyEditor.handleAction (BE.InitBlocklyProject source)
+        void $ toBlocklyEditor $ BlocklyEditor.handleAction (BE.InitBlocklyProject (not comesFromBlockly) source)
         assign _workflow (Just Blockly)
         selectView BlocklyEditor
     ME.HandleEditorMessage (Monaco.TextChanged _) -> setUnsavedChangesForLanguage Marlowe true
@@ -384,6 +386,7 @@ handleAction (BlocklyEditorAction action) = do
         selectView MarloweEditor
         assign _workflow (Just Marlowe)
         toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject code
+      assign (_marloweEditorState <<< _comesFromBlockly) true
     BE.HandleBlocklyMessage Blockly.CodeChange -> setUnsavedChangesForLanguage Blockly true
     BE.BottomPanelAction (BP.PanelAction (BE.MetadataAction metadataAction)) -> carryMetadataAction metadataAction
     _ -> pure unit
@@ -470,7 +473,7 @@ handleAction (NewProjectAction (NewProject.CreateProject lang)) = do
   toHaskellEditor $ HaskellEditor.handleAction $ HE.InitHaskellProject mempty mempty
   toJavascriptEditor $ JavascriptEditor.handleAction $ JS.InitJavascriptProject mempty mempty
   toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject mempty
-  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject mempty
+  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true mempty
   -- TODO: implement ActusBlockly.SetCode
   case lang of
     Haskell ->
@@ -484,7 +487,7 @@ handleAction (NewProjectAction (NewProject.CreateProject lang)) = do
         toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject contents
     Blockly ->
       for_ (Map.lookup "Example" StaticData.marloweContracts) \contents -> do
-        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject contents
+        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true contents
     _ -> pure unit
   selectView $ selectLanguageView lang
   modify_
@@ -508,7 +511,7 @@ handleAction (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
         toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject contents
     Blockly -> do
       for_ (preview (ix key) StaticData.marloweContracts) \contents -> do
-        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject contents
+        toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true contents
     Actus -> pure unit
   modify_
     ( set _showModal Nothing
@@ -803,7 +806,7 @@ loadGist gist = do
   toHaskellEditor $ HaskellEditor.handleAction $ HE.InitHaskellProject metadataHints $ fromMaybe mempty haskell
   toJavascriptEditor $ JavascriptEditor.handleAction $ JS.InitJavascriptProject metadataHints $ fromMaybe mempty javascript
   toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject $ fromMaybe mempty marlowe
-  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject $ fromMaybe mempty blockly
+  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true $ fromMaybe mempty blockly
   assign _contractMetadata metadata
   -- Actus doesn't have a SetCode to reset for the moment, so we only set if present.
   -- TODO add SetCode to Actus

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -3,7 +3,7 @@ module Marlowe.Blockly where
 import Prelude
 import Blockly.Dom as BDom
 import Blockly.Generator (Connection, Input, NewBlockFunction, clearWorkspace, connect, connectToOutput, connectToPrevious, fieldName, fieldRow, getInputWithName, inputList, inputName, inputType, nextConnection, previousConnection, setFieldText)
-import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), Pair(..), defaultBlockDefinition, getBlockById, initializeWorkspace, render, typedArguments)
+import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), Pair(..), clearUndoStack, defaultBlockDefinition, getBlockById, initializeWorkspace, render, typedArguments)
 import Blockly.Toolbox (Category, Toolbox(..), category, leaf, rename, separator)
 import Blockly.Types (Block, BlocklyState, Workspace)
 import Control.Monad.Error.Class (catchError)
@@ -1452,6 +1452,7 @@ buildBlocks newBlock bs contract = do
   for_ mInput \input -> do
     toBlockly newBlock bs.workspace input contract
     render bs.workspace
+  clearUndoStack bs.workspace
 
 setField :: Block -> String -> String -> Effect Unit
 setField block name value = do

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -3,7 +3,7 @@ module Marlowe.Blockly where
 import Prelude
 import Blockly.Dom as BDom
 import Blockly.Generator (Connection, Input, NewBlockFunction, clearWorkspace, connect, connectToOutput, connectToPrevious, fieldName, fieldRow, getInputWithName, inputList, inputName, inputType, nextConnection, previousConnection, setFieldText)
-import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), Pair(..), clearUndoStack, defaultBlockDefinition, getBlockById, initializeWorkspace, render, typedArguments)
+import Blockly.Internal (AlignDirection(..), Arg(..), BlockDefinition(..), Pair(..), clearUndoStack, defaultBlockDefinition, getBlockById, initializeWorkspace, isWorkspaceEmpty, render, setGroup, typedArguments)
 import Blockly.Toolbox (Category, Toolbox(..), category, leaf, rename, separator)
 import Blockly.Types (Block, BlocklyState, Workspace)
 import Control.Monad.Error.Class (catchError)
@@ -1436,8 +1436,10 @@ instance blockToTermBound :: BlockToTerm Bound where
   blockToTerm block = throwError $ InvalidBlock block "Bound"
 
 ---------------------------------------------------------------------------------------------------
-buildBlocks :: NewBlockFunction -> BlocklyState -> Term Contract -> Effect Unit
-buildBlocks newBlock bs contract = do
+buildBlocks :: Boolean -> NewBlockFunction -> BlocklyState -> Term Contract -> Effect Unit
+buildBlocks shouldClearUndoStack newBlock bs contract = do
+  workspaceWasEmpty <- isWorkspaceEmpty bs.workspace
+  setGroup bs.blockly true -- We group the events together so that the are undone at the same time
   clearWorkspace bs.workspace
   initializeWorkspace bs.blockly bs.workspace
   -- Get or create rootBlock
@@ -1452,7 +1454,10 @@ buildBlocks newBlock bs contract = do
   for_ mInput \input -> do
     toBlockly newBlock bs.workspace input contract
     render bs.workspace
-  clearUndoStack bs.workspace
+  setGroup bs.blockly false
+  -- If `shouldClearUndoStack` is `true` or the workspace was empty (which means it is the first time we populate blockly)
+  -- we clean up the stack. This way we prevent UNDO from deleting every block (we cannot allow the CONTRACT block to be deleted)
+  if shouldClearUndoStack || workspaceWasEmpty then clearUndoStack bs.workspace else pure unit
 
 setField :: Block -> String -> String -> Effect Unit
 setField block name value = do

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -38,7 +38,7 @@ import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import MarloweEditor.Types (Action(..), BottomPanelView, State, _hasHoles, _bottomPanelState, _editorErrors, _editorWarnings, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
+import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _comesFromBlockly, _editorErrors, _editorWarnings, _hasHoles, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
 import Monaco (isError, isWarning)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
@@ -113,6 +113,7 @@ handleAction ViewAsBlockly = pure unit
 
 handleAction (InitMarloweProject contents) = do
   editorSetValue contents
+  assign (_comesFromBlockly) false
   liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey contents
 
 handleAction (SelectHole hole) = assign _selectedHole hole

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -94,6 +94,7 @@ type State
     , editorErrors :: Array IMarkerData
     , editorWarnings :: Array IMarkerData
     , hasHoles :: Boolean
+    , comesFromBlockly :: Boolean
     }
 
 _keybindings :: Lens' State KeyBindings
@@ -120,6 +121,9 @@ _bottomPanelState = prop (SProxy :: SProxy "bottomPanelState")
 _hasHoles :: Lens' State Boolean
 _hasHoles = prop (SProxy :: SProxy "hasHoles")
 
+_comesFromBlockly :: Lens' State Boolean
+_comesFromBlockly = prop (SProxy :: SProxy "comesFromBlockly")
+
 initialState :: State
 initialState =
   { keybindings: DefaultBindings
@@ -131,6 +135,7 @@ initialState =
   , editorErrors: mempty
   , editorWarnings: mempty
   , hasHoles: false
+  , comesFromBlockly: false
   }
 
 contractHasHoles :: State -> Boolean


### PR DESCRIPTION
This PR:
- First commit:
  - Clears the stack when initialising Blockly
- Second commit:
  - Groups events that populate Blockly (in `SetCode`), so that they are undone as one
  - It doesn't clear the stack when returning from a roundtrip from Blockly (so that modifications done using Marlowe editor can be undone from Blockly in one step, as suggested by #2899).

Resolves #2899

Deployed to https://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
