### PR TITLE
Move doctest dependency from plutus-tx lib to test

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-tx.nix
@@ -50,9 +50,6 @@
           (hsPkgs."ghc-prim" or (errorHandler.buildDepError "ghc-prim"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           ];
-        build-tools = [
-          (hsPkgs.buildPackages.doctest.components.exes.doctest or (pkgs.buildPackages.doctest or (errorHandler.buildToolDepError "doctest:doctest")))
-          ];
         buildable = true;
         modules = [
           "PlutusTx/IsData/Instances"
@@ -104,6 +101,9 @@
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.doctest.components.exes.doctest or (pkgs.buildPackages.doctest or (errorHandler.buildToolDepError "doctest:doctest")))
             ];
           buildable = true;
           hsSourceDirs = [ "test" ];

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -72,7 +72,6 @@ library
         PlutusTx.IsData.TH
         PlutusTx.Lift.THUtils
         PlutusTx.Lift.Instances
-    build-tool-depends: doctest:doctest
     build-depends:
         base >=4.9 && <5,
         bytestring -any,
@@ -96,6 +95,7 @@ test-suite plutus-tx-test
     type: exitcode-stdio-1.0
     main-is: Spec.hs
     hs-source-dirs: test
+    build-tool-depends: doctest:doctest
     build-depends:
         base >=4.9 && <5,
         plutus-tx -any,


### PR DESCRIPTION
Doctest cannot be built when cross compiling for windows.

This will allow projects that do not want to build the tests to avoid the dependency on `doctest`.

Is there a reason for this dependency needs to be on the library?