### PR TITLE
Making transactions impossible if wallet has insufficient funds.

### DIFF
--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -35,7 +35,7 @@ import MainFrame.View (render)
 import Marlowe.PAB (PlutusAppId)
 import Pickup.Lenses (_walletLibrary)
 import Pickup.State (handleAction, dummyState, mkInitialState) as Pickup
-import Pickup.Types (Action(..), State) as Pickup
+import Pickup.Types (Action(..), Card(..), State) as Pickup
 import Play.Lenses (_allContracts, _selectedContract, _walletDetails)
 import Play.State (dummyState, handleAction, mkInitialState) as Play
 import Play.Types (Action(..), State) as Play
@@ -224,7 +224,8 @@ handleAction (EnterPlayState walletLibrary walletDetails) = do
   currentSlot <- use _currentSlot
   case ajaxFollowerApps of
     Left decodedAjaxError -> do
-      handleAction $ PickupAction Pickup.CloseCard
+      handleAction $ PickupAction $ Pickup.CloseCard Pickup.PickupWalletCard
+      handleAction $ PickupAction $ Pickup.CloseCard Pickup.PickupNewWalletCard
       addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
     Right followerApps -> do
       subscribeToWallet $ view (_walletInfo <<< _wallet) walletDetails
@@ -241,7 +242,8 @@ handleAction (EnterPlayState walletLibrary walletDetails) = do
       ajaxRoleContracts <- getRoleContracts walletDetails
       case ajaxRoleContracts of
         Left decodedAjaxError -> do
-          handleAction $ PickupAction Pickup.CloseCard
+          handleAction $ PickupAction $ Pickup.CloseCard Pickup.PickupWalletCard
+          handleAction $ PickupAction $ Pickup.CloseCard Pickup.PickupNewWalletCard
           addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
         Right companionState -> handleAction $ PlayAction $ Play.UpdateRunningContracts companionState
 

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -32,7 +32,7 @@ derive instance eqCard :: Eq Card
 
 data Action
   = OpenCard Card
-  | CloseCard
+  | CloseCard Card
   | GenerateWallet
   | SetWalletNicknameOrId String
   | SetWalletDropdownOpen Boolean
@@ -46,7 +46,7 @@ data Action
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
   toEvent (OpenCard _) = Nothing
