### PR TITLE
SCP-2214 Switch to POSIXTime instead of Slot in TxInfo

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
@@ -42,7 +42,6 @@
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
-          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
@@ -78,6 +77,7 @@
           "Plutus/V1/Ledger/Slot"
           "Plutus/V1/Ledger/Tx"
           "Plutus/V1/Ledger/TxId"
+          "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
           ];
         hsSourceDirs = [ "src" ];

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger.nix
@@ -80,6 +80,7 @@
           "Ledger/Oracle"
           "Ledger/Orphans"
           "Ledger/Index"
+          "Ledger/TimeSlot"
           "Ledger/Tokens"
           "Ledger/Typed/Scripts"
           "Ledger/Typed/Scripts/Validators"

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -52,6 +52,7 @@ library
         Plutus.V1.Ledger.Slot
         Plutus.V1.Ledger.Tx
         Plutus.V1.Ledger.TxId
+        Plutus.V1.Ledger.Time
         Plutus.V1.Ledger.Value
     build-depends:
         base >=4.9 && <5,
@@ -63,7 +64,6 @@ library
         cardano-crypto -any,
         flat -any,
         hashable -any,
-        hedgehog -any,
         plutus-core -any,
         memory -any,
         mtl -any,

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
+{-# OPTIONS_GHC -Wno-identities #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+
+-- | UTCTime and UTCTime ranges.
+module Plutus.V1.Ledger.Time(
+      POSIXTime(..)
+    , POSIXTimeRange
+    ) where
+
+import           Codec.Serialise.Class     (Serialise)
+import           Control.DeepSeq           (NFData)
+import           Data.Aeson                (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import           Data.Hashable             (Hashable)
+import           Data.Text.Prettyprint.Doc (Pretty (pretty), comma, (<+>))
+import           GHC.Generics              (Generic)
+import qualified Prelude                   as Haskell
+
+import qualified PlutusTx
+import           PlutusTx.Lift             (makeLift)
+import           PlutusTx.Prelude
+
+import           Plutus.V1.Ledger.Interval
+
+-- | POSIX time is measured as the number of seconds since 1970-01-01 00:00 UTC
+newtype POSIXTime = POSIXTime { getPOSIXTime :: Integer }
+  deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+  deriving anyclass (FromJSON, FromJSONKey, ToJSON, ToJSONKey, NFData)
+  deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Enum, Eq, Ord, Real, Integral, Serialise, Hashable, PlutusTx.IsData)
+
+makeLift ''POSIXTime
+
+instance Pretty POSIXTime where
+  pretty (POSIXTime i) = "POSIXTime" <+> pretty i
+
+instance Pretty (Interval POSIXTime) where
+  pretty (Interval l h) = pretty l <+> comma <+> pretty h
+
+-- | An 'Interval' of 'POSIXTime's.
+type POSIXTimeRange = Interval POSIXTime

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -52,6 +52,7 @@ library
         Ledger.Oracle
         Ledger.Orphans
         Ledger.Index
+        Ledger.TimeSlot
         Ledger.Tokens
         Ledger.Typed.Scripts
         Ledger.Typed.Scripts.Validators
@@ -73,11 +74,12 @@ library
         Plutus.V1.Ledger.Slot as Ledger.Slot,
         Plutus.V1.Ledger.Tx as Ledger.Tx,
         Plutus.V1.Ledger.TxId as Ledger.TxId,
+        Plutus.V1.Ledger.Time as Ledger.Time,
         Plutus.V1.Ledger.Value as Ledger.Value
     build-depends:
         base >=4.9 && <5,
         aeson -any,
-        base16-bytestring, 
+        base16-bytestring,
         bytestring -any,
         cborg -any,
         containers -any,

--- a/plutus-ledger/src/Ledger.hs
+++ b/plutus-ledger/src/Ledger.hs
@@ -17,6 +17,7 @@ import           Plutus.V1.Ledger.Interval as Export
 import           Plutus.V1.Ledger.Orphans  ()
 import           Plutus.V1.Ledger.Scripts  as Export
 import           Plutus.V1.Ledger.Slot     as Export
+import           Plutus.V1.Ledger.Time     as Export
 import           Plutus.V1.Ledger.Tx       as Export
 import           Plutus.V1.Ledger.TxId     as Export
 import           Plutus.V1.Ledger.Value    (CurrencySymbol, TokenName, Value)

--- a/plutus-ledger/src/Ledger/Constraints/OnChain.hs
+++ b/plutus-ledger/src/Ledger/Constraints/OnChain.hs
@@ -15,6 +15,7 @@ import           PlutusTx                         (IsData (..))
 import           PlutusTx.Prelude
 
 import           Ledger.Constraints.TxConstraints
+import qualified Ledger.TimeSlot                  as TimeSlot
 import qualified Plutus.V1.Ledger.Address         as Address
 import           Plutus.V1.Ledger.Contexts        (ScriptContext (..), TxInInfo (..), TxInfo (..))
 import qualified Plutus.V1.Ledger.Contexts        as V
@@ -54,7 +55,7 @@ checkTxConstraint ScriptContext{scriptContextTxInfo} = \case
         $ dv `elem` fmap snd (txInfoData scriptContextTxInfo)
     MustValidateIn interval ->
         traceIfFalse "Wrong validation interval"
-        $ interval `contains` txInfoValidRange scriptContextTxInfo
+        $ TimeSlot.slotRangeToPOSIXTimeRange interval `contains` txInfoValidRange scriptContextTxInfo
     MustBeSignedBy pubKey ->
         traceIfFalse "Missing signature"
         $ scriptContextTxInfo `V.txSignedBy` pubKey

--- a/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
@@ -23,7 +23,7 @@ import qualified Data.Map                  as Map
 import           Data.Text.Prettyprint.Doc hiding ((<>))
 import           GHC.Generics              (Generic)
 
-import qualified PlutusTx                  as PlutusTx
+import qualified PlutusTx
 import qualified PlutusTx.AssocMap         as AssocMap
 import           PlutusTx.Prelude
 

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -52,6 +52,7 @@ import           Data.Text.Prettyprint.Doc        (Pretty)
 import           Data.Text.Prettyprint.Doc.Extras (PrettyShow (..))
 import           GHC.Generics                     (Generic)
 import           Ledger.Blockchain
+import           Ledger.TimeSlot                  (slotRangeToPOSIXTimeRange)
 import qualified Plutus.V1.Ledger.Ada             as Ada
 import           Plutus.V1.Ledger.Address
 import           Plutus.V1.Ledger.Contexts        (ScriptContext (..), ScriptPurpose (..), TxInfo (..))
@@ -361,7 +362,7 @@ mkTxInfo tx = do
             , txInfoFee = txFee tx
             , txInfoDCert = [] -- DCerts not supported in emulator
             , txInfoWdrl = [] -- Withdrawals not supported in emulator
-            , txInfoValidRange = txValidRange tx
+            , txInfoValidRange = slotRangeToPOSIXTimeRange $ txValidRange tx
             , txInfoSignatories = fmap pubKeyHash $ Map.keys (tx ^. signatures)
             , txInfoData = Map.toList (tx ^. datumWitnesses)
             , txInfoId = txId tx

--- a/plutus-ledger/src/Ledger/TimeSlot.hs
+++ b/plutus-ledger/src/Ledger/TimeSlot.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- This GHC option prevents the error:
+-- "GHC Core to PLC plugin: E042:Error: Unsupported feature: Kind: *"
+-- Because Plutus can't handle unboxed tuples which come from worker/wrapper
+{-# OPTIONS_GHC -fno-worker-wrapper #-}
+
+module Ledger.TimeSlot(
+  slotRangeToPOSIXTimeRange
+, slotToPOSIXTime
+, posixTimeRangeToSlotRange
+, posixTimeToSlot
+) where
+
+import           Plutus.V1.Ledger.Slot (Slot (Slot), SlotRange)
+import           Plutus.V1.Ledger.Time (POSIXTime (POSIXTime), POSIXTimeRange)
+import           PlutusTx.Prelude
+
+{-# INLINABLE shelleyLaunchDate #-}
+-- | 'shelleyLaunchDatePOSIXTime' corresponds to the time 2020-07-29T21:44:51Z
+-- which is 1596059091 in POSIX time.
+shelleyLaunchDate :: Integer
+shelleyLaunchDate = 1596059091
+
+{-# INLINABLE slotRangeToPOSIXTimeRange #-}
+-- | Convert a 'SlotRange' to 'POSIXTimeRange'
+slotRangeToPOSIXTimeRange :: SlotRange -> POSIXTimeRange
+slotRangeToPOSIXTimeRange sr = slotToPOSIXTime <$> sr
+
+{-# INLINABLE slotToPOSIXTime #-}
+-- | Convert a 'Slot to 'POSIXTime
+slotToPOSIXTime :: Slot -> POSIXTime
+slotToPOSIXTime (Slot n) = POSIXTime (n + shelleyLaunchDate)
+
+{-# INLINABLE posixTimeRangeToSlotRange #-}
+-- | Convert a 'POSIXTimeRange' to 'SlotRange'
+posixTimeRangeToSlotRange :: POSIXTimeRange -> SlotRange
+posixTimeRangeToSlotRange ptr = posixTimeToSlot <$> ptr
+
+{-# INLINABLE posixTimeToSlot #-}
+-- | Convert a 'POSIXTime' to 'Slot'
+posixTimeToSlot :: POSIXTime -> Slot
+posixTimeToSlot (POSIXTime t) = Slot (t - shelleyLaunchDate)
+

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -6,7 +6,7 @@
 module Main(main) where
 
 import           Control.Lens
-import           Control.Monad               (forM_, guard, void)
+import           Control.Monad               (forM_, guard, replicateM, void)
 import           Control.Monad.Trans.Except  (runExcept)
 import qualified Data.Aeson                  as JSON
 import qualified Data.Aeson.Extras           as JSON
@@ -34,12 +34,13 @@ import qualified Ledger.Generators           as Gen
 import qualified Ledger.Index                as Index
 import qualified Ledger.Interval             as Interval
 import qualified Ledger.Scripts              as Scripts
+import qualified Ledger.TimeSlot             as TimeSlot
 import           Ledger.Value                (CurrencySymbol, Value (Value))
 import qualified Ledger.Value                as Value
 import qualified PlutusCore.Builtins         as PLC
 import qualified PlutusCore.Universe         as PLC
 import           PlutusTx                    (CompiledCode, applyCode, liftCode)
-import qualified PlutusTx                    as PlutusTx
+import qualified PlutusTx
 import qualified PlutusTx.AssocMap           as AMap
 import qualified PlutusTx.AssocMap           as AssocMap
 import qualified PlutusTx.Builtins           as Builtins
@@ -93,6 +94,10 @@ tests = testGroup "all tests" [
                 in byteStringJson vlJson vlValue)),
     testGroup "Constraints" [
         testProperty "missing value spent" missingValueSpentProp
+        ],
+    testGroup "TimeSlot" [
+        initialSlotTime,
+        testProperty " inverse property" inverseProp
         ]
     ]
 
@@ -215,8 +220,8 @@ pubkeyHashOnChainAndOffChain = property $ do
     pk <- forAll $ PubKey . LedgerBytes <$> Gen.genSizedByteString 32 -- this won't generate a valid public key but that doesn't matter for the purposes of pubKeyHash
     let offChainHash = Crypto.pubKeyHash pk
         onchainProg :: CompiledCode (PubKey -> PubKeyHash -> ())
-        onchainProg = $$(PlutusTx.compile [|| \pk expected -> if (expected PlutusTx.== Validation.pubKeyHash pk) then PlutusTx.trace "correct" () else PlutusTx.traceError "not correct" ||])
-        script = Scripts.fromCompiledCode $ onchainProg `applyCode` (liftCode pk) `applyCode` (liftCode offChainHash)
+        onchainProg = $$(PlutusTx.compile [|| \pk expected -> if expected PlutusTx.== Validation.pubKeyHash pk then PlutusTx.trace "correct" () else PlutusTx.traceError "not correct" ||])
+        script = Scripts.fromCompiledCode $ onchainProg `applyCode` liftCode pk `applyCode` liftCode offChainHash
         result = runExcept $ evaluateScript script
     Hedgehog.assert (result == Right ["correct"])
 
@@ -253,7 +258,7 @@ reduceByOne (Value.Value value) = do
             (tokenName, amount) <- AMap.toList rest
             guard (amount > 0)
             pure (currency, tokenName, pred amount)
-    if (null flat)
+    if null flat
         then pure Nothing
         else (\(cur, tok, amt) -> Just $ Value.singleton cur tok amt) <$> Gen.element flat
 
@@ -264,6 +269,18 @@ nonNegativeValue =
     let mpsHashes = ["ffff", "dddd", "cccc", "eeee", "1010"]
         tokenNames = ["a", "b", "c", "d"]
     in Value.singleton
-        <$> (Gen.element mpsHashes)
-        <*> (Gen.element tokenNames)
+        <$> Gen.element mpsHashes
+        <*> Gen.element tokenNames
         <*> Gen.integral (Range.linear 0 10000)
+
+initialSlotTime :: TestTree
+initialSlotTime = do
+  testCase "Initial slot to time" $
+    HUnit.assertBool "should be equal to Shelley launch date" $ TimeSlot.slotToPOSIXTime (Slot 0) == POSIXTime 1596059091
+
+inverseProp :: Property
+inverseProp = property $ do
+  [b, e] <- forAll $ sort <$> replicateM 2 (Gen.integral (fromIntegral <$> Range.linearBounded @Int))
+  let slotRange = Interval.interval (Slot b) (Slot e)
+  Hedgehog.assert $ slotRange == TimeSlot.posixTimeRangeToSlotRange (TimeSlot.slotRangeToPOSIXTimeRange slotRange)
+

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -22,6 +22,7 @@ import           Ledger
 import qualified Ledger.Ada                    as Ada
 import           Ledger.Bytes
 import qualified Ledger.Crypto                 as Crypto
+import qualified Ledger.TimeSlot               as TimeSlot
 import qualified Ledger.Typed.Scripts          as Scripts
 import           Ledger.Value                  (assetClass, currencySymbol)
 import qualified Plutus.Contracts.Future       as FT
@@ -34,14 +35,14 @@ import           Wallet.Emulator.Types         (Wallet (..), walletPubKey)
 
 import qualified PlutusCore                    as PLC
 import qualified PlutusCore.Evaluation.Result  as PLC
-import qualified PlutusTx                      as PlutusTx
+import qualified PlutusTx
 import           PlutusTx.Evaluation           (unsafeEvaluateCek)
 import qualified PlutusTx.Prelude              as PlutusTx
 import qualified UntypedPlutusCore             as UPLC
 
 import           Opt
 import qualified Recursion                     as Rec
-import qualified Scott                         as Scott
+import qualified Scott
 
 main :: IO ()
 main = defaultMain [ functions, validators, scriptHashes ]
@@ -283,7 +284,7 @@ mockCtx = ScriptContext
       , txInfoOutputs = []
       , txInfoFee = PlutusTx.zero
       , txInfoForge = PlutusTx.zero
-      , txInfoValidRange = defaultSlotRange
+      , txInfoValidRange = TimeSlot.slotRangeToPOSIXTimeRange defaultSlotRange
       , txInfoSignatories = []
       , txInfoId = TxId P.emptyByteString
       , txInfoData = []

--- a/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE MonoLocalBinds     #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -39,7 +38,8 @@ import           Ledger.Constraints       (TxConstraints, mustBeSignedBy, mustPa
 import           Ledger.Contexts          (ScriptContext (..), TxInfo (..))
 import qualified Ledger.Contexts          as Validation
 import qualified Ledger.Interval          as Interval
-import qualified Ledger.Slot              as Slot
+import qualified Ledger.Time              as Time
+import qualified Ledger.TimeSlot          as TimeSlot
 import qualified Ledger.Tx                as Tx
 import           Ledger.Typed.Scripts     (ScriptType (..))
 import qualified Ledger.Typed.Scripts     as Scripts
@@ -47,7 +47,7 @@ import           Ledger.Value             (Value)
 import qualified Ledger.Value             as Value
 import           Plutus.Contract          hiding (when)
 import qualified Plutus.Contract.Typed.Tx as Typed
-import qualified PlutusTx                 as PlutusTx
+import qualified PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), fold)
 import qualified Prelude                  as Haskell
 
@@ -106,10 +106,10 @@ totalAmount VestingParams{vestingTranche1,vestingTranche2} =
 
 {-# INLINABLE availableFrom #-}
 -- | The amount guaranteed to be available from a given tranche in a given slot range.
-availableFrom :: VestingTranche -> Slot.SlotRange -> Value
+availableFrom :: VestingTranche -> Time.POSIXTimeRange -> Value
 availableFrom (VestingTranche d v) range =
     -- The valid range is an open-ended range starting from the tranche vesting date
-    let validRange = Interval.from d
+    let validRange = Interval.from (TimeSlot.slotToPOSIXTime d)
     -- If the valid range completely contains the argument range (meaning in particular
     -- that the start slot of the argument range is after the tranche vesting date), then
     -- the money in the tranche is available, otherwise nothing is available.
@@ -123,7 +123,7 @@ availableAt VestingParams{vestingTranche1, vestingTranche2} sl =
 
 {-# INLINABLE remainingFrom #-}
 -- | The amount that has not been released from this tranche yet
-remainingFrom :: VestingTranche -> Slot.SlotRange -> Value
+remainingFrom :: VestingTranche -> Time.POSIXTimeRange -> Value
 remainingFrom t@VestingTranche{vestingTrancheAmount} range =
     vestingTrancheAmount - availableFrom t range
 
@@ -156,7 +156,7 @@ scriptInstance = Scripts.validatorParam @Vesting
     where
         wrap = Scripts.wrapValidator
 
-contractAddress :: VestingParams -> Ledger.Address
+contractAddress :: VestingParams -> Address
 contractAddress = Scripts.scriptAddress . scriptInstance
 
 data VestingError =
@@ -182,7 +182,7 @@ vestingContract vesting = mapError (review _VestingError) (vest `select` retriev
             Dead  -> pure ()
 
 payIntoContract :: Value -> TxConstraints () ()
-payIntoContract value = mustPayToTheScript () value
+payIntoContract = mustPayToTheScript ()
 
 vestFundsC
     :: ( HasWriteTx s

--- a/plutus-use-cases/test/Spec/crowdfunding.pir
+++ b/plutus-use-cases/test/Spec/crowdfunding.pir
@@ -2282,6 +2282,141 @@
           (termbind
             (strict)
             (vardecl
+              posixTimeRangeToSlotRange
+              (fun [Interval (con integer)] [Interval (con integer)])
+            )
+            (lam
+              ptr
+              [Interval (con integer)]
+              [
+                {
+                  [ { Interval_match (con integer) } ptr ]
+                  [Interval (con integer)]
+                }
+                (lam
+                  from
+                  [LowerBound (con integer)]
+                  (lam
+                    to
+                    [UpperBound (con integer)]
+                    [
+                      [
+                        { Interval (con integer) }
+                        [
+                          {
+                            [ { LowerBound_match (con integer) } from ]
+                            [LowerBound (con integer)]
+                          }
+                          (lam
+                            e
+                            [Extended (con integer)]
+                            (lam
+                              c
+                              Bool
+                              [
+                                [
+                                  { LowerBound (con integer) }
+                                  [
+                                    [
+                                      [
+                                        [
+                                          {
+                                            [
+                                              { Extended_match (con integer) } e
+                                            ]
+                                            (fun Unit [Extended (con integer)])
+                                          }
+                                          (lam
+                                            a
+                                            (con integer)
+                                            (lam
+                                              thunk
+                                              Unit
+                                              [
+                                                { Finite (con integer) }
+                                                [
+                                                  [
+                                                    (builtin subtractInteger) a
+                                                  ]
+                                                  (con integer 1596059091)
+                                                ]
+                                              ]
+                                            )
+                                          )
+                                        ]
+                                        (lam thunk Unit { NegInf (con integer) }
+                                        )
+                                      ]
+                                      (lam thunk Unit { PosInf (con integer) })
+                                    ]
+                                    Unit
+                                  ]
+                                ]
+                                c
+                              ]
+                            )
+                          )
+                        ]
+                      ]
+                      [
+                        {
+                          [ { UpperBound_match (con integer) } to ]
+                          [UpperBound (con integer)]
+                        }
+                        (lam
+                          e
+                          [Extended (con integer)]
+                          (lam
+                            c
+                            Bool
+                            [
+                              [
+                                { UpperBound (con integer) }
+                                [
+                                  [
+                                    [
+                                      [
+                                        {
+                                          [ { Extended_match (con integer) } e ]
+                                          (fun Unit [Extended (con integer)])
+                                        }
+                                        (lam
+                                          a
+                                          (con integer)
+                                          (lam
+                                            thunk
+                                            Unit
+                                            [
+                                              { Finite (con integer) }
+                                              [
+                                                [ (builtin subtractInteger) a ]
+                                                (con integer 1596059091)
+                                              ]
+                                            ]
+                                          )
+                                        )
+                                      ]
+                                      (lam thunk Unit { NegInf (con integer) })
+                                    ]
+                                    (lam thunk Unit { PosInf (con integer) })
+                                  ]
+                                  Unit
+                                ]
+                              ]
+                              c
+                            ]
+                          )
+                        )
+                      ]
+                    ]
+                  )
+                )
+              ]
+            )
+          )
+          (termbind
+            (strict)
+            (vardecl
               equalsByteString
               (fun (con bytestring) (fun (con bytestring) Bool))
             )
@@ -2722,7 +2857,14 @@
                                                   (lam
                                                     ds
                                                     [List [[Tuple2 (con bytestring)] Data]]
-                                                    (lam ds (con bytestring) ds)
+                                                    (lam
+                                                      ds
+                                                      (con bytestring)
+                                                      [
+                                                        posixTimeRangeToSlotRange
+                                                        ds
+                                                      ]
+                                                    )
                                                   )
                                                 )
                                               )
@@ -2858,7 +3000,12 @@
                                                       ds
                                                       [List [[Tuple2 (con bytestring)] Data]]
                                                       (lam
-                                                        ds (con bytestring) ds
+                                                        ds
+                                                        (con bytestring)
+                                                        [
+                                                          posixTimeRangeToSlotRange
+                                                          ds
+                                                        ]
                                                       )
                                                     )
                                                   )

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx 84cffc7a0608ff9bc07d9702c99c8551c96975082d1ee92f23029f63b14ca328:
+                Tx a6468a9812af25872e806fabd7236c39bf155bed5b9d74ca9fddf55e99b852ef:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db (no staking credential)
+                      addressed to ScriptCredential: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c (no staking credential)
                   forge: Value (Map [])
                   fee: Value (Map [(,Map [("",10)])])
                   mps:
@@ -33,7 +33,7 @@ Slot 1: W2: Balancing an unbalanced transaction:
                   data:
                     "9\247\DC3\208\166D%?\EOTR\148!\185\245\ESC\155\b\151\157\b)YY\196\243\153\SO\230\ETB\245\DC3\159"}
               Requires signatures:
-Slot 1: W2: TxSubmit: 91fc140d929226619fccce23074eee3275a86e4c9a4974bd7bae8495cd512c3e
+Slot 1: W2: TxSubmit: 2aaaf67b98c5908b6d166ba4d53c36977d908cd01a05cf743094dcb498f2bc76
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
@@ -42,12 +42,12 @@ Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx eaa7727342f443cbb7353b40a73975345846e3ec90e7c6cb017b9bd240f6030f:
+                Tx 40b40eb4ac9480503726ecca4351ee5cabc9ff36f18a58f14ad7e6802353ef3e:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db (no staking credential)
+                      addressed to ScriptCredential: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c (no staking credential)
                   forge: Value (Map [])
                   fee: Value (Map [(,Map [("",10)])])
                   mps:
@@ -56,15 +56,15 @@ Slot 1: W3: Balancing an unbalanced transaction:
                   data:
                     "\218\192s\224\DC2;\222\165\157\217\179\189\169\207`7\246:\202\130b}z\188\213\196\172)\221t\NUL>"}
               Requires signatures:
-Slot 1: W3: TxSubmit: 699112ede2af36f43feb0ee57045a26f19d2cf1bd49c6a028a3ea2840a2db480
+Slot 1: W3: TxSubmit: 1bd85856e7ef51c994cb9b0a84a1a80626dd23da2e51428dedf23091cf99ffe3
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx 24f68990b6940e35969cb340edc98c94caec230403695054e3067cf633c460b8:
+                Tx 5aac207a6670a48d13a7156a722fca966773bd922cb7c86c3f52c8227519d698:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      addressed to ScriptCredential: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db (no staking credential)
+                      addressed to ScriptCredential: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c (no staking credential)
                   forge: Value (Map [])
                   fee: Value (Map [(,Map [("",10)])])
                   mps:
@@ -73,21 +73,21 @@ Slot 1: W4: Balancing an unbalanced transaction:
                   data:
                     "\237\209\195sr\247R\201z\236\b\130E/\172\172\ETB\164\253\175F\230\FS\ETX?J\246x\164\a\155\205"}
               Requires signatures:
-Slot 1: W4: TxSubmit: 497552a2dbde58129877fbbf24f3f985a88bff702682b7b8609dce9c41a5acba
-Slot 1: TxnValidate 497552a2dbde58129877fbbf24f3f985a88bff702682b7b8609dce9c41a5acba
-Slot 1: TxnValidate 699112ede2af36f43feb0ee57045a26f19d2cf1bd49c6a028a3ea2840a2db480
-Slot 1: TxnValidate 91fc140d929226619fccce23074eee3275a86e4c9a4974bd7bae8495cd512c3e
+Slot 1: W4: TxSubmit: 93d26b0662b3078076f623d6ba8e613dbddc9e17f1bc0ae38729861b1b119462
+Slot 1: TxnValidate 93d26b0662b3078076f623d6ba8e613dbddc9e17f1bc0ae38729861b1b119462
+Slot 1: TxnValidate 1bd85856e7ef51c994cb9b0a84a1a80626dd23da2e51428dedf23091cf99ffe3
+Slot 1: TxnValidate 2aaaf67b98c5908b6d166ba4d53c36977d908cd01a05cf743094dcb498f2bc76
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 74c19843b3a793f02e60ca3c03e8e3123fdc56ad1c5ed154fe39de19aa0f2199:
+                 Tx a09ffe396b07de7ad0051c93656f169494d2895bd135cf48e2bbf67a754a9e4c:
                    {inputs:
-                      - 497552a2dbde58129877fbbf24f3f985a88bff702682b7b8609dce9c41a5acba!1
+                      - 1bd85856e7ef51c994cb9b0a84a1a80626dd23da2e51428dedf23091cf99ffe3!1
                         Redeemer: <>
-                      - 699112ede2af36f43feb0ee57045a26f19d2cf1bd49c6a028a3ea2840a2db480!1
+                      - 2aaaf67b98c5908b6d166ba4d53c36977d908cd01a05cf743094dcb498f2bc76!1
                         Redeemer: <>
-                      - 91fc140d929226619fccce23074eee3275a86e4c9a4974bd7bae8495cd512c3e!1
+                      - 93d26b0662b3078076f623d6ba8e613dbddc9e17f1bc0ae38729861b1b119462!1
                         Redeemer: <>
                    collateral inputs:
                    outputs:
@@ -98,7 +98,7 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 20})) True, ivTo = UpperBound (Finite (Slot {getSlot = 30})) True}
                    data:}
                Requires signatures:
