### PR TITLE
SCP-2254 (part 2): Improving the input elements 

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -17,7 +17,7 @@ import Data.BigInteger (BigInteger, fromInt, fromString)
 import Data.Foldable (foldMap)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lens ((^.))
-import Data.Map (filterKeys, keys, lookup, toUnfoldable) as Map
+import Data.Map (keys, lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), maybe, maybe')
 import Data.Set (Set)
 import Data.Set as Set
@@ -677,13 +677,7 @@ renderBalances state accounts =
     -- TODO: Right now we only have one type of Token (ada), but when we support multiple tokens we may want to group by
     --       participant and show the different tokens for each participant.
     accounts' :: Array (Tuple (Tuple Party Token) BigInteger)
-    accounts' = Map.toUnfoldable $ Map.filterKeys isRoleAccount accounts
-
-    -- Note we are currently filtering out PK accounts. We have no nice way to display them, and we are only using them
-    -- in one special case where it is confusing to display them anyway.
-    isRoleAccount (accountId /\ token) = case accountId of
-      Role _ -> true
-      _ -> false
+    accounts' = Map.toUnfoldable accounts
   in
     div [ classNames [ "text-xs" ] ]
       ( append

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -17,7 +17,7 @@ import Data.BigInteger (BigInteger, fromInt, fromString)
 import Data.Foldable (foldMap)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lens ((^.))
-import Data.Map as Map
+import Data.Map (filterKeys, keys, lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), maybe, maybe')
 import Data.Set (Set)
 import Data.Set as Set
@@ -677,7 +677,13 @@ renderBalances state accounts =
     -- TODO: Right now we only have one type of Token (ada), but when we support multiple tokens we may want to group by
     --       participant and show the different tokens for each participant.
     accounts' :: Array (Tuple (Tuple Party Token) BigInteger)
-    accounts' = Map.toUnfoldable accounts
+    accounts' = Map.toUnfoldable $ Map.filterKeys isRoleAccount accounts
+
+    -- Note we are currently filtering out PK accounts. We have no nice way to display them, and we are only using them
+    -- in one special case where it is confusing to display them anyway.
+    isRoleAccount (accountId /\ token) = case accountId of
+      Role _ -> true
+      _ -> false
   in
     div [ classNames [ "text-xs" ] ]
       ( append

--- a/marlowe-dashboard-client/src/InputField/Lenses.purs
+++ b/marlowe-dashboard-client/src/InputField/Lenses.purs
@@ -7,6 +7,7 @@ module InputField.Lenses
   , _id_
   , _placeholder
   , _readOnly
+  , _datalistId
   ) where
 
 import Data.Lens (Lens')
@@ -39,3 +40,6 @@ _placeholder = prop (SProxy :: SProxy "placeholder")
 
 _readOnly :: Lens' InputDisplayOptions Boolean
 _readOnly = prop (SProxy :: SProxy "readOnly")
+
+_datalistId :: Lens' InputDisplayOptions (Maybe String)
+_datalistId = prop (SProxy :: SProxy "datalistId")

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -1,5 +1,6 @@
 module InputField.State
-  ( initialState
+  ( dummyState
+  , initialState
   , handleAction
   , validate
   ) where
@@ -12,10 +13,13 @@ import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, modify_)
 import InputField.Lenses (_pristine, _validator, _value)
-import InputField.Types (Action(..), State)
-import MainFrame.Types (ChildSlots, Msg)
+import InputField.Types (class InputFieldError, Action(..), State)
 
-initialState :: forall e. Show e => State e
+-- see note [dummyState] in MainFrame.State
+dummyState :: forall e. InputFieldError e => State e
+dummyState = initialState
+
+initialState :: forall e. InputFieldError e => State e
 initialState =
   { value: mempty
   , pristine: true
@@ -23,11 +27,11 @@ initialState =
   }
 
 handleAction ::
-  forall m e.
+  forall m e slots msg.
   MonadAff m =>
   MonadAsk Env m =>
-  Show e =>
-  Action e -> HalogenM (State e) (Action e) ChildSlots Msg m Unit
+  InputFieldError e =>
+  Action e -> HalogenM (State e) (Action e) slots msg m Unit
 handleAction (SetValue value) =
   modify_
     $ set _value value
@@ -41,7 +45,7 @@ handleAction Reset =
     <<< set _pristine true
     <<< set _validator (const Nothing)
 
-validate :: forall e. Show e => State e -> Maybe e
+validate :: forall e. InputFieldError e => State e -> Maybe e
 validate state =
   let
     value = view _value state

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -1,5 +1,7 @@
 module InputField.Types
   ( State
+  , class InputFieldError
+  , inputErrorToString
   , Action(..)
   , InputDisplayOptions
   ) where
@@ -13,12 +15,16 @@ type State error
     , validator :: String -> Maybe error
     }
 
+class InputFieldError e where
+  inputErrorToString :: e -> String
+
 type InputDisplayOptions
   = { baseCss :: Boolean -> Array String
     , additionalCss :: Array String
     , id_ :: String
     , placeholder :: String
     , readOnly :: Boolean
+    , datalistId :: Maybe String
     }
 
 data Action error

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -8,12 +8,12 @@ import Data.Lens (view)
 import Data.Maybe (isJust)
 import Halogen.HTML (HTML, div, div_, input, text)
 import Halogen.HTML.Events.Extra (onValueInput_)
-import Halogen.HTML.Properties (InputType(..), autocomplete, id_, placeholder, readOnly, type_, value)
-import InputField.Lenses (_additionalCss, _baseCss, _id_, _placeholder, _pristine, _readOnly, _value)
+import Halogen.HTML.Properties (InputType(..), autocomplete, list, id_, placeholder, readOnly, type_, value)
+import InputField.Lenses (_additionalCss, _baseCss, _datalistId, _id_, _placeholder, _pristine, _readOnly, _value)
 import InputField.State (validate)
-import InputField.Types (Action(..), InputDisplayOptions, State)
+import InputField.Types (class InputFieldError, Action(..), InputDisplayOptions, State, inputErrorToString)
 
-renderInput :: forall p e. Show e => State e -> InputDisplayOptions -> HTML p (Action e)
+renderInput :: forall p e. InputFieldError e => State e -> InputDisplayOptions -> HTML p (Action e)
 renderInput state options =
   let
     mError = validate state
@@ -25,19 +25,22 @@ renderInput state options =
     baseCss = view _baseCss options
 
     additionalCss = view _additionalCss options
+
+    mDatalistId = view _datalistId options
   in
     div_
       [ input
-          [ type_ InputText
-          , classNames $ (baseCss showError) <> additionalCss
-          , id_ $ view _id_ options
-          , placeholder $ view _placeholder options
-          , value $ view _value state
-          , readOnly $ view _readOnly options
-          , autocomplete false
-          , onValueInput_ SetValue
-          ]
+          $ [ type_ InputText
+            , classNames $ (baseCss showError) <> additionalCss
+            , id_ $ view _id_ options
+            , placeholder $ view _placeholder options
+            , value $ view _value state
+            , readOnly $ view _readOnly options
+            , autocomplete false
+            , onValueInput_ SetValue
+            ]
+          <> foldMap (\datalistId -> [ list datalistId ]) mDatalistId
       , div
           [ classNames Css.inputError ]
-          [ text if showError then foldMap show mError else mempty ]
+          [ text if showError then foldMap inputErrorToString mError else mempty ]
       ]

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -2,7 +2,7 @@ module MainFrame.State (mkMainFrame, handleAction) where
 
 import Prelude
 import Bridge (toFront)
-import Capability.Marlowe (class ManageMarlowe, followContract, lookupWalletDetails, getFollowerApps, getRoleContracts, subscribeToPlutusApp, subscribeToWallet, unsubscribeFromPlutusApp, unsubscribeFromWallet)
+import Capability.Marlowe (class ManageMarlowe, followContract, getFollowerApps, getRoleContracts, subscribeToPlutusApp, subscribeToWallet, unsubscribeFromPlutusApp, unsubscribeFromWallet)
 import Capability.Toast (class Toast, addToast)
 import Contract.Lenses (_marloweParams)
 import Contract.State (mkInitialState, updateState) as Contract
@@ -36,7 +36,7 @@ import MainFrame.View (render)
 import Marlowe.PAB (MarloweData, MarloweParams, PlutusAppId)
 import Pickup.Lenses (_walletLibrary)
 import Pickup.State (handleAction, dummyState, mkInitialState) as Pickup
-import Pickup.Types (Action(..), Card(..), State) as Pickup
+import Pickup.Types (Action(..), State) as Pickup
 import Play.Lenses (_allContracts, _walletDetails)
 import Play.State (dummyState, handleAction, mkInitialState) as Play
 import Play.Types (Action(..), State) as Play
@@ -45,7 +45,7 @@ import StaticData (walletDetailsLocalStorageKey, walletLibraryLocalStorageKey)
 import Toast.State (defaultState, handleAction) as Toast
 import Toast.Types (Action, State) as Toast
 import Toast.Types (decodedAjaxErrorToast, decodingErrorToast, errorToast, successToast)
-import WalletData.Lenses (_assets, _companionAppId, _wallet, _walletInfo, _walletNickname)
+import WalletData.Lenses (_assets, _companionAppId, _wallet, _walletInfo)
 import WebSocket.Support as WS
 
 mkMainFrame ::
@@ -181,11 +181,7 @@ handleAction Init = do
   mWalletDetailsJson <- liftEffect $ getItem walletDetailsLocalStorageKey
   for_ mWalletDetailsJson \json ->
     for_ (runExcept $ decodeJSON json) \walletDetails -> do
-      -- check the wallet still exists in the wallet server, and show the LocalWalletMissingCard if not
-      ajaxWalletDetails <- lookupWalletDetails $ view _companionAppId walletDetails
-      case ajaxWalletDetails of
-        Left ajaxError -> handleAction $ PickupAction $ Pickup.OpenCard Pickup.LocalWalletMissingCard
-        Right _ -> handleAction $ PickupAction $ Pickup.SetWalletNicknameOrId $ view _walletNickname walletDetails
+      handleAction $ PickupAction $ Pickup.OpenPickupWalletCardWithDetails walletDetails
 
 handleAction (EnterPickupState walletLibrary walletDetails followerApps) = do
   unsubscribeFromWallet $ view (_walletInfo <<< _wallet) walletDetails
@@ -201,7 +197,9 @@ handleAction (EnterPlayState walletLibrary walletDetails) = do
   ajaxFollowerApps <- getFollowerApps walletDetails
   currentSlot <- use _currentSlot
   case ajaxFollowerApps of
-    Left decodedAjaxError -> addToast $ decodedAjaxErrorToast "Failed to load wallet details." decodedAjaxError
+    Left decodedAjaxError -> do
+      handleAction $ PickupAction Pickup.CloseCard
+      addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
     Right followerApps -> do
       -- FIXME: we are currently including some dummy contracts for testing
       let
@@ -219,7 +217,9 @@ handleAction (EnterPlayState walletLibrary walletDetails) = do
       -- wallet since we last picked it up, we have to create FollowerApps for those contracts here
       ajaxRoleContracts <- getRoleContracts walletDetails
       case ajaxRoleContracts of
-        Left decodedAjaxError -> addToast $ decodedAjaxErrorToast "Failed to load wallet details." decodedAjaxError
+        Left decodedAjaxError -> do
+          handleAction $ PickupAction Pickup.CloseCard
+          addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
         Right companionState -> updateRunningContracts companionState
 
 handleAction (PickupAction pickupAction) = toPickup $ Pickup.handleAction pickupAction

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -8,7 +8,7 @@ import Data.Foldable (foldMap)
 import Data.Lens (view)
 import Data.List (toUnfoldable) as List
 import Data.Map (filter, values)
-import Data.Maybe (isJust, isNothing)
+import Data.Maybe (Maybe(..), isJust, isNothing)
 import Data.String (Pattern(..), contains, null, toLower)
 import Halogen.HTML (HTML, a, button, div, div_, footer, header, hr, img, input, label, main, p, span_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
@@ -85,6 +85,7 @@ pickupNewWalletCard state =
       , id_: "walletNickname"
       , placeholder: "Choose any nickname"
       , readOnly: false
+      , datalistId: Nothing
       }
 
     walletIdInputDisplayOptions =
@@ -93,6 +94,7 @@ pickupNewWalletCard state =
       , id_: "walletId"
       , placeholder: "Wallet ID"
       , readOnly: true
+      , datalistId: Nothing
       }
   in
     [ a
@@ -156,6 +158,7 @@ pickupWalletCard state =
       , id_: "walletNickname"
       , placeholder: "Nickname"
       , readOnly: true
+      , datalistId: Nothing
       }
 
     walletIdInputDisplayOptions =
