### PR TITLE
Zero Coupon Bond example - fixing a parameter name.

### DIFF
--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -184,7 +184,7 @@ zeroCouponBond :: String
 zeroCouponBond =
   """
     const discountedPrice: Value = ConstantParam("Discounted price");
-    const notional: Value = ConstantParam("Notional");
+    const notionalPrice: Value = ConstantParam("Notional price");
 
     const investor: Party = Role("Investor");
     const issuer: Party = Role("Issuer");

--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -201,7 +201,7 @@ zeroCouponBond =
 
     const contract: Contract =
         transfer(initialExchange, investor, issuer, discountedPrice,
-            transfer(maturityExchangeTimeout, issuer, investor, notional,
+            transfer(maturityExchangeTimeout, issuer, investor, notionalPrice,
                 Close))
 
     return contract;

--- a/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
+++ b/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
@@ -83,7 +83,7 @@ all =
                     , valueContent:
                         Map.fromFoldable
                           [ "Discounted price" /\ fromInt 50
-                          , "Notional" /\ fromInt 100
+                          , "Notional price" /\ fromInt 100
                           ]
                     }
                 )

--- a/marlowe-playground-server/contracts/ZeroCouponBond.hs
+++ b/marlowe-playground-server/contracts/ZeroCouponBond.hs
@@ -6,9 +6,9 @@ import           Language.Marlowe.Extended
 main :: IO ()
 main = print . pretty $ contract
 
-discountedPrice, notional :: Value
+discountedPrice, notionalPrice :: Value
 discountedPrice = ConstantParam "Discounted price"
-notional = ConstantParam "Notional"
+notionalPrice = ConstantParam "Notional price"
 
 investor, issuer :: Party
 investor = Role "Investor"
@@ -27,5 +27,5 @@ transfer timeout from to amount continuation =
 
 contract :: Contract
 contract = transfer initialExchange investor issuer discountedPrice
-         $ transfer maturityExchangeTimeout issuer investor notional
+         $ transfer maturityExchangeTimeout issuer investor notionalPrice
            Close

--- a/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
@@ -42,8 +42,8 @@ ada = Token "" ""
 discountedPrice :: Value
 discountedPrice = ConstantParam "Discounted price"
 
-notional :: Value
-notional = ConstantParam "Notional"
+notionalPrice :: Value
+notionalPrice = ConstantParam "Notional price"
 
 investor :: Party
 investor = Role "Investor"
@@ -69,5 +69,5 @@ transfer timeout from to amount continuation =
 fullExtendedContract :: Contract
 fullExtendedContract =
   transfer initialExchange investor issuer discountedPrice
-    $ transfer maturityExchangeTimeout issuer investor notional
+    $ transfer maturityExchangeTimeout issuer investor notionalPrice
         Close


### PR DESCRIPTION
The parameter name in the contract didn't match the parameter name in the metadata.