### PR TITLE
Fixing a contract step card scrolling display bug.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -236,7 +236,7 @@ renderContractCard stepNumber state currentTab cardBody =
       --       so the perceived margins are bigger than we'd want to. To solve this we add negative margin of 4
       --       to the "not selected" cards, a positive margin of 2 to the selected one
       -- Base classes
-      [ "rounded", "overflow-hidden", "flex-shrink-0", "w-contract-card", "h-contract-card", "transform", "transition-transform", "duration-100", "ease-out" ]
+      [ "grid", "grid-rows-contract-step-card", "rounded", "overflow-hidden", "flex-shrink-0", "w-contract-card", "h-contract-card", "transform", "transition-transform", "duration-100", "ease-out" ]
         <> toggleWhen (state ^. _selectedStep /= stepNumber)
             -- Not selected card modifiers
             [ "shadow", "scale-77", "-mx-4" ]
@@ -244,7 +244,7 @@ renderContractCard stepNumber state currentTab cardBody =
             [ "shadow-lg", "mx-2" ]
   in
     div [ classNames contractCardCss ]
-      [ div [ classNames [ "flex", "overflow-hidden" ] ]
+      [ div [ classNames [ "flex" ] ]
           [ a
               [ classNames (tabSelector $ currentTab == Tasks)
               , onClick_ $ SelectTab stepNumber Tasks
@@ -256,7 +256,7 @@ renderContractCard stepNumber state currentTab cardBody =
               ]
               [ span_ $ [ text "Balances" ] ]
           ]
-      , div [ classNames [ "bg-white", "h-full" ] ] cardBody
+      , div [ classNames [ "bg-white", "grid", "grid-rows-contract-step-card" ] ] cardBody
       ]
 
 statusIndicator :: forall p a. Maybe Icon -> String -> Array String -> HTML p a
@@ -288,7 +288,7 @@ renderPastStep state stepNumber step =
               TimeoutStep _ -> statusIndicator (Just Timer) "Timed out" [ "bg-red", "text-white" ]
               TransactionStep _ -> statusIndicator (Just Done) "Completed" [ "bg-green", "text-white" ]
           ]
-      , div [ classNames [ "overflow-y-auto", "px-4", "h-full" ] ]
+      , div [ classNames [ "overflow-y-auto", "px-4" ] ]
           [ renderBody currentTab step
           ]
       ]
@@ -379,7 +379,7 @@ renderTimeout stepNumber timeoutSlot =
         (\dt -> formatDate dt <> " at " <> formatTime dt)
         (slotToDateTime timeoutSlot)
   in
-    div [ classNames [ "flex", "flex-col", "items-center", "h-full" ] ]
+    div [ classNames [ "flex", "flex-col", "items-center" ] ]
       -- NOTE: we use pt-16 instead of making the parent justify-center because in the design it's not actually
       --       centered and it has more space above than below.
       [ icon Timer [ "pb-2", "pt-16", "text-red", "text-big-icon" ]
@@ -419,7 +419,7 @@ renderCurrentStep currentSlot state =
             else
               statusIndicator (Just Timer) timeoutStr [ "bg-lightgray" ]
           ]
-      , div [ classNames [ "overflow-y-auto", "px-4", "h-full" ] ]
+      , div [ classNames [ "overflow-y-auto", "px-4" ] ]
           [ case currentTab /\ contractIsClosed of
               Tasks /\ false -> renderTasks state
               Tasks /\ true -> renderContractClose
@@ -429,7 +429,7 @@ renderCurrentStep currentSlot state =
 
 renderContractClose :: forall p a. HTML p a
 renderContractClose =
-  div [ classNames [ "flex", "flex-col", "items-center", "h-full" ] ]
+  div [ classNames [ "flex", "flex-col", "items-center" ] ]
     -- NOTE: we use pt-16 instead of making the parent justify-center because in the design it's not actually
     --       centered and it has more space above than below.
     [ icon TaskAlt [ "pb-2", "pt-16", "text-green", "text-big-icon" ]

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -77,6 +77,7 @@ module.exports = {
       gridTemplateRows: {
         main: "auto minmax(0, 1fr) auto",
         "contract-setup": "auto auto minmax(0, 1fr)",
+        "contract-step-card": "auto minmax(0, 1fr)",
       },
       gridTemplateColumns: {
         "2-contract-home-card": "repeat(2, minmax(240px, 1fr))",


### PR DESCRIPTION
I just noticed a scrolling display bug arising from the use of `h-full` setting the height of an element to the full height of its parent, when it should be the full *remaining* height of the parent (not including the previous children). This PR fixes it, thanks to the magic of the grid layout. :mage: 

Before (you can't scroll down any further than this):
![localhost_8009_](https://user-images.githubusercontent.com/380759/122062357-a1c74100-cdef-11eb-9854-46624223b9e3.png)

After:
![localhost_8009_ (1)](https://user-images.githubusercontent.com/380759/122062388-a855b880-cdef-11eb-9fa8-c5b6debc15de.png)
