### PR TITLE
SCP-2263: Replace eventful memory backend with TVar

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-pab.nix
@@ -160,6 +160,7 @@
           "Plutus/PAB/Db/Eventful/ContractDefinitionStore"
           "Plutus/PAB/Db/Eventful/ContractStore"
           "Plutus/PAB/Db/Eventful/Query"
+          "Plutus/PAB/Db/Memory/ContractStore"
           "Plutus/PAB/Effects/Contract"
           "Plutus/PAB/Effects/Contract/ContractTest"
           "Plutus/PAB/Effects/Contract/Builtin"

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -82,6 +82,7 @@ library
         Plutus.PAB.Db.Eventful.ContractDefinitionStore
         Plutus.PAB.Db.Eventful.ContractStore
         Plutus.PAB.Db.Eventful.Query
+        Plutus.PAB.Db.Memory.ContractStore
         Plutus.PAB.Effects.Contract
         Plutus.PAB.Effects.Contract.ContractTest
         Plutus.PAB.Effects.Contract.Builtin

--- a/plutus-pab/plutus-pab.yaml
+++ b/plutus-pab/plutus-pab.yaml
@@ -42,5 +42,5 @@ endpointTimeout: 5
 
 # Optional EKG Server Config
 # ----
-# monitoringConfig:
-#   monitoringPort: 9090
+monitoringConfig:
+  monitoringPort: 9090

--- a/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
+++ b/plutus-pab/src/Plutus/PAB/Db/Memory/ContractStore.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators    #-}
+{-
+
+A handler for the 'ContractStore'  effect that stores everything in a TVar.
+
+-}
+module Plutus.PAB.Db.Memory.ContractStore(
+    InMemContractInstanceState(..)
+    , handleContractStore
+    , InMemInstances
+    , initialInMemInstances
+    ) where
+
+import           Control.Concurrent.STM      (TVar)
+import qualified Control.Concurrent.STM      as STM
+import           Control.Lens                (_Just, at, makeLensesFor, preview, set)
+import           Control.Monad.Freer         (Eff, LastMember, Member, type (~>))
+import           Control.Monad.Freer.Error   (Error, throwError)
+import           Control.Monad.Freer.Reader  (Reader, ask)
+import           Control.Monad.IO.Class      (MonadIO (..))
+import           Data.Aeson                  (Value)
+import           Data.Map                    (Map)
+import           Plutus.Contract.State       (ContractResponse)
+import           Plutus.PAB.Effects.Contract (ContractStore, State)
+import qualified Plutus.PAB.Effects.Contract as Contract
+import           Plutus.PAB.Events.Contract  (ContractPABRequest)
+import           Plutus.PAB.Types            (PABError (..))
+import           Plutus.PAB.Webserver.Types  (ContractActivationArgs)
+import           Wallet.Types                (ContractInstanceId)
+
+-- | The current state of a contract instance
+data InMemContractInstanceState t =
+    InMemContractInstanceState
+        { _contractDef   :: ContractActivationArgs (Contract.ContractDef t)
+        , _contractState :: Contract.State t
+        }
+
+makeLensesFor [("_contractState", "contractState")] ''InMemContractInstanceState
+
+newtype InMemInstances t = InMemInstances { unInMemInstances :: TVar (Map ContractInstanceId (InMemContractInstanceState t)) }
+
+initialInMemInstances :: forall t. IO (InMemInstances t)
+initialInMemInstances = InMemInstances <$> STM.newTVarIO mempty
+
+-- | Handle the 'ContractStore' effect by writing the state to the
+--   TVar in 'SimulatorState'
+handleContractStore ::
+    forall t effs.
+    ( LastMember IO effs
+    , Member (Reader (InMemInstances t)) effs
+    , Member (Error PABError) effs
+    , State t ~ ContractResponse Value Value Value ContractPABRequest
+    )
+    => ContractStore t
+    ~> Eff effs
+handleContractStore = \case
+    Contract.PutState definition instanceId state -> do
+        instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
+        liftIO $ STM.atomically $ do
+            let instState = InMemContractInstanceState{_contractDef = definition, _contractState = state}
+            STM.modifyTVar instancesTVar (set (at instanceId) (Just instState))
+    Contract.GetState instanceId -> do
+        instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
+        result <- preview (at instanceId . _Just . contractState) <$> liftIO (STM.readTVarIO instancesTVar)
+        case result of
+            Just s  -> pure s
+            Nothing -> throwError (ContractInstanceNotFound instanceId)
+    Contract.GetActiveContracts -> do
+        instancesTVar <- unInMemInstances <$> ask @(InMemInstances t)
+        fmap _contractDef <$> liftIO (STM.readTVarIO instancesTVar)
+    Contract.PutStartInstance{} -> pure ()
+    Contract.PutStopInstance{} -> pure ()


### PR DESCRIPTION
* When the `InMemory` backend is selected we now handle the `ContractStore` effect by writing everything to a TVar
  * Previously the sqlite memory backend was used, which resulted in a massive memory leak because the old events weren't discarded

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
