### PR TITLE
Fix SatInt (take 2)

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -306,6 +306,20 @@
           };
         };
       tests = {
+        "satint-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."test-framework" or (errorHandler.buildDepError "test-framework"))
+            (hsPkgs."test-framework-hunit" or (errorHandler.buildDepError "test-framework-hunit"))
+            (hsPkgs."test-framework-quickcheck2" or (errorHandler.buildDepError "test-framework-quickcheck2"))
+            (hsPkgs."HUnit" or (errorHandler.buildDepError "HUnit"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "plutus-core/satint-test" ];
+          mainPath = [ "TestSatInt.hs" ];
+          };
         "plutus-core-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))

--- a/nix/pkgs/haskell/materialized-unix/default.nix
+++ b/nix/pkgs/haskell/materialized-unix/default.nix
@@ -12,6 +12,9 @@
         "warp".flags.network-bytestring = false;
         "warp".flags.warp-debug = false;
         "groups".revision = (((hackage."groups")."0.5.2").revisions).default;
+        "test-framework-hunit".revision = (((hackage."test-framework-hunit")."0.3.0.2").revisions).default;
+        "test-framework-hunit".flags.base4 = true;
+        "test-framework-hunit".flags.base3 = false;
         "Stream".revision = (((hackage."Stream")."0.4.7.2").revisions).default;
         "http-client".revision = (((hackage."http-client")."0.6.4.1").revisions).default;
         "http-client".flags.network-uri = true;
@@ -107,6 +110,7 @@
         "unliftio".revision = (((hackage."unliftio")."0.2.14").revisions).default;
         "servant-websockets".revision = (((hackage."servant-websockets")."2.0.0").revisions).default;
         "indexed-traversable-instances".revision = (((hackage."indexed-traversable-instances")."0.1").revisions).default;
+        "extensible-exceptions".revision = (((hackage."extensible-exceptions")."0.1.1.4").revisions).default;
         "unix".revision = (((hackage."unix")."2.7.2.2").revisions).default;
         "SHA".revision = (((hackage."SHA")."1.6.4.4").revisions).default;
         "SHA".flags.exe = false;
@@ -404,6 +408,7 @@
         "witherable".revision = (((hackage."witherable")."0.4.1").revisions).default;
         "process-extras".revision = (((hackage."process-extras")."0.7.4").revisions).default;
         "setenv".revision = (((hackage."setenv")."0.1.1.3").revisions).default;
+        "test-framework".revision = (((hackage."test-framework")."0.8.2.0").revisions).default;
         "cryptohash-sha1".revision = (((hackage."cryptohash-sha1")."0.11.100.1").revisions).default;
         "serialise".revision = (((hackage."serialise")."0.2.3.0").revisions).default;
         "serialise".flags.newtime15 = true;
@@ -565,6 +570,7 @@
         "monad-loops".flags.base4 = true;
         "Unique".revision = (((hackage."Unique")."0.4.7.8").revisions).default;
         "unbounded-delays".revision = (((hackage."unbounded-delays")."0.1.1.1").revisions).default;
+        "test-framework-quickcheck2".revision = (((hackage."test-framework-quickcheck2")."0.3.0.5").revisions).default;
         "hedgehog".revision = (((hackage."hedgehog")."1.0.5").revisions).default;
         "hspec-core".revision = (((hackage."hspec-core")."2.7.9").revisions).default;
         "cborg".revision = (((hackage."cborg")."0.2.5.0").revisions).default;
@@ -641,6 +647,7 @@
         "array".revision = (((hackage."array")."0.5.4.0").revisions).default;
         "ekg".revision = (((hackage."ekg")."0.4.0.15").revisions).default;
         "loch-th".revision = (((hackage."loch-th")."0.2.2").revisions).default;
+        "xml".revision = (((hackage."xml")."1.3.14").revisions).default;
         "path-pieces".revision = (((hackage."path-pieces")."0.2.1").revisions).default;
         "conduit-extra".revision = (((hackage."conduit-extra")."1.3.5").revisions).default;
         "erf".revision = (((hackage."erf")."2.0.0.0").revisions).default;

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -286,6 +286,21 @@ library
         unordered-containers -any,
         witherable -any
 
+test-suite satint-test
+  import: lang
+  type:              exitcode-stdio-1.0
+  main-is:           TestSatInt.hs
+  ghc-options:       -Wall
+  build-depends:     base >=4.9 && <5,
+                     test-framework,
+                     test-framework-hunit,
+                     test-framework-quickcheck2,
+                     HUnit,
+                     QuickCheck,
+                     plutus-core
+  default-language:  Haskell2010
+  hs-source-dirs:    plutus-core/satint-test
+
 test-suite plutus-core-test
     import: lang
     type: exitcode-stdio-1.0
@@ -320,6 +335,7 @@ test-suite plutus-core-test
         tasty -any,
         tasty-golden -any,
         tasty-hedgehog -any,
+        tasty-hunit -any,
         tasty-hunit -any,
         text -any,
         transformers -any

--- a/plutus-core/plutus-core/satint-test/TestSatInt.hs
+++ b/plutus-core/plutus-core/satint-test/TestSatInt.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+-- These tests are deliberately not in the same style as our other tests, but rather mirror the tests
+-- in safeint, since I want to upstream this in due course.
+module Main where
+
+import           Control.Exception                    as E
+import           Data.List
+import           Data.Maybe
+import           Data.SatInt
+import           Test.Framework                       as TF
+import           Test.Framework.Providers.HUnit
+import           Test.Framework.Providers.QuickCheck2
+import           Test.HUnit                           as T
+import           Test.QuickCheck
+
+main :: IO ()
+main = defaultMain tests
+
+isArithException :: SatInt -> IO Bool
+isArithException n = E.catch (n `seq` return False)
+                             (\ (_ :: ArithException) -> return True)
+
+saturatesPos :: forall a . (Integral a, Bounded a) => a -> Bool
+saturatesPos n = n == maxBound
+
+saturatesNeg :: forall a . (Integral a, Bounded a) => a -> Bool
+saturatesNeg n = n == minBound
+
+behavesOk :: (forall a. Integral a => a) -> Bool
+behavesOk n =
+    let
+        sat = (n :: SatInt)
+        int = (n :: Integer)
+        lb = toInteger (minBound :: SatInt)
+        ub = toInteger (maxBound :: SatInt)
+    in if lb <= int && int <= ub then toInteger sat == int
+    else if int < lb then saturatesNeg sat
+    else if int > ub then saturatesPos sat
+    else False
+
+unitTest :: Assertable t => TestName -> t -> TF.Test
+unitTest msg p = testCase msg (T.assert p)
+
+wordSize :: Int
+wordSize = fromJust (find (\ n -> 2 ^ n == (0 :: Word)) [8,16,32,64,128])
+
+tests :: [TF.Test]
+tests =
+  [ unitTest "0"       ((0 :: SatInt) + 0 == 0),
+    unitTest "max+"    (saturatesPos ((maxBound :: SatInt) + 1)),
+    unitTest "min-"    (saturatesNeg ((minBound :: SatInt) - 1)),
+    unitTest "1/0"     (isArithException (1 `div` 0)),
+    unitTest "min*-1"  (saturatesPos ((minBound :: SatInt) * (-1))),
+    unitTest "min/-1"  (saturatesNeg ((minBound :: SatInt) `div` (-1))),
+    unitTest "max/2*2" (((maxBound :: SatInt) `div` 2) * 2 == (maxBound :: SatInt) - 1),
+    unitTest "max+min" ((maxBound :: SatInt) + (minBound :: SatInt) == -1),
+    unitTest "max+*"   (saturatesPos ((2 :: SatInt) ^ (wordSize `div` 2) * 2 ^ (wordSize `div` 2 - 1))),
+    unitTest "min-*"   (saturatesNeg (negate ((2 :: SatInt) ^ (wordSize `div` 2)) * 2 ^ (wordSize `div` 2 - 1))),
+    testProperty "*"   (propBinOp (*)),
+    testProperty "+"   (propBinOp (+)),
+    testProperty "-"   (propBinOp (-)),
+    testProperty "div" (propBinOp div),
+    testProperty "mod" (propBinOp mod),
+    testProperty "quot"(propBinOp quot),
+    testProperty "rem" (propBinOp rem),
+    testProperty "lcm" (propBinOp lcm),
+    testProperty "gcd" (propBinOp gcd)
+  ]
+
+anyInt :: Gen Int
+anyInt = choose (minBound, maxBound)
+
+propBinOp :: (forall a. Integral a => a -> a -> a) -> Property
+propBinOp (!) = forAll anyInt $ \ x ->
+                forAll anyInt $ \ y ->
+                property $ behavesOk (fromIntegral x ! fromIntegral y)

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -7,7 +7,7 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MagicHash          #-}
 {-# LANGUAGE UnboxedTuples      #-}
-module Data.SatInt (SatInt(..), fromSat, toSat) where
+module Data.SatInt (SatInt) where
 
 import           Control.DeepSeq            (NFData)
 import           Data.Aeson                 (FromJSON, ToJSON)
@@ -17,22 +17,16 @@ import           GHC.Num
 import           GHC.Real
 import           Language.Haskell.TH.Syntax (Lift)
 
-newtype SatInt = SI Int
+newtype SatInt = SI { unSatInt :: Int }
     deriving newtype (NFData, Bits, FiniteBits)
     deriving Lift
     deriving (FromJSON, ToJSON) via Int
 
-fromSat :: SatInt -> Int
-fromSat (SI x) = x
-
-toSat :: Int -> SatInt
-toSat = SI
-
 instance Show SatInt where
-  showsPrec p x = showsPrec p (fromSat x)
+  showsPrec p x = showsPrec p (unSatInt x)
 
 instance Read SatInt where
-  readsPrec p xs = [ (toSat x, r) | (x, r) <- readsPrec p xs ]
+  readsPrec p xs = [ (SI x, r) | (x, r) <- readsPrec p xs ]
 
 instance Eq SatInt where
   SI x == SI y = eqInt x y
@@ -77,7 +71,7 @@ instance Enum SatInt where
   succ (SI x) = SI (succ x)
   pred (SI x) = SI (pred x)
   toEnum                = SI
-  fromEnum              = fromSat
+  fromEnum              = unSatInt
 
   {-# INLINE enumFrom #-}
   enumFrom (SI (I# x)) = eftInt x maxInt#
@@ -250,24 +244,57 @@ quotRemSI a@(I# _) b@(I# _) = (SI (a `quotInt` b), SI (a `remInt` b))
 divModSI ::  Int -> Int -> (SatInt, SatInt)
 divModSI x@(I# _) y@(I# _) = (SI (x `divInt` y), SI (x `modInt` y))
 
+{-
+'addIntC#', 'subIntC#', and 'mulIntMayOflow#' have tricky returns:
+all of them return non-zero (*not* necessarily 1) in the case of an overflow,
+so we can't use 'isTrue#'; and the first two return a truncated value in
+case of overflow, but this is *not* the same as the saturating result,
+but rather a bitwise truncation that is typically not what we want.
+
+So we have to case on the result, and then do some logic to work out what
+kind of overflow we're facing, and pick the correct result accordingly.
+-}
+
 plusSI :: SatInt -> SatInt -> SatInt
 plusSI (SI (I# x#)) (SI (I# y#)) =
-  case addIntC# x# y# of
-    (# r#, _ #) -> SI (I# r#)
+  case addIntC# x# y#  of
+    (# r#, 0# #) -> SI (I# r#)
+    -- Overflow
+    _ ->
+      if      isTrue# ((x# ># 0#) `andI#` (y# ># 0#)) then maxBound
+      else if isTrue# ((x# <# 0#) `andI#` (y# <# 0#)) then minBound
+      -- x and y have opposite signs, and yet we've overflowed, should
+      -- be impossible
+      else overflowError
 
 minusSI :: SatInt -> SatInt -> SatInt
 minusSI (SI (I# x#)) (SI (I# y#)) =
   case subIntC# x# y# of
-    (# r#, _ #) -> SI (I# r#)
+    (# r#, 0# #) -> SI (I# r#)
+    -- Overflow
+    _ ->
+      if      isTrue# ((x# >=# 0#) `andI#` (y# <# 0#)) then maxBound
+      else if isTrue# ((x# <=# 0#) `andI#` (y# ># 0#)) then minBound
+      -- x and y have the same sign, and yet we've overflowed, should
+      -- be impossible
+      else overflowError
 
 timesSI :: SatInt -> SatInt -> SatInt
 timesSI (SI (I# x#)) (SI (I# y#)) =
   case mulIntMayOflo# x# y# of
-    0# -> SI (I# (x# *# y#))
-    _  -> maxBound
+      0# -> SI (I# (x# *# y#))
+      -- Overflow
+      _ ->
+          if      isTrue# ((x# ># 0#) `andI#` (y# ># 0#)) then maxBound
+          else if isTrue# ((x# ># 0#) `andI#` (y# <# 0#)) then minBound
+          else if isTrue# ((x# <# 0#) `andI#` (y# ># 0#)) then minBound
+          else if isTrue# ((x# <# 0#) `andI#` (y# <# 0#)) then maxBound
+          -- Logically unreachable unless x or y is 0, in which case
+          -- it should be impossible to overflow
+          else overflowError
 
 {-# RULES
-"fromIntegral/Int->SatInt"     fromIntegral = toSat
+"fromIntegral/Int->SatInt"     fromIntegral = SI
 "fromIntegral/SatInt->SatInt" fromIntegral = id :: SatInt -> SatInt
   #-}
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -80,10 +80,6 @@ module PlutusCore.Evaluation.Machine.ExBudget
     , ToExMemory(..)
     , ExBudgetBuiltin(..)
     , ExRestrictingBudget(..)
-    , isNegativeBudget
-    , minusExCPU
-    , minusExMemory
-    , minusExBudget
     )
 where
 
@@ -136,19 +132,3 @@ instance Pretty ExBudget where
 newtype ExRestrictingBudget = ExRestrictingBudget ExBudget deriving (Show, Eq)
     deriving (Semigroup, Monoid) via (GenericSemigroupMonoid ExBudget)
     deriving newtype (Pretty, PrettyBy config, NFData)
-
-isNegativeBudget :: ExRestrictingBudget -> Bool
-isNegativeBudget (ExRestrictingBudget (ExBudget cpu mem)) = cpu < 0 || mem < 0
-
--- | @(-)@ on 'ExCPU'.
-minusExCPU :: ExCPU -> ExCPU -> ExCPU
-minusExCPU = coerce $ (-) @CostingInteger
-
--- | @(-)@ on 'ExMemory'.
-minusExMemory :: ExMemory -> ExMemory -> ExMemory
-minusExMemory = coerce $ (-) @CostingInteger
-
--- | Subtract an 'ExBudget' from an 'ExRestrictingBudget'.
-minusExBudget :: ExRestrictingBudget -> ExBudget -> ExRestrictingBudget
-ExRestrictingBudget (ExBudget cpuL memL) `minusExBudget` ExBudget cpuR memR =
-    ExRestrictingBudget $ ExBudget (cpuL `minusExCPU` cpuR) (memL `minusExMemory` memR)

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -162,7 +162,8 @@ deriving via (GenericExMemoryUsage (Term tyname name uni fun ann)) instance
     , Closed uni, uni `Everywhere` ExMemoryUsage, ExMemoryUsage fun
     ) => ExMemoryUsage (Term tyname name uni fun ann)
 deriving newtype instance ExMemoryUsage TyName
-deriving newtype instance ExMemoryUsage SatInt
+instance ExMemoryUsage SatInt where
+    memoryUsage n = memoryUsage (fromIntegral @SatInt @Int n)
 deriving newtype instance ExMemoryUsage ExMemory
 deriving newtype instance ExMemoryUsage Unique
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -113,8 +113,8 @@ restricting (ExRestrictingBudget (ExBudget cpuInit memInit)) = ExBudgetMode $ do
     let spend _ (ExBudget cpuToSpend memToSpend) = do
             cpuLeft <- readSTRef cpuRef
             memLeft <- readSTRef memRef
-            let cpuLeft' = cpuLeft `minusExCPU` cpuToSpend
-            let memLeft' = memLeft `minusExMemory` memToSpend
+            let cpuLeft' = cpuLeft - cpuToSpend
+            let memLeft' = memLeft - memToSpend
             -- Note that even if we throw an out-of-budget error, we still need to record
             -- what the final state was.
             writeSTRef cpuRef $! cpuLeft'


### PR DESCRIPTION
This changes `SatInt` to use a safer implementation, and adds tests (mirroring those in `safeint`, so they're a bit weird in case I want to upstream later).

Unfortuantely, this loses us some performance, but I think we just have to eat it. It's very unclear to me what is making the difference now, and inspecting the core of `ExBudgetingMode` shows everything inlining nicely still.
```
crowdfunding/1           1.464 ms       1.476 ms    +0.8%
crowdfunding/2           1.466 ms       1.481 ms    +1.0%
crowdfunding/3           1.465 ms       1.484 ms    +1.3%
crowdfunding/4           713.7 μs       724.3 μs    +1.5%
crowdfunding/5           713.8 μs       724.6 μs    +1.5%
future/1                 836.7 μs       848.7 μs    +1.4%
future/2                 1.718 ms       1.741 ms    +1.3%
future/3                 1.719 ms       1.744 ms    +1.5%
future/4                 2.138 ms       2.167 ms    +1.4%
future/5                 2.608 ms       2.642 ms    +1.3%
future/6                 2.185 ms       2.216 ms    +1.4%
future/7                 2.606 ms       2.640 ms    +1.3%
multisigSM/1             1.533 ms       1.550 ms    +1.1%
multisigSM/2             1.551 ms       1.572 ms    +1.4%
multisigSM/3             1.576 ms       1.597 ms    +1.3%
multisigSM/4             1.596 ms       1.619 ms    +1.4%
multisigSM/5             1.910 ms       1.925 ms    +0.8%
multisigSM/6             1.538 ms       1.552 ms    +0.9%
multisigSM/7             1.561 ms       1.583 ms    +1.4%
multisigSM/8             1.590 ms       1.607 ms    +1.1%
multisigSM/9             1.605 ms       1.629 ms    +1.5%
multisigSM/10            1.911 ms       1.934 ms    +1.2%
vesting/1                1.481 ms       1.501 ms    +1.4%
vesting/2                1.290 ms       1.309 ms    +1.5%
vesting/3                1.478 ms       1.502 ms    +1.6%
marlowe/trustfund/1      4.105 ms       4.153 ms    +1.2%
marlowe/trustfund/2      3.024 ms       3.061 ms    +1.2%
marlowe/zerocoupon/1     4.193 ms       4.255 ms    +1.5%
marlowe/zerocoupon/2     2.648 ms       2.690 ms    +1.6%
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
