### PR TITLE
Fix shell depending on haskell libraries

### DIFF
--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -1,13 +1,13 @@
 { pkgs, gitignore-nix, haskell, webCommon, webCommonPlutus, buildPursPackage, buildNodeModules, filterNpm }:
 let
   server-invoker = haskell.packages.plutus-pab.components.exes.plutus-pab;
-  plutus-pab-test-psgenerator = haskell.packages.plutus-pab.components.exes.plutus-pab-test-psgenerator;
+  test-generator = haskell.packages.plutus-pab.components.exes.plutus-pab-test-psgenerator;
 
   generated-purescript = pkgs.runCommand "plutus-pab-purescript" { } ''
     mkdir $out
     ln -s ${haskell.packages.plutus-pab.src}/plutus-pab.yaml.sample plutus-pab.yaml
     ${server-invoker}/bin/plutus-pab psgenerator $out
-    ${plutus-pab-test-psgenerator}/bin/plutus-pab-test-psgenerator $out
+    ${test-generator}/bin/plutus-pab-test-psgenerator $out
   '';
 
   # For dev usage
@@ -17,7 +17,7 @@ let
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-invoker)/bin/plutus-pab psgenerator $generatedDir
-    ${plutus-pab-test-psgenerator}/bin/plutus-pab-test-psgenerator $generatedDir
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.test-generator)/bin/plutus-pab-test-psgenerator $generatedDir
   '';
 
   # For dev usage
@@ -90,5 +90,5 @@ let
 
 in
 {
-  inherit client demo-scripts server-invoker generated-purescript generate-purescript migrate start-backend start-all-servers start-all-servers-m mkConf pab-exes;
+  inherit client demo-scripts server-invoker test-generator generated-purescript generate-purescript migrate start-backend start-all-servers start-all-servers-m mkConf pab-exes;
 }


### PR DESCRIPTION
This command deliberately calls out to nix instead of directly using the
derivation, so that we can put it in the shell without incurring a
dependency on those derivations.

cc @luigy 

I _do_ have a check for this in `ci.nix`, so I'm not sure why it passed :/

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
