### PR TITLE
Fix plutus-pab-client npm start

### DIFF
--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -12,10 +12,12 @@ let
 
   # For dev usage
   generate-purescript = pkgs.writeShellScriptBin "plutus-pab-generate-purs" ''
-    rm -rf ./generated
+    generatedDir=./generated
+    rm -rf $generatedDir
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
-    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab psgenerator generated
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab psgenerator $generatedDir
+    ${plutus-pab-test-psgenerator}/bin/plutus-pab-test-psgenerator $generatedDir
   '';
 
   # For dev usage


### PR DESCRIPTION
by also generating the test files that plutus-pab-client imports

Fixes https://github.com/input-output-hk/plutus/issues/3328

Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