-Slot 20: W1: TxSubmit: 29045f015d23bbaa0a17bcdbe06d40923996a599e2e989e11aaff85c0ead9d54
+Slot 20: W1: TxSubmit: 03c72dcc4ae9ed7e5938752eeaeffca046f4be985f91f222a7c2b996a9ad340b
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 29045f015d23bbaa0a17bcdbe06d40923996a599e2e989e11aaff85c0ead9d54
+Slot 20: TxnValidate 03c72dcc4ae9ed7e5938752eeaeffca046f4be985f91f222a7c2b996a9ad340b

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -5363,126 +5363,79 @@
                                                                       [
                                                                         [
                                                                           {
-                                                                            [
-                                                                              {
-                                                                                Nil_match
-                                                                                TxInInfo
-                                                                              }
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        foldr
-                                                                                        TxInInfo
-                                                                                      }
-                                                                                      [List TxInInfo]
-                                                                                    }
-                                                                                    (lam
-                                                                                      e
-                                                                                      TxInInfo
-                                                                                      (lam
-                                                                                        xs
-                                                                                        [List TxInInfo]
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              TxInInfo_match
-                                                                                              e
-                                                                                            ]
-                                                                                            [List TxInInfo]
-                                                                                          }
-                                                                                          (lam
-                                                                                            ds
-                                                                                            TxOutRef
-                                                                                            (lam
-                                                                                              ds
-                                                                                              TxOut
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        [
-                                                                                                          [
-                                                                                                            fEqTxOutRef_c
-                                                                                                            ds
-                                                                                                          ]
-                                                                                                          txOutRef
-                                                                                                        ]
-                                                                                                      ]
-                                                                                                      (fun Unit [List TxInInfo])
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            Cons
-                                                                                                            TxInInfo
-                                                                                                          }
-                                                                                                          e
-                                                                                                        ]
-                                                                                                        xs
-                                                                                                      ]
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    xs
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  {
-                                                                                    Nil
-                                                                                    TxInInfo
-                                                                                  }
-                                                                                ]
-                                                                                ds
-                                                                              ]
-                                                                            ]
-                                                                            (fun Unit [Maybe TxInInfo])
-                                                                          }
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
                                                                             {
-                                                                              Nothing
-                                                                              TxInInfo
+                                                                              fFoldableNil_cfoldMap
+                                                                              [(lam a (type) [Maybe a]) TxInInfo]
                                                                             }
