### PR TITLE
SCP 2384 - Implement custom dropdowns everywhere.

### DIFF
--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -13,6 +13,7 @@ module Css
   , input
   , inputNoFocus
   , inputCard
+  , inputCardNoFocus
   , inputError
   , hasNestedLabel
   , nestedLabel
@@ -120,6 +121,9 @@ withNestedLabel = [ "border", "border-gray", "focus:border-gray" ]
 inputCard :: Boolean -> Array String
 inputCard invalid = inputBaseFocus <> toggleWhen invalid [ "border-red" ] [ "border-transparent" ]
 
+inputCardNoFocus :: Boolean -> Array String
+inputCardNoFocus invalid = inputBaseNoFocus <> toggleWhen invalid [ "border-red" ] [ "border-transparent" ]
+
 inputError :: Array String
 inputError = [ "px-3", "mt-1", "text-red", "text-sm" ]
 
@@ -127,7 +131,7 @@ hasNestedLabel :: Array String
 hasNestedLabel = [ "-mt-4" ]
 
 nestedLabel :: Array String
-nestedLabel = [ "relative", "left-2", "top-2.5", "px-1", "bg-white", "text-xs", "font-semibold" ]
+nestedLabel = [ "relative", "z-10", "left-2", "top-2.5", "px-1", "bg-white", "text-xs", "font-semibold" ]
 
 --- cards
 overlay :: Boolean -> Array String

--- a/marlowe-dashboard-client/src/InputField/Lenses.purs
+++ b/marlowe-dashboard-client/src/InputField/Lenses.purs
@@ -3,6 +3,7 @@ module InputField.Lenses
   , _pristine
   , _validator
   , _dropdownOpen
+  , _dropdownLocked
   , _baseCss
   , _additionalCss
   , _id_
@@ -29,6 +30,9 @@ _validator = prop (SProxy :: SProxy "validator")
 
 _dropdownOpen :: forall e. Lens' (State e) Boolean
 _dropdownOpen = prop (SProxy :: SProxy "dropdownOpen")
+
+_dropdownLocked :: forall e. Lens' (State e) Boolean
+_dropdownLocked = prop (SProxy :: SProxy "dropdownLocked")
 
 ------------------------------------------------------------
 _baseCss :: Lens' InputDisplayOptions (Boolean -> Array String)

--- a/marlowe-dashboard-client/src/InputField/Lenses.purs
+++ b/marlowe-dashboard-client/src/InputField/Lenses.purs
@@ -9,7 +9,6 @@ module InputField.Lenses
   , _id_
   , _placeholder
   , _readOnly
-  , _datalistId
   , _valueOptions
   ) where
 
@@ -49,9 +48,6 @@ _placeholder = prop (SProxy :: SProxy "placeholder")
 
 _readOnly :: Lens' InputDisplayOptions Boolean
 _readOnly = prop (SProxy :: SProxy "readOnly")
-
-_datalistId :: Lens' InputDisplayOptions (Maybe String)
-_datalistId = prop (SProxy :: SProxy "datalistId")
 
 _valueOptions :: Lens' InputDisplayOptions (Array String)
 _valueOptions = prop (SProxy :: SProxy "valueOptions")

