### PR TITLE
Update the content to match in `marlowe-step-by-step` to matches with `cardano-foundation / docs-cardano-org`

### DIFF
--- a/doc/marlowe/tutorials/index.rst
+++ b/doc/marlowe/tutorials/index.rst
@@ -21,9 +21,9 @@ This document gives an overview the Marlowe tutorials.
     standard terminology that we will use in describing Marlowe.
 
 4.  :ref:`marlowe-step-by-step`
-    This tutorial explains the five ways of building contracts in
-    Marlowe. Four of these – ``Pay``, ``Let``, ``If`` and ``When`` –
-    build a complex contract from simpler contracts, and the fifth,
+    This tutorial explains the six ways of building contracts in
+    Marlowe. Five of these – ``Pay``, ``Let``, ``If``, ``When`` and ``Assert`` –
+    build a complex contract from simpler contracts, and the sixth,
     ``Close``, is a simple contract. In explaining these contracts we
     will also explain Marlowe *values*, *observations* and *actions*,
     which are used to supply external information and inputs to a


### PR DESCRIPTION
This merge request update the content of section `marlowe-step-by-step` to match with the similar content from `cardano-foundation / docs-cardano-org`

<img width="1076" alt="Screen Shot 2021-05-11 at 21 29 49" src="https://user-images.githubusercontent.com/736223/117832851-0b5ba900-b2a0-11eb-8b94-e4cd33de57fc.png">
