### PR TITLE
SCP-1948: Basic formatting for metadata.

### DIFF
--- a/marlowe-dashboard-client/src/Template/Format.purs
+++ b/marlowe-dashboard-client/src/Template/Format.purs
@@ -1,7 +1,7 @@
 module Template.Format (formatText) where
 
 import Prelude
-import Data.String (codePointFromChar, drop, length, take, takeWhile)
+import Data.String (CodePoint, codePointFromChar, drop, length, take, takeWhile)
 import Halogen.HTML (HTML, b_, text)
 
 -- We want to include some very basic formatting in the metadata. A full implementation of
@@ -10,20 +10,30 @@ import Halogen.HTML (HTML, b_, text)
 formatText :: forall p a. String -> Array (HTML p a)
 formatText "" = []
 
+formatText string | take 2 string == "\\*" =
+  let
+    rest = drop 2 string
+  in
+    [ text "*" ] <> formatText rest
+
+formatText string | take 1 string == "*" =
+  let
+    boldText = takeWhile ((/=) asterisk) (drop 1 string)
+
+    rest = drop ((length boldText) + 2) string
+  in
+    [ b_ [ text boldText ] ] <> formatText rest
+
 formatText string =
-  if take 1 string == "*" then
-    let
-      boldText = takeWhile ((/=) asterisk) (drop 1 string)
+  let
+    plainText = takeWhile (\c -> c /= asterisk && c /= backslash) string
 
-      rest = drop ((length boldText) + 2) string
-    in
-      [ b_ [ text boldText ] ] <> formatText rest
-  else
-    let
-      plainText = takeWhile ((/=) asterisk) string
+    rest = drop (length plainText) string
+  in
+    [ text plainText ] <> formatText rest
 
-      rest = drop (length plainText) string
-    in
-      [ text plainText ] <> formatText rest
-  where
-  asterisk = codePointFromChar '*'
+asterisk :: CodePoint
+asterisk = codePointFromChar '*'
+
+backslash :: CodePoint
+backslash = codePointFromChar '\\'

--- a/marlowe-dashboard-client/src/Template/Format.purs
+++ b/marlowe-dashboard-client/src/Template/Format.purs
@@ -10,19 +10,21 @@ import Halogen.HTML (HTML, b_, text)
 formatText :: forall p a. String -> Array (HTML p a)
 formatText "" = []
 
-formatText string | take 2 string == "\\*" =
-  let
-    rest = drop 2 string
-  in
-    [ text "*" ] <> formatText rest
+formatText string
+  | take 2 string == "\\*" =
+    let
+      rest = drop 2 string
+    in
+      [ text "*" ] <> formatText rest
 
-formatText string | take 1 string == "*" =
-  let
-    boldText = takeWhile ((/=) asterisk) (drop 1 string)
+formatText string
+  | take 1 string == "*" =
+    let
+      boldText = takeWhile ((/=) asterisk) (drop 1 string)
 
-    rest = drop ((length boldText) + 2) string
-  in
-    [ b_ [ text boldText ] ] <> formatText rest
+      rest = drop ((length boldText) + 2) string
+    in
+      [ b_ [ text boldText ] ] <> formatText rest
 
 formatText string =
   let

--- a/marlowe-dashboard-client/src/Template/Format.purs
+++ b/marlowe-dashboard-client/src/Template/Format.purs
@@ -1,0 +1,29 @@
+module Template.Format (formatText) where
+
+import Prelude
+import Data.String (codePointFromChar, drop, length, take, takeWhile)
+import Halogen.HTML (HTML, b_, text)
+
+-- We want to include some very basic formatting in the metadata. A full implementation of
+-- something like Markdown would clearly be overkill (at least for now). So we just have
+-- this very simple function instead that puts text surrounded by asterisks in bold.
+formatText :: forall p a. String -> Array (HTML p a)
+formatText "" = []
+
+formatText string =
+  if take 1 string == "*" then
+    let
+      boldText = takeWhile ((/=) asterisk) (drop 1 string)
+
+      rest = drop ((length boldText) + 2) string
+    in
+      [ b_ [ text boldText ] ] <> formatText rest
+  else
+    let
+      plainText = takeWhile ((/=) asterisk) string
+
+      rest = drop (length plainText) string
+    in
+      [ text plainText ] <> formatText rest
+  where
+  asterisk = codePointFromChar '*'

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -27,6 +27,7 @@ import Marlowe.Market (contractTemplates)
 import Marlowe.PAB (contractCreationFee)
 import Marlowe.Semantics (Assets, Party(..), Slot)
 import Material.Icons (Icon(..), icon_)
