### PR TITLE
Fix for missing depth increment in LetFloat

### DIFF
--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -75,6 +75,7 @@ letFloat =
   ,"strictValueNonValue"
   ,"strictValueValue"
   ,"even3Eval"
+  ,"strictNonValueDeep"
   ]
 
 instance Semigroup SourcePos where

--- a/plutus-core/plutus-ir/test/TypeSpec.hs
+++ b/plutus-core/plutus-ir/test/TypeSpec.hs
@@ -35,6 +35,7 @@ types = testNested "types"
   ,"strictNonValue3"
   ,"strictValueNonValue"
   ,"strictValueValue"
+  ,"strictNonValueDeep"
   ,"even3Eval"
   ,"sameNameDifferentEnv"
   ]

--- a/plutus-core/plutus-ir/test/transform/letFloat/strictNonValueDeep
+++ b/plutus-core/plutus-ir/test/transform/letFloat/strictNonValueDeep
@@ -1,0 +1,16 @@
+(let (rec)
+      (termbind (strict) (vardecl x (con integer))
+         [(lam k (con integer)
+         (let (rec)
+         (termbind (nonstrict) (vardecl y (con integer))
+           [(lam h (con integer)
+             (let (nonrec)
+              (termbind (nonstrict) (vardecl z (con integer)) y)
+              [(builtin addInteger) z h]
+            ))
+            (con integer 4)
+            ])
+         [(builtin addInteger) y k])
+         ) (con integer 3)])
+     x
+)

--- a/plutus-core/plutus-ir/test/transform/letFloat/strictNonValueDeep.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/strictNonValueDeep.golden
@@ -1,0 +1,35 @@
+(let
+  (rec)
+  (termbind
+    (strict)
+    (vardecl x (con integer))
+    [
+      (lam
+        k
+        (con integer)
+        (let
+          (rec)
+          (termbind
+            (nonstrict)
+            (vardecl y (con integer))
+            [
+              (lam
+                h
+                (con integer)
+                (let
+                  (nonrec)
+                  (termbind (nonstrict) (vardecl z (con integer)) y)
+                  [ [ (builtin addInteger) z ] h ]
+                )
+              )
+              (con integer 4)
+            ]
+          )
+          [ [ (builtin addInteger) y ] k ]
+        )
+      )
+      (con integer 3)
+    ]
+  )
+  x
+)

--- a/plutus-core/plutus-ir/test/types/strictNonValueDeep
+++ b/plutus-core/plutus-ir/test/types/strictNonValueDeep
@@ -1,0 +1,16 @@
+(let (rec)
+      (termbind (strict) (vardecl x (con integer))
+         [(lam k (con integer)
+         (let (rec)
+         (termbind (nonstrict) (vardecl y (con integer))
+           [(lam h (con integer)
+             (let (nonrec)
+              (termbind (nonstrict) (vardecl z (con integer)) y)
+              [(builtin addInteger) z h]
+            ))
+            (con integer 4)
+            ])
+         [(builtin addInteger) y k])
+         ) (con integer 3)])
+     x
+)

--- a/plutus-core/plutus-ir/test/types/strictNonValueDeep.golden
+++ b/plutus-core/plutus-ir/test/types/strictNonValueDeep.golden
@@ -1,0 +1,1 @@
+(con integer)


### PR DESCRIPTION
This fixes a bug where the letfloat algorithm would not increment the "depth" for effectful-lets, although they are "anchors".

The bug was encountered in `ea3e1c0a0ffdeebed2226c8d651f4c4528bd2f9e`, when the Currency plutus-use-case was prior applied to multiple (>2) inliner pir passes.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
