### PR TITLE
Do not export Prelude in PlutusTx.Prelude

### DIFF
--- a/doc/plutus/tutorials/BasicApps.hs
+++ b/doc/plutus/tutorials/BasicApps.hs
@@ -27,6 +27,7 @@ import qualified Ledger.Typed.Scripts   as Scripts
 import           Plutus.Contract
 import qualified PlutusTx               as PlutusTx
 import           PlutusTx.Prelude
+import qualified Prelude                as Haskell
 import           Schema
 import           Wallet.Emulator.Wallet
 
@@ -38,7 +39,7 @@ data SplitData =
         , recipient2 :: PubKeyHash -- ^ Second recipient of the funds
         , amount     :: Ada -- ^ How much Ada we want to lock
         }
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
 
 -- For a 'real' application use 'makeIsDataIndexed' to ensure the output is stable over time
 PlutusTx.unstableMakeIsData ''SplitData
@@ -73,7 +74,7 @@ data LockArgs =
             , recipient2Wallet :: Wallet
             , totalAda         :: Ada
             }
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 type SplitSchema =
@@ -106,7 +107,7 @@ mkSplitData LockArgs{recipient1Wallet, recipient2Wallet, totalAda} =
 
 lockFunds :: SplitData -> Contract () SplitSchema T.Text ()
 lockFunds s@SplitData{amount} = do
-    logInfo $ "Locking " <> show amount
+    logInfo $ "Locking " <> Haskell.show amount
     let tx = Constraints.mustPayToTheScript s (Ada.toValue amount)
     void $ submitTxConstraints splitInstance tx
 

--- a/doc/plutus/tutorials/BasicValidators.hs
+++ b/doc/plutus/tutorials/BasicValidators.hs
@@ -16,8 +16,11 @@ import           Ledger.Ada
 import           Ledger.Typed.Scripts
 import           Ledger.Value
 
+import qualified Prelude              as Haskell
+
+
 myKeyHash :: PubKeyHash
-myKeyHash = undefined
+myKeyHash = Haskell.undefined
 
 -- BLOCK1
 -- | A specific date.

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -64,10 +64,10 @@ import           PlutusTx.Lift            (makeLift)
 import           PlutusTx.Prelude         hiding (mapM, (<$>), (<*>), (<>))
 import           PlutusTx.Ratio           (denominator, numerator)
 import           Prelude                  (mapM, (<$>))
-import qualified Prelude                  as P
+import qualified Prelude                  as Haskell
 import           Text.PrettyPrint.Leijen  (comma, hang, lbrace, line, rbrace, space, text, (<>))
 
-{-# ANN module ("HLint: ignore Avoid restricted function" :: P.String) #-}
+{-# ANN module ("HLint: ignore Avoid restricted function" :: Haskell.String) #-}
 
 {- Functions that used in Plutus Core must be inlineable,
    so their code is available for PlutusTx compiler -}
@@ -93,14 +93,14 @@ import           Text.PrettyPrint.Leijen  (comma, hang, lbrace, line, rbrace, sp
 -- * Aliaces
 
 data Party = PK PubKeyHash | Role TokenName
-  deriving stock (Generic,P.Eq,P.Ord)
+  deriving stock (Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
-instance P.Show Party where
-  showsPrec p (PK pk) = P.showParen (p P.>= 11) $ P.showString "PK \""
-                                              . P.showsPrec 11 pk
-                                              . P.showString "\""
-  showsPrec _ (Role role) = P.showsPrec 11 $ unTokenName role
+instance Haskell.Show Party where
+  showsPrec p (PK pk) = Haskell.showParen (p Haskell.>= 11) $ Haskell.showString "PK \""
+                                              . Haskell.showsPrec 11 pk
+                                              . Haskell.showString "\""
+  showsPrec _ (Role role) = Haskell.showsPrec 11 $ unTokenName role
 
 type AccountId = Party
 type Timeout = Slot
@@ -115,7 +115,7 @@ type Accounts = Map (AccountId, Token) Integer
     which combines a name for the choice with the Party who had made the choice.
 -}
 data ChoiceId = ChoiceId ByteString Party
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -123,18 +123,18 @@ data ChoiceId = ChoiceId ByteString Party
     a pair of a currency symbol and token name.
 -}
 data Token = Token CurrencySymbol TokenName
-  deriving stock (Generic,P.Eq,P.Ord)
+  deriving stock (Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
-instance P.Show Token where
+instance Haskell.Show Token where
   showsPrec p (Token cs tn) =
-    P.showParen (p P.>= 11) (P.showString $ "Token \"" P.++ P.show cs P.++ "\" " P.++ P.show tn)
+    Haskell.showParen (p Haskell.>= 11) (Haskell.showString $ "Token \"" Haskell.++ Haskell.show cs Haskell.++ "\" " Haskell.++ Haskell.show tn)
 
 {-| Values, as defined using Let ar e identified by name,
     and can be used by 'UseValue' construct.
 -}
 newtype ValueId = ValueId ByteString
-  deriving stock (P.Show,P.Eq,P.Ord,Generic)
+  deriving stock (Haskell.Show,Haskell.Eq,Haskell.Ord,Generic)
   deriving anyclass (Newtype)
 
 
@@ -156,7 +156,7 @@ data Value a = AvailableMoney AccountId Token
            | SlotIntervalEnd
            | UseValue ValueId
            | Cond a (Value a) (Value a)
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -177,12 +177,12 @@ data Observation = AndObs Observation Observation
                  | ValueEQ (Value Observation) (Value Observation)
                  | TrueObs
                  | FalseObs
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
 data Bound = Bound Integer Integer
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -201,7 +201,7 @@ data Bound = Bound Integer Integer
 data Action = Deposit AccountId Party Token (Value Observation)
             | Choice ChoiceId [Bound]
             | Notify Observation
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -211,7 +211,7 @@ data Action = Deposit AccountId Party Token (Value Observation)
 -}
 data Payee = Account AccountId
            | Party Party
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -219,7 +219,7 @@ data Payee = Account AccountId
     datatype Case is mutually recurvive with @Contract@
 -}
 data Case a = Case Action a
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -236,7 +236,7 @@ data Contract = Close
               | When [Case Contract] Timeout Contract
               | Let ValueId (Value Observation) Contract
               | Assert Observation Contract
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
 
@@ -246,12 +246,12 @@ data State = State { accounts    :: Accounts
                    , choices     :: Map ChoiceId ChosenNum
                    , boundValues :: Map ValueId Integer
                    , minSlot     :: Slot }
-  deriving stock (P.Show,Generic)
+  deriving stock (Haskell.Show,Generic)
 
 {-| Execution environment. Contains a slot interval of a transaction.
 -}
 newtype Environment = Environment { slotInterval :: SlotInterval }
-  deriving stock (P.Show,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Haskell.Eq,Haskell.Ord)
 
 
 {-| Input for a Marlowe contract. Correspond to expected 'Action's.
@@ -259,7 +259,7 @@ newtype Environment = Environment { slotInterval :: SlotInterval }
 data Input = IDeposit AccountId Party Token Integer
            | IChoice ChoiceId ChosenNum
            | INotify
-  deriving stock (P.Show,P.Eq,Generic)
+  deriving stock (Haskell.Show,Haskell.Eq,Generic)
   deriving anyclass (Pretty)
 
 instance FromJSON Input where
@@ -271,7 +271,7 @@ instance FromJSON Input where
                   <*> (v .: "that_deposits"))
     <|> (IChoice <$> (v .: "for_choice_id")
                  <*> (v .: "input_that_chooses_num"))
-  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = Haskell.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON Input where
   toJSON (IDeposit accId party tok amount) = object
@@ -295,27 +295,27 @@ instance ToJSON Input where
 -}
 data IntervalError = InvalidInterval SlotInterval
                    | IntervalInPastError Slot SlotInterval
-  deriving stock (P.Show, Generic)
+  deriving stock (Haskell.Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 
 -- | Result of 'fixInterval'
 data IntervalResult = IntervalTrimmed Environment State
                     | IntervalError IntervalError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 {-| Payment occurs during 'Pay' contract evaluation, and
     when positive balances are payed out on contract closure.
 -}
 data Payment = Payment Party Money
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Effect of 'reduceContractStep' computation
 data ReduceEffect = ReduceWithPayment Payment
                   | ReduceNoPayment
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Warning during 'reduceContractStep'
@@ -326,39 +326,39 @@ data ReduceWarning = ReduceNoWarning
                    | ReduceShadowing ValueId Integer Integer
 --                                     oldVal ^  newVal ^
                    | ReduceAssertionFailed
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Result of 'reduceContractStep'
 data ReduceStepResult = Reduced ReduceWarning ReduceEffect State Contract
                       | NotReduced
                       | AmbiguousSlotIntervalReductionError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Result of 'reduceContractUntilQuiescent'
 data ReduceResult = ContractQuiescent [ReduceWarning] [Payment] State Contract
                   | RRAmbiguousSlotIntervalError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Warning of 'applyCases'
 data ApplyWarning = ApplyNoWarning
                   | ApplyNonPositiveDeposit Party AccountId Token Integer
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Result of 'applyCases'
 data ApplyResult = Applied ApplyWarning State Contract
                  | ApplyNoMatchError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Result of 'applyAllInputs'
 data ApplyAllResult = ApplyAllSuccess [TransactionWarning] [Payment] State Contract
                     | ApplyAllNoMatchError
                     | ApplyAllAmbiguousSlotIntervalError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 -- | Warnings during transaction computation
@@ -369,7 +369,7 @@ data TransactionWarning = TransactionNonPositiveDeposit Party AccountId Token In
                         | TransactionShadowing ValueId Integer Integer
 --                                                 oldVal ^  newVal ^
                         | TransactionAssertionFailed
-  deriving stock (P.Show, Generic, P.Eq)
+  deriving stock (Haskell.Show, Generic, Haskell.Eq)
   deriving anyclass (Pretty)
 
 
@@ -378,7 +378,7 @@ data TransactionError = TEAmbiguousSlotIntervalError
                       | TEApplyNoMatchError
                       | TEIntervalError IntervalError
                       | TEUselessTransaction
-  deriving stock (P.Show, Generic)
+  deriving stock (Haskell.Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 
@@ -387,7 +387,7 @@ data TransactionError = TEAmbiguousSlotIntervalError
 data TransactionInput = TransactionInput
     { txInterval :: SlotInterval
     , txInputs   :: [Input] }
-  deriving stock (P.Show, P.Eq)
+  deriving stock (Haskell.Show, Haskell.Eq)
 
 instance Pretty TransactionInput where
     prettyFragment tInp = text "TransactionInput" <> space <> lbrace <> line <> txIntLine <> line <> txInpLine
@@ -405,7 +405,7 @@ data TransactionOutput =
         , txOutState    :: State
         , txOutContract :: Contract }
     | Error TransactionError
-  deriving stock (P.Show)
+  deriving stock (Haskell.Show)
 
 
 {-|
@@ -414,7 +414,7 @@ data TransactionOutput =
 data MarloweData = MarloweData {
         marloweState    :: State,
         marloweContract :: Contract
-    } deriving stock (P.Show, Generic)
+    } deriving stock (Haskell.Show, Generic)
       deriving anyclass (ToJSON, FromJSON)
 
 
@@ -422,7 +422,7 @@ data MarloweParams = MarloweParams {
         rolePayoutValidatorHash :: ValidatorHash,
         rolesCurrency           :: CurrencySymbol
     }
-  deriving stock (P.Show,Generic,P.Eq,P.Ord)
+  deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (FromJSON,ToJSON)
 
 
@@ -754,7 +754,7 @@ contractLifespanUpperBound contract = case contract of
         max (contractLifespanUpperBound contract1) (contractLifespanUpperBound contract2)
     When cases timeout subContract -> let
         contractsLifespans = fmap (\(Case _ cont) -> contractLifespanUpperBound cont) cases
-        in P.maximum (timeout : contractLifespanUpperBound subContract : contractsLifespans)
+        in Haskell.maximum (timeout : contractLifespanUpperBound subContract : contractsLifespans)
     Let _ _ cont -> contractLifespanUpperBound cont
     Assert _ cont -> contractLifespanUpperBound cont
 
@@ -781,9 +781,9 @@ customOptions = defaultOptions
                 }
 
 getInteger :: Scientific -> Parser Integer
-getInteger x = case (floatingOrInteger x :: Either P.Double Integer) of
+getInteger x = case (floatingOrInteger x :: Either Haskell.Double Integer) of
                  Right a -> return a
-                 Left _  -> P.fail "Account number is not an integer"
+                 Left _  -> Haskell.fail "Account number is not an integer"
 
 withInteger :: JSON.Value -> Parser Integer
 withInteger = withScientific "" getInteger
@@ -871,7 +871,7 @@ instance FromJSON (Value Observation) where
   parseJSON (String "slot_interval_start") = return SlotIntervalStart
   parseJSON (String "slot_interval_end") = return SlotIntervalEnd
   parseJSON (Number n) = Constant <$> getInteger n
-  parseJSON _ = P.fail "Value must be either an object or an integer"
+  parseJSON _ = Haskell.fail "Value must be either an object or an integer"
 instance ToJSON (Value Observation) where
   toJSON (AvailableMoney accountId token) = object
       [ "amount_of_token" .= token
@@ -932,7 +932,7 @@ instance FromJSON Observation where
                  <*> (v .: "le_than"))
     <|> (ValueEQ <$> (v .: "value")
                  <*> (v .: "equal_to"))
-  parseJSON _ = P.fail "Observation must be either an object or a boolean"
+  parseJSON _ = Haskell.fail "Observation must be either an object or a boolean"
 
 instance ToJSON Observation where
   toJSON (AndObs lhs rhs) = object
@@ -1054,7 +1054,7 @@ instance FromJSON Contract where
              <*> (v .: "then"))
     <|> (Assert <$> (v .: "assert")
                 <*> (v .: "then"))
-  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = Haskell.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON Contract where
   toJSON Close = JSON.String $ pack "close"
