### PR TITLE
better nsswitch file that allows queries to the internet...

### DIFF
--- a/nix/devcontainer/devcontainer.nix
+++ b/nix/devcontainer/devcontainer.nix
@@ -39,7 +39,19 @@ let
   # See: https://github.com/NixOS/docker/issues/7
   nsswitch-conf = pkgs.writeTextFile {
     name = "nsswitch.conf";
-    text = "hosts: dns files";
+    text = ''
+      passwd:    files systemd
+      group:     files systemd
+      shadow:    files
+
+      hosts:     files dns myhostname
+      networks:  files
+
+      ethers:    files
+      services:  files
+      protocols: files
+      rpc:       files
+    '';
     destination = "/etc/nsswitch.conf";
   };
   # I think we should be able to use buildLayeredImage, but for some reason it


### PR DESCRIPTION
The previous nsswitch.conf didn't seem to let `cabal update` succeed, because I think it couldn't get to the internet.

This one works; I just tested it on Ubuntu; I might try and test it on Windows first (but I'll have to set up the dev environment, etc, etc, or we can just merge this, and I'll test it via the dockerhub image, which is much easier).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
