### PR TITLE
SCP-2313  Binary Random Access List implementation, benchmarks, test suite

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -81,7 +81,6 @@
           (hsPkgs."prettyprinter-configurable" or (errorHandler.buildDepError "prettyprinter-configurable"))
           (hsPkgs."primitive" or (errorHandler.buildDepError "primitive"))
           (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
-          (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."semigroupoids" or (errorHandler.buildDepError "semigroupoids"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
@@ -283,6 +282,7 @@
           "Crypto"
           "Data/Text/Prettyprint/Doc/Custom"
           "Data/SatInt"
+          "Data/RandomAccessList/SkewBinary"
           ];
         hsSourceDirs = [
           "plutus-core/src"
@@ -414,6 +414,18 @@
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];
           };
+        "bral-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "untyped-plutus-core/test" ];
+          mainPath = [ "TestRAList.hs" ];
+          };
         };
       benchmarks = {
         "cost-model-budgeting-bench" = {
@@ -486,6 +498,18 @@
           buildable = true;
           modules = [ "CostModelCreation" ];
           hsSourceDirs = [ "cost-model/test" "cost-model/create-cost-model" ];
+          };
+        "bral-bench" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."random" or (errorHandler.buildDepError "random"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."ral" or (errorHandler.buildDepError "ral"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "untyped-plutus-core/bench" ];
           };
         };
       };

--- a/nix/pkgs/haskell/materialized-unix/default.nix
+++ b/nix/pkgs/haskell/materialized-unix/default.nix
@@ -307,6 +307,7 @@
         "call-stack".revision = (((hackage."call-stack")."0.3.0").revisions).default;
         "primitive".revision = (((hackage."primitive")."0.7.1.0").revisions).default;
         "profunctors".revision = (((hackage."profunctors")."5.6").revisions).default;
+        "fin".revision = (((hackage."fin")."0.1.1").revisions).default;
         "safe".revision = (((hackage."safe")."0.3.19").revisions).default;
         "size-based".revision = (((hackage."size-based")."0.1.2.0").revisions).default;
         "ListLike".revision = (((hackage."ListLike")."4.7.4").revisions).default;
@@ -380,6 +381,10 @@
         "these".flags.assoc = true;
         "bimap".revision = (((hackage."bimap")."0.4.0").revisions).default;
         "dependent-sum".revision = (((hackage."dependent-sum")."0.5").revisions).default;
+        "ral".revision = (((hackage."ral")."0.1").revisions).default;
+        "ral".flags.semigroupoids = true;
+        "ral".flags.adjunctions = true;
+        "ral".flags.distributive = true;
         "socks".revision = (((hackage."socks")."0.6.1").revisions).default;
         "wai-cors".revision = (((hackage."wai-cors")."0.2.7").revisions).default;
         "ekg-core".revision = (((hackage."ekg-core")."0.1.1.7").revisions).default;
@@ -496,6 +501,7 @@
         "bech32".revision = (((hackage."bech32")."1.1.0").revisions).default;
         "bech32".flags.release = false;
         "bech32".flags.werror = false;
