### PR TITLE
SCP-2205: Don't send 'newState' to client

### DIFF
--- a/plutus-pab-client/src/MainFrame.purs
+++ b/plutus-pab-client/src/MainFrame.purs
@@ -78,7 +78,6 @@ initialState =
     { currentView: ActiveContracts
     , contractSignatures: Stream.NotAsked
     , chainReport: NotAsked
-    , events: NotAsked
     , chainState: Chain.initialState
     , contractStates: Map.empty
     , webSocketMessage: Stream.NotAsked

--- a/plutus-pab-client/src/Types.purs
+++ b/plutus-pab-client/src/Types.purs
@@ -31,7 +31,6 @@ import Network.RemoteData (RemoteData)
 import Network.StreamData (StreamData)
 import Network.StreamData as Stream
 import Playground.Types (FunctionSchema)
-import Plutus.PAB.Events (PABEvent)
 import Plutus.PAB.Events.Contract (ContractPABRequest, _UserEndpointRequest)
 import Plutus.PAB.Effects.Contract.ContractExe (ContractExe)
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
@@ -97,7 +96,6 @@ newtype State
   { currentView :: View
   , contractSignatures :: WebStreamData ContractSignatures
   , chainReport :: WebData ChainReport
-  , events :: WebData (Array (PABEvent ContractExe))
   , chainState :: Chain.State
   , contractStates :: ContractStates
   , webSocketMessage :: WebStreamData CombinedWSStreamToClient

--- a/plutus-pab-client/src/View.purs
+++ b/plutus-pab-client/src/View.purs
@@ -32,7 +32,7 @@ render ::
   forall m slots.
   MonadAff m =>
   State -> ComponentHTML HAction slots m
-render (State { currentView, chainState, contractSignatures, chainReport, events, contractStates, webSocketStatus, webSocketMessage, metadata }) =
+render (State { currentView, chainState, contractSignatures, chainReport, contractStates, webSocketStatus, webSocketMessage, metadata }) =
   div
     [ class_ $ ClassName "main-frame" ]
     [ container_

--- a/plutus-pab-client/src/View/Events.purs
+++ b/plutus-pab-client/src/View/Events.purs
@@ -1,6 +1,5 @@
 module View.Events
-  ( eventsPane
-  , utxoIndexPane
+  ( utxoIndexPane
   ) where
 
 import Prelude
@@ -17,7 +16,6 @@ import Halogen.HTML (HTML, div_, h2_, text)
 import Ledger.Index (UtxoIndex)
 import Plutus.V1.Ledger.Tx (TxOut, TxOutRef)
 import Playground.Lenses (_utxoIndexEntries)
-import Plutus.PAB.Events (PABEvent)
 import Plutus.PAB.Effects.Contract.ContractExe (ContractExe)
 import Types (HAction(..))
 import View.Pretty (class Pretty, pretty)
@@ -33,26 +31,3 @@ utxoIndexPane utxoIndex =
 
 utxoEntryPane :: forall p. (TxOutRef /\ TxOut) -> HTML p HAction
 utxoEntryPane (txOutRef /\ txOut) = ChainAction <$> Chain.txOutOfView (const Nothing) false txOut Nothing
-
-eventsPane :: forall p i. Array (PABEvent ContractExe) -> HTML p i
-eventsPane events =
-  card_
-    [ cardHeader_
-        [ h2_ [ text "Event log" ]
-        , text (show (Array.length events))
-        , nbsp
-        , text "Event(s)"
-        ]
-    , cardBody_ [ div_ (countedEventPane <$> countConsecutive events) ]
-    ]
-
-countedEventPane :: forall t p i. Pretty t => Int /\ PABEvent t -> HTML p i
-countedEventPane (count /\ event) =
-  div_
-    [ preWrap_
-        [ badgePrimary_
-            [ text $ show count <> "x" ]
-        , nbsp
-        , pretty event
-        ]
-    ]

--- a/plutus-pab-client/src/View/Pretty.purs
+++ b/plutus-pab-client/src/View/Pretty.purs
@@ -14,8 +14,7 @@ import Plutus.Contract.Resumable (Response(..))
 import Ledger.Constraints.OffChain (UnbalancedTx(..))
 import Plutus.V1.Ledger.Tx (Tx(..))
 import Playground.Lenses (_aeDescription, _endpointValue, _getEndpointDescription, _txConfirmed, _txId)
-import Plutus.PAB.Events.Contract (ContractResponse(..), ContractPABRequest(..))
-import Plutus.PAB.Events (PABEvent(..))
+import Plutus.PAB.Events.Contract (ContractPABResponse(..), ContractPABRequest(..))
 import Plutus.PAB.Effects.Contract.ContractExe (ContractExe(..))
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse(..))
 import Plutus.PAB.Webserver.Types (ContractActivationArgs(..))
@@ -24,27 +23,6 @@ import Types (_contractInstanceIdString)
 
 class Pretty a where
   pretty :: forall p i. a -> HTML p i
-
-instance prettyPABEvent :: Pretty t => Pretty (PABEvent t) where
-  pretty e =
-    withHeading "PAB"
-      $ case e of
-          InstallContract contract -> span_ [ text $ "Install contract:", nbsp, pretty contract ]
-          UpdateContractInstanceState (ContractActivationArgs { caID }) instanceId (PartiallyDecodedResponse { hooks }) ->
-            span_
-              [ text "Update instance "
-              , text (view _contractInstanceIdString instanceId)
-              , text " of contract "
-              , pretty caID
-              , div_
-                  [ nbsp
-                  , text "with new active endpoint(s): "
-                  , text $ show hooks
-                  ]
-              ]
-          SubmitTx tx -> span_ [ text "SubmittedTx:", nbsp, pretty tx ]
-          ActivateContract _ instanceId -> span_ [ text $ "Activate contract:", nbsp, text (view _contractInstanceIdString instanceId) ]
-          StopContract instanceId -> span_ [ text $ "Stop contract:", nbsp, text (view _contractInstanceIdString instanceId) ]
 
 withHeading :: forall i p. String -> HTML p i -> HTML p i
 withHeading prefix content =
@@ -73,7 +51,7 @@ instance prettyResponse :: Pretty a => Pretty (Response a) where
       , div_ [ pretty rspResponse ]
       ]
 
-instance prettyContractResponse :: Pretty ContractResponse where
+instance prettyContractPABResponse :: Pretty ContractPABResponse where
   pretty (AwaitSlotResponse slot) =
     span_
       [ text "AwaitSlotResponse:"

--- a/plutus-pab/app/Cli.hs
+++ b/plutus-pab/app/Cli.hs
@@ -85,13 +85,13 @@ import           Cardano.Node.Types                       (MockServerConfig (..)
 import qualified PSGenerator
 import           Plutus.Contract.Resumable                (responses)
 import           Plutus.Contract.State                    (State (..))
+import qualified Plutus.Contract.State                    as State
 import           Plutus.Contracts.Currency                (SimpleMPS (..))
 import qualified Plutus.PAB.App                           as App
 import qualified Plutus.PAB.Core                          as Core
 import qualified Plutus.PAB.Db.Eventful                   as Eventful
 import           Plutus.PAB.Effects.Contract.ContractExe  (ContractExe)
 import           Plutus.PAB.Effects.Contract.ContractTest (TestContracts (Currency))
-import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedResponse (..))
 import qualified Plutus.PAB.Monitoring.Monitoring         as LM
 import qualified Plutus.PAB.Simulator                     as Simulator
 import           Plutus.PAB.Types                         (Config (..), chainIndexConfig, metadataServerConfig,
@@ -226,7 +226,7 @@ runCliCommand t _ Config{dbConfig} _ (ReportContractHistory contractInstanceId) 
         $ do
             logInfo @(LM.AppMsg ContractExe) LM.ContractHistoryMsg
             s <- Contract.getState @ContractExe contractInstanceId
-            let PartiallyDecodedResponse{newState=State{record}} = Contract.serialisableState (Proxy @ContractExe) s
+            let State.ContractResponse{State.newState=State{record}} = Contract.serialisableState (Proxy @ContractExe) s
             traverse_ logStep (responses record)
             drainLog
                 where

--- a/plutus-pab/app/PSGenerator.hs
+++ b/plutus-pab/app/PSGenerator.hs
@@ -48,7 +48,7 @@ import           Plutus.PAB.Effects.Contract.ContractExe    (ContractExe)
 import           Plutus.PAB.Effects.Contract.ContractTest   (TestContracts (Currency, GameStateMachine))
 import           Plutus.PAB.Events                          (PABEvent)
 import           Plutus.PAB.Events.Contract                 (ContractInstanceId (..), ContractPABRequest,
-                                                             ContractResponse)
+                                                             ContractPABResponse)
 import           Plutus.PAB.Events.ContractInstanceState    (PartiallyDecodedResponse)
 import qualified Plutus.PAB.Simulator                       as Simulator
 import qualified Plutus.PAB.Webserver.API                   as API
@@ -112,7 +112,7 @@ myTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(PartiallyDecodedResponse A))
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(ContractRequest A))
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ContractPABRequest)
-    , (equal <*> (genericShow <*> mkSumType)) (Proxy @ContractResponse)
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @ContractPABResponse)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @UnbalancedTx)
 
     -- Contract request / response types