-                                                                          )
+                                                                            TxInInfo
+                                                                          }
+                                                                          {
+                                                                            fMonoidFirst
+                                                                            TxInInfo
+                                                                          }
                                                                         ]
                                                                         (lam
                                                                           x
                                                                           TxInInfo
-                                                                          (lam
-                                                                            ds
-                                                                            [List TxInInfo]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
+                                                                          [
+                                                                            {
                                                                               [
-                                                                                {
-                                                                                  Just
-                                                                                  TxInInfo
-                                                                                }
+                                                                                TxInInfo_match
                                                                                 x
                                                                               ]
+                                                                              [Maybe TxInInfo]
+                                                                            }
+                                                                            (lam
+                                                                              ds
+                                                                              TxOutRef
+                                                                              (lam
+                                                                                ds
+                                                                                TxOut
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
+                                                                                          [
+                                                                                            [
+                                                                                              fEqTxOutRef_c
+                                                                                              ds
+                                                                                            ]
+                                                                                            txOutRef
+                                                                                          ]
+                                                                                        ]
+                                                                                        (fun Unit [Maybe TxInInfo])
+                                                                                      }
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          {
+                                                                                            Just
+                                                                                            TxInInfo
+                                                                                          }
+                                                                                          x
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        Nothing
+                                                                                        TxInInfo
+                                                                                      }
+                                                                                    )
+                                                                                  ]
+                                                                                  Unit
+                                                                                ]
+                                                                              )
                                                                             )
