### PR TITLE
SCP-2408 - Add choice format info editing to metadata editor

### DIFF
--- a/marlowe-playground-client/src/MetadataTab/View.purs
+++ b/marlowe-playground-client/src/MetadataTab/View.purs
@@ -10,7 +10,7 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Set (Set, toUnfoldable)
 import Data.Tuple.Nested (type (/\), (/\))
-import Halogen.Classes (minusBtn, plusBtn, smallBtn, btn)
+import Halogen.Classes (minusBtn, plusBtn, btn)
 import Halogen.HTML (ClassName(..), HTML, button, div, em_, h6_, input, option, select, text)
 import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), class_, classes, min, placeholder, required, selected, type_, value)
@@ -33,7 +33,7 @@ onlyDescriptionRenderer setAction deleteAction key info needed metadataAction ty
       ]
   , div [ class_ $ ClassName "metadata-prop-delete" ]
       [ button
-          [ classes [ if needed then plusBtn else minusBtn, smallBtn, ClassName "align-top", btn ]
+          [ classes [ if needed then plusBtn else minusBtn, ClassName "align-top", btn ]
           , onClick $ const $ Just $ metadataAction $ deleteAction key
           ]
           [ text "-" ]
@@ -75,7 +75,7 @@ choiceMetadataRenderer key info@{ choiceFormat } needed metadataAction typeNameT
       ]
   , div [ class_ $ ClassName "metadata-prop-delete" ]
       [ button
-          [ classes [ if needed then plusBtn else minusBtn, smallBtn, ClassName "align-top", btn ]
+          [ classes [ if needed then plusBtn else minusBtn, ClassName "align-top", btn ]
           , onClick $ const $ Just $ metadataAction $ DeleteChoiceInfo key
           ]
           [ text "-" ]
@@ -147,7 +147,7 @@ metadataList metadataAction metadataMap hintSet metadataRenderer typeNameTitle t
                           [ text $ typeNameTitle <> " " <> show key <> " meta-data not defined" ]
                       , div [ class_ $ ClassName "metadata-prop-create" ]
                           [ button
-                              [ classes [ minusBtn, smallBtn, ClassName "align-top", btn ]
+                              [ classes [ minusBtn, ClassName "align-top", btn ]
                               , onClick $ const $ Just $ metadataAction (setEmptyMetadata key)
                               ]
                               [ text "+" ]

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -307,7 +307,7 @@ button.minus-btn:hover {
 
 .metadata-form {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto 1fr 2fr auto auto;
   gap: 0.5rem 0px;
   width: clamp(calc(100% - 3rem), 75rem, 100%);
   box-sizing: border-box;
@@ -317,11 +317,13 @@ button.minus-btn:hover {
 }
 
 .metadata-mainprop-label { padding-right: 1rem; grid-column-start: 1; grid-column-end: 2; }
-.metadata-mainprop-edit { grid-column-start: 2; grid-column-end: 4; }
-.metadata-group-title { grid-column-start: 1; grid-column-end: 5; }
+.metadata-mainprop-edit { grid-column-start: 2; grid-column-end: 5; }
+.metadata-group-title { grid-column-start: 1; grid-column-end: 6; }
 .metadata-prop-label { padding: 0rem 1rem; grid-column-start: 1; grid-column-end: 2; }
-.metadata-prop-edit { grid-column-start: 2; grid-column-end: 3; }
-.metadata-prop-delete { grid-column-start: 3; grid-column-end: 4; }
-.metadata-prop-not-used { padding-left: 1rem; grid-column-start: 4; grid-column-end: 5; }
-.metadata-prop-not-defined { padding-left: 1rem; grid-column-start: 1; grid-column-end: 3; }
-.metadata-prop-create { grid-column-start: 3; grid-column-end: 4; }
+.metadata-prop-edit { grid-column-start: 2; grid-column-end: 4; }
+.metadata-prop-choice-col1 { grid-column-start: 2; grid-column-end: 3; }
+.metadata-prop-choice-col2 { grid-column-start: 3; grid-column-end: 4; }
+.metadata-prop-delete { grid-column-start: 4; grid-column-end: 5; }
+.metadata-prop-not-used { padding-left: 1rem; grid-column-start: 5; grid-column-end: 6; }
+.metadata-prop-not-defined { padding-left: 1rem; grid-column-start: 1; grid-column-end: 4; }
+.metadata-prop-create { grid-column-start: 4; grid-column-end: 5; }

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -28,14 +28,16 @@
 }
 
 button.plus-btn {
-  padding: 0.25rem 0.5rem;
-  margin-left: 0.5rem;
+  padding: 0;
+  width: 25px;
+  height: 25px;
 }
 
 button.minus-btn {
   background: var(--error-color);
-  padding: 0.3rem 0.5rem;
-  margin-left: 0.5rem;
+  padding: 0;
+  width: 25px;
+  height: 25px;
 }
 
 button.minus-btn.disabled {
@@ -308,7 +310,7 @@ button.minus-btn:hover {
 .metadata-form {
   display: grid;
   grid-template-columns: auto 1fr 2fr auto auto;
-  gap: 0.5rem 0px;
+  gap: 0.5rem;
   width: clamp(calc(100% - 3rem), 75rem, 100%);
   box-sizing: border-box;
   align-items: center;
@@ -316,14 +318,14 @@ button.minus-btn:hover {
   padding: 1rem;
 }
 
-.metadata-mainprop-label { padding-right: 1rem; grid-column-start: 1; grid-column-end: 2; }
+.metadata-mainprop-label { grid-column-start: 1; grid-column-end: 2; }
 .metadata-mainprop-edit { grid-column-start: 2; grid-column-end: 5; }
 .metadata-group-title { grid-column-start: 1; grid-column-end: 6; }
-.metadata-prop-label { padding: 0rem 1rem; grid-column-start: 1; grid-column-end: 2; }
+.metadata-prop-label { margin-left: 1rem; grid-column-start: 1; grid-column-end: 2; }
 .metadata-prop-edit { grid-column-start: 2; grid-column-end: 4; }
 .metadata-prop-choice-col1 { grid-column-start: 2; grid-column-end: 3; }
 .metadata-prop-choice-col2 { grid-column-start: 3; grid-column-end: 4; }
 .metadata-prop-delete { grid-column-start: 4; grid-column-end: 5; }
-.metadata-prop-not-used { padding-left: 1rem; grid-column-start: 5; grid-column-end: 6; }
-.metadata-prop-not-defined { padding-left: 1rem; grid-column-start: 1; grid-column-end: 4; }
+.metadata-prop-not-used { grid-column-start: 5; grid-column-end: 6; }
+.metadata-prop-not-defined { margin-left: 1rem; grid-column-start: 1; grid-column-end: 4; }
 .metadata-prop-create { grid-column-start: 4; grid-column-end: 5; }

--- a/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
+++ b/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
@@ -19,7 +19,7 @@ import Marlowe.Template (Placeholders(..), getPlaceholderIds)
 
 data ChoiceFormat
   = DefaultFormat
-  | Decimal Int String
+  | DecimalFormat Int String
 
 derive instance eqChoiceFormat :: Eq ChoiceFormat
 
@@ -35,13 +35,51 @@ instance showChoiceFormat :: Show ChoiceFormat where
   show = genericShow
 
 integerFormat :: ChoiceFormat
-integerFormat = Decimal 0 ""
+integerFormat = DecimalFormat 0 ""
 
 lovelaceFormat :: ChoiceFormat
-lovelaceFormat = Decimal 6 "₳"
+lovelaceFormat = DecimalFormat 6 "₳"
 
 oracleRatioFormat :: String -> ChoiceFormat
-oracleRatioFormat str = Decimal 8 str
+oracleRatioFormat str = DecimalFormat 8 str
+
+isDefaultFormat :: ChoiceFormat -> Boolean
+isDefaultFormat DefaultFormat = true
+
+isDefaultFormat _ = false
+
+isDecimalFormat :: ChoiceFormat -> Boolean
+isDecimalFormat (DecimalFormat _ _) = true
+
+isDecimalFormat _ = false
+
+data ChoiceFormatType
+  = DefaultFormatType
+  | DecimalFormatType
+
+derive instance eqChoiceFormatType :: Eq ChoiceFormatType
+
+toString :: ChoiceFormatType -> String
+toString DefaultFormatType = "DefaultFormatType"
+
+toString DecimalFormatType = "DecimalFormatType"
+
+fromString :: String -> Maybe ChoiceFormatType
+fromString "DefaultFormatType" = Just DefaultFormatType
+
+fromString "DecimalFormatType" = Just DecimalFormatType
+
+fromString _ = Nothing
+
+getFormatType :: ChoiceFormat -> ChoiceFormatType
+getFormatType DefaultFormat = DefaultFormatType
+
+getFormatType (DecimalFormat _ _) = DecimalFormatType
+
+defaultForFormatType :: ChoiceFormatType -> ChoiceFormat
+defaultForFormatType DefaultFormatType = DefaultFormat
+
+defaultForFormatType DecimalFormatType = DecimalFormat 0 ""
 
 type ChoiceInfo
   = { choiceFormat :: ChoiceFormat


### PR DESCRIPTION
This PR adds choice format editing to the metadata editor:

![choice-format](https://user-images.githubusercontent.com/638102/123018733-fd349880-d3c6-11eb-878a-b1cb0363ea1b.gif)

Deployed to: http://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
