### PR TITLE
Add equalsString to Plutus core

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
@@ -269,11 +269,11 @@ instance Serialise DefaultFun where
               IfThenElse           -> 21
               CharToString         -> 22
               Append               -> 23
+              EqualsString         -> 28
               Trace                -> 24
               Nop1                 -> 25
               Nop2                 -> 26
               Nop3                 -> 27
-              EqualsString         -> 28
 
     decode = go =<< decodeWord
         where go 0  = pure AddInteger
@@ -300,11 +300,11 @@ instance Serialise DefaultFun where
               go 21 = pure IfThenElse
               go 22 = pure CharToString
               go 23 = pure Append
+              go 28 = pure EqualsString
               go 24 = pure Trace
               go 25 = pure Nop1
               go 26 = pure Nop2
               go 27 = pure Nop3
-              go 28 = pure EqualsString
               go _  = fail "Failed to decode BuiltinName"
 
 -- It's set deliberately to give us "extra room" in the binary format to add things without running
@@ -347,11 +347,11 @@ instance Flat DefaultFun where
               IfThenElse           -> 21
               CharToString         -> 22
               Append               -> 23
+              EqualsString         -> 28
               Trace                -> 24
               Nop1                 -> 25
               Nop2                 -> 26
               Nop3                 -> 27
-              EqualsString         -> 28
 
     decode = go =<< decodeBuiltin
         where go 0  = pure AddInteger
@@ -378,11 +378,11 @@ instance Flat DefaultFun where
               go 21 = pure IfThenElse
               go 22 = pure CharToString
               go 23 = pure Append
+              go 28 = pure EqualsString
               go 24 = pure Trace
               go 25 = pure Nop1
               go 26 = pure Nop2
               go 27 = pure Nop3
-              go 28 = pure EqualsString
               go _  = fail "Failed to decode BuiltinName"
 
     size _ n = n + builtinTagWidth

--- a/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtins.hs
@@ -73,6 +73,7 @@ data DefaultFun
     | IfThenElse
     | CharToString
     | Append
+    | EqualsString
     | Trace
     | Nop1  -- TODO. These are only used for costing calibration and shouldn't be included in the defaults.
     | Nop2
@@ -106,6 +107,7 @@ instance Pretty DefaultFun where
     pretty IfThenElse           = "ifThenElse"
     pretty CharToString         = "charToString"
     pretty Append               = "append"
+    pretty EqualsString         = "equalsString"
     pretty Trace                = "trace"
     pretty Nop1                 = "nop1"
     pretty Nop2                 = "nop2"
@@ -219,6 +221,10 @@ instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni Default
         makeBuiltinMeaning
             ((++) :: String -> String -> String)
             mempty  -- TODO: budget.
+    toBuiltinMeaning EqualsString =
+        makeBuiltinMeaning
+            ((==) @String)
+            mempty  -- TODO: budget.
     toBuiltinMeaning Trace =
         makeBuiltinMeaning
             (emit :: String -> Emitter ())
@@ -267,6 +273,7 @@ instance Serialise DefaultFun where
               Nop1                 -> 25
               Nop2                 -> 26
               Nop3                 -> 27
+              EqualsString         -> 28
 
     decode = go =<< decodeWord
         where go 0  = pure AddInteger
@@ -297,6 +304,7 @@ instance Serialise DefaultFun where
               go 25 = pure Nop1
               go 26 = pure Nop2
               go 27 = pure Nop3
+              go 28 = pure EqualsString
               go _  = fail "Failed to decode BuiltinName"
 
 -- It's set deliberately to give us "extra room" in the binary format to add things without running
@@ -343,6 +351,7 @@ instance Flat DefaultFun where
               Nop1                 -> 25
               Nop2                 -> 26
               Nop3                 -> 27
+              EqualsString         -> 28
 
     decode = go =<< decodeBuiltin
         where go 0  = pure AddInteger
@@ -373,6 +382,7 @@ instance Flat DefaultFun where
               go 25 = pure Nop1
               go 26 = pure Nop2
               go 27 = pure Nop3
