### PR TITLE
Add OnChainDecimal to ledger api

### DIFF
--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/plutus-ledger-api.nix
@@ -56,6 +56,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."tagged" or (errorHandler.buildDepError "tagged"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           ];
         buildable = true;
         modules = [
@@ -70,6 +71,7 @@
           "Plutus/V1/Ledger/Credential"
           "Plutus/V1/Ledger/Crypto"
           "Plutus/V1/Ledger/DCert"
+          "Plutus/V1/Ledger/Decimal"
           "Plutus/V1/Ledger/Examples"
           "Plutus/V1/Ledger/Interval"
           "Plutus/V1/Ledger/Orphans"

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -45,6 +45,7 @@ library
         Plutus.V1.Ledger.Credential
         Plutus.V1.Ledger.Crypto
         Plutus.V1.Ledger.DCert
+        Plutus.V1.Ledger.Decimal
         Plutus.V1.Ledger.Examples
         Plutus.V1.Ledger.Interval
         Plutus.V1.Ledger.Orphans
@@ -77,7 +78,8 @@ library
         deepseq -any,
         newtype-generics -any,
         tagged -any,
-        lens -any
+        lens -any,
+        scientific -any
 
 test-suite plutus-ledger-api-test
     import: lang

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Decimal.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Decimal.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- TODO: Minimize round-off errors
+module Plutus.V1.Ledger.Decimal
+  ( OnChainDecimal(..)
+  , decimalUnit
+  ) where
+
+import           Data.Aeson
+import           Data.Scientific (Scientific)
+import qualified PlutusTx
+
+decimalsCnt :: Int
+decimalsCnt = 6
+
+decimalUnit :: Integer
+decimalUnit = 10 ^ decimalsCnt
+
+scientificUnit :: Scientific
+scientificUnit = fromIntegral decimalUnit
+
+-- TODO: Change `Integer` to `Double` then wrap it here?
+-- Also use this for `Value`?
+newtype OnChainDecimal = OnChainDecimal { getOnChainInt :: Integer }
+  deriving newtype (PlutusTx.IsData, Num, Enum, Real, Integral)
+  deriving (Eq, Ord, Show)
+
+instance ToJSON OnChainDecimal where
+  toJSON (OnChainDecimal i) = Number . (/ scientificUnit) . fromIntegral $ i
+
+instance FromJSON OnChainDecimal where
+  parseJSON = withScientific
+    "OnChainDecimal"
+    (return . OnChainDecimal . round . (*) scientificUnit)
+
+PlutusTx.makeLift ''OnChainDecimal

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -68,6 +68,7 @@ library
         Plutus.V1.Ledger.Contexts as Ledger.Contexts,
         Plutus.V1.Ledger.Credential as Ledger.Credential,
         Plutus.V1.Ledger.DCert as Ledger.DCert,
+        Plutus.V1.Ledger.Decimal as Ledger.Decimal,
         Plutus.V1.Ledger.Crypto as Ledger.Crypto,
         Plutus.V1.Ledger.Interval as Ledger.Interval,
         Plutus.V1.Ledger.Scripts as Ledger.Scripts,


### PR DESCRIPTION
We wanted an "interface" to auto-convert contract endpoints' JSON decimal parameters to its on-chain integer representation, and to auto-convert the on-chain integer representation to decimal for JSON endpoint responses. 
These auto conversions also help ensure on-chain integers only in Haskell code, instead of confusing on-chain integers, off-chain integers and off-chain decimals everywhere.
This is still very raw. We're still wondering if it makes sense to add this anywhere on this original repository. Or if this idea actually makes sense.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