-                                                                          )
+                                                                          ]
                                                                         )
                                                                       ]
-                                                                      Unit
+                                                                      ds
                                                                     ]
                                                                   )
                                                                 )
@@ -6546,7 +6499,7 @@
                             )
                             (termbind
                               (nonstrict)
-                              (vardecl fOrdSlot [Ord (con integer)])
+                              (vardecl fOrdPOSIXTime [Ord (con integer)])
                               [
                                 [
                                   [
@@ -8885,126 +8838,79 @@
                                                           [
                                                             [
                                                               {
-                                                                [
-                                                                  {
-                                                                    Nil_match
-                                                                    TxInInfo
-                                                                  }
-                                                                  [
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          {
-                                                                            foldr
-                                                                            TxInInfo
-                                                                          }
-                                                                          [List TxInInfo]
-                                                                        }
-                                                                        (lam
-                                                                          e
-                                                                          TxInInfo
-                                                                          (lam
-                                                                            xs
-                                                                            [List TxInInfo]
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  TxInInfo_match
-                                                                                  e
-                                                                                ]
-                                                                                [List TxInInfo]
-                                                                              }
-                                                                              (lam
-                                                                                ds
-                                                                                TxOutRef
-                                                                                (lam
-                                                                                  ds
-                                                                                  TxOut
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                fEqTxOutRef_c
-                                                                                                ds
-                                                                                              ]
-                                                                                              outRef
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit [List TxInInfo])
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                Cons
-                                                                                                TxInInfo
-                                                                                              }
-                                                                                              e
-                                                                                            ]
-                                                                                            xs
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        xs
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                      {
-                                                                        Nil
-                                                                        TxInInfo
-                                                                      }
-                                                                    ]
-                                                                    ds
-                                                                  ]
-                                                                ]
-                                                                (fun Unit [Maybe TxInInfo])
-                                                              }
-                                                              (lam
-                                                                thunk
-                                                                Unit
                                                                 {
-                                                                  Nothing
-                                                                  TxInInfo
+                                                                  fFoldableNil_cfoldMap
+                                                                  [(lam a (type) [Maybe a]) TxInInfo]
                                                                 }
-                                                              )
+                                                                TxInInfo
+                                                              }
+                                                              {
+                                                                fMonoidFirst
+                                                                TxInInfo
+                                                              }
                                                             ]
                                                             (lam
                                                               x
                                                               TxInInfo
-                                                              (lam
-                                                                ds
-                                                                [List TxInInfo]
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
+                                                              [
+                                                                {
                                                                   [
-                                                                    {
-                                                                      Just
-                                                                      TxInInfo
-                                                                    }
+                                                                    TxInInfo_match
                                                                     x
                                                                   ]
+                                                                  [Maybe TxInInfo]
+                                                                }
+                                                                (lam
+                                                                  ds
+                                                                  TxOutRef
+                                                                  (lam
+                                                                    ds
+                                                                    TxOut
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              Bool_match
+                                                                              [
+                                                                                [
+                                                                                  fEqTxOutRef_c
+                                                                                  ds
+                                                                                ]
+                                                                                outRef
+                                                                              ]
+                                                                            ]
+                                                                            (fun Unit [Maybe TxInInfo])
+                                                                          }
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              {
+                                                                                Just
+                                                                                TxInInfo
+                                                                              }
+                                                                              x
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          {
+                                                                            Nothing
+                                                                            TxInInfo
+                                                                          }
+                                                                        )
+                                                                      ]
+                                                                      Unit
+                                                                    ]
+                                                                  )
                                                                 )
-                                                              )
+                                                              ]
                                                             )
                                                           ]
-                                                          Unit
+                                                          ds
                                                         ]
                                                       )
                                                     )
@@ -9018,6 +8924,201 @@
                                     )
                                   ]
                                 )
+                              )
+                            )
+                            (termbind
+                              (strict)
+                              (vardecl
+                                slotRangeToPOSIXTimeRange
+                                (fun [Interval (con integer)] [Interval (con integer)])
+                              )
+                              (lam
+                                sr
+                                [Interval (con integer)]
+                                [
+                                  {
+                                    [ { Interval_match (con integer) } sr ]
+                                    [Interval (con integer)]
+                                  }
+                                  (lam
+                                    from
+                                    [LowerBound (con integer)]
+                                    (lam
+                                      to
+                                      [UpperBound (con integer)]
+                                      [
+                                        [
+                                          { Interval (con integer) }
+                                          [
+                                            {
+                                              [
+                                                {
+                                                  LowerBound_match (con integer)
+                                                }
+                                                from
+                                              ]
+                                              [LowerBound (con integer)]
+                                            }
+                                            (lam
+                                              e
+                                              [Extended (con integer)]
+                                              (lam
+                                                c
+                                                Bool
+                                                [
+                                                  [
+                                                    { LowerBound (con integer) }
+                                                    [
+                                                      [
+                                                        [
+                                                          [
+                                                            {
+                                                              [
+                                                                {
+                                                                  Extended_match
+                                                                  (con integer)
+                                                                }
+                                                                e
+                                                              ]
+                                                              (fun Unit [Extended (con integer)])
+                                                            }
+                                                            (lam
+                                                              a
+                                                              (con integer)
+                                                              (lam
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  {
+                                                                    Finite
+                                                                    (con integer)
+                                                                  }
+                                                                  [
+                                                                    [
+                                                                      (builtin
+                                                                        addInteger
+                                                                      )
+                                                                      a
+                                                                    ]
+                                                                    (con
+                                                                      integer
+                                                                        1596059091
+                                                                    )
+                                                                  ]
+                                                                ]
+                                                              )
+                                                            )
+                                                          ]
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            {
+                                                              NegInf
+                                                              (con integer)
+                                                            }
+                                                          )
+                                                        ]
+                                                        (lam
+                                                          thunk
+                                                          Unit
+                                                          {
+                                                            PosInf (con integer)
+                                                          }
+                                                        )
+                                                      ]
+                                                      Unit
+                                                    ]
+                                                  ]
+                                                  c
+                                                ]
+                                              )
+                                            )
+                                          ]
+                                        ]
+                                        [
+                                          {
+                                            [
+                                              { UpperBound_match (con integer) }
+                                              to
+                                            ]
+                                            [UpperBound (con integer)]
+                                          }
+                                          (lam
+                                            e
+                                            [Extended (con integer)]
+                                            (lam
+                                              c
+                                              Bool
+                                              [
+                                                [
+                                                  { UpperBound (con integer) }
+                                                  [
+                                                    [
+                                                      [
+                                                        [
+                                                          {
+                                                            [
+                                                              {
+                                                                Extended_match
+                                                                (con integer)
+                                                              }
+                                                              e
+                                                            ]
+                                                            (fun Unit [Extended (con integer)])
+                                                          }
+                                                          (lam
+                                                            a
+                                                            (con integer)
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [
+                                                                {
+                                                                  Finite
+                                                                  (con integer)
+                                                                }
+                                                                [
+                                                                  [
+                                                                    (builtin
+                                                                      addInteger
+                                                                    )
+                                                                    a
+                                                                  ]
+                                                                  (con
+                                                                    integer
+                                                                      1596059091
+                                                                  )
+                                                                ]
+                                                              ]
+                                                            )
+                                                          )
+                                                        ]
+                                                        (lam
+                                                          thunk
+                                                          Unit
+                                                          {
+                                                            NegInf (con integer)
+                                                          }
+                                                        )
+                                                      ]
+                                                      (lam
+                                                        thunk
+                                                        Unit
+                                                        { PosInf (con integer) }
+                                                      )
+                                                    ]
+                                                    Unit
+                                                  ]
+                                                ]
+                                                c
+                                              ]
+                                            )
+                                          )
+                                        ]
+                                      ]
+                                    )
+                                  )
+                                ]
                               )
                             )
                             (termbind
@@ -11100,9 +11201,12 @@
                                                               contains
                                                               (con integer)
                                                             }
-                                                            fOrdSlot
+                                                            fOrdPOSIXTime
                                                           ]
-                                                          interval
+                                                          [
+                                                            slotRangeToPOSIXTimeRange
+                                                            interval
+                                                          ]
                                                         ]
                                                         [
                                                           {

--- a/plutus-use-cases/test/Spec/governance.pir
+++ b/plutus-use-cases/test/Spec/governance.pir
@@ -11005,126 +11005,79 @@
                                                                                 [
                                                                                   [
                                                                                     {
-                                                                                      [
-                                                                                        {
-                                                                                          Nil_match
-                                                                                          TxInInfo
-                                                                                        }
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                {
-                                                                                                  foldr
-                                                                                                  TxInInfo
-                                                                                                }
-                                                                                                [List TxInInfo]
-                                                                                              }
-                                                                                              (lam
-                                                                                                e
-                                                                                                TxInInfo
-                                                                                                (lam
-                                                                                                  xs
-                                                                                                  [List TxInInfo]
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        TxInInfo_match
-                                                                                                        e
-                                                                                                      ]
-                                                                                                      [List TxInInfo]
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ds
-                                                                                                      TxOutRef
-                                                                                                      (lam
-                                                                                                        ds
-                                                                                                        TxOut
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  Bool_match
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      fEqTxOutRef_c
-                                                                                                                      ds
-                                                                                                                    ]
-                                                                                                                    txOutRef
-                                                                                                                  ]
-                                                                                                                ]
-                                                                                                                (fun Unit [List TxInInfo])
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      Cons
-                                                                                                                      TxInInfo
-                                                                                                                    }
-                                                                                                                    e
-                                                                                                                  ]
-                                                                                                                  xs
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              xs
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            {
-                                                                                              Nil
-                                                                                              TxInInfo
-                                                                                            }
-                                                                                          ]
-                                                                                          ds
-                                                                                        ]
-                                                                                      ]
-                                                                                      (fun Unit [Maybe TxInInfo])
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
                                                                                       {
-                                                                                        Nothing
-                                                                                        TxInInfo
+                                                                                        fFoldableNil_cfoldMap
+                                                                                        [(lam a (type) [Maybe a]) TxInInfo]
                                                                                       }