+import Template.Format (formatText)
 import Template.Lenses (_contractName, _contractNickname, _extendedContract, _metaData, _roleWallets, _slotContentStrings, _template, _templateContent)
 import Template.Types (Action(..), State)
 import Template.Validation (roleError, roleWalletsAreValid, slotError, templateContentIsValid, valueError)
@@ -181,7 +182,7 @@ roleInputs wallets extendedContract metaData roleWallets =
                 [ classNames [ "font-bold" ] ]
                 [ text $ "Role " <> (show $ index + 1) <> " (" <> tokenName <> ")*" ]
             , br_
-            , text description
+            , span_ $ formatText description
             ]
         , div
             [ classNames [ "relative" ] ]
@@ -236,7 +237,7 @@ parameterInputs wallets currentSlot metaData templateContent slotContentStrings 
                 [ classNames [ "font-bold" ] ]
                 [ text $ "Timeout " <> (show $ index + 1) <> " (" <> key <> ")*" ]
             , br_
-            , text description
+            , span_ $ formatText description
             ]
         , input
             [ classNames $ Css.inputCard (isJust mParameterError)
@@ -268,7 +269,7 @@ parameterInputs wallets currentSlot metaData templateContent slotContentStrings 
                 [ classNames [ "font-bold" ] ]
                 [ text $ "Value " <> (show $ index + 1) <> " (" <> key <> ")*" ]
             , br_
-            , text description
+            , span_ $ formatText description
             ]
         , input
             [ classNames $ Css.inputCard (isJust mParameterError)
@@ -344,8 +345,7 @@ templateLibraryCard =
               ]
               [ text "Setup" ]
           ]
-      , p_
-          [ text template.metaData.contractDescription ]
+      , p_ $ formatText template.metaData.contractDescription
       ]
 
 -- TODO: This helper is really similar to contractCard in ContractHome.View, see if it makes sense to factor a component out

