### PR TITLE
SCP-2300

### DIFF
--- a/plutus-metatheory/src/Algorithmic.lagda
+++ b/plutus-metatheory/src/Algorithmic.lagda
@@ -219,7 +219,6 @@ data _⊢_ {Φ} (Γ : Ctx Φ) : Φ ⊢Nf⋆ * → Set where
   ibuiltin : (b :  Builtin) → Γ ⊢ itype b
 
   error : (A : Φ ⊢Nf⋆ *) → Γ ⊢ A
-
 \end{code}
 
 Utility functions

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1,8 +1,9 @@
 ```
 {-# OPTIONS --allow-unsolved-metas #-}
-
 module Algorithmic.ReductionEC where
 ```
+
+This is currently unfinished
 
 ## Imports
 
@@ -1320,14 +1321,26 @@ data RProgress {A : ∅ ⊢Nf⋆ *} (M : ∅ ⊢ A) : Set where
 -- rigid representation e.g, removing some green slime or even via
 -- extrinsic typing
 
-lem-·⋆ : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B}{B'}
+lem-·⋆ : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B B'}
   → (o : K ≡ K')
   → (p : substEq (∅ ⊢Nf⋆_) o A ≡ A')
   → (q : Π B ≡ Π B')
   → (r : B [ A ]Nf ≡ B' [ A' ]Nf)
   → ∀{M}
-  → substEq (λ B → ∅ ⊢ B) q M ·⋆ A' ≡ substEq (∅ ⊢_) r (M ·⋆ A)
+  → substEq (∅ ⊢_) q M ·⋆ A' ≡ substEq (∅ ⊢_) r (M ·⋆ A)
 lem-·⋆ refl refl refl refl = refl
+
+open import Relation.Binary.HeterogeneousEquality using (_≅_;≡-subst-removable;refl)
+
+{-
+lem-·⋆' : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B' : ∅ ,⋆ K' ⊢Nf⋆ *}
+    → (r : B [ A ]Nf ≡ B' [ A' ]Nf)
+  → ∀{M : ∅ ⊢ Π B}{M' : ∅ ⊢ Π B'}
+--  → M' ·⋆ A' ≡ substEq (∅ ⊢_) r (M ·⋆ A)
+  → M' _⊢_.·⋆ A' ≅ M _⊢_.·⋆ A
+  → M' ≅ M
+lem-·⋆' p q = {!!}
+-}
 
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
 rlemma51! (ƛ M)        = done (V-ƛ M)

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1,10 +1,6 @@
 ```
-{-# OPTIONS --injective-type-constructors #-}
 module Algorithmic.ReductionEC where
 ```
-
-This is currently unfinished
-
 ## Imports
 
 ```
@@ -43,6 +39,14 @@ open import Utils
 open import Data.Maybe using (just;from-just)
 open import Data.String using (String)
 ```
+
+## Pragmas
+
+```
+{-# INJECTIVE _⊢Nf⋆_ #-}
+{-# INJECTIVE _⊢_ #-}
+```
+
 
 ## Values
 
@@ -1369,6 +1373,8 @@ lemΛE : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
 lemΛE eq [] p = refl ,, p
 
 -- a beta⋆ reduction happened
+{-# INJECTIVE _⊢Nf⋆_ #-}
+
 U·⋆1 : ∀{A : ∅ ⊢Nf⋆ K}{B}{L : ∅ ,⋆ K ⊢ B}{X}
  {B' : ∅ ⊢Nf⋆ *}
  → X ≡ B [ A ]Nf →

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1438,6 +1438,41 @@ U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X
 U·⋆3 eq [] _ refl q = refl ,, refl ,, refl
 U·⋆3 eq (E ·⋆ A) VM refl q = ⊥-elim (valredex (lemVE _ E (Value2VALUE VM)) q)
 
+-- body of wrap made a step, it's not a value
+Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
+ → X ≡ μ A B
+ → (E' : EC X B') {L' : ∅ ⊢ B'} →
+ _⊢_.wrap A B M ≅ E' [ L' ]ᴱ →
+ Redex L' →
+ (U : {B' : ∅ ⊢Nf⋆ *}
+      (E' : EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) B')
+      {L' : ∅ ⊢ B'} →
+      M ≡ (E' [ L' ]ᴱ) →
+      Redex L' →
+      ∃
+      (λ p₁ →
+         substEq
+         (EC
+          ((eval (embNf A) (λ x → reflect (` x)) ·V
+            inj₂
+            (λ ρ v →
+               μ
+               (reify
+                (eval (embNf (renNf S A))
+                 ((λ x → renVal ρ (reflect (` x))) ,,⋆ v)))
+               (reify v)))
+           ·V eval (embNf B) (λ x → reflect (` x))))
+         p₁ E
+         ≡ E'
+         × substEq (_⊢_ ∅) p₁ L ≡ L'))
+ → 
+ ∃
+ (λ (p₁ : C ≡ B') →
+    substEq (EC (μ A B)) p₁ (wrap E) ≅ E' × substEq (_⊢_ ∅) p₁ L ≅ L')
+Uwrap eq [] refl (β ()) U
+Uwrap eq (wrap E') refl q U with U E' refl q
+... | refl ,, refl ,, refl = refl ,, refl ,, refl
+
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
 rlemma51! (ƛ M)        = done (V-ƛ M)
 rlemma51! (M · M') with rlemma51! M
@@ -1529,7 +1564,8 @@ rlemma51! (wrap A B M) with rlemma51! M
   (wrap E)
   p
   (cong (wrap A B) q)
-  {!!}
+  λ E p q → let X ,, Y ,, Y' = Uwrap refl E (≡-to-≅ p) q U in
+    X ,, ≅-to-≡ Y ,, ≅-to-≡ Y' 
 rlemma51! (unwrap M) with rlemma51! M
 ... | step ¬VM E p q U = step
   (λ V → lemVunwrap (Value2VALUE V))

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1372,6 +1372,7 @@ lemΛE : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
   → E ≅ EC.[] {A = Y} × Λ L ≅ L'
 lemΛE eq [] p = refl ,, p
 
+-- a beta⋆ reduction happened
 U·⋆1 : ∀{A : ∅ ⊢Nf⋆ K}{B}{L : ∅ ,⋆ K ⊢ B}{X}
  {B' : ∅ ⊢Nf⋆ *}
  → X ≡ B [ A ]Nf →
@@ -1387,7 +1388,7 @@ U·⋆1 : ∀{A : ∅ ⊢Nf⋆ K}{B}{L : ∅ ,⋆ K ⊢ B}{X}
    p []
    ≅ E'
    × substEq (_⊢_ ∅) p (Λ L ·⋆ A) ≅ L')
-U·⋆1  {A = A}{B}{L} eq []        p q = sym eq ,, htrans (≡-subst-removable (EC (B [ A ]Nf)) (sym eq) []) (hcong (λ X → [] {A = X}) (hsym (≡-to-≅ eq))) ,, htrans (≡-subst-removable (∅ ⊢_) (sym eq) (Λ L ·⋆ A)) p
+U·⋆1 eq [] refl q = refl ,, refl ,, refl
 U·⋆1 eq (E' ·⋆ A) p q with lem-·⋆' p
 ... | X ,, refl ,, refl with lemΛE refl E' X
 U·⋆1 eq (.[] ·⋆ A) p (β ()) | X ,, refl ,, refl | refl ,, refl
@@ -1418,6 +1419,24 @@ U·⋆2 ¬VM eq [] refl (β β-Λ) U = ⊥-elim (¬VM (V-Λ _))
 U·⋆2 ¬VM eq [] refl (β (β-sbuiltin⋆ b _ p bt _)) U = ⊥-elim (¬VM (V-IΠ b p bt))
 U·⋆2 ¬VM eq (E ·⋆ A) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
+
+-- BUILTIN
+U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X}
+      → X ≡ B [ A ]Nf →
+      (E' : EC X B')
+      {L' : ∅ ⊢ B'} →
+      Value M → 
+      M _⊢_.·⋆ A ≅ (E' [ L' ]ᴱ) →
+      Redex L' →
+      Σ
+      (B [ A ]Nf ≡ B')
+      (λ p₁ →
+         Σ
+         (substEq (EC (B [ A ]Nf)) p₁ []
+          ≅ E')
+         (λ x₁ → substEq (_⊢_ ∅) p₁ (M _⊢_.·⋆ A) ≅ L'))
+U·⋆3 eq [] _ refl q = refl ,, refl ,, refl
+U·⋆3 eq (E ·⋆ A) VM refl q = ⊥-elim (valredex (lemVE _ E (Value2VALUE VM)) q)
 
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
 rlemma51! (ƛ M)        = done (V-ƛ M)
@@ -1493,7 +1512,8 @@ rlemma51! (M ·⋆ A) | done (V-IΠ b {as' = []} p x) = step
   []
   (β (β-sbuiltin⋆ b M p x A))
   refl
-  {!!}
+  λ E p q → let X ,, Y ,, Y' = U·⋆3 refl E (V-IΠ b _ x) (≡-to-≅ p) q in
+    X ,, ≅-to-≡ Y ,, ≅-to-≡ Y' 
 rlemma51! (M ·⋆ A) | done (V-IΠ b {as' = Term ∷ as'} p x)
   with bappTermLem b (M ·⋆ A) (bubble p) (BApp2BAPP (step⋆ p x))
 ... | _ ,, _ ,, X =
@@ -1522,7 +1542,7 @@ rlemma51! (unwrap M) with rlemma51! M
   []
   (β (β-wrap VM))
   refl
-  λ {E p q → {!!}}
+  {!!}
 rlemma51! (con c)      = done (V-con c)
 rlemma51! (ibuiltin b) = done (ival b)
 rlemma51! (error _)    = step


### PR DESCRIPTION
This PR makes use of injectivity of the type (specifically normal type) and term datatype constructors to finish lemma51!. Turning on this flag made it possible to do the necessary pattern matching in the proofs.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