-                                                                                    )
+                                                                                      TxInInfo
+                                                                                    }
+                                                                                    {
+                                                                                      fMonoidFirst
+                                                                                      TxInInfo
+                                                                                    }
                                                                                   ]
                                                                                   (lam
                                                                                     x
                                                                                     TxInInfo
-                                                                                    (lam
-                                                                                      ds
-                                                                                      [List TxInInfo]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
+                                                                                    [
+                                                                                      {
                                                                                         [
-                                                                                          {
-                                                                                            Just
-                                                                                            TxInInfo
-                                                                                          }
+                                                                                          TxInInfo_match
                                                                                           x
                                                                                         ]
+                                                                                        [Maybe TxInInfo]
+                                                                                      }
+                                                                                      (lam
+                                                                                        ds
+                                                                                        TxOutRef
+                                                                                        (lam
+                                                                                          ds
+                                                                                          TxOut
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    Bool_match
+                                                                                                    [
+                                                                                                      [
+                                                                                                        fEqTxOutRef_c
+                                                                                                        ds
+                                                                                                      ]
+                                                                                                      txOutRef
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                  (fun Unit [Maybe TxInInfo])
+                                                                                                }
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Just
+                                                                                                      TxInInfo
+                                                                                                    }
+                                                                                                    x
+                                                                                                  ]
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  Nothing
+                                                                                                  TxInInfo
+                                                                                                }
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
+                                                                                        )
                                                                                       )
-                                                                                    )
+                                                                                    ]
                                                                                   )
                                                                                 ]
-                                                                                Unit
+                                                                                ds
                                                                               ]
                                                                             )
                                                                           )
@@ -12219,7 +12172,9 @@
                                       )
                                       (termbind
                                         (nonstrict)
-                                        (vardecl fOrdSlot [Ord (con integer)])
+                                        (vardecl
+                                          fOrdPOSIXTime [Ord (con integer)]
+                                        )
                                         [
                                           [
                                             [
@@ -14639,126 +14594,79 @@
                                                                     [
                                                                       [
                                                                         {
-                                                                          [
-                                                                            {
-                                                                              Nil_match
-                                                                              TxInInfo
-                                                                            }
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    {
-                                                                                      foldr
-                                                                                      TxInInfo
-                                                                                    }
-                                                                                    [List TxInInfo]
-                                                                                  }
-                                                                                  (lam
-                                                                                    e
-                                                                                    TxInInfo
-                                                                                    (lam
-                                                                                      xs
-                                                                                      [List TxInInfo]
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            TxInInfo_match
-                                                                                            e
-                                                                                          ]
-                                                                                          [List TxInInfo]
-                                                                                        }
-                                                                                        (lam
-                                                                                          ds
-                                                                                          TxOutRef
-                                                                                          (lam
-                                                                                            ds
-                                                                                            TxOut
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          fEqTxOutRef_c
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        outRef
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit [List TxInInfo])
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Cons
-                                                                                                          TxInInfo
-                                                                                                        }
-                                                                                                        e
-                                                                                                      ]
-                                                                                                      xs
-                                                                                                    ]
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  xs
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                {
-                                                                                  Nil
-                                                                                  TxInInfo
-                                                                                }
-                                                                              ]
-                                                                              ds
-                                                                            ]
-                                                                          ]
-                                                                          (fun Unit [Maybe TxInInfo])
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
                                                                           {
-                                                                            Nothing
-                                                                            TxInInfo
+                                                                            fFoldableNil_cfoldMap
+                                                                            [(lam a (type) [Maybe a]) TxInInfo]
                                                                           }
-                                                                        )
+                                                                          TxInInfo
+                                                                        }
+                                                                        {
+                                                                          fMonoidFirst
+                                                                          TxInInfo
+                                                                        }
                                                                       ]
                                                                       (lam
                                                                         x
                                                                         TxInInfo
-                                                                        (lam
-                                                                          ds
-                                                                          [List TxInInfo]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
+                                                                        [
+                                                                          {
                                                                             [
-                                                                              {
-                                                                                Just
-                                                                                TxInInfo
-                                                                              }
+                                                                              TxInInfo_match
                                                                               x
                                                                             ]
+                                                                            [Maybe TxInInfo]
+                                                                          }
+                                                                          (lam
+                                                                            ds
+                                                                            TxOutRef
+                                                                            (lam
+                                                                              ds
+                                                                              TxOut
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        [
+                                                                                          [
+                                                                                            fEqTxOutRef_c
+                                                                                            ds
+                                                                                          ]
+                                                                                          outRef
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit [Maybe TxInInfo])
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        {
+                                                                                          Just
+                                                                                          TxInInfo
+                                                                                        }
+                                                                                        x
+                                                                                      ]
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      Nothing
+                                                                                      TxInInfo
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
                                                                           )
-                                                                        )
+                                                                        ]
                                                                       )
                                                                     ]
-                                                                    Unit
+                                                                    ds
                                                                   ]
                                                                 )
                                                               )
@@ -14772,6 +14680,219 @@
                                               )
                                             ]
                                           )
+                                        )
+                                      )
+                                      (termbind
+                                        (strict)
+                                        (vardecl
+                                          slotRangeToPOSIXTimeRange
+                                          (fun [Interval (con integer)] [Interval (con integer)])
+                                        )
+                                        (lam
+                                          sr
+                                          [Interval (con integer)]
+                                          [
+                                            {
+                                              [
+                                                { Interval_match (con integer) }
+                                                sr
+                                              ]
+                                              [Interval (con integer)]
+                                            }
+                                            (lam
+                                              from
+                                              [LowerBound (con integer)]
+                                              (lam
+                                                to
+                                                [UpperBound (con integer)]
+                                                [
+                                                  [
+                                                    { Interval (con integer) }
+                                                    [
+                                                      {
+                                                        [
+                                                          {
+                                                            LowerBound_match
+                                                            (con integer)
+                                                          }
+                                                          from
+                                                        ]
+                                                        [LowerBound (con integer)]
+                                                      }
+                                                      (lam
+                                                        e
+                                                        [Extended (con integer)]
+                                                        (lam
+                                                          c
+                                                          Bool
+                                                          [
+                                                            [
+                                                              {
+                                                                LowerBound
+                                                                (con integer)
+                                                              }
+                                                              [
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          {
+                                                                            Extended_match
+                                                                            (con integer)
+                                                                          }
+                                                                          e
+                                                                        ]
+                                                                        (fun Unit [Extended (con integer)])
+                                                                      }
+                                                                      (lam
+                                                                        a
+                                                                        (con integer)
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            {
+                                                                              Finite
+                                                                              (con integer)
+                                                                            }
+                                                                            [
+                                                                              [
+                                                                                (builtin
+                                                                                  addInteger
+                                                                                )
+                                                                                a
+                                                                              ]
+                                                                              (con
+                                                                                integer
+                                                                                  1596059091
+                                                                              )
+                                                                            ]
+                                                                          ]
+                                                                        )
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      {
+                                                                        NegInf
+                                                                        (con integer)
+                                                                      }
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    {
+                                                                      PosInf
+                                                                      (con integer)
+                                                                    }
+                                                                  )
+                                                                ]
+                                                                Unit
+                                                              ]
+                                                            ]
+                                                            c
+                                                          ]
+                                                        )
+                                                      )
+                                                    ]
+                                                  ]
+                                                  [
+                                                    {
+                                                      [
+                                                        {
+                                                          UpperBound_match
+                                                          (con integer)
+                                                        }
+                                                        to
+                                                      ]
+                                                      [UpperBound (con integer)]
+                                                    }
+                                                    (lam
+                                                      e
+                                                      [Extended (con integer)]
+                                                      (lam
+                                                        c
+                                                        Bool
+                                                        [
+                                                          [
+                                                            {
+                                                              UpperBound
+                                                              (con integer)
+                                                            }
+                                                            [
+                                                              [
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          Extended_match
+                                                                          (con integer)
+                                                                        }
+                                                                        e
+                                                                      ]
+                                                                      (fun Unit [Extended (con integer)])
+                                                                    }
+                                                                    (lam
+                                                                      a
+                                                                      (con integer)
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          {
+                                                                            Finite
+                                                                            (con integer)
+                                                                          }
+                                                                          [
+                                                                            [
+                                                                              (builtin
+                                                                                addInteger
+                                                                              )
+                                                                              a
+                                                                            ]
+                                                                            (con
+                                                                              integer
+                                                                                1596059091
+                                                                            )
+                                                                          ]
+                                                                        ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    {
+                                                                      NegInf
+                                                                      (con integer)
+                                                                    }
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  {
+                                                                    PosInf
+                                                                    (con integer)
+                                                                  }
+                                                                )
+                                                              ]
+                                                              Unit
+                                                            ]
+                                                          ]
+                                                          c
+                                                        ]
+                                                      )
+                                                    )
+                                                  ]
+                                                ]
+                                              )
+                                            )
+                                          ]
                                         )
                                       )
                                       (termbind
@@ -16894,9 +17015,12 @@
                                                                         contains
                                                                         (con integer)
                                                                       }
-                                                                      fOrdSlot
+                                                                      fOrdPOSIXTime
                                                                     ]