--- a/web-common-marlowe/src/Examples/Metadata.purs
+++ b/web-common-marlowe/src/Examples/Metadata.purs
@@ -12,45 +12,45 @@ escrow :: MetaData
 escrow =
   { contractType: Escrow
   , contractName: "Simple escrow"
-  , contractDescription: "Regulates a money exchange between a \"Buyer\" and a \"Seller\". If there is a disagreement, an \"Arbiter\" will decide whether the money is refunded or paid to the \"Seller\"."
+  , contractDescription: "Regulates a money exchange between a *Buyer* and a *Seller*. If there is a disagreement, an *Arbiter* will decide whether the money is refunded or paid to the *Seller*."
   , choiceDescriptions:
       ( fromFoldable
           [ "Confirm problem" /\ "Acknowledge there was a problem and a refund must be granted."
-          , "Dismiss claim" /\ "The \"Arbiter\" does not see any problem with the exchange and the \"Seller\" must be paid."
-          , "Dispute problem" /\ "The \"Seller\" disagrees with the \"Buyer\" about the claim that something went wrong."
-          , "Everything is alright" /\ "The transaction was uneventful, \"Buyer\" agrees to pay the \"Seller\"."
-          , "Report problem" /\ "The \"Buyer\" claims not having received the product that was paid for as agreed and would like a refund."
+          , "Dismiss claim" /\ "The *Arbiter* does not see any problem with the exchange and the *Seller* must be paid."
+          , "Dispute problem" /\ "The *Seller* disagrees with the *Buyer* about the claim that something went wrong."
+          , "Everything is alright" /\ "The transaction was uneventful, *Buyer* agrees to pay the *Seller*."
+          , "Report problem" /\ "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
           ]
       )
   , roleDescriptions:
       ( fromFoldable
-          [ "Arbiter" /\ "The party that will choose who gets the money in the event of a disagreement between the \"Buyer\" and the \"Seller\" about the outcome."
-          , "Buyer" /\ "The party that wants to buy the item. Payment is made to the \"Seller\" if they acknowledge receiving the item."
+          [ "Arbiter" /\ "The party that will choose who gets the money in the event of a disagreement between the *Buyer* and the *Seller* about the outcome."
+          , "Buyer" /\ "The party that wants to buy the item. Payment is made to the *Seller* if they acknowledge receiving the item."
           , "Seller" /\ "The party that wants to sell the item. They receive the payment if the exchange is uneventful."
           ]
       )
   , slotParameterDescriptions:
       ( fromFoldable
-          [ "Buyer's deposit timeout" /\ "Deadline by which the \"Buyer\" must deposit the selling \"Price\" in the contract."
-          , "Buyer's dispute timeout" /\ "Deadline by which, if the \"Buyer\" has not opened a dispute, the \"Seller\" will be paid."
-          , "Seller's response timeout" /\ "Deadline by which, if the \"Seller\" has not responded to the dispute, the \"Buyer\" will be refunded."
-          , "Timeout for arbitrage" /\ "Deadline by which, if the \"Arbiter\" has not resolved the dispute, the \"Buyer\" will be refunded."
+          [ "Buyer's deposit timeout" /\ "Deadline by which the *Buyer* must deposit the selling *Price* in the contract."
+          , "Buyer's dispute timeout" /\ "Deadline by which, if the *Buyer* has not opened a dispute, the *Seller* will be paid."
+          , "Seller's response timeout" /\ "Deadline by which, if the *Seller* has not responded to the dispute, the *Buyer* will be refunded."
+          , "Timeout for arbitrage" /\ "Deadline by which, if the *Arbiter* has not resolved the dispute, the *Buyer* will be refunded."
           ]
       )
-  , valueParameterDescriptions: (fromFoldable [ "Price" /\ "Amount of Lovelace to be paid by the \"Buyer\" for the item." ])
+  , valueParameterDescriptions: (fromFoldable [ "Price" /\ "Amount of Lovelace to be paid by the *Buyer* for the item." ])
   }
 
 escrowWithCollateral :: MetaData
 escrowWithCollateral =
   { contractType: Escrow
   , contractName: "Escrow with collateral"
-  , contractDescription: "Regulates a money exchange between a \"Buyer\" and a \"Seller\" using a collateral from both parties to incentivize collaboration. If there is a disagreement the collateral is burned."
+  , contractDescription: "Regulates a money exchange between a *Buyer* and a *Seller* using a collateral from both parties to incentivize collaboration. If there is a disagreement the collateral is burned."
   , choiceDescriptions:
       ( fromFoldable
           [ "Confirm problem" /\ "Acknowledge that there was a problem and a refund must be granted."
-          , "Dispute problem" /\ "The \"Seller\" disagrees with the \"Buyer\" about the claim that something went wrong and the collateral will be burnt."
-          , "Everything is alright" /\ "The exchange was successful and the \"Buyer\" agrees to pay the \"Seller\"."
-          , "Report problem" /\ "The \"Buyer\" claims not having received the product that was paid for as agreed and would like a refund."
+          , "Dispute problem" /\ "The *Seller* disagrees with the *Buyer* about the claim that something went wrong and the collateral will be burnt."
+          , "Everything is alright" /\ "The exchange was successful and the *Buyer* agrees to pay the *Seller*."
+          , "Report problem" /\ "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
           ]
       )
   , roleDescriptions:
@@ -61,17 +61,17 @@ escrowWithCollateral =
       )
   , slotParameterDescriptions:
       ( fromFoldable
-          [ "Collateral deposit by seller timeout" /\ "The deadline by which the \"Seller\" must deposit the \"Collateral amount\" in the contract."
-          , "Deposit of collateral by buyer timeout" /\ "The deadline by which the \"Buyer\" must deposit the \"Collateral amount\" in the contract."
-          , "Deposit of price by buyer timeout" /\ "The deadline by which the \"Buyer\" must deposit the \"Price\" in the contract."
-          , "Dispute by buyer timeout" /\ "The deadline by which, if the \"Buyer\" has not opened a dispute, the \"Seller\" will be paid."
-          , "Seller's response timeout" /\ "The deadline by which, if the \"Seller\" has not responded to the dispute, the \"Buyer\" will be refunded."
+          [ "Collateral deposit by seller timeout" /\ "The deadline by which the *Seller* must deposit the *Collateral amount* in the contract."
+          , "Deposit of collateral by buyer timeout" /\ "The deadline by which the *Buyer* must deposit the *Collateral amount* in the contract."
+          , "Deposit of price by buyer timeout" /\ "The deadline by which the *Buyer* must deposit the *Price* in the contract."
+          , "Dispute by buyer timeout" /\ "The deadline by which, if the *Buyer* has not opened a dispute, the *Seller* will be paid."
+          , "Seller's response timeout" /\ "The deadline by which, if the *Seller* has not responded to the dispute, the *Buyer* will be refunded."
           ]
       )
   , valueParameterDescriptions:
       ( fromFoldable
           [ "Collateral amount" /\ "The amount of Lovelace to be deposited by both parties at the start of the contract to serve as an incentive for collaboration."
-          , "Price" /\ "The amount of Lovelace to be paid by the \"Buyer\" as part of the exchange."
+          , "Price" /\ "The amount of Lovelace to be paid by the *Buyer* as part of the exchange."
           ]
       )
   }
@@ -90,8 +90,8 @@ zeroCouponBond =
       )
   , slotParameterDescriptions:
       ( fromFoldable
-          [ "Initial exchange deadline" /\ "The \"Investor\" must deposit the discounted price of the bond before this deadline or the offer will expire."
-          , "Maturity exchange deadline" /\ "The \"Issuer\" must deposit the full price of the bond before this deadline or it will default."
+          [ "Initial exchange deadline" /\ "The *Investor* must deposit the discounted price of the bond before this deadline or the offer will expire."
+          , "Maturity exchange deadline" /\ "The *Issuer* must deposit the full price of the bond before this deadline or it will default."
           ]
       )
   , valueParameterDescriptions:
@@ -106,20 +106,20 @@ couponBondGuaranteed :: MetaData
 couponBondGuaranteed =
   { contractType: CouponBondGuaranteed
   , contractName: "Coupon Bond Guaranteed"
-  , contractDescription: "Debt agreement between an \"Investor\" and an \"Issuer\". \"Investor\" will advance the \"Principal\" amount at the beginning of the contract, and the \"Issuer\" will pay back \"Interest instalment\" every 30 slots and the \"Principal\" amount by the end of 3 instalments. The debt is backed by a collateral provided by the \"Guarantor\" which will be refunded as long as the \"Issuer\" pays back on time."
+  , contractDescription: "Debt agreement between an *Investor* and an *Issuer*. *Investor* will advance the *Principal* amount at the beginning of the contract, and the *Issuer* will pay back *Interest instalment* every 30 slots and the *Principal* amount by the end of 3 instalments. The debt is backed by a collateral provided by the *Guarantor* which will be refunded as long as the *Issuer* pays back on time."
   , choiceDescriptions: empty
   , roleDescriptions:
       ( fromFoldable
-          [ "Guarantor" /\ "Provides a collateral in case the \"Issuer\" defaults."
-          , "Investor" /\ "Provides the money that the \"Issuer\" borrows."
-          , "Issuer" /\ "Borrows the money provided by the \"Investor\" and returns it together with three \"Interest instalment\"s."
+          [ "Guarantor" /\ "Provides a collateral in case the *Issuer* defaults."
+          , "Investor" /\ "Provides the money that the *Issuer* borrows."
+          , "Issuer" /\ "Borrows the money provided by the *Investor* and returns it together with three *Interest instalment*s."
           ]
       )
   , slotParameterDescriptions: empty
   , valueParameterDescriptions:
       ( fromFoldable
-          [ "Interest instalment" /\ "Amount of Lovelace that will be paid by the \"Issuer\" every 30 slots for 3 iterations."
-          , "Principal" /\ "Amount of Lovelace that will be borrowed by the \"Issuer\"."
+          [ "Interest instalment" /\ "Amount of Lovelace that will be paid by the *Issuer* every 30 slots for 3 iterations."
+          , "Principal" /\ "Amount of Lovelace that will be borrowed by the *Issuer*."
           ]
       )
   }
@@ -154,7 +154,7 @@ contractForDifferences :: MetaData
 contractForDifferences =
   { contractType: ContractForDifferences
   , contractName: "Contract for Differences"
-  , contractDescription: "\"Party\" and \"Counterparty\" deposit 100 Ada and after 60 slots is redistributed depending on the change in a given trade price reported by \"Oracle\". If the price increases, the difference goes to \"Counterparty\"; if it decreases, the difference goes to \"Party\", up to a maximum of 100 Ada."
+  , contractDescription: "*Party* and *Counterparty* deposit 100 Ada and after 60 slots is redistributed depending on the change in a given trade price reported by *Oracle*. If the price increases, the difference goes to *Counterparty*; if it decreases, the difference goes to *Party*, up to a maximum of 100 Ada."
   , choiceDescriptions:
       ( fromFoldable
           [ "Price at beginning" /\ "Trade price at the beginning of the contract."
@@ -176,7 +176,7 @@ contractForDifferencesWithOracle :: MetaData
 contractForDifferencesWithOracle =
   { contractType: ContractForDifferences
   , contractName: "Contract for Differences with Oracle"
-  , contractDescription: "\"Party\" and \"Counterparty\" deposit 100 Ada and after 60 slots these assets are redistributed depending on the change in price of 100 Ada worth of dollars between the start and the end of the contract. If the price increases, the difference goes to \"Counterparty\"; if it decreases, the difference goes to \"Party\", up to a maximum of 100 Ada."
+  , contractDescription: "*Party* and *Counterparty* deposit 100 Ada and after 60 slots these assets are redistributed depending on the change in price of 100 Ada worth of dollars between the start and the end of the contract. If the price increases, the difference goes to *Counterparty*; if it decreases, the difference goes to *Party*, up to a maximum of 100 Ada."
   , choiceDescriptions:
       ( fromFoldable
           [ "dir-adausd" /\ "Exchange rate ADA/USD at the beginning of the contract."

--- a/web-common-marlowe/src/Examples/Metadata.purs
+++ b/web-common-marlowe/src/Examples/Metadata.purs
@@ -80,7 +80,7 @@ zeroCouponBond :: MetaData
 zeroCouponBond =
   { contractType: ZeroCouponBond
   , contractName: "Zero Coupon Bond"
-  , contractDescription: "A simple loan. The investor pays the issuer the discounted price at the start, and is repaid the full (notional) price at the end."
+  , contractDescription: "A simple loan. The *Investor* pays the *Issuer* the *Discounted price* at the start, and is repaid the full *Notional price* at the end."
   , choiceDescriptions: empty
   , roleDescriptions:
       ( fromFoldable
@@ -97,7 +97,7 @@ zeroCouponBond =
   , valueParameterDescriptions:
       ( fromFoldable
           [ "Discounted price" /\ "The price in Lovelace of the Zero Coupon Bond at the start date."
-          , "Notional" /\ "The full price in Lovelace of the Zero Coupon Bond."
+          , "Notional price" /\ "The full price in Lovelace of the Zero Coupon Bond."
           ]
       )
   }


### PR DESCRIPTION
I investigated the possibility of including a Markdown parser, and a library on top of that for converting its output to Halogen HTML. It looked like too much work, and entirely unnecessary for our simple needs. So I just wrote a very crude parser to put text surrounded by asterisks in bold.