@@ -164,6 +167,7 @@ pickupWalletCard state =
       , id_: "walletId"
       , placeholder: "Wallet ID"
       , readOnly: true
+      , datalistId: Nothing
       }
   in
     [ a

--- a/marlowe-dashboard-client/src/Play/Lenses.purs
+++ b/marlowe-dashboard-client/src/Play/Lenses.purs
@@ -4,9 +4,9 @@ module Play.Lenses
   , _menuOpen
   , _screen
   , _cards
-  , _newWalletNickname
-  , _newWalletCompanionAppIdString
-  , _newWalletInfo
+  , _walletNicknameInput
+  , _walletIdInput
+  , _remoteWalletInfo
   , _templateState
   , _contractsState
   , _allContracts
@@ -21,11 +21,13 @@ import Data.Lens (Lens', Traversal')
 import Data.Lens.Record (prop)
 import Data.Map (Map)
 import Data.Symbol (SProxy(..))
+import InputField.Types (State) as InputField
 import Marlowe.PAB (PlutusAppId)
 import Play.Types (Card, Screen, State)
 import Template.Types (State) as Template
 import Types (WebData)
-import WalletData.Types (WalletDetails, WalletInfo, WalletLibrary, WalletNickname)
+import WalletData.Types (WalletDetails, WalletInfo, WalletLibrary)
+import WalletData.Validation (WalletIdError, WalletNicknameError)
 
 _walletLibrary :: Lens' State WalletLibrary
 _walletLibrary = prop (SProxy :: SProxy "walletLibrary")
@@ -42,14 +44,14 @@ _screen = prop (SProxy :: SProxy "screen")
 _cards :: Lens' State (Array Card)
 _cards = prop (SProxy :: SProxy "cards")
 
-_newWalletNickname :: Lens' State WalletNickname
-_newWalletNickname = prop (SProxy :: SProxy "newWalletNickname")
+_walletNicknameInput :: Lens' State (InputField.State WalletNicknameError)
+_walletNicknameInput = prop (SProxy :: SProxy "walletNicknameInput")
 
-_newWalletCompanionAppIdString :: Lens' State String
-_newWalletCompanionAppIdString = prop (SProxy :: SProxy "newWalletCompanionAppIdString")
+_walletIdInput :: Lens' State (InputField.State WalletIdError)
+_walletIdInput = prop (SProxy :: SProxy "walletIdInput")
 
-_newWalletInfo :: Lens' State (WebData WalletInfo)
-_newWalletInfo = prop (SProxy :: SProxy "newWalletInfo")
+_remoteWalletInfo :: Lens' State (WebData WalletInfo)
+_remoteWalletInfo = prop (SProxy :: SProxy "remoteWalletInfo")
 
 _templateState :: Lens' State Template.State
 _templateState = prop (SProxy :: SProxy "templateState")

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -12,11 +12,13 @@ import Contract.Types (Action) as Contract
 import ContractHome.Types (Action, State) as ContractHome
 import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Minutes)
