### PR TITLE
Fix link to docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ If you find yourself building GHC, STOP and fix the cache.
 
 === User documentation
 
-The main documentation is located https://docs.cardano.org/projects/plutus/en/latest/[here].
+The main documentation is located https://plutus.readthedocs.io/en/latest/[here].
 
 === Talks
 


### PR DESCRIPTION
`docs.cardano.org` is now the new doc site which doesn't have any of our
docs on it. Go back to the RTD site which works fine.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