--- a/plutus-pab/app/PSGenerator.hs
+++ b/plutus-pab/app/PSGenerator.hs
@@ -46,7 +46,6 @@ import           Plutus.Contract.State                      (ContractRequest, St
 import           Plutus.Contracts.Currency                  (SimpleMPS (..))
 import           Plutus.PAB.Effects.Contract.ContractExe    (ContractExe)
 import           Plutus.PAB.Effects.Contract.ContractTest   (TestContracts (Currency, GameStateMachine))
-import           Plutus.PAB.Events                          (PABEvent)
 import           Plutus.PAB.Events.Contract                 (ContractInstanceId (..), ContractPABRequest,
                                                              ContractPABResponse)
 import           Plutus.PAB.Events.ContractInstanceState    (PartiallyDecodedResponse)
@@ -144,7 +143,6 @@ myTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(AnnotatedSignature A))
 
     -- * Web API types
-    , (equal <*> (genericShow <*> mkSumType)) (Proxy @(PABEvent A))
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(ContractActivationArgs A))
     , (genericShow <*> mkSumType) (Proxy @(ContractInstanceClientState A))
     , (genericShow <*> mkSumType) (Proxy @InstanceStatusToClient)

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -185,7 +185,7 @@ instance Arbitrary WaitingForSlot where
 -- | Generate responses for mock requests. This function returns a
 -- 'Maybe' because we can't (yet) create a generator for every request
 -- type.