--- a/marlowe-dashboard-client/src/InputField/Lenses.purs
+++ b/marlowe-dashboard-client/src/InputField/Lenses.purs
@@ -2,12 +2,14 @@ module InputField.Lenses
   ( _value
   , _pristine
   , _validator
+  , _dropdownOpen
   , _baseCss
   , _additionalCss
   , _id_
   , _placeholder
   , _readOnly
   , _datalistId
+  , _valueOptions
   ) where
 
 import Data.Lens (Lens')
@@ -24,6 +26,9 @@ _pristine = prop (SProxy :: SProxy "pristine")
 
 _validator :: forall e. Lens' (State e) (String -> Maybe e)
 _validator = prop (SProxy :: SProxy "validator")
+
+_dropdownOpen :: forall e. Lens' (State e) Boolean
+_dropdownOpen = prop (SProxy :: SProxy "dropdownOpen")
 
 ------------------------------------------------------------
 _baseCss :: Lens' InputDisplayOptions (Boolean -> Array String)
@@ -43,3 +48,6 @@ _readOnly = prop (SProxy :: SProxy "readOnly")
 
 _datalistId :: Lens' InputDisplayOptions (Maybe String)
 _datalistId = prop (SProxy :: SProxy "datalistId")
+
+_valueOptions :: Lens' InputDisplayOptions (Array String)
+_valueOptions = prop (SProxy :: SProxy "valueOptions")

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -12,7 +12,7 @@ import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, modify_)
-import InputField.Lenses (_dropdownOpen, _pristine, _validator, _value)
+import InputField.Lenses (_dropdownLocked, _dropdownOpen, _pristine, _validator, _value)
 import InputField.Types (class InputFieldError, Action(..), State)
 
 -- see note [dummyState] in MainFrame.State
@@ -25,6 +25,7 @@ initialState =
   , pristine: true
   , validator: const Nothing
   , dropdownOpen: false
+  , dropdownLocked: false
   }
 
 handleAction ::
@@ -38,9 +39,15 @@ handleAction (SetValue value) =
     $ set _value value
     <<< set _pristine false
 
+handleAction (SetValueFromDropdown value) = do
+  handleAction $ SetValue value
+  assign _dropdownOpen false
+
 handleAction (SetValidator validator) = assign _validator validator
 
 handleAction (SetDropdownOpen dropdownOpen) = assign _dropdownOpen dropdownOpen
+
+handleAction (SetDropdownLocked dropdownLocked) = assign _dropdownLocked dropdownLocked
 
 handleAction Reset =
   modify_

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -12,7 +12,7 @@ import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, modify_)
-import InputField.Lenses (_pristine, _validator, _value)
+import InputField.Lenses (_dropdownOpen, _pristine, _validator, _value)
 import InputField.Types (class InputFieldError, Action(..), State)
 
 -- see note [dummyState] in MainFrame.State
@@ -24,6 +24,7 @@ initialState =
   { value: mempty
   , pristine: true
   , validator: const Nothing
+  , dropdownOpen: false
   }
 
 handleAction ::
@@ -39,11 +40,14 @@ handleAction (SetValue value) =
 
 handleAction (SetValidator validator) = assign _validator validator
 
+handleAction (SetDropdownOpen dropdownOpen) = assign _dropdownOpen dropdownOpen
+
 handleAction Reset =
   modify_
     $ set _value mempty
     <<< set _pristine true
     <<< set _validator (const Nothing)
+    <<< set _dropdownOpen false
 
 validate :: forall e. InputFieldError e => State e -> Maybe e
 validate state =

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -34,7 +34,6 @@ type InputDisplayOptions
     , id_ :: String
     , placeholder :: String
     , readOnly :: Boolean
-    , datalistId :: Maybe String
     , valueOptions :: Array String
     }
 

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -14,6 +14,15 @@ type State error
     , pristine :: Boolean
     , validator :: String -> Maybe error
     , dropdownOpen :: Boolean
+    -- This is a bit fiddly. We want the dropdown to close when the input element loses focus (onBlur).
+    -- But when we click on a valueOption in the dropdown, we want to set the value to that option, and
+    -- initially I couldn't get this to work because the onBlur event listener was getting in the way.
+    -- There might be a more idiomatic solution with stopPropagation, but I tried a few things with that
+    -- and nothing seemed to work. In the end I added this flag, which is set to true onMouseEnter for
+    -- the dropdown (and false again onMouseLeave) - and if it's true, we shortcircuit the onBlur (and
+    -- the handler for SetValueFromDropdown closes the dropdown instead). Maybe not the nicest solution,
+    -- but it works.
+    , dropdownLocked :: Boolean
     }
 
 class InputFieldError e where
@@ -31,14 +40,18 @@ type InputDisplayOptions
 
 data Action error
   = SetValue String
