### PR TITLE
SCP-2299: Fix a Json decoding error when using ContractModel

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -130,7 +130,7 @@ import           Plutus.Trace.Emulator.Types            (ContractConstraints, Co
 import qualified Streaming                              as S
 import qualified Streaming.Prelude                      as S
 import           Wallet.Emulator.Chain                  (ChainEvent)
-import           Wallet.Emulator.Folds                  (EmulatorFoldErr, Outcome (..), postMapM)
+import           Wallet.Emulator.Folds                  (EmulatorFoldErr (..), Outcome (..), describeError, postMapM)
 import qualified Wallet.Emulator.Folds                  as Folds
 import           Wallet.Emulator.Stream                 (filterLogLevel, foldEmulatorStreamM, initialChainState,
                                                          initialDist, takeUntilSlot)
@@ -216,6 +216,7 @@ checkPredicateInner CheckOptions{_minLogLevel, _maxSlot, _emulatorConfig} predic
         case result of
             Left err -> do
                 annot "Error:"
+                annot (describeError err)
                 annot (show err)
                 assert False
             Right _ -> assert False

--- a/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
+++ b/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs
@@ -124,8 +124,8 @@ import           Ledger.Slot
 import           Ledger.Value                          (Value)
 import           Plutus.Contract                       (Contract, HasBlockchainActions)
 import           Plutus.Contract.Test
-import           Plutus.Trace.Emulator                 as Trace (ContractHandle, EmulatorTrace, activateContractWallet,
-                                                                 walletInstanceTag)
+import           Plutus.Trace.Emulator                 as Trace (ContractHandle, ContractInstanceTag, EmulatorTrace,
+                                                                 activateContract, walletInstanceTag)
 import           PlutusTx.Monoid                       (inv)
 import qualified Test.QuickCheck.DynamicLogic.Monad    as DL
 import           Test.QuickCheck.DynamicLogic.Quantify (Quantifiable (..), Quantification, arbitraryQ, chooseQ,
@@ -261,6 +261,11 @@ class ( Typeable state
     --   >      Buyer  :: Wallet -> ContractInstanceKey MyModel MyObsState MySchema MyError
     --   >      Seller :: ContractInstanceKey MyModel MyObsState MySchema MyError
     data ContractInstanceKey state :: * -> Row * -> * -> *
+
+    -- | The 'ContractInstanceTag' of an instance key for a wallet. Defaults to 'walletInstanceTag'.
+    --   You must override this if you have multiple instances per wallet.
+    instanceTag :: forall a b c. ContractInstanceKey state a b c -> Wallet -> ContractInstanceTag
+    instanceTag _ = walletInstanceTag
 
     -- | Given the current model state, provide a QuickCheck generator for a random next action.
     --   This is used in the `Arbitrary` instance for `Actions`s as well as by `anyAction` and
@@ -929,7 +934,7 @@ finalChecks opts predicate prop = do
 activateWallets :: forall state. ContractModel state => [ContractInstanceSpec state] -> EmulatorTrace (Handles state)
 activateWallets [] = return IMNil
 activateWallets (ContractInstanceSpec key wallet contract : spec) = do
-    h <- activateContractWallet wallet contract
+    h <- activateContract wallet contract (instanceTag key wallet)
     m <- activateWallets spec
     return $ IMCons key h m
 
@@ -1011,8 +1016,8 @@ propRunActionsWithOptions opts handleSpecs predicate actions' =
 checkBalances :: ModelState state -> TracePredicate
 checkBalances s = Map.foldrWithKey (\ w val p -> walletFundsChange w val .&&. p) (pure True) (s ^. balanceChanges)
 
-checkNoCrashes :: [ContractInstanceSpec state] -> TracePredicate
-checkNoCrashes = foldr (\ (ContractInstanceSpec _ w c) -> (assertOutcome c (walletInstanceTag w) notError "Contract instance stopped with error" .&&.))
+checkNoCrashes :: ContractModel state => [ContractInstanceSpec state] -> TracePredicate
+checkNoCrashes = foldr (\ (ContractInstanceSpec k w c) -> (assertOutcome c (instanceTag k w) notError "Contract instance stopped with error" .&&.))
                        (pure True)
     where
         notError Failed{}  = False

--- a/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/Types.hs
@@ -169,7 +169,7 @@ instance Pretty EmulatorRuntimeError where
 newtype ContractInstanceTag = ContractInstanceTag { unContractInstanceTag :: Text }
     deriving stock (Eq, Ord, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
-    deriving newtype (IsString, Pretty)
+    deriving newtype (IsString, Pretty, Semigroup, Monoid)
 
 -- | The 'ContractInstanceTag' for the contract instance of a wallet. See note
 --   [Wallet contract instances]


### PR DESCRIPTION
State machine property tests that use multiple contract instances per wallet are likely to fail with a `JSONDecodingError`. This is because all those instances use the same `ContractInstanceTag`. The `ContractInstanceTag` is used in `Wallet.Emulator.Folds` to identify events for a specific instance, so folds such as `Wallet.Emulator.Folds.instanceState` break because they are fed the wrong events.

This PR adds an `instanceTag` function to the `ContractModel` class. The default implementation of `instanceTag` gives the old behavior (ie. `walletInstanceTag`). I tried it on the sample code fom #3249 and the JSON decoding error went away (the test failed for some other reason though).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
