### PR TITLE
Multiplying timeouts by 10.

### DIFF
--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -259,17 +259,17 @@ couponBondGuaranteed =
 
     const contract: Contract =
         deposit(guaranteedAmount(3n), guarantor, investor,
-            30n, Close,
+            300n, Close,
             transfer(principal, investor, issuer,
-                60n, refundGuarantor(guaranteedAmount(3n), Close),
+                600n, refundGuarantor(guaranteedAmount(3n), Close),
                 transfer(instalment, issuer, investor,
-                    90n, giveCollateralToInvestor(guaranteedAmount(3n)),
+                    900n, giveCollateralToInvestor(guaranteedAmount(3n)),
                     refundGuarantor(instalment,
                         transfer(instalment, issuer, investor,
-                            120n, giveCollateralToInvestor(guaranteedAmount(2n)),
+                            1200n, giveCollateralToInvestor(guaranteedAmount(2n)),
                             refundGuarantor(instalment,
                                 transfer(lastInstalment, issuer, investor,
-                                    150n, giveCollateralToInvestor(guaranteedAmount(1n)),
+                                    1500n, giveCollateralToInvestor(guaranteedAmount(1n)),
                                     refundGuarantor(lastInstalment,
                                         Close))))))));
 
@@ -434,11 +434,11 @@ contractForDifferences =
     }
 
     const contract: Contract =
