### PR TITLE
SCP-2409 - Apply format info to simulator

### DIFF
--- a/marlowe-playground-client/src/Halogen/CurrencyInput.js
+++ b/marlowe-playground-client/src/Halogen/CurrencyInput.js
@@ -1,0 +1,53 @@
+const { convertCompilerOptionsFromJson } = require("typescript");
+
+
+exports.setOldValues_ = function(input) {
+    input.old_value = input.value;
+    input.old_selectionStart = input.selectionStart;
+    input.old_selectionEnd = input.selectionEnd;
+}
+
+exports.checkChange_ = function(input) {
+    if (/^-?[0-9]*(\.[0-9]*)?$/.test(input.value)) {
+        exports.setOldValues_(input);
+    } else {
+        input.value = input.old_value;
+        input.selectionStart = input.old_selectionStart;
+        input.selectionEnd = input.old_selectionEnd;
+    }
+}
+
+exports.formatValueString_ = function(text, decimalPlaces) {
+    var positionSeparator = text.indexOf(".");
+    if (positionSeparator < 0) {
+        if (decimalPlaces > 0) {
+            text += '.';
+            text = text.padEnd(text.length + decimalPlaces, '0');
+        }
+    } else {
+        text = text.substring(0, positionSeparator + decimalPlaces + 1);
+        text = text.padEnd(positionSeparator + decimalPlaces + 1, '0');
+    }
+    if (text == '') {
+	text = '0';
+    } else if (text[0] == '.') {
+        text = '0' + text;
+    } else if ((text == '-') || ((text[0] == '-') && (text[1] == '.'))) {
+        text = '-0' + text.substring(1);
+    }
+    return text;
+}
+
+exports.formatValue_ = function(input, decimalPlaces) {
+    input.value = exports.formatValueString_(input.value, decimalPlaces);
+}
+
+exports.setValue_ = function(input, str) {
+    input.value = str;
+}
+
+exports.onChangeHandler_ = function(input, decimalPlaces) {
+    exports.checkChange_(input);
+    exports.formatValue_(input, decimalPlaces);
+    return input.value;
+}

