### PR TITLE
Calling redeem for any payments a contract makes.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -20,7 +20,8 @@ import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Data.Set (Set)
 import Data.Symbol (SProxy(..))
-import Marlowe.Execution.Types (ExecutionState, NamedAction)
+import Marlowe.Execution.Types (NamedAction)
+import Marlowe.Execution.Types (State) as Execution
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.PAB (PlutusAppId, MarloweParams)
 import Marlowe.Semantics (Party, TransactionInput)
@@ -32,7 +33,7 @@ _nickname = prop (SProxy :: SProxy "nickname")
 _tab :: forall a. Lens' { tab :: Tab | a } Tab
 _tab = prop (SProxy :: SProxy "tab")
 
-_executionState :: Lens' State ExecutionState
+_executionState :: Lens' State Execution.State
 _executionState = prop (SProxy :: SProxy "executionState")
 
 _pendingTransaction :: Lens' State (Maybe TransactionInput)

--- a/marlowe-dashboard-client/src/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Contract/State.purs
@@ -47,9 +47,11 @@ import Halogen.Query.EventSource as EventSource
 import MainFrame.Types (Action(..)) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
 import Marlowe.Deinstantiate (findTemplate)
-import Marlowe.Execution.Lenses (_currentContract, _currentState, _pendingTimeouts, _previousExecutionStates, _previousTransactions)
-import Marlowe.Execution.State (expandBalances, extractNamedActions, initExecution, isClosed, mkTx, nextState, timeoutState)
-import Marlowe.Execution.Types (ExecutionState, NamedAction(..), PreviousExecutionState)
+import Marlowe.Execution.Lenses (_contract, _semanticState, _history, _pendingTimeouts, _previousTransactions)
+import Marlowe.Execution.State (expandBalances, extractNamedActions, isClosed, mkTx, nextState, timeoutState)
+import Marlowe.Execution.State (mkInitialState) as Execution
+import Marlowe.Execution.Types (NamedAction(..))
+import Marlowe.Execution.Types (PastState, State) as Execution
 import Marlowe.Extended.Metadata (MetaData, emptyContractMetadata)
 import Marlowe.HasParties (getParties)
 import Marlowe.PAB (ContractHistory, PlutusAppId(..), MarloweParams)
