### PR TITLE
SCP-2440: Fix an error with address change request

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -219,7 +219,9 @@ addressChangeRequest ::
     )
     => AddressChangeRequest
     -> Contract w s e AddressChangeResponse
-addressChangeRequest r = pabReq (AddressChangeReq r) E._AddressChangeResp
+addressChangeRequest r = do
+  _ <- awaitSlot (targetSlot r)
+  pabReq (AddressChangeReq r) E._AddressChangeResp
 
 -- | Call 'addresssChangeRequest' for the address in each slot, until at least one
 --   transaction is returned that modifies the address.

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -272,5 +272,5 @@ respondToRequestsSTM ::
     -> Eff effs (STM (Response PABResp))
 respondToRequestsSTM instanceId currentState = do
     let rqs = Contract.requests @t currentState
-    logInfo @(ContractInstanceMsg t) $ HandlingRequests instanceId rqs
+    logDebug @(ContractInstanceMsg t) $ HandlingRequests instanceId rqs
     tryHandler' stmRequestHandler rqs


### PR DESCRIPTION
We can only respond to the request if the request's slot range is in the past (some time for the chain index to update itself). `targetSlot` is the earliest time at which we can answer the request, so we may need to wait a little before we submit it.

This caused the marlowe follower contract to miss the past updates when it is first started.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
