### PR TITLE
Instantiating builtin meanings on the fly instead of caching them (impressively bad results)

### DIFF
--- a/plutus-benchmark/nofib/bench/BenchPlc.hs
+++ b/plutus-benchmark/nofib/bench/BenchPlc.hs
@@ -25,7 +25,7 @@ import           UntypedPlutusCore.Evaluation.Machine.Cek
 benchCek :: Term NamedDeBruijn DefaultUni DefaultFun () -> Benchmarkable
 benchCek t = case runExcept @PLC.FreeVariableError $ PLC.runQuoteT $ unDeBruijnTerm t of
     Left e   -> throw e
-    Right t' -> nf (unsafeEvaluateCek PLC.defaultCekParameters) t'
+    Right t' -> nf (unsafeEvaluateCek PLC.defaultCekCostModel) t'
 
 benchClausify :: Clausify.StaticFormula -> Benchmarkable
 benchClausify f = benchCek $ Clausify.mkClausifyTerm f

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -187,7 +187,7 @@ options = hsubparser
 ---------------- Evaluation ----------------
 
 evaluateWithCek :: UPLC.Term Name DefaultUni DefaultFun () -> EvaluationResult (UPLC.Term Name DefaultUni DefaultFun ())
-evaluateWithCek = unsafeEvaluateCekNoEmit PLC.defaultCekParameters
+evaluateWithCek = unsafeEvaluateCekNoEmit PLC.defaultCekCostModel
 
 toDeBruijn :: UPLC.Program Name DefaultUni DefaultFun a -> IO (UPLC.Program UPLC.DeBruijn DefaultUni DefaultFun a)
 toDeBruijn prog = do

--- a/plutus-core/common/PlcTestUtils.hs
+++ b/plutus-core/common/PlcTestUtils.hs
@@ -88,7 +88,7 @@ runUPlc
 runUPlc values = do
     ps <- traverse toUPlc values
     let (UPLC.Program _ _ t) = foldl1 UPLC.applyProgram ps
-    liftEither $ first toException $ TPLC.extractEvaluationResult $ UPLC.evaluateCekNoEmit TPLC.defaultCekParameters t
+    liftEither $ first toException $ TPLC.extractEvaluationResult $ UPLC.evaluateCekNoEmit TPLC.defaultCekCostModel t
 
 ppCatch :: PrettyPlc a => ExceptT SomeException IO a -> IO (Doc ann)
 ppCatch value = either (PP.pretty . show) prettyPlcClassicDebug <$> runExceptT value

--- a/plutus-core/generators/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/generators/PlutusCore/Generators/NEAT/Spec.hs
@@ -162,7 +162,7 @@ prop_agree_termEval tyG tmG = do
 
   -- run untyped CEK on erased input
   tmUCek <- withExceptT UCekP $ liftEither $
-    U.evaluateCekNoEmit defaultCekParameters (U.erase tm) `catchError` handleUError
+    U.evaluateCekNoEmit defaultCekCostModel (U.erase tm) `catchError` handleUError
 
   -- check if typed CK and untyped CEK give the same output modulo erasure
   unless (tmUCk == tmUCek) $
@@ -511,4 +511,3 @@ bigTestTypeG_NO_LIST s GenOptions{..} t f = testCaseInfo s $ do
   as <- search' genMode genDepth (\a -> noListTypeG a &&& check t a)
   _  <- traverse (f t) as
   return $ show (length as)
-

