### PR TITLE
Kwxm/forgot to fix cost model interface for ints

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -128,9 +128,9 @@ extractCostModelParams model = -- this is using the applicative instance of Mayb
    applyParams any superfluous objects in the map being decoded will be
    discarded, so we could update both components of the cost model with the
    entire set of parameters without having to worry about splitting the
-   parameters on a prefix of the key.  This appears to be an undocumented
-   implementation choice in Aeson though (other JSON decoders (for other
-   languages) seem to vary in how unknown fields are handled), so let's be
+   parameters on a prefix of the key.  This relies on what appears to be an
+   undocumented implementation choice in Aeson though (other JSON decoders (for
+   other languages) seem to vary in how unknown fields are handled), so let's be
    explicit. -}
 applySplitCostModelParams
     :: (FromJSON evaluatorcosts, ToJSON evaluatorcosts)

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -41,9 +41,9 @@ The numbers in CostModel objects are CostingIntegers, which are usually the
 Aeson-encoded JSON objects are represented as Data.Scientific (Integer mantissa,
 Int exponent). We should be able to convert between these types without loss of
 precision, except that Scientific numbers of large magnitude will overflow to
-SatInt::MaxBound or SatInt::MinBound.  This is OK because CostModelParams
-objects should never contain such large numbers. Any Plutus Core programs whose
-cost reaches MaxBound will fail due to excesssive resoutce usage.
+SatInt::MaxBound or underflow to SatInt::MinBound.  This is OK because
+CostModelParams objects should never contain such large numbers. Any Plutus Core
+programs whose cost reaches MaxBound will fail due to excesssive resoutce usage.
 
 3. BuiltinCostModel includes the *type* of the model, which isn't a parameter
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -40,7 +40,7 @@ The numbers in CostModel objects are CostingIntegers, which are usually the
 64-bit SatInt type (but Integer on 32-bit machines).  Numerical values in
 Aeson-encoded JSON objects are represented as Data.Scientific (Integer mantissa,
 Int exponent). We should be able to convert between these types without loss of
-precision, except that large Scientific numbers will overflow to
+precision, except that Scientific numbers of large magnitude will overflow to
 SatInt::MaxBound or SatInt::MinBound.  This is OK because CostModelParams
 objects should never contain such large numbers. Any Plutus Core programs whose
 cost reaches MaxBound will fail due to excesssive resoutce usage.

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -80,7 +80,7 @@ extractParams cm = case toJSON cm of
         let
             flattened = flattenObject "-" o
             usingCostingIntegers = HM.mapMaybe (\case { Number n -> Just $ ceiling n; _ -> Nothing }) flattened
-            -- ^ Only the "Just" values are retained in the output map.
+            -- ^ Only (the contents of) the "Just" values are retained in the output map.
             mapified = Map.fromList $ HM.toList usingCostingIntegers
         in Just mapified
     _ -> Nothing

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -43,7 +43,7 @@ Int exponent). We should be able to convert between these types without loss of
 precision, except that Scientific numbers of large magnitude will overflow to
 SatInt::MaxBound or underflow to SatInt::MinBound.  This is OK because
 CostModelParams objects should never contain such large numbers. Any Plutus Core
-programs whose cost reaches MaxBound will fail due to excesssive resoutce usage.
+programs whose cost reaches MaxBound will fail due to excesssive resource usage.
 
 3. BuiltinCostModel includes the *type* of the model, which isn't a parameter
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -16,7 +16,6 @@ import           Data.Aeson
 import           Data.Aeson.Flatten
 import qualified Data.HashMap.Strict                                      as HM
 import qualified Data.Map                                                 as Map
--- import qualified Data.Scientific                                          as S
 import qualified Data.Text                                                as Text
 
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -36,8 +36,8 @@ look only at the numbers.
 
 2. We use CostingIntegers, Aeson uses Data.Scientific.
 
-The numbers in CostModel objects are CostingIntegers, which are either (a) the
-64-bit SatInt type, or Integer (only on 32-bit machines).  Numerical values in
+The numbers in CostModel objects are CostingIntegers, which are usually the
+64-bit SatInt type (but Integer on 32-bit machines).  Numerical values in
 Aeson-encoded JSON objects are represented as Data.Scientific (Integer mantissa,
 Int exponent). We should be able to convert between these types without loss of
 precision, except that large Scientific numbers will overflow to

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -32,7 +32,7 @@ data CostModel machinecosts =
   cost model for builtins and their denotations.  This bundles one of those
   together with the cost model for evaluator steps.  The 'term' type will be
   CekValue when we're using this with the CEK machine. -}
