### PR TITLE
SCP-2394 - Add choice format information to metadata and examples

### DIFF
--- a/marlowe-dashboard-client/package-lock.json
+++ b/marlowe-dashboard-client/package-lock.json
@@ -351,9 +351,9 @@
       }
     },
     "@webpack-cli/serve": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.1.tgz",
-      "integrity": "sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz",
+      "integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==",
       "dev": true
     },
     "@xtuc/ieee754": {

--- a/marlowe-dashboard-client/package.json
+++ b/marlowe-dashboard-client/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.3.2",
+    "@webpack-cli/serve": "^1.5.1",
     "autoprefixer": "^10.2.5",
     "css-loader": "^5.2.4",
     "cssnano": "^5.0.2",

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -21,6 +21,7 @@ import Data.Map (keys, lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), isJust, maybe, maybe')
 import Data.Set (Set)
 import Data.Set as Set
+import Data.String (trim)
 import Data.String as String
 import Data.String.Extra (capitalize)
 import Data.Tuple (Tuple(..), fst, uncurry)
@@ -605,9 +606,10 @@ renderAction state party namedAction@(MakeChoice choiceId bounds mChosenNum) =
 
     ChoiceId choiceIdKey _ = choiceId
 
-    choiceDescription = case Map.lookup choiceIdKey metadata.choiceDescriptions of
-      Nothing -> div_ []
-      Just description -> shortDescription isActiveParticipant description
+    choiceDescription = case Map.lookup choiceIdKey metadata.choiceInfo of
+      Just { choiceDescription: description }
+        | trim description /= "" -> shortDescription isActiveParticipant description
+      _ -> div_ []
 
     isValid = maybe false (between minBound maxBound) mChosenNum
 

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -12,7 +12,7 @@ module Template.Lenses
   , _contractDescription
   , _slotParameterDescriptions
   , _valueParameterDescriptions
-  , _choiceDescriptions
+  , _choiceInfo
   ) where
 
 import Prelude
@@ -24,7 +24,7 @@ import Data.Map (Map)
 import Data.Symbol (SProxy(..))
 import InputField.Types (State) as InputField
 import Marlowe.Extended (Contract, ContractType)
-import Marlowe.Extended.Metadata (MetaData, ContractTemplate)
+import Marlowe.Extended.Metadata (ContractTemplate, MetaData, ChoiceInfo)
 import Marlowe.Semantics (TokenName)
 import Marlowe.Template (TemplateContent)
 import Template.Types (State)
@@ -74,5 +74,8 @@ _slotParameterDescriptions = prop (SProxy :: SProxy "slotParameterDescriptions")
 _valueParameterDescriptions :: Lens' MetaData (Map String String)
 _valueParameterDescriptions = prop (SProxy :: SProxy "valueParameterDescriptions")
 
-_choiceDescriptions :: Lens' MetaData (Map String String)
-_choiceDescriptions = prop (SProxy :: SProxy "choiceDescriptions")
+_choiceInfo :: Lens' MetaData (Map String ChoiceInfo)
+_choiceInfo = prop (SProxy :: SProxy "choiceInfo")
+
+_choiceDescription :: Lens' ChoiceInfo String
+_choiceDescription = prop (SProxy :: SProxy "choiceDescription")

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -9,10 +9,8 @@ module Template.Lenses
   , _extendedContract
   , _contractType
   , _contractName
-  , _contractDescription
   , _slotParameterDescriptions
   , _valueParameterDescriptions
-  , _choiceInfo
   ) where
 
 import Prelude
@@ -73,9 +71,3 @@ _slotParameterDescriptions = prop (SProxy :: SProxy "slotParameterDescriptions")
 
 _valueParameterDescriptions :: Lens' MetaData (Map String String)
 _valueParameterDescriptions = prop (SProxy :: SProxy "valueParameterDescriptions")
-
-_choiceInfo :: Lens' MetaData (Map String ChoiceInfo)
-_choiceInfo = prop (SProxy :: SProxy "choiceInfo")
-
-_choiceDescription :: Lens' ChoiceInfo String
-_choiceDescription = prop (SProxy :: SProxy "choiceDescription")