-                                                                    interval
+                                                                    [
+                                                                      slotRangeToPOSIXTimeRange
+                                                                      interval
+                                                                    ]
                                                                   ]
                                                                   [
                                                                     {

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -7995,126 +7995,79 @@
                                                                           [
                                                                             [
                                                                               {
-                                                                                [
-                                                                                  {
-                                                                                    Nil_match
-                                                                                    TxInInfo
-                                                                                  }
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          {
-                                                                                            foldr
-                                                                                            TxInInfo
-                                                                                          }
-                                                                                          [List TxInInfo]
-                                                                                        }
-                                                                                        (lam
-                                                                                          e
-                                                                                          TxInInfo
-                                                                                          (lam
-                                                                                            xs
-                                                                                            [List TxInInfo]
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  TxInInfo_match
-                                                                                                  e
-                                                                                                ]
-                                                                                                [List TxInInfo]
-                                                                                              }
-                                                                                              (lam
-                                                                                                ds
-                                                                                                TxOutRef
-                                                                                                (lam
-                                                                                                  ds
-                                                                                                  TxOut
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          [
-                                                                                                            Bool_match
-                                                                                                            [
-                                                                                                              [
-                                                                                                                fEqTxOutRef_c
-                                                                                                                ds
-                                                                                                              ]
-                                                                                                              txOutRef
-                                                                                                            ]
-                                                                                                          ]
-                                                                                                          (fun Unit [List TxInInfo])
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                Cons
-                                                                                                                TxInInfo
-                                                                                                              }
-                                                                                                              e
-                                                                                                            ]
-                                                                                                            xs
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        xs
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      {
-                                                                                        Nil
-                                                                                        TxInInfo
-                                                                                      }
-                                                                                    ]
-                                                                                    ds
-                                                                                  ]
-                                                                                ]
-                                                                                (fun Unit [Maybe TxInInfo])
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
                                                                                 {
-                                                                                  Nothing
-                                                                                  TxInInfo
+                                                                                  fFoldableNil_cfoldMap
+                                                                                  [(lam a (type) [Maybe a]) TxInInfo]
                                                                                 }
-                                                                              )
+                                                                                TxInInfo
+                                                                              }
+                                                                              {
+                                                                                fMonoidFirst
+                                                                                TxInInfo
+                                                                              }
                                                                             ]
                                                                             (lam
                                                                               x
                                                                               TxInInfo
-                                                                              (lam
-                                                                                ds
-                                                                                [List TxInInfo]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
+                                                                              [
+                                                                                {
                                                                                   [
-                                                                                    {
-                                                                                      Just
-                                                                                      TxInInfo
-                                                                                    }
+                                                                                    TxInInfo_match
                                                                                     x
                                                                                   ]
+                                                                                  [Maybe TxInInfo]
+                                                                                }
+                                                                                (lam
+                                                                                  ds
+                                                                                  TxOutRef
+                                                                                  (lam
+                                                                                    ds
+                                                                                    TxOut
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              [
+                                                                                                [
+                                                                                                  fEqTxOutRef_c
+                                                                                                  ds
+                                                                                                ]
+                                                                                                txOutRef
+                                                                                              ]
+                                                                                            ]
+                                                                                            (fun Unit [Maybe TxInInfo])
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            [
+                                                                                              {
+                                                                                                Just
+                                                                                                TxInInfo
+                                                                                              }
+                                                                                              x
+                                                                                            ]
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            Nothing
+                                                                                            TxInInfo
+                                                                                          }
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
                                                                                 )
-                                                                              )
+                                                                              ]
                                                                             )
                                                                           ]
-                                                                          Unit
+                                                                          ds
                                                                         ]
                                                                       )
                                                                     )
@@ -8830,7 +8783,7 @@
                                 )
                                 (termbind
                                   (nonstrict)
-                                  (vardecl fOrdSlot [Ord (con integer)])
+                                  (vardecl fOrdPOSIXTime [Ord (con integer)])
                                   [
                                     [
                                       [
@@ -11202,126 +11155,79 @@
                                                               [
                                                                 [
                                                                   {
-                                                                    [
-                                                                      {
-                                                                        Nil_match
-                                                                        TxInInfo
-                                                                      }
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              {
-                                                                                foldr
-                                                                                TxInInfo
-                                                                              }
-                                                                              [List TxInInfo]
-                                                                            }
-                                                                            (lam
-                                                                              e
-                                                                              TxInInfo
-                                                                              (lam
-                                                                                xs
-                                                                                [List TxInInfo]
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      TxInInfo_match
-                                                                                      e
-                                                                                    ]
-                                                                                    [List TxInInfo]
-                                                                                  }
-                                                                                  (lam
-                                                                                    ds
-                                                                                    TxOutRef
-                                                                                    (lam
-                                                                                      ds
-                                                                                      TxOut
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            {
-                                                                                              [
-                                                                                                Bool_match
-                                                                                                [
-                                                                                                  [
-                                                                                                    fEqTxOutRef_c
-                                                                                                    ds
-                                                                                                  ]
-                                                                                                  outRef
-                                                                                                ]
-                                                                                              ]
-                                                                                              (fun Unit [List TxInInfo])
-                                                                                            }
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    Cons
-                                                                                                    TxInInfo
-                                                                                                  }
-                                                                                                  e
-                                                                                                ]
-                                                                                                xs
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            xs
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          {
-                                                                            Nil
-                                                                            TxInInfo
-                                                                          }
-                                                                        ]
-                                                                        ds
-                                                                      ]
-                                                                    ]
-                                                                    (fun Unit [Maybe TxInInfo])
-                                                                  }
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
                                                                     {
-                                                                      Nothing
-                                                                      TxInInfo
+                                                                      fFoldableNil_cfoldMap
+                                                                      [(lam a (type) [Maybe a]) TxInInfo]
                                                                     }
-                                                                  )
+                                                                    TxInInfo
+                                                                  }
+                                                                  {
+                                                                    fMonoidFirst
+                                                                    TxInInfo
+                                                                  }
                                                                 ]
                                                                 (lam
                                                                   x
                                                                   TxInInfo
-                                                                  (lam
-                                                                    ds
-                                                                    [List TxInInfo]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
+                                                                  [
+                                                                    {
                                                                       [
-                                                                        {
-                                                                          Just
-                                                                          TxInInfo
-                                                                        }
+                                                                        TxInInfo_match
                                                                         x
                                                                       ]
+                                                                      [Maybe TxInInfo]
+                                                                    }
+                                                                    (lam
+                                                                      ds
+                                                                      TxOutRef
+                                                                      (lam
+                                                                        ds
+                                                                        TxOut
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              {
+                                                                                [
+                                                                                  Bool_match
+                                                                                  [
+                                                                                    [
+                                                                                      fEqTxOutRef_c
+                                                                                      ds
+                                                                                    ]
+                                                                                    outRef
+                                                                                  ]
+                                                                                ]
+                                                                                (fun Unit [Maybe TxInInfo])
+                                                                              }
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                [
+                                                                                  {
+                                                                                    Just
+                                                                                    TxInInfo
+                                                                                  }
+                                                                                  x
+                                                                                ]
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              {
+                                                                                Nothing
+                                                                                TxInInfo
+                                                                              }
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
                                                                     )
-                                                                  )
+                                                                  ]
                                                                 )
                                                               ]
-                                                              Unit
+                                                              ds
                                                             ]
                                                           )
                                                         )
@@ -11335,6 +11241,215 @@
                                         )
                                       ]
                                     )
+                                  )
+                                )
+                                (termbind
+                                  (strict)
+                                  (vardecl
+                                    slotRangeToPOSIXTimeRange
+                                    (fun [Interval (con integer)] [Interval (con integer)])
+                                  )
+                                  (lam
+                                    sr
+                                    [Interval (con integer)]
+                                    [
+                                      {
+                                        [ { Interval_match (con integer) } sr ]
+                                        [Interval (con integer)]
+                                      }
+                                      (lam
+                                        from
+                                        [LowerBound (con integer)]
+                                        (lam
+                                          to
+                                          [UpperBound (con integer)]
+                                          [
+                                            [
+                                              { Interval (con integer) }
+                                              [
+                                                {
+                                                  [
+                                                    {
+                                                      LowerBound_match
+                                                      (con integer)
+                                                    }
+                                                    from
+                                                  ]
+                                                  [LowerBound (con integer)]
+                                                }
+                                                (lam
+                                                  e
+                                                  [Extended (con integer)]
+                                                  (lam
+                                                    c
+                                                    Bool
+                                                    [
+                                                      [
+                                                        {
+                                                          LowerBound
+                                                          (con integer)
+                                                        }
+                                                        [
+                                                          [
+                                                            [
+                                                              [
+                                                                {
+                                                                  [
+                                                                    {
+                                                                      Extended_match
+                                                                      (con integer)
+                                                                    }
+                                                                    e
+                                                                  ]
+                                                                  (fun Unit [Extended (con integer)])
+                                                                }
+                                                                (lam
+                                                                  a
+                                                                  (con integer)
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    [
+                                                                      {
+                                                                        Finite
+                                                                        (con integer)
+                                                                      }
+                                                                      [
+                                                                        [
+                                                                          (builtin
+                                                                            addInteger
+                                                                          )
+                                                                          a
+                                                                        ]
+                                                                        (con
+                                                                          integer
+                                                                            1596059091
+                                                                        )
+                                                                      ]
+                                                                    ]
+                                                                  )
+                                                                )
+                                                              ]
+                                                              (lam
+                                                                thunk
+                                                                Unit
+                                                                {
+                                                                  NegInf
+                                                                  (con integer)
+                                                                }
+                                                              )
+                                                            ]
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              {
+                                                                PosInf
+                                                                (con integer)
+                                                              }
+                                                            )
+                                                          ]
+                                                          Unit
+                                                        ]
+                                                      ]
+                                                      c
+                                                    ]
+                                                  )
+                                                )
+                                              ]
+                                            ]
+                                            [
+                                              {
+                                                [
+                                                  {
+                                                    UpperBound_match
+                                                    (con integer)
+                                                  }
+                                                  to
+                                                ]
+                                                [UpperBound (con integer)]
+                                              }
+                                              (lam
+                                                e
+                                                [Extended (con integer)]
+                                                (lam
+                                                  c
+                                                  Bool
+                                                  [
+                                                    [
+                                                      {
+                                                        UpperBound (con integer)
+                                                      }
+                                                      [
+                                                        [
+                                                          [
+                                                            [
+                                                              {
+                                                                [
+                                                                  {
+                                                                    Extended_match
+                                                                    (con integer)
+                                                                  }
+                                                                  e
+                                                                ]
+                                                                (fun Unit [Extended (con integer)])
+                                                              }
+                                                              (lam
+                                                                a
+                                                                (con integer)
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    {
+                                                                      Finite
+                                                                      (con integer)
+                                                                    }
+                                                                    [
+                                                                      [
+                                                                        (builtin
+                                                                          addInteger
+                                                                        )
+                                                                        a
+                                                                      ]
+                                                                      (con
+                                                                        integer
+                                                                          1596059091
+                                                                      )
+                                                                    ]
+                                                                  ]
+                                                                )
+                                                              )
+                                                            ]
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              {
+                                                                NegInf
+                                                                (con integer)
+                                                              }
+                                                            )
+                                                          ]
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            {
+                                                              PosInf
+                                                              (con integer)
+                                                            }
+                                                          )
+                                                        ]
+                                                        Unit
+                                                      ]
+                                                    ]
+                                                    c
+                                                  ]
+                                                )
+                                              )
+                                            ]
+                                          ]
+                                        )
+                                      )
+                                    ]
                                   )
                                 )
                                 (termbind
@@ -13444,9 +13559,12 @@
                                                                   contains
                                                                   (con integer)
                                                                 }
