### PR TITLE
Add Plutus implementation of head (fix #3187).

### DIFF
--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.List (map, filter, listToMaybe, uniqueElement, findIndices, findIndex, foldr, reverse, zip, (++), (!!)) where
+module PlutusTx.List (map, filter, listToMaybe, uniqueElement, findIndices, findIndex, foldr, reverse, zip, (++), (!!), head) where
 
 import qualified PlutusTx.Builtins as Builtins
-import           Prelude           hiding (Eq (..), all, any, elem, filter, foldl, foldr, length, map, null, reverse,
-                                    zip, (!!), (&&), (++), (||))
+import           Prelude           hiding (Eq (..), all, any, elem, filter, foldl, foldr, head, length, map, null,
+                                    reverse, zip, (!!), (&&), (++), (||))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 
@@ -103,3 +103,9 @@ zip :: [a] -> [b] -> [(a,b)]
 zip []     _bs    = []
 zip _as    []     = []
 zip (a:as) (b:bs) = (a,b) : zip as bs
+
+{-# INLINABLE head #-}
+-- | Plutus Tx version of 'Data.List.head'.
+head :: [a] -> a
+head []      = Builtins.error ()
+head (x : _) = x

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -87,9 +87,9 @@ import           PlutusTx.Traversable as Traversable
 import           Prelude              as Prelude hiding (Applicative (..), Eq (..), Foldable (..), Functor (..),
                                                   Monoid (..), Num (..), Ord (..), Rational, Semigroup (..),
                                                   Traversable (..), all, and, any, concat, concatMap, const, divMod,
-                                                  either, elem, error, filter, fst, id, length, map, max, maybe, min,
-                                                  not, notElem, null, or, quotRem, reverse, round, sequence, snd, zip,
-                                                  (!!), ($), (&&), (++), (<$>), (||))
+                                                  either, elem, error, filter, fst, head, id, length, map, max, maybe,
+                                                  min, not, notElem, null, or, quotRem, reverse, round, sequence, snd,
+                                                  zip, (!!), ($), (&&), (++), (<$>), (||))
 import           Prelude              as Prelude (maximum, minimum)
 
 -- this module does lots of weird stuff deliberately


### PR DESCRIPTION
The problem in #3187 is that `PlutusTx.Prelude` re-exports `Prelude.head` which fails to compile. The fix is to add Plutus's own implementation.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