+  | SetValueFromDropdown String
   | SetValidator (String -> Maybe error)
   | SetDropdownOpen Boolean
+  | SetDropdownLocked Boolean
   | Reset
 
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
 instance actionIsEvent :: IsEvent (Action e) where
   toEvent (SetValue _) = Nothing
+  toEvent (SetValueFromDropdown _) = Nothing
   toEvent (SetValidator _) = Nothing
   toEvent (SetDropdownOpen _) = Nothing
+  toEvent (SetDropdownLocked _) = Nothing
   toEvent Reset = Nothing

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -13,6 +13,7 @@ type State error
   = { value :: String
     , pristine :: Boolean
     , validator :: String -> Maybe error
+    , dropdownOpen :: Boolean
     }
 
 class InputFieldError e where
@@ -25,11 +26,13 @@ type InputDisplayOptions
     , placeholder :: String
     , readOnly :: Boolean
     , datalistId :: Maybe String
+    , valueOptions :: Array String
     }
 
 data Action error
   = SetValue String
   | SetValidator (String -> Maybe error)
+  | SetDropdownOpen Boolean
   | Reset
 
 -- | Here we decide which top-level queries to track as GA events, and
@@ -37,4 +40,5 @@ data Action error
 instance actionIsEvent :: IsEvent (Action e) where
   toEvent (SetValue _) = Nothing
   toEvent (SetValidator _) = Nothing
+  toEvent (SetDropdownOpen _) = Nothing
   toEvent Reset = Nothing

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -1,15 +1,17 @@
 module InputField.View (renderInput) where
 
 import Prelude hiding (div)
-import Css (classNames)
+import Css (classNames, hideWhen)
 import Css as Css
+import Data.Array (filter)
 import Data.Foldable (foldMap)
 import Data.Lens (view)
 import Data.Maybe (isJust)
-import Halogen.HTML (HTML, div, div_, input, text)
-import Halogen.HTML.Events.Extra (onValueInput_)
+import Data.String (Pattern(..), contains, toLower)
+import Halogen.HTML (HTML, a, div, input, text)
+import Halogen.HTML.Events.Extra (onClick_, onFocus_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), autocomplete, list, id_, placeholder, readOnly, type_, value)
-import InputField.Lenses (_additionalCss, _baseCss, _datalistId, _id_, _placeholder, _pristine, _readOnly, _value)
+import InputField.Lenses (_additionalCss, _baseCss, _datalistId, _dropdownOpen, _id_, _placeholder, _pristine, _readOnly, _value, _valueOptions)
 import InputField.State (validate)
 import InputField.Types (class InputFieldError, Action(..), InputDisplayOptions, State, inputErrorToString)
 
@@ -18,7 +20,11 @@ renderInput state options =
   let
     mError = validate state
 
+    currentValue = view _value state
+
     pristine = view _pristine state
+
+    dropdownOpen = view _dropdownOpen state
 
     showError = not pristine && isJust mError
 
@@ -27,20 +33,42 @@ renderInput state options =
     additionalCss = view _additionalCss options
 
     mDatalistId = view _datalistId options
+
+    valueOptions = view _valueOptions options
+
+    matchingValueOptions = filter (\v -> contains (Pattern $ toLower currentValue) (toLower $ v)) valueOptions
   in
-    div_
+    div
+      [ classNames [ "relative" ] ]
       [ input
           $ [ type_ InputText
             , classNames $ (baseCss showError) <> additionalCss
             , id_ $ view _id_ options
             , placeholder $ view _placeholder options
-            , value $ view _value state
+            , value currentValue
             , readOnly $ view _readOnly options
             , autocomplete false
             , onValueInput_ SetValue
             ]
-          <> foldMap (\datalistId -> [ list datalistId ]) mDatalistId
+          <> if valueOptions /= mempty then
+              [ autocomplete false, onFocus_ $ SetDropdownOpen true ]
+            else
+              []
+                <> foldMap (\datalistId -> [ list datalistId ]) mDatalistId
+      , div
+          [ classNames
+              $ [ "absolute", "z-10", "w-full", "max-h-56", "overflow-x-hidden", "overflow-y-scroll", "-mt-2", "pt-2", "bg-white", "shadow", "rounded-b" ]
+              <> (hideWhen $ not dropdownOpen || matchingValueOptions /= mempty)
+          ]
+          (valueOptionsList <$> matchingValueOptions)
       , div
           [ classNames Css.inputError ]
           [ text if showError then foldMap inputErrorToString mError else mempty ]
       ]