-genResponse :: ContractPABRequest -> Maybe (Gen ContractResponse)
+genResponse :: ContractPABRequest -> Maybe (Gen ContractPABResponse)
 genResponse (AwaitSlotRequest (WaitingForSlot slot))        = Just . pure . AwaitSlotResponse $ slot
 genResponse (AwaitTxConfirmedRequest txId) = Just . pure . AwaitTxConfirmedResponse . TxConfirmed $ txId
 genResponse (UserEndpointRequest _)        = Just $ UserEndpointResponse <$> arbitrary <*> (EndpointValue <$> arbitrary)

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -125,7 +125,7 @@ import qualified Plutus.PAB.Effects.ContractRuntime       as ContractRuntime
 import           Plutus.PAB.Effects.TimeEffect            (TimeEffect (..), systemTime)
 import           Plutus.PAB.Effects.UUID                  (UUIDEffect, handleUUIDEffect)
 import           Plutus.PAB.Events.Contract               (ContractPABRequest)
-import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedResponse)
+import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedResponse, fromResp)
 import           Plutus.PAB.Monitoring.PABLogMsg          (PABMultiAgentMsg (..))
 import           Plutus.PAB.Timeout                       (Timeout)
 import qualified Plutus.PAB.Timeout                       as Timeout
@@ -426,7 +426,7 @@ reportContractState ::
     )
     => ContractInstanceId
     -> Eff effs (PartiallyDecodedResponse ContractPABRequest)
-reportContractState cid = Contract.serialisableState (Proxy @t) <$> getState @t cid
+reportContractState cid = fromResp . Contract.serialisableState (Proxy @t) <$> getState @t cid
 
 -- | Annotate log messages with the current slot number.
 timed ::

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/RequestHandlers.hs
@@ -41,7 +41,7 @@ import           Plutus.Contract.Trace.RequestHandler    (RequestHandler (..), R
 import qualified Plutus.Contract.Trace.RequestHandler    as RequestHandler
 import qualified Plutus.PAB.Effects.Contract             as Contract
 import           Plutus.PAB.Events.Contract              (ContractInstanceId (..), ContractPABRequest (..),
-                                                          ContractResponse (..))
+                                                          ContractPABResponse (..))
 import qualified Plutus.PAB.Events.Contract              as Events.Contract
 import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
 import           Wallet.Effects                          (ChainIndexEffect, ContractRuntimeEffect, WalletEffect)
