### PR TITLE
SCP-2435: Use strict environments and make many uses of them strict

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Name.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name.hs
@@ -34,7 +34,7 @@ import           PlutusCore.Pretty.ConfigName
 
 import           Control.Lens
 import           Data.Hashable
-import qualified Data.IntMap                  as IM
+import qualified Data.IntMap.Strict           as IM
 import qualified Data.Text                    as T
 import           Instances.TH.Lift            ()
 import           Language.Haskell.TH.Syntax   (Lift)


### PR DESCRIPTION
Making the parameter patterns strict is crucial otherwise this is a
regression! Making the remaining occurence of `CekValEnv` strict is also
a regression, perhaps unsurprisingly.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