+  where
+  valueOptionsList valueOption =
+    a
+      [ classNames [ "block", "p-4", "hover:bg-black", "hover:text-white" ]
+      , onClick_ $ SetValue valueOption
+      ]
+      [ text valueOption ]

--- a/marlowe-dashboard-client/src/Pickup/Lenses.purs
+++ b/marlowe-dashboard-client/src/Pickup/Lenses.purs
@@ -1,8 +1,7 @@
 module Pickup.Lenses
   ( _card
   , _walletLibrary
-  , _walletNicknameOrId
-  , _walletDropdownOpen
+  , _walletNicknameOrIdInput
   , _walletNicknameInput
   , _walletIdInput
   , _remoteWalletDetails
@@ -17,7 +16,7 @@ import InputField.Types (State) as InputField
 import Pickup.Types (Card, State)
 import Types (WebData)
 import WalletData.Types (WalletDetails, WalletLibrary)
-import WalletData.Validation (WalletIdError, WalletNicknameError)
+import WalletData.Validation (WalletIdError, WalletNicknameError, WalletNicknameOrIdError)
 
 _card :: Lens' State (Maybe Card)
 _card = prop (SProxy :: SProxy "card")
@@ -25,11 +24,8 @@ _card = prop (SProxy :: SProxy "card")
 _walletLibrary :: Lens' State WalletLibrary
 _walletLibrary = prop (SProxy :: SProxy "walletLibrary")
 
-_walletNicknameOrId :: Lens' State String
-_walletNicknameOrId = prop (SProxy :: SProxy "walletNicknameOrId")
-
-_walletDropdownOpen :: Lens' State Boolean
-_walletDropdownOpen = prop (SProxy :: SProxy "walletDropdownOpen")
+_walletNicknameOrIdInput :: Lens' State (InputField.State WalletNicknameOrIdError)
+_walletNicknameOrIdInput = prop (SProxy :: SProxy "walletNicknameOrIdInput")
 
 _walletNicknameInput :: Lens' State (InputField.State WalletNicknameError)
 _walletNicknameInput = prop (SProxy :: SProxy "walletNicknameInput")

--- a/marlowe-dashboard-client/src/Pickup/Types.purs
+++ b/marlowe-dashboard-client/src/Pickup/Types.purs
@@ -10,13 +10,12 @@ import Data.Maybe (Maybe(..))
 import InputField.Types (Action, State) as InputField
 import Types (WebData)
 import WalletData.Types (WalletDetails, WalletLibrary, WalletNickname)
-import WalletData.Validation (WalletIdError, WalletNicknameError)
+import WalletData.Validation (WalletIdError, WalletNicknameError, WalletNicknameOrIdError)
 
 type State
   = { card :: Maybe Card
     , walletLibrary :: WalletLibrary
-    , walletNicknameOrId :: String
-    , walletDropdownOpen :: Boolean
+    , walletNicknameOrIdInput :: InputField.State WalletNicknameOrIdError
     , walletNicknameInput :: InputField.State WalletNicknameError
     , walletIdInput :: InputField.State WalletIdError
     , remoteWalletDetails :: WebData WalletDetails
@@ -34,8 +33,7 @@ data Action
   = OpenCard Card
   | CloseCard Card
   | GenerateWallet
-  | SetWalletNicknameOrId String
-  | SetWalletDropdownOpen Boolean
+  | WalletNicknameOrIdInputAction (InputField.Action WalletNicknameOrIdError)
   | OpenPickupWalletCardWithDetails WalletDetails
   | WalletNicknameInputAction (InputField.Action WalletNicknameError)
   | WalletIdInputAction (InputField.Action WalletIdError)
@@ -48,8 +46,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (OpenCard _) = Nothing
   toEvent (CloseCard _) = Nothing
   toEvent GenerateWallet = Just $ defaultEvent "GenerateWallet"
-  toEvent (SetWalletNicknameOrId _) = Nothing
-  toEvent (SetWalletDropdownOpen _) = Nothing
+  toEvent (WalletNicknameOrIdInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (OpenPickupWalletCardWithDetails _) = Nothing
   toEvent (WalletNicknameInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (WalletIdInputAction inputFieldAction) = toEvent inputFieldAction

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -86,6 +86,7 @@ pickupNewWalletCard state =
       , placeholder: "Choose any nickname"
       , readOnly: false
       , datalistId: Nothing
+      , valueOptions: mempty
       }
 
     walletIdInputDisplayOptions =
@@ -95,6 +96,7 @@ pickupNewWalletCard state =
       , placeholder: "Wallet ID"
       , readOnly: true
       , datalistId: Nothing
+      , valueOptions: mempty
       }
   in
     [ a
@@ -159,6 +161,7 @@ pickupWalletCard state =
       , placeholder: "Nickname"
       , readOnly: true
       , datalistId: Nothing
+      , valueOptions: mempty
       }
 
     walletIdInputDisplayOptions =
@@ -168,6 +171,7 @@ pickupWalletCard state =
       , placeholder: "Wallet ID"
       , readOnly: true
       , datalistId: Nothing
+      , valueOptions: mempty
       }
   in
     [ a
@@ -326,7 +330,7 @@ pickupWalletScreen state =
               ]
           , div
               [ classNames
-                  $ [ "absolute", "z-10", "w-full", "max-h-56", "overflow-x-hidden", "overflow-y-scroll", "-mt-2", "pt-2", "bg-white", "shadow", "rounded-b" ]
+                  $ [ "absolute", "z-10", "w-full", "max-h-56", "overflow-x-hidden", "overflow-y-auto", "-mt-2", "pt-2", "bg-white", "shadow", "rounded-b" ]
                   <> (hideWhen $ not walletDropdownOpen || length matchingWallets == 0)
               ]
               (walletList <$> matchingWallets)

--- a/marlowe-dashboard-client/src/Pickup/View.purs
+++ b/marlowe-dashboard-client/src/Pickup/View.purs
@@ -85,7 +85,6 @@ pickupNewWalletCard state =
       , id_: "walletNickname"
       , placeholder: "Choose any nickname"
       , readOnly: false
-      , datalistId: Nothing
       , valueOptions: mempty
       }
 
