### PR TITLE
StateMachine step and initialise with additional constraints and lookups

### DIFF
--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -34,6 +34,9 @@ module Plutus.Contract.StateMachine(
     , runGuardedStep
     , runStep
     , runInitialise
+    , runGuardedStepWith
+    , runStepWith
+    , runInitialiseWith
     , getOnChainState
     , waitForUpdate
     , waitForUpdateUntilSlot
@@ -341,11 +344,83 @@ runInitialise StateMachineClient{scInstance} initialState initialValue = mapErro
 -- | Constraints & lookups needed to transition a state machine instance
 data StateMachineTransition state input =
     StateMachineTransition
-        { smtConstraints :: TxConstraints (Scripts.RedeemerType (StateMachine state input)) (Scripts.DatumType (StateMachine state input))
+        { smtConstraints :: TxConstraints input state
         , smtOldState    :: State state
         , smtNewState    :: State state
         , smtLookups     :: ScriptLookups (StateMachine state input)
         }
+
+-- | Initialise a state machine and supply additional constraints and lookups for transaction.
+runInitialiseWith ::
+    forall w e state schema input.
+    ( PlutusTx.IsData state
+    , PlutusTx.IsData input
+    , AsSMContractError e
+    )
+    => ScriptLookups (StateMachine state input)
+    -- ^ Additional lookups
+    -> TxConstraints input state
+    -- ^ Additional constraints
+    -> StateMachineClient state input
+    -- ^ The state machine
+    -> state
+    -- ^ The initial state
+    -> Value
+    -- ^ The value locked by the contract at the beginning
+    -> Contract w schema e state
+runInitialiseWith customLookups customConstraints StateMachineClient{scInstance} initialState initialValue = mapError (review _SMContractError) $ do
+    let StateMachineInstance{typedValidator, stateMachine} = scInstance
+        tx = mustPayToTheScript initialState (initialValue <> SM.threadTokenValue stateMachine) <> customConstraints
+    let lookups = Constraints.typedValidatorLookups typedValidator <> customLookups
+    utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups tx)
+    submitTxConfirmed utx
+    pure initialState
+
+-- | Run one step of a state machine, returning the new state. We can supply additional constraints and lookups for transaction.
+runStepWith ::
+    forall w e state schema input.
+    ( AsSMContractError e
+    , PlutusTx.IsData state
+    , PlutusTx.IsData input
+    )
+    => ScriptLookups (StateMachine state input)
+    -- ^ Additional lookups
+    -> TxConstraints input state
+    -- ^ Additional constraints
+    -> StateMachineClient state input
+    -- ^ The state machine
+    -> input
+    -- ^ The input to apply to the state machine
+    -> Contract w schema e (TransitionResult state input)
+runStepWith lookups constraints smc input =
+    runGuardedStepWith lookups constraints smc input (\_ _ _ -> Nothing) >>= pure . \case
+        Left a  -> absurd a
+        Right a -> a
+
+-- | The same as 'runGuardedStep' but we can supply additional constraints and lookups for transaction.
+runGuardedStepWith ::
+    forall w a e state schema input.
+    ( AsSMContractError e
+    , PlutusTx.IsData state
+    , PlutusTx.IsData input
+    )
+    => ScriptLookups (StateMachine state input)    -- ^ Additional lookups
+    -> TxConstraints input state                   -- ^ Additional constraints
+    -> StateMachineClient state input              -- ^ The state machine
+    -> input                                       -- ^ The input to apply to the state machine
+    -> (UnbalancedTx -> state -> state -> Maybe a) -- ^ The guard to check before running the step
+    -> Contract w schema e (Either a (TransitionResult state input))
+runGuardedStepWith userLookups userConstraints smc input guard = mapError (review _SMContractError) $ mkStep smc input >>= \case
+     Right (StateMachineTransition{smtConstraints,smtOldState=State{stateData=os}, smtNewState=State{stateData=ns}, smtLookups}) -> do
+         pk <- ownPubKey
+         let lookups = smtLookups { Constraints.slOwnPubkey = Just $ pubKeyHash pk }
+         utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx (lookups <> userLookups) (smtConstraints <> userConstraints))
+         case guard utx os ns of
+             Nothing -> do
+                 submitTxConfirmed utx
+                 pure $ Right $ TransitionSuccess ns
+             Just a  -> pure $ Left a
+     Left e -> pure $ Right $ TransitionFailure e
 
 -- | Given a state machine client and an input to apply to
 --   the client's state machine instance, compute the 'StateMachineTransition'


### PR DESCRIPTION
we have nice function  `submitTxConstraintsWith` that allows to pass additional constraints and lookups.
It would be great to have the same counterpart for StateMachine.

* **problem**:

We have useful functions for SM transitions: `runStep` and `runInitialise`.
But I've found that they are often not enough because we want to supply additional constraints and lookups 
for transaction that relies on SM. For `runStep` we can make a workaround with `mkStep`, but for `runInitialise` there is no such way.

* **solution**:

With this PR we can define functions similar to `submitTxConstraintsWith` that allow SM-user to pass additional constraints and lookups. They are called `runStepWith`, `runInitialiseWith`.