### PR TITLE
Two small CSS tweaks.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -92,7 +92,7 @@ cardNavigationButtons state =
               [ classNames [ "text-purple" ]
               , onClick_ $ MoveToStep $ selectedStep - 1
               ]
-              [ icon ArrowLeft [ "text-2xl" ] ]
+              [ icon ArrowLeft [ "text-2xl", "py-4" ] ]
       | otherwise = Nothing
 
     rightButton selectedStep

--- a/marlowe-dashboard-client/src/ContractHome/View.purs
+++ b/marlowe-dashboard-client/src/ContractHome/View.purs
@@ -116,7 +116,7 @@ contractCard currentSlot contractState =
     div
       -- NOTE: The overflow hidden helps fix a visual bug in which the background color eats away the border-radius
       [ classNames
-          [ "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
+          [ "flex", "flex-col", "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
       , onClick_ $ OpenContract contractInstanceId
       ]
       -- TODO: This part is really similar to contractTitle in Template.View, see if it makes sense to factor a component out
@@ -125,7 +125,7 @@ contractCard currentSlot contractState =
           , span [ classNames [ "flex-grow", "ml-2", "self-start", "text-xs", "uppercase" ] ] [ text contractType ]
           , icon ArrowRight [ "text-28px" ]
           ]
-      , div [ classNames [ "px-4", "py-2", "text-lg" ] ]
+      , div [ classNames [ "flex-1", "px-4", "py-2", "text-lg" ] ]
           [ text longTitle
           ]
       , div [ classNames [ "bg-lightgray", "flex", "flex-col", "px-4", "py-2" ] ]


### PR DESCRIPTION
A couple of tiny visual bug fixes:

1. The vertical position of the "back" arrow in the contract card is different on the last step (because the "next" button is absent there, making the containing element slightly shorter). Adding vertical padding to match the button fixes this.
2. The gray bit at the bottom of contract boxes isn't always right at the bottom (see the Simple escrow box in the screenshot attached). Flexbox to the rescue.

![localhost_8009_](https://user-images.githubusercontent.com/380759/120667891-3647b000-c48e-11eb-9de8-4d5a8e607ff8.png)