+        "bin".revision = (((hackage."bin")."0.1").revisions).default;
         "managed".revision = (((hackage."managed")."1.0.8").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.4").revisions).default;
         "base16-bytestring".revision = (((hackage."base16-bytestring")."1.0.1.0").revisions).default;

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -139,6 +139,7 @@ library
         Crypto
         Data.Text.Prettyprint.Doc.Custom
         Data.SatInt
+        Data.RandomAccessList.SkewBinary
     build-tool-depends: alex:alex -any, happy:happy >=1.17.1
     hs-source-dirs:
         plutus-core/src
@@ -280,7 +281,6 @@ library
         prettyprinter-configurable -any,
         primitive -any,
         recursion-schemes -any,
-        scientific -any,
         semigroupoids -any,
         semigroups -any,
         serialise -any,
@@ -512,3 +512,27 @@ benchmark cost-model-test
         vector -any
     other-modules:
         CostModelCreation
+
+benchmark bral-bench
+    type: exitcode-stdio-1.0
+    hs-source-dirs:      untyped-plutus-core/bench
+    main-is: Main.hs
+    build-depends:
+        base -any,
+        plutus-core -any,
+        criterion >= 1.5.9.0,
+        random >= 1.2.0,
+        containers -any,
+        -- broken for ral-0.2 conflic with  cardano-binary:recursion-schemes
+        ral == 0.1
+
+test-suite bral-test
+    type: exitcode-stdio-1.0
+    hs-source-dirs:      untyped-plutus-core/test
+    main-is: TestRAList.hs
+    build-depends:
+        base -any,
+        plutus-core -any,
+        tasty -any,
+        tasty-hunit -any,
+        tasty-quickcheck -any

--- a/plutus-core/untyped-plutus-core/bench/Main.hs
+++ b/plutus-core/untyped-plutus-core/bench/Main.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE BangPatterns #-}
+module Main where
+
+import           Criterion.Main
+import           Data.Function
+import           Data.Semigroup
+import           System.Random
+import           Unsafe.Coerce
+
+import qualified Data.IntMap.Strict               as I
+import qualified Data.RAList                      as R
+import qualified Data.RandomAccessList.SkewBinary as B
+
+
+main :: IO ()
+main = defaultMain
+    -- NOTE: there is a faster/better way to create a map using fromAscList
+    -- but we want to bench cons-ing because that is what we are using in our machine.
+    [ bgroup "create/100" [ bench "ours" $ whnf (extendB B.Nil) 100
+                           , bench "ral" $ whnf (extendR R.empty) 100
+                           , bench "imap" $ whnf (extendI I.empty) 100
+                           ]
+    , bgroup "create/250" [ bench "ours" $ whnf (extendB B.Nil) 250
+                           , bench "ral" $ whnf (extendR R.empty) 250
+                           , bench "imap" $ whnf (extendI I.empty) 250
+                            ]
+
+
+    , bgroup "query/front/100" [ bench "ours" $ whnf (queryFrontB 100) b100
+                                , bench "ral" $ whnf (queryFrontR 100) r100
+                                , bench "imap" $ whnf (queryFrontI 100) i100
+                                ]
+    , bgroup "query/front/250" [ bench "ours" $ whnf (queryFrontB 250) b250
+                                , bench "ral" $ whnf (queryFrontR 250) r250
+                                , bench "imap" $ whnf (queryFrontI 250) i250
+                                ]
+
+    , bgroup "query/back/100" [ bench "ours" $ whnf (queryBackB 100) b100
+                               , bench "ral" $ whnf (queryBackR 100) r100
+                               , bench "imap" $ whnf (queryBackI 100) i100
+                               ]
+    , bgroup "query/back/250" [ bench "ours" $ whnf (queryBackB 250) b250
+                               , bench "ral" $ whnf (queryBackR 250) r250
+                               , bench "imap" $ whnf (queryBackI 250) i250
+                               ]
+
+
+    , bgroup "query/rand/100" [ bench "ours" $ whnf (uncurry queryRandB) (rand100Word, b100)
+                               , bench "ral" $ whnf (uncurry queryRandR) (rand100Int, r100)
+                               , bench "imap" $ whnf (uncurry queryRandI) (rand100Int, i100)
+                               ]
+    , bgroup "query/rand/250" [ bench "ours" $ whnf (uncurry queryRandB) (rand250Word, b250)
+                               , bench "ral" $ whnf (uncurry queryRandR) (rand250Int, r250)
+                               , bench "imap" $ whnf (uncurry queryRandI) (rand250Int, i250)
+                               ]
+
+    , bgroup "create100/front100/cons100/back100/cons100/rand100"
+            [ bench "ours" $ whnf (uncurry $ mixB 100 100 100 100) (rand100Word, b100)
+            , bench "ral" $ whnf (uncurry $ mixR 100 100 100 100) (rand100Int, r100)
+            , bench "imap" $ whnf (uncurry $ mixI 100 100 100 100) (rand100Int, i100)
+            ]
+    , bgroup "create250/front100/cons100/back100/cons100/rand250"
+            [ bench "ours" $ whnf (uncurry $ mixB 100 100 100 100) (rand250Word, b250)
+            , bench "ral" $ whnf (uncurry $ mixR 100 100 100 100) (rand250Int, r250)
+            , bench "imap" $ whnf (uncurry $ mixI 100 100 100 100) (rand250Int, i250)
+            ]
+
+
+    ]
+  where
+        -- the Words in these lists are smaller than maxBound :: Int
+        -- so they will not overflow when unsafe coerced to Int
+        b100 = extendB B.Nil 100
+        r100 = extendR R.empty 100
+        i100 = extendI I.empty 100
+        b250 = extendB B.Nil 250
+        r250 = extendR R.empty 250
+        i250 = extendI I.empty 250
+        -- if the range is the same, they should produce the same numbers for word and int
+        rand100Word = take 100 $ randomRs (0,100-1) g
+        rand250Word = take 250 $ randomRs (0,250-1) g
+        rand100Int = take 100 $ randomRs (0,100-1) g
+        rand250Int = take 250 $ randomRs (0,250-1) g
+        -- note: fixed rand-seed to make benchmarks deterministic
+        g = mkStdGen 59950
+
+--- EXTEND
+
+applyN :: Integral b => (a -> a) -> a -> b -> a
+applyN f init n = appEndo (stimes n $ Endo f) init
+
+extendB :: B.RAList () -> Word -> B.RAList ()
+extendB = applyN $ B.Cons ()
+
+extendR :: R.RAList () -> Int -> R.RAList ()
+extendR = applyN $ R.cons ()
+
+
+extendI :: I.IntMap () -> Int -> I.IntMap ()
+extendI f n | n == 0 = f
+            | otherwise = let n' = n -1
+                  in I.insert n' () $ extendI f n'
+
+
+-- QUERY FRONT
+
+queryFrontB :: Word -> B.RAList () -> ()
+queryFrontB 0 _ = ()
+queryFrontB !i d = B.index d i' `seq` queryFrontB i' d
+  where i' = i-1
+
+queryFrontR :: Int -> R.RAList () -> ()
+queryFrontR 0 _ = ()
+queryFrontR !i d = d R.! i' `seq` queryFrontR i' d
+  where i' = i-1
+
+queryFrontI :: Int -> I.IntMap () -> ()
+queryFrontI 0 _ = ()
+queryFrontI !i d = d I.! i' `seq` queryFrontI i' d
+  where i' = i-1
+
+-- QUERY BACK
+
+queryBackB :: Word -> B.RAList () -> ()
+queryBackB size = go 0
+ where
+   go !i d | i == size = ()
+           | otherwise = B.index d i `seq` go (i+1) d
+
+queryBackR :: Int -> R.RAList () -> ()
+queryBackR size = go 0
+ where
+   go !i d | i == size = ()
+           | otherwise = d R.! i `seq` go (i+1) d
+
+queryBackI :: Int -> I.IntMap () -> ()
+queryBackI size = go 0
+ where
+   go !i d | i == size = ()
+           | otherwise = d I.! i `seq` go (i+1) d
+
+-- QUERY RAND
+
+queryRandB :: [Word] -> B.RAList () -> ()
+queryRandB [] _     = ()
+queryRandB (i:is) d = B.index d i `seq` queryRandB is d
+
+queryRandR :: [Int] -> R.RAList () -> ()
+queryRandR [] _     = ()
+queryRandR (i:is) d = d R.! i `seq` queryRandR is d
+
+queryRandI :: [Int] -> I.IntMap () -> ()
+queryRandI [] _     = ()
+queryRandI (i:is) d = d I.! i `seq` queryRandI is d
+
+-- MIX
+
+mixB :: Word -> Word -> Word -> Word -> [Word] -> B.RAList () -> ()
+mixB front cons1 back cons2 rand d =
+    queryFrontB front d
+    `seq`
+    let d1 = extendB d cons1
+    in queryBackB back d1
+    `seq`
+    let d2 = extendB d1 cons2
+    in queryRandB rand d2
+
+
+mixR :: Int -> Int -> Int -> Int -> [Int] -> R.RAList () -> ()
+mixR front cons1 back cons2 rand d =
+    queryFrontR front d
+    `seq`
+    let d1 = extendR d cons1
+    in queryBackR back d1
+    `seq`
+    let d2 = extendR d1 cons2
+    in queryRandR rand d2
+
+mixI :: Int -> Int -> Int -> Int -> [Int] -> I.IntMap () -> ()
+mixI front cons1 back cons2 rand d =
+    queryFrontI front d
+    `seq`
+    let d1 = extendI d cons1
+    in queryBackI back d1
+    `seq`
+    let d2 = extendI d1 cons2
+    in queryRandI rand d2
+
+
+
+
+

--- a/plutus-core/untyped-plutus-core/src/Data/RandomAccessList/SkewBinary.hs
+++ b/plutus-core/untyped-plutus-core/src/Data/RandomAccessList/SkewBinary.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE BangPatterns    #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies    #-}
+{-# LANGUAGE ViewPatterns    #-}
+module Data.RandomAccessList.SkewBinary ( RAList(Cons,Nil)
+                 , index
+                 , Data.RandomAccessList.SkewBinary.null
+                 , Data.RandomAccessList.SkewBinary.head
+                 , Data.RandomAccessList.SkewBinary.tail
+                 , uncons
+                 ) where
+
+import           Data.Bits  (unsafeShiftR)
+import qualified Data.List  as List (unfoldr)
+import           Data.Maybe
+import           GHC.Exts
+
+-- | βA complete binary tree.
+-- Note: the size of the tree is not stored/cached,
+-- unless it appears as a root tree in 'RAList', which the size is stored inside the Cons.
+data Tree a = Leaf a
+            | Node a !(Tree a) !(Tree a)
+            deriving (Eq, Show)
+
+-- | A strict list of complete binary trees accompanied by their size.
+-- The trees appear in >=-size order.
+-- Note: this list is strict in its spine, unlike the Prelude list
+data RAList a = BHead
+               {-# UNPACK #-} !Word -- ^ the size of the head tree
+               !(Tree a) -- ^ the head tree
+               !(RAList a) -- ^ the tail trees
+             | Nil
+             -- the derived Eq instance is correct,
+             -- because binary skew numbers have unique representation
+             -- and hence all trees of the same size will have the same structure
+             deriving (Eq, Show)
+
+
+instance IsList (RAList a) where
+  type Item (RAList a) = a
+  fromList = foldr cons Nil
+  toList = List.unfoldr uncons
+
+{-# INLINABLE null #-}
+null :: RAList a -> Bool
+null Nil = True
+null _   = False
+
+{-# complete Cons, Nil #-}
+{-# complete BHead, Nil #-}
+
+-- /O(1)/
+pattern Cons :: a -> RAList a -> RAList a
+pattern Cons x xs <- (uncons -> Just (x, xs)) where
+  Cons x xs = cons x xs
+
+-- O(1) worst-case
+cons :: a -> RAList a -> RAList a
+cons x = \case
+    (BHead w1 t1 (BHead w2 t2 ts')) | w1 == w2 -> BHead (2*w1+1) (Node x t1 t2) ts'
+    ts                                         -> BHead 1 (Leaf x) ts
+
+
+-- /O(1)/
+uncons :: RAList a -> Maybe (a, RAList a)
+uncons = \case
+    BHead _ (Leaf x) ts -> Just (x, ts)
+    BHead treeSize (Node x t1 t2) ts ->
+        -- probably faster than `div w 2`
+        let halfSize = unsafeShiftR treeSize 1
+            -- split the node in two)
+        in Just ( x, BHead halfSize t1 $ BHead halfSize t2 ts)
+    Nil -> Nothing
+
+{-# INLINABLE head #-}
+-- O(1) worst-case
+head :: RAList a -> a
+head = fst . fromMaybe (error "empty RAList") . uncons
+
+{-# INLINABLE tail #-}
+-- O(1) worst-case
+tail :: RAList a -> RAList a
+tail = snd. fromMaybe (error "empty RAList") . uncons
+
+-- 0-based
+index :: RAList a -> Word -> a
+index Nil _  = error "out of bounds"
+index (BHead w t ts) !i  =
+    if i < w
+    then indexTree w i t
+    else index ts (i-w)
+  where
+    indexTree :: Word -> Word -> Tree a -> a
+    indexTree 1 0 (Leaf x) = x
+    indexTree _ _ (Leaf _) = error "out of bounds"
+    indexTree _ 0 (Node x _ _) = x
+    indexTree treeSize offset (Node _ t1 t2 ) =
+        let halfSize = unsafeShiftR treeSize 1 -- probably faster than `div w 2`
+        in if offset <= halfSize
+           then indexTree halfSize (offset - 1) t1
+           else indexTree halfSize (offset - 1 - halfSize) t2
+
+-- TODO: safeIndex

--- a/plutus-core/untyped-plutus-core/test/TestRAList.hs
+++ b/plutus-core/untyped-plutus-core/test/TestRAList.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE TemplateHaskell #-}
+import qualified Data.RandomAccessList.SkewBinary as B
+import           Data.Semigroup
+import           GHC.Exts
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+
+instance Arbitrary a => Arbitrary (B.RAList a) where
+    arbitrary = fromList <$> arbitrary
+
+hundred :: B.RAList Word
+hundred = foldr B.Cons B.Nil [1..100]
+
+prop_null x = not $ B.null $ B.Cons x B.Nil
+
+prop_cons1 x = B.Cons x hundred /= hundred
+prop_cons2 x xs = B.Cons x xs /= xs
+
+
+unit_null1 = not (B.null hundred) @? "list is empty"
+unit_null2 = B.null B.Nil @? "list not empty"
+
+unit_head1 = B.head hundred @?= 1
+unit_head2 = B.head (B.Cons 0 hundred) @?= 0
+unit_head3 = B.head (foldr B.Cons hundred [200.. 300]) @?= 200
+unit_head4 = (B.head (B.tail hundred) == B.head hundred + 1) @? "head mismatch"
+
+unit_tail1 = B.head (B.tail (B.tail hundred)) == 3 @?  "tail broken"
+unit_tail2 = B.tail (B.Cons 1 hundred) == hundred @? "tail is not inverse of cons"
+unit_tail3 = B.null (B.tail (B.Cons () B.Nil)) @? "tail is not inverse of cons"
+unit_tail4 = (tailN 150 (applyN (B.Cons 0) 100 hundred) == tailN 50 hundred) @? "tail/cons broken"
+    where
+      tailN :: Word -> B.RAList a -> B.RAList a
+      tailN = applyN B.tail
+
+applyN :: (a->a) -> Word -> a -> a
+applyN f n = appEndo $ stimes n $ Endo f
+
+unit_ix1 = B.index hundred 0 == B.head hundred @? "index error"
+unit_ix2 = B.index (B.Cons 1 (B.Cons 2 B.Nil)) 1 @?= 2
+unit_ix3 = all (\x -> B.index hundred (x-1) == x) [1..100] @? "index wrong"
+prop_ix1 x y = B.index (B.Cons x (B.Cons y B.Nil)) 0 == x
+prop_ix2 x y = B.index (B.Cons x (B.Cons y B.Nil)) 1 == y
+prop_ix3 xs =
+    not (B.null xs) ==>
+    B.index xs 0 == B.head xs
+
+unit_ixzero1 = B.index hundred 0 == B.head hundred @? "index error"
+unit_ixzero2 = B.index (B.Cons 1 (B.Cons 2 B.Nil)) 1 @?= 2
+unit_ixzero3 = all (\x -> B.index hundred (x-1) == x) [1..100] @? "index wrong"
+prop_ixzero1 x y = B.index (B.Cons x (B.Cons y B.Nil)) 0 == x
+prop_ixzero2 x y = B.index (B.Cons x (B.Cons y B.Nil)) 1 == y
+prop_ixzero3 xs =
+    not (B.null xs) ==>
+    B.index xs 0 == B.head xs
+
+prop_fail1 (NonZero i) = total $ B.index (applyN (B.Cons ()) i B.Nil) i
+prop_fail2 (NonZero i) = total $ B.index (B.Nil :: B.RAList ()) i
+
+prop_constail :: Eq a => Word -> Word -> a -> B.RAList a -> Bool
+prop_constail reps skips x xs =
+    applyN (applyN B.tail skips . applyN (B.Cons x) skips) reps xs == xs
+
+-- needed by QuickCheck TH
+$(pure [])
+
+main :: IO ()
+main = defaultMain $ testGroup "Data.RandomAccessList.SkewBinary"
+    [ testProperty "prop_null" $(monomorphic 'prop_null)
+    , testCase "unit_null1" unit_null1
+    , testCase "unit_null2" unit_null2
+    , testProperty "prop_cons1" $(monomorphic 'prop_cons1)
+    , testProperty "prop_cons2" $(monomorphic 'prop_cons2)
+    , testCase "unit_head1" unit_head1
+    , testCase "unit_head2" unit_head2
+    , testCase "unit_head3" unit_head3
+    , testCase "unit_head4" unit_head4
+    , testCase "unit_tail1" unit_tail1
+    , testCase "unit_tail2" unit_tail2
+    , testCase "unit_tail3" unit_tail3
+    , testCase "unit_tail4" unit_tail4
+    , testCase "unit_ix1" unit_ix1
+    , testCase "unit_ix2" unit_ix2
+    , testCase "unit_ix3" unit_ix3
+    , testProperty "prop_ix1" $(monomorphic 'prop_ix1)
+    , testProperty "prop_ix2" $(monomorphic 'prop_ix2)
+    , testProperty "prop_ix3" $(monomorphic 'prop_ix3)
+    , testCase "unit_ixzero1" unit_ixzero1
+    , testCase "unit_ixzero2" unit_ixzero2
+    , testCase "unit_ixzero3" unit_ixzero3
+    , testProperty "prop_ixzero1" $(monomorphic 'prop_ixzero1)
+    , testProperty "prop_ixzero2" $(monomorphic 'prop_ixzero2)
+    , testProperty "prop_ixzero3" $(monomorphic 'prop_ixzero3)
+    , testProperty "prop_fail1" (expectFailure $(monomorphic 'prop_fail1))
+    , testProperty "prop_fail2" (expectFailure $(monomorphic 'prop_fail2))
+    , testProperty "prop_constail" $(monomorphic 'prop_constail)
+    ]


### PR DESCRIPTION
This PR introduces a binary random access list (BRAL) implementation, 
influenced by Okasaki book (purely functional data structures) and Kmett: https://github.com/ekmett/coda/blob/bca7e36ab00036f92d94eb86298712ab1dbf9b8d/wip/bdd/Data/List/Skew.hs

BRAL is supposed to be faster (overall) than IntMap patricia trees (what we use right now for the CEK environments), and this PR would help us eventually switch CEK environments to use BRAL.

There is also quickcheck&unit testing and a criterion micro-benchmark comparing it against IntMap and [ral](https://hackage.haskell.org/package/ral).


Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