--- a/marlowe-playground-client/src/MetadataTab/State.purs
+++ b/marlowe-playground-client/src/MetadataTab/State.purs
@@ -8,7 +8,7 @@ import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen.Query (HalogenM)
 import MainFrame.Types (Action, ChildSlots, State, _contractMetadata, _hasUnsavedChanges)
-import Marlowe.Extended.Metadata (_choiceDescriptions, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions)
+import Marlowe.Extended.Metadata (ChoiceFormat, ChoiceInfo, _choiceInfo, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions, updateChoiceInfo)
 import MetadataTab.Types (MetadataAction(..))
 
 carryMetadataAction ::
@@ -28,6 +28,13 @@ carryMetadataAction action = do
     DeleteSlotParameterDescription slotParam -> over _slotParameterDescriptions $ Map.delete slotParam
     SetValueParameterDescription valueParam description -> over _valueParameterDescriptions $ Map.insert valueParam description
     DeleteValueParameterDescription valueParam -> over _valueParameterDescriptions $ Map.delete valueParam
-    SetChoiceDescription choiceName description -> over _choiceDescriptions $ Map.insert choiceName description
-    DeleteChoiceDescription choiceName -> over _choiceDescriptions $ Map.delete choiceName
+    SetChoiceDescription choiceName description -> over _choiceInfo $ updateChoiceInfo (setChoiceDescription description) choiceName
+    SetChoiceFormat choiceName format -> over _choiceInfo $ updateChoiceInfo (setChoiceFormat format) choiceName
+    DeleteChoiceInfo choiceName -> over _choiceInfo $ Map.delete choiceName
   assign (_hasUnsavedChanges) true
+  where
+  setChoiceDescription :: String -> ChoiceInfo -> ChoiceInfo
+  setChoiceDescription newDescription x = x { choiceDescription = newDescription }
+
+  setChoiceFormat :: ChoiceFormat -> ChoiceInfo -> ChoiceInfo
+  setChoiceFormat newChoiceFormat x = x { choiceFormat = newChoiceFormat }

--- a/marlowe-playground-client/src/MetadataTab/Types.purs
+++ b/marlowe-playground-client/src/MetadataTab/Types.purs
@@ -1,6 +1,7 @@
 module MetadataTab.Types where
 
 import Marlowe.Extended (ContractType)
+import Marlowe.Extended.Metadata (ChoiceFormat)
 import Marlowe.Semantics as S
 
 class ShowConstructor a where
@@ -17,7 +18,8 @@ data MetadataAction
   | SetValueParameterDescription String String
   | DeleteValueParameterDescription String
   | SetChoiceDescription String String
-  | DeleteChoiceDescription String
+  | SetChoiceFormat String ChoiceFormat
+  | DeleteChoiceInfo String
 
 instance metadataActionShowConstructor :: ShowConstructor MetadataAction where
   showConstructor (SetContractName _) = "SetContractName"
@@ -30,4 +32,5 @@ instance metadataActionShowConstructor :: ShowConstructor MetadataAction where
   showConstructor (SetValueParameterDescription _ _) = "SetValueParameterDescription"
   showConstructor (DeleteValueParameterDescription _) = "DeleteValueParameterDescription"
   showConstructor (SetChoiceDescription _ _) = "SetChoiceDescription"
-  showConstructor (DeleteChoiceDescription _) = "DeleteChoiceDescription"
+  showConstructor (SetChoiceFormat _ _) = "SetChoiceFormat"
+  showConstructor (DeleteChoiceInfo _) = "DeleteChoiceInfo"

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -13,6 +13,7 @@ import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), isJust, maybe)
 import Data.Newtype (unwrap, wrap)
+import Data.String (trim)
 import Data.Tuple (Tuple(..), snd)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
@@ -412,13 +413,18 @@ inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwn
                             ([ text "“" ] <> markdownToHTML explanation <> [ text "„" ])
                         ]
                     )
-                    $ Map.lookup choiceName metadata.choiceDescriptions
+                    (Map.lookup choiceName metadata.choiceInfo >>= mExtractDescription)
                 )
           )
       ]
         <> addButton
     )
   where
