### PR TITLE
SCP-2274: Allow some slippage while calculating machine steps in the evaluator

### DIFF
--- a/plutus-core/cost-model/data/cekMachineCosts.json
+++ b/plutus-core/cost-model/data/cekMachineCosts.json
@@ -1,11 +1,4 @@
 {
     "cek_startup_cost" : {"_ex_budget_cpu": 1000000, "_ex_budget_memory":  0},
-    "cek_var_cost"     : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_const_cost"   : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_lam_cost"     : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_delay_cost"   : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_force_cost"   : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_apply_cost"   : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10},
-    "cek_builtin_cost" : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10}
+    "cek_step_cost"    : {"_ex_budget_cpu":   39000, "_ex_budget_memory": 10}
 }
-

--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -763,14 +763,7 @@ printBudgetStateBudget _ model b =
 printBudgetStateTally :: (Eq fun, Cek.Hashable fun, Show fun)
        => UPLC.Term UPLC.Name PLC.DefaultUni PLC.DefaultFun () -> CekModel ->  Cek.CekExTally fun -> IO ()
 printBudgetStateTally term model (Cek.CekExTally costs) = do
-  putStrLn $ "Const      " ++ pbudget Cek.BConst
-  putStrLn $ "Var        " ++ pbudget Cek.BVar
-  putStrLn $ "LamAbs     " ++ pbudget Cek.BLamAbs
-  putStrLn $ "Apply      " ++ pbudget Cek.BApply
-  putStrLn $ "Delay      " ++ pbudget Cek.BDelay
-  putStrLn $ "Force      " ++ pbudget Cek.BForce
-  putStrLn $ "Error      " ++ pbudget Cek.BError
-  putStrLn $ "Builtin    " ++ pbudget Cek.BBuiltin
+  putStrLn $ "Step       " ++ pbudget Cek.BStep
   putStrLn ""
   putStrLn $ "startup    " ++ pbudget Cek.BStartup
   putStrLn $ "compute    " ++ printf "%-20s" (budgetToString totalComputeCost)
@@ -792,7 +785,7 @@ printBudgetStateTally term model (Cek.CekExTally costs) = do
             case H.lookup k costs of
               Just v  -> v
               Nothing -> ExBudget 0 0
-        allNodeTags = [Cek.BConst, Cek.BVar, Cek.BLamAbs, Cek.BApply, Cek.BDelay, Cek.BForce, Cek.BError, Cek.BBuiltin]
+        allNodeTags = [Cek.BStep]
         totalComputeCost = mconcat $ map getSpent allNodeTags  -- For unitCekCosts this will be the total number of compute steps
         budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) =
             printf "%15s  %15s" (show cpu) (show mem) :: String -- Not %d: doesn't work when CostingInteger is SatInt.

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -22,17 +22,11 @@ type CekCostModel = CostModel CekMachineCosts
 randomCekCosts :: CekMachineCosts
 randomCekCosts =
     CekMachineCosts { cekStartupCost = ExBudget 2342 234321
-                    , cekVarCost     = ExBudget 12312 56545
-                    , cekConstCost   = ExBudget 23490290838 2323423
-                    , cekLamCost     = ExBudget 0 712127381
-                    , cekDelayCost   = ExBudget 999 7777
-                    , cekForceCost   = ExBudget 1028234 0
-                    , cekApplyCost   = ExBudget 324628348 8273
-                    , cekBuiltinCost = ExBudget 4 4
+                    , cekStepCost    = ExBudget 12312 56545
                     }
 
-cekVarCostCpuKey :: Text.Text
-cekVarCostCpuKey = "cek_var_cost-_ex_budget_cpu"  -- This is the result of flatten . camelToSnake
+cekStepCostCpuKey :: Text.Text
+cekStepCostCpuKey = "cek_step_cost-_ex_budget_cpu"  -- This is the result of flatten . camelToSnake
 
 randomCekCostModel :: CekCostModel
 randomCekCostModel = CostModel randomCekCosts defaultBuiltinCostModel
@@ -91,8 +85,8 @@ testSelfUpdateWithMissingEntry :: CekCostModel -> IO ()
 testSelfUpdateWithMissingEntry model =
     do
       params <- extractParams model
-      assertBool "CekVarCost not found in params" (Map.member cekVarCostCpuKey params)
-      let params' = Map.delete cekVarCostCpuKey params
+      assertBool "CekStepCost not found in params" (Map.member cekStepCostCpuKey params)
+      let params' = Map.delete cekStepCostCpuKey params
       model' <- applyParams model params'
       model' @?= model
 