@@ -54,7 +54,7 @@ processOwnPubkeyRequests ::
     ( Member (LogObserve (LogMessage Text.Text)) effs
     , Member WalletEffect effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processOwnPubkeyRequests =
     maybeToHandler (extract Events.Contract._OwnPubkeyRequest) >>>
         fmap OwnPubkeyResponse RequestHandler.handleOwnPubKey
@@ -65,7 +65,7 @@ processUtxoAtRequests ::
     , Member (LogObserve (LogMessage Text.Text)) effs
     , Member (LogMsg RequestHandlerLogMsg) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processUtxoAtRequests =
     maybeToHandler (extract Events.Contract._UtxoAtRequest)
     >>> RequestHandler.handleUtxoQueries
@@ -79,7 +79,7 @@ processWriteTxRequests ::
     , Member (LogMsg RequestHandlerLogMsg) effs
     , Member (LogMsg TxBalanceMsg) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processWriteTxRequests =
     maybeToHandler (extract Events.Contract._WriteTxRequest)
     >>> RequestHandler.handlePendingTransactions
@@ -92,7 +92,7 @@ processAddressChangedAtRequests ::
     , Member ChainIndexEffect effs
     , Member (LogMsg RequestHandlerLogMsg) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processAddressChangedAtRequests =
     maybeToHandler (extract Events.Contract._AddressChangedAtRequest)
     >>> RequestHandler.handleAddressChangedAtQueries
@@ -103,7 +103,7 @@ processTxConfirmedRequests ::
     ( Member ChainIndexEffect effs
     , Member (LogObserve (LogMessage Text.Text)) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processTxConfirmedRequests =
     maybeToHandler (extract Events.Contract._AwaitTxConfirmedRequest)
     >>> RequestHandler.handleTxConfirmedQueries
@@ -114,7 +114,7 @@ processInstanceRequests ::
     ( Member (Reader ContractInstanceId) effs
     , Member (LogObserve (LogMessage Text.Text)) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processInstanceRequests =
     maybeToHandler (extract Events.Contract._OwnInstanceIdRequest)
     >>> RequestHandler.handleOwnInstanceIdQueries
@@ -125,7 +125,7 @@ processNotificationEffects ::
     ( Member ContractRuntimeEffect effs
     , Member (LogObserve (LogMessage Text.Text)) effs
     )
-    => RequestHandler effs ContractPABRequest ContractResponse
+    => RequestHandler effs ContractPABRequest ContractPABResponse
 processNotificationEffects =
     maybeToHandler (extract Events.Contract._SendNotificationRequest)
     >>> RequestHandler.handleContractNotifications
@@ -133,7 +133,7 @@ processNotificationEffects =
 
 -- | Log messages about the
 data ContractInstanceMsg t =
-    ProcessFirstInboxMessage ContractInstanceId (Response ContractResponse)
+    ProcessFirstInboxMessage ContractInstanceId (Response ContractPABResponse)
     | SendingContractStateMessages ContractInstanceId IterationID [Request ContractPABRequest]
     | LookingUpStateOfContractInstance
     | CurrentIteration IterationID
@@ -145,7 +145,7 @@ data ContractInstanceMsg t =
     | UpdatedContract ContractInstanceId IterationID
     | LookingUpContract (Contract.ContractDef t)
     | InitialisingContract (Contract.ContractDef t) ContractInstanceId
-    | InitialContractResponse (PartiallyDecodedResponse ContractPABRequest)
+    | InitialContractPABResponse (PartiallyDecodedResponse ContractPABRequest)
     | ActivatedContractInstance (Contract.ContractDef t) Wallet ContractInstanceId
     | RunRequestHandler ContractInstanceId Int -- number of requests
     | RunRequestHandlerDidNotHandleAnyEvents
@@ -191,7 +191,7 @@ instance (ToJSON (Contract.ContractDef t)) => ToObject (ContractInstanceMsg t) w
             mkObjectStr "looking up contract" (Tagged @"contract" t)
         InitialisingContract t instanceID ->
             mkObjectStr "initialising contract" (Tagged @"contract" t, instanceID)
-        InitialContractResponse rsp ->
+        InitialContractPABResponse rsp ->
             mkObjectStr "initial contract response" $
                 case v of
                     MaximalVerbosity -> Left (Tagged @"response" rsp)
@@ -247,7 +247,7 @@ instance Pretty (Contract.ContractDef t) => Pretty (ContractInstanceMsg t) where
         UpdatedContract instanceID iterationID -> "Updated contract" <+> pretty instanceID <+> "to new iteration" <+> pretty iterationID
         LookingUpContract c -> "Looking up contract" <+> pretty c
         InitialisingContract c instanceID -> "Initialising contract" <+> pretty c <+> "with ID" <+> pretty instanceID
-        InitialContractResponse rsp -> "Initial contract response:" <+> pretty rsp
+        InitialContractPABResponse rsp -> "Initial contract response:" <+> pretty rsp
         ActivatedContractInstance _ wallet instanceID -> "Activated instance" <+> pretty instanceID <+> "on" <+> pretty wallet
         RunRequestHandler instanceID numRequests -> "Running request handler for" <+> pretty instanceID <+> "with" <+> pretty numRequests <+> "requests."
         RunRequestHandlerDidNotHandleAnyEvents -> "runRequestHandler: did not handle any requests"

--- a/plutus-pab/src/Plutus/PAB/Db/Eventful/Command.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Eventful/Command.hs
@@ -25,15 +25,15 @@ module Plutus.PAB.Db.Eventful.Command
     , stopContractInstance
     ) where
 
-import           Eventful                                (Aggregate (Aggregate), aggregateCommandHandler,
-                                                          aggregateProjection)
+import           Data.Aeson                   (Value)
+import           Eventful                     (Aggregate (Aggregate), aggregateCommandHandler, aggregateProjection)
 import qualified Ledger
-import           Plutus.PAB.Db.Eventful.Query            (nullProjection)
-import           Plutus.PAB.Events                       (PABEvent (..))
-import           Plutus.PAB.Events.Contract              (ContractPABRequest)
-import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
-import           Plutus.PAB.Webserver.Types              (ContractActivationArgs)
-import           Wallet.Types                            (ContractInstanceId)
+import           Plutus.Contract.State        (ContractResponse)
+import           Plutus.PAB.Db.Eventful.Query (nullProjection)
+import           Plutus.PAB.Events            (PABEvent (..))
+import           Plutus.PAB.Events.Contract   (ContractPABRequest)
+import           Plutus.PAB.Webserver.Types   (ContractActivationArgs)
+import           Wallet.Types                 (ContractInstanceId)
 
 -- | An aggregate that just sends a list of events with no state
 sendEvents ::
@@ -53,7 +53,7 @@ installCommand = sendEvents (return . InstallContract)
 saveBalancedTxResult :: forall t. Aggregate () (PABEvent t) Ledger.Tx
 saveBalancedTxResult = sendEvents (return . SubmitTx)
 
-updateContractInstanceState :: forall t. Aggregate () (PABEvent t) (ContractActivationArgs t, ContractInstanceId, (PartiallyDecodedResponse ContractPABRequest))
+updateContractInstanceState :: forall t. Aggregate () (PABEvent t) (ContractActivationArgs t, ContractInstanceId, (ContractResponse Value Value Value ContractPABRequest))
 updateContractInstanceState = sendEvents (\(x, y, z) -> return $ UpdateContractInstanceState x y z)
 
 startContractInstance :: forall t. Aggregate () (PABEvent t) (ContractActivationArgs t, ContractInstanceId)

--- a/plutus-pab/src/Plutus/PAB/Db/Eventful/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Eventful/ContractStore.hs
@@ -8,18 +8,19 @@ module Plutus.PAB.Db.Eventful.ContractStore(
     handleContractStore
     ) where
 
-import           Control.Monad                           (void)
-import           Control.Monad.Freer                     (Eff, Member, type (~>))
-import           Control.Monad.Freer.Error               (Error, throwError)
-import qualified Data.Map                                as Map
-import qualified Plutus.PAB.Db.Eventful.Command          as Command
-import qualified Plutus.PAB.Db.Eventful.Query            as Query
-import           Plutus.PAB.Effects.Contract             (ContractStore (..), PABContract (..))
-import           Plutus.PAB.Effects.EventLog             (EventLogEffect, runCommand, runGlobalQuery)
-import           Plutus.PAB.Events                       (PABEvent)
-import           Plutus.PAB.Events.Contract              (ContractPABRequest)
-import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
-import           Plutus.PAB.Types                        (PABError (..), Source (..))
+import           Control.Monad                  (void)
+import           Control.Monad.Freer            (Eff, Member, type (~>))
+import           Control.Monad.Freer.Error      (Error, throwError)
+import           Data.Aeson                     (Value)
+import qualified Data.Map                       as Map
+import           Plutus.Contract.State          (ContractResponse)
+import qualified Plutus.PAB.Db.Eventful.Command as Command
+import qualified Plutus.PAB.Db.Eventful.Query   as Query
+import           Plutus.PAB.Effects.Contract    (ContractStore (..), PABContract (..))
+import           Plutus.PAB.Effects.EventLog    (EventLogEffect, runCommand, runGlobalQuery)
+import           Plutus.PAB.Events              (PABEvent)
+import           Plutus.PAB.Events.Contract     (ContractPABRequest)
+import           Plutus.PAB.Types               (PABError (..), Source (..))
 
 -- | Handle the 'ContractStore' effect by storing states
 --   in the eventful database.
@@ -27,7 +28,7 @@ handleContractStore ::
     forall t effs.
     ( Member (EventLogEffect (PABEvent (ContractDef t))) effs
     , Member (Error PABError) effs
-    , State t ~ PartiallyDecodedResponse ContractPABRequest -- FIXME
+    , State t ~ ContractResponse Value Value Value ContractPABRequest
     )
     => ContractStore t
     ~> Eff effs

--- a/plutus-pab/src/Plutus/PAB/Db/Eventful/Query.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Eventful/Query.hs
@@ -25,18 +25,19 @@ module Plutus.PAB.Db.Eventful.Query
     ) where
 
 import           Control.Lens
-import           Data.Map.Strict                         (Map)
-import qualified Data.Map.Strict                         as Map
-import           Data.Set                                (Set)
-import qualified Data.Set                                as Set
-import           Data.Text.Prettyprint.Doc               (Pretty, pretty)
-import           Eventful                                (Projection (Projection), StreamEvent (StreamEvent),
-                                                          StreamProjection, projectionEventHandler, projectionMapMaybe,
-                                                          projectionSeed, streamProjectionState)
-import           Plutus.PAB.Events                       (PABEvent (InstallContract, UpdateContractInstanceState))
-import           Plutus.PAB.Events.Contract              (ContractInstanceId, ContractPABRequest)
-import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
-import           Plutus.PAB.Webserver.Types              (ContractActivationArgs (..))
+import           Data.Aeson                 (Value)
+import           Data.Map.Strict            (Map)
+import qualified Data.Map.Strict            as Map
+import           Data.Set                   (Set)
+import qualified Data.Set                   as Set
+import           Data.Text.Prettyprint.Doc  (Pretty, pretty)
+import           Eventful                   (Projection (Projection), StreamEvent (StreamEvent), StreamProjection,
+                                             projectionEventHandler, projectionMapMaybe, projectionSeed,
+                                             streamProjectionState)
+import           Plutus.Contract.State      (ContractResponse)
+import           Plutus.PAB.Events          (PABEvent (InstallContract, UpdateContractInstanceState))
+import           Plutus.PAB.Events.Contract (ContractInstanceId, ContractPABRequest)
+import           Plutus.PAB.Webserver.Types (ContractActivationArgs (..))
 
 -- | The empty projection. Particularly useful for commands that have no 'state'.
 nullProjection :: Projection () event
@@ -68,9 +69,9 @@ instance Pretty state =>
     pretty = pretty . streamProjectionState
 
 -- | The last known state of the contract.
-contractState :: forall t key position. Projection (Map ContractInstanceId (PartiallyDecodedResponse ContractPABRequest)) (StreamEvent key position (PABEvent t))
+contractState :: forall t key position. Projection (Map ContractInstanceId (ContractResponse Value Value Value ContractPABRequest)) (StreamEvent key position (PABEvent t))
 contractState =
-    let projectionEventHandler :: Map ContractInstanceId (PartiallyDecodedResponse ContractPABRequest) -> StreamEvent key position (PABEvent t) -> Map ContractInstanceId (PartiallyDecodedResponse ContractPABRequest)
+    let projectionEventHandler :: Map ContractInstanceId (ContractResponse Value Value Value ContractPABRequest) -> StreamEvent key position (PABEvent t) -> Map ContractInstanceId (ContractResponse Value Value Value ContractPABRequest)
         projectionEventHandler oldMap = \case
             (StreamEvent _ _ (UpdateContractInstanceState _ i s)) ->
                 Map.union (Map.singleton i s) oldMap

--- a/plutus-pab/src/Plutus/PAB/Events.hs
+++ b/plutus-pab/src/Plutus/PAB/Events.hs
@@ -19,20 +19,20 @@ module Plutus.PAB.Events
     , _StopContract
     ) where
 
