### PR TITLE
Exported the variable 'compiler-nix-name' in Nix

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -10,7 +10,7 @@ let
 
   gitignore-nix = pkgs.callPackage sources."gitignore.nix" { };
 
-  # { index-state, project, projectPackages, packages, extraPackages }
+  # { index-state, compiler-nix-name, project, projectPackages, packages, extraPackages }
   haskell = pkgs.callPackage ./haskell {
     inherit gitignore-nix sources;
     inherit agdaWithStdlib checkMaterialization enableHaskellProfiling;

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -60,6 +60,6 @@ let
 
 in
 rec {
-  inherit index-state project projectAllHaddock projectPackages projectPackagesAllHaddock packages;
+  inherit index-state compiler-nix-name project projectAllHaddock projectPackages projectPackagesAllHaddock packages;
   inherit extraPackages;
 }


### PR DESCRIPTION
Exported the variable `compiler-nix-name` in Nix to use it in other projects such as `plutus-starter`. The goal is to reuse the exact same GHC version in both projects.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