@@ -102,9 +96,9 @@ testOtherUpdateWithMissingEntry :: CekCostModel -> CekCostModel -> IO ()
 testOtherUpdateWithMissingEntry model1 model2 =
     do
       params2 <- extractParams model2
-      assertBool "CekVarCost not found in params" (Map.member cekVarCostCpuKey params2)
-      let params2' = Map.delete cekVarCostCpuKey params2
-      assertBool "CekVarCost still in params" (not (Map.member cekVarCostCpuKey params2'))
+      assertBool "CekStepCost not found in params" (Map.member cekStepCostCpuKey params2)
+      let params2' = Map.delete cekStepCostCpuKey params2
+      assertBool "CekStepCost still in params" (not (Map.member cekStepCostCpuKey params2'))
       assertBool "params are the same" (params2 /= params2')
       model1' <- applyParams model1 params2'
       assertBool "The updated model is the same as the other model" (model1' /= model2)
@@ -154,5 +148,3 @@ test_costModelInterface =
              , testCase "defaultCekCostModel <- randomCekCostModel"  $ testExtractAfterUpdate defaultCekCostModel randomCekCostModel
              ]
      ]
-
-

--- a/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop1.plc.golden
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop1.plc.golden
@@ -1,0 +1,1 @@
+(fun (con integer) (con unit))

--- a/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop2.plc.golden
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop2.plc.golden
@@ -1,0 +1,1 @@
+(fun (con integer) (fun (con integer) (con unit)))

--- a/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop3.plc.golden
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Golden/Nop3.plc.golden
@@ -1,0 +1,1 @@
+(fun (con integer) (fun (con integer) (fun (con integer) (con unit))))

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -25,6 +25,7 @@ module UntypedPlutusCore.Evaluation.Machine.Cek
     , tallying
     , restricting
     , restrictingEnormous
+    , defaultSlippageFraction
     , extractEvaluationResult
     , runCek
     , runCekNoEmit

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
@@ -27,16 +27,7 @@ cekMachineCostsPrefix = "cek"
 data CekMachineCosts =
     CekMachineCosts {
       cekStartupCost :: ExBudget  -- General overhead
-    , cekVarCost     :: ExBudget
-    , cekConstCost   :: ExBudget
-    , cekLamCost     :: ExBudget
-    , cekDelayCost   :: ExBudget
-    , cekForceCost   :: ExBudget
-    , cekApplyCost   :: ExBudget
-    , cekBuiltinCost :: ExBudget
-    -- ^ Just the cost of evaluating a Builtin node, not the builtin itself.
-    -- There's no entry for Error since we'll be exiting anyway; also, what would
-    -- happen if calling 'Error' caused the budget to be exceeded?
+    , cekStepCost    :: ExBudget
     }
     deriving (Eq, Show, Generic, Lift)
     deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier (CamelToSnake)] CekMachineCosts
@@ -47,13 +38,7 @@ data CekMachineCosts =
 unitCekMachineCosts :: CekMachineCosts
 unitCekMachineCosts =
     CekMachineCosts { cekStartupCost = zeroCost
-                    , cekVarCost     = unitCost
-                    , cekConstCost   = unitCost
-                    , cekLamCost     = unitCost
-                    , cekDelayCost   = unitCost
-                    , cekForceCost   = unitCost
-                    , cekApplyCost   = unitCost
-                    , cekBuiltinCost = unitCost
+                    , cekStepCost    = unitCost
                     }
         where
           zeroCost = ExBudget 0 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/FoldrInterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/FoldrInterList.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\f -> \z -> force (force (force (force (delay (delay (\f -> force (delay (\s -> s s)) (\s -> \x -> f (force (delay (\s -> s s)) s) x))))) (\rec -> \u -> delay (delay (\f' -> \xs -> force xs z (\x -> \y -> \xs' -> f' x y (force (force (rec ())) (\y' -> \x' -> f' x' y') xs'))))) ())))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \y -> \xs -> delay (\z -> \f -> f x y xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\z -> \f -> z)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/RecUnit/runRecUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/RecUnit/runRecUnit.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\ru -> force ru ru)))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Shad/mkShad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Shad/mkShad.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\x -> delay (\y -> 0))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\tr -> \fr -> delay (\z -> \f -> f tr fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\z -> \f -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/TreeNode.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/TreeNode.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\x -> \fr -> delay (\f -> f x fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchConcat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchConcat.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\xs -> \ys -> delay (\f -> \z -> force xs (delay (force f)) (force ys f z)))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x (force xs f z))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottHead.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottHead.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ()))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottSumHeadsOr0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottSumHeadsOr0.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\xs -> \ys -> force xs (delay (\x -> \xs' -> \coe -> addInteger x (force (force (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ())))) (coe ys)))) (\coe -> 0) (\xs' -> xs'))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 117000
-| mem: 30
-})
-| BVar causes ({ cpu: 507000
-| mem: 130
-})
-| BLamAbs causes ({ cpu: 546000
-| mem: 140
-})
-| BApply causes ({ cpu: 702000
-| mem: 180
-})
-| BDelay causes ({ cpu: 195000
-| mem: 50
-})
-| BForce causes ({ cpu: 234000
-| mem: 60
-})
-| BBuiltin causes ({ cpu: 78000
-| mem: 20
+, ({ tally: ({ BStep causes ({ cpu: 2379000
+| mem: 610
 })
 | BBuiltinApp LessThanEqInteger causes ({ cpu: 216714
 | mem: 1

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 351000
-| mem: 90
-})
-| BVar causes ({ cpu: 1404000
-| mem: 360
-})
-| BLamAbs causes ({ cpu: 1170000
-| mem: 300
-})
-| BApply causes ({ cpu: 2028000
-| mem: 520
-})
-| BDelay causes ({ cpu: 351000
-| mem: 90
-})
-| BForce causes ({ cpu: 468000
-| mem: 120
-})
-| BBuiltin causes ({ cpu: 351000
-| mem: 90
+, ({ tally: ({ BStep causes ({ cpu: 6123000
+| mem: 1570
 })
 | BBuiltinApp AddInteger causes ({ cpu: 237457
 | mem: 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (2))
-, ({ tally: ({ BConst causes ({ cpu: 585000
-| mem: 150
-})
-| BVar causes ({ cpu: 2301000
-| mem: 590
-})
-| BLamAbs causes ({ cpu: 1794000
-| mem: 460
-})
-| BApply causes ({ cpu: 3354000
-| mem: 860
-})
-| BDelay causes ({ cpu: 507000
-| mem: 130
-})
-| BForce causes ({ cpu: 702000
-| mem: 180
-})
-| BBuiltin causes ({ cpu: 624000
-| mem: 160
+, ({ tally: ({ BStep causes ({ cpu: 9867000
+| mem: 2530
 })
 | BBuiltinApp AddInteger causes ({ cpu: 474914
 | mem: 4

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/0.plc.golden
@@ -1,18 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
-| mem: 1400
-})
-| BLamAbs causes ({ cpu: 3666000
-| mem: 940
-})
-| BApply causes ({ cpu: 4758000
-| mem: 1220
-})
-| BDelay causes ({ cpu: 1443000
-| mem: 370
-})
-| BForce causes ({ cpu: 1014000
-| mem: 260
+, ({ tally: ({ BStep causes ({ cpu: 16341000
+| mem: 4190
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/3.plc.golden
@@ -1,21 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
-| mem: 1400
-})
-| BLamAbs causes ({ cpu: 3666000
-| mem: 940
-})
-| BApply causes ({ cpu: 4875000
-| mem: 1250
-})
-| BDelay causes ({ cpu: 1443000
-| mem: 370
-})
-| BForce causes ({ cpu: 1131000
-| mem: 290
-})
-| BBuiltin causes ({ cpu: 117000
-| mem: 30
+, ({ tally: ({ BStep causes ({ cpu: 16692000
+| mem: 4280
 })
 | BBuiltinApp Id causes ({ cpu: 3
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/6.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/6.plc.golden
@@ -1,21 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
-| mem: 1400
-})
-| BLamAbs causes ({ cpu: 3666000
-| mem: 940
-})
-| BApply causes ({ cpu: 4992000
-| mem: 1280
-})
-| BDelay causes ({ cpu: 1443000
-| mem: 370
-})
-| BForce causes ({ cpu: 1248000
-| mem: 320
-})
-| BBuiltin causes ({ cpu: 234000
-| mem: 60
+, ({ tally: ({ BStep causes ({ cpu: 17043000
+| mem: 4370
 })
 | BBuiltinApp Id causes ({ cpu: 6
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/9.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/9.plc.golden
@@ -1,21 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
-| mem: 1400
-})
-| BLamAbs causes ({ cpu: 3666000
-| mem: 940
-})
-| BApply causes ({ cpu: 5109000
-| mem: 1310
-})
-| BDelay causes ({ cpu: 1443000
-| mem: 370
-})
-| BForce causes ({ cpu: 1365000
-| mem: 350
-})
-| BBuiltin causes ({ cpu: 351000
-| mem: 90
+, ({ tally: ({ BStep causes ({ cpu: 17394000
+| mem: 4460
 })
 | BBuiltinApp Id causes ({ cpu: 9
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/0.plc.golden
@@ -1,18 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
-| mem: 1400
-})
-| BLamAbs causes ({ cpu: 3666000
-| mem: 940
-})
-| BApply causes ({ cpu: 4758000
-| mem: 1220
-})
-| BDelay causes ({ cpu: 1443000
-| mem: 370
-})
-| BForce causes ({ cpu: 1014000
-| mem: 260
+, ({ tally: ({ BStep causes ({ cpu: 16341000
+| mem: 4190
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/1.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 39000
-| mem: 10
-})
-| BVar causes ({ cpu: 5772000
-| mem: 1480
-})
-| BLamAbs causes ({ cpu: 4134000
-| mem: 1060
-})
-| BApply causes ({ cpu: 5265000
-| mem: 1350
-})
-| BDelay causes ({ cpu: 1677000
-| mem: 430
-})
-| BForce causes ({ cpu: 1248000
-| mem: 320
-})
-| BBuiltin causes ({ cpu: 39000
-| mem: 10
+, ({ tally: ({ BStep causes ({ cpu: 18174000
+| mem: 4660
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/2.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 78000
-| mem: 20
-})
-| BVar causes ({ cpu: 5811000
-| mem: 1490
-})
-| BLamAbs causes ({ cpu: 4212000
-| mem: 1080
-})
-| BApply causes ({ cpu: 5421000
-| mem: 1390
-})
-| BDelay causes ({ cpu: 1677000
-| mem: 430
-})
-| BForce causes ({ cpu: 1287000
-| mem: 330
-})
-| BBuiltin causes ({ cpu: 78000
-| mem: 20
+, ({ tally: ({ BStep causes ({ cpu: 18564000
+| mem: 4760
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/3.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 117000
-| mem: 30
-})
-| BVar causes ({ cpu: 5850000
-| mem: 1500
-})
-| BLamAbs causes ({ cpu: 4290000
-| mem: 1100
-})
-| BApply causes ({ cpu: 5577000
-| mem: 1430
-})
-| BDelay causes ({ cpu: 1677000
-| mem: 430
-})
-| BForce causes ({ cpu: 1326000
-| mem: 340
-})
-| BBuiltin causes ({ cpu: 117000
-| mem: 30
+, ({ tally: ({ BStep causes ({ cpu: 18954000
+| mem: 4860
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/4.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/4.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 156000
-| mem: 40
-})
-| BVar causes ({ cpu: 5889000
-| mem: 1510
-})
-| BLamAbs causes ({ cpu: 4368000
-| mem: 1120
-})
-| BApply causes ({ cpu: 5733000
-| mem: 1470
-})
-| BDelay causes ({ cpu: 1677000
-| mem: 430
-})
-| BForce causes ({ cpu: 1365000
-| mem: 350
-})
-| BBuiltin causes ({ cpu: 156000
-| mem: 40
+, ({ tally: ({ BStep causes ({ cpu: 19344000
+| mem: 4960
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/5.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/5.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 195000
-| mem: 50
-})
-| BVar causes ({ cpu: 5928000
-| mem: 1520
-})
-| BLamAbs causes ({ cpu: 4446000
-| mem: 1140
-})
-| BApply causes ({ cpu: 5889000
-| mem: 1510
-})
-| BDelay causes ({ cpu: 1677000
-| mem: 430
-})
-| BForce causes ({ cpu: 1404000
-| mem: 360
-})
-| BBuiltin causes ({ cpu: 195000
-| mem: 50
+, ({ tally: ({ BStep causes ({ cpu: 19734000
+| mem: 5060
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/FoldrInterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/FoldrInterList.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\f -> \z -> force (force (force (force (delay (delay (\f -> force (delay (\s -> s s)) (\s -> \x -> f (force (delay (\s -> s s)) s) x))))) (\rec -> \u -> delay (delay (\f' -> \xs -> force xs z (\x -> \y -> \xs' -> f' x y (force (force (rec ())) (\y' -> \x' -> f' x' y') xs'))))) ())))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \y -> \xs -> delay (\z -> \f -> f x y xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\z -> \f -> z)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/RecUnit/runRecUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/RecUnit/runRecUnit.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\ru -> force ru ru)))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Shad/mkShad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Shad/mkShad.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\x -> delay (\y -> 0))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\tr -> \fr -> delay (\z -> \f -> f tr fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\z -> \f -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/TreeNode.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/TreeNode.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\x -> \fr -> delay (\f -> f x fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchConcat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchConcat.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (delay (\xs -> \ys -> delay (\f -> \z -> force xs (delay (force f)) (force ys f z)))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x (force xs f z))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottCons.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottHead.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottHead.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ()))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottNil.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottSumHeadsOr0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottSumHeadsOr0.plc.golden
@@ -1,5 +1,5 @@
 ( (Right (delay (\xs -> \ys -> force xs (delay (\x -> \xs' -> \coe -> addInteger x (force (force (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ())))) (coe ys)))) (\coe -> 0) (\xs' -> xs'))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep causes ({ cpu: 39000
 | mem: 10
 })
 | BStartup causes ({ cpu: 1000000

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/1.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 117000
-| mem: 30
-})
-| BVar causes ({ cpu: 507000
-| mem: 130
-})
-| BLamAbs causes ({ cpu: 546000
-| mem: 140
-})
-| BApply causes ({ cpu: 702000
-| mem: 180
-})
-| BDelay causes ({ cpu: 195000
-| mem: 50
-})
-| BForce causes ({ cpu: 234000
-| mem: 60
-})
-| BBuiltin causes ({ cpu: 78000
-| mem: 20
+, ({ tally: ({ BStep causes ({ cpu: 2379000
+| mem: 610
 })
 | BBuiltinApp LessThanEqInteger causes ({ cpu: 216714
 | mem: 1

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/2.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 351000
-| mem: 90
-})
-| BVar causes ({ cpu: 1404000
-| mem: 360
-})
-| BLamAbs causes ({ cpu: 1170000
-| mem: 300
-})
-| BApply causes ({ cpu: 2028000
-| mem: 520
-})
-| BDelay causes ({ cpu: 351000
-| mem: 90
-})
-| BForce causes ({ cpu: 468000
-| mem: 120
-})
-| BBuiltin causes ({ cpu: 351000
-| mem: 90
+, ({ tally: ({ BStep causes ({ cpu: 6123000
+| mem: 1570
 })
 | BBuiltinApp AddInteger causes ({ cpu: 237457
 | mem: 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/3.plc.golden
@@ -1,24 +1,6 @@
 ( (Right (2))
-, ({ tally: ({ BConst causes ({ cpu: 585000
-| mem: 150
-})
-| BVar causes ({ cpu: 2301000
-| mem: 590
-})
-| BLamAbs causes ({ cpu: 1794000
-| mem: 460
-})
-| BApply causes ({ cpu: 3354000
-| mem: 860
-})
-| BDelay causes ({ cpu: 507000
-| mem: 130
-})
-| BForce causes ({ cpu: 702000
-| mem: 180
-})
-| BBuiltin causes ({ cpu: 624000
-| mem: 160
+, ({ tally: ({ BStep causes ({ cpu: 9867000
+| mem: 2530
 })
 | BBuiltinApp AddInteger causes ({ cpu: 474914
 | mem: 4


### PR DESCRIPTION
This allows us to do slightly inaccurate, but faster costing calculations.
The effect of this is that we can overshoot our budget by some amount.
We will eventually notice that we've gone over, and so
long as this is bounded reasonably, it seems worth it.

The way we do it is to:
1. Assume all the machine steps cost the same.
2. Keep a simple counter of the machine steps.
3. Only when the counter exceeds a threshold (the "slippage") do we do
properly account for the steps we've taken.

This isn't quite complete, since currently it has a fixed amount of
slippage (100 steps), which would e.g. be too high for very short
programs. We should probably instead do something like calculate it
based on a proportion of the total budget. (draft until I do this)

Overall this seems to give another 15-20% in benchmarks.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