-import           Control.Lens.TH                         (makePrisms)
-import           Data.Aeson                              (FromJSON, ToJSON)
-import           Data.Text.Prettyprint.Doc               (Pretty, pretty, (<+>))
-import           GHC.Generics                            (Generic)
-import           Ledger.Tx                               (Tx, txId)
-import           Plutus.PAB.Events.Contract              (ContractPABRequest)
-import           Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
-import           Plutus.PAB.Webserver.Types              (ContractActivationArgs)
-import           Wallet.Types                            (ContractInstanceId)
+import           Control.Lens.TH            (makePrisms)
+import           Data.Aeson                 (FromJSON, ToJSON, Value)
+import           Data.Text.Prettyprint.Doc  (Pretty, pretty, (<+>))
+import           GHC.Generics               (Generic)
+import           Ledger.Tx                  (Tx, txId)
+import           Plutus.Contract.State      (ContractResponse)
+import           Plutus.PAB.Events.Contract (ContractPABRequest)
+import           Plutus.PAB.Webserver.Types (ContractActivationArgs)
+import           Wallet.Types               (ContractInstanceId)
 
 -- | A structure which ties together all possible event types into one parent.
 data PABEvent t =
     InstallContract !t -- ^ Install a contract
-    | UpdateContractInstanceState !(ContractActivationArgs t) !ContractInstanceId !(PartiallyDecodedResponse ContractPABRequest) -- ^ Update the state of a contract instance
+    | UpdateContractInstanceState !(ContractActivationArgs t) !ContractInstanceId !(ContractResponse Value Value Value ContractPABRequest) -- ^ Update the state of a contract instance
     | SubmitTx !Tx -- ^ Send a transaction to the node
     | ActivateContract !(ContractActivationArgs t) !ContractInstanceId
     | StopContract !ContractInstanceId

