### PR TITLE
Filter out input values before coin selection (fix #3246).

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Plutus/Contract/Wallet.hs
@@ -131,7 +131,8 @@ balanceTx ::
     -- ^ The unbalanced transaction
     -> Eff effs Tx
 balanceTx utxo pk UnbalancedTx{unBalancedTxTx} = do
-    inputValues <- traverse lookupValue (Set.toList $ Tx.txInputs unBalancedTxTx)
+    let txInputs = Set.toList $ Tx.txInputs unBalancedTxTx
+    inputValues <- traverse lookupValue txInputs
     collateral  <- traverse lookupValue (Set.toList $ Tx.txCollateral unBalancedTxTx)
     let fees = L.txFee unBalancedTxTx
         left = L.txForge unBalancedTxTx <> fold inputValues
@@ -142,8 +143,8 @@ balanceTx utxo pk UnbalancedTx{unBalancedTxTx} = do
 
     tx' <- if Value.isZero pos
            then do
-               logDebug NoOutputsAdded
-               pure unBalancedTxTx
+                logDebug NoOutputsAdded
+                pure unBalancedTxTx
            else do
                 logDebug $ AddingPublicKeyOutputFor pos
                 pure $ addOutputs pk pos unBalancedTxTx
@@ -154,7 +155,11 @@ balanceTx utxo pk UnbalancedTx{unBalancedTxTx} = do
                 pure tx'
             else do
                 logDebug $ AddingInputsFor neg
-                addInputs utxo inputValues pk neg tx'
+                -- filter out inputs from utxo that are already in unBalancedTx
+                let inputsOutRefs = map Tx.txInRef txInputs
+                    filteredUtxo = flip Map.filterWithKey utxo $ \txOutRef _ ->
+                        txOutRef `notElem` inputsOutRefs
+                addInputs filteredUtxo pk neg tx'
 
     if remainingFees `Value.leq` P.zero
     then do
@@ -165,22 +170,18 @@ balanceTx utxo pk UnbalancedTx{unBalancedTxTx} = do
         addCollateral utxo remainingFees tx''
 
 
--- | @addInputs mp iv pk vl tx@ selects transaction outputs worth at least
---   @vl@ from the UTXO map @mp@, with filtered out values from @iv@ that are already presented in unbalanced tx,
---   and adds them as inputs to @tx@. A public key output for @pk@ is added containing any leftover change.
+-- | @addInputs mp pk vl tx@ selects transaction outputs worth at least
+--   @vl@ from the UTXO map @mp@ and adds them as inputs to @tx@. A public
+--   key output for @pk@ is added containing any leftover change.
 addInputs
     :: Member (Error WalletAPIError) effs
     => UtxoMap
-    -> [Value]
     -> PubKey
     -> Value
     -> Tx
     -> Eff effs Tx
-addInputs mp iv pk vl tx = do
-    let
-        utxoVals = second (Tx.txOutValue . Tx.txOutTxOut) <$> Map.toList mp
-        filteredVals = filter ((`notElem` iv) . snd) utxoVals
-    (spend, change) <- E.selectCoin filteredVals vl
+addInputs mp pk vl tx = do
+    (spend, change) <- E.selectCoin (second (Tx.txOutValue . Tx.txOutTxOut) <$> Map.toList mp) vl
     let
 
         addTxIns  =


### PR DESCRIPTION
This PR fixes the problem occurred in #3246 where the token gets passed into two transactions for pubkey and script using `mustSpendPubKeyOutput` constraint.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