@@ -95,7 +94,6 @@ pickupNewWalletCard state =
       , id_: "walletId"
       , placeholder: "Wallet ID"
       , readOnly: true
-      , datalistId: Nothing
       , valueOptions: mempty
       }
   in
@@ -160,7 +158,6 @@ pickupWalletCard state =
       , id_: "walletNickname"
       , placeholder: "Nickname"
       , readOnly: true
-      , datalistId: Nothing
       , valueOptions: mempty
       }
 
@@ -170,7 +167,6 @@ pickupWalletCard state =
       , id_: "walletId"
       , placeholder: "Wallet ID"
       , readOnly: true
-      , datalistId: Nothing
       , valueOptions: mempty
       }
   in

--- a/marlowe-dashboard-client/src/Play/State.purs
+++ b/marlowe-dashboard-client/src/Play/State.purs
@@ -165,6 +165,7 @@ handleAction input (OpenCard card) = do
       assign _remoteWalletInfo NotAsked
       handleAction input $ WalletNicknameInputAction InputField.Reset
       handleAction input $ WalletNicknameInputAction $ InputField.SetValidator $ walletNicknameError walletLibrary
+      handleAction input $ WalletIdInputAction InputField.Reset
       handleAction input $ WalletIdInputAction $ InputField.SetValidator $ walletIdError NotAsked walletLibrary
     _ -> pure unit
   modify_

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -37,7 +37,6 @@ import Template.Validation (RoleError, roleWalletsAreValid, slotError, templateC
 import WalletData.Lenses (_walletNickname)
 import WalletData.State (adaToken, getAda)
 import WalletData.Types (WalletLibrary)
-import WalletData.View (nicknamesDataList, nicknamesDataListId)
 
 contractSetupScreen :: forall p. WalletLibrary -> Slot -> State -> HTML p Action
 contractSetupScreen walletLibrary currentSlot state =
@@ -177,7 +176,6 @@ roleInputs walletLibrary metaData roleWalletInputs =
                 ]
                 [ icon_ AddCircle ]
             ]
