### PR TITLE
Add 'staging' environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
-  - label: 'deploy (staging) 🚀'
+  - label: 'deploy (alpha) 🚀'
     command:
       - "./.buildkite/deploy.sh alpha"
-    branches: "master"
+    branches: "alpha"
     concurrency: 1
     concurrency_group: "plutus-alpha-deploy"
     agents:
@@ -14,6 +14,15 @@ steps:
     branches: "production"
     concurrency: 1
     concurrency_group: "plutus-production-deploy"
+    agents:
+      system: x86_64-linux
+
+  - label: 'deploy (staging) 🚀'
+    command:
+      - "./.buildkite/deploy.sh staging"
+    branches: "master"
+    concurrency: 1
+    concurrency_group: "plutus-staging-deploy"
     agents:
       system: x86_64-linux
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -2,6 +2,8 @@
 
 <img align="left" src="https://badge.buildkite.com/d1e532e610e22c0e918b69938be8a644f615c9920e3d17cdaf.svg?branch=master"> staging environment deployment
 
+<img align="left" src="https://badge.buildkite.com/d1e532e610e22c0e918b69938be8a644f615c9920e3d17cdaf.svg?branch=alpha"> alpha environment deployment
+
 <img align="left" src="https://badge.buildkite.com/d1e532e610e22c0e918b69938be8a644f615c9920e3d17cdaf.svg?branch=production"> production environment deployment
 
 ## Overview

--- a/deployment/envs.nix
+++ b/deployment/envs.nix
@@ -6,4 +6,5 @@
   hernan = { region = "us-west-2"; };
   tobias = { region = "eu-west-1"; };
   amyas = { region = "eu-west-2"; };
+  staging = { region = "eu-west-3"; };
 }

--- a/deployment/terraform/locals.tf
+++ b/deployment/terraform/locals.tf
@@ -34,6 +34,7 @@ locals {
     testing    = ["pablo", "tobias", "bozhidar", "dimitar"]
     hernan     = ["hernan"]
     tobias     = ["tobias", "ci-deployer"]
+    staging    = ["ci-deployer"]
   }
   bastion_ssh_keys = [for k in local.bastion_ssh_keys_ks[var.env] : local.ssh_keys[k]]
 
@@ -45,6 +46,7 @@ locals {
     testing    = ["pablo", "tobias", "bozhidar", "dimitar"]
     hernan     = ["hernan"]
     tobias     = ["tobias", "ci-deployer"]
+    staging    = ["ci-deployer"]
   }
   root_ssh_keys = [for k in local.root_ssh_keys_ks[var.env] : local.ssh_keys[k]]
 


### PR DESCRIPTION
Add a 'staging' environment which replaces 'alpha' as the continuous
integration environment reflecting the master branch.

- Add staging to envs.nix in eu-west-3
- Add staging in the terraform configuration
- Configure staging in the buildkite pipeline
- Add staging badge for staging in the deployment README

Notes:
- The buildkite pipeline was updated to include the alpha branch
- credentials for staging were uploaded to the aws secrets manager

--------------

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
