### PR TITLE
Improved game contract playground example

### DIFF
--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -26,12 +26,17 @@ module Game where
 -- If it isn't, the funds stay locked.
 import           Control.Monad         (void)
 import qualified Data.ByteString.Char8 as C
-import           Ledger                (Address, ScriptContext, Validator, Value, scriptAddress)
+import qualified Data.Map              as Map
+import           Data.Maybe            (catMaybes)
+import           Ledger                (Address, Datum (Datum), ScriptContext, TxOutTx, Validator, Value)
+import qualified Ledger
+import qualified Ledger.Ada            as Ada
+import           Ledger.AddressMap     (UtxoMap)
 import qualified Ledger.Constraints    as Constraints
 import qualified Ledger.Typed.Scripts  as Scripts
 import           Playground.Contract
 import           Plutus.Contract
-import qualified PlutusTx              as PlutusTx
+import qualified PlutusTx
 import           PlutusTx.Prelude      hiding (pure, (<$>))
 import qualified Prelude               as Haskell
 
@@ -73,7 +78,10 @@ clearString = ClearString . C.pack
 
 -- | The validation function (Datum -> Redeemer -> ScriptContext -> Bool)
 validateGuess :: HashedString -> ClearString -> ScriptContext -> Bool
-validateGuess (HashedString actual) (ClearString guess') _ = actual == sha2_256 guess'
+validateGuess hs cs _ = isGoodGuess hs cs
+
+isGoodGuess :: HashedString -> ClearString -> Bool
+isGoodGuess (HashedString actual) (ClearString guess') = actual == sha2_256 guess'
 
 -- | The validator script of the game.
 gameValidator :: Validator
@@ -101,18 +109,49 @@ newtype GuessParams = GuessParams
 -- | The "lock" contract endpoint. See note [Contract endpoints]
 lock :: AsContractError e => Contract () GameSchema e ()
 lock = do
+    logInfo @Haskell.String "Waiting for lock endpoint..."
     LockParams secret amt <- endpoint @"lock" @LockParams
+    logInfo @Haskell.String $ "Pay " <> Haskell.show amt <> " to the script"
     let tx         = Constraints.mustPayToTheScript (hashString secret) amt
     void (submitTxConstraints gameInstance tx)
 
 -- | The "guess" contract endpoint. See note [Contract endpoints]
 guess :: AsContractError e => Contract () GameSchema e ()
 guess = do
+    -- Wait for a call on the guess endpoint
+    logInfo @Haskell.String "Waiting for guess endpoint..."
     GuessParams theGuess <- endpoint @"guess" @GuessParams
-    unspentOutputs <- utxoAt gameAddress
+    -- Wait for script to have a UTxO of a least 1 lovelace
+    logInfo @Haskell.String "Waiting for script to have a UTxO of at least 1 lovelace"
+    utxos <- fundsAtAddressGeq gameAddress (Ada.lovelaceValueOf 1)
+
     let redeemer = clearString theGuess
-        tx       = collectFromScript unspentOutputs redeemer
-    void (submitTxConstraintsSpending gameInstance unspentOutputs tx)
+        tx       = collectFromScript utxos redeemer
+
+    -- Log a message saying if the secret word was correctly guessed
+    let hashedSecretWord = findSecretWordValue utxos
+        isCorrectSecretWord = fmap (`isGoodGuess` redeemer) hashedSecretWord == Just True
+    if isCorrectSecretWord
+       then logWarn @Haskell.String "Correct secret word! Submitting the transaction"
+       else logWarn @Haskell.String "Incorrect secret word, but still submiting the transaction"
+
+    -- This is only for test purposes to have a possible failing transaction.
+    -- In a real use-case, we would not submit the transaction if the guess is
+    -- wrong.
+    logInfo @Haskell.String "Submitting transaction to guess the secret word"
+    void (submitTxConstraintsSpending gameInstance utxos tx)
+
+-- | Find the secret word in the Datum of the UTxOs
+findSecretWordValue :: UtxoMap -> Maybe HashedString
+findSecretWordValue =
+  listToMaybe . catMaybes . Map.elems . Map.map secretWordValue
+
+-- | Extract the secret word in the Datum of a given transaction output is possible
+secretWordValue :: TxOutTx -> Maybe HashedString
+secretWordValue o = do
+  dh <- Ledger.txOutDatum $ Ledger.txOutTxOut o
+  Datum d <- Map.lookup dh $ Ledger.txData $ Ledger.txOutTxTx o
+  PlutusTx.fromData d
 
 game :: AsContractError e => Contract () GameSchema e ()
 game = lock `select` guess


### PR DESCRIPTION
Improved game contract playground example by adding logs and applying the validator function in the off-chain part of the code before submitting a transaction.

Same change as https://github.com/input-output-hk/plutus-starter/pull/15, except for a small difference in the `guess` function. In the `plutus-starter` PR, we would call `fundsAtAddressGeq` before `endpoint` to ensure that the `guess` endpoint is only available when script has at least one UTxO of a least 1 lovelace. However, doing that doesn't work when combined with the `select` function between two contracts. 

Therefore, in the game contract of the playground, which needs to use the `select` function, I swapped the call order. The `guess` endpoint will first wait for an endpoint call, and then wait for the script to have at least one UTxO of a least 1 lovelace.

To summarize, the only difference is these lines:

```
    -- Wait for a call on the guess endpoint
    logInfo @String "Waiting for guess endpoint..."
    -- Wait for script to have a UTxO of a least 1 lovelace
    logInfo @String "Waiting for script to have a UTxO of at least 1 lovelace"
    utxos <- fundsAtAddressGeq gameAddress (Ada.lovelaceValueOf 1)
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