+              go 28 = pure EqualsString
               go _  = fail "Failed to decode BuiltinName"
 
     size _ n = n + builtinTagWidth

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -199,6 +199,7 @@ builtinNames = [
     , 'Builtins.appendString
     , 'Builtins.emptyString
     , 'Builtins.charToString
+    , 'Builtins.equalsString
     , 'String.stringToBuiltinString
 
     , 'Builtins.trace
@@ -336,6 +337,9 @@ defineBuiltinTerms = do
     do
         let term = mkBuiltin PLC.CharToString
         defineBuiltinTerm 'Builtins.charToString term [char, str]
+    do
+        term <- wrapRel strTy 2 $ mkBuiltin PLC.EqualsString
+        defineBuiltinTerm 'Builtins.equalsString term [str, bool]
     do
         term <- wrapUnitFun strTy $ mkBuiltin PLC.Trace
         defineBuiltinTerm 'Builtins.trace term [str, unit]

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -56,6 +56,7 @@ primitives = testNested "Primitives" [
   , goldenPir "trace" trace
   , goldenPir "stringLiteral" stringLiteral
   , goldenPir "stringConvert" stringConvert
+  , goldenUEval "equalsString" [ getPlc stringEquals, liftProgram ("hello" :: String), liftProgram ("hello" :: String)]
   ]
 
 string :: CompiledCode String
@@ -130,3 +131,6 @@ stringLiteral = plc (Proxy @"stringLiteral") ("abc"::Builtins.String)
 
 stringConvert :: CompiledCode (Builtins.String)
 stringConvert = plc (Proxy @"stringConvert") ((noinline P.stringToBuiltinString) "abc")
+
+stringEquals :: CompiledCode (String -> String -> Bool)
+stringEquals = plc (Proxy @"string32Equals") (\(x :: String) (y :: String) -> Builtins.equalsString (P.stringToBuiltinString x) (P.stringToBuiltinString y))

--- a/plutus-tx-plugin/test/Plugin/Primitives/equalsString.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/equalsString.plc.golden
@@ -1,0 +1,1 @@
+(delay (lam case_True_38 (lam case_False_39 case_True_38)))

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -40,6 +40,7 @@ module PlutusTx.Builtins (
                                 , appendString
                                 , emptyString
                                 , charToString
+                                , equalsString
                                 -- * Tracing
                                 , trace
                                 ) where
@@ -214,6 +215,11 @@ emptyString = mustBeReplaced "emptyString"
 -- | Turn a 'Char' into a 'String'.
 charToString :: Char -> String
 charToString = mustBeReplaced "charToString"
+
+{-# NOINLINE equalsString #-}
+-- | Check if two strings are equal
+equalsString :: String -> String -> Bool
+equalsString = mustBeReplaced "equalsString"
 
 {-# NOINLINE trace #-}
 -- | Logs the given 'String' to the evaluation log.

--- a/plutus-tx/src/PlutusTx/Eq.hs
+++ b/plutus-tx/src/PlutusTx/Eq.hs
@@ -31,6 +31,10 @@ instance Eq Builtins.ByteString where
     {-# INLINABLE (==) #-}
     (==) = Builtins.equalsByteString
 
+instance Eq Builtins.String where
+    {-# INLINABLE (==) #-}
+    (==) = Builtins.equalsString
+
 instance Eq a => Eq [a] where
     {-# INLINABLE (==) #-}
     [] == []         = True

--- a/plutus-tx/src/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Instances.hs
@@ -84,6 +84,12 @@ instance uni `PLC.Includes` BS.ByteString => Typeable uni BS.ByteString where
 instance uni `PLC.Includes` BS.ByteString => Lift uni BS.ByteString where
     lift = liftBuiltin
 
+instance uni `PLC.Includes` Char => Typeable uni Char where
+    typeRep = typeRepBuiltin
+
+instance uni `PLC.Includes` Char => Lift uni Char where
+    lift = liftBuiltin
+
 -- Standard types
 -- These need to be in a separate file for TH staging reasons
 


### PR DESCRIPTION
The PR adds `equalsString` and `Eq` instance for `Builtins.String` (should help in #3254).

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