-                                                                fOrdSlot
+                                                                fOrdPOSIXTime
                                                               ]
-                                                              interval
+                                                              [
+                                                                slotRangeToPOSIXTimeRange
+                                                                interval
+                                                              ]
                                                             ]
                                                             [
                                                               {

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       497552a2dbde58129877fbbf24f3f985a88bff702682b7b8609dce9c41a5acba
+TxId:       93d26b0662b3078076f623d6ba8e613dbddc9e17f1bc0ae38729861b1b119462
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840c39248fd2eba7a4cc0f8506c95aa861bdbba...
+              Signature: 58405adf5308845de66e871e28fab4692c18dbf6...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       699112ede2af36f43feb0ee57045a26f19d2cf1bd49c6a028a3ea2840a2db480
+TxId:       1bd85856e7ef51c994cb9b0a84a1a80626dd23da2e51428dedf23091cf99ffe3
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584002e4aa6041d9582904418ba8c3d27e5cbd0c...
+              Signature: 5840ab1cb9d9c599d8da6855f49cef7637c0981f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       91fc140d929226619fccce23074eee3275a86e4c9a4974bd7bae8495cd512c3e
+TxId:       2aaaf67b98c5908b6d166ba4d53c36977d908cd01a05cf743094dcb498f2bc76
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584030cf11561b8fc42f4db10468dc12768da51e...
+              Signature: 5840f52814a8ae1c598dc42b373198617a510d6d...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  100
 
@@ -318,43 +318,43 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       29045f015d23bbaa0a17bcdbe06d40923996a599e2e989e11aaff85c0ead9d54
+TxId:       03c72dcc4ae9ed7e5938752eeaeffca046f4be985f91f222a7c2b996a9ad340b
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58409292db962aa1b6e58c22b7916e3b6f0132f2...
+              Signature: 5840b788ab624714f3d3ff6bb9d4e5a76903418e...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
+  Value:
+    Ada:      Lovelace:  100
+  Source:
+    Tx:     1bd85856e7ef51c994cb9b0a84a1a80626dd23da2e51428dedf23091cf99ffe3
+    Output #1
+    Script: 591ff60100003320033320020020033320020020...
+
+  ---- Input 1 ----
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
+  Value:
+    Ada:      Lovelace:  100
+  Source:
+    Tx:     2aaaf67b98c5908b6d166ba4d53c36977d908cd01a05cf743094dcb498f2bc76
+    Output #1
+    Script: 591ff60100003320033320020020033320020020...
+
+  ---- Input 2 ----
+  Destination:  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  25
   Source:
-    Tx:     497552a2dbde58129877fbbf24f3f985a88bff702682b7b8609dce9c41a5acba
+    Tx:     93d26b0662b3078076f623d6ba8e613dbddc9e17f1bc0ae38729861b1b119462
     Output #1
-    Script: 591f8e0100003320033320020020033320020020...
-
-  ---- Input 1 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     699112ede2af36f43feb0ee57045a26f19d2cf1bd49c6a028a3ea2840a2db480
-    Output #1
-    Script: 591f8e0100003320033320020020033320020020...
-
-  ---- Input 2 ----
-  Destination:  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     91fc140d929226619fccce23074eee3275a86e4c9a4974bd7bae8495cd512c3e
-    Output #1
-    Script: 591f8e0100003320033320020020033320020020...
+    Script: 591ff60100003320033320020020033320020020...
 
 
 Outputs:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 5ff2e1e74e4ccc45dfd700c774ab22ca85eac7b72f744871a951b669693dc2db
+  Script: 501ad86b4065d6ca104affc283f3dec198e9631a9c04e6a7ba213eb7ac9dbc0c
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       174e3c8dac07b5a2b55f825bcb423ad2905fb16910a1ec13932ca5abe0507954
+TxId:       3177f430225a6cdd6b54185ba5164a982739eb13a204b4fa81d49fe9d29c1aae
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840c77d15c36c9fa45b32623c92024d2abdf043...
+              Signature: 5840c212e61d30dcd2c0b8c905cc80707cea1cf0...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999982
 
   ---- Output 1 ----
-  Destination:  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Destination:  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
 
@@ -170,34 +170,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       8dbcf1c15d6f7def49a79e5bb895479790f58382bd5f2d53ee0a33c153d7fc94
+TxId:       24c1e6293d08c55cd9e87efe951d0dfea9277efbc1db8f90af2ee28230987eab
 Fee:        Ada:      Lovelace:  10
-Forge:      a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+Forge:      88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840a6fe63ca9e8c70db953be27af26061954570...
+              Signature: 584080e1ef22d2c57b2efcb7c41107d7c70d2447...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     174e3c8dac07b5a2b55f825bcb423ad2905fb16910a1ec13932ca5abe0507954
+    Tx:     3177f430225a6cdd6b54185ba5164a982739eb13a204b4fa81d49fe9d29c1aae
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Destination:  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     174e3c8dac07b5a2b55f825bcb423ad2905fb16910a1ec13932ca5abe0507954
+    Tx:     3177f430225a6cdd6b54185ba5164a982739eb13a204b4fa81d49fe9d29c1aae
     Output #1
-    Script: 593ca70100003320033200200332002003332002...
+    Script: 593ce80100003320033200200332002003332002...
 
 
 Outputs:
@@ -205,16 +205,16 @@ Outputs:
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999972
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  -
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Destination:  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
 
@@ -223,7 +223,7 @@ Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999972
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       1490ac5d666c22841a7a1c4cdc265e00bd6f2a557623752f9cc9251dcd7a09a6
+TxId:       1bfbeafde9c89457b496ae7fabccd28434416872525fcd3b46e6c91fd59142f0
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840461fa3ae2c3c2320592a6bba81625ca59d9c...
+              Signature: 58400d5e4b9fe0861fb2bd92e52227aad04bbda3...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999972
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  -
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  -
   Source:
-    Tx:     8dbcf1c15d6f7def49a79e5bb895479790f58382bd5f2d53ee0a33c153d7fc94
+    Tx:     24c1e6293d08c55cd9e87efe951d0dfea9277efbc1db8f90af2ee28230987eab
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
     Ada:      -
   Source:
-    Tx:     8dbcf1c15d6f7def49a79e5bb895479790f58382bd5f2d53ee0a33c153d7fc94
+    Tx:     24c1e6293d08c55cd9e87efe951d0dfea9277efbc1db8f90af2ee28230987eab
     Output #1
 
 
@@ -297,25 +297,25 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999962
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    0
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    0
 
 
 Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999962
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    0
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    0
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
 
   PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 5)
   Value:
@@ -349,34 +349,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       1142ae2704d603d9f9b390aeda405c75a9d6688fd9876a71c9ce40a01adb5cb9
+TxId:       951c4a61e35f9dae82146752b5ec137e3801673344879406db90fe4ed94ab17e
 Fee:        Ada:      Lovelace:  10
-Forge:      a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    0
+Forge:      88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584000702c5af945fddf603a9bd4f3768c98a389...
+              Signature: 5840622c0c44b091f43561e77c9965117c5519b6...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
   Source:
-    Tx:     1490ac5d666c22841a7a1c4cdc265e00bd6f2a557623752f9cc9251dcd7a09a6
+    Tx:     1bfbeafde9c89457b496ae7fabccd28434416872525fcd3b46e6c91fd59142f0
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Destination:  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     8dbcf1c15d6f7def49a79e5bb895479790f58382bd5f2d53ee0a33c153d7fc94
+    Tx:     24c1e6293d08c55cd9e87efe951d0dfea9277efbc1db8f90af2ee28230987eab
     Output #2
-    Script: 593ca70100003320033200200332002003332002...
+    Script: 593ce80100003320033200200332002003332002...
 
   ---- Input 2 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -392,17 +392,17 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    0
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    0
     Ada:      Lovelace:  99999993
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Destination:  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  5
 
@@ -411,12 +411,12 @@ Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999962
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    0
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    0
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
     Ada:      Lovelace:  99999993
-    a455a021f2cbf87984ec6ae430198adfb3785cb7fa398058336fb357ec152c88:  guess:    1
+    88a7fd2f9ed6d8b7c36fe335de707ca847f2c214ed87276157a94bb7c2a69cb4:  guess:    1
 
   PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 5)
   Value:
@@ -450,6 +450,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 376665a9f98c16ff128102882e8947c6ea5ef26e1d92574a739448dbf5a627de
+  Script: 5f21d3261cfd7a57c5b88359c73076ac8a5985e4ffb29475bc6c4706e34d4069
   Value:
     Ada:      Lovelace:  5

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       aee31bed7868959428739e96272ad80d60678d6ee2c1b1a67bcfa168fdfdc912
+TxId:       761f107f7a01ed71e5821809ff2cc047b8e82f4aa4173304a01017af6ab53658
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 58400c86f3e2e479720cdc4bc9576bd0f3309c16...
+              Signature: 584004f96da10265bd2923c83d7e76e4cf56054f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: 47d5b370b08abad4afff8c7416d250e8a4164fd12e8ecdd2512a44efe66e178d
+  Destination:  Script: a70c1c60454172164fc9602c1068544d129cb70209bb0295939c92ed17b10667
   Value:
     Ada:      Lovelace:  60
 
@@ -170,30 +170,30 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 47d5b370b08abad4afff8c7416d250e8a4164fd12e8ecdd2512a44efe66e178d
+  Script: a70c1c60454172164fc9602c1068544d129cb70209bb0295939c92ed17b10667
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       60e92358917b06a1055003b83c2f6b01f615f964e3deafda552d2fff33e08646
+TxId:       f3d20a02dbd0003d1d07e1145eb5019e93533c63a7653984cc101ad37adc391d
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840a96fe24b0765a6388d1ba5599aa4209f6227...
+              Signature: 58401864dc676869ecc401f460e67c6fe62f11a2...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 47d5b370b08abad4afff8c7416d250e8a4164fd12e8ecdd2512a44efe66e178d
+  Destination:  Script: a70c1c60454172164fc9602c1068544d129cb70209bb0295939c92ed17b10667
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     aee31bed7868959428739e96272ad80d60678d6ee2c1b1a67bcfa168fdfdc912
+    Tx:     761f107f7a01ed71e5821809ff2cc047b8e82f4aa4173304a01017af6ab53658
     Output #1
