### PR TITLE
Restrict Data bytestring length to 64

### DIFF
--- a/plutus-tx/src/PlutusTx/Data.hs
+++ b/plutus-tx/src/PlutusTx/Data.hs
@@ -107,8 +107,12 @@ fromTerm = \case
     CBOR.TListI l                             -> List <$> traverse fromTerm l
     CBOR.TInteger i                           -> pure $ I i
     CBOR.TInt i                               -> pure $ I $ fromIntegral i
-    CBOR.TBytes b                             -> pure $ B b
-    CBOR.TBytesI b                            -> pure $ B $ BSL.toStrict b
+    CBOR.TBytes b                             -> if BS.length b <= 64
+                                                   then pure $ B b
+                                                   else throwError "ByteString exceeds 64"
+    CBOR.TBytesI b                            -> if BSL.length b <= 64
+                                                   then pure $ B $ BSL.toStrict b
+                                                   else throwError "ByteString exceeds 64"
     _                                         -> throwError "Unsupported kind of CBOR"
 
 -- See Note [Definite and indefinite forms of CBOR]

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -113,7 +113,7 @@ genData =
     in
     Gen.recursive Gen.choice
         [ I <$> Gen.integral (Range.linear (-100000) 100000)
-        , B <$> Gen.bytes (Range.linear 0 1000) ]
+        , B <$> Gen.bytes (Range.linear 0 64) ]
         [ Constr <$> positiveInteger <*> constructorArgList
         , List <$> constructorArgList
         , Map <$> kvMapList


### PR DESCRIPTION
Throw an error when decoding Plutus Data values that contain any bytestrings with length greater than 64.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
