### PR TITLE
SCP-2370: let minting policies take redeemers

### DIFF
--- a/doc/plutus/tutorials/BasicPolicies.hs
+++ b/doc/plutus/tutorials/BasicPolicies.hs
@@ -21,8 +21,8 @@ key :: PubKeyHash
 key = error ()
 
 -- BLOCK1
-oneAtATimePolicy :: ScriptContext -> Bool
-oneAtATimePolicy ctx =
+oneAtATimePolicy :: () -> ScriptContext -> Bool
+oneAtATimePolicy _ ctx =
     -- 'ownCurrencySymbol' lets us get our own hash (= currency symbol)
     -- from the context
     let ownSymbol = ownCurrencySymbol ctx
@@ -35,7 +35,7 @@ oneAtATimePolicy ctx =
 -- We can use 'compile' to turn a forging policy into a compiled Plutus Core program,
 -- just as for validator scripts. We also provide a 'wrapMonetaryPolicy' function
 -- to handle the boilerplate.
-oneAtATimeCompiled :: CompiledCode (Data -> ())
+oneAtATimeCompiled :: CompiledCode (Data -> Data -> ())
 oneAtATimeCompiled = $$(compile [|| wrapMonetaryPolicy oneAtATimePolicy ||])
 -- BLOCK2
 singleSignerPolicy :: ScriptContext -> Bool

--- a/doc/plutus/tutorials/basic-forging-policies.rst
+++ b/doc/plutus/tutorials/basic-forging-policies.rst
@@ -12,9 +12,6 @@ Forging policy arguments
 
 Forging policies, like validators, receive some information from the validating node:
 
-..
-    TODO: redeemers for policies aren't currently implemented in the mock version!
-
 - The :term:`redeemer`, which is some script-specific data specified by the party performing the forging.
 - The :term:`forging context`, which contains a representation of the spending transaction, as well as the hash of the forging policy which is currently being run.
 

--- a/plutus-ledger/src/Ledger/Typed/TypeUtils.hs
+++ b/plutus-ledger/src/Ledger/Typed/TypeUtils.hs
@@ -11,6 +11,8 @@ module Ledger.Typed.TypeUtils where
 
 import           Data.Kind
 
