### PR TITLE
Marlowe Playground: Fix build optimization

### DIFF
--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -2,7 +2,7 @@
   "name": "marlowe-playground-client",
   "version": "1.0.0",
   "scripts": {
-    "webpack": "NODE_OPTIONS=\"--max-old-space-size=8192\" DEBUG=purs-loader* DEBUG_DEPTH=100 webpack --progress --bail --mode=production -p",
+    "webpack": "NODE_ENV=production NODE_OPTIONS=\"--max-old-space-size=8192\" DEBUG=purs-loader* DEBUG_DEPTH=100 webpack --progress --bail --mode=production -p",
     "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development --host 0.0.0.0 --display verbose",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",


### PR DESCRIPTION
This PR fixes a build issue were the CSS was not being minified and purged.

I've tried the same option that the dashboard uses `--node-env=production` but it didn't work for this version of webpack, so I had to use the `NODE_ENV` env variable.

The CSS changes from 231kb compressed to 45kb compressed.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
