### PR TITLE
Fix assertFailedTransactions

### DIFF
--- a/plutus-contract/src/Wallet/Emulator/Folds.hs
+++ b/plutus-contract/src/Wallet/Emulator/Folds.hs
@@ -48,6 +48,7 @@ module Wallet.Emulator.Folds (
     , postMapM
     ) where
 
+import           Control.Applicative                    ((<|>))
 import           Control.Foldl                          (Fold (..), FoldM (..))
 import qualified Control.Foldl                          as L
 import           Control.Lens                           hiding (Empty, Fold)
@@ -80,10 +81,12 @@ import           Plutus.Trace.Emulator.Types            (ContractInstanceLog, Co
                                                          _HandledRequest, cilMessage, cilTag, toInstanceState)
 import           Wallet.Emulator.Chain                  (ChainEvent (..), _TxnValidate, _TxnValidationFail)
 import           Wallet.Emulator.ChainIndex             (_AddressStartWatching)
+import           Wallet.Emulator.LogMessages            (_ValidationFailed)
 import           Wallet.Emulator.MultiAgent             (EmulatorEvent, EmulatorTimeEvent, chainEvent, chainIndexEvent,
-                                                         eteEvent, instanceEvent, userThreadEvent, walletClientEvent)
+                                                         eteEvent, instanceEvent, userThreadEvent, walletClientEvent,
+                                                         walletEvent')
 import           Wallet.Emulator.NodeClient             (_TxSubmit)
-import           Wallet.Emulator.Wallet                 (Wallet, walletAddress)
+import           Wallet.Emulator.Wallet                 (Wallet, _TxBalanceLog, walletAddress)
 import qualified Wallet.Rollup                          as Rollup
 import           Wallet.Rollup.Types                    (AnnotatedTx)
 
@@ -94,8 +97,10 @@ type EmulatorEventFoldM effs a = FoldM (Eff effs) EmulatorEvent a
 
 -- | Transactions that failed to validate, in the given validation phase (if specified).
 failedTransactions :: Maybe ValidationPhase -> EmulatorEventFold [(TxId, Tx, ValidationError, [ScriptValidationEvent])]
-failedTransactions phase = preMapMaybe (preview (eteEvent . chainEvent . _TxnValidationFail) >=> filterPhase phase) L.list
+failedTransactions phase = preMapMaybe (f >=> filterPhase phase) L.list
     where
+        f e = preview (eteEvent . chainEvent . _TxnValidationFail) e
+          <|> preview (eteEvent . walletEvent' . _2 . _TxBalanceLog . _ValidationFailed) e
         filterPhase Nothing (_, i, t, v, e)   = Just (i, t, v, e)
         filterPhase (Just p) (p', i, t, v, e) = if p == p' then Just (i, t, v, e) else Nothing
 

--- a/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
+++ b/plutus-contract/src/Wallet/Emulator/MultiAgent.hs
@@ -107,6 +107,9 @@ walletClientEvent w = prism' (ClientEvent w) (\case { ClientEvent w' c | w == w'
 walletEvent :: Wallet.Wallet -> Prism' EmulatorEvent' Wallet.WalletEvent
 walletEvent w = prism' (WalletEvent w) (\case { WalletEvent w' c | w == w' -> Just c; _ -> Nothing })
 
+walletEvent' :: Prism' EmulatorEvent' (Wallet.Wallet, Wallet.WalletEvent)
+walletEvent' = prism' (uncurry WalletEvent) (\case { WalletEvent w c -> Just (w, c); _ -> Nothing })
+
 chainIndexEvent :: Wallet.Wallet -> Prism' EmulatorEvent' ChainIndex.ChainIndexEvent
 chainIndexEvent w = prism' (ChainIndexEvent w) (\case { ChainIndexEvent w' c | w == w' -> Just c; _ -> Nothing })
 

--- a/plutus-contract/test/Spec/Emulator.hs
+++ b/plutus-contract/test/Spec/Emulator.hs
@@ -78,6 +78,7 @@ tests = testGroup "all tests" [
         ],
     testGroup "traces" [
         testProperty "accept valid txn" validTrace,
+        testProperty "accept valid txn 2" validTrace2,
         testProperty "reject invalid txn" invalidTrace,
         testProperty "notify wallet" notifyWallet,
         testProperty "watch funds at an address" walletWatchinOwnAddress,
@@ -197,6 +198,16 @@ validTrace = property $ do
     let options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
         trace = Trace.liftWallet wallet1 (submitTxn txn)
     checkPredicateInner options assertNoFailedTransactions trace Hedgehog.annotate Hedgehog.assert
+
+validTrace2 :: Property
+validTrace2 = property $ do
+    (Mockchain m _, txn) <- forAll genChainTxn
+    let options = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Right m
+        trace = do
+            Trace.liftWallet wallet1 (submitTxn txn)
+            Trace.liftWallet wallet1 (submitTxn txn)
+        predicate = assertFailedTransaction (\_ _ _ -> True)
+    checkPredicateInner options predicate trace Hedgehog.annotate Hedgehog.assert
 
 invalidTrace :: Property
 invalidTrace = property $ do


### PR DESCRIPTION
https://github.com/input-output-hk/plutus/pull/3222 added validations to transactions in the Wallet Emulator that excluded invalid ones from being submitted to the chain, but `assertFailedTransactions` was only "listening" for transactions that have been submitted to the chain. This PR adds Validation Failed messages to the Wallet Emulator and updates `failedTransactions` to also "listen" for them to recover the previous behavior

Fixes https://github.com/input-output-hk/plutus/issues/3338

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
