### PR TITLE
Use action index to give labels a unique id

### DIFF
--- a/plutus-pab-client/src/View/Contracts.purs
+++ b/plutus-pab-client/src/View/Contracts.purs
@@ -158,7 +158,7 @@ actionCard contractInstanceId wrapper endpointForm =
   col4_
     [ card_
         [ cardHeader_ [ h2_ [ text $ view (_schema <<< _FunctionSchema <<< _endpointDescription <<< _getEndpointDescription) endpointForm ] ]
-        , cardBody_ [ actionArgumentForm wrapper (view _argument endpointForm) ]
+        , cardBody_ [ actionArgumentForm 0 wrapper (view _argument endpointForm) ]
         , cardFooter_
             [ button
                 [ classes [ btn, btnSmall, btnPrimary ]

--- a/plutus-playground-client/src/Action/View.purs
+++ b/plutus-playground-client/src/Action/View.purs
@@ -93,7 +93,7 @@ actionPaneBody index (CallEndpoint { caller, argumentValues }) =
         , text ": "
         , text $ view (_FunctionSchema <<< _endpointDescription <<< _getEndpointDescription) argumentValues
         ]
-    , actionArgumentForm (PopulateAction index) $ view (_FunctionSchema <<< _argument) argumentValues
+    , actionArgumentForm index (PopulateAction index) $ view (_FunctionSchema <<< _argument) argumentValues
     ]
 
 actionPaneBody index (PayToWallet { sender, recipient, amount }) =

--- a/web-common-plutus/src/Schema/View.purs
+++ b/web-common-plutus/src/Schema/View.purs
@@ -31,12 +31,13 @@ import ValueEditor (valueForm)
 
 actionArgumentForm ::
   forall p i.
+  Int ->
   (FormEvent -> i) ->
   FormArgument ->
   HTML p i
-actionArgumentForm wrapper argument =
+actionArgumentForm index wrapper argument =
   div [ class_ wasValidated ]
-    [ wrapper <$> actionArgumentField [] false argument ]
+    [ wrapper <$> actionArgumentField [ show index ] false argument ]
 
 actionArgumentField ::
   forall p.


### PR DESCRIPTION
[plutus-playground-client]
This PR makes use of the action index in order to give input ids a unique name which fixes #3196