### PR TITLE
SCP-2380: Fixed auction and uniswap trace in in plutus-use-cases-scripts

### DIFF
--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -181,6 +181,7 @@ start = do
         tx   = mustPayToTheScript (Factory []) $ unitValue c
     ledgerTx <- submitTxConstraints inst tx
     void $ awaitTxConfirmed $ txId ledgerTx
+    void $ waitNSlots 1
 
     logInfo @String $ printf "started Uniswap %s at address %s" (show us) (show $ uniswapAddress us)
     return us
@@ -488,7 +489,9 @@ findSwapB oldA oldB inB = findSwapA (switch oldB) (switch oldA) (switch inB)
 ownerEndpoint :: Contract (Last (Either Text Uniswap)) EmptySchema ContractError ()
 ownerEndpoint = do
     e <- mapError absurd $ runError start
+    void $ waitNSlots 1
     tell $ Last $ Just e
+    void $ waitNSlots 1
 
 -- | Provides the following endpoints for users of a Uniswap instance:
 --

--- a/plutus-use-cases/test/Spec/Auction.hs
+++ b/plutus-use-cases/test/Spec/Auction.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeFamilies       #-}
-module Spec.Auction(tests, auctionTrace1, auctionTrace2,
+module Spec.Auction(tests, theToken, auctionTrace1, auctionTrace2,
                     prop_Auction, prop_FinishAuction) where
 
 import           Control.Lens
@@ -107,7 +107,8 @@ auctionTrace2 = do
     Trace.callEndpoint @"bid" hdl3 60
     _ <- Trace.waitNSlots 35
     Trace.callEndpoint @"bid" hdl2 trace2WinningBid
-    void $ Trace.waitUntilSlot (succ $ succ $ TimeSlot.posixTimeToSlot $ apEndTime params)
+    void $ Trace.waitUntilTime $ apEndTime params
+    void $ Trace.waitNSlots 2
 
 trace1FinalState :: AuctionOutput
 trace1FinalState =

--- a/plutus-use-cases/test/Spec/Uniswap.hs
+++ b/plutus-use-cases/test/Spec/Uniswap.hs
@@ -5,11 +5,16 @@ module Spec.Uniswap(
 
 import           Plutus.Contract.Test
 import qualified Plutus.Contracts.Uniswap.Trace as Uniswap
+import qualified Plutus.Trace.Emulator          as Trace
+
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "uniswap" [
     checkPredicate "can create a liquidity pool and add liquidity"
-        assertNoFailedTransactions
+        (assertNotDone Uniswap.setupTokens
+                       (Trace.walletInstanceTag (Wallet 1))
+                       "setupTokens contract should be still running"
+        .&&. assertNoFailedTransactions)
         Uniswap.uniswapTrace
     ]


### PR DESCRIPTION
Fixed auction and uniswap trace not working in plutus-use-cases-scripts. They would wait for an infinite amount of slots when calling `observableState`. Basically fixed my adding a few `await` actions. Also, the auctioned token needs to be part of the initial emulator distribution.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