--- a/plutus-core/plc/Main.hs
+++ b/plutus-core/plc/Main.hs
@@ -856,8 +856,8 @@ runEval (EvalOptions language inp ifmt evalMode printMode budgetMode timingMode 
                   let term = void . UPLC.toTerm $ prog
                       !_ = rnf term
                       cekparams = case cekModel of
-                                Default -> PLC.defaultCekParameters  -- AST nodes are charged according to the default cost model
-                                Unit    -> PLC.unitCekParameters     -- AST nodes are charged one unit each, so we can see how many times each node
+                                Default -> PLC.defaultCekCostModel  -- AST nodes are charged according to the default cost model
+                                Unit    -> PLC.unitCekCostModel  -- AST nodes are charged one unit each, so we can see how many times each node
                                                                      -- type is encountered.  This is useful for calibrating the budgeting code.
                   case budgetMode of
                     Silent -> do

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -121,13 +121,12 @@ module PlutusCore
     , programSize
     , serialisedSize
     -- * Budgeting defaults
+    , unitCekCostModel
     , defaultBuiltinCostModel
     , defaultBuiltinsRuntime
     , defaultCekCostModel
     , defaultCekMachineCosts
-    , defaultCekParameters
     , defaultCostModelParams
-    , unitCekParameters
     -- * CEK machine costs
     , cekMachineCostsPrefix
     , CekMachineCosts (..)

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -50,9 +50,9 @@ import           Universe
 -- functions from a certain set, hence the @cost@ parameter.
 data BuiltinMeaning term cost =
     forall args res. BuiltinMeaning
-        !(TypeScheme term args res)
-        !(FoldArgs args res)
-        !(cost -> FoldArgsEx args)
+        (TypeScheme term args res)
+        (FoldArgs args res)
+        (cost -> FoldArgsEx args)
 -- I tried making it @(forall term. HasConstantIn uni term => TypeScheme term args res)@ instead of
 -- @TypeScheme term args res@, but 'makeBuiltinMeaning' has to talk about
 -- @KnownPolytype binds term args res a@ (note the @term@), because instances of 'KnownMonotype'

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -50,9 +50,9 @@ import           Universe
 -- functions from a certain set, hence the @cost@ parameter.
 data BuiltinMeaning term cost =
     forall args res. BuiltinMeaning
-        (TypeScheme term args res)
-        (FoldArgs args res)
-        (cost -> FoldArgsEx args)
+        !(TypeScheme term args res)
+        !(FoldArgs args res)
+        !(cost -> FoldArgsEx args)
 -- I tried making it @(forall term. HasConstantIn uni term => TypeScheme term args res)@ instead of
 -- @TypeScheme term args res@, but 'makeBuiltinMeaning' has to talk about
 -- @KnownPolytype binds term args res a@ (note the @term@), because instances of 'KnownMonotype'

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -5,11 +5,9 @@
 module PlutusCore.Evaluation.Machine.ExBudgetingDefaults
     ( defaultBuiltinsRuntime
     , defaultCekCostModel
+    , unitCekCostModel
     , defaultCekMachineCosts
-    , defaultCekParameters
     , defaultCostModelParams
-    , unitCekMachineCosts
-    , unitCekParameters
     , defaultBuiltinCostModel
     )
 
@@ -27,7 +25,6 @@ import           PlutusCore.Evaluation.Machine.ExMemory                   ()
 import           PlutusCore.Evaluation.Machine.MachineParameters
 
 import           UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
-import           UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 
 -- | The default cost model for built-in functions.
@@ -51,16 +48,13 @@ defaultCekCostModel :: CostModel CekMachineCosts BuiltinCostModel
 defaultCekCostModel = CostModel defaultCekMachineCosts defaultBuiltinCostModel
 --- defaultCekMachineCosts is CekMachineCosts
 
+unitCekCostModel :: CostModel CekMachineCosts BuiltinCostModel
+unitCekCostModel = CostModel unitCekMachineCosts defaultBuiltinCostModel
+
 -- | The default cost model data.  This is exposed to the ledger, so let's not
 -- confuse anybody by mentioning the CEK machine
 defaultCostModelParams :: Maybe CostModelParams
 defaultCostModelParams = extractCostModelParams defaultCekCostModel
-
-defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
-defaultCekParameters = toMachineParameters defaultCekCostModel
-
-unitCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
-unitCekParameters = toMachineParameters (CostModel unitCekMachineCosts defaultBuiltinCostModel)
 
 defaultBuiltinsRuntime :: HasConstantIn DefaultUni term => BuiltinsRuntime DefaultFun term
 defaultBuiltinsRuntime = toBuiltinsRuntime defaultBuiltinCostModel

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -5,13 +5,6 @@
 module PlutusCore.Evaluation.Machine.MachineParameters
 where
 
-import           PlutusCore.Constant
-
-import           PlutusCore.Core.Type                   hiding (Type)
-import           PlutusCore.Evaluation.Machine.ExBudget ()
-
-import           GHC.Types                              (Type)
-
 {-| We need to account for the costs of evaluator steps and also built-in function
    evaluation.  The models for these have different structures and are used in
    different parts of the code, so inside the valuator we pass separate objects
@@ -27,25 +20,17 @@ data CostModel machinecosts builtincosts =
     , builtinCostModel :: builtincosts
     } deriving (Eq, Show)
 
-{-| At execution time we need a 'BuiltinsRuntime' object which includes both the
-  cost model for builtins and their denotations.  This bundles one of those
-  together with the cost model for evaluator steps.  The 'term' type will be
-  CekValue when we're using this with the CEK machine. -}
-data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
-    MachineParameters {
-      machineCosts    :: machinecosts
-    , builtinsRuntime :: BuiltinsRuntime fun (term uni fun)
+
+
+{-
+data CostModel machinecosts uni fun =
+    CostModel {
+      machineCostModel :: machinecosts
+    , builtinCostModel :: CostingPart uni fun
     }
 
-{-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}
-toMachineParameters ::
-    ( UniOf (val uni fun) ~ uni
-      -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
-    , CostingPart uni fun ~ builtincosts
-    , HasConstant (val uni fun)
-    , ToBuiltinMeaning uni fun
-    )
-    => CostModel machinecosts builtincosts
-    -> MachineParameters machinecosts val uni fun
-toMachineParameters (CostModel mchnCosts builtinCosts) =
-    MachineParameters mchnCosts (toBuiltinsRuntime builtinCosts)
+deriving instance (Eq machinecosts, Eq (CostingPart uni fun)) =>
+            Eq (CostModel machinecosts uni fun)
+deriving instance (Show machinecosts, Show (CostingPart uni fun)) =>
+            Show (CostModel machinecosts uni fun)
+-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -53,7 +53,6 @@ import           PlutusCore.Evaluation.Machine.MachineParameters
 import           PlutusCore.Name
 import           PlutusCore.Pretty
 
-import           Data.Ix
 import           Universe
 
 {- Note [CEK runners naming convention]
@@ -69,8 +68,8 @@ allow one to specify an 'ExBudgetMode'. I.e. such functions are only for fully e
 
 -- | Evaluate a term using the CEK machine with logging disabled and keep track of costing.
 runCekNoEmit
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, ToBuiltinMeaning uni fun, PrettyUni uni fun)
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ()
     -> (Either (CekEvaluationException uni fun) (Term Name uni fun ()), cost)
@@ -83,9 +82,9 @@ runCekNoEmit params mode term =
 unsafeRunCekNoEmit
     :: ( GShow uni, Typeable uni
        , Closed uni, uni `EverywhereAll` '[ExMemoryUsage, PrettyConst]
-       , Ix fun, Pretty fun, Typeable fun
+       , ToBuiltinMeaning uni fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ()
     -> (EvaluationResult (Term Name uni fun ()), cost)
@@ -94,8 +93,8 @@ unsafeRunCekNoEmit params mode =
 
 -- | Evaluate a term using the CEK machine with logging enabled.
 evaluateCek
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, ToBuiltinMeaning uni fun, PrettyUni uni fun)
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> Term Name uni fun ()
     -> (Either (CekEvaluationException uni fun) (Term Name uni fun ()), [String])
 evaluateCek params term =
@@ -104,8 +103,8 @@ evaluateCek params term =
 
 -- | Evaluate a term using the CEK machine with logging disabled.
 evaluateCekNoEmit
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, ToBuiltinMeaning uni fun, PrettyUni uni fun)
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> Term Name uni fun ()
     -> Either (CekEvaluationException uni fun) (Term Name uni fun ())
 evaluateCekNoEmit params = fst . runCekNoEmit params restrictingEnormous
@@ -114,9 +113,9 @@ evaluateCekNoEmit params = fst . runCekNoEmit params restrictingEnormous
 unsafeEvaluateCek
     :: ( GShow uni, Typeable uni
        , Closed uni, uni `EverywhereAll` '[ExMemoryUsage, PrettyConst]
-       , Ix fun, Pretty fun, Typeable fun
+       , ToBuiltinMeaning uni fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> Term Name uni fun ()
     -> (EvaluationResult (Term Name uni fun ()), [String])
 unsafeEvaluateCek params = first unsafeExtractEvaluationResult . evaluateCek params
@@ -125,9 +124,9 @@ unsafeEvaluateCek params = first unsafeExtractEvaluationResult . evaluateCek par
 unsafeEvaluateCekNoEmit
     :: ( GShow uni, Typeable uni
        , Closed uni, uni `EverywhereAll` '[ExMemoryUsage, PrettyConst]
-       , Ix fun, Pretty fun, Typeable fun
+       , ToBuiltinMeaning uni fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> Term Name uni fun ()
     -> EvaluationResult (Term Name uni fun ())
 unsafeEvaluateCekNoEmit params = unsafeExtractEvaluationResult . evaluateCekNoEmit params
@@ -136,9 +135,9 @@ unsafeEvaluateCekNoEmit params = unsafeExtractEvaluationResult . evaluateCekNoEm
 readKnownCek
     :: ( uni `Everywhere` ExMemoryUsage
        , KnownType (Term Name uni fun ()) a
-       , Ix fun, PrettyUni uni fun
+       , ToBuiltinMeaning uni fun, PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> Term Name uni fun ()
     -> Either (CekEvaluationException uni fun) a
 readKnownCek params = evaluateCekNoEmit params >=> readKnown

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
@@ -36,7 +36,7 @@ typecheckEvaluateCek
     :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> TPLC.Term TyName Name uni fun ()
     -> m (EvaluationResult (UPLC.Term Name uni fun ()), [String])
 typecheckEvaluateCek = typecheckAnd unsafeEvaluateCek
@@ -46,7 +46,7 @@ typecheckEvaluateCekNoEmit
     :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> TPLC.Term TyName Name uni fun ()
     -> m (EvaluationResult (UPLC.Term Name uni fun ()))
 typecheckEvaluateCekNoEmit = typecheckAnd unsafeEvaluateCekNoEmit
@@ -57,7 +57,7 @@ typecheckReadKnownCek
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni fun
        , KnownType (UPLC.Term Name uni fun ()) a
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => CostModel CekMachineCosts (CostingPart uni fun)
     -> TPLC.Term TyName Name uni fun ()
     -> m (Either (CekEvaluationException uni fun) a)
 typecheckReadKnownCek = typecheckAnd readKnownCek

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
@@ -34,7 +34,7 @@ readMakeHetero
     => a -> EvaluationResult b
 readMakeHetero x = do
     xTerm <- makeKnownNoEmit @(TPLC.Term TyName Name DefaultUni DefaultFun ()) x
-    case extractEvaluationResult <$> typecheckReadKnownCek TPLC.defaultCekParameters xTerm of
+    case extractEvaluationResult <$> typecheckReadKnownCek TPLC.defaultCekCostModel xTerm of
         Left err          -> error $ "Type error" ++ displayPlcCondensedErrorClassic err
         Right (Left err)  -> error $ "Evaluation error: " ++ show err
         Right (Right res) -> res
@@ -82,7 +82,7 @@ test_collectStrings = testProperty "collectStrings" . property $ do
             , rest
             ]
         term = foldr step unitval strs
-    strs' <- case typecheckEvaluateCek TPLC.defaultCekParameters term of
+    strs' <- case typecheckEvaluateCek TPLC.defaultCekCostModel term of
         Left _                             -> failure
         Right (EvaluationFailure, _)       -> failure
         Right (EvaluationSuccess _, strs') -> return strs'

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -93,7 +93,6 @@ import           PlutusCore.Evaluation.Machine.CostModelInterface (CostModelPara
 import           PlutusCore.Evaluation.Machine.ExBudget           (ExBudget (..))
 import qualified PlutusCore.Evaluation.Machine.ExBudget           as PLC
 import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..))
-import           PlutusCore.Evaluation.Machine.MachineParameters
 import qualified PlutusCore.MkPlc                                 as PLC
 import           PlutusCore.Pretty
 import           PlutusTx                                         (Data (..), IsData (..))
@@ -184,7 +183,7 @@ evaluateScriptRestricting verbose cmdata budget p args = swap $ runWriter @LogOu
 
     let (res, _, logs) =
             UPLC.runCek
-                (toMachineParameters model)
+                model
                 (UPLC.restricting $ PLC.ExRestrictingBudget budget)
                 (verbose == Verbose)
                 appliedTerm
@@ -208,7 +207,7 @@ evaluateScriptCounting verbose cmdata p args = swap $ runWriter @LogOutput $ run
 
     let (res, UPLC.CountingSt final, logs) =
             UPLC.runCek
-                (toMachineParameters model)
+                model
                 UPLC.counting
                 (verbose == Verbose)
                 appliedTerm

--- a/plutus-tx/src/PlutusTx/Evaluation.hs
+++ b/plutus-tx/src/PlutusTx/Evaluation.hs
@@ -26,13 +26,13 @@ import qualified UntypedPlutusCore.Evaluation.Machine.Cek as Cek
 evaluateCek
     :: (uni ~ DefaultUni, fun ~ DefaultFun)
     => Program Name uni fun () -> Either (CekEvaluationException uni fun) (Term Name uni fun ())
-evaluateCek (Program _ _ t) = Cek.evaluateCekNoEmit PLC.defaultCekParameters t
+evaluateCek (Program _ _ t) = Cek.evaluateCekNoEmit PLC.defaultCekCostModel t
 
 -- | Evaluate a program in the CEK machine with the usual string dynamic builtins. May throw.
 unsafeEvaluateCek
     :: (uni ~ DefaultUni, fun ~ DefaultFun)
     => Program Name uni fun () -> EvaluationResult (Term Name uni fun ())
-unsafeEvaluateCek (Program _ _ t) = Cek.unsafeEvaluateCekNoEmit PLC.defaultCekParameters t
+unsafeEvaluateCek (Program _ _ t) = Cek.unsafeEvaluateCekNoEmit PLC.defaultCekCostModel t
 
 -- | Evaluate a program in the CEK machine with the usual string dynamic builtins and tracing, additionally
 -- returning the trace output.
@@ -41,5 +41,5 @@ evaluateCekTrace
     => Program Name uni fun ()
     -> ([String], CekExTally fun, Either (CekEvaluationException uni fun) (Term Name uni fun ()))
 evaluateCekTrace (Program _ _ t) =
-    case runCek PLC.defaultCekParameters Cek.tallying True t of
+    case runCek PLC.defaultCekCostModel Cek.tallying True t of
         (errOrRes, TallyingSt st _, logs) -> (logs, st, errOrRes)


### PR DESCRIPTION
This simplifies the API, but destroys performance. Here are the stats that I got for the `nofib` benchmarks:

```
clausify/formula1         49.45 ms	 48.95 ms       -1.0%
clausify/formula2         61.90 ms	 61.01 ms       -1.4%
clausify/formula3         172.0 ms	 169.4 ms       -1.5%
clausify/formula4         238.6 ms	 243.4 ms       +2.0%
clausify/formula5         1.119 s 	 1.097 s        -2.0%
knights/4x4               133.8 ms	 158.6 ms       +18.5%
knights/6x6               373.0 ms	 432.3 ms       +15.9%
knights/8x8               622.0 ms	 711.6 ms       +14.4%
primetest/05digits        89.00 ms	 124.2 ms       +39.6%
primetest/08digits        162.3 ms	 228.9 ms       +41.0%
primetest/10digits        229.0 ms	 325.9 ms       +42.3%
primetest/20digits        453.7 ms	 633.6 ms       +39.7%
primetest/30digits        656.2 ms	 916.2 ms       +39.6%
primetest/40digits        884.4 ms	 1.212 s        +37.0%
primetest/50digits        877.8 ms	 1.216 s        +38.5%
queens4x4/bt              22.25 ms	 25.24 ms       +13.4%
queens4x4/bm              28.83 ms	 32.53 ms       +12.8%
queens4x4/bjbt1           27.37 ms	 30.58 ms       +11.7%
queens4x4/bjbt2           29.26 ms	 32.81 ms       +12.1%
queens4x4/fc              68.36 ms	 73.28 ms       +7.2%
queens5x5/bt              290.4 ms	 343.5 ms       +18.3%
queens5x5/bm              328.2 ms	 365.1 ms       +11.2%
queens5x5/bjbt1           350.4 ms	 398.1 ms       +13.6%
queens5x5/bjbt2           371.1 ms	 420.6 ms       +13.3%
```

It gets a bit better with some additional strictness, but still utterly awful:

```
clausify/formula1         49.45 ms	 48.10 ms       -2.7%
clausify/formula2         61.90 ms	 60.31 ms       -2.6%
clausify/formula3         172.0 ms	 167.0 ms       -2.9%
clausify/formula4         238.6 ms	 238.7 ms       +0.0%
clausify/formula5         1.119 s 	 1.095 s        -2.1%
knights/4x4               133.8 ms	 149.6 ms       +11.8%
knights/6x6               373.0 ms	 416.8 ms       +11.7%
knights/8x8               622.0 ms	 690.9 ms       +11.1%
primetest/05digits        89.00 ms	 118.7 ms       +33.4%
primetest/08digits        162.3 ms	 218.8 ms       +34.8%
primetest/10digits        229.0 ms	 312.5 ms       +36.5%
primetest/20digits        453.7 ms	 597.6 ms       +31.7%
primetest/30digits        656.2 ms	 863.3 ms       +31.6%
primetest/40digits        884.4 ms	 1.144 s        +29.4%
primetest/50digits        877.8 ms	 1.144 s        +30.3%
queens4x4/bt              22.25 ms	 23.82 ms       +7.1%
queens4x4/bm              28.83 ms	 30.87 ms       +7.1%
queens4x4/bjbt1           27.37 ms	 29.12 ms       +6.4%
queens4x4/bjbt2           29.26 ms	 31.09 ms       +6.3%
queens4x4/fc              68.36 ms	 69.80 ms       +2.1%
queens5x5/bt              290.4 ms	 326.2 ms       +12.3%
queens5x5/bm              328.2 ms	 350.2 ms       +6.7%
queens5x5/bjbt1           350.4 ms	 379.0 ms       +8.2%
queens5x5/bjbt2           371.1 ms	 402.9 ms       +8.6%
```

I double-checked the results.

I'm rather surprised that such a tiny thing does this to performance. We should try using unsafe indexing as that has the potential to give us a decent boost (and people do use `a[i]` in C all the time, I suppose we can afford one such case).