### PR TITLE
SCP-2295: Make tasks and balances tabs independent for each step.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -24,7 +24,7 @@ import Marlowe.PAB (PlutusAppId, MarloweParams)
 import Marlowe.Semantics as Semantic
 import WalletData.Types (WalletNickname)
 
-_tab :: Lens' State Tab
+_tab :: forall a. Lens' { tab :: Tab | a } Tab
 _tab = prop (SProxy :: SProxy "tab")
 
 _executionState :: Lens' State ExecutionState

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -21,7 +21,7 @@ import Marlowe.Semantics (ChoiceId, ChosenNum, Party, Slot, TransactionInput, Ac
 import WalletData.Types (WalletDetails, WalletNickname)
 
 type State
-  = { tab :: Tab
+  = { tab :: Tab -- this is the tab of the current (latest) step - previous steps have their own tabs
     , executionState :: ExecutionState
     , previousSteps :: Array PreviousStep
     , followerAppId :: PlutusAppId
@@ -40,7 +40,8 @@ type State
 
 -- Represents a historical step in a contract's life.
 type PreviousStep
-  = { balances :: Accounts
+  = { tab :: Tab
+    , balances :: Accounts
     , state :: PreviousStepState
     }
 
@@ -62,12 +63,12 @@ type Input
 data Action
   = ConfirmAction NamedAction
   | ChangeChoice ChoiceId (Maybe ChosenNum)
-  | SelectTab Tab
+  | SelectTab Int Tab
   | AskConfirmation NamedAction
   | CancelConfirmation
   -- The SelectStep action is what changes the model and causes the card to seem bigger.
   | SelectStep Int
-  -- The MoveToStep action scrolls the step carousel so that the indicated step is at the center
+  -- The MoveToStep action scrolls the step carousel so that the indicated step is at the center (without changing the model).
   | MoveToStep Int
   | CarouselOpened
   | CarouselClosed
@@ -75,11 +76,11 @@ data Action
 instance actionIsEvent :: IsEvent Action where
   toEvent (ConfirmAction _) = Just $ defaultEvent "ConfirmAction"
   toEvent (ChangeChoice _ _) = Just $ defaultEvent "ChangeChoice"
-  toEvent (SelectTab _) = Just $ defaultEvent "SelectTab"
+  toEvent (SelectTab _ _) = Just $ defaultEvent "SelectTab"
   toEvent (AskConfirmation _) = Just $ defaultEvent "AskConfirmation"
   toEvent CancelConfirmation = Just $ defaultEvent "CancelConfirmation"
   toEvent (SelectStep _) = Just $ defaultEvent "SelectStep"
-  toEvent (MoveToStep _) = Just $ defaultEvent "MoveToStep"
+  toEvent (MoveToStep _) = Nothing
   toEvent CarouselOpened = Just $ defaultEvent "CarouselOpened"
   toEvent CarouselClosed = Just $ defaultEvent "CarouselClosed"
 

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -207,11 +207,9 @@ actionConfirmationCard assets state namedAction =
           ]
       ]
 
-renderContractCard :: forall p. Int -> State -> Array (HTML p Action) -> HTML p Action
-renderContractCard stepNumber state cardBody =
+renderContractCard :: forall p. Int -> State -> Tab -> Array (HTML p Action) -> HTML p Action
+renderContractCard stepNumber state currentTab cardBody =
   let
-    currentTab = state ^. _tab
-
     tabSelector isActive =
       [ "flex-grow", "text-center", "py-2", "trapesodial-card-selector", "text-sm", "font-semibold" ]
         <> case isActive of
@@ -235,12 +233,12 @@ renderContractCard stepNumber state cardBody =
       [ div [ classNames [ "flex", "overflow-hidden" ] ]
           [ a
               [ classNames (tabSelector $ currentTab == Tasks)
-              , onClick_ $ SelectTab Tasks
+              , onClick_ $ SelectTab stepNumber Tasks
               ]
               [ span_ $ [ text "Tasks" ] ]
           , a
               [ classNames (tabSelector $ currentTab == Balances)
-              , onClick_ $ SelectTab Balances
+              , onClick_ $ SelectTab stepNumber Balances
               ]
               [ span_ $ [ text "Balances" ] ]
           ]
@@ -259,8 +257,7 @@ statusIndicator mIcon status extraClasses =
 renderPastStep :: forall p. State -> Int -> PreviousStep -> HTML p Action
 renderPastStep state stepNumber step =
   let
-    -- FIXME: We need to make the tab independent.
-    currentTab = state ^. _tab
+    currentTab = step ^. _tab
 
     renderBody Tasks { state: TransactionStep txInput } = renderPastActions state txInput
 
@@ -268,7 +265,7 @@ renderPastStep state stepNumber step =
 
     renderBody Balances { balances } = renderBalances state balances
   in
-    renderContractCard stepNumber state
+    renderContractCard stepNumber state currentTab
       [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
           [ span
               [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
@@ -398,7 +395,7 @@ renderCurrentStep currentSlot state =
         (\nextTimeout -> humanizeDuration $ secondsDiff nextTimeout currentSlot)
         mNextTimeout
   in
-    renderContractCard stepNumber state
+    renderContractCard stepNumber state currentTab
       [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
           [ span
               [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]


### PR DESCRIPTION
Does what it says in the title. I want to get this up quickly in time for the video recording, so I've left out a bonus feature (remembering which tab is showing for previous steps whenever a new transaction or timeout moves things forward).