@@ -1097,7 +1097,7 @@ instance FromJSON TransactionInput where
                to <- Slot <$> (withInteger =<< (v .: "to"))
                return (from, to)
                                                       )
-  parseJSON _ = P.fail "TransactionInput must be an object"
+  parseJSON _ = Haskell.fail "TransactionInput must be an object"
 
 instance ToJSON TransactionInput where
   toJSON (TransactionInput (Slot from, Slot to) txInps) = object
@@ -1129,7 +1129,7 @@ instance FromJSON TransactionWarning where
     <|> (TransactionShadowing <$> (v .: "value_id")
                               <*> (v .: "had_value")
                               <*> (v .: "is_now_assigned"))
-  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = Haskell.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON TransactionWarning where
   toJSON (TransactionNonPositiveDeposit party accId tok amount) = object

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -67,7 +67,7 @@ import           Prelude                  (mapM, (<$>))
 import qualified Prelude                  as P
 import           Text.PrettyPrint.Leijen  (comma, hang, lbrace, line, rbrace, space, text, (<>))
 
-{-# ANN module ("HLint: ignore Avoid restricted function" :: String) #-}
+{-# ANN module ("HLint: ignore Avoid restricted function" :: P.String) #-}
 
 {- Functions that used in Plutus Core must be inlineable,
    so their code is available for PlutusTx compiler -}
@@ -96,11 +96,11 @@ data Party = PK PubKeyHash | Role TokenName
   deriving stock (Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
-instance Show Party where
-  showsPrec p (PK pk) = showParen (p P.>= 11) $ showString "PK \""
-                                              . showsPrec 11 pk
-                                              . showString "\""
-  showsPrec _ (Role role) = showsPrec 11 $ unTokenName role
+instance P.Show Party where
+  showsPrec p (PK pk) = P.showParen (p P.>= 11) $ P.showString "PK \""
+                                              . P.showsPrec 11 pk
+                                              . P.showString "\""
+  showsPrec _ (Role role) = P.showsPrec 11 $ unTokenName role
 
 type AccountId = Party
 type Timeout = Slot
@@ -115,7 +115,7 @@ type Accounts = Map (AccountId, Token) Integer
     which combines a name for the choice with the Party who had made the choice.
 -}
 data ChoiceId = ChoiceId ByteString Party
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -126,15 +126,15 @@ data Token = Token CurrencySymbol TokenName
   deriving stock (Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
-instance Show Token where
+instance P.Show Token where
   showsPrec p (Token cs tn) =
-    showParen (p P.>= 11) (showString $ "Token \"" P.++ show cs P.++ "\" " P.++ show tn)
+    P.showParen (p P.>= 11) (P.showString $ "Token \"" P.++ P.show cs P.++ "\" " P.++ P.show tn)
 
 {-| Values, as defined using Let ar e identified by name,
     and can be used by 'UseValue' construct.
 -}
 newtype ValueId = ValueId ByteString
-  deriving stock (Show,P.Eq,P.Ord,Generic)
+  deriving stock (P.Show,P.Eq,P.Ord,Generic)
   deriving anyclass (Newtype)
 
 
@@ -156,7 +156,7 @@ data Value a = AvailableMoney AccountId Token
            | SlotIntervalEnd
            | UseValue ValueId
            | Cond a (Value a) (Value a)
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -177,12 +177,12 @@ data Observation = AndObs Observation Observation
                  | ValueEQ (Value Observation) (Value Observation)
                  | TrueObs
                  | FalseObs
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
 data Bound = Bound Integer Integer
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -201,7 +201,7 @@ data Bound = Bound Integer Integer
 data Action = Deposit AccountId Party Token (Value Observation)
             | Choice ChoiceId [Bound]
             | Notify Observation
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -211,7 +211,7 @@ data Action = Deposit AccountId Party Token (Value Observation)
 -}
 data Payee = Account AccountId
            | Party Party
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -219,7 +219,7 @@ data Payee = Account AccountId
     datatype Case is mutually recurvive with @Contract@
 -}
 data Case a = Case Action a
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -236,7 +236,7 @@ data Contract = Close
               | When [Case Contract] Timeout Contract
               | Let ValueId (Value Observation) Contract
               | Assert Observation Contract
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (Pretty)
 
 
@@ -246,12 +246,12 @@ data State = State { accounts    :: Accounts
                    , choices     :: Map ChoiceId ChosenNum
                    , boundValues :: Map ValueId Integer
                    , minSlot     :: Slot }
-  deriving stock (Show,Generic)
+  deriving stock (P.Show,Generic)
 
 {-| Execution environment. Contains a slot interval of a transaction.
 -}
 newtype Environment = Environment { slotInterval :: SlotInterval }
-  deriving stock (Show,P.Eq,P.Ord)
+  deriving stock (P.Show,P.Eq,P.Ord)
 
 
 {-| Input for a Marlowe contract. Correspond to expected 'Action's.
@@ -259,7 +259,7 @@ newtype Environment = Environment { slotInterval :: SlotInterval }
 data Input = IDeposit AccountId Party Token Integer
            | IChoice ChoiceId ChosenNum
            | INotify
-  deriving stock (Show,P.Eq,Generic)
+  deriving stock (P.Show,P.Eq,Generic)
   deriving anyclass (Pretty)
 
 instance FromJSON Input where
@@ -271,7 +271,7 @@ instance FromJSON Input where
                   <*> (v .: "that_deposits"))
     <|> (IChoice <$> (v .: "for_choice_id")
                  <*> (v .: "input_that_chooses_num"))
-  parseJSON _ = fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON Input where
   toJSON (IDeposit accId party tok amount) = object
@@ -295,27 +295,27 @@ instance ToJSON Input where
 -}
 data IntervalError = InvalidInterval SlotInterval
                    | IntervalInPastError Slot SlotInterval
-  deriving stock (Show, Generic)
+  deriving stock (P.Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 
 -- | Result of 'fixInterval'
 data IntervalResult = IntervalTrimmed Environment State
                     | IntervalError IntervalError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 {-| Payment occurs during 'Pay' contract evaluation, and
     when positive balances are payed out on contract closure.
 -}
 data Payment = Payment Party Money
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Effect of 'reduceContractStep' computation
 data ReduceEffect = ReduceWithPayment Payment
                   | ReduceNoPayment
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Warning during 'reduceContractStep'
@@ -326,39 +326,39 @@ data ReduceWarning = ReduceNoWarning
                    | ReduceShadowing ValueId Integer Integer
 --                                     oldVal ^  newVal ^
                    | ReduceAssertionFailed
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Result of 'reduceContractStep'
 data ReduceStepResult = Reduced ReduceWarning ReduceEffect State Contract
                       | NotReduced
                       | AmbiguousSlotIntervalReductionError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Result of 'reduceContractUntilQuiescent'
 data ReduceResult = ContractQuiescent [ReduceWarning] [Payment] State Contract
                   | RRAmbiguousSlotIntervalError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Warning of 'applyCases'
 data ApplyWarning = ApplyNoWarning
                   | ApplyNonPositiveDeposit Party AccountId Token Integer
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Result of 'applyCases'
 data ApplyResult = Applied ApplyWarning State Contract
                  | ApplyNoMatchError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Result of 'applyAllInputs'
 data ApplyAllResult = ApplyAllSuccess [TransactionWarning] [Payment] State Contract
                     | ApplyAllNoMatchError
                     | ApplyAllAmbiguousSlotIntervalError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 -- | Warnings during transaction computation
@@ -369,7 +369,7 @@ data TransactionWarning = TransactionNonPositiveDeposit Party AccountId Token In
                         | TransactionShadowing ValueId Integer Integer
 --                                                 oldVal ^  newVal ^
                         | TransactionAssertionFailed
-  deriving stock (Show, Generic, P.Eq)
+  deriving stock (P.Show, Generic, P.Eq)
   deriving anyclass (Pretty)
 
 
@@ -378,7 +378,7 @@ data TransactionError = TEAmbiguousSlotIntervalError
                       | TEApplyNoMatchError
                       | TEIntervalError IntervalError
                       | TEUselessTransaction
-  deriving stock (Show, Generic)
+  deriving stock (P.Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 
@@ -387,7 +387,7 @@ data TransactionError = TEAmbiguousSlotIntervalError
 data TransactionInput = TransactionInput
     { txInterval :: SlotInterval
     , txInputs   :: [Input] }
-  deriving stock (Show, P.Eq)
+  deriving stock (P.Show, P.Eq)
 
 instance Pretty TransactionInput where
     prettyFragment tInp = text "TransactionInput" <> space <> lbrace <> line <> txIntLine <> line <> txInpLine
@@ -405,7 +405,7 @@ data TransactionOutput =
         , txOutState    :: State
         , txOutContract :: Contract }
     | Error TransactionError
-  deriving stock (Show)
+  deriving stock (P.Show)
 
 
 {-|
@@ -414,7 +414,7 @@ data TransactionOutput =
 data MarloweData = MarloweData {
         marloweState    :: State,
         marloweContract :: Contract
-    } deriving stock (Show, Generic)
+    } deriving stock (P.Show, Generic)
       deriving anyclass (ToJSON, FromJSON)
 
 
@@ -422,7 +422,7 @@ data MarloweParams = MarloweParams {
         rolePayoutValidatorHash :: ValidatorHash,
         rolesCurrency           :: CurrencySymbol
     }
-  deriving stock (Show,Generic,P.Eq,P.Ord)
+  deriving stock (P.Show,Generic,P.Eq,P.Ord)
   deriving anyclass (FromJSON,ToJSON)
 
 
@@ -754,7 +754,7 @@ contractLifespanUpperBound contract = case contract of
         max (contractLifespanUpperBound contract1) (contractLifespanUpperBound contract2)
     When cases timeout subContract -> let
         contractsLifespans = fmap (\(Case _ cont) -> contractLifespanUpperBound cont) cases
-        in maximum (timeout : contractLifespanUpperBound subContract : contractsLifespans)
+        in P.maximum (timeout : contractLifespanUpperBound subContract : contractsLifespans)
     Let _ _ cont -> contractLifespanUpperBound cont
     Assert _ cont -> contractLifespanUpperBound cont
 
@@ -781,9 +781,9 @@ customOptions = defaultOptions
                 }
 
 getInteger :: Scientific -> Parser Integer
-getInteger x = case (floatingOrInteger x :: Either Double Integer) of
+getInteger x = case (floatingOrInteger x :: Either P.Double Integer) of
                  Right a -> return a
-                 Left _  -> fail "Account number is not an integer"
+                 Left _  -> P.fail "Account number is not an integer"
 
 withInteger :: JSON.Value -> Parser Integer
 withInteger = withScientific "" getInteger
@@ -871,7 +871,7 @@ instance FromJSON (Value Observation) where
   parseJSON (String "slot_interval_start") = return SlotIntervalStart
   parseJSON (String "slot_interval_end") = return SlotIntervalEnd
   parseJSON (Number n) = Constant <$> getInteger n
-  parseJSON _ = fail "Value must be either an object or an integer"
+  parseJSON _ = P.fail "Value must be either an object or an integer"
 instance ToJSON (Value Observation) where
   toJSON (AvailableMoney accountId token) = object
       [ "amount_of_token" .= token
@@ -932,7 +932,7 @@ instance FromJSON Observation where
                  <*> (v .: "le_than"))
     <|> (ValueEQ <$> (v .: "value")
                  <*> (v .: "equal_to"))
-  parseJSON _ = fail "Observation must be either an object or a boolean"
+  parseJSON _ = P.fail "Observation must be either an object or a boolean"
 
 instance ToJSON Observation where
   toJSON (AndObs lhs rhs) = object
@@ -1054,7 +1054,7 @@ instance FromJSON Contract where
              <*> (v .: "then"))
     <|> (Assert <$> (v .: "assert")
                 <*> (v .: "then"))
-  parseJSON _ = fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON Contract where
   toJSON Close = JSON.String $ pack "close"
@@ -1097,7 +1097,7 @@ instance FromJSON TransactionInput where
                to <- Slot <$> (withInteger =<< (v .: "to"))
                return (from, to)
                                                       )
-  parseJSON _ = fail "TransactionInput must be an object"
+  parseJSON _ = P.fail "TransactionInput must be an object"
 
 instance ToJSON TransactionInput where
   toJSON (TransactionInput (Slot from, Slot to) txInps) = object
@@ -1129,7 +1129,7 @@ instance FromJSON TransactionWarning where
     <|> (TransactionShadowing <$> (v .: "value_id")
                               <*> (v .: "had_value")
                               <*> (v .: "is_now_assigned"))
-  parseJSON _ = fail "Contract must be either an object or a the string \"close\""
+  parseJSON _ = P.fail "Contract must be either an object or a the string \"close\""
 
 instance ToJSON TransactionWarning where
   toJSON (TransactionNonPositiveDeposit party accId tok amount) = object

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -32,7 +32,7 @@ import           PlutusTx.Prelude                         as TxPrelude hiding (f
 import qualified UntypedPlutusCore                        as UPLC
 import           UntypedPlutusCore.Evaluation.Machine.Cek
 
-failWithMsg :: String -> IO a
+failWithMsg :: P.String -> IO a
 failWithMsg s = hPutStrLn stderr s >> exitFailure
 
 
@@ -56,10 +56,10 @@ data Options
 
 -- Clausify options --
 
-knownFormulae :: String
+knownFormulae :: P.String
 knownFormulae = "one of F1, F2, F3, F4, F5, F6, F7"
 
-clausifyFormulaReader :: String -> Either String Clausify.StaticFormula
+clausifyFormulaReader :: P.String -> Either P.String Clausify.StaticFormula
 clausifyFormulaReader "F1" = Right Clausify.F1
 clausifyFormulaReader "F2" = Right Clausify.F2
 clausifyFormulaReader "F3" = Right Clausify.F3
@@ -94,10 +94,10 @@ lastpieceOptions = P.pure LastPiece
 
 -- Primes options --
 
-knownPrimes :: String
+knownPrimes :: P.String
 knownPrimes = "P05, P08, P10, P20, P30, P40, P50, P60, P100, P150, or P200 (a prime with the indicated number of digits)"
 
-primeIdReader :: String -> Either String Prime.PrimeID
+primeIdReader :: P.String -> Either P.String Prime.PrimeID
 primeIdReader "P05"  = Right Prime.P5
 primeIdReader "P08"  = Right Prime.P8
 primeIdReader "P10"  = Right Prime.P10
@@ -128,10 +128,10 @@ primetestOptions =
 
 -- Queens options --
 
-knownAlgorithms :: String
+knownAlgorithms :: P.String
 knownAlgorithms = "bt, bm, bjbt1, bjbt2, fc"
 
-queensAlgorithmReader :: String -> Either String Queens.Algorithm
+queensAlgorithmReader :: P.String -> Either P.String Queens.Algorithm
 queensAlgorithmReader "bt"    = Right Queens.Bt
 queensAlgorithmReader "bm"    = Right Queens.Bm
 queensAlgorithmReader "bjbt1" = Right Queens.Bjbt1
@@ -204,7 +204,7 @@ writeCBORdeBruijn ::UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> 
 writeCBORdeBruijn  prog = BSL.putStr . UPLC.serialiseOmittingUnits $
                       UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) $ prog
 