-  toEvent CloseCard = Nothing
+  toEvent (CloseCard _) = Nothing
   toEvent GenerateWallet = Just $ defaultEvent "GenerateWallet"
   toEvent (SetWalletNicknameOrId _) = Nothing
   toEvent (SetWalletDropdownOpen _) = Nothing

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -99,7 +99,7 @@ pickupNewWalletCard state =
   in
     [ a
         [ classNames [ "absolute", "top-4", "right-4" ]
-        , onClick_ CloseCard
+        , onClick_ $ CloseCard PickupNewWalletCard
         ]
         [ icon_ Close ]
     , div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
@@ -128,7 +128,7 @@ pickupNewWalletCard state =
             [ classNames [ "flex" ] ]
             [ button
                 [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-                , onClick_ CloseCard
+                , onClick_ $ CloseCard PickupNewWalletCard
                 ]
                 [ text "Cancel" ]
             , button
@@ -172,7 +172,7 @@ pickupWalletCard state =
   in
     [ a
         [ classNames [ "absolute", "top-4", "right-4" ]
-        , onClick_ CloseCard
+        , onClick_ $ CloseCard PickupWalletCard
         ]
         [ icon_ Close ]
     , div [ classNames [ "p-5", "pb-6", "md:pb-8" ] ]
@@ -201,7 +201,7 @@ pickupWalletCard state =
             [ classNames [ "flex" ] ]
             [ button
                 [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-                , onClick_ CloseCard
+                , onClick_ $ CloseCard PickupWalletCard
                 ]
                 [ text "Cancel" ]
             , button
@@ -218,7 +218,7 @@ localWalletMissingCard :: forall p. Array (HTML p Action)
 localWalletMissingCard =
   [ a
       [ classNames [ "absolute", "top-4", "right-4" ]
-      , onClick_ CloseCard
+      , onClick_ $ CloseCard LocalWalletMissingCard
       ]
       [ icon_ Close ]
   , div [ classNames [ "flex", "font-semibold", "px-5", "py-4", "bg-gray" ] ]

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -18,7 +18,7 @@ import ContractHome.Lenses (_contracts)
 import ContractHome.State (handleAction, mkInitialState) as ContractHome
 import ContractHome.Types (Action(..), State) as ContractHome
 import Control.Monad.Reader (class MonadAsk)
-import Data.Array (difference, init, snoc)
+import Data.Array (difference, head, init, reverse, snoc)
 import Data.Either (Either(..))
 import Data.Foldable (for_)
 import Data.Lens (assign, filtered, modifying, over, set, use, view)
@@ -44,6 +44,7 @@ import InputField.Types (Action(..), State) as InputField
 import LocalStorage (setItem)
 import MainFrame.Types (Action(..)) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
+import Marlowe.Execution (NamedAction(..))
 import Marlowe.PAB (ContractHistory, PlutusAppId(..))
 import Marlowe.Semantics (Slot(..))
 import Network.RemoteData (RemoteData(..), fromEither)
@@ -126,7 +127,7 @@ handleAction input (SaveNewWallet mTokenName) = do
     mWalletId = parsePlutusAppId walletIdString
   case remoteWalletInfo, mWalletId of
     Success walletInfo, Just walletId -> do
-      handleAction input CloseCard
+      handleAction input $ CloseCard $ SaveWalletCard Nothing
       let
         -- note the empty properties are fine for saved wallets - these will be fetched if/when
         -- this wallet is picked up
@@ -169,10 +170,19 @@ handleAction input (OpenCard card) = do
     $ over _cards (flip snoc card)
     <<< set _menuOpen false
 
-handleAction _ CloseCard = do
+handleAction _ (CloseCard card) = do
   cards <- use _cards
-  for_ (init cards) \remainingCards ->
-    assign _cards remainingCards
+  let
+    topCard = head $ reverse cards
+
+    cardsMatch = case topCard, card of
+      Just (SaveWalletCard _), SaveWalletCard _ -> true
+      Just (ViewWalletCard _), ViewWalletCard _ -> true
+      Just (ContractActionConfirmationCard _), ContractActionConfirmationCard _ -> true
+      _, _ -> topCard == Just card
+  when cardsMatch $ void
+    $ for_ (init cards) \remainingCards ->
+        assign _cards remainingCards
 
 -- Until everything is working in the PAB, we are simulating persistent and shared data using localStorage; this
 -- action updates the state to match the localStorage, and should be called whenever the stored data changes
@@ -257,7 +267,7 @@ handleAction input@{ currentSlot } (TemplateAction templateAction) = case templa
   Template.OpenTemplateLibraryCard -> handleAction input $ OpenCard TemplateLibraryCard
   Template.OpenCreateWalletCard tokenName -> handleAction input $ OpenCard $ SaveWalletCard $ Just tokenName
   Template.OpenSetupConfirmationCard -> handleAction input $ OpenCard ContractSetupConfirmationCard
-  Template.CloseSetupConfirmationCard -> handleAction input CloseCard -- TODO: guard against closing the wrong card
+  Template.CloseSetupConfirmationCard -> handleAction input $ CloseCard ContractSetupConfirmationCard
   Template.StartContract -> do
     extendedContract <- use (_templateState <<< _template <<< _extendedContract)
     templateContent <- use (_templateState <<< _templateContent)
@@ -300,8 +310,8 @@ handleAction input@{ currentSlot } (ContractAction contractAction) = do
     Contract.AskConfirmation action -> handleAction input $ OpenCard $ ContractActionConfirmationCard action
     Contract.ConfirmAction action -> do
       void $ toContract $ Contract.handleAction contractInput contractAction
-      handleAction input CloseCard -- TODO: guard against closing the wrong card
-    Contract.CancelConfirmation -> handleAction input CloseCard -- TODO: guard against closing the wrong card
+      handleAction input $ CloseCard $ ContractActionConfirmationCard CloseContract
+    Contract.CancelConfirmation -> handleAction input $ CloseCard $ ContractActionConfirmationCard CloseContract
     _ -> toContract $ Contract.handleAction contractInput contractAction
 
 ------------------------------------------------------------

--- a/marlowe-dashboard-client/src/Play/Types.purs
+++ b/marlowe-dashboard-client/src/Play/Types.purs
@@ -67,7 +67,7 @@ data Action
   | ToggleMenu
   | SetScreen Screen
   | OpenCard Card
-  | CloseCard
+  | CloseCard Card
   | UpdateFromStorage
   | UpdateRunningContracts (Map MarloweParams MarloweData)
   | AdvanceTimedoutSteps
@@ -86,7 +86,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
   toEvent (SetScreen _) = Just $ defaultEvent "SetScreen"
   toEvent (OpenCard _) = Nothing
-  toEvent CloseCard = Nothing
+  toEvent (CloseCard _) = Nothing
   toEvent UpdateFromStorage = Nothing
   toEvent (UpdateRunningContracts _) = Nothing
   toEvent AdvanceTimedoutSteps = Nothing

--- a/marlowe-dashboard-client/src/Play/View.purs
+++ b/marlowe-dashboard-client/src/Play/View.purs
@@ -154,7 +154,7 @@ renderCard currentSlot state card =
       if hasCloseButton then
         [ a
             [ classNames [ "absolute", "top-4", "right-4" ]
-            , onClick_ CloseCard
+            , onClick_ $ CloseCard card
             ]
             [ icon_ Close ]
         ]

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -17,7 +17,7 @@ import Data.String (null)
 import Data.Tuple.Nested ((/\))
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, p, p_, span, span_, text, ul, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
-import Halogen.HTML.Properties (InputType(..), for, id_, placeholder, readOnly, type_, value)
+import Halogen.HTML.Properties (InputType(..), enabled, for, id_, placeholder, readOnly, type_, value)
 import Humanize (humanizeValue)
 import InputField.Types (inputErrorToString)
 import InputField.Types (State) as InputField
@@ -340,32 +340,43 @@ contractTitle metaData =
         [ text $ metaData.contractName ]
     ]
 
+-- TODO: This is a lot like the `actionConfirmationCard` in `Contract.View`. Consider factoring out a shared component.
 contractSetupConfirmationCard :: forall p. Assets -> HTML p Action
 contractSetupConfirmationCard assets =
-  div_
-    [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
-        [ span_ [ text "Demo wallet balance:" ]
-        , span_ [ text $ humanizeValue adaToken $ getAda assets ]
-        ]
-    , div [ classNames [ "px-5", "pb-6", "md:pb-8" ] ]
-        [ p
-            [ classNames [ "mt-4", "text-sm", "font-semibold" ] ]
-            [ text "Confirm payment of:" ]
-        , p
-            [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
-            [ text $ humanizeValue adaToken contractCreationFee ]
-        , div
-            [ classNames [ "flex" ] ]
-            [ button
-                [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-2" ]
-                , onClick_ CloseSetupConfirmationCard
-                ]
-                [ text "Cancel" ]
-            , button
-                [ classNames $ Css.primaryButton <> [ "flex-1" ]
-                , onClick_ StartContract
-                ]
-                [ text "Pay and run" ]
-            ]
-        ]
-    ]
+  let
+    hasSufficientFunds = getAda assets >= contractCreationFee
+  in
+    div_
+      [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
+          [ span_ [ text "Demo wallet balance:" ]
+          , span_ [ text $ humanizeValue adaToken $ getAda assets ]
+          ]
+      , div [ classNames [ "px-5", "pb-6", "md:pb-8" ] ]
+          [ p
+              [ classNames [ "mt-4", "text-sm", "font-semibold" ] ]
+              [ text "Confirm payment of:" ]
+          , p
+              [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
+              [ text $ humanizeValue adaToken contractCreationFee ]
+          , div
+              [ classNames [ "flex" ] ]
+              [ button
+                  [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-2" ]
+                  , onClick_ CloseSetupConfirmationCard
+                  ]
+                  [ text "Cancel" ]
+              , button
+                  [ classNames $ Css.primaryButton <> [ "flex-1" ]
+                  , onClick_ StartContract
+                  , enabled hasSufficientFunds
+                  ]
+                  [ text "Pay and run" ]
+              ]
+          , div
+              [ classNames [ "mt-4", "text-sm", "text-red" ] ]
+              if hasSufficientFunds then
+                []
+              else
+                [ text "You have insufficient funds to initialise this contract." ]
+          ]
+      ]

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -86,7 +86,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
           [ classNames [ "flex" ] ]
           [ button
               [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ CloseCard
+              , onClick_ $ CloseCard $ SaveWalletCard Nothing
               ]
               [ text "Cancel" ]
           , button
@@ -161,7 +161,7 @@ putdownWalletCard walletDetails =
           [ classNames [ "flex" ] ]
           [ button
               [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ CloseCard
+              , onClick_ $ CloseCard PutdownWalletCard
               ]
               [ text "Cancel" ]
           , button


### PR DESCRIPTION
This PR prevents transactions on the frontend for which the wallet has insufficient funds. When we move to the real thing, we'll have to think this through a bit more carefully, given that we don't know in advance exactly how much each transaction will cost. (E.g. maybe we just discount the transaction fee from the calculation, and only rule out deposits for which the wallet has insufficient funds. Or maybe we assume a minimum transaction fee.) Anyway, for now this seems sensible.

While I was at it I noticed an odd case: if an action times out while you have the action confirmation card open, you are still able to complete the action. Of course the PAB would rule it out on the other end, but since we can already determine that it won't work, we shouldn't let the user do it in the first place. I thought the most straightforward behaviour in this case is simply to close the action confirmation card. Since the user will then see that the action has timed out, and get the next step card, it should be obvious why it has closed.

![localhost_8009_ (9)](https://user-images.githubusercontent.com/380759/120805250-df9dad00-c545-11eb-9ac3-777df9d3020b.png)

![localhost_8009_ (10)](https://user-images.githubusercontent.com/380759/120805269-e75d5180-c545-11eb-9efc-17b4d99f9396.png)