+import InputField.Types (Action, State) as InputField
 import Marlowe.Execution (NamedAction)
 import Marlowe.Semantics (Slot, TokenName)
 import Template.Types (Action, State) as Template
 import Types (WebData)
-import WalletData.Types (WalletDetails, WalletInfo, WalletLibrary, WalletNickname)
+import WalletData.Types (WalletDetails, WalletInfo, WalletLibrary)
+import WalletData.Validation (WalletIdError, WalletNicknameError)
 
 type State
   = { walletLibrary :: WalletLibrary
@@ -24,9 +26,9 @@ type State
     , menuOpen :: Boolean
     , screen :: Screen
     , cards :: Array Card
-    , newWalletNickname :: WalletNickname
-    , newWalletCompanionAppIdString :: String
-    , newWalletInfo :: WebData WalletInfo
+    , walletNicknameInput :: InputField.State WalletNicknameError
+    , walletIdInput :: InputField.State WalletIdError
+    , remoteWalletInfo :: WebData WalletInfo
     , timezoneOffset :: Minutes
     , templateState :: Template.State
     , contractsState :: ContractHome.State
@@ -56,8 +58,9 @@ type Input
 
 data Action
   = PutdownWallet
-  | SetNewWalletNickname WalletNickname
-  | SetNewWalletCompanionAppIdString String
+  | WalletNicknameInputAction (InputField.Action WalletNicknameError)
+  | WalletIdInputAction (InputField.Action WalletIdError)
+  | SetRemoteWalletInfo (WebData WalletInfo)
   | SaveNewWallet (Maybe TokenName)
   | ToggleMenu
   | SetScreen Screen
@@ -72,8 +75,9 @@ data Action
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
   toEvent PutdownWallet = Just $ defaultEvent "PutdownWallet"
-  toEvent (SetNewWalletNickname _) = Just $ defaultEvent "SetNewWalletNickname"
-  toEvent (SetNewWalletCompanionAppIdString _) = Just $ defaultEvent "SetNewWalletCompanionAppId"
+  toEvent (WalletNicknameInputAction inputAction) = toEvent inputAction
+  toEvent (WalletIdInputAction inputAction) = toEvent inputAction
+  toEvent (SetRemoteWalletInfo _) = Nothing
   toEvent (SaveNewWallet _) = Just $ defaultEvent "SaveNewWallet"
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
   toEvent (SetScreen _) = Just $ defaultEvent "SetScreen"

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -14,7 +14,7 @@ import Halogen.HTML.Properties (href, src)
 import Images (marloweRunNavLogo, marloweRunNavLogoDark)
 import Marlowe.Semantics (PubKey, Slot)
 import Material.Icons (Icon(..), icon_)
-import Play.Lenses (_cards, _contractsState, _menuOpen, _newWalletNickname, _newWalletCompanionAppIdString, _newWalletInfo, _screen, _selectedContract, _templateState, _walletDetails, _walletLibrary)
+import Play.Lenses (_cards, _contractsState, _menuOpen, _walletIdInput, _walletNicknameInput, _remoteWalletInfo, _screen, _selectedContract, _templateState, _walletDetails, _walletLibrary)
 import Play.Types (Action(..), Card(..), Screen(..), State)
 import Prim.TypeError (class Warn, Text)
 import Template.View (contractSetupConfirmationCard, contractSetupScreen, templateLibraryCard)
@@ -132,11 +132,11 @@ renderCard currentSlot state card =
 
     assets = view _assets currentWalletDetails
 
-    newWalletNickname = view _newWalletNickname state
+    walletNicknameInput = view _walletNicknameInput state
 
-    newWalletCompanionAppIdString = view _newWalletCompanionAppIdString state
+    walletIdInput = view _walletIdInput state
 
-    newWalletInfo = view _newWalletInfo state
+    remoteWalletInfo = view _remoteWalletInfo state
 
     mSelectedContractState = preview _selectedContract state
 
@@ -167,7 +167,7 @@ renderCard currentSlot state card =
           [ classNames cardClasses ]
           $ closeButton
           <> case card of
-              SaveWalletCard mTokenName -> [ saveWalletCard walletLibrary newWalletNickname newWalletCompanionAppIdString newWalletInfo mTokenName ]
+              SaveWalletCard mTokenName -> [ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo mTokenName ]
               ViewWalletCard walletDetails -> [ walletDetailsCard walletDetails ]
               PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
               TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard ]

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -1,7 +1,8 @@
 module Template.Lenses
   ( _template
   , _contractNickname
-  , _roleWallets
+  , _roleWalletInputs
+  , _roleWalletInput
   , _templateContent
   , _slotContentStrings
   , _metaData
@@ -14,15 +15,20 @@ module Template.Lenses
   , _choiceDescriptions
   ) where
 
