### PR TITLE
defaultCekCostModelParams -> defaultCostModelParams

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -115,9 +115,9 @@ module PlutusCore
     , defaultBuiltinCostModel
     , defaultBuiltinsRuntime
     , defaultCekCostModel
-    , defaultCekCostModelParams
     , defaultCekMachineCosts
     , defaultCekParameters
+    , defaultCostModelParams
     , unitCekParameters
     -- * CEK machine costs
     , cekMachineCostsPrefix

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -5,9 +5,9 @@
 module PlutusCore.Evaluation.Machine.ExBudgetingDefaults
     ( defaultBuiltinsRuntime
     , defaultCekCostModel
-    , defaultCekCostModelParams
     , defaultCekMachineCosts
     , defaultCekParameters
+    , defaultCostModelParams
     , unitCekMachineCosts
     , unitCekParameters
     , defaultBuiltinCostModel
@@ -52,9 +52,10 @@ defaultCekCostModel :: CostModel CekMachineCosts
 defaultCekCostModel = CostModel defaultCekMachineCosts defaultBuiltinCostModel
 --- defaultCekMachineCosts is CekMachineCosts
 
--- | The default cost model data.
-defaultCekCostModelParams :: Maybe CostModelParams
-defaultCekCostModelParams = extractCostModelParams defaultCekCostModel
+-- | The default cost model data.  This is exposed to the ledger, so let's not
+-- confuse anybody by mentioning the CEK machine
+defaultCostModelParams :: Maybe CostModelParams
+defaultCostModelParams = extractCostModelParams defaultCekCostModel
 
 defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
 defaultCekParameters = toMachineParameters defaultCekCostModel

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -10,7 +10,7 @@ module Plutus.V1.Ledger.Api (
     , validateScript
     -- * Cost model
     , validateCostModelParams
-    , defaultCekCostModelParams
+    , defaultCostModelParams
     , CostModelParams
     -- * Running scripts
     , evaluateScriptRestricting

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -14,12 +14,12 @@ main = defaultMain tests
 
 alwaysTrue :: TestTree
 alwaysTrue = testCase "always true script returns true" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCekCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
     in assertBool "succeeds" (isRight res)
 
 alwaysFalse :: TestTree
 alwaysFalse = testCase "always false script returns false" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCekCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
     in assertBool "fails" (isLeft res)
 
 tests :: TestTree


### PR DESCRIPTION
The cost model parameters exposed to the ledger was called `defaultCekCostModelParams`, but that we just confusing: see eg https://input-output-rnd.slack.com/archives/C21UF2WVC/p1621890076035500.  This changes it to `defaultCostModelParams`.  

There's still some potential for confusion because what we call "cost model parameters" the ledger people just call a "cost model", but I think we can't really resolve that.


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
