### PR TITLE
SCP-2375: Kwxm/rescale ledger costs

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -140,6 +140,7 @@ module PlutusCore.Evaluation.Machine.ExBudget
     , ExBudgetBuiltin(..)
     , ExRestrictingBudget(..)
     , enormousBudget
+    , multiplyBudget
     )
 where
 
@@ -178,12 +179,22 @@ instance Semigroup ExBudget where
 instance Monoid ExBudget where
     mempty = ExBudget mempty mempty
 
+{- | Make budgets scalable.  We only want to scale the cpu costs because they're
+   in picoseconds, which are too big for general use.  Memory costs are in
+   bytes, which don't require scaling. -}
+instance Scalable ExBudget where
+    scaleUp   k (ExBudget cpu mem) = ExBudget (scaleUp   k cpu) mem
+    scaleDown k (ExBudget cpu mem) = ExBudget (scaleDown k cpu) mem
+
 instance Pretty ExBudget where
     pretty (ExBudget cpu memory) = parens $ fold
         [ "{ cpu: ", pretty cpu, line
         , "| mem: ", pretty memory, line
         , "}"
         ]
+
+multiplyBudget :: CostingInteger -> ExBudget -> ExBudget
+multiplyBudget k (ExBudget cpu mem) = ExBudget (stimes k cpu) (stimes k mem)
 
 newtype ExRestrictingBudget = ExRestrictingBudget
     { unExRestrictingBudget :: ExBudget

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -140,7 +140,6 @@ module PlutusCore.Evaluation.Machine.ExBudget
     , ExBudgetBuiltin(..)
     , ExRestrictingBudget(..)
     , enormousBudget
-    , multiplyBudget
     )
 where
 
@@ -192,9 +191,6 @@ instance Pretty ExBudget where
         , "| mem: ", pretty memory, line
         , "}"
         ]
-
-multiplyBudget :: CostingInteger -> ExBudget -> ExBudget
-multiplyBudget k (ExBudget cpu mem) = ExBudget (stimes k cpu) (stimes k mem)
 
 newtype ExRestrictingBudget = ExRestrictingBudget
     { unExRestrictingBudget :: ExBudget

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -111,14 +111,23 @@ a `upperIntegerQuotient` b =
     in if r==0 then q else q+1
 
 {- | A class which allows us to scale budget-related quantities upwards and
-   downwards by a given factor. -}
+downwards by a strictly positive integer factor.  The operations are NOT
+required to be mutually inverse: in the instances for costing integers we
+always have `scaleDown k . scaleUp k = id`, but `scaleDown` loses information
+and so we don't have `scaleUp k (scaleDown k c) = c`; instead (and by design)
+we have `c <= scaleUp k (scaleDown k c) <= c+k` for all c and for all k > 0. -}
 class Scalable a where
     scaleUp   :: Integer -> a -> a
     scaleDown :: Integer -> a -> a
 
+checkPositive :: Integer -> a -> a
+checkPositive k r =
+    if k > 0 then r
+    else error $ "Scalable: strictly positive scale factor expected, but found " ++ show k
+
 instance Scalable CostingInteger where
-    scaleUp k n = (fromInteger k) * n
-    scaleDown k n = n `upperIntegerQuotient` (fromInteger k)
+    scaleUp   k c = checkPositive k $ (fromInteger k) * c
+    scaleDown k c = checkPositive k $ c `upperIntegerQuotient` (fromInteger k)
 
 -- | Counts size in machine words.
 newtype ExMemory = ExMemory CostingInteger

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -13,7 +13,7 @@ module PlutusCore.Evaluation.Machine.ExMemory
 , ExCPU(..)
 , GenericExMemoryUsage(..)
 , ExMemoryUsage(..)
-, uppperIntegerQuotient
+, uppperIntegerQuotient  -- Exported for testing
 , Scalable (..)
 ) where
 
@@ -105,7 +105,7 @@ real units we want that to be converted to 12346 ledger units, since 12345 (as
 given by `div`) would convert to 12345000 real units, which wouldn't be enough
 to run the script.  We want a <= (a `uppperIntegerQuotient` b) * b < a+b for all
 a and for all b>0, except that we may get '==' instead of '<' when we're using
-SatInt and a+b == MaxBound.
+SatInt and a+b == MaxBound.  The behaviour when b <= 0 is unspecified.
 -}
 uppperIntegerQuotient :: CostingInteger -> CostingInteger -> CostingInteger
 a `uppperIntegerQuotient` b =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -13,7 +13,7 @@ module PlutusCore.Evaluation.Machine.ExMemory
 , ExCPU(..)
 , GenericExMemoryUsage(..)
 , ExMemoryUsage(..)