-import Data.Lens (Lens')
+import Prelude
+import Data.Lens (Lens', Traversal')
+import Data.Lens.At (at)
+import Data.Lens.Prism.Maybe (_Just)
 import Data.Lens.Record (prop)
 import Data.Map (Map)
 import Data.Symbol (SProxy(..))
+import InputField.Types (State) as InputField
 import Marlowe.Extended (Contract, ContractType, TemplateContent)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (TokenName)
 import Template.Types (State)
+import Template.Validation (RoleError)
 
 _template :: Lens' State ContractTemplate
 _template = prop (SProxy :: SProxy "template")
@@ -30,8 +36,11 @@ _template = prop (SProxy :: SProxy "template")
 _contractNickname :: Lens' State String
 _contractNickname = prop (SProxy :: SProxy "contractNickname")
 
-_roleWallets :: Lens' State (Map String String)
-_roleWallets = prop (SProxy :: SProxy "roleWallets")
+_roleWalletInputs :: Lens' State (Map TokenName (InputField.State RoleError))
+_roleWalletInputs = prop (SProxy :: SProxy "roleWalletInputs")
+
+_roleWalletInput :: TokenName -> Traversal' State (InputField.State RoleError)
+_roleWalletInput tokenName = _roleWalletInputs <<< at tokenName <<< _Just
 
 _templateContent :: Lens' State TemplateContent
 _templateContent = prop (SProxy :: SProxy "templateContent")

--- a/marlowe-dashboard-client/src/Template/Types.purs
+++ b/marlowe-dashboard-client/src/Template/Types.purs
@@ -4,19 +4,21 @@ module Template.Types
   ) where
 
 import Prelude