-        , nicknamesDataList walletLibrary
         ]
 
   roleWalletInputDisplayOptions tokenName =
@@ -186,7 +184,6 @@ roleInputs walletLibrary metaData roleWalletInputs =
     , id_: tokenName
     , placeholder: "Choose any nickname"
     , readOnly: false
-    , datalistId: Just nicknamesDataListId
     , valueOptions: List.toUnfoldable $ values $ view _walletNickname <$> walletLibrary
     }
 

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -10,7 +10,8 @@ import Css as Css
 import Data.Array (filter, mapWithIndex)
 import Data.BigInteger (fromString) as BigInteger
 import Data.Lens (view)
-import Data.Map (Map, lookup)
+import Data.List (toUnfoldable) as List
+import Data.Map (Map, lookup, values)
 import Data.Map (toUnfoldable) as Map
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.String (null)
@@ -19,8 +20,8 @@ import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, 
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, for, id_, placeholder, readOnly, type_, value)
 import Humanize (humanizeValue)
-import InputField.Types (inputErrorToString)
 import InputField.Types (State) as InputField
+import InputField.Types (inputErrorToString)
 import InputField.View (renderInput)
 import Marlowe.Extended (contractTypeInitials)
 import Marlowe.Extended.Metadata (MetaData)
@@ -33,6 +34,7 @@ import Template.Format (formatText)
 import Template.Lenses (_contractName, _contractNickname, _metaData, _roleWalletInputs, _slotContentStrings, _template, _templateContent)
 import Template.Types (Action(..), State)
 import Template.Validation (RoleError, roleWalletsAreValid, slotError, templateContentIsValid, valueError)
+import WalletData.Lenses (_walletNickname)
 import WalletData.State (adaToken, getAda)
 import WalletData.Types (WalletLibrary)
 import WalletData.View (nicknamesDataList, nicknamesDataListId)
@@ -179,12 +181,13 @@ roleInputs walletLibrary metaData roleWalletInputs =
         ]
 
   roleWalletInputDisplayOptions tokenName =