-, uppperIntegerQuotient  -- Exported for testing
+, upperIntegerQuotient  -- Exported for testing
 , Scalable (..)
 ) where
 
@@ -96,8 +96,6 @@ type CostingInteger =
     SatInt
 #endif
 
--- $(if finiteBitSize (0::SatInt) < 64 then [t|Integer|] else [t|SatInt|])
-
 {- | Divide one costing integer by another, "rounding upwards".  This is needed
 when we expose costs to the ledger, which will use different (smaller) units.
 Suppose one ledger unit is 1000 real cost units: then if a script costs 12345678
@@ -107,8 +105,8 @@ to run the script.  We want a <= (a `uppperIntegerQuotient` b) * b < a+b for all
 a and for all b>0, except that we may get '==' instead of '<' when we're using
 SatInt and a+b == MaxBound.  The behaviour when b <= 0 is unspecified.
 -}
-uppperIntegerQuotient :: CostingInteger -> CostingInteger -> CostingInteger
-a `uppperIntegerQuotient` b =
+upperIntegerQuotient :: CostingInteger -> CostingInteger -> CostingInteger
+a `upperIntegerQuotient` b =
     let (q,r) = a `divMod` b
     in if r==0 then q else q+1
 
@@ -120,12 +118,12 @@ class Scalable a where
 
 instance Scalable CostingInteger where
     scaleUp k n = (fromInteger k) * n
-    scaleDown k n = n `uppperIntegerQuotient` (fromInteger k)
+    scaleDown k n = n `upperIntegerQuotient` (fromInteger k)
 
 -- | Counts size in machine words.
 newtype ExMemory = ExMemory CostingInteger
   deriving (Eq, Ord, Show, Lift)
-  deriving newtype (Num, NFData, Scalable)
+  deriving newtype (Num, NFData)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
 instance Pretty ExMemory where

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -198,8 +198,10 @@ propDivideUpwards = withTests 10000 . property $ do
     else do
       let d = a `divideUpwards` b
       Hedgehog.assert $ a <= d*b
-      Hedgehog.assert $ d*b <= a+b  -- We really want <, but that can fail at maxBound, eg if a=maxBound, b=1
+      Hedgehog.assert $ d*b == m || d*b < a+b
+      -- We really want <, but that can fail at maxBound, eg if a=maxBound and b=1
     where r = Range.linearBounded :: Range Int64
+          m = fromIntegral (maxBound :: Int64)
 
 propRename :: Property
 propRename = property $ do

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -185,21 +185,20 @@ propParser = property $ do
     Hedgehog.tripping prog (reprint . unTextualProgram)
                 (\p -> fmap (TextualProgram . void) $ runQuote $ runExceptT $ parseProgram @(DefaultError AlexPosn) p)
 
-
--- | Check that the `divideUpwards` function behaves sensibly.  This operates on
--- CostingIntegers (which are either SatInt or Integer), so we have to be a
--- little careful to use a generator which works for both and includes the
--- SatInt upper bound.
+-- | Check that the `uppperIntegerQuotient` function behaves sensibly.  This
+-- operates on CostingIntegers (which are either SatInt or Integer), so we have
+-- to be a little careful to use a generator which works for both and includes
+-- the SatInt upper bound.
 propDivideUpwards :: Property
-propDivideUpwards = withTests 10000 . property $ do
+propDivideUpwards = withTests 1000000 . property $ do  -- REDUCE THE LIMIT FOR THE REAL TEST
     a <- forAll $ fromIntegral <$> Gen.integral r
     b <- forAll $ fromIntegral <$> Gen.integral r
     if b <= 0 then success  -- What behaviour do we want if b < 0?
     else do
       let d = a `divideUpwards` b
       Hedgehog.assert $ a <= d*b
-      Hedgehog.assert $ d*b == m || d*b < a+b
-      -- We really want <, but that can fail at maxBound, eg if a=maxBound and b=1
+      Hedgehog.assert $ d*b < a+b || a+b == m  -- or d*b == m?
+      -- We really want <, but that can fail for large a, eg if a=maxBound and b=1
     where r = Range.linearBounded :: Range Int64
           m = fromIntegral (maxBound :: Int64)
 

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -194,7 +194,7 @@ propUpperIntegerQuotient = withTests 100000 . property $ do
     a <- forAll $ fromIntegral <$> Gen.choice [uniform, small, largePositive, largeNegative]
     b <- forAll $ fromIntegral <$> Gen.choice [uniformPositive, smallPositive, largePositive]
     -- ^ The behaviour isn't specified for b<=0, so we only check strictly positive b.