@@ -71,7 +73,7 @@ dummyState :: State
 dummyState =
   { nickname: mempty
   , tab: Tasks
-  , executionState: initExecution zero contract
+  , executionState: Execution.mkInitialState zero contract
   , pendingTransaction: Nothing
   , previousSteps: mempty
   , mMarloweParams: Nothing
@@ -97,7 +99,7 @@ mkPlaceholderState :: PlutusAppId -> String -> MetaData -> Contract -> State
 mkPlaceholderState followerAppId nickname metaData contract =
   { nickname
   , tab: Tasks
-  , executionState: initExecution zero contract
+  , executionState: Execution.mkInitialState zero contract
   , pendingTransaction: Nothing
   , previousSteps: mempty
   , mMarloweParams: Nothing
@@ -122,7 +124,7 @@ mkInitialState walletDetails currentSlot followerAppId nickname { chParams, chHi
 
       minSlot = view _minSlot marloweData.marloweState
 
-      initialExecutionState = initExecution minSlot contract
+      initialExecutionState = Execution.mkInitialState minSlot contract
     in
       flip map mTemplate \template ->
         let
@@ -235,13 +237,13 @@ handleAction _ (SetNickname nickname) = do
   insertIntoContractNicknames followerAppId nickname
 
 handleAction input@{ currentSlot, walletDetails } (ConfirmAction namedAction) = do
-  currentExeState <- use _executionState
+  executionState <- use _executionState
   mMarloweParams <- use _mMarloweParams
   for_ mMarloweParams \marloweParams -> do
     let
       contractInput = toInput namedAction
 
-      txInput = mkTx currentSlot (currentExeState ^. _currentContract) (Unfoldable.fromMaybe contractInput)
+      txInput = mkTx currentSlot (executionState ^. _contract) (Unfoldable.fromMaybe contractInput)
     ajaxApplyInputs <- applyTransactionInput walletDetails marloweParams txInput
     case ajaxApplyInputs of
       Left ajaxError -> addToast $ ajaxErrorToast "Failed to submit transaction." ajaxError
@@ -291,7 +293,7 @@ handleAction _ CarouselOpened = do
 
 handleAction _ CarouselClosed = unsubscribeFromSelectCenteredStep
 
-applyTransactionInputs :: Array TransactionInput -> ExecutionState -> ExecutionState
+applyTransactionInputs :: Array TransactionInput -> Execution.State -> Execution.State
 applyTransactionInputs transactionInputs state = foldl nextState state transactionInputs
 
 currentStep :: State -> Int
@@ -341,14 +343,14 @@ toInput (MakeNotify _) = Just $ Semantic.INotify
 
 toInput _ = Nothing
 
-transactionsToStep :: State -> PreviousExecutionState -> PreviousStep
-transactionsToStep { participants } { txInput, state } =
+transactionsToStep :: State -> Execution.PastState -> PreviousStep
+transactionsToStep { participants } { initialSemanticState, txInput } =
   let
     TransactionInput { interval: SlotInterval minSlot maxSlot, inputs } = txInput
 
     -- TODO: When we add support for multiple tokens we should extract the possible tokens from the
     --       contract, store it in ContractState and pass them here.
-    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] state
+    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] initialSemanticState
 
     stepState =
       -- For the moment the only way to get an empty transaction is if there was a timeout,
@@ -367,9 +369,9 @@ transactionsToStep { participants } { txInput, state } =
 timeoutToStep :: State -> Slot -> PreviousStep
 timeoutToStep { participants, executionState } slot =
   let
-    currentContractState = executionState ^. _currentState
+    semanticState = executionState ^. _semanticState
 
-    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] currentContractState
+    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] semanticState
   in
     { tab: Tasks
     , balances
@@ -382,7 +384,7 @@ regenerateStepCards currentSlot state =
   -- the Tasks tab). If any of them are showing the Balances tab, it would be nice to keep them that way.
   let
     confirmedSteps :: Array PreviousStep
-    confirmedSteps = toArrayOf (_executionState <<< _previousExecutionStates <<< traversed <<< to (transactionsToStep state)) state
+    confirmedSteps = toArrayOf (_executionState <<< _history <<< traversed <<< to (transactionsToStep state)) state
 
     pendingTimeoutSteps :: Array PreviousStep
     pendingTimeoutSteps = toArrayOf (_executionState <<< _pendingTimeouts <<< traversed <<< to (timeoutToStep state)) state

--- a/marlowe-dashboard-client/src/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Contract/State.purs
@@ -47,9 +47,9 @@ import Halogen.Query.EventSource as EventSource
 import MainFrame.Types (Action(..)) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
 import Marlowe.Deinstantiate (findTemplate)
-import Marlowe.Execution.Lenses (_currentContract, _currentState, _pendingTimeouts, _previousState, _previousTransactions)
+import Marlowe.Execution.Lenses (_currentContract, _currentState, _pendingTimeouts, _previousExecutionStates, _previousTransactions)
 import Marlowe.Execution.State (expandBalances, extractNamedActions, initExecution, isClosed, mkTx, nextState, timeoutState)
-import Marlowe.Execution.Types (ExecutionState, NamedAction(..), PreviousState)
+import Marlowe.Execution.Types (ExecutionState, NamedAction(..), PreviousExecutionState)
 import Marlowe.Extended.Metadata (MetaData, emptyContractMetadata)
 import Marlowe.HasParties (getParties)
 import Marlowe.PAB (ContractHistory, PlutusAppId(..), MarloweParams)