+data Any
+
 -- | A heterogeneous list where every element is wrapped with the given functor.
 data HListF (f :: Type -> Type) (l :: [Type]) where
     HNilF  :: HListF f '[]

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -36,7 +36,7 @@ acceptingValidator = Ledger.mkValidatorScript $$(PlutusTx.compile [|| (\_ _ _ ->
 
 -- | A monetary policy that always succeeds.
 acceptingMonetaryPolicy :: Ledger.MonetaryPolicy
-acceptingMonetaryPolicy = Ledger.mkMonetaryPolicyScript $$(PlutusTx.compile [|| (\_ -> ()) ||])
+acceptingMonetaryPolicy = Ledger.mkMonetaryPolicyScript $$(PlutusTx.compile [|| (\_ _ -> ()) ||])
 
 instance Arbitrary LedgerBytes where
     arbitrary = LedgerBytes.fromBytes <$> arbitrary

--- a/plutus-use-cases/src/Plutus/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Currency.hs
@@ -87,8 +87,8 @@ mkCurrency (TxOutRef h i) amts =
         , curAmounts              = AssocMap.fromList amts
         }
 
-validate :: OneShotCurrency -> V.ScriptContext -> Bool
-validate c@(OneShotCurrency (refHash, refIdx) _) ctx@V.ScriptContext{V.scriptContextTxInfo=txinfo} =
+validate :: OneShotCurrency -> () -> V.ScriptContext -> Bool
+validate c@(OneShotCurrency (refHash, refIdx) _) _ ctx@V.ScriptContext{V.scriptContextTxInfo=txinfo} =
     let
         -- see note [Obtaining the currency symbol]
         ownSymbol = V.ownCurrencySymbol ctx

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/Credential.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/Credential.hs
@@ -50,8 +50,8 @@ data Credential =
 
 -- | The forging policy script validating the creation of credential tokens
 {-# INLINABLE validateForge #-}
-validateForge :: CredentialAuthority -> ScriptContext -> Bool
-validateForge CredentialAuthority{unCredentialAuthority} ScriptContext{scriptContextTxInfo=txinfo} =
+validateForge :: CredentialAuthority -> () -> ScriptContext -> Bool
+validateForge CredentialAuthority{unCredentialAuthority} _ ScriptContext{scriptContextTxInfo=txinfo} =
     -- the credential authority is allwoed to forge or destroy any number of
     -- tokens, so we just need to check the signature
     txinfo `txSignedBy` unCredentialAuthority

--- a/plutus-use-cases/src/Plutus/Contracts/Prism/STO.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Prism/STO.hs
@@ -52,8 +52,8 @@ data STOData =
     deriving anyclass (ToJSON, FromJSON)
 
 {-# INLINABLE validateSTO #-}
-validateSTO :: STOData -> ScriptContext -> Bool
-validateSTO STOData{stoIssuer,stoCredentialToken,stoTokenName} ScriptContext{scriptContextTxInfo=txInfo,scriptContextPurpose=Minting ownHash} =
+validateSTO :: STOData -> () -> ScriptContext -> Bool
+validateSTO STOData{stoIssuer,stoCredentialToken,stoTokenName} _ ScriptContext{scriptContextTxInfo=txInfo,scriptContextPurpose=Minting ownHash} =
     let tokenOK = stoCredentialToken `Value.leq` Validation.valueSpent txInfo
         Lovelace paidToIssuer = fromValue (Validation.valuePaidTo txInfo stoIssuer)
         forgeOK =
@@ -61,7 +61,7 @@ validateSTO STOData{stoIssuer,stoCredentialToken,stoTokenName} ScriptContext{scr
             -- 'stoTokenName' from being forged
             Value.valueOf (Validation.txInfoForge txInfo) ownHash stoTokenName == paidToIssuer
     in tokenOK && forgeOK
-validateSTO _ _ = error ()
+validateSTO _ _ _ = error ()
 
 policy :: STOData -> MonetaryPolicy
 policy stoData = mkMonetaryPolicyScript $

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OnChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OnChain.hs
@@ -280,8 +280,8 @@ mkUniswapValidator _  c (Pool lp a)   Add         ctx = validateAdd c lp a ctx
 mkUniswapValidator _  _ _             _           _   = False
 
 {-# INLINABLE validateLiquidityForging #-}
-validateLiquidityForging :: Uniswap -> TokenName -> ScriptContext -> Bool
-validateLiquidityForging Uniswap{..} tn ctx
+validateLiquidityForging :: Uniswap -> TokenName -> () -> ScriptContext -> Bool
+validateLiquidityForging Uniswap{..} tn _ ctx
   = case [ i
          | i <- txInfoInputs $ scriptContextTxInfo ctx
          , let v = valueWithin i

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       9c7392e26e7a0e0754d52df6b678843ac2168e60ff2ab667b24362b894eada4f
+TxId:       1187b8afe74584eacf82a9e9307f2e8e3f35bf8d757cd08ff66456725060d617
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58409c7609909a820002e926dd3ff7b02887dd3a...
+              Signature: 5840418e92121d20f2806e6f37fff9df259a00ea...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
@@ -175,18 +175,18 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       55a059e38eec719ef84507841bcfb4c020121e825d2aa60bfdd47e5df3eb11a2
-Fee:        Ada:      Lovelace:  20901
-Forge:      dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+TxId:       8c0796b4d6161ea310ab2b17d10c702c5752921d2915614f797575456a1a8277
+Fee:        Ada:      Lovelace:  21108
+Forge:      996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840ac5196564e338dc36631f126c95b3960b176...
+              Signature: 58409c5f72bbba7fd012795f95e56e2d6ab62d2d...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     9c7392e26e7a0e0754d52df6b678843ac2168e60ff2ab667b24362b894eada4f
+    Tx:     1187b8afe74584eacf82a9e9307f2e8e3f35bf8d757cd08ff66456725060d617
     Output #0
 
 
@@ -195,7 +195,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     9c7392e26e7a0e0754d52df6b678843ac2168e60ff2ab667b24362b894eada4f
+    Tx:     1187b8afe74584eacf82a9e9307f2e8e3f35bf8d757cd08ff66456725060d617
     Output #1
     Script: 593c910100003320033200200332002003332002...
 
@@ -204,13 +204,13 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979081
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  -
+    Ada:      Lovelace:  99978874
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
@@ -222,8 +222,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979081
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    Ada:      Lovelace:  99978874
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
@@ -266,29 +266,29 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       57b64689f11826c46a06f566061f325863aa166a79b4ec4ed9a81053eafaab7a
+TxId:       0eafa2dc61475b391955903a4e727850f767a631e167ac73ef161cae45393571
 Fee:        Ada:      Lovelace:  10
 Forge:      -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840222b4040b8728a6f2bc2769252303b7fecbe...
+              Signature: 5840e2fa8c3a2d45da65aa2bc97384adaa18c3ae...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979081
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  -
+    Ada:      Lovelace:  99978874
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  -
   Source:
-    Tx:     55a059e38eec719ef84507841bcfb4c020121e825d2aa60bfdd47e5df3eb11a2
+    Tx:     8c0796b4d6161ea310ab2b17d10c702c5752921d2915614f797575456a1a8277
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
     Ada:      -
   Source:
-    Tx:     55a059e38eec719ef84507841bcfb4c020121e825d2aa60bfdd47e5df3eb11a2
+    Tx:     8c0796b4d6161ea310ab2b17d10c702c5752921d2915614f797575456a1a8277
     Output #1
 
 
@@ -297,25 +297,25 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979071
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    0
+    Ada:      Lovelace:  99978864
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
 
 
 Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979071
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    0
+    Ada:      Lovelace:  99978864
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    0
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
 
   PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 5)
   Value:
@@ -354,29 +354,29 @@ Balances Carried Forward:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       02741de81f03dfb242395601d920bcb2265f960468f68f028e9d280737393213
-Fee:        Ada:      Lovelace:  21566
-Forge:      dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    0
+TxId:       b55bd8ca37fe9c27e93babbd5e1414473492579546433aca2265c5e195a91c95
+Fee:        Ada:      Lovelace:  21773
+Forge:      996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840888c38b93cc5dac3a491384b6c8f40323681...
+              Signature: 584030403ce24421f8ecc2acbeeb9b56e0cc1aa3...
 Inputs:
   ---- Input 0 ----
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
+  Value:
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
+  Source:
+    Tx:     0eafa2dc61475b391955903a4e727850f767a631e167ac73ef161cae45393571
+    Output #1
+
+
+  ---- Input 1 ----
   Destination:  Script: 956c48eb95cf208d22d0c0e6448c52f03a057ed24373f4633caac3a76bce58b9
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     55a059e38eec719ef84507841bcfb4c020121e825d2aa60bfdd47e5df3eb11a2
+    Tx:     8c0796b4d6161ea310ab2b17d10c702c5752921d2915614f797575456a1a8277
     Output #2
     Script: 593c910100003320033200200332002003332002...
-
-  ---- Input 1 ----
-  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
-  Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
-  Source:
-    Tx:     57b64689f11826c46a06f566061f325863aa166a79b4ec4ed9a81053eafaab7a
-    Output #1
-
 
   ---- Input 2 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -392,13 +392,13 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    0
-    Ada:      Lovelace:  99978437
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    0
+    Ada:      Lovelace:  99978230
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
@@ -410,13 +410,13 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99979071
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    0
+    Ada:      Lovelace:  99978864
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    0
 
   PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99978437
-    dc75b02ac8438cc9bf3b7a63009f77a5481a6791152e42f6f05930ab5983e569:  guess:    1
+    Ada:      Lovelace:  99978230
+    996b2503f61b55556fe3003e71cf30fbc5c035d21ccb2075db1517ee6ea81fd3:  guess:    1
 
   PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 5)
   Value:


### PR DESCRIPTION
This is really only the beginning of this: it completely punts on
handling actually passing the redeemers around properly, instead just
conjuring `()` in all cases. The main point of this is so that
downstream can use our libraries to make minting policies that will work
with the real ledger, which will pass the extra argument (and does
already handle the redeemers).

I will make a follow-up PR for actually doing things properly, but it's
a bit of a rabbit-hole, so I thought I should get this one done first.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