-    { baseCss: Css.inputCard
+    { baseCss: Css.inputCardNoFocus
     , additionalCss: [ "pr-9" ]
     , id_: tokenName
     , placeholder: "Choose any nickname"
     , readOnly: false
     , datalistId: Just nicknamesDataListId
+    , valueOptions: List.toUnfoldable $ values $ view _walletNickname <$> walletLibrary
     }
 
 parameterInputs :: forall p. Slot -> MetaData -> TemplateContent -> Map String String -> Boolean -> HTML p Action

--- a/marlowe-dashboard-client/src/WalletData/Validation.purs
+++ b/marlowe-dashboard-client/src/WalletData/Validation.purs
@@ -1,5 +1,7 @@
 module WalletData.Validation
-  ( WalletNicknameError(..)
+  ( WalletNicknameOrIdError(..)
+  , walletNicknameOrIdError
+  , WalletNicknameError(..)
   , walletNicknameError
   , WalletIdError(..)
   , walletIdError
@@ -17,7 +19,23 @@ import InputField.Types (class InputFieldError)
 import Marlowe.PAB (PlutusAppId(..))
 import Network.RemoteData (RemoteData(..))
 import Types (WebData)
-import WalletData.Types (WalletInfo, WalletNickname, WalletLibrary)
+import WalletData.Types (WalletInfo, WalletLibrary, WalletNickname, WalletDetails)
+
+data WalletNicknameOrIdError
+  = UnconfirmedWalletNicknameOrId
+  | NonexistentWalletNicknameOrId
+
+derive instance eqWalletNicknameOrIdError :: Eq WalletNicknameOrIdError
+
+instance inputFieldErrorWalletNicknameOrIdError :: InputFieldError WalletNicknameOrIdError where
+  inputErrorToString UnconfirmedWalletNicknameOrId = "Looking up wallet..."
+  inputErrorToString NonexistentWalletNicknameOrId = "Wallet not found"
+
+walletNicknameOrIdError :: WebData WalletDetails -> String -> Maybe WalletNicknameOrIdError
+walletNicknameOrIdError remoteWalletDetails _ = case remoteWalletDetails of
+  Loading -> Just UnconfirmedWalletNicknameOrId
+  Failure _ -> Just NonexistentWalletNicknameOrId
+  _ -> Nothing
 
 data WalletNicknameError
   = EmptyWalletNickname

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -48,6 +48,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , placeholder: "Nickname"
       , readOnly: false
       , datalistId: Nothing
+      , valueOptions: mempty
       }
 
     walletIdInputDisplayOptions =
@@ -57,6 +58,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , placeholder: "Wallet ID"
       , readOnly: false
       , datalistId: Nothing
+      , valueOptions: mempty
       }
   in
     div

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -3,8 +3,6 @@ module WalletData.View
   , walletDetailsCard
   , putdownWalletCard
   , walletLibraryScreen
-  , nicknamesDataList
-  , nicknamesDataListId
   ) where
 
 import Prelude hiding (div)
@@ -18,9 +16,9 @@ import Data.Newtype (unwrap)
 import Data.String (null)
 import Data.Tuple (Tuple(..))
 import Data.UUID (toString) as UUID
-import Halogen.HTML (HTML, button, datalist, div, h2, h3, h4, input, label, li, option, p, p_, text, ul_)
+import Halogen.HTML (HTML, button, div, h2, h3, h4, input, label, li, p, p_, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_)
-import Halogen.HTML.Properties (InputType(..), disabled, for, id_, readOnly, type_, value)
+import Halogen.HTML.Properties (InputType(..), disabled, for, readOnly, type_, value)
 import Humanize (humanizeValue)
 import InputField.Lenses (_value)
 import InputField.State (validate)
@@ -47,7 +45,6 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , id_: "newWalletNickname"
       , placeholder: "Nickname"
       , readOnly: false
-      , datalistId: Nothing
       , valueOptions: mempty
       }
 
@@ -57,7 +54,6 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , id_: "newWalletId"
       , placeholder: "Wallet ID"
       , readOnly: false
-      , datalistId: Nothing
       , valueOptions: mempty
       }
   in
@@ -200,15 +196,3 @@ walletLibraryScreen library =
       , onClick_ $ OpenCard $ ViewWalletCard walletDetails
       ]
       [ text nickname ]
-
-nicknamesDataList :: forall p a. WalletLibrary -> HTML p a
-nicknamesDataList library =
-  datalist
-    [ id_ nicknamesDataListId ]
-    $ walletOption
-    <$> toUnfoldable library
-  where
-  walletOption (Tuple nickname _) = option [ value nickname ] []
-
-nicknamesDataListId :: String
-nicknamesDataListId = "walletNicknames"


### PR DESCRIPTION
Russ reported a "bug" with Firefox not showing the datalist dropdown when you click inside an input with a linked datalist (that's just the way Firefox does it, but it does make things quite unfriendly in our use case). Using a version of the custom dropdown already implemented for the wallet pickup screen solves this problem.