+  mExtractDescription { choiceDescription }
+    | trim choiceDescription /= "" = Just choiceDescription
+
+  mExtractDescription _ = Nothing
+
   addButton =
     if inBounds chosenNum bounds then
       [ button

--- a/web-common-marlowe/src/Examples/Metadata.purs
+++ b/web-common-marlowe/src/Examples/Metadata.purs
@@ -3,7 +3,7 @@ module Examples.Metadata where
 import Data.Map (fromFoldable, empty)
 import Data.Tuple.Nested ((/\))
 import Marlowe.Extended (ContractType(..))
-import Marlowe.Extended.Metadata (MetaData, emptyContractMetadata)
+import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData, emptyContractMetadata, lovelaceFormat, oracleRatioFormat)
 
 example :: MetaData
 example = emptyContractMetadata
@@ -13,13 +13,28 @@ escrow =
   { contractType: Escrow
   , contractName: "Simple escrow"
   , contractDescription: "Regulates a money exchange between a *Buyer* and a *Seller*. If there is a disagreement, an *Arbiter* will decide whether the money is refunded or paid to the *Seller*."
-  , choiceDescriptions:
+  , choiceInfo:
       ( fromFoldable
-          [ "Confirm problem" /\ "Acknowledge there was a problem and a refund must be granted."
-          , "Dismiss claim" /\ "The *Arbiter* does not see any problem with the exchange and the *Seller* must be paid."
-          , "Dispute problem" /\ "The *Seller* disagrees with the *Buyer* about the claim that something went wrong."
-          , "Everything is alright" /\ "The transaction was uneventful, *Buyer* agrees to pay the *Seller*."
-          , "Report problem" /\ "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
+          [ "Confirm problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "Acknowledge there was a problem and a refund must be granted."
+                }
+          , "Dismiss claim"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The *Arbiter* does not see any problem with the exchange and the *Seller* must be paid."
+                }
+          , "Dispute problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The *Seller* disagrees with the *Buyer* about the claim that something went wrong."
+                }
+          , "Everything is alright"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The transaction was uneventful, *Buyer* agrees to pay the *Seller*."
+                }
+          , "Report problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
+                }
           ]
       )
   , roleDescriptions:
@@ -45,12 +60,24 @@ escrowWithCollateral =
   { contractType: Escrow
   , contractName: "Escrow with collateral"
   , contractDescription: "Regulates a money exchange between a *Buyer* and a *Seller* using a collateral from both parties to incentivize collaboration. If there is a disagreement the collateral is burned."
-  , choiceDescriptions:
+  , choiceInfo:
       ( fromFoldable
-          [ "Confirm problem" /\ "Acknowledge that there was a problem and a refund must be granted."
-          , "Dispute problem" /\ "The *Seller* disagrees with the *Buyer* about the claim that something went wrong and the collateral will be burnt."
-          , "Everything is alright" /\ "The exchange was successful and the *Buyer* agrees to pay the *Seller*."
-          , "Report problem" /\ "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
+          [ "Confirm problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "Acknowledge that there was a problem and a refund must be granted."
+                }
+          , "Dispute problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The *Seller* disagrees with the *Buyer* about the claim that something went wrong and the collateral will be burnt."
+                }
+          , "Everything is alright"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The exchange was successful and the *Buyer* agrees to pay the *Seller*."
+                }
+          , "Report problem"
+              /\ { choiceFormat: DefaultFormat
+                , choiceDescription: "The *Buyer* claims not having received the product that was paid for as agreed and would like a refund."
+                }
           ]
       )
   , roleDescriptions:
@@ -81,7 +108,7 @@ zeroCouponBond =
   { contractType: ZeroCouponBond
   , contractName: "Zero Coupon Bond"
   , contractDescription: "A simple loan. The *Investor* pays the *Issuer* the *Discounted price* at the start, and is repaid the full *Notional price* at the end."
-  , choiceDescriptions: empty
+  , choiceInfo: empty
   , roleDescriptions:
       ( fromFoldable
           [ "Investor" /\ "The party that buys the bond at a discounted price, i.e. makes the loan."
@@ -107,7 +134,7 @@ couponBondGuaranteed =
   { contractType: CouponBondGuaranteed
   , contractName: "Coupon Bond Guaranteed"
   , contractDescription: "Debt agreement between an *Investor* and an *Issuer*. *Investor* will advance the *Principal* amount at the beginning of the contract, and the *Issuer* will pay back *Interest instalment* every 30 slots and the *Principal* amount by the end of 3 instalments. The debt is backed by a collateral provided by the *Guarantor* which will be refunded as long as the *Issuer* pays back on time."
-  , choiceDescriptions: empty
+  , choiceInfo: empty
   , roleDescriptions:
       ( fromFoldable
           [ "Guarantor" /\ "Provides a collateral in case the *Issuer* defaults."
@@ -129,7 +156,7 @@ swap =
   { contractType: Swap
   , contractName: "Swap of Ada and dollar tokens"
   , contractDescription: "Takes Ada from one party and dollar tokens from another party, and it swaps them atomically."
-  , choiceDescriptions: empty
+  , choiceInfo: empty
   , roleDescriptions:
       ( fromFoldable
           [ "Ada provider" /\ "The party that provides the Ada."
@@ -155,10 +182,16 @@ contractForDifferences =
   { contractType: ContractForDifferences
   , contractName: "Contract for Differences"
   , contractDescription: "*Party* and *Counterparty* deposit 100 Ada and after 60 slots is redistributed depending on the change in a given trade price reported by *Oracle*. If the price increases, the difference goes to *Counterparty*; if it decreases, the difference goes to *Party*, up to a maximum of 100 Ada."
-  , choiceDescriptions:
+  , choiceInfo:
       ( fromFoldable
-          [ "Price at beginning" /\ "Trade price at the beginning of the contract."
-          , "Price at end" /\ "Trade price at the end of the contract."
+          [ "Price at beginning"
+              /\ { choiceFormat: lovelaceFormat
+                , choiceDescription: "Trade price at the beginning of the contract."
+                }
+          , "Price at end"
+              /\ { choiceFormat: lovelaceFormat
+                , choiceDescription: "Trade price at the end of the contract."
+                }
           ]
       )
   , roleDescriptions:
@@ -177,10 +210,16 @@ contractForDifferencesWithOracle =
   { contractType: ContractForDifferences
   , contractName: "Contract for Differences with Oracle"
   , contractDescription: "*Party* and *Counterparty* deposit 100 Ada and after 60 slots these assets are redistributed depending on the change in price of 100 Ada worth of dollars between the start and the end of the contract. If the price increases, the difference goes to *Counterparty*; if it decreases, the difference goes to *Party*, up to a maximum of 100 Ada."
-  , choiceDescriptions:
+  , choiceInfo:
       ( fromFoldable
-          [ "dir-adausd" /\ "Exchange rate ADA/USD at the beginning of the contract."
-          , "inv-adausd" /\ "Exchange rate USD/ADA at the end of the contract."
+          [ "dir-adausd"
+              /\ { choiceFormat: oracleRatioFormat "ADA/USD"
+                , choiceDescription: "Exchange rate ADA/USD at the beginning of the contract."
+                }
+          , "inv-adausd"
+              /\ { choiceFormat: oracleRatioFormat "USD/ADA"
+                , choiceDescription: "Exchange rate USD/ADA at the end of the contract."
+                }
           ]
       )
   , roleDescriptions:


### PR DESCRIPTION
This PR modifies the type of metadata to include information about the format that the choices have.

In the end, I am suggesting the following formatting options for now:

```haskell
data ChoiceFormat
  = DefaultFormat
  | Decimal Int String
```

Where `DefaultFormat` just represents that we didn't bother setting up a formatting for the choice (we can have the same behaviour as until now, some kind of "auto" option). And `Decimal` means that this is a number representing a number with `Int` decimals and the `String` decorating label, which could be used for currency symbol or something else that is very brief.

I found this to be most useful when looking at the current examples because we currently use it for:
- Ada, which I have defined to be `Decimal 6 "₳"`
- And conversion coefficients, which I have defined to be `Decimal 8 str`, where `str` would be "USD/ADA" for example.

We can still discuss whether we want to add formatters like enum or change this to have currency information (like special formatter for ADA, for example), at the moment this is very easy to change since it is not yet used by anything.

And I have also modified empty string in `choiceDescription` to mean no choice description, since I thought having two levels of `Maybe` was overkill.

Deployed to http://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