-import Analytics (class IsEvent, defaultEvent)
+import Analytics (class IsEvent, defaultEvent, toEvent)
 import Data.BigInteger (BigInteger)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))
+import InputField.Types (Action, State) as InputField
 import Marlowe.Extended (TemplateContent)
 import Marlowe.Extended.Template (ContractTemplate)
 import Marlowe.Semantics (TokenName)
-import WalletData.Types (WalletNickname)
+import Template.Validation (RoleError)
+import WalletData.Types (WalletLibrary)
 
 type State
   = { template :: ContractTemplate
     , contractNickname :: String
-    , roleWallets :: Map TokenName WalletNickname
+    , roleWalletInputs :: Map TokenName (InputField.State RoleError)
     , templateContent :: TemplateContent
     , slotContentStrings :: Map String String
     }
@@ -28,7 +30,8 @@ data Action
   | OpenSetupConfirmationCard
   | CloseSetupConfirmationCard
   | SetContractNickname String
-  | SetRoleWallet TokenName WalletNickname
+  | UpdateRoleWalletValidators WalletLibrary
+  | RoleWalletInputAction TokenName (InputField.Action RoleError)
   | SetSlotContent String String -- slot input comes from the HTML as a dateTimeString
   | SetValueContent String (Maybe BigInteger)
   | StartContract
