### PR TITLE
SCP-2252 - Add trimmed down markdown processing to playground metadata

### DIFF
--- a/marlowe-playground-client/packages.dhall
+++ b/marlowe-playground-client/packages.dhall
@@ -178,6 +178,18 @@ let additions =
           , repo = "https://github.com/LiamGoodacre/purescript-filterable"
           , version = "v3.0.1"
           }
+      , markdown =
+          { dependencies =
+            [ "const", "datetime", "functors", "lists", "ordered-collections", "parsing", "partial", "precise", "prelude", "strings", "unicode", "validation" ]
+          , repo = "https://github.com/input-output-hk/purescript-markdown"
+          , version = "b51ee0e4aa04c9e6a5a70f2552a400c3f9cad439"
+          }
+      , precise =
+          { dependencies =
+            [ "arrays", "console", "effect", "exceptions", "gen", "integers", "lists", "numbers", "prelude", "strings" ]
+          , repo = "https://github.com/purescript-contrib/purescript-precise"
+          , version = "v5.1.0"
+          }
       }
 
 in  upstream ⫽ overrides ⫽ additions

--- a/marlowe-playground-client/spago-packages.nix
+++ b/marlowe-playground-client/spago-packages.nix
@@ -665,6 +665,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "markdown" = pkgs.stdenv.mkDerivation {
+        name = "markdown";
+        version = "b51ee0e4aa04c9e6a5a70f2552a400c3f9cad439";
+        src = pkgs.fetchgit {
+          url = "https://github.com/input-output-hk/purescript-markdown";
+          rev = "b51ee0e4aa04c9e6a5a70f2552a400c3f9cad439";
+          sha256 = "0xp41wg1p4dwivgpy121mzpimkdakg0m83hx8ypb5ayjk98vvyf0";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "math" = pkgs.stdenv.mkDerivation {
         name = "math";
         version = "v2.1.1";
@@ -821,6 +833,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "numbers" = pkgs.stdenv.mkDerivation {
+        name = "numbers";
+        version = "v7.0.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/sharkdp/purescript-numbers.git";
+          rev = "6262a5f17dcdfba11dfae03f4fa8eec02f7ed29f";
+          sha256 = "1l9s22fkjf7wc0zd3wjax4hlif7gqh6ij0ijb8sq20mfh2xl4hj8";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "ordered-collections" = pkgs.stdenv.mkDerivation {
         name = "ordered-collections";
         version = "v1.6.1";
@@ -888,6 +912,18 @@ let
           url = "https://github.com/felixSchl/purescript-pipes.git";
           rev = "a9533035f6fe8e59a65c6d11a3a7c767f3c9ae67";
           sha256 = "0vl37f42dy4w4hswiay22w0n14k7sr670x54iwn7428larzrzs8y";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
+    "precise" = pkgs.stdenv.mkDerivation {
+        name = "precise";
+        version = "v5.1.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/purescript-contrib/purescript-precise";
+          rev = "5bedbf520022ce15b03a70474d9cf1a8dc3e6b2d";
+          sha256 = "1zashxhy100r0pgmnjxbqjf9q9bml9rwm0hqqcxzkd2l0llxaggc";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";
@@ -1245,7 +1281,7 @@ let
         name = "unsafe-reference";
         version = "v3.0.1";
         src = pkgs.fetchgit {
-          url = "https://github.com/purescript-contrib/purescript-unsafe-reference";
+          url = "https://github.com/purescript-contrib/purescript-unsafe-reference.git";
           rev = "79d7de7b9351346a73e6c060d80532c95ba1c7c1";
           sha256 = "0q758dz59qz0li4s3w1qcg921xp5i5rh6i1l611iv7rr8cbj11al";
         };

--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -20,6 +20,7 @@ You can edit this file as you like.
   , "halogen"
   , "matryoshka"
   , "node-fs"
+  , "markdown"
   , "prelude"
   , "psci-support"
   , "remotedata"

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -36,6 +36,7 @@ import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
 import SimulationPage.Types (Action(..), ActionInput(..), ActionInputId, BottomPanelView(..), ExecutionState(..), InitialConditionsRecord, MarloweEvent(..), State, _SimulationRunning, _bottomPanelState, _currentContract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _slot, _transactionError, _transactionWarnings, otherActionsParty)
 import Simulator (hasHistory, inFuture)
+import Text.Markdown.TrimmedInline (markdownToHTML)
 
 render ::
   forall m.
@@ -249,7 +250,7 @@ integerTemplateParameters explanations actionGen typeName title prefix content =
                             , marloweActionInput (actionGen typeName key) value
                             ]
                               <> [ div [ classes [ ClassName "action-group-explanation" ] ]
-                                    $ maybe [] (\explanation -> [ text ("“" <> explanation <> "„") ])
+                                    $ maybe [] (\explanation -> [ text "“" ] <> markdownToHTML explanation <> [ text "„" ])
                                     $ Map.lookup key explanations
                                 ]
                           )
@@ -361,7 +362,7 @@ participant metadata state party actionInputs =
         [ div [ classes [ ClassName "action-group-title" ] ] [ h6_ [ em_ [ text "Participant ", strong_ [ text partyName ] ] ] ] ]
           <> [ div [ classes [ ClassName "action-group-explanation" ] ]
                 ( case party of
-                    Role roleName -> maybe [] (\explanation -> [ text ("“" <> explanation <> "„") ]) $ Map.lookup roleName metadata.roleDescriptions
+                    Role roleName -> maybe [] (\explanation -> [ text "“" ] <> markdownToHTML explanation <> [ text "„" ]) $ Map.lookup roleName metadata.roleDescriptions
                     _ -> []
                 )
             ]
@@ -403,7 +404,7 @@ inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwn
               <> ( maybe []
                     ( \explanation ->
                         [ div [ class_ (ClassName "action-explanation") ]
-                            [ text ("“" <> explanation <> "„") ]
+                            ([ text "“" ] <> markdownToHTML explanation <> [ text "„" ])
                         ]
                     )
                     $ Map.lookup choiceName metadata.choiceDescriptions

--- a/marlowe-playground-client/src/Text/Markdown/TrimmedInline.purs
+++ b/marlowe-playground-client/src/Text/Markdown/TrimmedInline.purs
@@ -1,0 +1,87 @@
+module Text.Markdown.TrimmedInline
+  ( markdownToHTML
+  ) where
+
+import Prelude
+import Control.Monad.Reader (ReaderT, ask, runReaderT)
+import Control.Monad.State (StateT, evalStateT, get, modify)
+import Data.Array as A
+import Data.Either (Either(..))
+import Data.Identity (Identity)
+import Data.List (List(..))
+import Data.List as L
+import Data.Maybe as M
+import Data.Newtype (unwrap)
+import Data.Traversable (traverse)
+import Halogen.HTML (HTML)
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Text.Markdown.SlamDown as SD
+import Text.Markdown.SlamDown.Parser (parseMd)
+import Text.Markdown.SlamDown.Pretty (prettyPrintMd)
+
+-- This code is a trimmed down version of the renderer in https://github.com/slamdata/purescript-markdown-halogen/
+type FreshT m
+  = ReaderT String (StateT Int m)
+
+type Fresh
+  = FreshT Identity
+
+fresh ::
+  forall m.
+  Monad m =>
+  FreshT m String
+fresh = do
+  prefix <- ask
+  n <- get :: FreshT m Int
+  void $ modify (_ + 1)
+  pure (prefix <> "-" <> show n)
+
+runFreshT ::
+  forall m.
+  Monad m =>
+  String ->
+  FreshT m
+    ~> m
+runFreshT prefix m =
+  evalStateT
+    (runReaderT m prefix)
+    1
+
+runFresh ::
+  forall a.
+  String ->
+  Fresh a ->
+  a
+runFresh prefix =
+  unwrap
+    <<< runFreshT prefix
+
+type FreshRenderer v m a
+  = a -> Fresh (HTML v m)
+
+renderInline :: forall v m. SD.Inline String -> Fresh (HTML v m)
+renderInline i = case i of
+  SD.Str s -> pure $ HH.text s
+  SD.Entity s -> pure $ HH.text s
+  SD.Space -> pure $ HH.text " "
+  SD.SoftBreak -> pure $ HH.text "\n"
+  SD.LineBreak -> pure $ HH.br_
+  SD.Emph is -> HH.em_ <$> traverse renderInline (A.fromFoldable is)
+  SD.Strong is -> HH.strong_ <$> traverse renderInline (A.fromFoldable is)
+  SD.Code _ c -> pure $ HH.code_ [ HH.text c ]
+  SD.Link body tgt -> do
+    let
+      href (SD.InlineLink url) = url
+
+      href (SD.ReferenceLink tgt') = M.maybe "" ("#" <> _) tgt'
+    HH.a [ HP.href $ href tgt ] <$> traverse renderInline (A.fromFoldable body)
+  other -> pure $ HH.text (prettyPrintMd (SD.SlamDown $ L.singleton $ SD.Paragraph $ L.singleton other :: SD.SlamDown))
+
+renderSlamDownInline :: forall a p. SD.Inline String -> HTML p a
+renderSlamDownInline i = runFresh "markdown" (renderInline i)
+
+markdownToHTML :: forall a p. String -> Array (HTML p a)
+markdownToHTML md = case parseMd md of
+  Right (SD.SlamDown (Cons (SD.Paragraph singleLine) Nil)) -> map renderSlamDownInline (A.fromFoldable singleLine)
+  _ -> [ HH.text md ]

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -209,7 +209,7 @@ button.minus-btn:hover {
   margin-top: 1rem;
 }
 
-.participants em {
+.participants > em {
   display: inline-block;
   margin-bottom: 0.5rem;
 }
@@ -263,7 +263,7 @@ button.minus-btn:hover {
   align-self: center;
 }
 
-.templates li {
+.templates > li {
   margin: 1.5rem 0;
 }
 
@@ -271,7 +271,7 @@ button.minus-btn:hover {
   margin: 0 0 1rem 0;
 }
 
-.templates em {
+.templates > em {
   display: inline-block;
 }
 


### PR DESCRIPTION
This PR applies a trimmed down version of SlamDown before showing metadata in the Marlowe Playground

Deployed to: http://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
