### PR TITLE
Add Plutus implementation of mapM_ (fix #3203).

### DIFF
--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -1,31 +1,39 @@
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Foldable
-  ( Foldable(..)
-  , fold
-  , foldr
-  , foldl
-  , toList
-  , null
-  , length
-  , elem
-  , sum
-  , product
-  , foldrM
-  , foldlM
-  , traverse_
-  , for_
-  , sequenceA_
-  , sequence_
-  , asum
-  , concat
-  , concatMap
-  , and
-  , or
-  , any
-  , all
-  , notElem
-  , find
+module PlutusTx.Foldable (
+  Foldable(..),
+  -- * Special biased folds
+  foldrM,
+  foldlM,
+  -- * Folding actions
+  -- ** Applicative actions
+  traverse_,
+  for_,
+  sequenceA_,
+  sequence_,
+  asum,
+  -- ** Monadic actions
+  mapM_,
+  -- * Specialized folds
+  concat,
+  concatMap,
+  and,
+  or,
+  any,
+  all,
+  -- * Searches
+  notElem,
+  find,
+  -- * Other
+  fold,
+  foldr,
+  foldl,
+  toList,
+  null,
+  length,
+  elem,
+  sum,
+  product
   ) where
 
 import           Control.Applicative   (Alternative (..), Const (..))
@@ -208,3 +216,10 @@ find p = getFirst . foldMap (\ x -> First (if p x then Just x else Nothing))
 (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
 (#.) _f = coerce
 {-# INLINE (#.) #-}
+
+{-# INLINABLE mapM_ #-}
+mapM_ :: (Foldable t, Monad m) => (a -> m b) -> t a -> m ()
+mapM_ f = foldr c (return ())
+  -- See Note [List fusion and continuations in 'c']
+  where c x k = f x >> k
+        {-# INLINE c #-}

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -217,9 +217,9 @@ find p = getFirst . foldMap (\ x -> First (if p x then Just x else Nothing))
 (#.) _f = coerce
 {-# INLINE (#.) #-}
 
+-- | Plutus Tx version of 'Data.Foldable.mapM_'.
 {-# INLINABLE mapM_ #-}
 mapM_ :: (Foldable t, Monad m) => (a -> m b) -> t a -> m ()
 mapM_ f = foldr c (return ())
-  -- See Note [List fusion and continuations in 'c']
   where c x k = f x >> k
         {-# INLINE c #-}

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -99,9 +99,9 @@ import           PlutusTx.Traversable as Traversable
 import           Prelude              as Prelude hiding (Applicative (..), Eq (..), Foldable (..), Functor (..),
                                                   Monoid (..), Num (..), Ord (..), Rational, Semigroup (..),
                                                   Traversable (..), all, and, any, concat, concatMap, const, divMod,
-                                                  either, elem, error, filter, fst, head, id, length, map, max, maybe,
-                                                  min, not, notElem, null, or, quotRem, reverse, round, sequence, snd,
-                                                  take, zip, (!!), ($), (&&), (++), (<$>), (||))
+                                                  either, elem, error, filter, fst, head, id, length, map, mapM_, max,
+                                                  maybe, min, not, notElem, null, or, quotRem, reverse, round, sequence,
+                                                  snd, take, zip, (!!), ($), (&&), (++), (<$>), (||))
 import           Prelude              as Prelude (maximum, minimum)
 
 -- this module does lots of weird stuff deliberately


### PR DESCRIPTION
The problem in #3203 is that PlutusTx.Prelude re-exports Prelude.mapM_ which fails to compile. The fix is to add Plutus's own implementation.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
