### PR TITLE
Add Plutus implementation of take (fix #3202)

### DIFF
--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -1,9 +1,23 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.List (map, filter, listToMaybe, uniqueElement, findIndices, findIndex, foldr, reverse, zip, (++), (!!), head) where
+module PlutusTx.List (
+    map,
+    filter,
+    listToMaybe,
+    uniqueElement,
+    findIndices,
+    findIndex,
+    foldr,
+    reverse,
+    zip,
+    (++),
+    (!!),
+    head,
+    take
+    ) where
 
 import qualified PlutusTx.Builtins as Builtins
 import           Prelude           hiding (Eq (..), all, any, elem, filter, foldl, foldr, head, length, map, null,
-                                    reverse, zip, (!!), (&&), (++), (||))
+                                    reverse, take, zip, (!!), (&&), (++), (||))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 
@@ -109,3 +123,10 @@ zip (a:as) (b:bs) = (a,b) : zip as bs
 head :: [a] -> a
 head []      = Builtins.error ()
 head (x : _) = x
+
+{-# INLINABLE take #-}
+-- | Plutus Tx version of 'Data.List.take'.
+take :: Integer -> [a] -> [a]
+take n _      | n <= 0 =  []
+take _ []              =  []
+take n (x:xs)          =  x : take (n-1) xs

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -89,7 +89,7 @@ import           Prelude              as Prelude hiding (Applicative (..), Eq (.
                                                   Traversable (..), all, and, any, concat, concatMap, const, divMod,
                                                   either, elem, error, filter, fst, head, id, length, map, max, maybe,
                                                   min, not, notElem, null, or, quotRem, reverse, round, sequence, snd,
-                                                  zip, (!!), ($), (&&), (++), (<$>), (||))
+                                                  take, zip, (!!), ($), (&&), (++), (<$>), (||))
 import           Prelude              as Prelude (maximum, minimum)
 
 -- this module does lots of weird stuff deliberately


### PR DESCRIPTION
The problem in #3202 is that PlutusTx.Prelude re-exports Prelude.take which fails to compile. The fix is to add Plutus's own implementation.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
