### PR TITLE
deploy plutus-starter devcontainer to dockerhub wip

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,11 +7,21 @@ steps:
     concurrency_group: "plutus-alpha-deploy"
     agents:
       system: x86_64-linux
+
   - label: 'deploy (production) 🚀'
     command:
       - "./.buildkite/deploy.sh production"
     branches: "production"
     concurrency: 1
     concurrency_group: "plutus-production-deploy"
+    agents:
+      system: x86_64-linux
+
+  - label: ':shipit: deploy devcontainer image for plutus-starter'
+    branches: 'plutus-starter-devcontainer/v*'
+    command:
+      - "./.buildkite/plutus-starter-devcontainer-push.sh"
+    concurrency: 1
+    concurrency_group: "plutus-starter-devcontainer-push"
     agents:
       system: x86_64-linux

--- a/.buildkite/plutus-starter-devcontainer-push.sh
+++ b/.buildkite/plutus-starter-devcontainer-push.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+nix-build default.nix -A build-and-push-devcontainer-script -o build-and-push-image.sh
+./build-and-push-image.sh

--- a/default.nix
+++ b/default.nix
@@ -106,4 +106,5 @@ rec {
 
   # This builds a vscode devcontainer that can be used with the plutus-starter project (or probably the plutus project itself).
   devcontainer = import ./nix/devcontainer/plutus-devcontainer.nix { inherit pkgs plutus; };
+  build-and-push-devcontainer-script = import ./nix/devcontainer/deploy/default.nix { inherit pkgs plutus; };
 }

--- a/nix/devcontainer/deploy/default.nix
+++ b/nix/devcontainer/deploy/default.nix
@@ -1,0 +1,29 @@
+{ pkgs ? import <nixpkgs> { }
+, plutus
+, dockerImage ? import ../plutus-devcontainer.nix { inherit pkgs plutus; }
+}:
+let
+  imageRef = dockerImage.imageName + ":" + dockerImage.imageTag;
+  dockerHubRepoName = "inputoutput/plutus-starter-devcontainer";
+in
+pkgs.writeScript "docker-build-push-devcontainer" ''
+  #!${pkgs.runtimeShell}
+  set -euo pipefail
+
+  echo "Loading the docker image ..."
+  docker load -i ${dockerImage}
+
+  tag="''${BUILDKITE_TAG:-}"
+  echo "Git tag: ''${tag}."
+    
+  # Pick out only the version component of a tag like:
+  # "plutus-starter-devcontainer/v1.0" -> "v1.0"
+  version="$(echo $tag | sed -e 's/.*[\/]//')"
+
+  # Construct a tag to push up to dockerHub
+  docker tag "${imageRef}" "${dockerHubRepoName}:''${version}"
+  docker tag "${imageRef}" "${dockerHubRepoName}:latest"
+
+  docker push "${dockerHubRepoName}:''${version}"
+  docker push "${dockerHubRepoName}:latest"
+''


### PR DESCRIPTION
Fixes SCP-2127

I think this is ready; but I can't test it until I push a tag and this code is in master; so it'd be good for people to take a glance now and see if anything seems a-miss.

Thanks! :)

I this to be pushed to the right reop if the tag is named for example, `plutus-starter-devcontainer/v1.0`, which is enforced via the .buildkit config ( thanks @gilligan ! )

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
