### PR TITLE
Fix materialization checking for cardano-repo-tool

### DIFF
--- a/nix/pkgs/haskell/cardano-repo-tool.sha
+++ b/nix/pkgs/haskell/cardano-repo-tool.sha
@@ -1,1 +1,1 @@
-01rgy6gwvgham0z1z2xc7zwhcpn81jxzz8yjybpl3agfmqwk92ai
+00lja2zjzgjazb1xfchcjqbjkad8n0n2kxhl8zvsm8s4hfj3igci

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -59,7 +59,7 @@ let
   };
   cardanoRepoToolProject = haskell-nix.cabalProject' {
     src = sources.cardano-repo-tool;
-    inherit compiler-nix-name index-state;
+    inherit compiler-nix-name index-state checkMaterialization;
     plan-sha256 = lib.removeSuffix "\n" (builtins.readFile ./cardano-repo-tool.sha);
     sha256map = {
       "https://github.com/input-output-hk/nix-archive"."7dcf21b2af54d0ab267f127b6bd8fa0b31cfa49d" = "0mhw896nfqbd2iwibzymydjlb3yivi9gm0v2g1nrjfdll4f7d8ly";


### PR DESCRIPTION
We weren't passing `checkMaterialization` down to `cardano-repo-tool`,
so the CI wasn't telling us if it was out-of-date.

`updateMaterialized` fixed the sha file actually being wrong.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
