### PR TITLE
Revert "SCP-2375: Kwxm/rescale ledger costs"

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -178,13 +178,6 @@ instance Semigroup ExBudget where
 instance Monoid ExBudget where
     mempty = ExBudget mempty mempty
 
-{- | Make budgets scalable.  We only want to scale the cpu costs because they're
-   in picoseconds, which are too big for general use.  Memory costs are in
-   bytes, which don't require scaling. -}
-instance Scalable ExBudget where
-    scaleUp   k (ExBudget cpu mem) = ExBudget (scaleUp   k cpu) mem
-    scaleDown k (ExBudget cpu mem) = ExBudget (scaleDown k cpu) mem
-
 instance Pretty ExBudget where
     pretty (ExBudget cpu memory) = parens $ fold
         [ "{ cpu: ", pretty cpu, line

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -13,8 +13,6 @@ module PlutusCore.Evaluation.Machine.ExMemory
 , ExCPU(..)
 , GenericExMemoryUsage(..)
 , ExMemoryUsage(..)
-, upperIntegerQuotient  -- Exported for testing
-, Scalable (..)
 ) where
 
 import           PlutusCore.Core
@@ -96,38 +94,8 @@ type CostingInteger =
     SatInt
 #endif
 
-{- | Divide one costing integer by another, "rounding upwards".  This is needed
-when we expose costs to the ledger, which will use different (smaller) units.
-Suppose one ledger unit is 1000 real cost units: then if a script costs 12345678
-real units we want that to be converted to 12346 ledger units, since 12345 (as
-given by `div`) would convert to 12345000 real units, which wouldn't be enough
-to run the script.  We want a <= (a `uppperIntegerQuotient` b) * b < a+b for all
-a and for all b>0, except that we may get '==' instead of '<' when we're using
-SatInt and a+b == MaxBound.  The behaviour when b <= 0 is unspecified.
--}
-upperIntegerQuotient :: CostingInteger -> CostingInteger -> CostingInteger
-a `upperIntegerQuotient` b =
-    let (q,r) = a `divMod` b
-    in if r==0 then q else q+1
 
-{- | A class which allows us to scale budget-related quantities upwards and
-downwards by a strictly positive integer factor.  The operations are NOT
-required to be mutually inverse: in the instances for costing integers we
-always have `scaleDown k . scaleUp k = id`, but `scaleDown` loses information
-and so we don't have `scaleUp k (scaleDown k c) = c`; instead (and by design)
-we have `c <= scaleUp k (scaleDown k c) <= c+k` for all c and for all k > 0. -}
-class Scalable a where
-    scaleUp   :: Integer -> a -> a
-    scaleDown :: Integer -> a -> a
-
-checkPositive :: Integer -> a -> a
-checkPositive k r =
-    if k > 0 then r
-    else error $ "Scalable: strictly positive scale factor expected, but found " ++ show k
-
-instance Scalable CostingInteger where
-    scaleUp   k c = checkPositive k $ (fromInteger k) * c
-    scaleDown k c = checkPositive k $ c `upperIntegerQuotient` (fromInteger k)
+-- $(if finiteBitSize (0::SatInt) < 64 then [t|Integer|] else [t|SatInt|])
 
 -- | Counts size in machine words.
 newtype ExMemory = ExMemory CostingInteger
@@ -144,7 +112,7 @@ instance PrettyBy config ExMemory where
 -- appproximately 106 days.
 newtype ExCPU = ExCPU CostingInteger
   deriving (Eq, Ord, Show, Lift)
-  deriving newtype (Num, NFData, Scalable)
+  deriving newtype (Num, NFData)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
 instance Pretty ExCPU where

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -8,35 +8,33 @@ module Main
 
 import           PlutusPrelude
 
-import qualified Check.Spec                             as Check
+import qualified Check.Spec                        as Check
 import           CostModelInterface.Spec
-import           Evaluation.Spec                        (test_evaluation)
+import           Evaluation.Spec                   (test_evaluation)
 import           Normalization.Check
 import           Normalization.Type
 import           Pretty.Readable
-import           TypeSynthesis.Spec                     (test_typecheck)
+import           TypeSynthesis.Spec                (test_typecheck)
 
 import           PlutusCore
 import           PlutusCore.DeBruijn
-import           PlutusCore.Evaluation.Machine.ExMemory
 import           PlutusCore.Generators
-import           PlutusCore.Generators.AST              as AST
+import           PlutusCore.Generators.AST         as AST
 import           PlutusCore.Generators.Interesting
-import qualified PlutusCore.Generators.NEAT.Spec        as NEAT
+import qualified PlutusCore.Generators.NEAT.Spec   as NEAT
 import           PlutusCore.MkPlc
 import           PlutusCore.Pretty
 
 import           Codec.Serialise
 import           Control.Monad.Except
-import qualified Data.ByteString.Lazy                   as BSL
-import           Data.Int                               (Int64)
-import qualified Data.Text                              as T
-import           Data.Text.Encoding                     (encodeUtf8)
-import           Flat                                   (flat)
+import qualified Data.ByteString.Lazy              as BSL
+import qualified Data.Text                         as T
+import           Data.Text.Encoding                (encodeUtf8)
+import           Flat                              (flat)
 import qualified Flat
-import           Hedgehog                               hiding (Var)
-import qualified Hedgehog.Gen                           as Gen
-import qualified Hedgehog.Range                         as Range
+import           Hedgehog                          hiding (Var)
+import qualified Hedgehog.Gen                      as Gen
+import qualified Hedgehog.Range                    as Range
 import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
@@ -185,32 +183,6 @@ propParser = property $ do
     Hedgehog.tripping prog (reprint . unTextualProgram)
                 (\p -> fmap (TextualProgram . void) $ runQuote $ runExceptT $ parseProgram @(DefaultError AlexPosn) p)
 
--- | Check that the `uppperIntegerQuotient` function behaves sensibly.  This
--- operates on CostingIntegers (which are either SatInt or Integer), so we have
--- to be a little careful to use generators which work for both and include
--- the SatInt upper bound.
-propUpperIntegerQuotient :: Property
-propUpperIntegerQuotient = withTests 100000 . property $ do
-    a <- forAll $ fromIntegral <$> Gen.choice [uniform, small, largePositive, largeNegative]
-    b <- forAll $ fromIntegral <$> Gen.choice [uniformPositive, smallPositive, largePositive]
-    -- ^ The behaviour isn't specified for b<=0, so we only check strictly positive b.
-    let d = a `upperIntegerQuotient` b
-    Hedgehog.assert $ a <= d*b
-    Hedgehog.assert $ d*b < a+b || a+b == fromIntegral max64
-      -- We really want <, but that can fail for large a with SatInt, eg if a=maxBound and b=1.
-    where min64 = minBound :: Int64
-          max64 = maxBound :: Int64
-          -- A selection of generators to get good coverage including the centre and the extremes.
-          -- The 'constant' Range gives a uniform distribution.  For the default Size, 'linear...'
-          -- ranges appear to give distributions which only include the lower 30% or so of the
-          -- given interval.
-          uniform         = Gen.integral $ Range.constant min64 max64
-          small           = Gen.integral $ Range.constant (-10) 10
-          largeNegative   = Gen.integral $ Range.constant min64 (min64 + 100)
-          largePositive   = Gen.integral $ Range.constant (max64-100) max64
-          uniformPositive = Gen.integral $ Range.constant 1 max64
-          smallPositive   = Gen.integral $ Range.constant 1 10
-
 propRename :: Property
 propRename = property $ do
     prog <- forAllPretty $ runAstGen genProgram
@@ -247,7 +219,6 @@ allTests plcFiles rwFiles typeFiles typeErrorFiles =
     , testProperty "parser round-trip" propParser
     , testProperty "serialization round-trip (CBOR)" propCBOR
     , testProperty "serialization round-trip (Flat)" propFlat
-    , testProperty "upperIntegerQuotient behaves correctly" propUpperIntegerQuotient
     , testProperty "equality survives renaming" propRename
     , testProperty "equality does not survive mangling" propMangle
     , testGroup "de Bruijn transformation round-trip" $

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -95,7 +95,7 @@ import qualified PlutusCore.DeBruijn                              as PLC
 import           PlutusCore.Evaluation.Machine.CostModelInterface (CostModelParams, applyCostModelParams)
 import           PlutusCore.Evaluation.Machine.ExBudget           (ExBudget (..))
 import qualified PlutusCore.Evaluation.Machine.ExBudget           as PLC
-import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..), Scalable (..))
+import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..))
 import           PlutusCore.Evaluation.Machine.MachineParameters
 import qualified PlutusCore.MkPlc                                 as PLC
 import           PlutusCore.Pretty
