### PR TITLE
Slippage: word-packing

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,6 +25,7 @@ packages: doc
           prettyprinter-configurable
           quickcheck-dynamic
           web-ghc
+          word-array
 
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-core.nix
@@ -76,6 +76,7 @@
           (hsPkgs."monoidal-containers" or (errorHandler.buildDepError "monoidal-containers"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."nonempty-containers" or (errorHandler.buildDepError "nonempty-containers"))
+          (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
           (hsPkgs."parser-combinators" or (errorHandler.buildDepError "parser-combinators"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."prettyprinter-configurable" or (errorHandler.buildDepError "prettyprinter-configurable"))
@@ -96,6 +97,7 @@
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+          (hsPkgs."word-array" or (errorHandler.buildDepError "word-array"))
           ];
         build-tools = [
           (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/word-array.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/word-array.nix
@@ -1,0 +1,76 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "word-array"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Zachary Churchill, Michael Peyton Jones";
+      homepage = "https://github.com/plutus";
+      url = "";
+      synopsis = "";
+      description = "Treat integral types as arrays of smaller integral types";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
+          (hsPkgs."primitive" or (errorHandler.buildDepError "primitive"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          ];
+        buildable = true;
+        modules = [ "Data/Word64Array/Word8" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            (hsPkgs."word-array" or (errorHandler.buildDepError "word-array"))
+            (hsPkgs."mono-traversable" or (errorHandler.buildDepError "mono-traversable"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      benchmarks = {
+        "bench" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-bench" or (errorHandler.buildDepError "tasty-bench"))
+            (hsPkgs."word-array" or (errorHandler.buildDepError "word-array"))
+            (hsPkgs."primitive" or (errorHandler.buildDepError "primitive"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "bench" ];
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../word-array; }

--- a/nix/pkgs/haskell/materialized-unix/default.nix
+++ b/nix/pkgs/haskell/materialized-unix/default.nix
@@ -319,6 +319,7 @@
         "math-functions".revision = (((hackage."math-functions")."0.3.4.2").revisions).default;
         "math-functions".flags.system-expm1 = true;
         "math-functions".flags.system-erf = true;
+        "tasty-bench".revision = (((hackage."tasty-bench")."0.2.5").revisions).default;
         "regex-compat".revision = (((hackage."regex-compat")."0.95.2.1").revisions).default;
         "time-compat".revision = (((hackage."time-compat")."1.9.5").revisions).default;
         "time-compat".flags.old-locale = false;
@@ -744,6 +745,7 @@
         cardano-crypto = ./.plan.nix/cardano-crypto.nix;
         plutus-tx = ./.plan.nix/plutus-tx.nix;
         prettyprinter-configurable = ./.plan.nix/prettyprinter-configurable.nix;
+        word-array = ./.plan.nix/word-array.nix;
         plutus-pab = ./.plan.nix/plutus-pab.nix;
         cardano-prelude-test = ./.plan.nix/cardano-prelude-test.nix;
         plutus-chain-index = ./.plan.nix/plutus-chain-index.nix;
@@ -871,6 +873,7 @@
             };
           "plutus-tx" = { flags = {}; };
           "prettyprinter-configurable" = { flags = {}; };
+          "word-array" = { flags = {}; };
           "plutus-pab" = {
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };

--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -763,14 +763,13 @@ printBudgetStateBudget _ model b =
 printBudgetStateTally :: (Eq fun, Cek.Hashable fun, Show fun)
        => UPLC.Term UPLC.Name PLC.DefaultUni PLC.DefaultFun () -> CekModel ->  Cek.CekExTally fun -> IO ()
 printBudgetStateTally term model (Cek.CekExTally costs) = do
-  putStrLn $ "Const      " ++ pbudget Cek.BConst
-  putStrLn $ "Var        " ++ pbudget Cek.BVar
-  putStrLn $ "LamAbs     " ++ pbudget Cek.BLamAbs
-  putStrLn $ "Apply      " ++ pbudget Cek.BApply
-  putStrLn $ "Delay      " ++ pbudget Cek.BDelay
-  putStrLn $ "Force      " ++ pbudget Cek.BForce
-  putStrLn $ "Error      " ++ pbudget Cek.BError
-  putStrLn $ "Builtin    " ++ pbudget Cek.BBuiltin
+  putStrLn $ "Const      " ++ pbudget (Cek.BStep Cek.BConst)
+  putStrLn $ "Var        " ++ pbudget (Cek.BStep Cek.BVar)
+  putStrLn $ "LamAbs     " ++ pbudget (Cek.BStep Cek.BLamAbs)
+  putStrLn $ "Apply      " ++ pbudget (Cek.BStep Cek.BApply)
+  putStrLn $ "Delay      " ++ pbudget (Cek.BStep Cek.BDelay)
+  putStrLn $ "Force      " ++ pbudget (Cek.BStep Cek.BForce)
+  putStrLn $ "Builtin    " ++ pbudget (Cek.BStep Cek.BBuiltin)
   putStrLn ""
   putStrLn $ "startup    " ++ pbudget Cek.BStartup
   putStrLn $ "compute    " ++ printf "%-20s" (budgetToString totalComputeCost)
@@ -792,7 +791,7 @@ printBudgetStateTally term model (Cek.CekExTally costs) = do
             case H.lookup k costs of
               Just v  -> v
               Nothing -> ExBudget 0 0
-        allNodeTags = [Cek.BConst, Cek.BVar, Cek.BLamAbs, Cek.BApply, Cek.BDelay, Cek.BForce, Cek.BError, Cek.BBuiltin]
+        allNodeTags = fmap Cek.BStep [Cek.BConst, Cek.BVar, Cek.BLamAbs, Cek.BApply, Cek.BDelay, Cek.BForce, Cek.BBuiltin]
         totalComputeCost = mconcat $ map getSpent allNodeTags  -- For unitCekCosts this will be the total number of compute steps
         budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) =
             printf "%15s  %15s" (show cpu) (show mem) :: String -- Not %d: doesn't work when CostingInteger is SatInt.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -275,6 +275,7 @@ library
         monoidal-containers,
         mtl -any,
         nonempty-containers -any,
+        mono-traversable -any,
         parser-combinators >= 0.4.0,
         prettyprinter >=1.1.0.1,
         prettyprinter-configurable -any,
@@ -294,7 +295,8 @@ library
         th-utilities -any,
         transformers -any,
         unordered-containers -any,
-        witherable -any
+        witherable -any,
+        word-array -any
 
 test-suite satint-test
   import: lang

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -149,7 +149,7 @@ import           PlutusPrelude                          hiding (toList)
 import           PlutusCore.Core
 import           PlutusCore.Name
 
-import           Data.Semigroup.Generic
+import           Data.Semigroup
 import           Data.Text.Prettyprint.Doc
 import           Deriving.Aeson
 import           Language.Haskell.TH.Lift               (Lift)
@@ -179,9 +179,19 @@ instance ExBudgetBuiltin fun () where
 
 data ExBudget = ExBudget { _exBudgetCPU :: ExCPU, _exBudgetMemory :: ExMemory }
     deriving stock (Eq, Show, Generic, Lift)
-    deriving (Semigroup, Monoid) via (GenericSemigroupMonoid ExBudget)
     deriving anyclass (PrettyBy config, NFData)
     deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier (CamelToSnake)] ExBudget
+
+-- These functions are performance critical, so we can't use GenericSemigroupMonoid, and we insist that they be inlined.
+instance Semigroup ExBudget where
+    {-# INLINE (<>) #-}
+    (ExBudget cpu1 mem1) <> (ExBudget cpu2 mem2) = ExBudget (cpu1 <> cpu2) (mem1 <> mem2)
+    -- This absolutely must be inlined so that the 'fromIntegral' calls can get optimized away, or it destroys performance
+    {-# INLINE stimes #-}
+    stimes r (ExBudget (ExCPU cpu) (ExMemory mem)) = ExBudget (ExCPU (fromIntegral r * cpu)) (ExMemory (fromIntegral r * mem))
+
+instance Monoid ExBudget where
+    mempty = ExBudget mempty mempty
 
 instance Pretty ExBudget where
     pretty (ExBudget cpu memory) = parens $ fold
@@ -193,7 +203,7 @@ instance Pretty ExBudget where
 newtype ExRestrictingBudget = ExRestrictingBudget
     { unExRestrictingBudget :: ExBudget
     } deriving (Show, Eq)
-      deriving (Semigroup, Monoid) via (GenericSemigroupMonoid ExBudget)
+      deriving newtype (Semigroup, Monoid)
       deriving newtype (Pretty, PrettyBy config, NFData)
 
 -- | When we want to just evaluate the program we use the 'Restricting' mode with an enormous

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -13,6 +13,7 @@ module UntypedPlutusCore.Evaluation.Machine.Cek
     , ErrorWithCause(..)
     , EvaluationError(..)
     , ExBudgetCategory(..)
+    , StepKind(..)
     , CekExTally(..)
     , ExBudgetMode(..)
     , CountingSt (..)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -35,6 +35,7 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     , ErrorWithCause(..)
     , EvaluationError(..)
     , ExBudgetCategory(..)
+    , StepKind(..)
     , PrettyUni
     , extractEvaluationResult
     , runCek
@@ -70,7 +71,9 @@ import           Data.Hashable                                            (Hasha
 import qualified Data.Kind                                                as GHC
 import           Data.Proxy
 import           Data.STRef
+import           Data.Semigroup                                           (stimes)
 import           Data.Text.Prettyprint.Doc
+import           Data.Word64Array.Word8
 
 {- Note [Compilation peculiarities]
 READ THIS BEFORE TOUCHING ANYTHING IN THIS FILE
@@ -121,6 +124,9 @@ points in it).
 
 In general, it's advised to run benchmarks (and look at Core output if the results are suspicious)
 on any changes in this file.
+
+Finally, it's important to put bang patterns on any Int arguments to ensure that GHC unboxes them:
+this can make a surprisingly large difference.
 -}
 
 {- Note [Scoping]
@@ -128,15 +134,29 @@ The CEK machine does not rely on the global uniqueness condition, so the renamer
 prerequisite. The CEK machine correctly handles name shadowing.
 -}
 
-data ExBudgetCategory fun
+data StepKind
     = BConst
     | BVar
     | BLamAbs
     | BApply
     | BDelay
     | BForce
-    | BError
-    | BBuiltin         -- Cost of evaluating a Builtin AST node
+    | BBuiltin -- Cost of evaluating a Builtin AST node, not the function itself
+    deriving stock (Show, Eq, Ord, Generic, Enum, Bounded)
+    deriving anyclass (NFData, Hashable)
+
+cekStepCost :: CekMachineCosts -> StepKind -> ExBudget
+cekStepCost costs = \case
+    BConst   -> cekConstCost costs
+    BVar     -> cekVarCost costs
+    BLamAbs  -> cekLamCost costs
+    BApply   -> cekApplyCost costs
+    BDelay   -> cekDelayCost costs
+    BForce   -> cekForceCost costs
+    BBuiltin -> cekBuiltinCost costs
+
+data ExBudgetCategory fun
+    = BStep StepKind
     | BBuiltinApp fun  -- Cost of evaluating a fully applied builtin function
     | BStartup
     deriving stock (Show, Eq, Ord, Generic)
@@ -203,6 +223,59 @@ newtype ExBudgetMode cost uni fun = ExBudgetMode
     { unExBudgetMode :: forall s. ST s (ExBudgetInfo cost uni fun s)
     }
 
+{- Note [Cost slippage]
+Tracking the budget usage for every step in the machine adds a lot of overhead. To reduce this,
+we adopt a technique which allows some overshoot of the budget ("slippage"), but only a bounded
+amount.
+
+To do this we:
+- Track all the machine steps of all kinds in an optimized way in a 'WordArray'.
+- Actually "spend" the budget when we've done more than some fixed number of steps, or at the end.
+
+This saves a *lot* of time, at the cost of potentially overshooting the budget by slippage*step_cost,
+which is okay so long as we bound the slippage appropriately.
+
+Note that we're only proposing to do this for machine steps, since it's plausible that we can track
+them in an optimized way. Builtins are more complicated (and infrequent), so we can just budget them
+properly when we hit them.
+
+There are two options for how to bound the slippage:
+1. As a fixed number of steps
+2. As a proportion of the overall budget
+
+Option 2 initially seems much better as a bound: if we run N scripts with an overall budget of B, then
+the potential overrun from 1 is N*slippage, whereas the overrun from 2 is B*slippage. That is, 2
+says we always overrun by a fraction of the total amount of time you were expecting, whereas 1 says
+it depends how many scripts you run... so if I send you a lot of small scripts, I could cause a lot
+of overrun.
+
+However, it turns out (empirically) that we can pick a number for 1 that gives us most of the speedup, but such
+that the maximum overrun is negligible (e.g. much smaller than the "startup cost"). So in the end
+we opted for option 1, which also happens to be simpler to implement.
+-}
+
+{- Note [Structure of the step counter]
+The step counter is kept in a 'WordArray', which is 8 'Word8's packed into a single 'Word64'.
+This happens to suit our purposes exactly, as we want to keep a counter for each kind of step
+that we know about (of which there are 7) and one for the total number.
+
+We keep the counters for each step in the first 7 indices, so we can index them simply by using
+the 'Enum' instance of 'StepKind', and the total counter in the last index.
+
+Why use a 'WordArray'? It optimizes well, since GHC can often do quite a lot of constant-folding
+on the bitwise operations that get emitted. We are restricted to counters of size 'Word8', but this
+is fine since we will reset when we get to 200 steps.
+
+The sharp-eyed reader might notice that the benchmarks in 'word-array' show that 'PrimArray'
+seems to be faster! However, we tried that and it was slower overall, we don't know why.
+-}
+
+type Slippage = Word8
+-- See Note [Cost slippage]
+-- | The default number of slippage (in machine steps) to allow.
+defaultSlippage :: Slippage
+defaultSlippage = 200
+
 {- Note [Implicit parameters in the machine]
 The traditional way to pass context into a function is to use 'ReaderT'. However, 'ReaderT' has some
 disadvantages.
@@ -234,8 +307,11 @@ type GivenCekRuntime uni fun = (?cekRuntime :: (BuiltinsRuntime fun (CekValue un
 type GivenCekEmitter s = (?cekEmitter :: (Maybe (STRef s (DList String))))
 -- | Implicit parameter for budget spender.
 type GivenCekSpender uni fun s = (?cekBudgetSpender :: (CekBudgetSpender uni fun s))
+type GivenCekSlippage = (?cekSlippage :: Slippage)
+type GivenCekCosts = (?cekCosts :: CekMachineCosts)
+
 -- | Constraint requiring all of the machine's implicit parameters.
-type GivenCekReqs uni fun s = (GivenCekRuntime uni fun, GivenCekEmitter s, GivenCekSpender uni fun s)
+type GivenCekReqs uni fun s = (GivenCekRuntime uni fun, GivenCekEmitter s, GivenCekSpender uni fun s, GivenCekSlippage, GivenCekCosts)
 
 data CekUserError
     = CekOutOfExError ExRestrictingBudget -- ^ The final overspent (i.e. negative) budget.
@@ -458,17 +534,19 @@ tryError a = (Right <$> a) `catchError` (pure . Left)
 runCekM
     :: forall a cost uni fun.
     (PrettyUni uni fun)
-    => BuiltinsRuntime fun (CekValue uni fun)
+    => MachineParameters CekMachineCosts CekValue uni fun
     -> ExBudgetMode cost uni fun
     -> Bool
     -> (forall s. GivenCekReqs uni fun s => CekM uni fun s a)
     -> (Either (CekEvaluationException uni fun) a, cost, [String])
-runCekM runtime (ExBudgetMode getExBudgetInfo) emitting a = runST $ do
+runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) emitting a = runST $ do
     exBudgetMode <- getExBudgetInfo
     mayLogsRef <- if emitting then Just <$> newSTRef DList.empty else pure Nothing
     let ?cekRuntime = runtime
         ?cekEmitter = mayLogsRef
         ?cekBudgetSpender = _exBudgetModeSpender exBudgetMode
+        ?cekCosts = costs
+        ?cekSlippage = defaultSlippage
     -- See Note Note [Being generic over 'term' in errors].
     errValOrErrTermOrRes <- unCekCarryingM . tryError . withTermErrors $ tryError a
     let errOrRes = join $ first (mapCauseInMachineException dischargeCekValue) errValOrErrTermOrRes
@@ -513,12 +591,11 @@ evalBuiltinApp fun term env runtime@(BuiltinRuntime sch x cost) = case sch of
 enterComputeCek
     :: forall uni fun s
     . (Ix fun, PrettyUni uni fun, GivenCekReqs uni fun s, uni `Everywhere` ExMemoryUsage)
-    => CekMachineCosts
-    -> Context uni fun
+    => Context uni fun
     -> CekValEnv uni fun
     -> Term Name uni fun ()
     -> CekM uni fun s (Term Name uni fun ())
-enterComputeCek costs = computeCek where
+enterComputeCek = computeCek (toWordArray 0) where
     -- | The computing part of the CEK machine.
     -- Either
     -- 1. adds a frame to the context and calls 'computeCek' ('Force', 'Apply')
@@ -526,41 +603,42 @@ enterComputeCek costs = computeCek where
     -- 3. throws 'EvaluationFailure' ('Error')
     -- 4. looks up a variable in the environment and calls 'returnCek' ('Var')
     computeCek
-        :: Context uni fun
+        :: WordArray
+        -> Context uni fun
         -> CekValEnv uni fun
         -> Term Name uni fun ()
         -> CekM uni fun s (Term Name uni fun ())
     -- s ; ρ ▻ {L A}  ↦ s , {_ A} ; ρ ▻ L
-    computeCek ctx env (Var _ varName) = do
-        spendBudgetCek BVar (cekVarCost costs)
+    computeCek !unbudgetedSteps ctx env (Var _ varName) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BVar unbudgetedSteps
         val <- lookupVarName varName env
-        returnCek ctx val
-    computeCek ctx _ (Constant _ val) = do
-        spendBudgetCek BConst (cekConstCost costs)
-        returnCek ctx (VCon val)
-    computeCek ctx env (LamAbs _ name body) = do
-        spendBudgetCek BLamAbs (cekLamCost costs)
-        returnCek ctx (VLamAbs name body env)
-    computeCek ctx env (Delay _ body) = do
-        spendBudgetCek BDelay (cekDelayCost costs)
-        returnCek ctx (VDelay body env)
+        returnCek unbudgetedSteps' ctx val
+    computeCek !unbudgetedSteps ctx _ (Constant _ val) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BConst unbudgetedSteps
+        returnCek unbudgetedSteps' ctx (VCon val)
+    computeCek !unbudgetedSteps ctx env (LamAbs _ name body) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BLamAbs unbudgetedSteps
+        returnCek unbudgetedSteps' ctx (VLamAbs name body env)
+    computeCek !unbudgetedSteps ctx env (Delay _ body) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BDelay unbudgetedSteps
+        returnCek unbudgetedSteps' ctx (VDelay body env)
     -- s ; ρ ▻ lam x L  ↦  s ◅ lam x (L , ρ)
-    computeCek ctx env (Force _ body) = do
-        spendBudgetCek BForce (cekForceCost costs)
-        computeCek (FrameForce : ctx) env body
+    computeCek !unbudgetedSteps ctx env (Force _ body) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BForce unbudgetedSteps
+        computeCek unbudgetedSteps' (FrameForce : ctx) env body
     -- s ; ρ ▻ [L M]  ↦  s , [_ (M,ρ)]  ; ρ ▻ L
-    computeCek ctx env (Apply _ fun arg) = do
-        spendBudgetCek BApply (cekApplyCost costs)
-        computeCek (FrameApplyArg env arg : ctx) env fun
+    computeCek !unbudgetedSteps ctx env (Apply _ fun arg) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BApply unbudgetedSteps
+        computeCek unbudgetedSteps' (FrameApplyArg env arg : ctx) env fun
     -- s ; ρ ▻ abs α L  ↦  s ◅ abs α (L , ρ)
     -- s ; ρ ▻ con c  ↦  s ◅ con c
-    -- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn (Builtin () bn) (runtimeOf bn) ρ
-    computeCek ctx env term@(Builtin _ bn) = do
-        spendBudgetCek BBuiltin (cekBuiltinCost costs)
+    -- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] [] ρ
+    computeCek !unbudgetedSteps ctx env term@(Builtin _ bn) = do
+        !unbudgetedSteps' <- stepAndMaybeSpend BBuiltin unbudgetedSteps
         meaning <- lookupBuiltin bn ?cekRuntime
-        returnCek ctx (VBuiltin bn term env meaning)
+        returnCek unbudgetedSteps' ctx (VBuiltin bn term env meaning)
     -- s ; ρ ▻ error A  ↦  <> A
-    computeCek _ _ (Error _) =
+    computeCek !_ _ _ (Error _) =
         throwing_ _EvaluationFailure
 
     {- | The returning phase of the CEK machine.
@@ -572,19 +650,21 @@ enterComputeCek costs = computeCek where
       * 'FrameApplyFun': call 'applyEvaluate' to attempt to apply the function
           stored in the frame to an argument.
     -}
-    returnCek :: Context uni fun -> CekValue uni fun -> CekM uni fun s (Term Name uni fun ())
+    returnCek :: WordArray -> Context uni fun -> CekValue uni fun -> CekM uni fun s (Term Name uni fun ())
     --- Instantiate all the free variable of the resulting term in case there are any.
     -- . ◅ V           ↦  [] V
-    returnCek [] val = pure $ dischargeCekValue val
+    returnCek !unbudgetedSteps [] val = do
+        spendAccumulatedBudget unbudgetedSteps
+        pure $ dischargeCekValue val
     -- s , {_ A} ◅ abs α M  ↦  s ; ρ ▻ M [ α / A ]*
-    returnCek (FrameForce : ctx) fun = forceEvaluate ctx fun
+    returnCek !unbudgetedSteps (FrameForce : ctx) fun = forceEvaluate unbudgetedSteps ctx fun
     -- s , [_ (M,ρ)] ◅ V  ↦  s , [V _] ; ρ ▻ M
-    returnCek (FrameApplyArg argVarEnv arg : ctx) fun =
-        computeCek (FrameApplyFun fun : ctx) argVarEnv arg
+    returnCek !unbudgetedSteps (FrameApplyArg argVarEnv arg : ctx) fun =
+        computeCek unbudgetedSteps (FrameApplyFun fun : ctx) argVarEnv arg
     -- s , [(lam x (M,ρ)) _] ◅ V  ↦  s ; ρ [ x  ↦  V ] ▻ M
     -- FIXME: add rule for VBuiltin once it's in the specification.
-    returnCek (FrameApplyFun fun : ctx) arg =
-        applyEvaluate ctx fun arg
+    returnCek !unbudgetedSteps (FrameApplyFun fun : ctx) arg =
+        applyEvaluate unbudgetedSteps ctx fun arg
 
     -- | @force@ a term and proceed.
     -- If v is a delay then compute the body of v;
@@ -593,9 +673,12 @@ enterComputeCek costs = computeCek where
     -- representation depending on whether the application is saturated or not,
     -- if v is anything else, fail.
     forceEvaluate
-        :: Context uni fun -> CekValue uni fun -> CekM uni fun s (Term Name uni fun ())
-    forceEvaluate ctx (VDelay body env) = computeCek ctx env body
-    forceEvaluate ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) = do
+        :: WordArray
+        -> Context uni fun
+        -> CekValue uni fun
+        -> CekM uni fun s (Term Name uni fun ())
+    forceEvaluate !unbudgetedSteps ctx (VDelay body env) = computeCek unbudgetedSteps ctx env body
+    forceEvaluate !unbudgetedSteps ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) = do
         let term' = Force () term
         case sch of
             -- It's only possible to force a builtin application if the builtin expects a type
@@ -606,10 +689,10 @@ enterComputeCek costs = computeCek where
                 -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
                 -- application.
                 res <- evalBuiltinApp fun term' env runtime'
-                returnCek ctx res
+                returnCek unbudgetedSteps ctx res
             _ ->
                 throwingWithCause _MachineError BuiltinTermArgumentExpectedMachineError (Just term')
-    forceEvaluate _ val =
+    forceEvaluate !_ _ val =
         throwingDischarged _MachineError NonPolymorphicInstantiationMachineError val
 
     -- | Apply a function to an argument and proceed.
@@ -620,13 +703,14 @@ enterComputeCek costs = computeCek where
     -- representation depending on whether the application is saturated or not.
     -- If v is anything else, fail.
     applyEvaluate
-        :: Context uni fun
+        :: WordArray
+        -> Context uni fun
         -> CekValue uni fun   -- lhs of application
         -> CekValue uni fun   -- rhs of application
         -> CekM uni fun s (Term Name uni fun ())
-    applyEvaluate ctx (VLamAbs name body env) arg = computeCek ctx (extendEnv name arg env) body
+    applyEvaluate !unbudgetedSteps ctx (VLamAbs name body env) arg = computeCek unbudgetedSteps ctx (extendEnv name arg env) body
     -- TODO: check if annotating @f@ and @exF@ with bangs speeds anything up.
-    applyEvaluate ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) arg = do
+    applyEvaluate !unbudgetedSteps ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) arg = do
         let term' = Apply () term $ dischargeCekValue arg
         case sch of
             -- It's only possible to apply a builtin application if the builtin expects a term
@@ -638,11 +722,35 @@ enterComputeCek costs = computeCek where
                 -- TODO: should we bother computing that 'ExMemory' eagerly? We may not need it.
                 let runtime' = BuiltinRuntime schB (f x) . exF $ toExMemory arg
                 res <- evalBuiltinApp fun term' env runtime'
-                returnCek ctx res
+                returnCek unbudgetedSteps ctx res
             _ ->
                 throwingWithCause _MachineError UnexpectedBuiltinTermArgumentMachineError (Just term')
-    applyEvaluate _ val _ =
+    applyEvaluate !_ _ val _ =
         throwingDischarged _MachineError NonFunctionalApplicationMachineError val
+
+    -- | Spend the budget that has been accumulated for a number of machine steps.
+    spendAccumulatedBudget :: WordArray -> CekM uni fun s ()
+    spendAccumulatedBudget !unbudgetedSteps = iforWordArray unbudgetedSteps spend
+
+    -- Making this a definition of its own causes it to inline better than actually writing it inline, for
+    -- some reason.
+    -- Skip index 7, that's the total counter!
+    -- See Note [Structure of the step counter]
+    {-# INLINE spend #-}
+    spend !i !w = unless (i == 7) $ let kind = toEnum i in spendBudgetCek (BStep kind) (stimes w (cekStepCost ?cekCosts kind))
+
+    -- | Accumulate a step, and maybe spend the budget that has accumulated for a number of machine steps, but only if we've exceeded our slippage.
+    stepAndMaybeSpend :: StepKind -> WordArray -> CekM uni fun s WordArray
+    stepAndMaybeSpend !kind !unbudgetedSteps = do
+        -- See Note [Structure of the step counter]
+        let !ix = fromIntegral $ fromEnum kind
+            !unbudgetedSteps' = overIndex 7 (+1) $ overIndex ix (+1) unbudgetedSteps
+            !unbudgetedStepsTotal = readArray unbudgetedSteps' 7
+        -- There's no risk of overflow here, since we only ever increment the total
+        -- steps by 1 and then check this condition.
+        if unbudgetedStepsTotal >= ?cekSlippage
+        then spendAccumulatedBudget unbudgetedSteps' >> pure (toWordArray 0)
+        else pure unbudgetedSteps'
 
 -- See Note [Compilation peculiarities].
 -- | Evaluate a term using the CEK machine and keep track of costing, logging is optional.
@@ -653,7 +761,7 @@ runCek
     -> Bool
     -> Term Name uni fun ()
     -> (Either (CekEvaluationException uni fun) (Term Name uni fun ()), cost, [String])
-runCek (MachineParameters cekcosts runtime) mode emitting term =
-    runCekM runtime mode emitting $ do
-        spendBudgetCek BStartup (cekStartupCost cekcosts)
-        enterComputeCek cekcosts [] mempty term
+runCek params mode emitting term =
+    runCekM params mode emitting $ do
+        spendBudgetCek BStartup (cekStartupCost ?cekCosts)
+        enterComputeCek [] mempty term

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/FoldrInterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/FoldrInterList.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\f -> \z -> force (force (force (force (delay (delay (\f -> force (delay (\s -> s s)) (\s -> \x -> f (force (delay (\s -> s s)) s) x))))) (\rec -> \u -> delay (delay (\f' -> \xs -> force xs z (\x -> \y -> \xs' -> f' x y (force (force (rec ())) (\y' -> \x' -> f' x' y') xs'))))) ())))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \y -> \xs -> delay (\z -> \f -> f x y xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/InterList/InterNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\z -> \f -> z)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/RecUnit/runRecUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/RecUnit/runRecUnit.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\ru -> force ru ru)))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Shad/mkShad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Shad/mkShad.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\x -> delay (\y -> 0))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\tr -> \fr -> delay (\z -> \f -> f tr fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/ForestNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\z -> \f -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/TreeNode.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/TreeForest/TreeNode.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\x -> \fr -> delay (\f -> f x fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchConcat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchConcat.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\xs -> \ys -> delay (\f -> \z -> force xs (delay (force f)) (force ys f z)))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x (force xs f z))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/churchNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottHead.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottHead.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ()))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottSumHeadsOr0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Examples/Vec/scottSumHeadsOr0.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\xs -> \ys -> force xs (delay (\x -> \xs' -> \coe -> addInteger x (force (force (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ())))) (coe ys)))) (\coe -> 0) (\xs' -> xs'))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 117000
+, ({ tally: ({ BStep BConst causes ({ cpu: 117000
 | mem: 30
 })
-| BVar causes ({ cpu: 507000
+| BStep BVar causes ({ cpu: 507000
 | mem: 130
 })
-| BLamAbs causes ({ cpu: 546000
+| BStep BLamAbs causes ({ cpu: 546000
 | mem: 140
 })
-| BApply causes ({ cpu: 702000
+| BStep BApply causes ({ cpu: 702000
 | mem: 180
 })
-| BDelay causes ({ cpu: 195000
+| BStep BDelay causes ({ cpu: 195000
 | mem: 50
 })
-| BForce causes ({ cpu: 234000
+| BStep BForce causes ({ cpu: 234000
 | mem: 60
 })
-| BBuiltin causes ({ cpu: 78000
+| BStep BBuiltin causes ({ cpu: 78000
 | mem: 20
 })
 | BBuiltinApp LessThanEqInteger causes ({ cpu: 216714

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 351000
+, ({ tally: ({ BStep BConst causes ({ cpu: 351000
 | mem: 90
 })
-| BVar causes ({ cpu: 1404000
+| BStep BVar causes ({ cpu: 1404000
 | mem: 360
 })
-| BLamAbs causes ({ cpu: 1170000
+| BStep BLamAbs causes ({ cpu: 1170000
 | mem: 300
 })
-| BApply causes ({ cpu: 2028000
+| BStep BApply causes ({ cpu: 2028000
 | mem: 520
 })
-| BDelay causes ({ cpu: 351000
+| BStep BDelay causes ({ cpu: 351000
 | mem: 90
 })
-| BForce causes ({ cpu: 468000
+| BStep BForce causes ({ cpu: 468000
 | mem: 120
 })
-| BBuiltin causes ({ cpu: 351000
+| BStep BBuiltin causes ({ cpu: 351000
 | mem: 90
 })
 | BBuiltinApp AddInteger causes ({ cpu: 237457

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (2))
-, ({ tally: ({ BConst causes ({ cpu: 585000
+, ({ tally: ({ BStep BConst causes ({ cpu: 585000
 | mem: 150
 })
-| BVar causes ({ cpu: 2301000
+| BStep BVar causes ({ cpu: 2301000
 | mem: 590
 })
-| BLamAbs causes ({ cpu: 1794000
+| BStep BLamAbs causes ({ cpu: 1794000
 | mem: 460
 })
-| BApply causes ({ cpu: 3354000
+| BStep BApply causes ({ cpu: 3354000
 | mem: 860
 })
-| BDelay causes ({ cpu: 507000
+| BStep BDelay causes ({ cpu: 507000
 | mem: 130
 })
-| BForce causes ({ cpu: 702000
+| BStep BForce causes ({ cpu: 702000
 | mem: 180
 })
-| BBuiltin causes ({ cpu: 624000
+| BStep BBuiltin causes ({ cpu: 624000
 | mem: 160
 })
 | BBuiltinApp AddInteger causes ({ cpu: 474914

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/0.plc.golden
@@ -1,18 +1,24 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 5460000
 | mem: 1400
 })
-| BLamAbs causes ({ cpu: 3666000
+| BStep BLamAbs causes ({ cpu: 3666000
 | mem: 940
 })
-| BApply causes ({ cpu: 4758000
+| BStep BApply causes ({ cpu: 4758000
 | mem: 1220
 })
-| BDelay causes ({ cpu: 1443000
+| BStep BDelay causes ({ cpu: 1443000
 | mem: 370
 })
-| BForce causes ({ cpu: 1014000
+| BStep BForce causes ({ cpu: 1014000
 | mem: 260
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/3.plc.golden
@@ -1,20 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 5460000
 | mem: 1400
 })
-| BLamAbs causes ({ cpu: 3666000
+| BStep BLamAbs causes ({ cpu: 3666000
 | mem: 940
 })
-| BApply causes ({ cpu: 4875000
+| BStep BApply causes ({ cpu: 4875000
 | mem: 1250
 })
-| BDelay causes ({ cpu: 1443000
+| BStep BDelay causes ({ cpu: 1443000
 | mem: 370
 })
-| BForce causes ({ cpu: 1131000
+| BStep BForce causes ({ cpu: 1131000
 | mem: 290
 })
-| BBuiltin causes ({ cpu: 117000
+| BStep BBuiltin causes ({ cpu: 117000
 | mem: 30
 })
 | BBuiltinApp Id causes ({ cpu: 3

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/6.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/6.plc.golden
@@ -1,20 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 5460000
 | mem: 1400
 })
-| BLamAbs causes ({ cpu: 3666000
+| BStep BLamAbs causes ({ cpu: 3666000
 | mem: 940
 })
-| BApply causes ({ cpu: 4992000
+| BStep BApply causes ({ cpu: 4992000
 | mem: 1280
 })
-| BDelay causes ({ cpu: 1443000
+| BStep BDelay causes ({ cpu: 1443000
 | mem: 370
 })
-| BForce causes ({ cpu: 1248000
+| BStep BForce causes ({ cpu: 1248000
 | mem: 320
 })
-| BBuiltin causes ({ cpu: 234000
+| BStep BBuiltin causes ({ cpu: 234000
 | mem: 60
 })
 | BBuiltinApp Id causes ({ cpu: 6

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/9.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IdNat/9.plc.golden
@@ -1,20 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 5460000
 | mem: 1400
 })
-| BLamAbs causes ({ cpu: 3666000
+| BStep BLamAbs causes ({ cpu: 3666000
 | mem: 940
 })
-| BApply causes ({ cpu: 5109000
+| BStep BApply causes ({ cpu: 5109000
 | mem: 1310
 })
-| BDelay causes ({ cpu: 1443000
+| BStep BDelay causes ({ cpu: 1443000
 | mem: 370
 })
-| BForce causes ({ cpu: 1365000
+| BStep BForce causes ({ cpu: 1365000
 | mem: 350
 })
-| BBuiltin causes ({ cpu: 351000
+| BStep BBuiltin causes ({ cpu: 351000
 | mem: 90
 })
 | BBuiltinApp Id causes ({ cpu: 9

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/0.plc.golden
@@ -1,18 +1,24 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BVar causes ({ cpu: 5460000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 5460000
 | mem: 1400
 })
-| BLamAbs causes ({ cpu: 3666000
+| BStep BLamAbs causes ({ cpu: 3666000
 | mem: 940
 })
-| BApply causes ({ cpu: 4758000
+| BStep BApply causes ({ cpu: 4758000
 | mem: 1220
 })
-| BDelay causes ({ cpu: 1443000
+| BStep BDelay causes ({ cpu: 1443000
 | mem: 370
 })
-| BForce causes ({ cpu: 1014000
+| BStep BForce causes ({ cpu: 1014000
 | mem: 260
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/1.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 39000
 | mem: 10
 })
-| BVar causes ({ cpu: 5772000
+| BStep BVar causes ({ cpu: 5772000
 | mem: 1480
 })
-| BLamAbs causes ({ cpu: 4134000
+| BStep BLamAbs causes ({ cpu: 4134000
 | mem: 1060
 })
-| BApply causes ({ cpu: 5265000
+| BStep BApply causes ({ cpu: 5265000
 | mem: 1350
 })
-| BDelay causes ({ cpu: 1677000
+| BStep BDelay causes ({ cpu: 1677000
 | mem: 430
 })
-| BForce causes ({ cpu: 1248000
+| BStep BForce causes ({ cpu: 1248000
 | mem: 320
 })
-| BBuiltin causes ({ cpu: 39000
+| BStep BBuiltin causes ({ cpu: 39000
 | mem: 10
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/2.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 78000
+, ({ tally: ({ BStep BConst causes ({ cpu: 78000
 | mem: 20
 })
-| BVar causes ({ cpu: 5811000
+| BStep BVar causes ({ cpu: 5811000
 | mem: 1490
 })
-| BLamAbs causes ({ cpu: 4212000
+| BStep BLamAbs causes ({ cpu: 4212000
 | mem: 1080
 })
-| BApply causes ({ cpu: 5421000
+| BStep BApply causes ({ cpu: 5421000
 | mem: 1390
 })
-| BDelay causes ({ cpu: 1677000
+| BStep BDelay causes ({ cpu: 1677000
 | mem: 430
 })
-| BForce causes ({ cpu: 1287000
+| BStep BForce causes ({ cpu: 1287000
 | mem: 330
 })
-| BBuiltin causes ({ cpu: 78000
+| BStep BBuiltin causes ({ cpu: 78000
 | mem: 20
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/3.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 117000
+, ({ tally: ({ BStep BConst causes ({ cpu: 117000
 | mem: 30
 })
-| BVar causes ({ cpu: 5850000
+| BStep BVar causes ({ cpu: 5850000
 | mem: 1500
 })
-| BLamAbs causes ({ cpu: 4290000
+| BStep BLamAbs causes ({ cpu: 4290000
 | mem: 1100
 })
-| BApply causes ({ cpu: 5577000
+| BStep BApply causes ({ cpu: 5577000
 | mem: 1430
 })
-| BDelay causes ({ cpu: 1677000
+| BStep BDelay causes ({ cpu: 1677000
 | mem: 430
 })
-| BForce causes ({ cpu: 1326000
+| BStep BForce causes ({ cpu: 1326000
 | mem: 340
 })
-| BBuiltin causes ({ cpu: 117000
+| BStep BBuiltin causes ({ cpu: 117000
 | mem: 30
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/4.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/4.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 156000
+, ({ tally: ({ BStep BConst causes ({ cpu: 156000
 | mem: 40
 })
-| BVar causes ({ cpu: 5889000
+| BStep BVar causes ({ cpu: 5889000
 | mem: 1510
 })
-| BLamAbs causes ({ cpu: 4368000
+| BStep BLamAbs causes ({ cpu: 4368000
 | mem: 1120
 })
-| BApply causes ({ cpu: 5733000
+| BStep BApply causes ({ cpu: 5733000
 | mem: 1470
 })
-| BDelay causes ({ cpu: 1677000
+| BStep BDelay causes ({ cpu: 1677000
 | mem: 430
 })
-| BForce causes ({ cpu: 1365000
+| BStep BForce causes ({ cpu: 1365000
 | mem: 350
 })
-| BBuiltin causes ({ cpu: 156000
+| BStep BBuiltin causes ({ cpu: 156000
 | mem: 40
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/5.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Budget/IfThenElse/5.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> f (delay (\z -> \f -> z)))))))))))))))))))))))
-, ({ tally: ({ BConst causes ({ cpu: 195000
+, ({ tally: ({ BStep BConst causes ({ cpu: 195000
 | mem: 50
 })
-| BVar causes ({ cpu: 5928000
+| BStep BVar causes ({ cpu: 5928000
 | mem: 1520
 })
-| BLamAbs causes ({ cpu: 4446000
+| BStep BLamAbs causes ({ cpu: 4446000
 | mem: 1140
 })
-| BApply causes ({ cpu: 5889000
+| BStep BApply causes ({ cpu: 5889000
 | mem: 1510
 })
-| BDelay causes ({ cpu: 1677000
+| BStep BDelay causes ({ cpu: 1677000
 | mem: 430
 })
-| BForce causes ({ cpu: 1404000
+| BStep BForce causes ({ cpu: 1404000
 | mem: 360
 })
-| BBuiltin causes ({ cpu: 195000
+| BStep BBuiltin causes ({ cpu: 195000
 | mem: 50
 })
 | BBuiltinApp IfThenElse causes ({ cpu: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/FoldrInterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/FoldrInterList.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\f -> \z -> force (force (force (force (delay (delay (\f -> force (delay (\s -> s s)) (\s -> \x -> f (force (delay (\s -> s s)) s) x))))) (\rec -> \u -> delay (delay (\f' -> \xs -> force xs z (\x -> \y -> \xs' -> f' x y (force (force (rec ())) (\y' -> \x' -> f' x' y') xs'))))) ())))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \y -> \xs -> delay (\z -> \f -> f x y xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/InterList/InterNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\z -> \f -> z)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/RecUnit/runRecUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/RecUnit/runRecUnit.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\ru -> force ru ru)))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Shad/mkShad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Shad/mkShad.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\x -> delay (\y -> 0))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\tr -> \fr -> delay (\z -> \f -> f tr fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/ForestNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\z -> \f -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/TreeNode.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/TreeForest/TreeNode.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\x -> \fr -> delay (\f -> f x fr))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchConcat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchConcat.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (delay (\xs -> \ys -> delay (\f -> \z -> force xs (delay (force f)) (force ys f z)))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x (force xs f z))))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/churchNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottCons.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\x -> \xs -> delay (\f -> \z -> force f x xs)))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottHead.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottHead.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ()))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottNil.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (delay (\f -> \z -> z))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottSumHeadsOr0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Examples/Vec/scottSumHeadsOr0.plc.golden
@@ -1,6 +1,24 @@
 ( (Right (delay (\xs -> \ys -> force xs (delay (\x -> \xs' -> \coe -> addInteger x (force (force (delay (delay (\xs -> force xs (delay (\x -> \xs' -> x)) ())))) (coe ys)))) (\coe -> 0) (\xs' -> xs'))))
-, ({ tally: ({ BDelay causes ({ cpu: 39000
+, ({ tally: ({ BStep BConst causes ({ cpu: 0
+| mem: 0
+})
+| BStep BVar causes ({ cpu: 0
+| mem: 0
+})
+| BStep BLamAbs causes ({ cpu: 0
+| mem: 0
+})
+| BStep BApply causes ({ cpu: 0
+| mem: 0
+})
+| BStep BDelay causes ({ cpu: 39000
 | mem: 10
+})
+| BStep BForce causes ({ cpu: 0
+| mem: 0
+})
+| BStep BBuiltin causes ({ cpu: 0
+| mem: 0
 })
 | BStartup causes ({ cpu: 1000000
 | mem: 0

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/1.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 117000
+, ({ tally: ({ BStep BConst causes ({ cpu: 117000
 | mem: 30
 })
-| BVar causes ({ cpu: 507000
+| BStep BVar causes ({ cpu: 507000
 | mem: 130
 })
-| BLamAbs causes ({ cpu: 546000
+| BStep BLamAbs causes ({ cpu: 546000
 | mem: 140
 })
-| BApply causes ({ cpu: 702000
+| BStep BApply causes ({ cpu: 702000
 | mem: 180
 })
-| BDelay causes ({ cpu: 195000
+| BStep BDelay causes ({ cpu: 195000
 | mem: 50
 })
-| BForce causes ({ cpu: 234000
+| BStep BForce causes ({ cpu: 234000
 | mem: 60
 })
-| BBuiltin causes ({ cpu: 78000
+| BStep BBuiltin causes ({ cpu: 78000
 | mem: 20
 })
 | BBuiltinApp LessThanEqInteger causes ({ cpu: 216714

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/2.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (1))
-, ({ tally: ({ BConst causes ({ cpu: 351000
+, ({ tally: ({ BStep BConst causes ({ cpu: 351000
 | mem: 90
 })
-| BVar causes ({ cpu: 1404000
+| BStep BVar causes ({ cpu: 1404000
 | mem: 360
 })
-| BLamAbs causes ({ cpu: 1170000
+| BStep BLamAbs causes ({ cpu: 1170000
 | mem: 300
 })
-| BApply causes ({ cpu: 2028000
+| BStep BApply causes ({ cpu: 2028000
 | mem: 520
 })
-| BDelay causes ({ cpu: 351000
+| BStep BDelay causes ({ cpu: 351000
 | mem: 90
 })
-| BForce causes ({ cpu: 468000
+| BStep BForce causes ({ cpu: 468000
 | mem: 120
 })
-| BBuiltin causes ({ cpu: 351000
+| BStep BBuiltin causes ({ cpu: 351000
 | mem: 90
 })
 | BBuiltinApp AddInteger causes ({ cpu: 237457

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/3.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Tallying/Fib/3.plc.golden
@@ -1,23 +1,23 @@
 ( (Right (2))
-, ({ tally: ({ BConst causes ({ cpu: 585000
+, ({ tally: ({ BStep BConst causes ({ cpu: 585000
 | mem: 150
 })
-| BVar causes ({ cpu: 2301000
+| BStep BVar causes ({ cpu: 2301000
 | mem: 590
 })
-| BLamAbs causes ({ cpu: 1794000
+| BStep BLamAbs causes ({ cpu: 1794000
 | mem: 460
 })
-| BApply causes ({ cpu: 3354000
+| BStep BApply causes ({ cpu: 3354000
 | mem: 860
 })
-| BDelay causes ({ cpu: 507000
+| BStep BDelay causes ({ cpu: 507000
 | mem: 130
 })
-| BForce causes ({ cpu: 702000
+| BStep BForce causes ({ cpu: 702000
 | mem: 180
 })
-| BBuiltin causes ({ cpu: 624000
+| BStep BBuiltin causes ({ cpu: 624000
 | mem: 160
 })
 | BBuiltinApp AddInteger causes ({ cpu: 474914

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,6 +25,7 @@ packages:
 - prettyprinter-configurable
 - quickcheck-dynamic
 - web-ghc
+- word-array
 
 extra-deps:
 # Flat compression

--- a/word-array/LICENSE
+++ b/word-array/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/word-array/NOTICE
+++ b/word-array/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/word-array/bench/Main.hs
+++ b/word-array/bench/Main.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+import           Test.Tasty.Bench        (bench, bgroup, defaultMain, env, nf, nfIO)
+
+import           Control.Monad.Primitive
+import           Data.Foldable           (for_)
+import           Data.Functor.Const
+import           Data.Monoid
+import           Data.Primitive
+import           Data.Word
+import           Data.Word64Array.Word8
+
+main :: IO ()
+main = do
+  let someArray = toWordArray (maxBound `div` 2)
+      {-# NOINLINE someArray #-}
+      mkPrimArray = do
+          arr <- newPrimArray 8
+          setPrimArray arr 0 8 (0 :: Word8)
+          pure arr
+      {-# NOINLINE mkPrimArray #-}
+      overIndexPA :: (Prim a, PrimMonad m) => Int -> (a -> a) -> MutablePrimArray (PrimState m) a -> m ()
+      overIndexPA i f arr = do
+          v <- readPrimArray arr i
+          writePrimArray arr i (f v)
+      iforPrimArray :: (Prim a, PrimMonad m) => MutablePrimArray (PrimState m) a -> (Int -> a -> m ()) -> m ()
+      iforPrimArray arr f = for_ [0..sizeofMutablePrimArray arr] $ \i -> do
+          v <- readPrimArray arr i
+          f i v
+
+  defaultMain
+    [
+      bgroup "word-array"
+        [ bench "overIndex" $ nf (overIndex 0 (+1)) someArray
+        , bench "ifor" $ nf (flip iforWordArray (\i w -> Const $ Sum i)) (toWordArray maxBound)
+        ]
+      , bgroup "prim-array"
+        [ env mkPrimArray $ \arr -> bench "overIndex" $ nfIO (overIndexPA 0 (+1) arr)
+        , env mkPrimArray $ \arr -> bench "ifor" $ nfIO (flip iforPrimArray (\i w -> pure ()) arr)
+        ]
+    ]

--- a/word-array/src/Data/Word64Array/Word8.hs
+++ b/word-array/src/Data/Word64Array/Word8.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE BinaryLiterals             #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UnboxedTuples              #-}
+
+module Data.Word64Array.Word8
+  ( WordArray(..)
+  , Index(..)
+  , toWordArray
+  , readArray
+  , writeArray
+  , overIndex
+  , iforWordArray
+  , ifoldWordArray
+  , toList
+  , toTuple
+  , displayWordArray
+  ) where
+
+import           Control.DeepSeq
+import           Data.Bits
+import           Data.Functor
+import           Data.Maybe           (fromMaybe)
+import           Data.MonoTraversable
+import           Data.Word
+import           Numeric              (showHex)
+import           Text.Show            (showListWith)
+
+{- Note [Representation of WordArray]
+WordArray has its constituent Word8s packed in order from *left-to-right*, i.e.
+the first Word8 occupies the most-significant bits. However, we write the
+Word8 itself in its normal order, i.e. with its least significant bits on the right.
+
+Hence the offset to find the "start" of the ith Word8 is (-8*i) + 56.
+-}
+
+-- | A vector of 8 'Word8's packed into a 'Word64'.
+newtype WordArray = WordArray { fromWordArray :: Word64 }
+  deriving (Eq, Ord, NFData)
+
+instance Show WordArray where
+    show = displayWordArray
+
+type instance Element WordArray = Word8
+
+newtype Index = Index { getIndex :: Int }
+  deriving (Show, Eq, Ord, Num)
+
+instance Bounded Index where
+  maxBound = 7
+  minBound = 0
+
+{-# INLINE toWordArray #-}
+toWordArray :: Word64 -> WordArray
+toWordArray = WordArray
+
+displayWordArray :: WordArray -> String
+displayWordArray wa = displayWordArrayS wa ""
+  where
+  displayHex x s = "0x" <> showHex x s
+  displayWordArrayS = showListWith displayHex . toList
+
+{-# INLINE toTuple #-}
+toTuple :: WordArray -> (# Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray #)
+toTuple (WordArray !w) =
+  let
+    !w7 = w
+    !w6 = unsafeShiftR w7 8
+    !w5 = unsafeShiftR w6 8
+    !w4 = unsafeShiftR w5 8
+    !w3 = unsafeShiftR w4 8
+    !w2 = unsafeShiftR w3 8
+    !w1 = unsafeShiftR w2 8
+    !w0 = unsafeShiftR w1 8
+  in
+  (# fromIntegral w0
+  ,  fromIntegral w1
+  ,  fromIntegral w2
+  ,  fromIntegral w3
+  ,  fromIntegral w4
+  ,  fromIntegral w5
+  ,  fromIntegral w6
+  ,  fromIntegral w7
+  #)
+
+{-# INLINE fromTuple #-}
+fromTuple :: (# Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray, Element WordArray #) -> WordArray
+fromTuple (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) =
+    WordArray
+      (                (fromIntegral w7)
+      .|. unsafeShiftL (fromIntegral w6) 8
+      .|. unsafeShiftL (fromIntegral w5) 16
+      .|. unsafeShiftL (fromIntegral w4) 24
+      .|. unsafeShiftL (fromIntegral w3) 32
+      .|. unsafeShiftL (fromIntegral w2) 40
+      .|. unsafeShiftL (fromIntegral w1) 48
+      .|. unsafeShiftL (fromIntegral w0) 56
+      )
+
+{-# INLINE toList #-}
+toList :: WordArray -> [Element WordArray]
+toList !w =
+  let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+  in [w0, w1, w2, w3, w4, w5, w6, w7]
+
+{-# INLINE readArray #-}
+readArray :: WordArray -> Index -> Element WordArray
+readArray (WordArray !w) (Index !i) =
+  -- See Note [Representation of WordArray]
+  let offset = -8*i + 56
+  in fromIntegral $ unsafeShiftR w offset
+
+{-# INLINE writeArray #-}
+writeArray :: WordArray -> Index -> Element WordArray -> WordArray
+writeArray (WordArray !w) (Index !i) !w8 =
+  -- See Note [Representation of WordArray]
+  let offset = -8*i + 56
+      w64 :: Word64
+      w64 = unsafeShiftL (fromIntegral w8) offset
+  in WordArray ((w .&. mask i) + w64)
+
+{-# INLINE overIndex #-}
+-- | Modify the word at a given index.
+overIndex :: Index -> (Element WordArray -> Element WordArray) -> WordArray -> WordArray
+overIndex !i f !w = writeArray w i $ f $ readArray w i
+
+{-# INLINE mask #-}
+mask :: Int -> Word64
+mask 0 = 0x00ffffffffffffff
+mask 1 = 0xff00ffffffffffff
+mask 2 = 0xffff00ffffffffff
+mask 3 = 0xffffff00ffffffff
+mask 4 = 0xffffffff00ffffff
+mask 5 = 0xffffffffff00ffff
+mask 6 = 0xffffffffffff00ff
+mask 7 = 0xffffffffffffff00
+mask _ = error "mask"
+
+{-# INLINE iforWordArray #-}
+iforWordArray :: Applicative f => WordArray -> (Int -> Element WordArray -> f ()) -> f ()
+iforWordArray !w f =
+  let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+  in   f 0 w0 *> f 1 w1 *> f 2 w2 *> f 3 w3 *> f 4 w4 *> f 5 w5 *> f 6 w6 *> f 7 w7
+
+{-# INLINE ifoldWordArray #-}
+ifoldWordArray :: (Int -> Element WordArray -> b -> b) -> b -> WordArray -> b
+ifoldWordArray f !b !w =
+  let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+  in  f 0 w0 $ f 1 w1 $ f 2 w2 $ f 3 w3 $ f 4 w4 $ f 5 w5 $ f 6 w6 $ f 7 w7 b
+
+instance MonoFunctor WordArray where
+  omap f w =
+    let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+    in fromTuple (# f w0, f w1, f w2, f w3, f w4, f w5, f w6, f w7 #)
+
+instance MonoFoldable WordArray where
+  otoList = toList
+  ofoldr f !b !w =
+    let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+    in  f w0 $ f w1 $ f w2 $ f w3 $ f w4 $ f w5 $ f w6 $ f w7 b
+  ofoldl' f z0 xs = ofoldr f' id xs z0
+    where f' x k z = k $! f z x
+  ofoldMap f = ofoldr (mappend . f) mempty
+  onull _ = False
+  oelem e = ofoldr (\a b -> a == e || b) False
+  ofoldr1Ex f xs = fromMaybe
+      (errorWithoutStackTrace "error in word-array ofoldr1Ex: empty array")
+      (ofoldr mf Nothing xs)
+    where
+    mf x m = Just $ case m of
+      Nothing -> x
+      Just y  -> f x y
+  ofoldl1Ex' f xs = fromMaybe
+      (errorWithoutStackTrace "error in word-array ofoldr1Ex: empty array")
+      (ofoldl' mf Nothing xs)
+    where
+    mf m y = Just $ case m of
+      Nothing -> y
+      Just x  -> f x y
+  otraverse_ f !w =
+    let (# !w0, !w1, !w2, !w3, !w4, !w5, !w6, !w7 #) = toTuple w
+    in void (f w0 *> f w1 *> f w2 *> f w3 *> f w4 *> f w5 *> f w6 *> f w7)

--- a/word-array/test/Spec.hs
+++ b/word-array/test/Spec.hs
@@ -1,0 +1,31 @@
+module Main (main) where
+
+import           Data.MonoTraversable
+import           Data.Vector
+import           Data.Word
+import           Data.Word64Array.Word8 as WordArray
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+toVector :: WordArray -> Vector Word8
+toVector = fromList . WordArray.toList
+
+instance Arbitrary WordArray where
+    arbitrary = toWordArray <$> arbitrary
+    shrink (WordArray w) = WordArray <$> shrink w
+
+instance Arbitrary Index where
+    arbitrary = Index <$> choose (0, 7)
+    shrink (Index i) = if i == 0 then [] else [Index (i-1)]
+
+main :: IO ()
+main = defaultMain $
+    testGroup "word-array" [
+        testProperty "write" $ \(arr, ix@(Index i), w8) ->
+            toVector (writeArray arr ix w8) == toVector arr // [(i, w8)]
+        , testProperty "read" $ \(arr, ix@(Index i)) ->
+            readArray arr ix == toVector arr ! i
+        , testProperty "fold" $ \arr ->
+            ofoldr (+) 0 arr == Prelude.foldr (+) 0 (toVector arr)
+    ]

--- a/word-array/word-array.cabal
+++ b/word-array/word-array.cabal
@@ -1,0 +1,57 @@
+cabal-version: 2.4
+name: word-array
+version: 0.1.0.0
+synopsis:
+description: Treat integral types as arrays of smaller integral types
+homepage: https://github.com/plutus
+license: Apache-2.0
+license-file: LICENSE
+author: Zachary Churchill, Michael Peyton Jones
+maintainer: michael.peyton-jones@iohk.io
+
+category: Data
+
+source-repository head
+    type: git
+    location: https://github.com/iohk/plutus
+
+library
+  exposed-modules:
+      Data.Word64Array.Word8
+
+  build-depends:
+    , base >=4.13 && <5.0
+    , mono-traversable
+    , primitive
+    , deepseq
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall -O2
+
+test-suite test
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
+  build-depends:
+      base
+    , tasty
+    , tasty-quickcheck
+    , QuickCheck
+    , vector
+    , word-array
+    , mono-traversable
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  build-depends:
+      base
+    , tasty
+    , tasty-bench
+    , word-array
+    , primitive
+    , deepseq
+  ghc-options: -Wall -O2
+  default-language: Haskell2010
+  hs-source-dirs: bench
+  main-is: Main.hs


### PR DESCRIPTION
I opened a new PR for clarity.

This is the same idea as https://github.com/input-output-hk/plutus/pull/3210, but instead of just keeping a single counter, it keeps a counter for each kind of step by packing them all into a `Word64`. This gives us 8 `Word8` counters, which is exactly what we need.

The result is a bit slower than the other PR, but still quite a bit better than master.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
