### PR TITLE
Notify hls/ghcide that we are using a patched ghc

### DIFF
--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -80,6 +80,8 @@ let
       packages.ghcide.patches = [ ../../patches/ghcide_partial_iface.patch ];
       # Workaround for https://github.com/haskell/haskell-language-server/issues/1160
       packages.haskell-language-server.patches = lib.mkIf stdenv.isDarwin [ ../../patches/haskell-language-server-dynamic.patch ];
+      # See https://github.com/haskell/haskell-language-server/pull/1382#issuecomment-780472005
+      packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;
     }];
   };
 


### PR DESCRIPTION
Enable hls/ghcide special flag to make it aware that we are using a patched ghc, that can handle `UnboxedTuples`.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