@@ -131,14 +131,6 @@ So we're going to end up with multiple versions of the types and functions that 
 internally. That means we don't lose anything by exposing all the details: we're never going to remove
 anything, we're just going to create new versions.
 -}
-
-{- | Internally the evaluator uses costs which approximate execution times in
-picoseconds.  This gives huge numbers which are unsuitable for users so we
-expose nanosecond-based costs to the ledger and scale them up and down to and
-from picoseconds for internal use.  The maximum possible cost from the viewpoint
-of the ledger will be 9223372036854776 units. -}
-costScaleFactor :: Integer
-costScaleFactor = 1000
 
 -- | Check if a 'Script' is "valid". At the moment this just means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and cannot be interpreted as some other kind of encoded data.
@@ -205,7 +197,7 @@ evaluateScriptRestricting verbose cmdata budget p args = swap $ runWriter @LogOu
     let (res, _, logs) =
             UPLC.runCek
                 (toMachineParameters model)
-                (UPLC.restricting $ PLC.ExRestrictingBudget (scaleUp costScaleFactor budget))
+                (UPLC.restricting $ PLC.ExRestrictingBudget budget)
                 (verbose == Verbose)
                 appliedTerm
 
@@ -235,4 +227,4 @@ evaluateScriptCounting verbose cmdata p args = swap $ runWriter @LogOutput $ run
 
     tell $ Prelude.map Text.pack logs
     liftEither $ first CekError $ void res
-    pure $ scaleDown costScaleFactor final
+    pure final


### PR DESCRIPTION
Reverts input-output-hk/plutus#3379

In a [Slack discussion](https://input-output-rnd.slack.com/archives/C21UF2WVC/p1624308474236900?thread_ts=1623683048.160500&cid=C21UF2WVC) the ledger people have decided that they'll do cost scaling on their side.  It seems risky to scale costs in multiple places, so let's revert this and use picoseconds everywhere in `plutus-core`.