@@ -42,7 +45,8 @@ instance actionIsEvent :: IsEvent Action where
   toEvent OpenSetupConfirmationCard = Nothing
   toEvent CloseSetupConfirmationCard = Nothing
   toEvent (SetContractNickname _) = Just $ defaultEvent "SetContractNickname"
-  toEvent (SetRoleWallet _ _) = Just $ defaultEvent "SetRoleWallet"
+  toEvent (UpdateRoleWalletValidators _) = Nothing
+  toEvent (RoleWalletInputAction _ inputFieldAction) = toEvent inputFieldAction
   toEvent (SetSlotContent _ _) = Just $ defaultEvent "SetSlotContent"
   toEvent (SetValueContent _ _) = Just $ defaultEvent "SetValueContent"
   toEvent StartContract = Just $ defaultEvent "StartContract"

--- a/marlowe-dashboard-client/src/Template/Validation.purs
+++ b/marlowe-dashboard-client/src/Template/Validation.purs
@@ -17,8 +17,10 @@ import Prelude
 import Data.BigInteger (BigInteger)
 import Data.Map (Map, isEmpty, mapMaybe, member)
 import Data.Maybe (Maybe(..))
+import InputField.Types (class InputFieldError, State)
+import InputField.State (validate)
 import Marlowe.Extended (TemplateContent(..))