-description :: String
+description :: P.String
 description = "This program provides operations on a number of Plutus programs "
               ++ "ported from the nofib Haskell test suite.  "
               ++ "The programs are written in Haskell and can be run directly "
@@ -245,8 +245,8 @@ main = do
           Prime input             -> print $ Prime.runFixedPrimalityTest input
           Primetest n             -> if n<0 then P.error "Positive number expected"
                                      else print $ Prime.runPrimalityTest n
-    DumpPLC pa -> mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug . mkProg . getUnDBrTerm $ pa
-        where unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+    DumpPLC pa -> P.mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug . mkProg . getUnDBrTerm $ pa
+        where unindent d = map (dropWhile isSpace) $ (P.lines . P.show $ d)
     DumpCBORnamed pa   -> writeCBORnamed . mkProg . getUnDBrTerm $ pa
     DumpCBORdeBruijn pa-> writeCBORdeBruijn . mkProg . getDBrTerm $ pa
     -- Write the output to stdout and let the user deal with redirecting it.

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -4,7 +4,7 @@
 module Main where
 
 import           Prelude                                  ((<>))
-import qualified Prelude                                  as P
+import qualified Prelude                                  as Haskell
 
 import           Control.Exception
 import           Control.Monad                            ()
@@ -28,19 +28,19 @@ import           PlutusCore.Builtins
 import           PlutusCore.CBOR                          ()
 import qualified PlutusCore.Pretty                        as PLC
 import           PlutusCore.Universe
-import           PlutusTx.Prelude                         as TxPrelude hiding (fmap, mappend, (<$), (<$>), (<*>), (<>))
+import           PlutusTx.Prelude                         as Plutus hiding (fmap, mappend, (<$), (<$>), (<*>), (<>))
 import qualified UntypedPlutusCore                        as UPLC
 import           UntypedPlutusCore.Evaluation.Machine.Cek
 
-failWithMsg :: P.String -> IO a
+failWithMsg :: Haskell.String -> IO a
 failWithMsg s = hPutStrLn stderr s >> exitFailure
 
 
 -- | A program together with its arguments
 data ProgAndArgs =
     Clausify  Clausify.StaticFormula
-  | Queens    P.Integer Queens.Algorithm
-  | Knights   P.Integer P.Integer
+  | Queens    Haskell.Integer Queens.Algorithm
+  | Knights   Haskell.Integer Haskell.Integer
   | LastPiece
   | Prime     Prime.PrimeID
   | Primetest Integer
@@ -56,10 +56,10 @@ data Options
 
 -- Clausify options --
 
-knownFormulae :: P.String
+knownFormulae :: Haskell.String
 knownFormulae = "one of F1, F2, F3, F4, F5, F6, F7"
 
-clausifyFormulaReader :: P.String -> Either P.String Clausify.StaticFormula
+clausifyFormulaReader :: Haskell.String -> Either Haskell.String Clausify.StaticFormula
 clausifyFormulaReader "F1" = Right Clausify.F1
 clausifyFormulaReader "F2" = Right Clausify.F2
 clausifyFormulaReader "F3" = Right Clausify.F3
@@ -89,15 +89,15 @@ knightsOptions =
 -- Lastpiece options --
 
 lastpieceOptions :: Parser ProgAndArgs
-lastpieceOptions = P.pure LastPiece
+lastpieceOptions = Haskell.pure LastPiece
 
 
 -- Primes options --
 
-knownPrimes :: P.String
+knownPrimes :: Haskell.String
 knownPrimes = "P05, P08, P10, P20, P30, P40, P50, P60, P100, P150, or P200 (a prime with the indicated number of digits)"
 
-primeIdReader :: P.String -> Either P.String Prime.PrimeID
+primeIdReader :: Haskell.String -> Either Haskell.String Prime.PrimeID
 primeIdReader "P05"  = Right Prime.P5
 primeIdReader "P08"  = Right Prime.P8
 primeIdReader "P10"  = Right Prime.P10
@@ -128,10 +128,10 @@ primetestOptions =
 
 -- Queens options --
 
-knownAlgorithms :: P.String
+knownAlgorithms :: Haskell.String
 knownAlgorithms = "bt, bm, bjbt1, bjbt2, fc"
 
-queensAlgorithmReader :: P.String -> Either P.String Queens.Algorithm
+queensAlgorithmReader :: Haskell.String -> Either Haskell.String Queens.Algorithm
 queensAlgorithmReader "bt"    = Right Queens.Bt
 queensAlgorithmReader "bm"    = Right Queens.Bm
 queensAlgorithmReader "bjbt1" = Right Queens.Bjbt1
@@ -204,7 +204,7 @@ writeCBORdeBruijn ::UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () -> 
 writeCBORdeBruijn  prog = BSL.putStr . UPLC.serialiseOmittingUnits $
                       UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) $ prog
 
-description :: P.String
+description :: Haskell.String
 description = "This program provides operations on a number of Plutus programs "
               ++ "ported from the nofib Haskell test suite.  "
               ++ "The programs are written in Haskell and can be run directly "
@@ -243,10 +243,10 @@ main = do
           LastPiece               -> print $ LastPiece.runLastPiece
           Queens boardSize alg    -> print $ Queens.runQueens boardSize alg
           Prime input             -> print $ Prime.runFixedPrimalityTest input
-          Primetest n             -> if n<0 then P.error "Positive number expected"
+          Primetest n             -> if n<0 then Haskell.error "Positive number expected"
                                      else print $ Prime.runPrimalityTest n
