### PR TITLE
[Builtins] Removed usages of '<:'

### DIFF
--- a/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
@@ -112,7 +112,7 @@ revealUnique (Name name uniq) =
 -- TODO: we can generate more types here.
 -- | Generate a 'Builtin' and supply its typed version to a continuation.
 withTypedBuiltinGen
-    :: (Generatable uni, HasConstantIn uni term, Monad m)
+    :: (uni ~ DefaultUni, HasConstantIn uni term, Monad m)
     => (forall a. AsKnownType term a -> GenT m c) -> GenT m c
 withTypedBuiltinGen k = Gen.choice
     [ k @Integer       AsKnownType
@@ -172,7 +172,7 @@ genIterAppValue (Denotation object embed meta scheme) = result where
 -- Arguments to functions and 'Builtin's are generated recursively.
 genTerm
     :: forall uni fun m.
-       (Generatable uni, Monad m)
+       (uni ~ DefaultUni, Monad m)
     => TypedBuiltinGenT (Plain Term uni fun) m
        -- ^ Ground generators of built-ins. The base case of the recursion.
     -> DenotationContext (Plain Term uni fun)

--- a/plutus-core/generators/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
@@ -15,7 +15,6 @@ module PlutusCore.Generators.Internal.TypedBuiltinGen
     ( TermOf(..)
     , TypedBuiltinGenT
     , TypedBuiltinGen
-    , Generatable
     , genLowerBytes
     , genTypedBuiltinFail
     , genTypedBuiltinDef
@@ -56,8 +55,6 @@ type TypedBuiltinGenT term m = forall a. AsKnownType term a -> GenT m (TermOf te
 -- | 'TypedBuiltinGenT' specified to 'Identity'.
 type TypedBuiltinGen term = TypedBuiltinGenT term Identity
 
-type Generatable uni = (GShow uni, GEq uni, DefaultUni <: uni)
-
 instance (PrettyBy config a, PrettyBy config term) =>
         PrettyBy config (TermOf term a) where
     prettyBy config (TermOf t x) = prettyBy config t <+> "~>" <+> prettyBy config x
@@ -95,7 +92,7 @@ genTypedBuiltinFail tb = fail $ fold
 
 -- | A default built-ins generator.
 genTypedBuiltinDef
-    :: (Generatable uni, HasConstantIn uni term, Monad m)
+    :: (HasConstantIn DefaultUni term, Monad m)
     => TypedBuiltinGenT term m
 genTypedBuiltinDef
     = updateTypedBuiltinGen @Integer (Gen.integral $ Range.linearFrom 0 0 10)

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -117,7 +117,7 @@ nonZeroArg :: (Integer -> Integer -> Integer) -> Integer -> Integer -> Evaluatio
 nonZeroArg _ _ 0 = EvaluationFailure
 nonZeroArg f x y = EvaluationSuccess $ f x y
 
-instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni DefaultFun where
+instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     type CostingPart uni DefaultFun = BuiltinCostModel
     toBuiltinMeaning AddInteger =
         makeBuiltinMeaning


### PR DESCRIPTION
This is a simplification on its own, but there's a chance that the 

```
- instance (GShow uni, GEq uni, DefaultUni <: uni) => ToBuiltinMeaning uni DefaultFun where
+ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
```

change can give us some speed-up. Haven't run the benchmarks yet.