-import Marlowe.Semantics (Slot)
+import Marlowe.Semantics (Slot, TokenName)
 import Marlowe.Slot (dateTimeStringToSlot)
 import WalletData.Types (WalletLibrary)
 
@@ -28,9 +30,9 @@ data RoleError
 
 derive instance eqRoleError :: Eq RoleError
 
-instance showRoleError :: Show RoleError where
-  show EmptyNickname = "Role nickname cannot be blank"
-  show NonExistentNickname = "Nickname not found in your wallet library"
+instance inputFieldErrorRoleError :: InputFieldError RoleError where
+  inputErrorToString EmptyNickname = "Role nickname cannot be blank"
+  inputErrorToString NonExistentNickname = "Nickname not found in your wallet library"
 
 data ParameterError
   = EmptyTimeout
@@ -39,25 +41,25 @@ data ParameterError
 
 derive instance eqParameterError :: Eq ParameterError
 
-instance showParameterError :: Show ParameterError where
-  show EmptyTimeout = "Timeout cannot be blank"
-  show PastTimeout = "Timeout date is past"
-  show BadDateTimeString = "Invalid timeout"
+instance inputFieldErrorParameterError :: InputFieldError ParameterError where
+  inputErrorToString EmptyTimeout = "Timeout cannot be blank"
+  inputErrorToString PastTimeout = "Timeout date is past"
+  inputErrorToString BadDateTimeString = "Invalid timeout"
 
-roleError :: String -> WalletLibrary -> Maybe RoleError
-roleError "" _ = Just EmptyNickname
+roleError :: WalletLibrary -> String -> Maybe RoleError
+roleError _ "" = Just EmptyNickname
 
-roleError nickname library =
-  if member nickname library then
+roleError walletLibrary walletNickname =
+  if member walletNickname walletLibrary then
     Nothing
   else
     Just NonExistentNickname
 
 -- note: we validate slot inputs against the dateTimeString that we get from HTML
-slotError :: String -> Slot -> Maybe ParameterError
-slotError "" _ = Just EmptyTimeout
+slotError :: Slot -> String -> Maybe ParameterError
+slotError _ "" = Just EmptyTimeout
 
-slotError dateTimeString currentSlot = case dateTimeStringToSlot dateTimeString of
+slotError currentSlot dateTimeString = case dateTimeStringToSlot dateTimeString of
   Just slot ->
     if slot <= currentSlot then
       Just PastTimeout
@@ -70,10 +72,10 @@ valueError :: BigInteger -> Maybe ParameterError
 valueError _ = Nothing
 
 ------------------------------------------------------------
-roleWalletsAreValid :: Map String String -> WalletLibrary -> Boolean
-roleWalletsAreValid roleWallets wallets = isEmpty $ mapMaybe (\value -> roleError value wallets) roleWallets
+roleWalletsAreValid :: Map TokenName (State RoleError) -> Boolean
+roleWalletsAreValid roleWallets = isEmpty $ mapMaybe (\input -> validate input) roleWallets
 
 templateContentIsValid :: TemplateContent -> Map String String -> Slot -> Boolean
 templateContentIsValid (TemplateContent { valueContent }) slotContentStrings currentSlot =
