### PR TITLE
Bound dependent-sum

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,6 +57,10 @@ constraints:
   singletons < 3.0
   -- breaks eventful even more than it already was
   , persistent-template < 2.12
+  -- bizarre issue: in earlier versions they define their own 'GEq', in newer
+  -- ones they reuse the one from 'some', but there isn't e.g. a proper version
+  -- constraint from dependent-sum-template (which is the library we actually use).
+  , dependent-sum > 0.6.2.0
 
 -- See the note on nix/pkgs/default.nix:agdaPackages for why this is here.
 -- (NOTE this will change to ieee754 in newer versions of nixpkgs).


### PR DESCRIPTION
This is quite irritating:
- Before this version `dependent-sum` had its own `GEq`.
- After this version they use the one from `some`.
- We used to use the version from `dependent-sum`, now we use the one
from `some`.
- We only depend on `dependent-sum-template`, *not* `dependent-sum`.
- `dependent-sum-template` does not constrain `dependent-sum` very
heavily.

The result is that the old `dependent-sum` appears in our build plan, so
the call to `deriveGEq` generates an instance of *its* `GEq`, which is
wrong.

Since we don't depend on `dependent-sum` directly (and we insist that
`plutus-core` doesn't have excess dependencies), the only way I can
see to ensure that we don't pick the old `dependent-sum` is to add a
constraint in `cabal.project`.

(tagging @effectfully in case you know of any way to avoid this)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