-    let d = a `uppperIntegerQuotient` b
+    let d = a `upperIntegerQuotient` b
     Hedgehog.assert $ a <= d*b
     Hedgehog.assert $ d*b < a+b || a+b == fromIntegral max64
       -- We really want <, but that can fail for large a with SatInt, eg if a=maxBound and b=1.

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -120,13 +120,13 @@ internally. That means we don't lose anything by exposing all the details: we're
 anything, we're just going to create new versions.
 -}
 
-{- | Internally the evaluator uses costs which approximate execution times
-in picoseconds.  This gives huge numbers which are unsuitable for users
-so we expose microsecond-based costs to the ledger and scale them up and
-down to and from picoseconds for internal use.  The maximum possible cost
-from the viewpoint of the ledger will be 9223372036855 units. -}
+{- | Internally the evaluator uses costs which approximate execution times in
+picoseconds.  This gives huge numbers which are unsuitable for users so we
+expose nanosecond-based costs to the ledger and scale them up and down to and
+from picoseconds for internal use.  The maximum possible cost from the viewpoint
+of the ledger will be 9223372036854776 units. -}
 costScaleFactor :: Integer
-costScaleFactor = 1000 * 1000
+costScaleFactor = 1000
 
 -- | Check if a 'Script' is "valid". At the moment this just means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and cannot be interpreted as some other kind of encoded data.

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -92,7 +92,7 @@ import qualified PlutusCore.DeBruijn                              as PLC
 import           PlutusCore.Evaluation.Machine.CostModelInterface (CostModelParams, applyCostModelParams)
 import           PlutusCore.Evaluation.Machine.ExBudget           (ExBudget (..))
 import qualified PlutusCore.Evaluation.Machine.ExBudget           as PLC
-import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..))
+import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..), Scalable (..))
 import           PlutusCore.Evaluation.Machine.MachineParameters
 import qualified PlutusCore.MkPlc                                 as PLC
 import           PlutusCore.Pretty
@@ -119,6 +119,13 @@ So we're going to end up with multiple versions of the types and functions that 
 internally. That means we don't lose anything by exposing all the details: we're never going to remove
 anything, we're just going to create new versions.
 -}
+
+{- | Internally the evaluator uses costs which approximate execution times
+in picoseconds.  This gives huge numbers which are unsuitable for users
+so we expose microsecond-based costs to the ledger and scale them up and
+down to and from picoseconds for internal use. -}
+costScaleFactor :: Integer
+costScaleFactor = 1000 * 1000
 
 -- | Check if a 'Script' is "valid". At the moment this just means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and cannot be interpreted as some other kind of encoded data.
@@ -185,7 +192,7 @@ evaluateScriptRestricting verbose cmdata budget p args = swap $ runWriter @LogOu
     let (res, _, logs) =
             UPLC.runCek
                 (toMachineParameters model)
-                (UPLC.restricting $ PLC.ExRestrictingBudget budget)
+                (UPLC.restricting $ PLC.ExRestrictingBudget (scaleUp costScaleFactor budget))
                 (verbose == Verbose)
                 appliedTerm
 
@@ -215,4 +222,4 @@ evaluateScriptCounting verbose cmdata p args = swap $ runWriter @LogOutput $ run
 
     tell $ Prelude.map Text.pack logs
     liftEither $ first CekError $ void res
-    pure final
+    pure $ scaleDown costScaleFactor final

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -123,7 +123,8 @@ anything, we're just going to create new versions.
 {- | Internally the evaluator uses costs which approximate execution times
 in picoseconds.  This gives huge numbers which are unsuitable for users
 so we expose microsecond-based costs to the ledger and scale them up and
-down to and from picoseconds for internal use. -}
+down to and from picoseconds for internal use.  The maximum possible cost
+from the viewpoint of the ledger will be 9223372036855 units. -}
 costScaleFactor :: Integer
 costScaleFactor = 1000 * 1000
 


### PR DESCRIPTION
This rescales costs as seen by the ledger by a factor of ~10^6~ 10^3, shifting them into ~microseconds~ nanoesconds.  For the validation benchmarks reported [here](https://github.com/input-output-hk/plutus/pull/3378#issuecomment-861749038) that gives cpu costs roughly in the range 500,000 - 4,000,000 (microseconds gives 500-4,000 which is maybe a bit too coarse). We could divide by another 10 or 100 to get smaller numbers but that might get a bit confusing when trying to compare costs with times.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