@@ -341,7 +341,7 @@ toInput (MakeNotify _) = Just $ Semantic.INotify
 
 toInput _ = Nothing
 
-transactionsToStep :: State -> PreviousState -> PreviousStep
+transactionsToStep :: State -> PreviousExecutionState -> PreviousStep
 transactionsToStep { participants } { txInput, state } =
   let
     TransactionInput { interval: SlotInterval minSlot maxSlot, inputs } = txInput
@@ -382,7 +382,7 @@ regenerateStepCards currentSlot state =
   -- the Tasks tab). If any of them are showing the Balances tab, it would be nice to keep them that way.
   let
     confirmedSteps :: Array PreviousStep
-    confirmedSteps = toArrayOf (_executionState <<< _previousState <<< traversed <<< to (transactionsToStep state)) state
+    confirmedSteps = toArrayOf (_executionState <<< _previousExecutionStates <<< traversed <<< to (transactionsToStep state)) state
 
     pendingTimeoutSteps :: Array PreviousStep
     pendingTimeoutSteps = toArrayOf (_executionState <<< _pendingTimeouts <<< traversed <<< to (timeoutToStep state)) state

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -14,7 +14,8 @@ import Data.Map (Map)
 import Data.Maybe (Maybe(..))
 import Data.Set (Set)
 import Halogen (RefLabel(..))
-import Marlowe.Execution.Types (ExecutionState, NamedAction)
+import Marlowe.Execution.Types (NamedAction)
+import Marlowe.Execution.Types (State) as Execution
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.PAB (PlutusAppId, MarloweParams)
 import Marlowe.Semantics (ChoiceId, ChosenNum, Party, Slot, TransactionInput, Accounts)
@@ -23,7 +24,7 @@ import WalletData.Types (WalletDetails, WalletNickname)
 type State
   = { nickname :: String
     , tab :: Tab -- this is the tab of the current (latest) step - previous steps have their own tabs
-    , executionState :: ExecutionState
+    , executionState :: Execution.State
     -- When the user submits a transaction, we save it here until we get confirmation from the PAB and
     -- can advance the contract. This enables us to show immediate feedback to the user while we wait.
     , pendingTransaction :: Maybe TransactionInput

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -31,7 +31,7 @@ import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, 
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
 import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
-import Marlowe.Execution.Lenses (_currentState, _mNextTimeout)
+import Marlowe.Execution.Lenses (_semanticState, _mNextTimeout)
 import Marlowe.Execution.State (expandBalances, getActionParticipant)
 import Marlowe.Execution.Types (NamedAction(..))
 import Marlowe.Extended (contractTypeName)
@@ -444,9 +444,9 @@ renderCurrentStep currentSlot state =
 
     participants = state ^. _participants
 
-    currentState = state ^. (_executionState <<< _currentState)
+    semanticState = state ^. (_executionState <<< _semanticState)
 
-    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] currentState
+    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] semanticState
 
     timeoutStr =
       maybe "timed out"

--- a/marlowe-dashboard-client/src/Dashboard/State.purs
+++ b/marlowe-dashboard-client/src/Dashboard/State.purs
@@ -8,7 +8,7 @@ module Dashboard.State
 import Prelude
 import Capability.Contract (class ManageContract)
 import Capability.MainFrameLoop (class MainFrameLoop, callMainFrameAction)
-import Capability.Marlowe (class ManageMarlowe, createContract, createPendingFollowerApp, followContract, followContractWithPendingFollowerApp, getFollowerApps, getRoleContracts, lookupWalletInfo, subscribeToPlutusApp)
+import Capability.Marlowe (class ManageMarlowe, createContract, createPendingFollowerApp, followContract, followContractWithPendingFollowerApp, getFollowerApps, getRoleContracts, lookupWalletInfo, redeem, subscribeToPlutusApp)
 import Capability.MarloweStorage (class ManageMarloweStorage, getWalletLibrary, insertIntoContractNicknames, insertIntoWalletLibrary)
 import Capability.Toast (class Toast, addToast)
 import Contract.Lenses (_mMarloweParams, _nickname, _selectedStep)
