### PR TITLE
SCP-2415 - Extending payment type to include source account and transfers.

### DIFF
--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -31,11 +31,11 @@ import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe.Extended.Metadata (MetaData, NumberFormat(..), getChoiceFormat)
 import Marlowe.Monaco (daylightTheme, languageExtensionPoint)
 import Marlowe.Monaco as MM
-import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party(..), Payment(..), PubKey, Slot, SlotInterval(..), Token(..), TransactionInput(..), inBounds, timeouts)
+import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party(..), Payee(..), Payment(..), PubKey, Slot, SlotInterval(..), Token(..), TransactionInput(..), inBounds, timeouts)
 import Marlowe.Template (IntegerTemplateType(..))
 import Monaco (Editor)
 import Monaco as Monaco
-import Pretty (renderPrettyParty, renderPrettyToken, showPrettyChoice, showPrettyMoney)
+import Pretty (renderPrettyParty, renderPrettyPayee, renderPrettyToken, showPrettyChoice, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
 import SimulationPage.Lenses (_bottomPanelState)
 import SimulationPage.Types (Action(..), BottomPanelView(..), State)
@@ -617,17 +617,19 @@ inputToLine _ (SlotInterval start end) INotify =
   ]
 
 paymentToLines :: forall p a. MetaData -> SlotInterval -> Payment -> Array (HTML p a)
-paymentToLines metadata slotInterval (Payment party money) = join $ unfoldAssets money (paymentToLine metadata slotInterval party)
+paymentToLines metadata slotInterval (Payment accountId payee money) = join $ unfoldAssets money (paymentToLine metadata slotInterval accountId payee)
 
-paymentToLine :: forall p a. MetaData -> SlotInterval -> Party -> Token -> BigInteger -> Array (HTML p a)
-paymentToLine metadata (SlotInterval start end) party token money =
+paymentToLine :: forall p a. MetaData -> SlotInterval -> AccountId -> Payee -> Token -> BigInteger -> Array (HTML p a)
+paymentToLine metadata (SlotInterval start end) accountId payee token money =
   [ span_
       [ text "The contract pays "
       , strong_ [ text (showPrettyMoney money) ]
       , text " units of "
       , strong_ [ renderPrettyToken token ]
-      , text " to participant "
-      , strong_ [ renderPrettyParty metadata party ]
+      , text " to "
+      , strong_ $ renderPrettyPayee metadata payee
+      , text " from "
+      , strong_ $ renderPrettyPayee metadata (Account accountId)
       ]
   , span [ class_ justifyEnd ] [ text $ showSlotRange start end ]
   ]

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -561,19 +561,19 @@ mkMarloweStateMachineTransition params SM.State{ SM.stateData=MarloweData{..}, S
     collectDeposits _                                     = P.zero
 
     payoutConstraints :: [Payment] -> TxConstraints i0 o0
-    payoutConstraints payments = P.foldMap paymentToTxOut paymentsByParty
+    payoutConstraints payments = P.foldMap payoutToTxOut payoutsByParty
       where
-        paymentsByParty = AssocMap.toList $ P.foldMap paymentByParty payments
+        payoutsByParty = AssocMap.toList $ P.foldMap payoutByParty payments
 
-        paymentToTxOut (party, value) = case party of
+        payoutToTxOut (party, value) = case party of
             PK pk  -> mustPayToPubKey pk value
             Role role -> let
                 dataValue = Datum $ PlutusTx.toData role
                 in mustPayToOtherScript (rolePayoutValidatorHash params) dataValue value
 
-        paymentByParty (Payment _ (Party party) money) = AssocMap.singleton party money
+        payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party money
 
-        paymentByParty (Payment _ (Account _) _)       = AssocMap.empty
+        payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
 
 
 {-# INLINABLE isFinal #-}

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -553,11 +553,11 @@ addMoneyToAccount accId token amount accounts = let
     Returns the appropriate effect and updated accounts
 -}
 giveMoney :: AccountId -> Payee -> Token -> Integer -> Accounts -> (ReduceEffect, Accounts)
-giveMoney accountId payee (Token cur tok) amount accounts = case payee of
-    Party _       -> (ReduceWithPayment (Payment accountId payee (Val.singleton cur tok amount)), accounts)
-    Account accId -> let
-        newAccs = addMoneyToAccount accId (Token cur tok) amount accounts
-        in (ReduceNoPayment, newAccs)
+giveMoney accountId payee (Token cur tok) amount accounts = let
+    newAccounts = case payee of
+        Party _       -> accounts
+        Account accId -> addMoneyToAccount accId (Token cur tok) amount accounts
+    in (ReduceWithPayment (Payment accountId payee (Val.singleton cur tok amount)), newAccounts)
 
 
 -- | Carry a step of the contract with no inputs

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -48,8 +48,8 @@ getAccountsDiff :: [Payment] -> [Input] -> AccountsDiff
 getAccountsDiff payments inputs =
     foldl' (\acc (p, m) -> addAccountsDiff p m acc) emptyAccountsDiff (incomes ++ outcomes)
   where
-    incomes  = [ (p,  Val.singleton cur tok m) | IDeposit _ p (Token cur tok) m <- inputs ]
-    outcomes = [ (p, P.negate m) | Payment p m  <- payments ]
+    incomes  = [ (p, Val.singleton cur tok m) | IDeposit _ p (Token cur tok) m <- inputs ]
+    outcomes = [ (p, P.negate m) | Payment _ (Party p) m  <- payments ]
 
 
 foldMapContract :: Monoid m

--- a/web-common-marlowe/src/Marlowe/Semantics.purs
+++ b/web-common-marlowe/src/Marlowe/Semantics.purs
@@ -1400,13 +1400,13 @@ addMoneyToAccount accId token amount accounts =
     Returns the appropriate effect and updated accounts
 -}
 giveMoney :: AccountId -> Payee -> Token -> BigInteger -> Accounts -> Tuple ReduceEffect Accounts
-giveMoney accountId payee token@(Token cur tok) amount accounts = case payee of
-  Party _ -> Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
-  Account accId ->
-    let
-      newAccs = addMoneyToAccount accId token amount accounts
-    in
-      Tuple ReduceNoPayment newAccs
+giveMoney accountId payee token@(Token cur tok) amount accounts =
+  let
+    newAccounts = case payee of
+      Party _ -> accounts
+      Account accId -> addMoneyToAccount accId token amount accounts
+  in
+    Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
 
 -- | Carry a step of the contract with no inputs
 reduceContractStep :: Environment -> State -> Contract -> ReduceStepResult

--- a/web-common-marlowe/src/Marlowe/Semantics.purs
+++ b/web-common-marlowe/src/Marlowe/Semantics.purs
@@ -1401,7 +1401,7 @@ addMoneyToAccount accId token amount accounts =
 -}
 giveMoney :: AccountId -> Payee -> Token -> BigInteger -> Accounts -> Tuple ReduceEffect Accounts
 giveMoney accountId payee token@(Token cur tok) amount accounts = case payee of
-  Party party -> Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
+  Party _ -> Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
   Account accId ->
     let
       newAccs = addMoneyToAccount accId token amount accounts


### PR DESCRIPTION
This PR extends the `Payment` type (part of the `TransactionOutput`) to include the account from which the payment is made, and changes `Party` to `Payee` so that it covers internal transfers as well.

I don't know what I'm doing with the Haskell side of things, so @nau and @palas please check that closely. :flushed: 