### PR TITLE
Improve NixOS vm test asserts

### DIFF
--- a/nix/tests/vm-tests/all.nix
+++ b/nix/tests/vm-tests/all.nix
@@ -280,7 +280,7 @@ makeTest {
     # plutus-playground / webghc : using api/contract
     # marlowe-playground / webghc : using /runghc
     #
-    with subtest("********************************************************************************************* TEST: All content is being served on playgrounds"):
+    with subtest("********************************************************************************************* TEST: compilation works"):
       res = playgrounds.succeed("curl --silent -H 'Content-Type: application/json' --request POST --data @${plutusApiRequest} http://plutus-playground:8080/api/contract")
       assert "Right" in res, "Expected response wrapped in 'Right'. Actual: {}".format(res)
 

--- a/nix/tests/vm-tests/all.nix
+++ b/nix/tests/vm-tests/all.nix
@@ -210,6 +210,9 @@ makeTest {
     playgrounds.wait_for_unit("network-online.target")
     pab.wait_for_unit("network-online.target")
     pab.wait_for_unit("pab.service")
+
+    # Refer to `services.pab` configuration  above to see what
+    # service each individual port relates to.
     pab.wait_for_open_port(8080)
     pab.wait_for_open_port(8081)
     pab.wait_for_open_port(8082)

--- a/nix/tests/vm-tests/marlowe-playground.nix
+++ b/nix/tests/vm-tests/marlowe-playground.nix
@@ -5,11 +5,12 @@ let
     FRONTEND_URL="http://localhost:8080"
     GITHUB_CALLBACK_PATH="/#/gh-oauth-cb"
     GITHUB_CLIENT_ID="314123123a312fe"
-    GITHUB_CLIENT_SECRET=kljfks234dskjhfeskjr"
+    GITHUB_CLIENT_SECRET="kljfks234dskjhfeskjr"
   '';
 in
 makeTest {
   name = "marlowe";
+  skipLint = true;
   machine = { pkgs, ... }:
     {
       imports = [ ../../modules/marlowe-playground.nix ];
@@ -29,13 +30,15 @@ makeTest {
     machine.wait_for_unit("marlowe-playground.service")
     machine.wait_for_open_port(4001)
     machine.succeed("curl localhost:4001/health")
-    machine.succeed("mkdir -p /var/lib/playgrounds")
-    machine.succeed("cp ${envFile} /var/lib/playgrounds/marlowe.env")
-    machine.succeed("systemctl restart marlowe-playground")
-    machine.wait_for_unit("marlowe-playground.service")
-    # TODO: verify it is using the file - for some reason
-    # i am having problems verifying this with a 'journalctl |grep'
-    # even though i can see the output in the terminal.
+
+    with subtest("********************************************************************************************* TEST: Can reload a config file"):
+      machine.succeed("mkdir -p /var/lib/playgrounds")
+      machine.succeed("cp ${envFile} /var/lib/playgrounds/marlowe.env")
+      machine.succeed("systemctl restart marlowe-playground")
+      machine.wait_for_unit("marlowe-playground.service")
+
+      res = machine.succeed("journalctl -u marlowe-playground.service --no-pager")
+      assert "Loading environment config from '/var/lib/playgrounds/marlowe.env'" in res, "Expected playground to load config. Actual: {}".format(res)
   '';
 
 }

--- a/nix/tests/vm-tests/pab.nix
+++ b/nix/tests/vm-tests/pab.nix
@@ -1,6 +1,7 @@
 { makeTest, plutus-pab, marlowe-dashboard }:
 makeTest {
   name = "pab";
+  skipLint = true;
   machine = { pkgs, ... }:
     {
       imports = [ ../../modules/pab.nix ];
@@ -28,8 +29,15 @@ makeTest {
     machine.wait_for_open_port(8083)
     machine.wait_for_open_port(8081)
     machine.wait_for_open_port(8082)
-    machine.succeed("curl -s localhost:8080 | grep marlowe-dashboard")
-    machine.succeed("pab-exec contracts installed | grep '/tmp/file-that-does-not-exist'")
+
+    with subtest("********************************************************************************************* TEST: Serves static files from config"):
+      res = machine.succeed("curl -s localhost:8080 | grep marlowe-dashboard")
+      assert "marlowe-dashboard" in res, "Expected string 'marlowe-dashboard' in served content. Actual: {}".format(res)
+
+    with subtest("********************************************************************************************* TEST: Loads contracts in config"):
+      res = machine.succeed("pab-exec contracts installed")
+      assert "/tmp/file-that-does-not-exist" in res, "Expected '/tmp/file-that-does-not-exist' in output. Actual: {}".format(res)
+
   '';
 
 }

--- a/nix/tests/vm-tests/plutus-playground.nix
+++ b/nix/tests/vm-tests/plutus-playground.nix
@@ -10,6 +10,7 @@ let
 in
 makeTest {
   name = "plutus-playground";
+  skipLint = true;
   machine = { pkgs, ... }:
     {
       imports = [ ../../modules/plutus-playground.nix ];
@@ -29,14 +30,15 @@ makeTest {
     machine.succeed("systemctl start plutus-playground")
     machine.wait_for_unit("plutus-playground.service")
     machine.wait_for_open_port(4000)
-    machine.succeed("curl localhost:4000/api/version")
-    machine.succeed("mkdir -p /var/lib/playgrounds")
-    machine.succeed("cp ${envFile} /var/lib/playgrounds/plutus.env")
-    machine.succeed("systemctl restart plutus-playground")
-    machine.wait_for_unit("plutus-playground.service")
-    # TODO: verify it is using the file - for some reason
-    # i am having problems verifying this with a 'journalctl |grep'
-    # even though i can see the output in the terminal.
+
+    with subtest("********************************************************************************************* TEST: Can reload a config file"):
+      machine.succeed("mkdir -p /var/lib/playgrounds")
+      machine.succeed("cp ${envFile} /var/lib/playgrounds/plutus.env")
+      machine.succeed("systemctl restart plutus-playground")
+      machine.wait_for_unit("plutus-playground.service")
+
+      res = machine.succeed("journalctl -u plutus-playground.service --no-pager")
+      assert "Loading environment config from '/var/lib/playgrounds/plutus.env'" in res, "Expected playground to load config. Actual: {}".format(res)
   '';
 
 }

--- a/nix/tests/vm-tests/web-ghc.nix
+++ b/nix/tests/vm-tests/web-ghc.nix
@@ -17,6 +17,7 @@ let
 in
 makeTest {
   name = "web-ghc";
+  skipLint = true;
   machine = { pkgs, ... }:
     {
       imports = [ ../../modules/web-ghc.nix ];
@@ -32,8 +33,14 @@ makeTest {
     machine.start()
     machine.wait_for_unit("web-ghc.service")
     machine.wait_for_open_port(80)
-    machine.succeed("curl -sSfL -H 'Content-Type: application/json' --request POST --data @${validCompileRequest} http://localhost:80/runghc 2>&1 | grep Right")
-    machine.succeed("curl -sSfL -H 'Content-Type: application/json' --request POST --data @${invalidCompileRequest} http://localhost:80/runghc 2>&1 | grep Left")
+
+    with subtest("********************************************************************************************* TEST: Can process a valid compilation request"):
+      response = machine.succeed("curl -sSfL -H 'Content-Type: application/json' --request POST --data @${validCompileRequest} http://localhost:80/runghc")
+      assert "Right" in response, "Expected response wrapped in 'Right'. Actual: {}".format(response)
+
+    with subtest("********************************************************************************************* TEST: Can process a invalid compilation request"):
+      response = machine.succeed("curl -sSfL -H 'Content-Type: application/json' --request POST --data @${invalidCompileRequest} http://localhost:80/runghc")
+      assert "Left" in response, "Expected response wrapped in 'Left'. Actual: {}".format(response)
   '';
 
 }


### PR DESCRIPTION
**Summary**: 

Improve NixOS vm tests by providing better output

**Details**:

This PR introduces the following changes:
- Add python subtests for logical grouping of asserts
- Proper asserts with expected and actual output
- Improve playground config reload testing with additional assert

The VM tests have been annoying because of the very limited information that was provided in case of errors. With the changes in this PR it definitely going to be easy to reason about the cause of error.

Example output:
```
(1.98 seconds)
Test "********************************************************************************************* TEST: Can process a valid compilation request" failed with error: "Expected response wrapped in 'Right'. Actual: {"Right":{"result":"","warnings":[]}}"
error:
Traceback (most recent call last):
  File "/nix/store/qan3biff266xjn238nl8n3kc5b7hix1j-nixos-test-driver/bin/.nixos-test-driver-wrapped", line 897, in run_tests
    exec(tests, globals())
  File "<string>", line 1, in <module>
  File "<string>", line 8, in <module>
AssertionError: Expected response wrapped in 'Right'. Actual: {"Left":{"result":"","warnings":[]}}
cleaning up
killing machine (pid 7)
(0.00 seconds)
```
While the output is still a bit noisy, you can now see relevant information in the `AssertionError` line:

```
AssertionError: Expected response wrapped in 'Right'. Actual: {"Left":{"result":"","warnings":[]}}
```

----
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