-        initialDeposit(party, 30n, Close,
-            initialDeposit(counterparty, 60n, refund(party, deposit, Close),
-                oracleInput(priceBeginning, 90n, refundBoth,
-                    wait(150n,
-                        oracleInput(priceEnd, 180n, refundBoth,
+        initialDeposit(party, 300n, Close,
+            initialDeposit(counterparty, 600n, refund(party, deposit, Close),
+                oracleInput(priceBeginning, 900n, refundBoth,
+                    wait(1500n,
+                        oracleInput(priceEnd, 1800n, refundBoth,
                             gtLtEq(ChoiceValue(priceBeginning), ChoiceValue(priceEnd),
                                 recordDifference(decreaseInPrice, priceBeginning, priceEnd,
                                     transferUpToDeposit(counterparty, party, UseValue(decreaseInPrice),
@@ -552,11 +552,11 @@ contractForDifferencesWithOracle =
     }
 
     const contract: Contract =
-        initialDeposit(party, 30n, Close,
-            initialDeposit(counterparty, 60n, refund(party, deposit, Close),
-                oracleInput(exchangeBeginning, 90n, refundBoth,
-                    wait(150n,
-                        oracleInput(exchangeEnd, 180n, refundBoth,
+        initialDeposit(party, 300n, Close,
+            initialDeposit(counterparty, 600n, refund(party, deposit, Close),
+                oracleInput(exchangeBeginning, 900n, refundBoth,
+                    wait(1500n,
+                        oracleInput(exchangeEnd, 1800n, refundBoth,
                             recordDelta(priceEnd, exchangeBeginning, exchangeEnd,
                                 gtLtEq(priceBeginning, UseValue(priceEnd),
                                     recordDifference(decreaseInPrice, priceBeginning, UseValue(priceEnd),

--- a/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
+++ b/marlowe-playground-client/test/Marlowe/DeinstantiatorTests.purs
@@ -28,10 +28,10 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Buyer's deposit timeout" /\ fromInt 60
-                          , "Buyer's dispute timeout" /\ fromInt 180
-                          , "Seller's response timeout" /\ fromInt 240
-                          , "Timeout for arbitrage" /\ fromInt 360
+                          [ "Buyer's deposit timeout" /\ fromInt 600
+                          , "Buyer's dispute timeout" /\ fromInt 1800
+                          , "Seller's response timeout" /\ fromInt 2400
+                          , "Timeout for arbitrage" /\ fromInt 3600
                           ]
                     , valueContent:
                         Map.fromFoldable
@@ -52,11 +52,11 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Collateral deposit by seller timeout" /\ fromInt 60
-                          , "Deposit of collateral by buyer timeout" /\ fromInt 120
-                          , "Deposit of price by buyer timeout" /\ fromInt 180
-                          , "Dispute by buyer timeout" /\ fromInt 300
-                          , "Seller's response timeout" /\ fromInt 360
+                          [ "Collateral deposit by seller timeout" /\ fromInt 600
+                          , "Deposit of collateral by buyer timeout" /\ fromInt 1200
+                          , "Deposit of price by buyer timeout" /\ fromInt 1800
+                          , "Dispute by buyer timeout" /\ fromInt 3000
+                          , "Seller's response timeout" /\ fromInt 3600
                           ]
                     , valueContent:
                         Map.fromFoldable
@@ -78,8 +78,8 @@ all =
                 ( TemplateContent
                     { slotContent:
                         Map.fromFoldable
-                          [ "Initial exchange deadline" /\ fromInt 60
-                          , "Maturity exchange deadline" /\ fromInt 150
+                          [ "Initial exchange deadline" /\ fromInt 600
+                          , "Maturity exchange deadline" /\ fromInt 1500
                           ]
                     , valueContent:
                         Map.fromFoldable

--- a/marlowe-playground-server/contracts/ContractForDifferences.hs
+++ b/marlowe-playground-server/contracts/ContractForDifferences.hs
@@ -86,11 +86,11 @@ refundAfterDifference payer payee difference =
     Close
 
 contract :: Contract
-contract = initialDeposit party 30 Close
-         $ initialDeposit counterparty 60 (refund party deposit Close)
-         $ oracleInput priceBeginning 90 refundBoth
-         $ wait 150
-         $ oracleInput priceEnd 180 refundBoth
+contract = initialDeposit party 300 Close
+         $ initialDeposit counterparty 600 (refund party deposit Close)
+         $ oracleInput priceBeginning 900 refundBoth
+         $ wait 1500
+         $ oracleInput priceEnd 1800 refundBoth
          $ gtLtEq (ChoiceValue priceBeginning) (ChoiceValue priceEnd)
                   ( recordDifference decreaseInPrice priceBeginning priceEnd
                   $ transferUpToDeposit counterparty party (UseValue decreaseInPrice)

--- a/marlowe-playground-server/contracts/ContractForDifferencesWithOracle.hs
+++ b/marlowe-playground-server/contracts/ContractForDifferencesWithOracle.hs
@@ -95,11 +95,11 @@ refundAfterDifference payer payee difference =
     Close
 
 contract :: Contract
-contract = initialDeposit party 30 Close
-         $ initialDeposit counterparty 60 (refund party deposit Close)
-         $ oracleInput exchangeBeginning 90 refundBoth
-         $ wait 150
-         $ oracleInput exchangeEnd 180 refundBoth
+contract = initialDeposit party 300 Close
+         $ initialDeposit counterparty 600 (refund party deposit Close)
+         $ oracleInput exchangeBeginning 900 refundBoth
+         $ wait 1500
+         $ oracleInput exchangeEnd 1800 refundBoth
          $ recordEndPrice priceEnd exchangeBeginning exchangeEnd
          $ gtLtEq priceBeginning (UseValue priceEnd)
                   ( recordDifference decreaseInPrice priceBeginning (UseValue priceEnd)

--- a/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
+++ b/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
@@ -48,16 +48,16 @@ giveCollateralToInvestor amount
 
 contract :: Contract
 contract = deposit (guaranteedAmount 3) guarantor investor
-                   30 Close
+                   300 Close
          $ transfer principal investor issuer
-                    60 (refundGuarantor (guaranteedAmount 3) Close)
+                    600 (refundGuarantor (guaranteedAmount 3) Close)
          $ transfer instalment issuer investor
-                    90 (giveCollateralToInvestor $ guaranteedAmount 3)
+                    900 (giveCollateralToInvestor $ guaranteedAmount 3)
          $ refundGuarantor instalment
          $ transfer instalment issuer investor
-                    120 (giveCollateralToInvestor $ guaranteedAmount 2)
+                    1200 (giveCollateralToInvestor $ guaranteedAmount 2)
          $ refundGuarantor instalment
          $ transfer lastInstalment issuer investor
-                    150 (giveCollateralToInvestor $ guaranteedAmount 1)
+                    1500 (giveCollateralToInvestor $ guaranteedAmount 1)
          $ refundGuarantor lastInstalment
            Close

--- a/web-common-marlowe/src/Examples/PureScript/ContractForDifferences.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ContractForDifferences.purs
@@ -79,11 +79,11 @@ transferUpToDeposit from to amount = Pay from (Account to) ada (Cond (ValueLT am
 
 extendedContract :: Contract
 extendedContract =
-  initialDeposit party (Slot $ fromInt 30) Close
-    $ initialDeposit counterparty (Slot $ fromInt 60) Close
-    $ oracleInput priceBeginning (Slot $ fromInt 90) Close
-    $ wait (Slot $ fromInt 150)
-    $ oracleInput priceEnd (Slot $ fromInt 180) Close
+  initialDeposit party (Slot $ fromInt 300) Close
+    $ initialDeposit counterparty (Slot $ fromInt 600) Close
+    $ oracleInput priceBeginning (Slot $ fromInt 900) Close
+    $ wait (Slot $ fromInt 1500)
+    $ oracleInput priceEnd (Slot $ fromInt 1800) Close
     $ gtLtEq (ChoiceValue priceBeginning) (ChoiceValue priceEnd)
         ( recordDifference decreaseInPrice priceBeginning priceEnd
             $ transferUpToDeposit counterparty party (UseValue decreaseInPrice)

--- a/web-common-marlowe/src/Examples/PureScript/ContractForDifferencesWithOracle.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ContractForDifferencesWithOracle.purs
@@ -88,11 +88,11 @@ transferUpToDeposit from to amount = Pay from (Account to) ada (Cond (ValueLT am
 
 extendedContract :: Contract
 extendedContract =
-  initialDeposit party (Slot $ fromInt 30) Close
-    $ initialDeposit counterparty (Slot $ fromInt 60) Close
-    $ oracleInput exchangeBeginning (Slot $ fromInt 90) Close
-    $ wait (Slot $ fromInt 150)
-    $ oracleInput exchangeEnd (Slot $ fromInt 180) Close
+  initialDeposit party (Slot $ fromInt 300) Close
+    $ initialDeposit counterparty (Slot $ fromInt 600) Close
+    $ oracleInput exchangeBeginning (Slot $ fromInt 900) Close
+    $ wait (Slot $ fromInt 1500)
+    $ oracleInput exchangeEnd (Slot $ fromInt 1800) Close
     $ recordEndPrice priceEnd exchangeBeginning exchangeEnd
     $ gtLtEq priceBeginning (UseValue priceEnd)
         ( recordDifference decreaseInPrice priceBeginning (UseValue priceEnd)

--- a/web-common-marlowe/src/Examples/PureScript/CouponBondGuaranteed.purs
+++ b/web-common-marlowe/src/Examples/PureScript/CouponBondGuaranteed.purs
@@ -59,21 +59,21 @@ transfer amount from to timeout timeoutContinuation continuation =
 extendedContract :: Contract
 extendedContract =
   deposit (guaranteedAmount (fromInt 3)) guarantor investor
-    (Slot $ fromInt 30)
+    (Slot $ fromInt 300)
     Close
     $ transfer principal investor issuer
-        (Slot $ fromInt 60)
+        (Slot $ fromInt 600)
         (refundGuarantor (guaranteedAmount (fromInt 3)) Close)
     $ transfer instalment issuer investor
-        (Slot $ fromInt 90)
+        (Slot $ fromInt 900)
         Close
     $ refundGuarantor instalment
     $ transfer instalment issuer investor
-        (Slot $ fromInt 120)
+        (Slot $ fromInt 1200)
         Close
     $ refundGuarantor instalment
     $ transfer lastInstalment issuer investor
-        (Slot $ fromInt 150)
+        (Slot $ fromInt 1500)
         Close
     $ refundGuarantor lastInstalment
         Close

--- a/web-common-marlowe/src/Examples/PureScript/Escrow.purs
+++ b/web-common-marlowe/src/Examples/PureScript/Escrow.purs
@@ -24,10 +24,10 @@ fixedTimeoutContract =
     ( TemplateContent
         { slotContent:
             Map.fromFoldable
-              [ "Buyer's deposit timeout" /\ fromInt 60
-              , "Buyer's dispute timeout" /\ fromInt 180
-              , "Seller's response timeout" /\ fromInt 240
-              , "Timeout for arbitrage" /\ fromInt 360
+              [ "Buyer's deposit timeout" /\ fromInt 600
+              , "Buyer's dispute timeout" /\ fromInt 1800
+              , "Seller's response timeout" /\ fromInt 2400
+              , "Timeout for arbitrage" /\ fromInt 3600
               ]
         , valueContent: Map.empty
         }

--- a/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
+++ b/web-common-marlowe/src/Examples/PureScript/EscrowWithCollateral.purs
@@ -24,11 +24,11 @@ fixedTimeoutContract =
     ( TemplateContent
         { slotContent:
             Map.fromFoldable
-              [ "Collateral deposit by seller timeout" /\ fromInt 60
-              , "Deposit of collateral by buyer timeout" /\ fromInt 120
-              , "Deposit of price by buyer timeout" /\ fromInt 180
-              , "Dispute by buyer timeout" /\ fromInt 300
-              , "Seller's response timeout" /\ fromInt 360
+              [ "Collateral deposit by seller timeout" /\ fromInt 600
+              , "Deposit of collateral by buyer timeout" /\ fromInt 1200
+              , "Deposit of price by buyer timeout" /\ fromInt 1800
+              , "Dispute by buyer timeout" /\ fromInt 3000
+              , "Seller's response timeout" /\ fromInt 3600
               ]
         , valueContent: Map.empty
         }

--- a/web-common-marlowe/src/Examples/PureScript/Swap.purs
+++ b/web-common-marlowe/src/Examples/PureScript/Swap.purs
@@ -24,8 +24,8 @@ fixedTimeoutContract =
     ( TemplateContent
         { slotContent:
             Map.fromFoldable
-              [ "Timeout for Ada deposit" /\ fromInt 60
-              , "Timeout for dollar deposit" /\ fromInt 120
+              [ "Timeout for Ada deposit" /\ fromInt 600
+              , "Timeout for dollar deposit" /\ fromInt 1200
               ]
         , valueContent:
             Map.empty

--- a/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ZeroCouponBond.purs
@@ -24,8 +24,8 @@ fixedTimeoutContract =
     ( TemplateContent
         { slotContent:
             Map.fromFoldable
-              [ "Initial exchange deadline" /\ fromInt 60
-              , "Maturity exchange deadline" /\ fromInt 150
+              [ "Initial exchange deadline" /\ fromInt 600
+              , "Maturity exchange deadline" /\ fromInt 1500
               ]
         , valueContent:
             Map.empty


### PR DESCRIPTION
This PR multiplies all timeouts in the example contracts by 10. They were all quite short before, and Russ said this was making users nervous in testing. We'll proabably want to think about the numbers more carefully later, but I'm pushing this through for now because there's more testing later today.