### PR TITLE
SCP-2377: Add placeholders for contracts/transactions while waiting confirmation (part 1 of 2).

### DIFF
--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -181,10 +181,9 @@ instance monadMarloweAppM :: ManageMarlowe AppM where
       PAB pabType -> do
         let
           wallet = view (_walletInfo <<< _wallet) walletDetails
-        followAppId <- case pabType of
+        case pabType of
           Plain -> Contract.activateContract (plutusAppPath MarloweFollower) wallet
           WithMarloweContracts -> Contract.activateContract MarloweFollower wallet
-        pure followAppId
       LocalStorage -> do
         uuid <- liftEffect genUUID
         pure $ Right $ PlutusAppId uuid

--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -1,6 +1,7 @@
 module Contract.Lenses
   ( _tab
   , _executionState
+  , _pendingTransaction
   , _previousSteps
   , _mMarloweParams
   , _followerAppId
@@ -21,7 +22,7 @@ import Data.Symbol (SProxy(..))
 import Marlowe.Execution.Types (ExecutionState, NamedAction)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.PAB (PlutusAppId, MarloweParams)
-import Marlowe.Semantics as Semantic
+import Marlowe.Semantics (Party, TransactionInput)
 import WalletData.Types (WalletNickname)
 
 _tab :: forall a. Lens' { tab :: Tab | a } Tab
@@ -29,6 +30,9 @@ _tab = prop (SProxy :: SProxy "tab")
 
 _executionState :: Lens' State ExecutionState
 _executionState = prop (SProxy :: SProxy "executionState")
+
+_pendingTransaction :: Lens' State (Maybe TransactionInput)
+_pendingTransaction = prop (SProxy :: SProxy "pendingTransaction")
 
 _previousSteps :: Lens' State (Array PreviousStep)
 _previousSteps = prop (SProxy :: SProxy "previousSteps")
@@ -45,10 +49,10 @@ _selectedStep = prop (SProxy :: SProxy "selectedStep")
 _metadata :: Lens' State MetaData
 _metadata = prop (SProxy :: SProxy "metadata")
 
-_participants :: Lens' State (Map Semantic.Party (Maybe WalletNickname))
+_participants :: Lens' State (Map Party (Maybe WalletNickname))
 _participants = prop (SProxy :: SProxy "participants")
 
-_userParties :: Lens' State (Set Semantic.Party)
+_userParties :: Lens' State (Set Party)
 _userParties = prop (SProxy :: SProxy "userParties")
 
 _namedActions :: Lens' State (Array NamedAction)

--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -2,7 +2,7 @@ module Contract.Lenses
   ( _tab
   , _executionState
   , _previousSteps
-  , _marloweParams
+  , _mMarloweParams
   , _followerAppId
   , _selectedStep
   , _metadata
@@ -33,8 +33,8 @@ _executionState = prop (SProxy :: SProxy "executionState")
 _previousSteps :: Lens' State (Array PreviousStep)
 _previousSteps = prop (SProxy :: SProxy "previousSteps")
 
-_marloweParams :: Lens' State MarloweParams
-_marloweParams = prop (SProxy :: SProxy "marloweParams")
+_mMarloweParams :: Lens' State (Maybe MarloweParams)
+_mMarloweParams = prop (SProxy :: SProxy "mMarloweParams")
 
 _followerAppId :: Lens' State PlutusAppId
 _followerAppId = prop (SProxy :: SProxy "followerAppId")

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -25,7 +25,10 @@ type State
     , executionState :: ExecutionState
     , previousSteps :: Array PreviousStep
     , followerAppId :: PlutusAppId
-    , marloweParams :: MarloweParams
+    -- Every contract needs MarloweParams, but this is a Maybe because we want to create "placeholder"
+    -- contracts when a user creates a contract, to show on the page until the blockchain settles and
+    -- we get the MarloweParams back from the PAB (through the MarloweFollower app).
+    , mMarloweParams :: Maybe MarloweParams
     -- Which step is selected. This index is 0 based and should be between [0, previousSteps.length]
     -- (both sides inclusive). This is because the array represent the past steps and the
     -- executionState has the current state and visually we can select any one of them.

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -23,6 +23,9 @@ import WalletData.Types (WalletDetails, WalletNickname)
 type State
   = { tab :: Tab -- this is the tab of the current (latest) step - previous steps have their own tabs
     , executionState :: ExecutionState
+    -- When the user submits a transaction, we save it here until we get confirmation from the PAB and
+    -- can advance the contract. This enables us to show immediate feedback to the user while we wait.
+    , pendingTransaction :: Maybe TransactionInput
     , previousSteps :: Array PreviousStep
     , followerAppId :: PlutusAppId
     -- Every contract needs MarloweParams, but this is a Maybe because we want to create "placeholder"

--- a/marlowe-dashboard-client/src/ContractHome/State.purs
+++ b/marlowe-dashboard-client/src/ContractHome/State.purs
@@ -10,11 +10,10 @@ import Contract.State (isContractClosed)
 import Contract.State (mkInitialState) as Contract
 import Contract.Types (State) as Contract
 import ContractHome.Lenses (_selectedContractIndex, _status)
-import ContractHome.Types (Action(..), ContractStatus(..), State, PartitionedContracts)
+import ContractHome.Types (Action(..), ContractStatus(..), PartitionedContracts, State)
 import Data.Array (partition)
 import Data.Lens (assign)
-import Data.Map (Map, mapMaybeWithKey)
-import Data.Map as Map
+import Data.Map (Map, mapMaybeWithKey, toUnfoldableUnordered)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (snd)
 import Halogen (HalogenM)
@@ -46,7 +45,7 @@ handleAction (OpenContract ix) = assign _selectedContractIndex $ Just ix
 
 partitionContracts :: Map PlutusAppId Contract.State -> PartitionedContracts
 partitionContracts contracts =
-  Map.toUnfoldableUnordered contracts
+  toUnfoldableUnordered contracts
     # map snd
     # partition isContractClosed
     # \{ no, yes } -> { completed: yes, running: no }

--- a/marlowe-dashboard-client/src/ContractHome/View.purs
+++ b/marlowe-dashboard-client/src/ContractHome/View.purs
@@ -1,17 +1,17 @@
 module ContractHome.View where
 
 import Prelude hiding (div)
-import Contract.Lenses (_followerAppId, _executionState, _metadata)
+import Contract.Lenses (_executionState, _followerAppId, _mMarloweParams, _metadata)
 import Contract.State (currentStep, isContractClosed)
 import Contract.Types (State) as Contract
 import ContractHome.Lenses (_status)
 import ContractHome.State (partitionContracts)
-import ContractHome.Types (Action(..), ContractStatus(..), State, PartitionedContracts)
+import ContractHome.Types (Action(..), ContractStatus(..), PartitionedContracts, State)
 import Css (classNames)
 import Css as Css
 import Data.Array (length)
 import Data.Lens ((^.))
-import Data.Maybe (maybe')
+import Data.Maybe (Maybe(..), maybe')
 import Halogen.HTML (HTML, a, div, h2, p_, span, text)
 import Halogen.HTML.Events.Extra (onClick_)
 import Humanize (humanizeDuration)
@@ -93,6 +93,8 @@ contractGrid currentSlot contracts =
 contractCard :: forall p. Slot -> Contract.State -> HTML p Action
 contractCard currentSlot contractState =
   let
+    mMarloweParams = contractState ^. _mMarloweParams
+
     metadata = contractState ^. _metadata
 
     longTitle = metadata.contractName
@@ -115,8 +117,7 @@ contractCard currentSlot contractState =
   in
     div
       -- NOTE: The overflow hidden helps fix a visual bug in which the background color eats away the border-radius
-      [ classNames
-          [ "flex", "flex-col", "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
+      [ classNames [ "flex", "flex-col", "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
       , onClick_ $ OpenContract contractInstanceId
       ]
       -- TODO: This part is really similar to contractTitle in Template.View, see if it makes sense to factor a component out
@@ -128,8 +129,10 @@ contractCard currentSlot contractState =
       , div [ classNames [ "flex-1", "px-4", "py-2", "text-lg" ] ]
           [ text longTitle
           ]
-      , div [ classNames [ "bg-lightgray", "flex", "flex-col", "px-4", "py-2" ] ]
-          [ span [ classNames [ "text-xs", "font-semibold" ] ] [ text $ "Step " <> show stepNumber <> ":" ]
-          , span [ classNames [ "text-xl" ] ] [ text timeoutStr ]
-          ]
+      , div [ classNames [ "bg-lightgray", "flex", "flex-col", "px-4", "py-2" ] ] case mMarloweParams of
+          Nothing -> [ text "pending confirmation" ]
+          _ ->
+            [ span [ classNames [ "text-xs", "font-semibold" ] ] [ text $ "Step " <> show stepNumber <> ":" ]
+            , span [ classNames [ "text-xl" ] ] [ text timeoutStr ]
+            ]
       ]

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -20,11 +20,9 @@ import LocalStorage (RawStorageEvent)
 import LocalStorage as LocalStorage
 import MainFrame.State (mkMainFrame)
 import MainFrame.Types (Action(..), Msg(..), Query(..))
-import MainFrame.Types as MainFrame
 import Marlowe.PAB (CombinedWSStreamToServer)
 import Plutus.PAB.Webserver (SPParams_(SPParams_))
 import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient)
---import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient, CombinedWSStreamToServer)
 import Servant.PureScript.Settings (SPSettingsDecodeJson_(..), SPSettingsEncodeJson_(..), SPSettings_(..), defaultSettings)
 import WebSocket.Support (WebSocketManager, mkWebSocketManager)
 import WebSocket.Support as WS
@@ -50,7 +48,7 @@ main :: Effect Unit
 main = do
   environment <- mkEnvironment
   let
-    mainFrame :: Component HTML MainFrame.Query MainFrame.Action MainFrame.Msg Aff
+    mainFrame :: Component HTML Query Action Msg Aff
     mainFrame = hoist (runAppM environment) mkMainFrame
   runHalogenAff do
     body <- awaitBody

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -10,7 +10,7 @@ import Effect.Aff (Aff, forkAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
-import Env (DataProvider(..), Env, PABType(..))
+import Env (DataProvider(..), Env)
 import Foreign.Generic (defaultOptions)
 import Halogen (Component, hoist)
 import Halogen.Aff (awaitBody, runHalogenAff)
@@ -41,7 +41,7 @@ mkEnvironment = do
   pure
     { ajaxSettings: SPSettings_ (settings { decodeJson = decodeJson, encodeJson = encodeJson })
     , contractStepCarouselSubscription
-    , dataProvider: PAB Plain
+    , dataProvider: LocalStorage
     }
 
 main :: Effect Unit

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -10,7 +10,7 @@ import Effect.Aff (Aff, forkAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
-import Env (DataProvider(..), Env)
+import Env (DataProvider(..), Env, PABType(..))
 import Foreign.Generic (defaultOptions)
 import Halogen (Component, hoist)
 import Halogen.Aff (awaitBody, runHalogenAff)
@@ -43,7 +43,7 @@ mkEnvironment = do
   pure
     { ajaxSettings: SPSettings_ (settings { decodeJson = decodeJson, encodeJson = encodeJson })
     , contractStepCarouselSubscription
-    , dataProvider: LocalStorage
+    , dataProvider: PAB Plain
     }
 
 main :: Effect Unit

--- a/marlowe-dashboard-client/src/WalletData/Lenses.purs
+++ b/marlowe-dashboard-client/src/WalletData/Lenses.purs
@@ -4,6 +4,7 @@ module WalletData.Lenses
   , _marloweAppId
   , _walletInfo
   , _assets
+  , _previousCompanionAppState
   , _wallet
   , _pubKey
   , _pubKeyHash
@@ -13,8 +14,10 @@ import Prelude
 import Data.Lens (Lens')
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
+import Data.Map (Map)
+import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
-import Marlowe.PAB (PlutusAppId)
+import Marlowe.PAB (MarloweData, MarloweParams, PlutusAppId)
 import Marlowe.Semantics (Assets, PubKey)
 import WalletData.Types (PubKeyHash, Wallet, WalletDetails, WalletInfo, WalletNickname)
 
@@ -32,6 +35,9 @@ _walletInfo = prop (SProxy :: SProxy "walletInfo")
 
 _assets :: Lens' WalletDetails Assets
 _assets = prop (SProxy :: SProxy "assets")
+
+_previousCompanionAppState :: Lens' WalletDetails (Maybe (Map MarloweParams MarloweData))
+_previousCompanionAppState = prop (SProxy :: SProxy "previousCompanionAppState")
 
 ------------------------------------------------------------
 _wallet :: Lens' WalletInfo Wallet

--- a/marlowe-dashboard-client/src/WalletData/State.purs
+++ b/marlowe-dashboard-client/src/WalletData/State.purs
@@ -7,7 +7,7 @@ module WalletData.State
 import Prelude
 import Data.BigInteger (BigInteger)
 import Data.Map (lookup)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (unwrap)
 import Data.UUID (emptyUUID)
 import Marlowe.PAB (PlutusAppId(..))
@@ -21,6 +21,7 @@ defaultWalletDetails =
   , marloweAppId: PlutusAppId emptyUUID
   , walletInfo: defaultWalletInfo
   , assets: mempty
+  , previousCompanionAppState: Nothing
   }
 
 defaultWalletInfo :: WalletInfo

--- a/marlowe-dashboard-client/src/WalletData/Types.purs
+++ b/marlowe-dashboard-client/src/WalletData/Types.purs
@@ -11,10 +11,11 @@ import Prelude
 import Data.BigInteger (BigInteger)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
+import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Foreign.Class (class Encode, class Decode)
 import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
-import Marlowe.PAB (PlutusAppId)
+import Marlowe.PAB (MarloweData, MarloweParams, PlutusAppId)
 import Marlowe.Semantics (Assets, PubKey)
 
 type WalletLibrary
@@ -29,6 +30,10 @@ type WalletDetails
     , marloweAppId :: PlutusAppId
     , walletInfo :: WalletInfo
     , assets :: Assets
+    -- this property shouldn't be necessary, but at the moment we are getting too many update notifications
+    -- through the PAB - so until that bug is fixed, we use this to check whether an update notification
+    -- really has changed anything
+    , previousCompanionAppState :: Maybe (Map MarloweParams MarloweData)
     }
 
 -- this is the data that the wallet API returns when creating a wallet and when subsequently requesting


### PR DESCRIPTION
This PR makes the necessary state modifications and view tweaks to enable showing placeholders after creating a contract or submitting a transaction (which are then replaced when we receive confirmation through the PAB).

They look ugly at the moment (see screenshots below) - part 2 will be making them look nice, once we get some designs from Russ.

![localhost_8009_ (1)](https://user-images.githubusercontent.com/380759/121924164-f01b0800-cd3b-11eb-8b87-5b373e687fe2.png)

![localhost_8009_](https://user-images.githubusercontent.com/380759/121924189-f3ae8f00-cd3b-11eb-8ac1-58626a316cf9.png)