@@ -25,6 +25,7 @@ import Data.Foldable (for_)
 import Data.Lens (assign, filtered, modifying, over, set, use, view)
 import Data.Lens.Extra (peruse)
 import Data.Lens.Traversal (traversed)
+import Data.List (filter, fromFoldable) as List
 import Data.Map (Map, alter, delete, filter, filterKeys, findMin, insert, lookup, mapMaybe, mapMaybeWithKey, toUnfoldable, toUnfoldableUnordered, values)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Minutes(..))
@@ -42,9 +43,10 @@ import InputField.Types (Action(..), State) as InputField
 import MainFrame.Types (Action(..)) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
 import Marlowe.Deinstantiate (findTemplate)
+import Marlowe.Execution.State (getAllPayments)
 import Marlowe.Extended.Metadata (_extendedContract, _metaData)
 import Marlowe.PAB (ContractHistory, MarloweParams, PlutusAppId(..), MarloweData)
-import Marlowe.Semantics (Slot(..))
+import Marlowe.Semantics (Party(..), Payee(..), Payment(..), Slot(..))
 import Network.RemoteData (RemoteData(..), fromEither)
 import Template.Lenses (_contractNickname, _roleWalletInputs, _template, _templateContent)
 import Template.State (dummyState, handleAction, mkInitialState) as Template
