### PR TITLE
devcontainer - Ensure ~/.cabal/packages exists with ownership

### DIFF
--- a/nix/devcontainer/devcontainer.nix
+++ b/nix/devcontainer/devcontainer.nix
@@ -111,7 +111,7 @@ let
       # and because docker won't let us map a volume not as root
       # (see: https://github.com/moby/moby/issues/2259 link), we have to make the
       # folder first and chown it ...
-      mkdir /home/${nonRootUser}/.cabal
+      mkdir -p /home/${nonRootUser}/.cabal/packages
 
       chown -R ${nonRootUser}:${nonRootUser} /home/${nonRootUser}
     '';


### PR DESCRIPTION
This is needed for people who ( 😱 ) don't have a ~/.cabal folder yet.

Very uncontroversial change; but I'll release a new devcontainer image once it's merged.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