-data MachineParameters machinecosts (term :: (Type -> Type) -> Type -> Type) (uni :: Type -> Type) (fun :: Type) =
+data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
     MachineParameters {
       machineCosts    :: machinecosts
     , builtinsRuntime :: BuiltinsRuntime fun (term uni fun)

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -124,35 +124,35 @@ test_costModelInterface :: TestTree
 test_costModelInterface =
     testGroup "cost model interface tests"
        [ testGroup "extractCostModelParams works"
-       [ testCase "defaultCekCostModel" $ testExtraction defaultCekCostModel
-       , testCase "randomCekCostModel"  $ testExtraction randomCekCostModel
-       ]
-     , testGroup "self-update is identity"
-       [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testSelfUpdate defaultCekCostModel
-       , testCase "randomCekCostModel  <- randomCekCostModel"  $ testSelfUpdate randomCekCostModel
-       ]
-      , testGroup "overwriting works"
-       [ testCase "defaultCekCostModel <- randomCekCostModel"  $ testOverwrite defaultCekCostModel randomCekCostModel
-       , testCase "randomCekCostModel  <- defaultCekCostModel" $ testOverwrite randomCekCostModel  defaultCekCostModel
-       ]
-     , testGroup "superfluous entry in params is OK in self-update"
-       [ testCase "defaultCekCostModel" $ testSelfUpdateWithExtraEntry defaultCekCostModel
-       , testCase "randomCekCostModel"  $ testSelfUpdateWithExtraEntry randomCekCostModel
-       ]
-     , testGroup "missing entry in params is OK in self-update"
-       [ testCase "defaultCekCostModel" $ testSelfUpdateWithMissingEntry defaultCekCostModel
-       , testCase "randomCekCostModel"  $ testSelfUpdateWithMissingEntry randomCekCostModel
-       ]
-     , testGroup "missing entry in update of different model"
-       [ testCase "defaultCekCostModel" $ testOtherUpdateWithMissingEntry defaultCekCostModel randomCekCostModel
-       , testCase "randomCekCostModel"  $ testOtherUpdateWithMissingEntry randomCekCostModel defaultCekCostModel
-       ]
-     , testGroup "extract after apply is identity"
-       [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testExtractAfterUpdate defaultCekCostModel defaultCekCostModel
-       , testCase "randomCekCostModel  <- randomCekCostModel"  $ testExtractAfterUpdate randomCekCostModel  randomCekCostModel
-       , testCase "randomCekCostModel  <- defaultCekCostModel" $ testExtractAfterUpdate randomCekCostModel  defaultCekCostModel
-       , testCase "defaultCekCostModel <- randomCekCostModel"  $ testExtractAfterUpdate defaultCekCostModel randomCekCostModel
-       ]
+             [ testCase "defaultCekCostModel" $ testExtraction defaultCekCostModel
+             , testCase "randomCekCostModel"  $ testExtraction randomCekCostModel
+             ]
+       , testGroup "self-update is identity"
+             [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testSelfUpdate defaultCekCostModel
+             , testCase "randomCekCostModel  <- randomCekCostModel"  $ testSelfUpdate randomCekCostModel
+             ]
+       , testGroup "overwriting works"
+             [ testCase "defaultCekCostModel <- randomCekCostModel"  $ testOverwrite defaultCekCostModel randomCekCostModel
+             , testCase "randomCekCostModel  <- defaultCekCostModel" $ testOverwrite randomCekCostModel  defaultCekCostModel
+             ]
+       , testGroup "superfluous entry in params is OK in self-update"
+             [ testCase "defaultCekCostModel" $ testSelfUpdateWithExtraEntry defaultCekCostModel
+             , testCase "randomCekCostModel"  $ testSelfUpdateWithExtraEntry randomCekCostModel
+             ]
+       , testGroup "missing entry in params is OK in self-update"
+             [ testCase "defaultCekCostModel" $ testSelfUpdateWithMissingEntry defaultCekCostModel
+             , testCase "randomCekCostModel"  $ testSelfUpdateWithMissingEntry randomCekCostModel
+             ]
+       , testGroup "missing entry in update of different model"
+             [ testCase "defaultCekCostModel" $ testOtherUpdateWithMissingEntry defaultCekCostModel randomCekCostModel
+             , testCase "randomCekCostModel"  $ testOtherUpdateWithMissingEntry randomCekCostModel defaultCekCostModel
+             ]
+       , testGroup "extract after apply is identity"
+             [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testExtractAfterUpdate defaultCekCostModel defaultCekCostModel
+             , testCase "randomCekCostModel  <- randomCekCostModel"  $ testExtractAfterUpdate randomCekCostModel  randomCekCostModel
+             , testCase "randomCekCostModel  <- defaultCekCostModel" $ testExtractAfterUpdate randomCekCostModel  defaultCekCostModel
+             , testCase "defaultCekCostModel <- randomCekCostModel"  $ testExtractAfterUpdate defaultCekCostModel randomCekCostModel
+             ]
      ]
 
 

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -122,7 +122,7 @@ testExtractAfterUpdate model1 model2 =
 
 test_costModelInterface :: TestTree
 test_costModelInterface =
-    testGroup" cost model interface tests"
+    testGroup "cost model interface tests"
        [ testGroup "extractCostModelParams works"
        [ testCase "defaultCekCostModel" $ testExtraction defaultCekCostModel
        , testCase "randomCekCostModel"  $ testExtraction randomCekCostModel
@@ -131,7 +131,7 @@ test_costModelInterface =
        [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testSelfUpdate defaultCekCostModel
        , testCase "randomCekCostModel  <- randomCekCostModel"  $ testSelfUpdate randomCekCostModel
        ]
-     , testGroup "overwriting works"
+      , testGroup "overwriting works"
        [ testCase "defaultCekCostModel <- randomCekCostModel"  $ testOverwrite defaultCekCostModel randomCekCostModel
        , testCase "randomCekCostModel  <- defaultCekCostModel" $ testOverwrite randomCekCostModel  defaultCekCostModel
        ]

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -32,7 +32,7 @@ randomCekCosts =
                     }
 
 cekVarCostCpuKey :: Text.Text
-cekVarCostCpuKey = "cek_var_cost-_ex_budget_cpu"  -- flatten . camelToSnake
+cekVarCostCpuKey = "cek_var_cost-_ex_budget_cpu"  -- This is the result of flatten . camelToSnake
 
 randomCekCostModel :: CekCostModel
 randomCekCostModel = CostModel randomCekCosts defaultBuiltinCostModel


### PR DESCRIPTION
[SCP-2298]

In #3240 I forgot that the ledger cost model parameters were undergoing scaling to convert from floats into ints.  This fixes that, I believe.  I also took the opportunity to deal with some comments from @effectfully from #3179 that didn't get done at the time.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
