### PR TITLE
Webghc fixes

### DIFF
--- a/nix/modules/web-ghc.nix
+++ b/nix/modules/web-ghc.nix
@@ -32,6 +32,13 @@ in
         ghc-web package to execute.
       '';
     };
+    timeout = mkOption {
+      type = types.int;
+      default = 80;
+      description = ''
+        Interpretation timeout in seconds.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -45,7 +52,7 @@ in
         TimeoutStopSec = 5;
         CapabilityBoundingSet = "~CAP_SYS_ADMIN";
         Restart = "always";
-        ExecStart = "${cfg.web-ghc-package}/bin/web-ghc-server webserver -b ${cfg.ipAddress} -p ${builtins.toString cfg.port}";
+        ExecStart = "${cfg.web-ghc-package}/bin/web-ghc-server webserver -b ${cfg.ipAddress} -p ${builtins.toString cfg.port} -t ${builtins.toString cfg.timeout}";
 
         # allow binding on port 80
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];

--- a/nix/pkgs/haskell/materialized-unix/.plan.nix/web-ghc.nix
+++ b/nix/pkgs/haskell/materialized-unix/.plan.nix/web-ghc.nix
@@ -66,6 +66,7 @@
             (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
             (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
             (hsPkgs."wai-cors" or (errorHandler.buildDepError "wai-cors"))
             (hsPkgs."wai-extra" or (errorHandler.buildDepError "wai-extra"))
             (hsPkgs."wai" or (errorHandler.buildDepError "wai"))

--- a/nix/tests/vm-tests/web-ghc.nix
+++ b/nix/tests/vm-tests/web-ghc.nix
@@ -26,6 +26,7 @@ makeTest {
         enable = true;
         port = 80;
         web-ghc-package = web-ghc;
+        timeout = 180;
       };
     };
   testScript = ''

--- a/web-ghc/src/Interpreter.hs
+++ b/web-ghc/src/Interpreter.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
 
 module Interpreter where
 
@@ -12,15 +10,12 @@ import           Control.Monad.IO.Class       (MonadIO, liftIO)
 import qualified Control.Newtype.Generics     as Newtype
 import           Data.Text                    (Text)
 import qualified Data.Text.IO                 as Text
-import           Data.Time.Units              (Second, TimeUnit)
+import           Data.Time.Units              (TimeUnit)
 import           Language.Haskell.Interpreter (InterpreterError, InterpreterResult, SourceCode, avoidUnsafe, runghc)
 import           System.FilePath              ((</>))
 import           System.IO                    (Handle, IOMode (ReadWriteMode), hFlush)
 import           System.IO.Extras             (withFile)
 import           System.IO.Temp               (withSystemTempDirectory)
-
-maxInterpretationTime :: Second
-maxInterpretationTime = 80
 
 runscript ::
   ( Show t,
@@ -82,4 +77,4 @@ runghcOpts implicitPrelude =
     "-fno-ignore-interface-pragmas",
     "-fobject-code"
   ]
-    <> if implicitPrelude then [] else ["-XNoImplicitPrelude"]
+    <> ["-XNoImplicitPrelude" | not implicitPrelude]

--- a/web-ghc/src/Webghc/Server.hs
+++ b/web-ghc/src/Webghc/Server.hs
@@ -11,8 +11,9 @@ import           Control.Monad.Except         (runExceptT)
 import           Control.Monad.IO.Class       (MonadIO, liftIO)
 import           Data.Aeson                   (FromJSON, ToJSON)
 import           Data.Text                    (Text)
+import           Data.Time.Units              (Second)
 import           GHC.Generics                 (Generic)
-import           Interpreter                  (compile, maxInterpretationTime)
+import           Interpreter                  (compile)
 import           Language.Haskell.Interpreter (InterpreterError, InterpreterResult, SourceCode (SourceCode))
 import           Servant                      (Get, JSON, Post, ReqBody, (:<|>) ((:<|>)), (:>))
 import           Servant.Server               (Server)
@@ -27,9 +28,9 @@ data CompileRequest = CompileRequest { code :: Text, implicitPrelude :: Bool }
   deriving stock (Generic)
   deriving anyclass (FromJSON, ToJSON)
 
-server :: Server API
-server =
-  health :<|> runghc
+server :: Second -> Server API
+server timeoutSecs =
+  health :<|> runghc timeoutSecs
 
 health :: Applicative m => m ()
 health = pure ()
@@ -37,8 +38,9 @@ health = pure ()
 runghc ::
   MonadMask m =>
   MonadIO m =>
+  Second ->
   CompileRequest ->
   m (Either InterpreterError (InterpreterResult String))
-runghc CompileRequest {..} = do
+runghc timeoutSecs CompileRequest {..} = do
   liftIO $ print code
-  runExceptT $ compile maxInterpretationTime implicitPrelude $ SourceCode code
+  runExceptT $ compile timeoutSecs implicitPrelude $ SourceCode code

--- a/web-ghc/web-ghc.cabal
+++ b/web-ghc/web-ghc.cabal
@@ -70,6 +70,7 @@ executable web-ghc-server
         servant-server,
         servant,
         text,
+        time-units,
         wai-cors,
         wai-extra,
         wai,


### PR DESCRIPTION
**Summary**: 
Make the interpretation timeout period for `web-ghc` configurable

**Details**:
Several VM tests have been very unstable in CI. After adding better asserts with more useful error messages we could recently see that in the case of `web-ghc` related tests, the failures are triggered by timeouts: Inside `web-ghc` the ghc invocation is limited to 80s - Apparently insufficient for CI runs (_argh_).

This PR adds `-t <seconds>` option to `webghc` and extends the webghc nixos service with a `timeout` option. The default value remains at 80s but for tests the value is bumped up to `180`.

**Note**: We could extend the timeout further if this is not sufficient but maybe then we would also have to consider finding out where these enormous delays come from.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
