### PR TITLE
Fix satint

### DIFF
--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -7,7 +7,7 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MagicHash          #-}
 {-# LANGUAGE UnboxedTuples      #-}
-module Data.SatInt  where
+module Data.SatInt (SatInt(..), fromSat, toSat) where
 
 import           Control.DeepSeq (NFData)
 import           Data.Aeson      (FromJSON, ToJSON)

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -10,10 +10,10 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE UnboxedTuples              #-}
-module SatInt  where
+module Data.SatInt  where
 
 import           Control.DeepSeq            (NFData)
---import           Data.Aeson                 (FromJSON, ToJSON)
+import           Data.Aeson                 (FromJSON, ToJSON)
 import           Data.Bits
 import           GHC.Base
 import           GHC.Num

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -286,10 +286,11 @@ plusSI (SI (I# x#)) (SI (I# y#)) =
 
 but that made the benchmarks slower, maybe because it has to go via Eq.
 
-I believe that things like ># return either 0 or 1, so it's safe to use bitwise `and#`
-here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.  That only matters when
-we've overflowed though, so it's probably not too important.
-**** -}
+I believe that things like ># return either 0 or 1, so it's safe to use bitwise
+`and#` here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.  That only
+matters when we've overflowed though, so it's probably not too important to be
+super-efficient in that case.
+ **** -}
 
 minusSI :: SatInt -> SatInt -> SatInt
 minusSI (SI (I# x#)) (SI (I# y#)) =

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -3,26 +3,21 @@ Adapted from 'Data.SafeInt' to perform saturating arithmetic (i.e. returning max
 
 This is not quite as fast as using 'Int' or 'Int64' directly, but we need the safety.
 -}
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DeriveLift                 #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
-{-# LANGUAGE MagicHash                  #-}
-{-# LANGUAGE UnboxedTuples              #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE MagicHash          #-}
+{-# LANGUAGE UnboxedTuples      #-}
 module Data.SatInt  where
 
-import           Control.DeepSeq            (NFData)
-import           Data.Aeson                 (FromJSON, ToJSON)
+import           Control.DeepSeq (NFData)
+import           Data.Aeson      (FromJSON, ToJSON)
 import           Data.Bits
 import           GHC.Base
 import           GHC.Num
 import           GHC.Real
-import           Language.Haskell.TH.Syntax (Lift)
 
 newtype SatInt = SI Int
     deriving newtype (NFData, Bits, FiniteBits)
-    deriving Lift
 
 fromSat :: SatInt -> Int
 fromSat (SI x) = x

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -20,10 +20,6 @@ import           GHC.Real
 newtype SatInt = SI Int
     deriving newtype (NFData, Bits, FiniteBits)
 
--- *** We need an instance of Lift for the CEK machine steps cost model PR.
--- I accidentally included this here earlier and it seems to slow things
--- down by a small amount for some reason
-
 fromSat :: SatInt -> Int
 fromSat (SI x) = x
 
@@ -42,7 +38,7 @@ toSat = SI
    > 12345678901234567890 :: SatInt
    9223372036854775807
 
--}
+**** -}
 
 
 instance Show SatInt where
@@ -286,13 +282,12 @@ plusSI (SI (I# x#)) (SI (I# y#)) =
     _ -> if isTrue# (x# ># 0#) && isTrue# (y# ># 0#) then maxBound
          else ...
 
-but that made the benchmarks slower, presumably because there are two `case`s:
-the rest of it's only executed in case of overflow.
+but that made the benchmarks slower, maybe because it has to go via Eq.
 
 I believe that things like ># return either 0 or 1, so it's safe to use bitwise `and#`
 here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.  That only matters when
 we've overflowed though, so it's probably not too important.
--}
+**** -}
 
 minusSI :: SatInt -> SatInt -> SatInt
 minusSI (SI (I# x#)) (SI (I# y#)) =

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -270,7 +270,7 @@ divModSI x@(I# _) y@(I# _) = (SI (x `divInt` y), SI (x `modInt` y))
 
 plusSI :: SatInt -> SatInt -> SatInt
 plusSI (SI (I# x#)) (SI (I# y#)) =
-  let (# r#, f# #) = addIntC# x# y#  -- Using `case` instead of `let` here is slower.
+  let !(# r#, f# #) = addIntC# x# y#  -- Using `case` instead of `let` here is slower.
   in if isTrue# f# then  -- Overflow;  I think the value of f# is always 1 in this case
                          -- and doesn't give us any other useful information
          if      isTrue# ((x# ># 0#) `andI#` (y# ># 0#)) then maxBound
@@ -294,7 +294,7 @@ here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.
 
 minusSI :: SatInt -> SatInt -> SatInt
 minusSI (SI (I# x#)) (SI (I# y#)) =
-    let (# r#, f# #) = subIntC# x# y# in
+    let !(# r#, f# #) = subIntC# x# y# in
     if isTrue# f# then -- Overflow
         if      isTrue# ((x# >=# 0#) `andI#` (y# <# 0#)) then maxBound
         else if isTrue# ((x# <=# 0#) `andI#` (y# ># 0#)) then minBound
@@ -303,7 +303,7 @@ minusSI (SI (I# x#)) (SI (I# y#)) =
 
 timesSI :: SatInt -> SatInt -> SatInt
 timesSI (SI (I# x#)) (SI (I# y#)) =
-  let f# = mulIntMayOflo# x# y# in
+  let !f# = mulIntMayOflo# x# y# in
   if isTrue# f# then  -- Overflow
       if      isTrue# ((x# ># 0#) `andI#` (y# ># 0#)) then maxBound
       else if isTrue# ((x# ># 0#) `andI#` (y# <# 0#)) then minBound

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -290,7 +290,8 @@ but that made the benchmarks slower, presumably because there are two `case`s:
 the rest of it's only executed in case of overflow.
 
 I believe that things like ># return either 0 or 1, so it's safe to use bitwise `and#`
-here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.
+here rather than `isTrue# (x# ># 0#) && isTrue# (y# ># 0#)`.  That only matters when
+we've overflowed though, so it's probably not too important.
 -}
 
 minusSI :: SatInt -> SatInt -> SatInt

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -9,7 +9,9 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 {-# LANGUAGE UnboxedTuples      #-}
 module Data.SatInt where
 -- module Data.SatInt (SatInt(..), fromSat, toSat) where
--- Removing the export list speeds up the validation benchmarks by 2-3%
+{- **** Removing the export list speeds up the validation benchmarks by 2-3%.
+   Presumably that's due to something specific being exported, but I was too
+   lazy to find out.  **** -}
 
 import           Control.DeepSeq (NFData)
 import           Data.Bits

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -10,7 +10,6 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 module Data.SatInt (SatInt(..), fromSat, toSat) where
 
 import           Control.DeepSeq (NFData)
-import           Data.Aeson      (FromJSON, ToJSON)
 import           Data.Bits
 import           GHC.Base
 import           GHC.Num


### PR DESCRIPTION
There were some problems with the version of `SatInt` in `master`. For example:
```
> n = -1111111111111111111 :: SatInt
> n
-1111111111111111111  -- 19 1's: add another 1 on the end and you get minBound because it overflows
> 9*n
9223372036854775807 -- MaxBound, but should surely be MinBound
> m = 8*n
> m
-8888888888888888888 
> m+n
8446744073709551617  -- Should be MinBound


> a = 1111111111111111111 :: SatInt
> b = 8888888888888888888 :: SatInt
> a
1111111111111111111
> b
8888888888888888888
> 9*a
9223372036854775807   -- MaxBound
> a*b
9223372036854775807   -- MxBound
> a+b
-8446744073709551617  -- ???
> (-8)*a
-8888888888888888888 
> (-9)*a
9223372036854775807  -- ???
```

This contains contains some experiments to try and fix these.  It's quite delicate: small modifications can change the benchmark execution times noticeably.  The version here is about the fastest one I was able to come up with.  It's slightly faster than the version in master: see below.

I only looked at `plusSI`, `minusSI` and `timesSI`.  I'd be inclined to get rid of `quot`, `rem` and so on because we don't really need them,  they'd be very difficult to get right, and it's not clear what should happen when one or both of the arguments is `minBound`/`maxBound`.

This isn't supposed to be a proper PR, just some suggestions and comments.  It'd be good to have some tests when we have a final version.

Validation benchmark results:

```
                          master      this branch
---------------------------------------------------------
crowdfunding/1           1.628 ms	1.608 ms    -1.2%
crowdfunding/2           1.639 ms	1.629 ms    -0.6%
crowdfunding/3           1.636 ms	1.625 ms    -0.7%
crowdfunding/4           807.9 μs	803.5 μs    -0.5%
crowdfunding/5           807.5 μs	803.5 μs    -0.5%
future/1                 952.8 μs	945.4 μs    -0.8%
future/2                 1.919 ms	1.907 ms    -0.6%
future/3                 1.917 ms	1.907 ms    -0.5%
future/4                 2.376 ms	2.362 ms    -0.6%
future/5                 2.895 ms	2.883 ms    -0.4%
future/6                 2.431 ms	2.404 ms    -1.1%
future/7                 2.914 ms	2.878 ms    -1.2%
multisigSM/1             1.706 ms	1.678 ms    -1.6%
multisigSM/2             1.725 ms	1.700 ms    -1.4%
multisigSM/3             1.748 ms	1.722 ms    -1.5%
multisigSM/4             1.770 ms	1.758 ms    -0.7%
multisigSM/5             2.118 ms	2.104 ms    -0.7%
multisigSM/6             1.700 ms	1.689 ms    -0.6%
multisigSM/7             1.721 ms	1.712 ms    -0.5%
multisigSM/8             1.740 ms	1.730 ms    -0.6%
multisigSM/9             1.769 ms	1.756 ms    -0.7%
multisigSM/10            2.112 ms	2.102 ms    -0.5%
vesting/1                1.638 ms	1.628 ms    -0.6%
vesting/2                1.428 ms	1.420 ms    -0.6%
vesting/3                1.638 ms	1.626 ms    -0.7%
marlowe/trustfund/1      4.582 ms	4.540 ms    -0.9%
marlowe/trustfund/2      3.398 ms	3.347 ms    -1.5%
marlowe/zerocoupon/1     4.747 ms	4.710 ms    -0.8%
marlowe/zerocoupon/2     2.940 ms	2.920 ms    -0.7%
```


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