-  (isEmpty $ mapMaybe (\value -> slotError value currentSlot) slotContentStrings)
+  (isEmpty $ mapMaybe (\value -> slotError currentSlot value) slotContentStrings)
     && (isEmpty $ mapMaybe (\value -> valueError value) valueContent)

--- a/marlowe-dashboard-client/src/WalletData/Validation.purs
+++ b/marlowe-dashboard-client/src/WalletData/Validation.purs
@@ -13,6 +13,7 @@ import Data.Map (isEmpty, filter, member)
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (toCharArray)
 import Data.UUID (parseUUID)
+import InputField.Types (class InputFieldError)
 import Marlowe.PAB (PlutusAppId(..))
 import Network.RemoteData (RemoteData(..))
 import Types (WebData)
@@ -25,10 +26,10 @@ data WalletNicknameError
 
 derive instance eqWalletNicknameError :: Eq WalletNicknameError
 
-instance showWalletNicknameError :: Show WalletNicknameError where
-  show EmptyWalletNickname = "Nickname cannot be blank"
-  show DuplicateWalletNickname = "Nickname is already in use in your contacts"
-  show BadWalletNickname = "Nicknames can only contain letters and numbers"
+instance inputFieldErrorWalletNicknameError :: InputFieldError WalletNicknameError where
+  inputErrorToString EmptyWalletNickname = "Nickname cannot be blank"
+  inputErrorToString DuplicateWalletNickname = "Nickname is already in use in your contacts"
+  inputErrorToString BadWalletNickname = "Nicknames can only contain letters and numbers"
 
 walletNicknameError :: WalletLibrary -> WalletNickname -> Maybe WalletNicknameError
 walletNicknameError _ "" = Just EmptyWalletNickname
@@ -51,12 +52,12 @@ data WalletIdError
 
 derive instance eqWalletIdError :: Eq WalletIdError
 
-instance showWalletIdError :: Show WalletIdError where
-  show EmptyWalletId = "Wallet ID cannot be blank"
-  show DuplicateWalletId = "Wallet ID is already in your contacts"
-  show InvalidWalletId = "Wallet ID is not valid"
-  show UnconfirmedWalletId = "Looking up wallet..."
-  show NonexistentWalletId = "Wallet not found"
+instance inputeFieldErrorWalletIdError :: InputFieldError WalletIdError where
+  inputErrorToString EmptyWalletId = "Wallet ID cannot be blank"
+  inputErrorToString DuplicateWalletId = "Wallet ID is already in your contacts"
+  inputErrorToString InvalidWalletId = "Wallet ID is not valid"
+  inputErrorToString UnconfirmedWalletId = "Looking up wallet..."
+  inputErrorToString NonexistentWalletId = "Wallet not found"
 
 walletIdError :: WebData WalletInfo -> WalletLibrary -> String -> Maybe WalletIdError
 walletIdError _ _ "" = Just EmptyWalletId


### PR DESCRIPTION
This PR uses the new `InputField` component for role inputs in the contract setup screen. I'm not using it for contract parameters (yet), but that will be a sizable chunk of extra work (we'll have to generalise the inputs to cover numbers and datetimes as well as strings), and it's not urgent - we're not using slot parameters at the moment, and value parameters have a default value of zero, so they don't show up as invalid by default anyway. So I think I'd better stop here and focus on some other more urgent things for the initial release.

Note I've replaced the `Show` instance for errors with a proper custom `InputFieldError` class. I've also fixed a couple of things in the Pickup workflow that part 1 didn't get quite right.

UPDATE: I've pushed an unrelated modification that didn't feel like it was worth a whole PR - hiding PK parties from the account balances tab. This gets rid of the ugly load of zeros in the Escrow with Collateral contract.