-    Script: 59264a0100003320033320020020032003320020...
+    Script: 59264c0100003320033320020020032003320020...
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  Script: 47d5b370b08abad4afff8c7416d250e8a4164fd12e8ecdd2512a44efe66e178d
+  Destination:  Script: a70c1c60454172164fc9602c1068544d129cb70209bb0295939c92ed17b10667
   Value:
     Ada:      Lovelace:  50
 
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 47d5b370b08abad4afff8c7416d250e8a4164fd12e8ecdd2512a44efe66e178d
+  Script: a70c1c60454172164fc9602c1068544d129cb70209bb0295939c92ed17b10667
   Value:
     Ada:      Lovelace:  50

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -2177,6 +2177,56 @@
                           (termbind
                             (strict)
                             (vardecl
+                              fSemigroupFirst_c
+                              (all a (type) (fun [(lam a (type) [Maybe a]) a] (fun [(lam a (type) [Maybe a]) a] [(lam a (type) [Maybe a]) a])))
+                            )
+                            (abs
+                              a
+                              (type)
+                              (lam
+                                ds
+                                [(lam a (type) [Maybe a]) a]
+                                (lam
+                                  b
+                                  [(lam a (type) [Maybe a]) a]
+                                  [
+                                    [
+                                      [
+                                        {
+                                          [ { Maybe_match a } ds ]
+                                          (fun Unit [(lam a (type) [Maybe a]) a])
+                                        }
+                                        (lam ipv a (lam thunk Unit ds))
+                                      ]
+                                      (lam thunk Unit b)
+                                    ]
+                                    Unit
+                                  ]
+                                )
+                              )
+                            )
+                          )
+                          (termbind
+                            (strict)
+                            (vardecl
+                              fMonoidFirst
+                              (all a (type) [Monoid [(lam a (type) [Maybe a]) a]])
+                            )
+                            (abs
+                              a
+                              (type)
+                              [
+                                [
+                                  { CConsMonoid [(lam a (type) [Maybe a]) a] }
+                                  { fSemigroupFirst_c a }
+                                ]
+                                { Nothing a }
+                              ]
+                            )
+                          )
+                          (termbind
+                            (strict)
+                            (vardecl
                               findOwnInput (fun ScriptContext [Maybe TxInInfo])
                             )
                             (lam
@@ -2283,126 +2333,79 @@
                                                                     [
                                                                       [
                                                                         {
-                                                                          [
-                                                                            {
-                                                                              Nil_match
-                                                                              TxInInfo
-                                                                            }
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    {
-                                                                                      foldr
-                                                                                      TxInInfo
-                                                                                    }
-                                                                                    [List TxInInfo]
-                                                                                  }
-                                                                                  (lam
-                                                                                    e
-                                                                                    TxInInfo
-                                                                                    (lam
-                                                                                      xs
-                                                                                      [List TxInInfo]
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            TxInInfo_match
-                                                                                            e
-                                                                                          ]
-                                                                                          [List TxInInfo]
-                                                                                        }
-                                                                                        (lam
-                                                                                          ds
-                                                                                          TxOutRef
-                                                                                          (lam
-                                                                                            ds
-                                                                                            TxOut
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          fEqTxOutRef_c
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        txOutRef
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit [List TxInInfo])
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Cons
-                                                                                                          TxInInfo
-                                                                                                        }
-                                                                                                        e
-                                                                                                      ]
-                                                                                                      xs
-                                                                                                    ]
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  xs
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                {
-                                                                                  Nil
-                                                                                  TxInInfo
-                                                                                }
-                                                                              ]
-                                                                              ds
-                                                                            ]
-                                                                          ]
-                                                                          (fun Unit [Maybe TxInInfo])
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
                                                                           {
-                                                                            Nothing
-                                                                            TxInInfo
+                                                                            fFoldableNil_cfoldMap
+                                                                            [(lam a (type) [Maybe a]) TxInInfo]
                                                                           }
-                                                                        )
+                                                                          TxInInfo
+                                                                        }
+                                                                        {
+                                                                          fMonoidFirst
+                                                                          TxInInfo
+                                                                        }
                                                                       ]
                                                                       (lam
                                                                         x
                                                                         TxInInfo
-                                                                        (lam
-                                                                          ds
-                                                                          [List TxInInfo]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
+                                                                        [
+                                                                          {
                                                                             [
-                                                                              {
-                                                                                Just
-                                                                                TxInInfo
-                                                                              }
+                                                                              TxInInfo_match
                                                                               x
                                                                             ]
+                                                                            [Maybe TxInInfo]
+                                                                          }
+                                                                          (lam
+                                                                            ds
+                                                                            TxOutRef
+                                                                            (lam
+                                                                              ds
+                                                                              TxOut
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        [
+                                                                                          [
+                                                                                            fEqTxOutRef_c
+                                                                                            ds
+                                                                                          ]
+                                                                                          txOutRef
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit [Maybe TxInInfo])
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        {
+                                                                                          Just
+                                                                                          TxInInfo
+                                                                                        }
+                                                                                        x
+                                                                                      ]
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      Nothing
+                                                                                      TxInInfo
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
                                                                           )
-                                                                        )
+                                                                        ]
                                                                       )
                                                                     ]
-                                                                    Unit
+                                                                    ds
                                                                   ]
                                                                 )
                                                               )
@@ -3055,7 +3058,7 @@
                           )
                           (termbind
                             (nonstrict)
-                            (vardecl fOrdSlot [Ord (con integer)])
+                            (vardecl fOrdPOSIXTime [Ord (con integer)])
                             [
                               [
                                 [
@@ -5132,6 +5135,95 @@
                           (termbind
                             (strict)
                             (vardecl
+                              wavailableFrom
+                              (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [Interval (con integer)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])))
+                            )
+                            (lam
+                              ww
+                              (con integer)
+                              (lam
+                                ww
+                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                (lam
+                                  w
+                                  [Interval (con integer)]
+                                  [
+                                    [
+                                      [
+                                        {
+                                          [
+                                            Bool_match
+                                            [
+                                              [
+                                                [
+                                                  { contains (con integer) }
+                                                  fOrdPOSIXTime
+                                                ]
+                                                [
+                                                  [
+                                                    { Interval (con integer) }
+                                                    [
+                                                      [
+                                                        {
+                                                          LowerBound
+                                                          (con integer)
+                                                        }
+                                                        [
+                                                          {
+                                                            Finite (con integer)
+                                                          }
+                                                          [
+                                                            [
+                                                              (builtin
+                                                                addInteger
+                                                              )
+                                                              ww
+                                                            ]
+                                                            (con
+                                                              integer 1596059091
+                                                            )
+                                                          ]
+                                                        ]
+                                                      ]
+                                                      True
+                                                    ]
+                                                  ]
+                                                  [
+                                                    [
+                                                      {
+                                                        UpperBound (con integer)
+                                                      }
+                                                      { PosInf (con integer) }
+                                                    ]
+                                                    True
+                                                  ]
+                                                ]
+                                              ]
+                                              w
+                                            ]
+                                          ]
+                                          (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
+                                        }
+                                        (lam thunk Unit ww)
+                                      ]
+                                      (lam
+                                        thunk
+                                        Unit
+                                        {
+                                          Nil
+                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                        }
+                                      )
+                                    ]
+                                    Unit
+                                  ]
+                                )
+                              )
+                            )
+                          )
+                          (termbind
+                            (strict)
+                            (vardecl
                               wremainingFrom
                               (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [Interval (con integer)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])))
                             )
@@ -5151,72 +5243,7 @@
                                         fAdditiveGroupValue_cscale
                                         (con integer -1)
                                       ]
-                                      [
-                                        [
-                                          [
-                                            {
-                                              [
-                                                Bool_match
-                                                [
-                                                  [
-                                                    [
-                                                      { contains (con integer) }
-                                                      fOrdSlot
-                                                    ]
-                                                    [
-                                                      [
-                                                        {
-                                                          Interval (con integer)
-                                                        }
-                                                        [
-                                                          [
-                                                            {
-                                                              LowerBound
-                                                              (con integer)
-                                                            }
-                                                            [
-                                                              {
-                                                                Finite
-                                                                (con integer)
-                                                              }
-                                                              ww
-                                                            ]
-                                                          ]
-                                                          True
-                                                        ]
-                                                      ]
-                                                      [
-                                                        [
-                                                          {
-                                                            UpperBound
-                                                            (con integer)
-                                                          }
-                                                          {
-                                                            PosInf (con integer)
-                                                          }
-                                                        ]
-                                                        True
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  w
-                                                ]
-                                              ]
-                                              (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                            }
-                                            (lam thunk Unit ww)
-                                          ]
-                                          (lam
-                                            thunk
-                                            Unit
-                                            {
-                                              Nil
-                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                            }
-                                          )
-                                        ]
-                                        Unit
-                                      ]
+                                      [ [ [ wavailableFrom ww ] ww ] w ]
                                     ]
                                   ]
                                 )
@@ -5497,56 +5524,6 @@
                                   ]
                                 )
                               )
-                            )
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl
-                              fSemigroupFirst_c
-                              (all a (type) (fun [(lam a (type) [Maybe a]) a] (fun [(lam a (type) [Maybe a]) a] [(lam a (type) [Maybe a]) a])))
-                            )
-                            (abs
-                              a
-                              (type)
-                              (lam
-                                ds
-                                [(lam a (type) [Maybe a]) a]
-                                (lam
-                                  b
-                                  [(lam a (type) [Maybe a]) a]
-                                  [
-                                    [
-                                      [
-                                        {
-                                          [ { Maybe_match a } ds ]
-                                          (fun Unit [(lam a (type) [Maybe a]) a])
-                                        }
-                                        (lam ipv a (lam thunk Unit ds))
-                                      ]
-                                      (lam thunk Unit b)
-                                    ]
-                                    Unit
-                                  ]
-                                )
-                              )
-                            )
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl
-                              fMonoidFirst
-                              (all a (type) [Monoid [(lam a (type) [Maybe a]) a]])
-                            )
-                            (abs
-                              a
-                              (type)
-                              [
-                                [
-                                  { CConsMonoid [(lam a (type) [Maybe a]) a] }
-                                  { fSemigroupFirst_c a }
-                                ]
-                                { Nothing a }
-                              ]
                             )
                           )
                           (termbind


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

Created a new type called `POSIXTime` similar to the one in `https://hackage.haskell.org/package/time-1.6.0.1`. The goal of this type is to use it in the on-chain part of Plutus. Most notably, `TxInfo` now uses `POSIXTimeRange` instead of `SlotRange`. Updated the rest of the code to work with this change.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
