### PR TITLE
Add start and close events to the logs of the simulator

### DIFF
--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -40,7 +40,7 @@ import SimulationPage.Lenses (_bottomPanelState)
 import SimulationPage.Types (Action(..), BottomPanelView(..), State)
 import Simulator.Lenses (_SimulationRunning, _currentContract, _currentMarloweState, _executionState, _log, _marloweState, _possibleActions, _slot, _transactionError, _transactionWarnings)
 import Simulator.State (hasHistory, inFuture)
-import Simulator.Types (ActionInput(..), ActionInputId, ExecutionState(..), InitialConditionsRecord, MarloweEvent(..), otherActionsParty)
+import Simulator.Types (ActionInput(..), ActionInputId, ExecutionState(..), InitialConditionsRecord, LogEntry(..), otherActionsParty)
 import Text.Markdown.TrimmedInline (markdownToHTML)
 
 render ::
@@ -536,10 +536,20 @@ logWidget metadata state =
   where
   inputLines = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _log <<< to (concatMap (logToLines metadata) <<< reverse))
 
-logToLines :: forall p a. MetaData -> MarloweEvent -> Array (HTML p a)
+logToLines :: forall p a. MetaData -> LogEntry -> Array (HTML p a)
+logToLines metadata (StartEvent slot) =
+  [ span_ [ text "Contract started" ]
+  , span [ class_ justifyEnd ] [ text $ show slot ]
+  ]
+
 logToLines metadata (InputEvent (TransactionInput { interval, inputs })) = inputToLine metadata interval =<< Array.fromFoldable inputs
 
 logToLines metadata (OutputEvent interval payment) = paymentToLines metadata interval payment
+
+logToLines metadata (CloseEvent (SlotInterval start end)) =
+  [ span_ [ text $ "Contract ended" ]
+  , span [ class_ justifyEnd ] [ text $ showSlotRange start end ]
+  ]
 
 inputToLine :: forall p a. MetaData -> SlotInterval -> Input -> Array (HTML p a)
 inputToLine metadata (SlotInterval start end) (IDeposit accountOwner party token money) =

--- a/marlowe-playground-client/src/Simulator/Lenses.purs
+++ b/marlowe-playground-client/src/Simulator/Lenses.purs
@@ -1,9 +1,8 @@
 module Simulator.Lenses where
 
 import Prelude
-import Data.Array (mapMaybe)
 import Data.Either (Either(..))
-import Data.Lens (Getter', Lens', Prism', Traversal', Optic', lens, preview, prism, set, to)
+import Data.Lens (Lens', Optic', Prism', Traversal', lens, preview, prism, set)
 import Data.Lens.At (at)
 import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (_Newtype)
@@ -17,8 +16,8 @@ import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Strong (class Strong)
 import Data.Symbol (SProxy(..))
 import Marlowe.Holes (Contract, Term)
-import Marlowe.Semantics (Party, Payment)
-import Simulator.Types (ActionInput, ActionInputId(..), ExecutionState(..), ExecutionStateRecord, InitialConditionsRecord, MarloweEvent(..), Parties, MarloweState, otherActionsParty)
+import Marlowe.Semantics (Party)
+import Simulator.Types (ActionInput, ActionInputId(..), ExecutionState(..), ExecutionStateRecord, InitialConditionsRecord, MarloweState, Parties, otherActionsParty)
 
 --------------------------------------------------------------------------
 -- ActionInput and ActionInputId Lenses
@@ -73,13 +72,6 @@ _contract = prop (SProxy :: SProxy "contract")
 
 _log :: forall s a. Lens' { log :: a | s } a
 _log = prop (SProxy :: SProxy "log")
-
-_payments :: forall s. Getter' { log :: Array MarloweEvent | s } (Array Payment)
-_payments = _log <<< to (mapMaybe f)
-  where
-  f (InputEvent _) = Nothing
-
-  f (OutputEvent _ payment) = Just payment
 
 --------------------------------------------------------------------------
 -- InitialConditionsRecord Lenses

--- a/marlowe-playground-client/src/Simulator/State.purs
+++ b/marlowe-playground-client/src/Simulator/State.purs
@@ -234,9 +234,9 @@ applyPendingInputs oldState@{ executionState: SimulationRunning executionState }
         newExecutionState =
           ( set _transactionError (Just txError)
               -- apart from setting the error, we also removing the pending inputs
-
+              
               -- otherwise there can be hidden pending inputs in the simulation
-
+              
               <<< set _pendingInputs mempty
           )
             executionState

--- a/marlowe-playground-client/src/Simulator/Types.purs
+++ b/marlowe-playground-client/src/Simulator/Types.purs
@@ -70,18 +70,18 @@ derive newtype instance decodeParties :: Decode Parties
 otherActionsParty :: Party
 otherActionsParty = Role "marlowe_other_actions"
 
--- TODO: Maybe rename to LogEntry
--- TODO: Add an Event/Entry for contract start and for contract close
-data MarloweEvent
-  = InputEvent TransactionInput
+data LogEntry
+  = StartEvent Slot
+  | InputEvent TransactionInput
   | OutputEvent SlotInterval Payment
+  | CloseEvent SlotInterval
 
-derive instance genericMarloweEvent :: Generic MarloweEvent _
+derive instance genericLogEntry :: Generic LogEntry _
 
-instance encodeMarloweEvent :: Encode MarloweEvent where
+instance encodeLogEntry :: Encode LogEntry where
   encode a = genericEncode aesonCompatibleOptions a
 
-instance decodeMarloweEvent :: Decode MarloweEvent where
+instance decodeLogEntry :: Decode LogEntry where
   decode = genericDecode aesonCompatibleOptions
 
 type ExecutionStateRecord
@@ -89,7 +89,7 @@ type ExecutionStateRecord
     , pendingInputs :: Array Input
     , transactionError :: Maybe TransactionError
     , transactionWarnings :: Array TransactionWarning
-    , log :: Array MarloweEvent
+    , log :: Array LogEntry
     , state :: S.State
     , slot :: Slot
     , moneyInContract :: Assets


### PR DESCRIPTION
This PR add contract start and contract end to the simulator log

<img width="545" alt="Screen Shot 2021-06-28 at 18 36 48" src="https://user-images.githubusercontent.com/2634059/123707388-05199000-d840-11eb-9519-e4e714dedcdf.png">

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
