### PR TITLE
Drop git rev argument

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -2,9 +2,6 @@
   # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
   # on a machine with e.g. no way to build the Darwin IFDs you need!
   supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-  # This will be used by the packages that get the git revision in lieu of actually trying to find it,
-  # which doesn't work in all situations. Set to null to get it from git.
-, rev ? "fake"
 }:
 let
   inherit (import ./nix/lib/ci.nix) dimension platformFilterGeneric filterAttrsOnlyRecursive filterSystems;
@@ -52,7 +49,7 @@ let
       # given a system ("x86_64-linux") return an attrset of derivations to build
       select = _: system:
         let
-          packages = import ./default.nix { inherit system rev; checkMaterialization = true; };
+          packages = import ./default.nix { inherit system; checkMaterialization = true; };
           pkgs = packages.pkgs;
           plutus = packages.plutus;
           isBuildable = platformFilterGeneric pkgs system;

--- a/default.nix
+++ b/default.nix
@@ -11,9 +11,8 @@
 , config ? { allowUnfreePredicate = (import ./nix/lib/unfree.nix).unfreePredicate; }
   # Overrides for niv
 , sourcesOverride ? { }
-, packages ? import ./nix { inherit system crossSystem config sourcesOverride rev checkMaterialization enableHaskellProfiling; }
+, packages ? import ./nix { inherit system crossSystem config sourcesOverride checkMaterialization enableHaskellProfiling; }
   # An explicit git rev to use, passed when we are in Hydra
-, rev ? null
   # Whether to check that the pinned shas for haskell.nix are correct. We want this to be
   # false, generally, since it does more work, but we set it to true in the CI
 , checkMaterialization ? false

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,7 +3,6 @@
 , config ? { }
 , overlays ? [ ]
 , sourcesOverride ? { }
-, rev ? null
 , checkMaterialization ? false
 , enableHaskellProfiling ? false
 }:
@@ -39,7 +38,7 @@ let
     config = haskellNix.config // config;
   };
 
-  plutus = import ./pkgs { inherit rev pkgs checkMaterialization enableHaskellProfiling sources; };
+  plutus = import ./pkgs { inherit pkgs checkMaterialization enableHaskellProfiling sources; };
 
 in
 {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -2,7 +2,6 @@
 , checkMaterialization
 , system ? builtins.currentSystem
 , config ? { allowUnfreePredicate = (import ../lib/unfree.nix).unfreePredicate; }
-, rev ? null
 , sources
 , enableHaskellProfiling
 }:
@@ -17,10 +16,6 @@ let
     };
 
   gitignore-nix = pkgs.callPackage sources."gitignore.nix" { };
-
-  # The git revision comes from `rev` if available (Hydra), otherwise
-  # it is read using IFD and git, which is avilable on local builds.
-  git-rev = if isNull rev then pkgs.lib.commitIdFromGitRepo ../../.git else rev;
 
   # { index-state, project, projectPackages, packages, extraPackages }
   haskell = pkgs.callPackage ./haskell {

--- a/release.nix
+++ b/release.nix
@@ -3,12 +3,9 @@
 , plutus ? null
 }:
 let
-  # The revision passed in by Hydra, if there is one
-  rev = if builtins.isNull plutus then null else plutus.rev;
-
   inherit (import ./nix/lib/ci.nix) stripAttrsForHydra filterDerivations derivationAggregate;
 
-  ci = import ./ci.nix { inherit supportedSystems rev; };
+  ci = import ./ci.nix { inherit supportedSystems; };
   # ci.nix is a set of attributes that work fine as jobs (albeit in a slightly different structure, the platform comes
   # first), but we mainly just need to get rid of some extra attributes.
   ciJobsets = stripAttrsForHydra (filterDerivations ci);

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,8 @@
 { crossSystem ? null
 , system ? builtins.currentSystem
 , config ? { allowUnfreePredicate = (import ./nix/lib/unfree.nix).unfreePredicate; }
-, rev ? "in-nix-shell"
 , sourcesOverride ? { }
-, packages ? import ./. { inherit crossSystem config sourcesOverride rev enableHaskellProfiling; }
+, packages ? import ./. { inherit crossSystem config sourcesOverride enableHaskellProfiling; }
 , enableHaskellProfiling ? false
 }:
 let


### PR DESCRIPTION
Drop the unused `rev` nix argument which was used to set the git
revision in packages using `set-git-rev`

The use of set-git-rev was dropped by #2984

----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