--- a/plutus-pab/src/Plutus/PAB/Events/Contract.hs
+++ b/plutus-pab/src/Plutus/PAB/Events/Contract.hs
@@ -14,7 +14,7 @@ module Plutus.PAB.Events.Contract(
   , ContractPABRequest(..)
   , ContractHandlersResponse(..)
   , ContractHandlerRequest(..)
-  , ContractResponse(..)
+  , ContractPABResponse(..)
   -- * Prisms
   -- ** ContractRequest
   , _AwaitSlotRequest
@@ -149,7 +149,7 @@ instance Pretty ContractPABRequest where
         OwnInstanceIdRequest r    -> "OwnInstanceId:" <+> pretty r
         SendNotificationRequest n -> "Notification:" <+> pretty n
 
-data ContractResponse =
+data ContractPABResponse =
   AwaitSlotResponse Slot
   | AwaitTxConfirmedResponse TxConfirmed
   | UserEndpointResponse EndpointDescription (EndpointValue Value)
@@ -162,7 +162,7 @@ data ContractResponse =
   deriving  (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
-instance Pretty ContractResponse where
+instance Pretty ContractPABResponse where
     pretty = \case
         AwaitSlotResponse s          -> "AwaitSlot:" <+> pretty s
         UserEndpointResponse n r     -> "UserEndpoint:" <+> pretty n <+> pretty r
@@ -176,7 +176,7 @@ instance Pretty ContractResponse where
 
 -- | 'ContractResponse' with a 'ToJSON' instance that is compatible with
 --   the 'FromJSON' instance of 'Plutus.Contract.Schema.Event'.
-newtype ContractHandlersResponse = ContractHandlersResponse { unContractHandlersResponse :: ContractResponse }
+newtype ContractHandlersResponse = ContractHandlersResponse { unContractHandlersResponse :: ContractPABResponse }
 
 instance ToJSON ContractHandlersResponse where
     toJSON (ContractHandlersResponse c) = case c of
@@ -191,4 +191,4 @@ instance ToJSON ContractHandlersResponse where
         UserEndpointResponse (EndpointDescription n) r -> object ["tag" .= n, "value" .= r]
 
 makePrisms ''ContractPABRequest
-makePrisms ''ContractResponse
+makePrisms ''ContractPABResponse

--- a/plutus-pab/src/Plutus/PAB/Events/ContractInstanceState.hs
+++ b/plutus-pab/src/Plutus/PAB/Events/ContractInstanceState.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Plutus.PAB.Events.ContractInstanceState(
     PartiallyDecodedResponse(..)
-    , toResp
     , fromResp
     , hasActiveRequests
     ) where
@@ -25,8 +24,7 @@ import qualified Plutus.Contract.State          as Contract
 -- TODO: Replace with type synonym for @ContractResponse Value Value Value h@
 data PartiallyDecodedResponse v =
     PartiallyDecodedResponse
-        { newState        :: Contract.State Value
-        , hooks           :: [Contract.Request v]
+        { hooks           :: [Contract.Request v]
         , logs            :: [LogMessage Value]
         , lastLogs        :: [LogMessage Value] -- The log messages returned by the last step ('lastLogs' is a suffix of 'logs')
         , err             :: Maybe Value
@@ -35,24 +33,19 @@ data PartiallyDecodedResponse v =
     deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
     deriving anyclass (ToJSON, FromJSON)
 
-
-toResp :: PartiallyDecodedResponse v -> Contract.ContractResponse Value Value Value v
-toResp PartiallyDecodedResponse{newState, hooks, logs, err, observableState, lastLogs} =
-    Contract.ContractResponse{Contract.newState = newState, Contract.hooks=hooks, Contract.logs=logs, Contract.err=err, Contract.observableState=observableState, Contract.lastLogs=lastLogs}
-
 fromResp :: Contract.ContractResponse Value Value Value v -> PartiallyDecodedResponse v
-fromResp Contract.ContractResponse{Contract.newState, Contract.hooks, Contract.logs, Contract.err, Contract.observableState, Contract.lastLogs} =
-    PartiallyDecodedResponse{newState, hooks, logs, err, observableState, lastLogs}
+fromResp Contract.ContractResponse{Contract.hooks, Contract.logs, Contract.err, Contract.observableState, Contract.lastLogs} =
+    PartiallyDecodedResponse{hooks, logs, err, observableState, lastLogs}
 
 instance Pretty v => Pretty (PartiallyDecodedResponse v) where
-    pretty PartiallyDecodedResponse {newState, hooks} =
+    pretty PartiallyDecodedResponse {hooks, observableState} =
         vsep
             [ "State:"
-            , indent 2 $ pretty $ abbreviate 120 $ Text.pack $ BS8.unpack $ JSON.encodePretty newState
+            , indent 2 $ pretty $ abbreviate 120 $ Text.pack $ BS8.unpack $ JSON.encodePretty observableState
             , "Hooks:"
             , indent 2 (vsep $ pretty <$> hooks)
             ]
 
 -- | Whether the instance has any active requests
-hasActiveRequests :: forall a. PartiallyDecodedResponse a -> Bool
-hasActiveRequests = not . null . hooks
+hasActiveRequests :: forall w s e a. Contract.ContractResponse w e s a -> Bool
+hasActiveRequests = not . null . Contract.hooks

--- a/plutus-pab/test/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab/test/Plutus/PAB/CoreSpec.hs
@@ -43,6 +43,7 @@ import           Ledger.Ada                               (adaSymbol, adaToken, 
 import qualified Ledger.Ada                               as Ada
 import qualified Ledger.AddressMap                        as AM
 import           Ledger.Value                             (valueOf)
+import           Plutus.Contract.State                    (ContractResponse (..))
 import           Plutus.Contracts.Currency                (OneShotCurrency, SimpleMPS (..))
 import qualified Plutus.Contracts.GameStateMachine        as Contracts.GameStateMachine
 import           Plutus.Contracts.PingPong                (PingPongState (..))
@@ -56,7 +57,7 @@ import           Plutus.PAB.Effects.Contract.Builtin      (Builtin)
 import qualified Plutus.PAB.Effects.Contract.Builtin      as Builtin
 import           Plutus.PAB.Effects.Contract.ContractTest (TestContracts (..))
 import           Plutus.PAB.Effects.EventLog              (EventLogEffect)
-import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedResponse (..))
+import           Plutus.PAB.Events.ContractInstanceState  (PartiallyDecodedResponse)
 import           Plutus.PAB.Simulator                     (Simulation, TxCounts (..))
 import qualified Plutus.PAB.Simulator                     as Simulator
 import           Plutus.PAB.Types                         (PABError (..), chainOverviewBlockchain, mkChainOverview)
@@ -313,7 +314,7 @@ assertDone ::
     -> ContractInstanceId
     -> Simulation (Builtin TestContracts) ()
 assertDone wallet i = do
-    PartiallyDecodedResponse{hooks} <- serialisableState (Proxy @(Builtin TestContracts)) <$> Simulator.instanceState wallet i
+    ContractResponse{hooks} <- serialisableState (Proxy @(Builtin TestContracts)) <$> Simulator.instanceState wallet i
     case hooks of
         [] -> pure ()
         xs ->


### PR DESCRIPTION
* Delete `newState` from `PartiallyDecodedResponse` - it can get quite big and we don't need it in the client
* Use `ContractResponse` instead of `PartiallyDecodedResponse` in the PAB whenever we actually need `newState`

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
