### PR TITLE
Fix the serialization format for scripts.

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
@@ -20,7 +20,7 @@ It seems better therefore to avoid depending on Plutus Tx in any "core" projects
 -}
 
 -- | Creates a script which has N arguments, and always succeeds.
-alwaysSucceedingNAryFunction :: Natural -> Script
+alwaysSucceedingNAryFunction :: Natural -> SerializedScript
 alwaysSucceedingNAryFunction n = toShort $ toStrict $ serialise $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
     where
         -- No more arguments! The body can be anything that doesn't fail, so we return `\x . x`
@@ -29,7 +29,7 @@ alwaysSucceedingNAryFunction n = toShort $ toStrict $ serialise $ Scripts.Script
         body i = UPLC.LamAbs () (UPLC.DeBruijn 0) $ body (i-1)
 
 -- | Creates a script which has N arguments, and always fails.
-alwaysFailingNAryFunction :: Natural -> Script
+alwaysFailingNAryFunction :: Natural -> SerializedScript
 alwaysFailingNAryFunction n = toShort $ toStrict $ serialise $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
     where
         -- No more arguments! The body should be error.

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
@@ -4,8 +4,9 @@ This module contains example values to be used for testing. These should NOT be 
 -}
 module Plutus.V1.Ledger.Examples where
 
+import           Codec.Serialise
+import           Data.ByteString.Lazy     (toStrict)
 import           Data.ByteString.Short
-import qualified Flat
 import           Numeric.Natural
 import           Plutus.V1.Ledger.Api
 import qualified Plutus.V1.Ledger.Scripts as Scripts
@@ -20,7 +21,7 @@ It seems better therefore to avoid depending on Plutus Tx in any "core" projects
 
 -- | Creates a script which has N arguments, and always succeeds.
 alwaysSucceedingNAryFunction :: Natural -> Script
-alwaysSucceedingNAryFunction n = toShort $ Flat.flat @Scripts.Script $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
+alwaysSucceedingNAryFunction n = toShort $ toStrict $ serialise $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
     where
         -- No more arguments! The body can be anything that doesn't fail, so we return `\x . x`
         body i | i == 0 = UPLC.LamAbs() (UPLC.DeBruijn 0) $ UPLC.Var () (UPLC.DeBruijn 1)
@@ -29,7 +30,7 @@ alwaysSucceedingNAryFunction n = toShort $ Flat.flat @Scripts.Script $ Scripts.S
 
 -- | Creates a script which has N arguments, and always fails.
 alwaysFailingNAryFunction :: Natural -> Script
-alwaysFailingNAryFunction n = toShort $ Flat.flat @Scripts.Script $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
+alwaysFailingNAryFunction n = toShort $ toStrict $ serialise $ Scripts.Script $ UPLC.Program () (PLC.defaultVersion ()) (body n)
     where
         -- No more arguments! The body should be error.
         body i | i == 0 = UPLC.Error ()

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -68,7 +68,7 @@ import           Data.Hashable                    (Hashable)
 import           Data.String
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Extras
-import           Flat                             (Flat, flat, unflat)
+import qualified Flat
 import           GHC.Generics                     (Generic)
 import           Plutus.V1.Ledger.Bytes           (LedgerBytes (..))
 import           Plutus.V1.Ledger.Orphans         ()
@@ -83,7 +83,6 @@ import qualified UntypedPlutusCore                as UPLC
 -- | A script on the chain. This is an opaque type as far as the chain is concerned.
 newtype Script = Script { unScript :: UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun () }
   deriving stock Generic
-  deriving newtype (Flat)
 
 {-| Note [Using Flat inside CBOR instance of Script]
 `plutus-ledger` uses CBOR for data serialisation and `plutus-core` uses Flat. The
@@ -100,10 +99,10 @@ data structures that include scripts (for example, transactions) no-longer benef
 for CBOR's ability to self-describe it's format.
 -}
 instance Serialise Script where
-  encode = encode . flat . unScript
+  encode = encode . Flat.flat . unScript
   decode = do
     bs <- decodeBytes
-    case unflat bs of
+    case Flat.unflat bs of
       Left  err    -> Haskell.fail (Haskell.show err)
       Right script -> return $ Script script
 


### PR DESCRIPTION
The whole point of having the CBOR serialization wrapping the Flat one
was so that we could present the "standard" format downstream. As it is,
I accidentally used Flat, so the ledger has been using it, and it's all
a mess.

The root technical cause insofar as there is one is that `Script` has
two serialization instances for different formats, which is asking for
trouble. I got rid of the Flat one.

While I was at it I fixed another papercut reported by Jordan: it's confusing to have multiple things called `Script`, let's just make the type alias be `SerializedScript` for clarity.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
