### PR TITLE
Fixing websocket subscription bug.

### DIFF
--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -4,6 +4,7 @@ module Env
   , PABType(..)
   ) where
 
+import Prelude
 import Effect.AVar (AVar)
 import Halogen (SubscriptionId)
 import Plutus.PAB.Webserver (SPParams_)
@@ -33,6 +34,10 @@ data DataProvider
   = PAB PABType
   | LocalStorage
 
+derive instance eqDataProvider :: Eq DataProvider
+
 data PABType
   = Plain
   | WithMarloweContracts
+
+derive instance eqPABType :: Eq PABType

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -23,7 +23,7 @@ import Data.Traversable (for)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Now (getTimezoneOffset)
-import Env (DataProvider(..), Env)
+import Env (Env)
 import Foreign.Generic (decodeJSON, encodeJSON)
 import Halogen (Component, HalogenM, liftEffect, mkComponent, mkEval, subscribe)
 import Halogen.Extra (mapMaybeSubmodule, mapSubmodule)
@@ -97,9 +97,8 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
           followAppIds :: Array PlutusAppId
           followAppIds = Set.toUnfoldable $ keys $ view _allContracts playState
         { dataProvider } <- ask
-        when (dataProvider /= LocalStorage) do
-          void $ subscribeToWallet wallet
-          void $ for followAppIds subscribeToPlutusApp
+        subscribeToWallet dataProvider wallet
+        for followAppIds $ subscribeToPlutusApp dataProvider
     (WS.WebSocketClosed closeEvent) -> do
       -- TODO: Consider whether we should show an error/warning when this happens. It might be more
       -- confusing than helpful, since the websocket is automatically reopened if it closes for any
@@ -214,13 +213,12 @@ handleAction Init = do
 
 handleAction (EnterPickupState walletLibrary walletDetails followerApps) = do
   { dataProvider } <- ask
-  when (dataProvider /= LocalStorage) do
-    let
-      followerAppIds :: Array PlutusAppId
-      followerAppIds = Set.toUnfoldable $ keys followerApps
-    void $ unsubscribeFromWallet $ view (_walletInfo <<< _wallet) walletDetails
-    void $ unsubscribeFromPlutusApp $ view _companionAppId walletDetails
-    void $ for_ followerAppIds unsubscribeFromPlutusApp
+  let
+    followerAppIds :: Array PlutusAppId
+    followerAppIds = Set.toUnfoldable $ keys followerApps
+  unsubscribeFromWallet dataProvider $ view (_walletInfo <<< _wallet) walletDetails
+  unsubscribeFromPlutusApp dataProvider $ view _companionAppId walletDetails
+  for_ followerAppIds $ unsubscribeFromPlutusApp dataProvider
   assign _subState $ Left $ Pickup.mkInitialState walletLibrary
   liftEffect $ removeItem walletDetailsLocalStorageKey
 
@@ -234,13 +232,12 @@ handleAction (EnterPlayState walletLibrary walletDetails) = do
       addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
     Right followerApps -> do
       { dataProvider } <- ask
-      when (dataProvider /= LocalStorage) do
-        let
-          followerAppIds :: Array PlutusAppId
-          followerAppIds = Set.toUnfoldable $ keys followerApps
-        void $ subscribeToWallet $ view (_walletInfo <<< _wallet) walletDetails
-        void $ subscribeToPlutusApp $ view _companionAppId walletDetails
-        void $ for_ followerAppIds subscribeToPlutusApp
+      let
+        followerAppIds :: Array PlutusAppId
+        followerAppIds = Set.toUnfoldable $ keys followerApps
+      subscribeToWallet dataProvider $ view (_walletInfo <<< _wallet) walletDetails
+      subscribeToPlutusApp dataProvider $ view _companionAppId walletDetails
+      for_ followerAppIds $ subscribeToPlutusApp dataProvider
       timezoneOffset <- liftEffect getTimezoneOffset
       assign _subState $ Right $ Play.mkInitialState walletLibrary walletDetails followerApps currentSlot timezoneOffset
       liftEffect $ setItem walletDetailsLocalStorageKey $ encodeJSON walletDetails

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -18,6 +18,7 @@ import ContractHome.Lenses (_contracts)
 import ContractHome.State (handleAction, mkInitialState) as ContractHome
 import ContractHome.Types (Action(..), State) as ContractHome
 import Control.Monad.Reader (class MonadAsk)
+import Control.Monad.Reader.Class (ask)
 import Data.Array (difference, head, init, reverse, snoc)
 import Data.Either (Either(..))
 import Data.Foldable (for_)
@@ -236,7 +237,9 @@ handleAction _ (UpdateRunningContracts companionAppState) = do
         ajaxFollowerContract <- followContract walletDetails marloweParams
         case ajaxFollowerContract of
           Left decodedAjaxError -> addToast $ decodedAjaxErrorToast "Failed to load new contract." decodedAjaxError
-          Right (plutusAppId /\ history) -> subscribeToPlutusApp plutusAppId
+          Right (plutusAppId /\ history) -> do
+            { dataProvider } <- ask
+            subscribeToPlutusApp dataProvider plutusAppId
 
 handleAction input@{ currentSlot } AdvanceTimedoutSteps = do
   walletDetails <- use _walletDetails


### PR DESCRIPTION
When using the localStorage dummy data, we were still subscribing to contracts and wallets in the PAB. I thought this wouldn't matter (I still think it doesn't for contracts), but when subscribing to a wallet that doesn't exist, the PAB gives us a websocket update saying that it has no funds. This is because there is no way of distinguishing between a wallet that doesn't exist and one that has no funds (there are no outputs in the UTXO set in both cases).

So this fixes the frontend to only subscribe/unsubscribe when we're not using the localStorage dummy data.