### PR TITLE
Constrain some < 1.0.3

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -287,7 +287,7 @@ library
         semigroups -any,
         serialise -any,
         size-based -any,
-        some -any,
+        some < 1.0.3,
         sop-core -any,
         tasty -any,
         tasty-golden -any,


### PR DESCRIPTION
For some reason we don't compile with 1.0.3, and in other contexts that
version is getting picked in the build plan.

(A tiny bit of looking suggests that 1.0.3 made some stuff poly-kinded, and `deriveGEq` comes from a different package that is maybe not up-to-date.)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