--- a/marlowe-playground-client/src/Halogen/CurrencyInput.js
+++ b/marlowe-playground-client/src/Halogen/CurrencyInput.js
@@ -1,5 +1,3 @@
-const { convertCompilerOptionsFromJson } = require("typescript");
-
 
 exports.setOldValues_ = function(input) {
     input.old_value = input.value;

--- a/marlowe-playground-client/src/Halogen/CurrencyInput.purs
+++ b/marlowe-playground-client/src/Halogen/CurrencyInput.purs
@@ -47,14 +47,14 @@ onChangeHandler = runEffectFn2 onChangeHandler_
 
 currencyInput :: forall p a. Array String -> BigInteger -> String -> Int -> (Maybe BigInteger -> Maybe a) -> HTML p a
 currencyInput classList number prefix rawNumDecimals onValueChangeHandler =
-  div [ classNames ([ "bg-gray-light", "flex", "items-center", "p-0", "m-0", "border-solid", "border", "rounded-sm", "overflow-hidden", "box-border", "focus-within:ring-1", "focus-within:ring-black" ] <> classList) ]
+  div [ classNames ([ "bg-gray-light", "flex", "items-center", "border-solid", "border", "rounded-sm", "overflow-hidden", "box-border", "focus-within:ring-1", "focus-within:ring-black" ] <> classList) ]
     ( ( guard hasPrefix
           [ div [ classNames [ "flex-none", "px-2", "py-0", "box-border", "self-center" ] ]
               [ text prefix ]
           ]
       )
         <> [ input
-              [ classNames [ "flex-1", "text-center", "box-border", "self-stretch", "border-0", "outline-none" ]
+              [ classNames [ "flex-1", "px-1", "box-border", "self-stretch", "border-0", "outline-none" ]
               , onFocus
                   ( \ev ->
                       maybe Nothing

--- a/marlowe-playground-client/src/Halogen/CurrencyInput.purs
+++ b/marlowe-playground-client/src/Halogen/CurrencyInput.purs
@@ -1,0 +1,133 @@
+module Halogen.CurrencyInput where
+
+import Prelude hiding (div)
+import Data.Array (concat, drop, dropWhile, filter, length, replicate, take)
+import Data.BigInteger (BigInteger, fromString)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Monoid (guard)
+import Data.String (trim)
+import Data.String.CodeUnits (fromCharArray, toCharArray)
+import Data.Traversable (for)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
+import Effect.Unsafe (unsafePerformEffect)
+import Halogen.Css (classNames)
+import Halogen.HTML (HTML, div, input, text)
+import Halogen.HTML.Events (onChange, onFocus, onInput, onKeyDown)
+import Halogen.HTML.Properties (InputType(..), type_, value)
+import Web.Event.Event (currentTarget)
+import Web.Event.Internal.Types (EventTarget)
+import Web.UIEvent.FocusEvent as FocusEvent
+import Web.UIEvent.KeyboardEvent as KeyboardEvent
+
+foreign import setOldValues_ :: EffectFn1 EventTarget Unit
+
+foreign import checkChange_ :: EffectFn1 EventTarget Unit
+
+foreign import formatValue_ :: EffectFn2 EventTarget Int Unit
+
+foreign import formatValueString_ :: EffectFn2 String Int String
+
+foreign import setValue_ :: EffectFn2 EventTarget String Unit
+
+foreign import onChangeHandler_ :: EffectFn2 EventTarget Int String
+
+setOldValues :: EventTarget -> Effect Unit
+setOldValues = runEffectFn1 setOldValues_
+
+checkChange :: EventTarget -> Effect Unit
+checkChange = runEffectFn1 checkChange_
+
+setValue :: EventTarget -> String -> Effect Unit
+setValue = runEffectFn2 setValue_
+
+onChangeHandler :: EventTarget -> Int -> Effect String
+onChangeHandler = runEffectFn2 onChangeHandler_
+
+currencyInput :: forall p a. Array String -> BigInteger -> String -> Int -> (Maybe BigInteger -> Maybe a) -> HTML p a
+currencyInput classList number prefix rawNumDecimals onValueChangeHandler =
+  div [ classNames ([ "bg-gray-light", "flex", "items-center", "p-0", "m-0", "border-solid", "border", "rounded-sm", "overflow-hidden", "box-border", "focus-within:ring-1", "focus-within:ring-black" ] <> classList) ]
+    ( ( guard hasPrefix
+          [ div [ classNames [ "flex-none", "px-2", "py-0", "box-border", "self-center" ] ]
+              [ text prefix ]
+          ]
+      )
+        <> [ input
+              [ classNames [ "flex-1", "text-center", "box-border", "self-stretch", "border-0", "outline-none" ]
+              , onFocus
+                  ( \ev ->
+                      maybe Nothing
+                        ( \target ->
+                            unsafePerformEffect
+                              $ do
+                                  setOldValues target
+                                  pure Nothing
+                        )
+                        (currentTarget (FocusEvent.toEvent ev))
+                  )
+              , onKeyDown
+                  ( \ev ->
+                      maybe Nothing
+                        ( \target ->
+                            unsafePerformEffect
+                              $ do
+                                  setOldValues target
+                                  pure Nothing
+                        )
+                        (currentTarget (KeyboardEvent.toEvent ev))
+                  )
+              , onChange
+                  ( \ev ->
+                      maybe Nothing
+                        ( \target ->
+                            unsafePerformEffect
+                              $ do
+                                  res <- onChangeHandler target numDecimals
+                                  let
+                                    mObtainedBigNumStr = fromString $ filterPoint res
+                                  void $ for mObtainedBigNumStr (\x -> setValue target $ renderBigIntegerAsCurrency x numDecimals)
+                                  pure $ onValueChangeHandler $ mObtainedBigNumStr
+                        )
+                        (currentTarget ev)
+                  )
+              , onInput
+                  ( \ev ->
+                      maybe Nothing
+                        ( \target ->
+                            unsafePerformEffect
+                              $ do
+                                  checkChange target
+                                  pure Nothing
+                        )
+                        (currentTarget ev)
+                  )
+              , type_ InputText
+              , value (renderBigIntegerAsCurrency number numDecimals)
+              ]
+          ]
+    )
+  where
+  numDecimals = max 0 rawNumDecimals
+
+  hasPrefix = trim prefix /= ""
+
+  filterPoint = fromCharArray <<< filter (\x -> x /= '.') <<< toCharArray
+
+renderBigIntegerAsCurrency :: BigInteger -> Int -> String
+renderBigIntegerAsCurrency number numDecimals = fromCharArray numberStr
+  where
+  absValStr = replicate (numDecimals + 1) '0' <> toCharArray (show (if number < zero then -number else number))
+
+  numDigits = length absValStr
+
+  numDigitsBeforeSeparator = numDigits - numDecimals
+
+  prefixStr = if number < zero then [ '-' ] else []
+
+  digitsNoZeros = dropWhile (\x -> x == '0') $ take numDigitsBeforeSeparator absValStr
+
+  digitsBeforeSeparator = if digitsNoZeros == [] then [ '0' ] else digitsNoZeros
+
+  digitsAfterSeparator = take numDecimals $ drop numDigitsBeforeSeparator (concat [ absValStr, replicate numDecimals '0' ])
+
+  numberStr = concat ([ prefixStr, digitsBeforeSeparator ] <> if digitsAfterSeparator /= [] then [ [ '.' ], digitsAfterSeparator ] else [])

--- a/marlowe-playground-client/src/Pretty.purs
+++ b/marlowe-playground-client/src/Pretty.purs
@@ -1,10 +1,12 @@
 module Pretty where
 
 import Prelude
+import Data.Array (concat, drop, dropWhile, length, replicate, take)
 import Data.BigInteger (BigInteger, format)
 import Data.Map as Map
 import Data.Maybe (maybe)
-import Data.String (length, take)
+import Data.String.CodeUnits (fromCharArray, toCharArray)
+import Data.String as String
 import Halogen.HTML (HTML, abbr, text)
 import Halogen.HTML.Properties (title)
 import Marlowe.Extended.Metadata (MetaData)
@@ -21,7 +23,7 @@ showPrettyToken (Token "" "") = "ADA"
 showPrettyToken (Token cur tok) = "\"" <> cur <> " " <> tok <> "\""
 
 renderPrettyParty :: forall p i. MetaData -> Party -> HTML p i
-renderPrettyParty _ (PK pkh) = if length pkh > 10 then abbr [ title $ "pubkey " <> pkh ] [ text $ take 10 pkh ] else text pkh
+renderPrettyParty _ (PK pkh) = if String.length pkh > 10 then abbr [ title $ "pubkey " <> pkh ] [ text $ String.take 10 pkh ] else text pkh
 
 renderPrettyParty metadata (Role role) = abbr [ title $ "role " <> role <> explanationOrEmptyString ] [ text role ]
   where
@@ -41,3 +43,22 @@ renderPrettyPayee :: forall p i. MetaData -> Payee -> Array (HTML p i)
 renderPrettyPayee metadata (Account owner2) = [ text "account of ", renderPrettyParty metadata owner2 ]
 
 renderPrettyPayee metadata (Party dest) = [ text "party ", renderPrettyParty metadata dest ]
+
+showBigIntegerAsCurrency :: BigInteger -> Int -> String
+showBigIntegerAsCurrency number numDecimals = fromCharArray numberStr
+  where
+  absValStr = replicate (numDecimals + 1) '0' <> toCharArray (show (if number < zero then -number else number))
+
+  numDigits = length absValStr
+
+  numDigitsBeforeSeparator = numDigits - numDecimals
+
+  prefixStr = if number < zero then [ '-' ] else []
+
+  digitsNoZeros = dropWhile (\x -> x == '0') $ take numDigitsBeforeSeparator absValStr
+
+  digitsBeforeSeparator = if digitsNoZeros == [] then [ '0' ] else digitsNoZeros
+
+  digitsAfterSeparator = take numDecimals $ drop numDigitsBeforeSeparator (concat [ absValStr, replicate numDecimals '0' ])
+
+  numberStr = concat ([ prefixStr, digitsBeforeSeparator ] <> if digitsAfterSeparator /= [] then [ [ '.' ], digitsAfterSeparator ] else [])

--- a/marlowe-playground-client/src/Pretty.purs
+++ b/marlowe-playground-client/src/Pretty.purs
@@ -5,11 +5,11 @@ import Data.Array (concat, drop, dropWhile, length, replicate, take)
 import Data.BigInteger (BigInteger, format)
 import Data.Map as Map
 import Data.Maybe (maybe)
-import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Data.String as String
+import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Halogen.HTML (HTML, abbr, text)
 import Halogen.HTML.Properties (title)
-import Marlowe.Extended.Metadata (MetaData)
+import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData)
 import Marlowe.Semantics (Party(..), Payee(..), Token(..))
 
 renderPrettyToken :: forall p i. Token -> HTML p i
@@ -62,3 +62,8 @@ showBigIntegerAsCurrency number numDecimals = fromCharArray numberStr
   digitsAfterSeparator = take numDecimals $ drop numDigitsBeforeSeparator (concat [ absValStr, replicate numDecimals '0' ])
 
   numberStr = concat ([ prefixStr, digitsBeforeSeparator ] <> if digitsAfterSeparator /= [] then [ [ '.' ], digitsAfterSeparator ] else [])
+
+showPrettyChoice :: ChoiceFormat -> BigInteger -> String
+showPrettyChoice DefaultFormat num = showBigIntegerAsCurrency num 0
+
+showPrettyChoice (DecimalFormat numDecimals strLabel) num = strLabel <> " " <> showBigIntegerAsCurrency num numDecimals

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -222,7 +222,7 @@ startSimulationWidget metadata { initialSlot, templateContent } =
     $ div_
         [ div [ classes [ ClassName "slot-input", ClassName "initial-slot-input" ] ]
             [ spanText "Initial slot:"
-            , marloweActionInput (SetInitialSlot <<< wrap) (unwrap initialSlot)
+            , marloweActionInput [ "mx-2", "flex-grow", "flex-shrink-0" ] (SetInitialSlot <<< wrap) (unwrap initialSlot)
             ]
         , div_
             [ ul [ class_ (ClassName "templates") ]
@@ -254,7 +254,7 @@ integerTemplateParameters explanations actionGen typeName title prefix content =
                                 , strong_ [ text key ]
                                 , text ":"
                                 ]
-                            , marloweActionInput (actionGen typeName key) value
+                            , marloweActionInput [ "mx-2", "flex-grow", "flex-shrink-0" ] (actionGen typeName key) value
                             ]
                               <> [ div [ classes [ ClassName "action-group-explanation" ] ]
                                     $ maybe [] (\explanation -> [ text "“" ] <> markdownToHTML explanation <> [ text "„" ])
@@ -405,8 +405,8 @@ inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwn
           ( [ div [ class_ (ClassName "choice-input") ]
                 [ span [ class_ (ClassName "break-word-span") ] [ text "Choice ", b_ [ text (show choiceName <> ": ") ] ]
                 , case mChoiceInfo of
-                    Just { choiceFormat: DecimalFormat numDecimals currencyLabel } -> marloweCurrencyInput (SetChoice choiceId) currencyLabel numDecimals chosenNum
-                    _ -> marloweCurrencyInput (SetChoice choiceId) "" 0 chosenNum
+                    Just { choiceFormat: DecimalFormat numDecimals currencyLabel } -> marloweCurrencyInput [ "mx-2", "flex-grow", "flex-shrink-0" ] (SetChoice choiceId) currencyLabel numDecimals chosenNum
+                    _ -> marloweCurrencyInput [ "mx-2", "flex-grow", "flex-shrink-0" ] (SetChoice choiceId) "" 0 chosenNum
                 ]
             , div [ class_ (ClassName "choice-error") ] error
             ]
@@ -470,7 +470,7 @@ inputItem _ state person (MoveToSlot slot) =
     ( [ div [ classes [ ClassName "action" ] ]
           [ p [ class_ (ClassName "slot-input") ]
               [ spanTextBreakWord "Move to slot "
-              , marloweActionInput (SetSlot <<< wrap) (unwrap slot)
+              , marloweActionInput [ "mx-2", "flex-grow", "flex-shrink-0" ] (SetSlot <<< wrap) (unwrap slot)
               ]
           , p [ class_ (ClassName "choice-error") ] error
           ]
@@ -493,11 +493,11 @@ inputItem _ state person (MoveToSlot slot) =
 
   boundsError = "The slot must be more than the current slot " <> (state ^. (_currentMarloweState <<< _executionState <<< _SimulationRunning <<< _slot <<< to show))
 
-marloweCurrencyInput :: forall p action. (BigInteger -> action) -> String -> Int -> BigInteger -> HTML p action
-marloweCurrencyInput f currencyLabel numDecimals current = currencyInput [ "mx-2", "flex-grow", "flex-shrink-0" ] current currencyLabel numDecimals (Just <<< f <<< fromMaybe zero)
+marloweCurrencyInput :: forall p action. Array String -> (BigInteger -> action) -> String -> Int -> BigInteger -> HTML p action
+marloweCurrencyInput classes f currencyLabel numDecimals current = currencyInput classes current currencyLabel numDecimals (Just <<< f <<< fromMaybe zero)
 
-marloweActionInput :: forall p action. (BigInteger -> action) -> BigInteger -> HTML p action
-marloweActionInput f current = marloweCurrencyInput f "" 0 current
+marloweActionInput :: forall p action. Array String -> (BigInteger -> action) -> BigInteger -> HTML p action
+marloweActionInput classes f current = marloweCurrencyInput classes f "" 0 current
 
 renderDeposit :: forall p. MetaData -> AccountId -> Party -> Token -> BigInteger -> HTML p Action
 renderDeposit metadata accountOwner party tok money =

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -28,14 +28,14 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, disabled)
 import Halogen.Monaco (Settings, monacoComponent)
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
-import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData)
+import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData, getChoiceFormat)
 import Marlowe.Monaco (daylightTheme, languageExtensionPoint)
 import Marlowe.Monaco as MM
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party(..), Payment(..), PubKey, Slot, SlotInterval(..), Token(..), TransactionInput(..), inBounds, timeouts)
 import Marlowe.Template (IntegerTemplateType(..))
 import Monaco (Editor)
 import Monaco as Monaco
-import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
+import Pretty (renderPrettyParty, renderPrettyToken, showPrettyChoice, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
 import SimulationPage.Lenses (_bottomPanelState)
 import SimulationPage.Types (Action(..), BottomPanelView(..), State)
@@ -554,7 +554,7 @@ inputToLine metadata (SlotInterval start end) (IChoice (ChoiceId choiceName choi
       [ text "Participant "
       , strong_ [ renderPrettyParty metadata choiceOwner ]
       , text " chooses the value "
-      , strong_ [ text (showPrettyMoney chosenNum) ]
+      , strong_ [ text (showPrettyChoice (getChoiceFormat metadata choiceName) chosenNum) ]
       , text " for choice with id "
       , strong_ [ text (show choiceName) ]
       ]

--- a/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
+++ b/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
@@ -7,7 +7,7 @@ import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Data.Map (Map, keys)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Set (Set)
 import Data.Set as Set
 import Data.Symbol (SProxy(..))
@@ -148,6 +148,9 @@ emptyContractMetadata =
   , valueParameterDescriptions: mempty
   , choiceInfo: mempty
   }
+
+getChoiceFormat :: MetaData -> String -> ChoiceFormat
+getChoiceFormat { choiceInfo } choiceName = maybe DefaultFormat (\choiceInfoVal -> choiceInfoVal.choiceFormat) $ Map.lookup choiceName choiceInfo
 
 type MetadataHintInfo
   = { roles :: Set S.TokenName


### PR DESCRIPTION
This PR applies information about choice formatting to simulator (both in inputs and rendering of values).

As part of this PR, I have implemented a custom input component for decimal numbers, and I have also added it to other things that are not choices, because it seems to work much better than the default one.

Deployed to http://pablo.marlowe.iohkdev.io/

![choice](https://user-images.githubusercontent.com/638102/123700491-7402e300-d858-11eb-8860-76c93d46d0f5.gif)

Just realised I need to add formatting to constant parameters too, but I will do that in a separate PR (SCP-2438)

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