-    DumpPLC pa -> P.mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug . mkProg . getUnDBrTerm $ pa
-        where unindent d = map (dropWhile isSpace) $ (P.lines . P.show $ d)
+    DumpPLC pa -> Haskell.mapM_ putStrLn $ unindent . PLC.prettyPlcClassicDebug . mkProg . getUnDBrTerm $ pa
+        where unindent d = map (dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
     DumpCBORnamed pa   -> writeCBORnamed . mkProg . getUnDBrTerm $ pa
     DumpCBORdeBruijn pa-> writeCBORdeBruijn . mkProg . getDBrTerm $ pa
     -- Write the output to stdout and let the user deal with redirecting it.
@@ -258,7 +258,7 @@ main = do
                Knights depth boardSize -> Knights.mkKnightsTerm depth boardSize
                LastPiece               -> LastPiece.mkLastPieceTerm
                Prime input             -> Prime.mkPrimalityBenchTerm input
-               Primetest n             -> if n<0 then P.error "Positive number expected"
+               Primetest n             -> if n<0 then Haskell.error "Positive number expected"
                                           else Prime.mkPrimalityTestTerm n
 
           getUnDBrTerm :: ProgAndArgs -> UPLC.Term Name DefaultUni DefaultFun ()

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
@@ -9,7 +9,8 @@ module Plutus.Benchmark.Clausify where
 import           PlutusCore.Builtins
 import           PlutusCore.Universe
 import qualified PlutusTx            as Tx
-import           PlutusTx.Prelude    as TxPrelude hiding (replicate)
+import           PlutusTx.Prelude    as TxPrelude
+import qualified Prelude             as Haskell
 import           UntypedPlutusCore
 
 type Var = Integer
@@ -23,7 +24,7 @@ data Formula =
   Con Formula Formula |
   Imp Formula Formula |
   Eqv Formula Formula
-      deriving (Show)
+      deriving (Haskell.Show)
 Tx.makeLift ''Formula
 
 -- separate positive and negative literals, eliminating duplicates

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Clausify.hs
@@ -9,7 +9,7 @@ module Plutus.Benchmark.Clausify where
 import           PlutusCore.Builtins
 import           PlutusCore.Universe
 import qualified PlutusTx            as Tx
-import           PlutusTx.Prelude    as TxPrelude
+import           PlutusTx.Prelude    as Plutus
 import qualified Prelude             as Haskell
 import           UntypedPlutusCore
 

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights.hs
@@ -13,7 +13,9 @@ import qualified PlutusCore.Pretty                        as PLC
 import           PlutusCore.Universe
 import qualified PlutusTx                                 as Tx
 import           PlutusTx.Prelude                         as Tx
+import qualified Prelude                                  as Haskell
 import           UntypedPlutusCore
+
 
 {-# INLINABLE zipConst #-}
 zipConst :: a -> [b] -> [(a,b)]
@@ -80,8 +82,8 @@ depthSearch depth q growFn finFn
                                  finFn
 
 -- % Only for textual output of PLC scripts
-unindent :: PLC.Doc ann -> [String]
-unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+unindent :: PLC.Doc ann -> [Haskell.String]
+unindent d = map (Haskell.dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
 
 
 -- % Haskell entry point for testing

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights/ChessSetList.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights/ChessSetList.hs
@@ -23,7 +23,9 @@ import           GHC.Generics
 import           Plutus.Benchmark.Knights.Sort
 import           Plutus.Benchmark.Knights.Utils
 
-import           PlutusTx.Prelude               as Tx hiding (init)
+import           PlutusTx.Prelude               as Tx
+
+import qualified Prelude                        as Haskell
 
 
 type Tile     = (Integer,Integer)
@@ -130,9 +132,9 @@ isSquareFree x (Board _ _ _ ts) = notIn x ts
 -- % Everything below here is only needed for printing boards.
 -- % This is useful for debugging.
 
-instance Show ChessSet where
+instance Haskell.Show ChessSet where
    showsPrec _ (Board sze n _ ts)
-      = showString (printBoard sze sortedTrail 1)
+      = Haskell.showString (printBoard sze sortedTrail 1)
         where sortedTrail = quickSort (assignMoveNo ts sze n)
 
 assignMoveNo :: [Tile] -> Integer -> Integer -> [Tile]
@@ -141,25 +143,25 @@ assignMoveNo [] _ _
 assignMoveNo ((x,y):t) size z
    = (((y-1)*size)+x,z):assignMoveNo t size (z-1)
 
-printBoard :: Integer -> [Tile] -> Integer -> String
+printBoard :: Integer -> [Tile] -> Integer -> Haskell.String
 printBoard s [] n
    | (n  > (s*s))   = ""
-   | ((n `mod` s) /=0)= "*"++(spaces (s*s) 1) ++(printBoard s [] (n+1))
-   | ((n `mod` s) ==0)= "*\n"                 ++(printBoard s [] (n+1))
+   | ((n `Haskell.mod` s) /=0)= "*"++(spaces (s*s) 1) ++(printBoard s [] (n+1))
+   | ((n `Haskell.mod` s) ==0)= "*\n"                 ++(printBoard s [] (n+1))
 printBoard s trail@((i,j):xs) n
    | (i==n) &&
-     ((n `mod` s) ==0) = (show j)++"\n"++(printBoard s xs (n+1))
+     ((n `Haskell.mod` s) ==0) = (Haskell.show j)++"\n"++(printBoard s xs (n+1))
    | (i==n) &&
-     ((n `mod` s) /=0)= (show j)++(spaces (s*s) j)++(printBoard s xs    (n+1))
-   | ((n `mod` s) /=0)= "*"     ++(spaces (s*s) 1)++(printBoard s trail (n+1))
-   | ((n `mod` s) ==0)= "*\n"                     ++(printBoard s trail (n+1))
+     ((n `Haskell.mod` s) /=0)= (Haskell.show j)++(spaces (s*s) j)++(printBoard s xs    (n+1))
+   | ((n `Haskell.mod` s) /=0)= "*"     ++(spaces (s*s) 1)++(printBoard s trail (n+1))
+   | ((n `Haskell.mod` s) ==0)= "*\n"                     ++(printBoard s trail (n+1))
 printBoard _ _ _ = "?"
 
-spaces :: Integer -> Integer -> String
+spaces :: Integer -> Integer -> Haskell.String
 spaces s y =
     take' ((logTen s) - (logTen y) + 1) [' ',' '..]
         where
           logTen :: Integer -> Integer
           logTen 0 = 0
-          logTen x = 1 + logTen (x `div` 10)
+          logTen x = 1 + logTen (x `Haskell.div` 10)
 

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/LastPiece.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/LastPiece.hs
@@ -20,7 +20,8 @@ import qualified PlutusCore.Pretty   as PLC
 import           PlutusCore.Universe
 import           PlutusTx            as PlutusTx
 import           PlutusTx.Builtins   as Tx
-import           PlutusTx.Prelude    as PLC hiding (Semigroup (..), check, foldMap, showList)
+import           PlutusTx.Prelude    as PLC hiding (Semigroup (..), check, foldMap)
+import qualified Prelude             as Haskell
 import           UntypedPlutusCore
 
 -------------------------------------
@@ -29,7 +30,7 @@ type Offset  = (Integer, Integer)
 type Square  = (Integer, Integer)
      -- (1,1) is bottom LH corner
 
-type PieceId = Char
+type PieceId = Haskell.Char
 
 type Board = [(Square, PieceId)]  -- Was Map.Map Square PieceId
 
@@ -42,7 +43,7 @@ data Piece = P PieceId
 data Solution = Soln Board
               | Choose [Solution]       -- Non-empty
               | Fail  -- Board Square
-                deriving (Show)
+                deriving (Haskell.Show)
 
 data Sex = Male | Female
 
@@ -290,8 +291,8 @@ bPiece = P 'b'  [ [(0,1),(0,2),(1,2)],
                   [(0,1),(1,0),(2,0)] ]
                 [ [(1,0),(1,1),(1,2)] ]
 
-unindent :: PLC.Doc ann -> [PLC.String]
-unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+unindent :: PLC.Doc ann -> [Haskell.String]
+unindent d = map (Haskell.dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
 
 runLastPiece :: Solution
 runLastPiece = search (1,2) Female initialBoard initialPieces

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -16,7 +16,7 @@ module Plutus.Benchmark.Prime where
 import           Control.DeepSeq     (NFData)
 import           Data.Char           (isSpace)
 import           GHC.Generics
-import qualified Prelude             (Eq (..), Read, Show, String, dropWhile, lines, show)
+import qualified Prelude             as Haskell
 
 import           PlutusCore.Builtins (DefaultFun)
 import qualified PlutusCore.Pretty   as PLC
@@ -94,7 +94,7 @@ cubeRoot x = until satisfy improve x
 
 {-# INLINABLE log2 #-}
 log2 :: Integer -> Integer
-log2 = fromIntegral . length . chop 2
+log2 = Haskell.fromIntegral . length . chop 2
 
 
 ---------------- Random ----------------
@@ -217,14 +217,14 @@ boundedRandom n r = (makeNumber 65536 (uniform ns rs), r')
 uniform :: [Integer] -> [Integer] -> [Integer]
 uniform [n]    [r]    = [r `modInteger` n]
 uniform (n:ns) (r:rs) = if t == n then t: uniform ns rs
-                                  else t: map ((`modInteger` 65536). toInteger) rs
-                        where t  = toInteger r `modInteger` (n+1)
+                                  else t: map ((`modInteger` 65536). Haskell.toInteger) rs
+                        where t  = Haskell.toInteger r `modInteger` (n+1)
 
 
 ---------------- Main ----------------
 
 data PrimeID = P5 | P8 | P10 | P20 | P30 | P40 | P50 | P60 | P100 | P150 | P200
-     deriving (Prelude.Read, Prelude.Show)
+     deriving (Haskell.Read, Haskell.Show)
 
 {- Some prime numbers.  The larger ones are taken from
    https://primes.utm.edu/lists/small/small.html and
@@ -248,8 +248,8 @@ getPrime =
 
 
 -- % Only for textual output of PLC scripts
-unindent :: PLC.Doc ann -> [Prelude.String]
-unindent d = map (Prelude.dropWhile isSpace) $ (Prelude.lines . Prelude.show $ d)
+unindent :: PLC.Doc ann -> [Haskell.String]
+unindent d = map (Haskell.dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
 
 
 -- % Initialise the RNG
@@ -263,8 +263,8 @@ numTests :: Integer
 numTests = 100
 
 data Result = Composite | Prime
-    deriving (Prelude.Show, Prelude.Eq, Generic, NFData)
--- Prelude.Eq needed for comparing Haskell results in tests.
+    deriving (Haskell.Show, Haskell.Eq, Generic, NFData)
+-- Haskell.Eq needed for comparing Haskell results in tests.
 
 -- % The @processList@ function takes a list of input numbers
 -- % and produces a list of output results.

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -16,7 +16,7 @@ module Plutus.Benchmark.Prime where
 import           Control.DeepSeq     (NFData)
 import           Data.Char           (isSpace)
 import           GHC.Generics
-import qualified Prelude             (Eq (..), String)
+import qualified Prelude             (Eq (..), Read, Show, String, dropWhile, lines, show)
 
 import           PlutusCore.Builtins (DefaultFun)
 import qualified PlutusCore.Pretty   as PLC
@@ -224,7 +224,7 @@ uniform (n:ns) (r:rs) = if t == n then t: uniform ns rs
 ---------------- Main ----------------
 
 data PrimeID = P5 | P8 | P10 | P20 | P30 | P40 | P50 | P60 | P100 | P150 | P200
-     deriving (Read, Show)
+     deriving (Prelude.Read, Prelude.Show)
 
 {- Some prime numbers.  The larger ones are taken from
    https://primes.utm.edu/lists/small/small.html and
@@ -249,7 +249,7 @@ getPrime =
 
 -- % Only for textual output of PLC scripts
 unindent :: PLC.Doc ann -> [Prelude.String]
-unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+unindent d = map (Prelude.dropWhile isSpace) $ (Prelude.lines . Prelude.show $ d)
 
 
 -- % Initialise the RNG
@@ -263,7 +263,7 @@ numTests :: Integer
 numTests = 100
 
 data Result = Composite | Prime
-    deriving (Show, Prelude.Eq, Generic, NFData)
+    deriving (Prelude.Show, Prelude.Eq, Generic, NFData)
 -- Prelude.Eq needed for comparing Haskell results in tests.
 
 -- % The @processList@ function takes a list of input numbers

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
@@ -19,7 +19,7 @@ import           Control.DeepSeq     (NFData)
 import           Control.Monad       (forM_)
 import           Data.Char           (isSpace)
 import           GHC.Generics
-import qualified Prelude
+import qualified Prelude             as Haskell
 import           System.Environment
 
 import           PlutusCore.Builtins
@@ -71,7 +71,7 @@ data Algorithm = Bt
                | Bjbt1
                | Bjbt2
                | Fc
-               deriving (Prelude.Show, Prelude.Read)
+               deriving (Haskell.Show, Haskell.Read)
 
 {-# INLINABLE lookupAlgorithm #-}
 lookupAlgorithm :: Algorithm -> Labeler
@@ -101,20 +101,20 @@ mkQueensTerm sz alg =
   in code
 
 
-main2 :: Prelude.IO ()  -- Haskell version
+main2 :: Haskell.IO ()  -- Haskell version
 main2 = do
   args <- getArgs
   case args of
-    [] -> Prelude.putStrLn "Integer parameter expected"
+    [] -> Haskell.putStrLn "Integer parameter expected"
     arg:_ -> do
-              let n = Prelude.read arg :: Integer
-                  try algorithm = Prelude.print (nqueens n algorithm)
+              let n = Haskell.read arg :: Integer
+                  try algorithm = Haskell.print (nqueens n algorithm)
               forM_ [1..240::Integer] $ const $ do
-                Prelude.sequence_ (map try allAlgorithms)
+                Haskell.sequence_ (map try allAlgorithms)
 
 -- % Only for textual output of PLC scripts
-unindent :: PLC.Doc ann -> [Prelude.String]
-unindent d = map (dropWhile isSpace) $ (Prelude.lines . Prelude.show $ d)
+unindent :: PLC.Doc ann -> [Haskell.String]
+unindent d = map (dropWhile isSpace) $ (Haskell.lines . Haskell.show $ d)
 
 
 -----------------------------------------------------------
@@ -232,7 +232,7 @@ type Var = Integer
 type Value = Integer
 
 data Assign = Var := Value
-    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord, Generic, NFData)
+    deriving (Haskell.Show, Haskell.Eq, Haskell.Ord, Generic, NFData)
 instance TxPrelude.Eq Assign
     where (a := b) == (a' := b') = a==a' && b==b'
 instance TxPrelude.Ord Assign
@@ -419,8 +419,8 @@ btr seed csp = bt csp . hrandom seed
 random2 :: Integer -> Integer
 random2 n = if test > 0 then test else test + 2147483647
   where test = 16807 * lo - 2836 * hi
-        hi   = n `Prelude.div` 127773
-        lo   = n `Prelude.rem` 127773
+        hi   = n `Haskell.div` 127773
+        lo   = n `Haskell.rem` 127773
 
 {-# INLINABLE randoms #-}
 randoms :: Integer -> Integer -> [Integer]

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
@@ -71,7 +71,7 @@ data Algorithm = Bt
                | Bjbt1
                | Bjbt2
                | Fc
-               deriving (Show, Read)
+               deriving (Prelude.Show, Prelude.Read)
 
 {-# INLINABLE lookupAlgorithm #-}
 lookupAlgorithm :: Algorithm -> Labeler
@@ -101,20 +101,20 @@ mkQueensTerm sz alg =
   in code
 
 
-main2 :: IO()  -- Haskell version
+main2 :: Prelude.IO ()  -- Haskell version
 main2 = do
   args <- getArgs
   case args of
-    [] -> putStrLn "Integer parameter expected"
+    [] -> Prelude.putStrLn "Integer parameter expected"
     arg:_ -> do
-              let n = read arg :: Integer
-                  try algorithm = print (nqueens n algorithm)
+              let n = Prelude.read arg :: Integer
+                  try algorithm = Prelude.print (nqueens n algorithm)
               forM_ [1..240::Integer] $ const $ do
-                sequence_ (map try allAlgorithms)
+                Prelude.sequence_ (map try allAlgorithms)
 
 -- % Only for textual output of PLC scripts
-unindent :: PLC.Doc ann -> [String]
-unindent d = map (dropWhile isSpace) $ (lines . show $ d)
+unindent :: PLC.Doc ann -> [Prelude.String]
+unindent d = map (dropWhile isSpace) $ (Prelude.lines . Prelude.show $ d)
 
 
 -----------------------------------------------------------
@@ -232,7 +232,7 @@ type Var = Integer
 type Value = Integer
 
 data Assign = Var := Value
-    deriving (Show, Prelude.Eq, Prelude.Ord, Generic, NFData)
+    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord, Generic, NFData)
 instance TxPrelude.Eq Assign
     where (a := b) == (a' := b') = a==a' && b==b'
 instance TxPrelude.Ord Assign
@@ -419,8 +419,8 @@ btr seed csp = bt csp . hrandom seed
 random2 :: Integer -> Integer
 random2 n = if test > 0 then test else test + 2147483647
   where test = 16807 * lo - 2836 * hi
-        hi   = n `div` 127773
-        lo   = n `rem` 127773
+        hi   = n `Prelude.div` 127773
+        lo   = n `Prelude.rem` 127773
 
 {-# INLINABLE randoms #-}
 randoms :: Integer -> Integer -> [Integer]

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Ada.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Ada.hs
@@ -56,10 +56,10 @@ adaToken = TH.tokenName emptyByteString
 --   1M Lovelace is one Ada.
 --   See note [Currencies] in 'Ledger.Validation.Value.TH'.
 newtype Ada = Lovelace { getLovelace :: Integer }
-    deriving (Enum)
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving (Haskell.Enum)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
-    deriving newtype (Eq, Ord, Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid, Integral, Real, Serialise, PlutusTx.IsData)
+    deriving newtype (Eq, Ord, Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid, Haskell.Integral, Haskell.Real, Serialise, PlutusTx.IsData)
     deriving Pretty via (Tagged "Lovelace:" Integer)
 
 instance Haskell.Semigroup Ada where

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
@@ -56,12 +56,12 @@ import           PlutusTx.Prelude
 --
 --   The interval can also be unbounded on either side.
 data Interval a = Interval { ivFrom :: LowerBound a, ivTo :: UpperBound a }
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, Serialise, Hashable, NFData)
 
 -- | A set extended with a positive and negative infinity.
 data Extended a = NegInf | Finite a | PosInf
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, Serialise, Hashable, NFData)
 
 instance Pretty a => Pretty (Extended a) where
@@ -74,7 +74,7 @@ type Closure = Bool
 
 -- | The upper bound of an interval.
 data UpperBound a = UpperBound (Extended a) Closure
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, Serialise, Hashable, NFData)
 
 instance Pretty a => Pretty (UpperBound a) where
@@ -85,7 +85,7 @@ instance Pretty a => Pretty (UpperBound a) where
 
 -- | The lower bound of an interval.
 data LowerBound a = LowerBound (Extended a) Closure
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, Serialise, Hashable, NFData)
 
 instance Pretty a => Pretty (LowerBound a) where

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -104,7 +104,7 @@ instance Serialise Script where
   decode = do
     bs <- decodeBytes
     case unflat bs of
-      Left  err    -> fail (show err)
+      Left  err    -> Haskell.fail (Haskell.show err)
       Right script -> return $ Script script
 
 {- Note [Eq and Ord for Scripts]
@@ -141,7 +141,7 @@ instance Haskell.Ord Script where
     a `compare` b = BSL.toStrict (serialise a) `compare` BSL.toStrict (serialise b)
 
 instance Haskell.Show Script where
-    showsPrec _ _ = showString "<Script>"
+    showsPrec _ _ = Haskell.showString "<Script>"
 
 instance NFData Script
 
@@ -181,12 +181,12 @@ evaluateScript s = do
             in UPLC.Program a v named
     p <- case PLC.runQuote $ runExceptT @PLC.FreeVariableError $ UPLC.unDeBruijnProgram namedProgram of
         Right p -> return p
-        Left e  -> throwError $ MalformedScript $ show e
+        Left e  -> throwError $ MalformedScript $ Haskell.show e
     let (logOut, _tally, result) = evaluateCekTrace p
     case result of
         Right _ -> Haskell.pure ()
         Left errWithCause@(ErrorWithCause err _) -> throwError $ case err of
-            InternalEvaluationError {} -> EvaluationException $ show errWithCause
+            InternalEvaluationError {} -> EvaluationException $ Haskell.show errWithCause
             UserEvaluationError {}     -> EvaluationError logOut -- TODO fix this error channel fuckery
     Haskell.pure logOut
 
@@ -221,7 +221,7 @@ newtype Validator = Validator { getValidator :: Script }
   deriving anyclass (ToJSON, FromJSON, NFData)
   deriving Pretty via (PrettyShow Validator)
 
-instance Show Validator where
+instance Haskell.Show Validator where
     show = const "Validator { <script> }"
 
 instance BA.ByteArrayAccess Validator where
@@ -232,7 +232,7 @@ instance BA.ByteArrayAccess Validator where
 
 -- | 'Datum' is a wrapper around 'Data' values which are used as data in transaction outputs.
 newtype Datum = Datum { getDatum :: Data  }
-  deriving stock (Generic, Show)
+  deriving stock (Generic, Haskell.Show)
   deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Serialise, IsData, NFData)
   deriving anyclass (ToJSON, FromJSON)
   deriving Pretty via Data
@@ -245,7 +245,7 @@ instance BA.ByteArrayAccess Datum where
 
 -- | 'Redeemer' is a wrapper around 'Data' values that are used as redeemers in transaction inputs.
 newtype Redeemer = Redeemer { getRedeemer :: Data }
-  deriving stock (Generic, Show)
+  deriving stock (Generic, Haskell.Show)
   deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Serialise, NFData)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -265,7 +265,7 @@ newtype MonetaryPolicy = MonetaryPolicy { getMonetaryPolicy :: Script }
   deriving anyclass (ToJSON, FromJSON, NFData)
   deriving Pretty via (PrettyShow MonetaryPolicy)
 
-instance Show MonetaryPolicy where
+instance Haskell.Show MonetaryPolicy where
     show = const "MonetaryPolicy { <script> }"
 
 instance BA.ByteArrayAccess MonetaryPolicy where
@@ -277,7 +277,7 @@ instance BA.ByteArrayAccess MonetaryPolicy where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
-    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, NFData)
@@ -285,7 +285,7 @@ newtype ValidatorHash =
 -- | Script runtime representation of a @Digest SHA256@.
 newtype DatumHash =
     DatumHash Builtins.ByteString
-    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData, NFData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
@@ -293,7 +293,7 @@ newtype DatumHash =
 -- | Script runtime representation of a @Digest SHA256@.
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
-    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
@@ -301,7 +301,7 @@ newtype RedeemerHash =
 -- | Script runtime representation of a @Digest SHA256@.
 newtype MonetaryPolicyHash =
     MonetaryPolicyHash Builtins.ByteString
-    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
@@ -327,7 +327,7 @@ monetaryPolicyHash vl = MonetaryPolicyHash $ BA.convert h' where
 -- | Information about the state of the blockchain and about the transaction
 --   that is currently being validated, represented as a value in 'Data'.
 newtype Context = Context Data
-    deriving stock (Generic, Show)
+    deriving stock (Generic, Haskell.Show)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | Apply a validator script to its arguments

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -35,14 +35,14 @@ import           PlutusTx.Prelude
 
 import           Plutus.V1.Ledger.Interval
 
-{-# ANN module ("HLint: ignore Redundant if" :: String) #-}
+{-# ANN module ("HLint: ignore Redundant if" :: Haskell.String) #-}
 
 -- | The slot number. This is a good proxy for time, since on the Cardano blockchain
 -- slots pass at a constant rate.
 newtype Slot = Slot { getSlot :: Integer }
-    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, FromJSONKey, ToJSON, ToJSONKey, NFData)
-    deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Enum, Eq, Ord, Real, Integral, Serialise, Hashable, PlutusTx.IsData)
+    deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Haskell.Enum, Eq, Ord, Haskell.Real, Haskell.Integral, Serialise, Hashable, PlutusTx.IsData)
 
 makeLift ''Slot
 

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
@@ -80,7 +80,7 @@ import           PlutusTx.Prelude
 import           PlutusTx.These
 
 newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: Builtins.ByteString }
-    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
     deriving anyclass (Hashable, ToJSONKey, FromJSONKey,  NFData)
@@ -141,10 +141,10 @@ asBase16 bs = Text.concat ["0x", JSON.encodeByteString bs]
 quoted :: Text -> Text
 quoted s = Text.concat ["\"", s, "\""]
 
-toString :: TokenName -> String
+toString :: TokenName -> Haskell.String
 toString = Text.unpack . fromTokenName asBase16 id
 
-instance Show TokenName where
+instance Haskell.Show TokenName where
     show = Text.unpack . fromTokenName asBase16 quoted
 
 {- note [Roundtripping token names]
@@ -169,7 +169,7 @@ instance FromJSON TokenName where
         fromJSONText raw
         where
             fromJSONText t = case Text.take 3 t of
-                "\NUL0x"       -> either fail (Haskell.pure . TokenName) . JSON.tryDecode . Text.drop 3 $ t
+                "\NUL0x"       -> either Haskell.fail (Haskell.pure . TokenName) . JSON.tryDecode . Text.drop 3 $ t
                 "\NUL\NUL\NUL" -> Haskell.pure . fromText . Text.drop 2 $ t
                 _              -> Haskell.pure . fromText $ t
 
@@ -182,7 +182,7 @@ tokenName = TokenName
 -- | An asset class, identified by currency symbol and token name.
 newtype AssetClass = AssetClass { unAssetClass :: (CurrencySymbol, TokenName) }
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData, Serialise, Show)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Haskell.Show, Eq, Ord, PlutusTx.IsData, Serialise)
     deriving anyclass (Hashable, NFData, ToJSON, FromJSON)
     deriving Pretty via (PrettyShow (CurrencySymbol, TokenName))
 
@@ -213,13 +213,13 @@ newtype Value = Value { getValue :: Map.Map CurrencySymbol (Map.Map TokenName In
     deriving newtype (Serialise, PlutusTx.IsData)
     deriving Pretty via (PrettyShow Value)
 
-instance Show Value where
+instance Haskell.Show Value where
     showsPrec d v =
-        showParen (d Haskell.== 11) $
-            showString "Value " . (showParen True (showsMap (showPair (showsMap shows)) rep))
+        Haskell.showParen (d Haskell.== 11) $
+            Haskell.showString "Value " . (Haskell.showParen True (showsMap (showPair (showsMap Haskell.shows)) rep))
         where Value rep = normalizeValue v
-              showsMap sh m = showString "Map " . showList__ sh (Map.toList m)
-              showPair s (x,y) = showParen True $ shows x . showString "," . s y
+              showsMap sh m = Haskell.showString "Map " . showList__ sh (Map.toList m)
+              showPair s (x,y) = Haskell.showParen True $ Haskell.shows x . Haskell.showString "," . s y
 
 normalizeValue :: Value -> Value
 normalizeValue = Value . Map.fromList . sort . filterRange (/=Map.empty)

--- a/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
@@ -50,7 +50,7 @@ data TxConstraint =
     | MustPayToPubKey PubKeyHash Value
     | MustPayToOtherScript ValidatorHash Datum Value
     | MustHashDatum DatumHash Datum
-    deriving stock (Show, Generic, Haskell.Eq)
+    deriving stock (Haskell.Show, Generic, Haskell.Eq)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Pretty TxConstraint where
@@ -82,7 +82,7 @@ data InputConstraint a =
     InputConstraint
         { icRedeemer :: a
         , icTxOutRef :: TxOutRef
-        } deriving stock (Show, Generic, Haskell.Functor)
+        } deriving stock (Haskell.Show, Generic, Haskell.Functor)
 
 addTxIn :: TxOutRef -> i -> TxConstraints i o -> TxConstraints i o
 addTxIn outRef red tc =
@@ -104,7 +104,7 @@ data OutputConstraint a =
     OutputConstraint
         { ocDatum :: a
         , ocValue :: Value
-        } deriving stock (Show, Generic, Haskell.Functor)
+        } deriving stock (Haskell.Show, Generic, Haskell.Functor)
 
 instance (Pretty a) => Pretty (OutputConstraint a) where
     pretty OutputConstraint{ocDatum, ocValue} =
@@ -124,7 +124,7 @@ data TxConstraints i o =
         , txOwnInputs   :: [InputConstraint i]
         , txOwnOutputs  :: [OutputConstraint o]
         }
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
 
 instance Bifunctor TxConstraints where
     bimap f g txc =
@@ -205,7 +205,7 @@ mustForgeValue :: forall i o. Value -> TxConstraints i o
 mustForgeValue = foldMap valueConstraint . (AssocMap.toList . Value.getValue) where
     valueConstraint (currencySymbol, mp) =
         let hs = Value.currencyMPSHash currencySymbol in
-        foldMap (uncurry (mustForgeCurrency hs)) (AssocMap.toList mp)
+        foldMap (Haskell.uncurry (mustForgeCurrency hs)) (AssocMap.toList mp)
 
 {-# INLINABLE mustForgeCurrency #-}
 -- | Create the given amount of the currency

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -63,12 +63,12 @@ gameInstance = Scripts.validator @Game
 
 -- create a data script for the guessing game by hashing the string
 -- and lifting the hash to its on-chain representation
-hashString :: String -> HashedString
+hashString :: Prelude.String -> HashedString
 hashString = HashedString . sha2_256 . C.pack
 
 -- create a redeemer script for the guessing game by lifting the
 -- string to its on-chain representation
-clearString :: String -> ClearString
+clearString :: Prelude.String -> ClearString
 clearString = ClearString . C.pack
 
 -- | The validation function (Datum -> Redeemer -> ScriptContext -> Bool)
@@ -85,7 +85,7 @@ gameAddress = Ledger.scriptAddress gameValidator
 
 -- | Parameters for the "lock" endpoint
 data LockParams = LockParams
-    { secretWord :: String
+    { secretWord :: Prelude.String
     , amount     :: Value
     }
     deriving stock (Prelude.Eq, Prelude.Show, Generic)
@@ -93,7 +93,7 @@ data LockParams = LockParams
 
 --  | Parameters for the "guess" endpoint
 newtype GuessParams = GuessParams
-    { guessWord :: String
+    { guessWord :: Prelude.String
     }
     deriving stock (Prelude.Eq, Prelude.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, ToSchema, ToArgument)

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -33,7 +33,7 @@ import           Playground.Contract
 import           Plutus.Contract
 import qualified PlutusTx              as PlutusTx
 import           PlutusTx.Prelude      hiding (pure, (<$>))
-import qualified Prelude
+import qualified Prelude               as Haskell
 
 ------------------------------------------------------------
 
@@ -63,12 +63,12 @@ gameInstance = Scripts.validator @Game
 
 -- create a data script for the guessing game by hashing the string
 -- and lifting the hash to its on-chain representation
-hashString :: Prelude.String -> HashedString
+hashString :: Haskell.String -> HashedString
 hashString = HashedString . sha2_256 . C.pack
 
 -- create a redeemer script for the guessing game by lifting the
 -- string to its on-chain representation
-clearString :: Prelude.String -> ClearString
+clearString :: Haskell.String -> ClearString
 clearString = ClearString . C.pack
 
 -- | The validation function (Datum -> Redeemer -> ScriptContext -> Bool)
@@ -85,17 +85,17 @@ gameAddress = Ledger.scriptAddress gameValidator
 
 -- | Parameters for the "lock" endpoint
 data LockParams = LockParams
-    { secretWord :: Prelude.String
+    { secretWord :: Haskell.String
     , amount     :: Value
     }
-    deriving stock (Prelude.Eq, Prelude.Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, ToSchema, ToArgument)
 
 --  | Parameters for the "guess" endpoint
 newtype GuessParams = GuessParams
-    { guessWord :: Prelude.String
+    { guessWord :: Haskell.String
     }
-    deriving stock (Prelude.Eq, Prelude.Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (FromJSON, ToJSON, ToSchema, ToArgument)
 
 -- | The "lock" contract endpoint. See note [Contract endpoints]

--- a/plutus-playground-server/usecases/HelloWorld.hs
+++ b/plutus-playground-server/usecases/HelloWorld.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# options_ghc -fno-warn-unused-imports #-}
 
 module HelloWorld where
 
@@ -8,6 +9,7 @@ module HelloWorld where
 import qualified Data.Text           as T
 import           Playground.Contract
 import           Plutus.Contract     hiding (when)
+import           PlutusTx.Prelude
 import qualified Prelude             as Haskell
 
 -- | A 'Contract' that logs a message.

--- a/plutus-playground-server/usecases/HelloWorld.hs
+++ b/plutus-playground-server/usecases/HelloWorld.hs
@@ -8,11 +8,11 @@ module HelloWorld where
 import qualified Data.Text           as T
 import           Playground.Contract
 import           Plutus.Contract     hiding (when)
-import qualified Prelude
+import qualified Prelude             as Haskell
 
 -- | A 'Contract' that logs a message.
 hello :: Contract () BlockchainActions T.Text ()
-hello = logInfo @Prelude.String "Hello, world"
+hello = logInfo @Haskell.String "Hello, world"
 
 endpoints :: Contract () BlockchainActions T.Text ()
 endpoints = hello

--- a/plutus-playground-server/usecases/HelloWorld.hs
+++ b/plutus-playground-server/usecases/HelloWorld.hs
@@ -8,11 +8,11 @@ module HelloWorld where
 import qualified Data.Text           as T
 import           Playground.Contract
 import           Plutus.Contract     hiding (when)
-import           PlutusTx.Prelude
+import qualified Prelude
 
 -- | A 'Contract' that logs a message.
 hello :: Contract () BlockchainActions T.Text ()
-hello = logInfo @String "Hello, world"
+hello = logInfo @Prelude.String "Hello, world"
 
 endpoints :: Contract () BlockchainActions T.Text ()
 endpoints = hello

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -33,7 +33,7 @@ import           Plutus.Contract          hiding (when)
 import qualified Plutus.Contract.Typed.Tx as Typed
 import qualified PlutusTx                 as PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), fold)
-import           Prelude                  (Semigroup (..))
+import           Prelude                  (Semigroup (..), show)
 import           Wallet.Emulator.Types    (walletPubKey)
 
 {- |

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -33,7 +33,7 @@ import           Plutus.Contract          hiding (when)
 import qualified Plutus.Contract.Typed.Tx as Typed
 import qualified PlutusTx                 as PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), fold)
-import           Prelude                  (Semigroup (..), show)
+import           Prelude                  as Haskell (Semigroup (..), show)
 import           Wallet.Emulator.Types    (walletPubKey)
 
 {- |

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -45,13 +45,13 @@ import           Control.Monad.Except
 import           Data.Text.Prettyprint.Doc
 import           Test.Tasty
 
-runPlcCek :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => [a] -> ExceptT SomeException IO (Term PLC.Name PLC.DefaultUni PLC.DefaultFun ())
+runPlcCek :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => [a] -> ExceptT SomeException Haskell.IO (Term PLC.Name PLC.DefaultUni PLC.DefaultFun ())
 runPlcCek values = do
      ps <- Haskell.traverse toUPlc values
      let p = Haskell.foldl1 UPLC.applyProgram ps
      either (throwError . SomeException) Haskell.pure $ evaluateCek p
 
-runPlcCekTrace :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => [a] -> ExceptT SomeException IO ([String], CekExTally PLC.DefaultFun, (Term PLC.Name PLC.DefaultUni PLC.DefaultFun ()))
+runPlcCekTrace :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => [a] -> ExceptT SomeException Haskell.IO ([Haskell.String], CekExTally PLC.DefaultFun, (Term PLC.Name PLC.DefaultUni PLC.DefaultFun ()))
 runPlcCekTrace values = do
      ps <- Haskell.traverse toUPlc values
      let p = Haskell.foldl1 UPLC.applyProgram ps
@@ -59,10 +59,10 @@ runPlcCekTrace values = do
      res <- either (throwError . SomeException) Haskell.pure result
      Haskell.pure (logOut, tally, res)
 
-goldenEvalCek :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => String -> [a] -> TestNested
+goldenEvalCek :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => Haskell.String -> [a] -> TestNested
 goldenEvalCek name values = nestedGoldenVsDocM name $ prettyPlcClassicDebug Haskell.<$> (rethrow $ runPlcCek values)
 
-goldenEvalCekLog :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => String -> [a] -> TestNested
+goldenEvalCekLog :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => Haskell.String -> [a] -> TestNested
 goldenEvalCekLog name values = nestedGoldenVsDocM name $ (pretty . (view _1)) Haskell.<$> (rethrow $ runPlcCekTrace values)
 
 tests :: TestNested
@@ -76,7 +76,7 @@ tests = testNested "TH" [
     , goldenEvalCekLog "tracePrelude" [tracePrelude]
     , goldenEvalCekLog "traceRepeatedly" [traceRepeatedly]
     -- want to see the raw structure, so using Show
-    , nestedGoldenVsDoc "someData" (pretty $ show someData)
+    , nestedGoldenVsDoc "someData" (pretty $ Haskell.show someData)
   ]
 
 simple :: CompiledCode (Bool -> Integer)

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -39,13 +39,13 @@ import           PlutusTx.Lift    (makeLift)
 import           PlutusTx.Prelude hiding (all, null, toList)
 import qualified PlutusTx.Prelude as P
 import           PlutusTx.These
-import qualified Prelude
+import qualified Prelude          as Haskell
 
-{-# ANN module ("HLint: ignore Use newtype instead of data"::Prelude.String) #-}
+{-# ANN module ("HLint: ignore Use newtype instead of data"::Haskell.String) #-}
 
 -- | A 'Map' of key-value pairs.
 newtype Map k v = Map { unMap :: [(k, v)] }
-    deriving stock (Generic, Prelude.Eq, Prelude.Show)
+    deriving stock (Generic, Haskell.Eq, Haskell.Show)
     deriving newtype (Eq, Ord, IsData, NFData)
 
 instance Functor (Map k) where

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -36,16 +36,16 @@ import           Control.DeepSeq  (NFData)
 import           GHC.Generics     (Generic)
 import           PlutusTx.IsData
 import           PlutusTx.Lift    (makeLift)
-import           PlutusTx.Prelude hiding (all, lookup, null, toList)
+import           PlutusTx.Prelude hiding (all, null, toList)
 import qualified PlutusTx.Prelude as P
 import           PlutusTx.These
 import qualified Prelude
 
-{-# ANN module ("HLint: ignore Use newtype instead of data"::String) #-}
+{-# ANN module ("HLint: ignore Use newtype instead of data"::Prelude.String) #-}
 
 -- | A 'Map' of key-value pairs.
 newtype Map k v = Map { unMap :: [(k, v)] }
-    deriving stock (Generic, Prelude.Eq, Show)
+    deriving stock (Generic, Prelude.Eq, Prelude.Show)
     deriving newtype (Eq, Ord, IsData, NFData)
 
 instance Functor (Map k) where

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Bool ((&&), (||), not) where
+module PlutusTx.Bool (Bool(..), (&&), (||), not) where
 
 import           Prelude hiding (not, (&&), (||))
 

--- a/plutus-tx/src/PlutusTx/Either.hs
+++ b/plutus-tx/src/PlutusTx/Either.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Either (isLeft, isRight, either) where
+module PlutusTx.Either (Either(..), isLeft, isRight, either) where
 
 import           Prelude (Bool (..), Either (..), String)
 

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -16,6 +16,7 @@ module PlutusTx.Foldable
   , traverse_
   , for_
   , sequenceA_
+  , sequence_
   , asum
   , concat
   , concatMap
@@ -151,6 +152,12 @@ for_ = flip traverse_
 sequenceA_ :: (Foldable t, Applicative f) => t (f a) -> f ()
 sequenceA_ = foldr c (pure ())
   where c m k = m *> k
+        {-# INLINE c #-}
+
+-- | Plutus Tx version of 'Data.Foldable.sequence_'.
+sequence_ :: (Foldable t, Monad m) => t (m a) -> m ()
+sequence_ = foldr c (return ())
+  where c m k = m >> k
         {-# INLINE c #-}
 
 -- | Plutus Tx version of 'Data.Foldable.asum'.

--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -12,7 +12,8 @@ module PlutusTx.List (
     (++),
     (!!),
     head,
-    take
+    take,
+    tail
     ) where
 
 import qualified PlutusTx.Builtins as Builtins

--- a/plutus-tx/src/PlutusTx/Maybe.hs
+++ b/plutus-tx/src/PlutusTx/Maybe.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Maybe (isJust, isNothing, maybe, fromMaybe, mapMaybe) where
+module PlutusTx.Maybe (Maybe(..), isJust, isNothing, maybe, fromMaybe, mapMaybe) where
 
 import           PlutusTx.List (foldr)
 import           Prelude       hiding (foldr, maybe)

--- a/plutus-tx/src/PlutusTx/Ord.hs
+++ b/plutus-tx/src/PlutusTx/Ord.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Ord (Ord(..), Max (..), Min (..)) where
+module PlutusTx.Ord (Ord(..), Max (..), Min (..), Ordering(..)) where
 
 import qualified PlutusTx.Builtins  as Builtins
 import           PlutusTx.Data

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -16,8 +16,14 @@ module PlutusTx.Prelude (
     module Lattice,
     module Foldable,
     module Traversable,
+    -- * Monad
+    (>>=),
+    (>>),
+    return,
     -- * Standard functions
     ($),
+    (.),
+    otherwise,
     -- * String and tracing functions
     trace,
     traceIfTrue,
@@ -60,7 +66,8 @@ module PlutusTx.Prelude (
     round,
     divMod,
     quotRem,
-    module Prelude
+    -- * Integer numbers
+    Integer
     ) where
 
 import           Data.String          (IsString (..))

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -40,8 +40,6 @@ module PlutusTx.Prelude (
     module Bool,
     -- * Integer numbers
     Integer,
-    toInteger,
-    fromIntegral,
     divide,
     modulo,
     quotient,

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -18,12 +18,15 @@ module PlutusTx.Prelude (
     module Traversable,
     -- * Monad
     (>>=),
+    (=<<),
     (>>),
     return,
     -- * Standard functions
     ($),
     (.),
     otherwise,
+    until,
+    flip,
     -- * String and tracing functions
     trace,
     traceIfTrue,
@@ -35,11 +38,15 @@ module PlutusTx.Prelude (
     check,
     -- * Booleans
     module Bool,
-    -- * Int operators
+    -- * Integer numbers
+    Integer,
+    toInteger,
+    fromIntegral,
     divide,
     modulo,
     quotient,
     remainder,
+    even,
     -- * Tuples
     fst,
     snd,
@@ -49,6 +56,8 @@ module PlutusTx.Prelude (
     module Either,
     -- * Lists
     module List,
+    dropWhile,
+    zipWith,
     -- * ByteStrings
     ByteString,
     takeByteString,
@@ -66,8 +75,6 @@ module PlutusTx.Prelude (
     round,
     divMod,
     quotRem,
-    -- * Integer numbers
-    Integer
     ) where
 
 import           Data.String          (IsString (..))

--- a/plutus-use-cases/src/Plutus/Contracts/Auction.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Auction.hs
@@ -188,7 +188,7 @@ data AuctionLog =
     | AuctionEnded HighestBid
     | CurrentStateNotFound
     | TransitionFailed (SM.InvalidTransition AuctionState AuctionInput)
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data AuctionError =
@@ -210,7 +210,7 @@ instance SM.AsSMContractError AuctionError where
 auctionSeller :: Value -> Slot -> Contract AuctionOutput SellerSchema AuctionError ()
 auctionSeller value slot = do
     threadToken <- mapError ThreadTokenError Currency.createThreadToken
-    logInfo $ "Obtained thread token: " <> show threadToken
+    logInfo $ "Obtained thread token: " <> Haskell.show threadToken
     tell $ threadTokenOut threadToken
     self <- Ledger.pubKeyHash <$> ownPubKey
     let params       = AuctionParams{apOwner = self, apAsset = value, apEndTime = slot }
@@ -228,7 +228,7 @@ auctionSeller value slot = do
     case r of
         SM.TransitionFailure i            -> logError (TransitionFailed i) -- TODO: Add an endpoint "retry" to the seller?
         SM.TransitionSuccess (Finished h) -> logInfo $ AuctionEnded h
-        SM.TransitionSuccess s            -> logWarn ("Unexpected state after Payout transition: " <> show s)
+        SM.TransitionSuccess s            -> logWarn ("Unexpected state after Payout transition: " <> Haskell.show s)
 
 
 -- | Get the current state of the contract and log it.
@@ -271,7 +271,7 @@ waitForChange AuctionParams{apEndTime} client lastHighestBid = do
         submitOwnBid = SubmitOwnBid <$> endpoint @"bid"
         otherBid = do
             let address = Scripts.scriptAddress (validatorInstance (SM.scInstance client))
-                targetSlot = succ (succ s) -- FIXME (jm): There is some off-by-one thing going on that requires us to
+                targetSlot = Haskell.succ (Haskell.succ s) -- FIXME (jm): There is some off-by-one thing going on that requires us to
                                            -- use succ.succ instead of just a single succ if we want 'addressChangeRequest'
                                            -- to wait for the next slot to begin.
                                            -- I don't have the time to look into that atm though :(

--- a/plutus-use-cases/src/Plutus/Contracts/Crowdfunding.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Crowdfunding.hs
@@ -107,7 +107,7 @@ type CrowdfundingSchema =
 newtype Contribution = Contribution
         { contribValue :: Value
         -- ^ how much to contribute
-        } deriving stock (Haskell.Eq, Show, Generic)
+        } deriving stock (Haskell.Eq, Haskell.Show, Generic)
           deriving anyclass (ToJSON, FromJSON, ToSchema, ToArgument)
 
 -- | Construct a 'Campaign' value from the campaign parameters,
@@ -202,7 +202,7 @@ theCampaign = Campaign
 contribute :: Campaign -> Contract () CrowdfundingSchema ContractError ()
 contribute cmp = do
     Contribution{contribValue} <- endpoint @"contribute"
-    logInfo @Text $ "Contributing " <> Text.pack (show contribValue)
+    logInfo @Text $ "Contributing " <> Text.pack (Haskell.show contribValue)
     contributor <- ownPubKey
     let inst = scriptInstance cmp
         tx = Constraints.mustPayToTheScript (pubKeyHash contributor) contribValue

--- a/plutus-use-cases/src/Plutus/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Currency.hs
@@ -55,10 +55,10 @@ import           Data.Semigroup          (Last (..))
 import           GHC.Generics            (Generic)
 import qualified PlutusTx.AssocMap       as AssocMap
 import           Prelude                 (Semigroup (..))
-import qualified Prelude
+import qualified Prelude                 as Haskell
 import           Schema                  (ToSchema)
 
-{-# ANN module ("HLint: ignore Use uncurry" :: Prelude.String) #-}
+{-# ANN module ("HLint: ignore Use uncurry" :: Haskell.String) #-}
 
 -- | A currency that can be created exactly once
 data OneShotCurrency = OneShotCurrency
@@ -69,7 +69,7 @@ data OneShotCurrency = OneShotCurrency
   -- ^ How many units of each 'TokenName' are to
   --   be forged.
   }
-  deriving stock (Generic, Prelude.Show, Prelude.Eq)
+  deriving stock (Generic, Haskell.Show, Haskell.Eq)
   deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.makeLift ''OneShotCurrency
@@ -139,7 +139,7 @@ currencySymbol = scriptCurrencySymbol . curPolicy
 data CurrencyError =
     CurPubKeyError PubKeyError
     | CurContractError ContractError
-    deriving stock (Prelude.Eq, Prelude.Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''CurrencyError
@@ -184,7 +184,7 @@ data SimpleMPS =
         { tokenName :: TokenName
         , amount    :: Integer
         }
-        deriving stock (Prelude.Eq, Prelude.Show, Generic)
+        deriving stock (Haskell.Eq, Haskell.Show, Generic)
         deriving anyclass (FromJSON, ToJSON, ToSchema)
 
 type CurrencySchema =

--- a/plutus-use-cases/src/Plutus/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Currency.hs
@@ -58,7 +58,7 @@ import           Prelude                 (Semigroup (..))
 import qualified Prelude
 import           Schema                  (ToSchema)
 
-{-# ANN module ("HLint: ignore Use uncurry" :: String) #-}
+{-# ANN module ("HLint: ignore Use uncurry" :: Prelude.String) #-}
 
 -- | A currency that can be created exactly once
 data OneShotCurrency = OneShotCurrency
@@ -139,7 +139,7 @@ currencySymbol = scriptCurrencySymbol . curPolicy
 data CurrencyError =
     CurPubKeyError PubKeyError
     | CurContractError ContractError
-    deriving stock (Prelude.Eq, Show, Generic)
+    deriving stock (Prelude.Eq, Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''CurrencyError

--- a/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Escrow.hs
@@ -74,14 +74,14 @@ type EscrowSchema =
         .\/ Endpoint "refund-escrow" ()
 
 data RedeemFailReason = DeadlinePassed | NotEnoughFundsAtAddress
-    deriving stock (Haskell.Eq, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data EscrowError =
     RedeemFailed RedeemFailReason
     | RefundFailed
     | EContractError ContractError
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''EscrowError
@@ -258,7 +258,7 @@ pay inst escrow vl = mapError (review _EContractError) $ do
     txId <$> submitTxConstraints inst tx
 
 newtype RedeemSuccess = RedeemSuccess TxId
-    deriving (Haskell.Eq, Show)
+    deriving (Haskell.Eq, Haskell.Show)
 
 -- | 'redeem' with an endpoint.
 redeemEp ::
@@ -292,7 +292,7 @@ redeem inst escrow = mapError (review _EscrowError) $ do
     current <- currentSlot
     unspentOutputs <- utxoAt addr
     let
-        valRange = Interval.to (pred $ escrowDeadline escrow)
+        valRange = Interval.to (Haskell.pred $ escrowDeadline escrow)
         tx = Typed.collectFromScript unspentOutputs Redeem
                 <> foldMap mkTx (escrowTargets escrow)
                 <> Constraints.mustValidateIn valRange
@@ -303,7 +303,7 @@ redeem inst escrow = mapError (review _EscrowError) $ do
          else RedeemSuccess . txId <$> submitTxConstraintsSpending inst unspentOutputs tx
 
 newtype RefundSuccess = RefundSuccess TxId
-    deriving newtype (Haskell.Eq, Show, Generic)
+    deriving newtype (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | 'refund' with an endpoint.
@@ -332,7 +332,7 @@ refund inst escrow = do
     unspentOutputs <- utxoAt (Scripts.scriptAddress inst)
     let flt _ (TxOutTx _ txOut) = Ledger.txOutDatum txOut == Just (Ledger.datumHash $ Datum (PlutusTx.toData $ Ledger.pubKeyHash pk))
         tx' = Typed.collectFromScriptFilter flt unspentOutputs Refund
-                <> Constraints.mustValidateIn (from (succ $ escrowDeadline escrow))
+                <> Constraints.mustValidateIn (from (Haskell.succ $ escrowDeadline escrow))
     if Constraints.modifiesUtxoSet tx'
     then RefundSuccess . txId <$> submitTxConstraintsSpending inst unspentOutputs tx'
     else throwing _RefundFailed ()

--- a/plutus-use-cases/src/Plutus/Contracts/Future.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Future.hs
@@ -109,7 +109,7 @@ data Future =
 
 -- | The two roles involved in the contract.
 data Role = Long | Short
-    deriving stock (Generic, Show)
+    deriving stock (Generic, Haskell.Show)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq Role where
@@ -140,7 +140,7 @@ data Margins =
         { ftsShortMargin :: Value
         , ftsLongMargin  :: Value
         }
-        deriving (Haskell.Eq, Show, Generic)
+        deriving (Haskell.Eq, Haskell.Show, Generic)
         deriving anyclass (ToJSON, FromJSON)
 
 instance Eq Margins where
@@ -152,7 +152,7 @@ data FutureState =
     -- ^ Ongoing contract, with the current margins.
     | Finished
     -- ^ Contract is finished.
-    deriving stock (Show, Generic, Haskell.Eq)
+    deriving stock (Haskell.Show, Generic, Haskell.Eq)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq FutureState where
@@ -171,7 +171,7 @@ data FutureAction =
     -- ^ Close the contract early after a margin payment has been missed.
     --   The value of both margin accounts will be paid to the role that
     --   *didn't* violate the margin requirement
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data FutureError =
@@ -184,7 +184,7 @@ data FutureError =
     | EscrowRefunded RefundSuccess
     -- ^ The other party didn't make their payment in time so the contract never
     --   started.
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''FutureError
@@ -628,7 +628,7 @@ testAccounts =
     let con = setupTokens @() @FutureSchema @FutureError
         fld = Folds.instanceOutcome con (Trace.walletInstanceTag (Wallet.Wallet 1))
         getOutcome (Folds.Done a) = a
-        getOutcome e              = Haskell.error $ "not finished: " <> show e
+        getOutcome e              = Haskell.error $ "not finished: " <> Haskell.show e
     in
     either (Haskell.error . Haskell.show) (getOutcome . S.fst')
         $ Freer.run

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -52,16 +52,18 @@ import qualified Plutus.Contract.StateMachine as SM
 
 import           Plutus.Contract
 
+import qualified Prelude                      as Haskell
+
 newtype HashedString = HashedString ByteString
     deriving newtype (PlutusTx.IsData, Eq)
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.makeLift ''HashedString
 
 newtype ClearString = ClearString ByteString
     deriving newtype (PlutusTx.IsData, Eq)
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.makeLift ''ClearString
@@ -69,23 +71,23 @@ PlutusTx.makeLift ''ClearString
 -- | Arguments for the @"lock"@ endpoint
 data LockArgs =
     LockArgs
-        { lockArgsSecret :: String
+        { lockArgsSecret :: Haskell.String
         -- ^ The secret
         , lockArgsValue  :: Value
         -- ^ Value that is locked by the contract initially
-        } deriving stock (Show, Generic)
+        } deriving stock (Haskell.Show, Generic)
           deriving anyclass (ToJSON, FromJSON, ToSchema, ToArgument)
 
 -- | Arguments for the @"guess"@ endpoint
 data GuessArgs =
     GuessArgs
-        { guessArgsOldSecret     :: String
+        { guessArgsOldSecret     :: Haskell.String
         -- ^ The guess
-        , guessArgsNewSecret     :: String
+        , guessArgsNewSecret     :: Haskell.String
         -- ^ The new secret
         , guessArgsValueTakenOut :: Value
         -- ^ How much to extract from the contract
-        } deriving stock (Show, Generic)
+        } deriving stock (Haskell.Show, Generic)
           deriving anyclass (ToJSON, FromJSON, ToSchema, ToArgument)
 
 -- | The schema of the contract. It consists of the usual
@@ -99,7 +101,7 @@ type GameStateMachineSchema =
 data GameError =
     GameContractError ContractError
     | GameSMError SM.SMContractError
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | Top-level contract, exposing both endpoints.
@@ -108,7 +110,7 @@ contract = (lock `select` guess) >> contract
 
 -- | The token that represents the right to make a guess
 newtype GameToken = GameToken { unGameToken :: Value }
-    deriving newtype (Eq, Show)
+    deriving newtype (Eq, Haskell.Show)
 
 token :: MonetaryPolicyHash -> TokenName -> Value
 token mps tn = V.singleton (V.mpsSymbol mps) tn 1
@@ -120,7 +122,7 @@ data GameState =
     | Locked MonetaryPolicyHash TokenName HashedString
     -- ^ Funds have been locked. In this state only the 'Guess' action is
     --   allowed.
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq GameState where
@@ -141,7 +143,7 @@ data GameInput =
     | Guess ClearString HashedString Value
     -- ^ Make a guess, extract the funds, and lock the remaining funds using a
     --   new secret word.
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 {-# INLINABLE transition #-}

--- a/plutus-use-cases/src/Plutus/Contracts/Governance.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Governance.hs
@@ -66,14 +66,14 @@ data Proposal = Proposal
     , votingDeadline :: Slot
     -- ^ The slot when voting ends and the votes are tallied.
     }
-    deriving stock (Show, Generic)
+    deriving stock (Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data Voting = Voting
     { proposal :: Proposal
     , votes    :: AssocMap.Map TokenName Bool
     }
-    deriving stock (Show, Generic)
+    deriving stock (Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data GovState = GovState
@@ -81,7 +81,7 @@ data GovState = GovState
     , mph    :: MonetaryPolicyHash
     , voting :: Maybe Voting
     }
-    deriving stock (Show, Generic)
+    deriving stock (Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data GovInput
@@ -89,7 +89,7 @@ data GovInput
     | ProposeChange Proposal
     | AddVote TokenName Bool
     | FinishVoting
-    deriving stock (Show, Generic)
+    deriving stock (Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | The endpoints of governance contracts are
@@ -114,7 +114,7 @@ data Params = Params
 data GovError =
     GovContractError ContractError
     | GovStateMachineError SM.SMContractError
-    deriving stock (Prelude.Eq, Show, Generic)
+    deriving stock (Prelude.Eq, Prelude.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''GovError
@@ -149,7 +149,7 @@ client params = SM.mkStateMachineClient $ SM.StateMachineInstance (machine param
 
 -- | Generate a voting token name by tagging on a number after the base token name.
 mkTokenName :: TokenName -> Integer -> TokenName
-mkTokenName base ix = fromString (Value.toString base ++ show ix)
+mkTokenName base ix = fromString (Value.toString base ++ Prelude.show ix)
 
 {-# INLINABLE votingValue #-}
 votingValue :: MonetaryPolicyHash -> TokenName -> Value.Value
@@ -203,7 +203,7 @@ contract params = forever $ mapError (review _GovError) endpoints where
         bsLaw <- endpoint @"new-law"
         let mph = Scripts.monetaryPolicyHash (scriptInstance params)
         void $ SM.runInitialise theClient (GovState bsLaw mph Nothing) mempty
-        let tokens = zipWith (const (mkTokenName (baseTokenName params))) (initialHolders params) [1..]
+        let tokens = Prelude.zipWith (const (mkTokenName (baseTokenName params))) (initialHolders params) [1..]
         SM.runStep theClient $ ForgeTokens tokens
 
 -- | The contract for proposing changes to a law.

--- a/plutus-use-cases/src/Plutus/Contracts/Governance.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Governance.hs
@@ -50,7 +50,7 @@ import qualified Plutus.Contract.StateMachine as SM
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap            as AssocMap
 import           PlutusTx.Prelude
-import qualified Prelude
+import qualified Prelude                      as Haskell
 
 -- $governance
 -- * When the contract starts it produces a number of tokens that represent voting rights.
@@ -66,14 +66,14 @@ data Proposal = Proposal
     , votingDeadline :: Slot
     -- ^ The slot when voting ends and the votes are tallied.
     }
-    deriving stock (Prelude.Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data Voting = Voting
     { proposal :: Proposal
     , votes    :: AssocMap.Map TokenName Bool
     }
-    deriving stock (Prelude.Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data GovState = GovState
@@ -81,7 +81,7 @@ data GovState = GovState
     , mph    :: MonetaryPolicyHash
     , voting :: Maybe Voting
     }
-    deriving stock (Prelude.Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data GovInput
@@ -89,7 +89,7 @@ data GovInput
     | ProposeChange Proposal
     | AddVote TokenName Bool
     | FinishVoting
-    deriving stock (Prelude.Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | The endpoints of governance contracts are
@@ -114,7 +114,7 @@ data Params = Params
 data GovError =
     GovContractError ContractError
     | GovStateMachineError SM.SMContractError
-    deriving stock (Prelude.Eq, Prelude.Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''GovError
@@ -149,7 +149,7 @@ client params = SM.mkStateMachineClient $ SM.StateMachineInstance (machine param
 
 -- | Generate a voting token name by tagging on a number after the base token name.
 mkTokenName :: TokenName -> Integer -> TokenName
-mkTokenName base ix = fromString (Value.toString base ++ Prelude.show ix)
+mkTokenName base ix = fromString (Value.toString base ++ Haskell.show ix)
 
 {-# INLINABLE votingValue #-}
 votingValue :: MonetaryPolicyHash -> TokenName -> Value.Value
@@ -203,7 +203,7 @@ contract params = forever $ mapError (review _GovError) endpoints where
         bsLaw <- endpoint @"new-law"
         let mph = Scripts.monetaryPolicyHash (scriptInstance params)
         void $ SM.runInitialise theClient (GovState bsLaw mph Nothing) mempty
-        let tokens = Prelude.zipWith (const (mkTokenName (baseTokenName params))) (initialHolders params) [1..]
+        let tokens = Haskell.zipWith (const (mkTokenName (baseTokenName params))) (initialHolders params) [1..]
         SM.runStep theClient $ ForgeTokens tokens
 
 -- | The contract for proposing changes to a law.

--- a/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
@@ -35,7 +35,7 @@ import qualified Plutus.Contract.Typed.Tx as Tx
 import qualified PlutusTx                 as PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), foldMap)
 
-import           Prelude                  (Semigroup (..), foldMap)
+import           Prelude                  (Semigroup (..), Show, foldMap)
 
 type MultiSigSchema =
     BlockchainActions

--- a/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
@@ -35,7 +35,7 @@ import qualified Plutus.Contract.Typed.Tx as Tx
 import qualified PlutusTx                 as PlutusTx
 import           PlutusTx.Prelude         hiding (Semigroup (..), foldMap)
 
-import           Prelude                  (Semigroup (..), Show, foldMap)
+import           Prelude                  as Haskell (Semigroup (..), Show, foldMap)
 
 type MultiSigSchema =
     BlockchainActions

--- a/plutus-use-cases/src/Plutus/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/MultiSigStateMachine.hs
@@ -51,6 +51,8 @@ import qualified Plutus.Contract.StateMachine as SM
 import qualified PlutusTx                     as PlutusTx
 import           PlutusTx.Prelude             hiding (Applicative (..))
 
+import qualified Prelude                      as Haskell
+
 -- $multisig
 --   The n-out-of-m multisig contract works like a joint account of
 --   m people, requiring the consent of n people for any payments.
@@ -74,7 +76,7 @@ data Payment = Payment
     , paymentDeadline  :: Slot
     -- ^ Time until the required amount of signatures has to be collected.
     }
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq Payment where
@@ -97,7 +99,7 @@ data MSState =
 
     | CollectingSignatures Payment [PubKeyHash]
     -- ^ A payment has been proposed and is awaiting signatures.
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq MSState where
@@ -121,13 +123,13 @@ data Input =
 
     | Pay
     -- ^ Make the payment.
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 data MultiSigError =
     MSContractError ContractError
     | MSStateMachineError SM.SMContractError
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 makeClassyPrisms ''MultiSigError
 

--- a/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
@@ -47,7 +47,7 @@ import qualified Plutus.Contract.StateMachine as SM
 import qualified Prelude                      as Haskell
 
 data PingPongState = Pinged | Ponged | Stopped
-    deriving stock (Haskell.Eq, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 instance Eq PingPongState where
@@ -56,7 +56,7 @@ instance Eq PingPongState where
     _ == _           = False
 
 data Input = Ping | Pong | Stop
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 type PingPongSchema =
@@ -71,7 +71,7 @@ data PingPongError =
     PingPongContractError ContractError
     | PingPongSMError SM.SMContractError
     | StoppedUnexpectedly
-    deriving stock (Show, Generic)
+    deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''PingPongError
@@ -153,12 +153,12 @@ combined :: Contract (Last PingPongState) PingPongSchema PingPongError ()
 combined = forever (void initialise `select` ping `select` pong `select` runStop `select` wait) where
     wait = do
         _ <- endpoint @"wait"
-        logInfo @String "runWaitForUpdate"
+        logInfo @Haskell.String "runWaitForUpdate"
         newState <- runWaitForUpdate
         case newState of
-            Nothing -> logWarn @String "runWaitForUpdate: Nothing"
+            Nothing -> logWarn @Haskell.String "runWaitForUpdate: Nothing"
             Just (TypedScriptTxOut{tyTxOutData=s}, _) -> do
-                logInfo $ "new state: " <> show s
+                logInfo $ "new state: " <> Haskell.show s
                 tell (Last $ Just s)
 
 PlutusTx.unstableMakeIsData ''PingPongState

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/CredentialManager.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/CredentialManager.hs
@@ -65,7 +65,7 @@ data CredentialManagerClientError =
 data CredentialManagerError =
     TokenAppServerContractError ContractError
     | TokenAppServerRPCError RPCRespondError
-    deriving stock (Show, Haskell.Eq, Generic)
+    deriving stock (Haskell.Show, Haskell.Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | Server side implementation of the 'CredentialManager' RPC. This simply calls the 'PresentCredential'

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/StateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/StateMachine.hs
@@ -56,7 +56,7 @@ data UserCredential =
         -- ^ The 'Value' containing a token of the credential
         -- (this needs to be included here because 'Credential.token'
         -- is not available in on-chain code)
-        } deriving stock (Haskell.Eq, Show, Generic)
+        } deriving stock (Haskell.Eq, Haskell.Show, Generic)
           deriving anyclass (ToJSON, FromJSON, Hashable)
 
 {-# INLINABLE transition #-}

--- a/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
@@ -356,7 +356,7 @@ data InvalidStateReason
     | MaxReserves { allowed :: BC (Ratio Integer), actual :: BC (Ratio Integer)  }
     | NegativeLiabilities
     | NegativeEquity
-    deriving (Show)
+    deriving (Haskell.Show)
 
 stablecoinStateMachine :: Stablecoin -> StateMachine BankState Input
 stablecoinStateMachine sc = StateMachine.mkStateMachine Nothing (transition sc) isFinal
@@ -413,15 +413,15 @@ checkTransition theClient sc i@Input{inpConversionRate} = do
                 case currentState of
                     Just ((TypedScriptTxOut{tyTxOutData}, _), _) -> do
                         case checkValidState sc tyTxOutData obsValue of
-                            Right _ -> logInfo @String "Current state OK"
-                            Left w  -> logInfo $ "Current state is invalid: " <> show w <> ". The transition may still be allowed."
+                            Right _ -> logInfo @Haskell.String "Current state OK"
+                            Left w  -> logInfo $ "Current state is invalid: " <> Haskell.show w <> ". The transition may still be allowed."
                         case applyInput sc tyTxOutData i of
                             Just (_, newState) -> case checkValidState sc newState obsValue of
-                                Right _ -> logInfo @String "New state OK"
-                                Left w  -> logWarn $ "New state is invalid: " <> show w <> ". The transition is not allowed."
-                            Nothing -> logWarn @String "applyInput is Nothing (transition failed)"
-                    Nothing -> logWarn @String "Unable to find current state."
-            Left e -> logWarn $ "Unable to decode oracle value from datum: " <> show e
+                                Right _ -> logInfo @Haskell.String "New state OK"
+                                Left w  -> logWarn $ "New state is invalid: " <> Haskell.show w <> ". The transition is not allowed."
+                            Nothing -> logWarn @Haskell.String "applyInput is Nothing (transition failed)"
+                    Nothing -> logWarn @Haskell.String "Unable to find current state."
+            Left e -> logWarn $ "Unable to decode oracle value from datum: " <> Haskell.show e
 
 PlutusTx.makeLift ''SC
 PlutusTx.makeLift ''RC

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -45,7 +45,7 @@ import           Plutus.Contracts.Uniswap.Pool
 import           Plutus.Contracts.Uniswap.Types
 import qualified PlutusTx
 import           PlutusTx.Prelude                 hiding (Semigroup (..), unless)
-import           Prelude                          (Semigroup (..))
+import           Prelude                          (Int, Semigroup (..), String, div, dropWhile, flip, show, (^))
 import           Text.Printf                      (printf)
 
 data Uniswapping

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -45,7 +45,8 @@ import           Plutus.Contracts.Uniswap.Pool
 import           Plutus.Contracts.Uniswap.Types
 import qualified PlutusTx
 import           PlutusTx.Prelude                 hiding (Semigroup (..), dropWhile, flip, unless)
-import           Prelude                          (Int, Semigroup (..), String, div, dropWhile, flip, show, (^))
+import           Prelude                          as Haskell (Int, Semigroup (..), String, div, dropWhile, flip, show,
+                                                              (^))
 import           Text.Printf                      (printf)
 
 data Uniswapping

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -44,7 +44,7 @@ import           Plutus.Contracts.Uniswap.OnChain (mkUniswapValidator, validateL
 import           Plutus.Contracts.Uniswap.Pool
 import           Plutus.Contracts.Uniswap.Types
 import qualified PlutusTx
-import           PlutusTx.Prelude                 hiding (Semigroup (..), unless)
+import           PlutusTx.Prelude                 hiding (Semigroup (..), dropWhile, flip, unless)
 import           Prelude                          (Int, Semigroup (..), String, div, dropWhile, flip, show, (^))
 import           Text.Printf                      (printf)
 

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/Types.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/Types.hs
@@ -24,7 +24,7 @@ import           Ledger.Value        (AssetClass (..), assetClass, assetClassVal
 import           Playground.Contract (FromJSON, Generic, ToJSON, ToSchema)
 import qualified PlutusTx
 import           PlutusTx.Prelude
-import qualified Prelude
+import qualified Prelude             as Haskell
 import           Text.Printf         (PrintfArg)
 
 -- | Uniswap coin token
@@ -58,17 +58,17 @@ deriving anyclass instance ToSchema AssetClass
 -- | A single 'AssetClass'. Because we use three coins, we use a phantom type to track
 -- which one is which.
 newtype Coin a = Coin { unCoin :: AssetClass }
-  deriving stock   (Prelude.Show, Generic)
-  deriving newtype (ToJSON, FromJSON, ToSchema, Eq, Prelude.Eq, Prelude.Ord)
+  deriving stock   (Haskell.Show, Generic)
+  deriving newtype (ToJSON, FromJSON, ToSchema, Eq, Haskell.Eq, Haskell.Ord)
 PlutusTx.makeIsDataIndexed ''Coin [('Coin, 0)]
 PlutusTx.makeLift ''Coin
 
 -- | Likewise for 'Integer'; the corresponding amount we have of the
 -- particular 'Coin'.
 newtype Amount a = Amount { unAmount :: Integer }
-  deriving stock   (Prelude.Show, Generic)
+  deriving stock   (Haskell.Show, Generic)
   deriving newtype (ToJSON, FromJSON, ToSchema, Eq, Ord, PrintfArg)
-  deriving newtype (Prelude.Eq, Prelude.Ord, Prelude.Num)
+  deriving newtype (Haskell.Eq, Haskell.Ord, Haskell.Num)
   deriving newtype (AdditiveGroup, AdditiveMonoid, AdditiveSemigroup, MultiplicativeSemigroup)
 PlutusTx.makeIsDataIndexed ''Amount [('Amount, 0)]
 PlutusTx.makeLift ''Amount
@@ -95,9 +95,9 @@ mkCoin c = Coin . assetClass c
 
 newtype Uniswap = Uniswap
     { usCoin :: Coin U
-    } deriving stock    (Prelude.Show, Generic)
+    } deriving stock    (Haskell.Show, Generic)
       deriving anyclass (ToJSON, FromJSON, ToSchema)
-      deriving newtype  (Prelude.Eq, Prelude.Ord)
+      deriving newtype  (Haskell.Eq, Haskell.Ord)
 PlutusTx.makeIsDataIndexed ''Uniswap [('Uniswap, 0)]
 PlutusTx.makeLift ''Uniswap
 
@@ -105,7 +105,7 @@ data LiquidityPool = LiquidityPool
     { lpCoinA :: Coin A
     , lpCoinB :: Coin B
     }
-    deriving (Prelude.Show, Generic, ToJSON, FromJSON, ToSchema)
+    deriving (Haskell.Show, Generic, ToJSON, FromJSON, ToSchema)
 PlutusTx.makeIsDataIndexed ''LiquidityPool [('LiquidityPool, 0)]
 PlutusTx.makeLift ''LiquidityPool
 
@@ -116,7 +116,7 @@ instance Eq LiquidityPool where
              (unCoin (lpCoinA x) == unCoin (lpCoinB y) && unCoin (lpCoinB x) == unCoin (lpCoinA y))
 
 data UniswapAction = Create LiquidityPool | Close | Swap | Remove | Add
-    deriving Prelude.Show
+    deriving Haskell.Show
 PlutusTx.makeIsDataIndexed ''UniswapAction [ ('Create , 0)
                                            , ('Close,   1)
                                            , ('Swap,    2)
@@ -128,7 +128,7 @@ PlutusTx.makeLift ''UniswapAction
 data UniswapDatum =
       Factory [LiquidityPool]
     | Pool LiquidityPool (Amount Liquidity)
-    deriving stock (Prelude.Show)
+    deriving stock (Haskell.Show)
 PlutusTx.makeIsDataIndexed ''UniswapDatum [ ('Factory, 0)
                                           , ('Pool,    1)
                                           ]

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/Types.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/Types.hs
@@ -58,7 +58,7 @@ deriving anyclass instance ToSchema AssetClass
 -- | A single 'AssetClass'. Because we use three coins, we use a phantom type to track
 -- which one is which.
 newtype Coin a = Coin { unCoin :: AssetClass }
-  deriving stock   (Show, Generic)
+  deriving stock   (Prelude.Show, Generic)
   deriving newtype (ToJSON, FromJSON, ToSchema, Eq, Prelude.Eq, Prelude.Ord)
 PlutusTx.makeIsDataIndexed ''Coin [('Coin, 0)]
 PlutusTx.makeLift ''Coin
@@ -66,7 +66,7 @@ PlutusTx.makeLift ''Coin
 -- | Likewise for 'Integer'; the corresponding amount we have of the
 -- particular 'Coin'.
 newtype Amount a = Amount { unAmount :: Integer }
-  deriving stock   (Show, Generic)
+  deriving stock   (Prelude.Show, Generic)
   deriving newtype (ToJSON, FromJSON, ToSchema, Eq, Ord, PrintfArg)
   deriving newtype (Prelude.Eq, Prelude.Ord, Prelude.Num)
   deriving newtype (AdditiveGroup, AdditiveMonoid, AdditiveSemigroup, MultiplicativeSemigroup)
@@ -95,7 +95,7 @@ mkCoin c = Coin . assetClass c
 
 newtype Uniswap = Uniswap
     { usCoin :: Coin U
-    } deriving stock    (Show, Generic)
+    } deriving stock    (Prelude.Show, Generic)
       deriving anyclass (ToJSON, FromJSON, ToSchema)
       deriving newtype  (Prelude.Eq, Prelude.Ord)
 PlutusTx.makeIsDataIndexed ''Uniswap [('Uniswap, 0)]
@@ -105,7 +105,7 @@ data LiquidityPool = LiquidityPool
     { lpCoinA :: Coin A
     , lpCoinB :: Coin B
     }
-    deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+    deriving (Prelude.Show, Generic, ToJSON, FromJSON, ToSchema)
 PlutusTx.makeIsDataIndexed ''LiquidityPool [('LiquidityPool, 0)]
 PlutusTx.makeLift ''LiquidityPool
 
@@ -116,7 +116,7 @@ instance Eq LiquidityPool where
              (unCoin (lpCoinA x) == unCoin (lpCoinB y) && unCoin (lpCoinB x) == unCoin (lpCoinA y))
 
 data UniswapAction = Create LiquidityPool | Close | Swap | Remove | Add
-    deriving Show
+    deriving Prelude.Show
 PlutusTx.makeIsDataIndexed ''UniswapAction [ ('Create , 0)
                                            , ('Close,   1)
                                            , ('Swap,    2)
@@ -128,7 +128,7 @@ PlutusTx.makeLift ''UniswapAction
 data UniswapDatum =
       Factory [LiquidityPool]
     | Pool LiquidityPool (Amount Liquidity)
-    deriving stock (Show)
+    deriving stock (Prelude.Show)
 PlutusTx.makeIsDataIndexed ''UniswapDatum [ ('Factory, 0)
                                           , ('Pool,    1)
                                           ]

--- a/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
@@ -162,7 +162,7 @@ contractAddress = Scripts.scriptAddress . scriptInstance
 data VestingError =
     VContractError ContractError
     | InsufficientFundsError Value Value Value
-    deriving stock (Haskell.Eq, Show, Generic)
+    deriving stock (Haskell.Eq, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 makeClassyPrisms ''VestingError


### PR DESCRIPTION
#3187, #3202, #3203 show that exporting of `Prelude` by default is a misleading feature. Users get plugin compilation errors that might be hard to understand.

The proposed solution is to do not export it at all and users will get "module missing function" error messages.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