@@ -292,6 +294,35 @@ handleAction input@{ currentSlot } (UpdateContract plutusAppId contractHistory@{
           $ for_ selectedStep' (handleAction input <<< ContractAction <<< Contract.MoveToStep)
       Nothing -> for_ (Contract.mkInitialState walletDetails currentSlot plutusAppId mempty contractHistory) (modifying _contracts <<< insert plutusAppId)
 
+-- This handler looks, in the given contract, for any payments to roles for which the current
+-- wallet holds the token, and then calls the "redeem" endpoint of the main marlowe app for each
+-- one, to make sure those funds reach the user's wallet (without the user having to do anything).
+-- The handler is called every time we receive a notification that the state of the contract's
+-- follower app has changed, so it will be called more often that is necessary. But there is no way
+-- to guard against that. (Well, we could keep track of payments redeemed in the application state,
+-- but that record would be lost when the browser is closed - and then those payments would all be
+-- redeemed again anyway the next time the user picks up the wallet. Since these duplicate requests
+-- will happen anyway, therefore, this extra complication doesn't seem worth the bother.
+handleAction input (RedeemPayments plutusAppId) = do
+  walletDetails <- use _walletDetails
+  contracts <- use _contracts
+  for_ (lookup plutusAppId contracts) \{ executionState, mMarloweParams, userParties } ->
+    for_ mMarloweParams \marloweParams ->
+      let
+        payments = getAllPayments executionState
+
+        isToParty party (Payment _ payee _) = case payee of
+          Party p -> p == party
+          _ -> false
+      in
+        for (List.fromFoldable userParties) \party ->
+          let
+            paymentsToParty = List.filter (isToParty party) payments
+          in
+            for paymentsToParty \payment -> case payment of
+              Payment _ (Party (Role tokenName)) _ -> void $ redeem walletDetails marloweParams tokenName
+              _ -> pure unit
+
 handleAction input@{ currentSlot } AdvanceTimedoutSteps = do
   walletDetails <- use _walletDetails
   selectedStep <- peruse $ _selectedContract <<< _selectedStep
@@ -309,8 +340,9 @@ handleAction input@{ currentSlot } AdvanceTimedoutSteps = do
     for_ selectedStep' (handleAction input <<< ContractAction <<< Contract.MoveToStep)
     handleAction input $ ContractAction Contract.CancelConfirmation
 
--- TODO: we have to handle quite a lot of submodule actions here (mainly just because of the cards),
--- so there's probably a better way of structuring this - perhaps making cards work more like toasts
+-- TODO: We have to handle quite a lot of submodule actions here (mainly just because of the
+-- cards), so there's probably a better way of structuring this - perhaps making cards work more
+-- like toasts.
 handleAction input@{ currentSlot } (TemplateAction templateAction) = case templateAction of
   Template.SetTemplate template -> do
     mCurrentTemplate <- peruse (_templateState <<< _template)

--- a/marlowe-dashboard-client/src/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Types.purs
@@ -78,6 +78,7 @@ data Action
   | UpdateFromStorage
   | UpdateFollowerApps (Map MarloweParams MarloweData)
   | UpdateContract PlutusAppId ContractHistory
+  | RedeemPayments PlutusAppId
   | AdvanceTimedoutSteps
   | TemplateAction Template.Action
   | ContractAction Contract.Action
@@ -98,6 +99,7 @@ instance actionIsEvent :: IsEvent Action where
   toEvent UpdateFromStorage = Nothing
   toEvent (UpdateFollowerApps _) = Nothing
   toEvent (UpdateContract _ _) = Nothing
+  toEvent (RedeemPayments _) = Nothing
   toEvent AdvanceTimedoutSteps = Nothing
   toEvent (TemplateAction templateAction) = toEvent templateAction
   toEvent (ContractAction contractAction) = toEvent contractAction

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -146,7 +146,9 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
               -- otherwise this should be one of the wallet's WalletFollowerApps
               else case runExcept $ decodeJSON $ unwrap rawJson of
                 Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError
-                Right contractHistory -> handleAction $ DashboardAction $ Dashboard.UpdateContract plutusAppId contractHistory
+                Right contractHistory -> do
+                  handleAction $ DashboardAction $ Dashboard.UpdateContract plutusAppId contractHistory
+                  handleAction $ DashboardAction $ Dashboard.RedeemPayments plutusAppId
         -- Plutus contracts in general can change in other ways, but the Marlowe contracts don't, so
         -- we can ignore these cases here
         _ -> pure unit

--- a/marlowe-dashboard-client/src/Marlowe/Execution/Lenses.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution/Lenses.purs
@@ -1,34 +1,60 @@
 module Marlowe.Execution.Lenses
-  ( _previousState
+  ( _previousExecutionStates
+  , _currentExecutionState
+  , _mPendingTimeouts
+  , _mNextTimeout
+  , _state
+  , _contract
+  , _payments
   , _previousTransactions
   , _currentState
   , _currentContract
-  , _mNextTimeout
+  , _currentPayments
   , _pendingTimeouts
   ) where
 
 import Prelude
 import Data.Lens (Lens', Traversal', _Just, traversed)
 import Data.Lens.Record (prop)
+import Data.List (List)
 import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
-import Marlowe.Execution.Types (ExecutionState, PreviousState)
-import Marlowe.Semantics (Contract, Slot, State, TransactionInput)
+import Marlowe.Execution.Types (CurrentExecutionState, ExecutionState, PendingTimeouts, PreviousExecutionState)
+import Marlowe.Semantics (Contract, Payment, Slot, State, TransactionInput)
 
-_previousState :: Lens' ExecutionState (Array PreviousState)
-_previousState = prop (SProxy :: SProxy "previous")
+_previousExecutionStates :: Lens' ExecutionState (Array PreviousExecutionState)
+_previousExecutionStates = prop (SProxy :: SProxy "previousExecutionStates")
 
-_previousTransactions :: Traversal' ExecutionState TransactionInput
-_previousTransactions = prop (SProxy :: SProxy "previous") <<< traversed <<< prop (SProxy :: SProxy "txInput")
+_currentExecutionState :: Lens' ExecutionState (CurrentExecutionState)
+_currentExecutionState = prop (SProxy :: SProxy "currentExecutionState")
 
-_currentState :: Lens' ExecutionState State
-_currentState = prop (SProxy :: SProxy "current") <<< prop (SProxy :: SProxy "state")
-
-_currentContract :: Lens' ExecutionState Contract
-_currentContract = prop (SProxy :: SProxy "current") <<< prop (SProxy :: SProxy "contract")
+_mPendingTimeouts :: Lens' ExecutionState (Maybe PendingTimeouts)
+_mPendingTimeouts = prop (SProxy :: SProxy "mPendingTimeouts")
 
 _mNextTimeout :: Lens' ExecutionState (Maybe Slot)
 _mNextTimeout = prop (SProxy :: SProxy "mNextTimeout")
+
+----------
+_state :: forall a. Lens' { state :: State | a } State
+_state = prop (SProxy :: SProxy "state")
+
+_contract :: forall a. Lens' { contract :: Contract | a } Contract
+_contract = prop (SProxy :: SProxy "contract")
+
+_payments :: forall a. Lens' { payments :: List Payment | a } (List Payment)
+_payments = prop (SProxy :: SProxy "payments")
+
+_previousTransactions :: Traversal' ExecutionState TransactionInput
+_previousTransactions = _previousExecutionStates <<< traversed <<< prop (SProxy :: SProxy "txInput")
+
+_currentState :: Lens' ExecutionState State
+_currentState = _currentExecutionState <<< _state
+
+_currentContract :: Lens' ExecutionState Contract
+_currentContract = _currentExecutionState <<< _contract
+
+_currentPayments :: Lens' ExecutionState (List Payment)
+_currentPayments = _currentExecutionState <<< _payments
 
 _pendingTimeouts :: Traversal' ExecutionState (Array Slot)
 _pendingTimeouts = prop (SProxy :: SProxy "mPendingTimeouts") <<< _Just <<< prop (SProxy :: SProxy "timeouts")

--- a/marlowe-dashboard-client/src/Marlowe/Execution/Types.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution/Types.purs
@@ -1,60 +1,80 @@
 module Marlowe.Execution.Types
   ( ExecutionState
-  , PreviousState
+  , PreviousExecutionState
+  , CurrentExecutionState
   , PendingTimeouts
   , NamedAction(..)
   ) where
 
 import Prelude
 import Data.BigInteger (BigInteger)
+import Data.List (List)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Marlowe.Semantics (AccountId, Bound, ChoiceId, ChosenNum, Contract, Observation, Party, Payment, Slot, State, Token, TransactionInput, ValueId)
 
 type ExecutionState
-  = { previous :: Array PreviousState
-    , current ::
-        { state :: State
-        , contract :: Contract
-        }
+  = { previousExecutionStates :: Array PreviousExecutionState
+    , currentExecutionState :: CurrentExecutionState
     , mPendingTimeouts :: Maybe PendingTimeouts
     , mNextTimeout :: Maybe Slot
     }
 
--- This represents a previous step in the execution. The state property corresponds to the state before the
--- txInput was applied and it's saved as an early optimization to calculate the balances at each step.
-type PreviousState
-  = { txInput :: TransactionInput
+-- The current execution state is either the initial state of the contract, or a function of the
+-- last element in the `previous` array. It is saved as an early optimisation so that we don't need
+-- to recalculate payments and account balances all the the time.
+type CurrentExecutionState
+  = { contract :: Contract
     , state :: State
+    , payments :: List Payment
     }
 
--- This represents the timeouts that hasn't been applied to the contract. When a step of a contract has timeout
--- nothing happens until the next InputTransaction. This could be an IDeposit or IChoose for the continuation
--- contract, or an empty transaction to advance or even close the contract. We store a separate contract and state
--- than the "current" contract/state because this is the predicted state that we would be in if we applied an
--- empty transaction, and this allow us to extract the NamedActions that needs to be applied next.
--- Also, we store the timeouts as an Array because it is possible that multiple continuations have timeouted
--- before we advance the contract.
+-- Similar to the current execution state, the first three properties of the previous execution
+-- state either represent the initial state of the contract, or are a function of the previous 
+-- element in the `previous` array. The final property is the transaction input that was applied at
+-- that step. In other words, apply the transaction input to the contract and state here, and you
+-- get the *next* contract, state, and payments. The only thing we *need* to keep around,
+-- therefore, is the transaction input - but we remember the rest to save having to calculate it
+-- multiple times.
+-- Note: the contract and state here represent the contract and state *before* the transaction
+-- input is applied. Likewise, the payments are the payments made as a result of the *previous*
+-- transaction input.
+type PreviousExecutionState
+  = { contract :: Contract
+    , state :: State
+    , payments :: List Payment
+    , txInput :: TransactionInput
+    }
+
+-- This represents the timeouts that haven't been applied to the contract. When a step of a
+-- contract has timedout, nothing happens until the next transaction input. This could be an
+-- IDeposit or IChoose for the continuation contract, or an empty transaction to advance or even
+-- close the contract. We store a separate contract and state than the "current" contract/state
+-- because this is the predicted state that we would be in if we applied an empty transaction, and
+-- this allows us to extract the NamedActions that need to be applied next. Also, we store the
+-- timeouts as an Array because it is possible that multiple continuations have timedout before we
+-- advance the contract.
 type PendingTimeouts
   = { timeouts :: Array Slot
     , contract :: Contract
     , state :: State
     }
 
--- Represents the possible buttons that can be displayed on a contract stage card
+-- Represents the possible buttons that can be displayed on a contract step card
 data NamedAction
   -- Equivalent to Semantics.Action(Deposit)
   -- Creates IDeposit
   = MakeDeposit AccountId Party Token BigInteger
-  -- Equivalent to Semantics.Action(Choice) but has ChosenNum since it is a stateful element that stores the users choice
+  -- Equivalent to Semantics.Action(Choice) but has ChosenNum since it is a stateful element that
+  -- stores the users choice
   -- Creates IChoice
   | MakeChoice ChoiceId (Array Bound) (Maybe ChosenNum)
   -- Equivalent to Semantics.Action(Notify) (can be applied by any user)
   -- Creates INotify
   | MakeNotify Observation
-  -- An empty transaction needs to be submitted in order to trigger a change in the contract
-  -- and we work out the details of what will happen when this occurs, currently we are interested
-  -- in any payments that will be made and new bindings that will be evaluated
+  -- An empty transaction needs to be submitted in order to trigger a change in the contract and
+  -- we work out the details of what will happen when this occurs, currently we are interested in
+  -- any payments that will be made and new bindings that will be evaluated
   -- Creates empty tx
   | Evaluate { payments :: Array Payment, bindings :: Map ValueId BigInteger }
   -- A special case of Evaluate where the only way the Contract can progress is to apply an empty

--- a/marlowe-dashboard-client/src/Marlowe/Execution/Types.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution/Types.purs
@@ -1,7 +1,6 @@
 module Marlowe.Execution.Types
-  ( ExecutionState
-  , PreviousExecutionState
-  , CurrentExecutionState
+  ( State
+  , PastState
   , PendingTimeouts
   , NamedAction(..)
   ) where
@@ -11,53 +10,35 @@ import Data.BigInteger (BigInteger)
 import Data.List (List)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
-import Marlowe.Semantics (AccountId, Bound, ChoiceId, ChosenNum, Contract, Observation, Party, Payment, Slot, State, Token, TransactionInput, ValueId)
+import Marlowe.Semantics (AccountId, Bound, ChoiceId, ChosenNum, Contract, Observation, Party, Payment, Slot, Token, TransactionInput, ValueId)
+import Marlowe.Semantics (State) as Semantic
 
-type ExecutionState
-  = { previousExecutionStates :: Array PreviousExecutionState
-    , currentExecutionState :: CurrentExecutionState
+type State
+  = { semanticState :: Semantic.State
+    , contract :: Contract
+    , history :: Array PastState
     , mPendingTimeouts :: Maybe PendingTimeouts
     , mNextTimeout :: Maybe Slot
     }
 
--- The current execution state is either the initial state of the contract, or a function of the
--- last element in the `previous` array. It is saved as an early optimisation so that we don't need
--- to recalculate payments and account balances all the the time.
-type CurrentExecutionState
-  = { contract :: Contract
-    , state :: State
-    , payments :: List Payment
-    }
-
--- Similar to the current execution state, the first three properties of the previous execution
--- state either represent the initial state of the contract, or are a function of the previous 
--- element in the `previous` array. The final property is the transaction input that was applied at
--- that step. In other words, apply the transaction input to the contract and state here, and you
--- get the *next* contract, state, and payments. The only thing we *need* to keep around,
--- therefore, is the transaction input - but we remember the rest to save having to calculate it
--- multiple times.
--- Note: the contract and state here represent the contract and state *before* the transaction
--- input is applied. Likewise, the payments are the payments made as a result of the *previous*
--- transaction input.
-type PreviousExecutionState
-  = { contract :: Contract
-    , state :: State
-    , payments :: List Payment
+type PastState
+  = { initialSemanticState :: Semantic.State
     , txInput :: TransactionInput
+    , resultingPayments :: List Payment
     }
 
 -- This represents the timeouts that haven't been applied to the contract. When a step of a
--- contract has timedout, nothing happens until the next transaction input. This could be an
+-- contract has timed out, nothing happens until the next TransactionInput. This could be an
 -- IDeposit or IChoose for the continuation contract, or an empty transaction to advance or even
--- close the contract. We store a separate contract and state than the "current" contract/state
--- because this is the predicted state that we would be in if we applied an empty transaction, and
--- this allows us to extract the NamedActions that need to be applied next. Also, we store the
--- timeouts as an Array because it is possible that multiple continuations have timedout before we
--- advance the contract.
+-- close the contract. We store a separate Semantic.State from the "current" Semantic.State because
+-- this is the predicted state that we would be in if we applied an empty transaction, and this
+-- allows us to extract the NamedActions that need to be applied next. Also, we store the timeouts
+-- as an Array because it is possible that multiple continuations have timedout before we advance
+-- the contract.
 type PendingTimeouts
-  = { timeouts :: Array Slot
-    , contract :: Contract
-    , state :: State
+  = { nextSemanticState :: Semantic.State
+    , continuationContract :: Contract
+    , timeouts :: Array Slot
     }
 
 -- Represents the possible buttons that can be displayed on a contract step card


### PR DESCRIPTION
This PR adds functionality to automatially redeem any payments made to the currently active wallet, so that the user doesn't have to worry about doing this manually. With these changes, the frontend app calls the "redeem" endpoint of the marlowe plutus app once for each payment made to the current wallet by a contract, every time we receive a notification that the state of that contract has changed (including when the wallet is first picked up, and we check the current state of all of its contracts). This means it will be called far too many times. If performance becomes an issue, we can revisit this - but I'm not sure what could be done about it anyway, for two reasons:

1. The most we could do is keep track of which payments have been redeemed in the browser, so duplicate requests will be made anyway whenever the user picks up the wallet again or switches to a different browser/machine.
2. A contract might pay the same role the same amount of money more than once. I don't see how we could distinguish these as separate payments.

While I was at it I couldn't resist a very small bit of refactoring/renaming in the `ExecutionState`. Also, the `payments` added here are not only useful for the functionality added in this PR, but will also be useful when we add this information to the balances tab.