### PR TITLE
SCP-2438 - Add formatting to constant params

### DIFF
--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -12,9 +12,9 @@ import Data.BigInteger (fromString) as BigInteger
 import Data.Lens (view)
 import Data.List (toUnfoldable) as List
 import Data.Map (Map, lookup, values)
-import Data.Map (toUnfoldable) as Map
+import Data.Map (lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
-import Data.String (null)
+import Data.String (null, trim)
 import Data.Tuple.Nested ((/\))
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, p, p_, span, span_, text, ul, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
@@ -24,7 +24,7 @@ import InputField.Types (State) as InputField
 import InputField.Types (inputErrorToString)
 import InputField.View (renderInput)
 import Marlowe.Extended (contractTypeInitials)
-import Marlowe.Extended.Metadata (MetaData, _contractName, _metaData)
+import Marlowe.Extended.Metadata (MetaData, _contractName, _metaData, _valueParameterDescription)
 import Marlowe.Market (contractTemplates)
 import Marlowe.PAB (contractCreationFee)
 import Marlowe.Semantics (Assets, Slot, TokenName)
@@ -223,7 +223,13 @@ parameterInputs currentSlot metaData templateContent slotContentStrings accessib
 
   valueInput index (key /\ parameterValue) =
     let
-      description = fromMaybe "no description available" $ lookup key metaData.valueParameterDescriptions
+      description =
+        fromMaybe "no description available"
+          ( case Map.lookup key metaData.valueParameterInfo of
+              Just { valueParameterDescription: description }
+                | trim description /= "" -> Just description
+              _ -> Nothing
+          )
 
       mParameterError = valueError parameterValue
     in

--- a/marlowe-playground-client/src/MetadataTab/State.purs
+++ b/marlowe-playground-client/src/MetadataTab/State.purs
@@ -8,7 +8,7 @@ import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen.Query (HalogenM)
 import MainFrame.Types (Action, ChildSlots, State, _contractMetadata, _hasUnsavedChanges)
-import Marlowe.Extended.Metadata (ChoiceFormat, ChoiceInfo, _choiceInfo, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions, updateChoiceInfo)
+import Marlowe.Extended.Metadata (NumberFormat, ChoiceInfo, _choiceInfo, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions, updateChoiceInfo)
 import MetadataTab.Types (MetadataAction(..))
 
 carryMetadataAction ::
@@ -36,5 +36,5 @@ carryMetadataAction action = do
   setChoiceDescription :: String -> ChoiceInfo -> ChoiceInfo
   setChoiceDescription newDescription x = x { choiceDescription = newDescription }
 
-  setChoiceFormat :: ChoiceFormat -> ChoiceInfo -> ChoiceInfo
+  setChoiceFormat :: NumberFormat -> ChoiceInfo -> ChoiceInfo
   setChoiceFormat newChoiceFormat x = x { choiceFormat = newChoiceFormat }

--- a/marlowe-playground-client/src/MetadataTab/State.purs
+++ b/marlowe-playground-client/src/MetadataTab/State.purs
@@ -8,7 +8,7 @@ import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen.Query (HalogenM)
 import MainFrame.Types (Action, ChildSlots, State, _contractMetadata, _hasUnsavedChanges)
-import Marlowe.Extended.Metadata (NumberFormat, ChoiceInfo, _choiceInfo, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterDescriptions, updateChoiceInfo)
+import Marlowe.Extended.Metadata (ChoiceInfo, NumberFormat, ValueParameterInfo, _choiceInfo, _contractDescription, _contractName, _contractType, _roleDescriptions, _slotParameterDescriptions, _valueParameterInfo, updateChoiceInfo, updateValueParameterInfo)
 import MetadataTab.Types (MetadataAction(..))
 
 carryMetadataAction ::
@@ -26,8 +26,9 @@ carryMetadataAction action = do
     DeleteRoleDescription tokenName -> over _roleDescriptions $ Map.delete tokenName
     SetSlotParameterDescription slotParam description -> over _slotParameterDescriptions $ Map.insert slotParam description
     DeleteSlotParameterDescription slotParam -> over _slotParameterDescriptions $ Map.delete slotParam
-    SetValueParameterDescription valueParam description -> over _valueParameterDescriptions $ Map.insert valueParam description
-    DeleteValueParameterDescription valueParam -> over _valueParameterDescriptions $ Map.delete valueParam
+    SetValueParameterDescription valueParameterName description -> over _valueParameterInfo $ updateValueParameterInfo (setValueParameterDescription description) valueParameterName
+    SetValueParameterFormat valueParameterName format -> over _valueParameterInfo $ updateValueParameterInfo (setValueParameterFormat format) valueParameterName
+    DeleteValueParameterInfo valueParameterName -> over _valueParameterInfo $ Map.delete valueParameterName
     SetChoiceDescription choiceName description -> over _choiceInfo $ updateChoiceInfo (setChoiceDescription description) choiceName
     SetChoiceFormat choiceName format -> over _choiceInfo $ updateChoiceInfo (setChoiceFormat format) choiceName
     DeleteChoiceInfo choiceName -> over _choiceInfo $ Map.delete choiceName
@@ -38,3 +39,9 @@ carryMetadataAction action = do
 
   setChoiceFormat :: NumberFormat -> ChoiceInfo -> ChoiceInfo
   setChoiceFormat newChoiceFormat x = x { choiceFormat = newChoiceFormat }
+
+  setValueParameterDescription :: String -> ValueParameterInfo -> ValueParameterInfo
+  setValueParameterDescription newDescription x = x { valueParameterDescription = newDescription }
+
+  setValueParameterFormat :: NumberFormat -> ValueParameterInfo -> ValueParameterInfo
+  setValueParameterFormat newValueParameterFormat x = x { valueParameterFormat = newValueParameterFormat }

--- a/marlowe-playground-client/src/MetadataTab/Types.purs
+++ b/marlowe-playground-client/src/MetadataTab/Types.purs
@@ -1,7 +1,7 @@
 module MetadataTab.Types where
 
 import Marlowe.Extended (ContractType)
-import Marlowe.Extended.Metadata (ChoiceFormat)
+import Marlowe.Extended.Metadata (NumberFormat)
 import Marlowe.Semantics as S
 
 class ShowConstructor a where
@@ -18,7 +18,7 @@ data MetadataAction
   | SetValueParameterDescription String String
   | DeleteValueParameterDescription String
   | SetChoiceDescription String String
-  | SetChoiceFormat String ChoiceFormat
+  | SetChoiceFormat String NumberFormat
   | DeleteChoiceInfo String
 
 instance metadataActionShowConstructor :: ShowConstructor MetadataAction where

--- a/marlowe-playground-client/src/MetadataTab/Types.purs
+++ b/marlowe-playground-client/src/MetadataTab/Types.purs
@@ -16,7 +16,8 @@ data MetadataAction
   | SetSlotParameterDescription String String
   | DeleteSlotParameterDescription String
   | SetValueParameterDescription String String
-  | DeleteValueParameterDescription String
+  | SetValueParameterFormat String NumberFormat
+  | DeleteValueParameterInfo String
   | SetChoiceDescription String String
   | SetChoiceFormat String NumberFormat
   | DeleteChoiceInfo String
@@ -30,7 +31,8 @@ instance metadataActionShowConstructor :: ShowConstructor MetadataAction where
   showConstructor (SetSlotParameterDescription _ _) = "SetSlotParameterDescription"
   showConstructor (DeleteSlotParameterDescription _) = "DeleteSlotParameterDescription"
   showConstructor (SetValueParameterDescription _ _) = "SetValueParameterDescription"
-  showConstructor (DeleteValueParameterDescription _) = "DeleteValueParameterDescription"
+  showConstructor (SetValueParameterFormat _ _) = "SetValueParameterFormat"
+  showConstructor (DeleteValueParameterInfo _) = "DeleteValueParameterInfo"
   showConstructor (SetChoiceDescription _ _) = "SetChoiceDescription"
   showConstructor (SetChoiceFormat _ _) = "SetChoiceFormat"
   showConstructor (DeleteChoiceInfo _) = "DeleteChoiceInfo"

--- a/marlowe-playground-client/src/MetadataTab/View.purs
+++ b/marlowe-playground-client/src/MetadataTab/View.purs
@@ -1,6 +1,6 @@
 module MetadataTab.View (metadataView) where
 
-import Prelude hiding (div)
+import Prelude hiding (div, min)
 import Data.Array (concat, concatMap)
 import Data.Int as Int
 import Data.Lens (Lens', (^.))
@@ -15,7 +15,7 @@ import Halogen.HTML (ClassName(..), HTML, button, div, em_, h6_, input, option, 
 import Halogen.HTML.Events (onClick, onValueChange)
 import Halogen.HTML.Properties (InputType(..), class_, classes, min, placeholder, required, selected, type_, value)
 import Marlowe.Extended (contractTypeArray, contractTypeInitials, contractTypeName, initialsToContractType)
-import Marlowe.Extended.Metadata (ChoiceFormat(..), ChoiceFormatType(..), ChoiceInfo, MetaData, MetadataHintInfo, _choiceDescription, _choiceInfo, _choiceNames, _roleDescriptions, _roles, _slotParameterDescriptions, _slotParameters, _valueParameterDescriptions, _valueParameters, defaultForFormatType, fromString, getFormatType, isDecimalFormat, isDefaultFormat, toString)
+import Marlowe.Extended.Metadata (NumberFormat(..), NumberFormatType(..), ChoiceInfo, MetaData, MetadataHintInfo, _choiceDescription, _choiceInfo, _choiceNames, _roleDescriptions, _roles, _slotParameterDescriptions, _slotParameters, _valueParameterDescriptions, _valueParameters, defaultForFormatType, fromString, getFormatType, isDecimalFormat, isDefaultFormat, toString)
 import MetadataTab.Types (MetadataAction(..))
 
 onlyDescriptionRenderer :: forall a b p. (String -> String -> b) -> (String -> b) -> String -> String -> Boolean -> (b -> a) -> String -> String -> Array (HTML p a)
@@ -107,14 +107,14 @@ choiceMetadataRenderer key info@{ choiceFormat } needed metadataAction typeNameT
               ]
           ]
   where
-  setChoiceFormatType :: String -> ChoiceFormat
+  setChoiceFormatType :: String -> NumberFormat
   setChoiceFormatType str = case fromString str of
     Just formatType
       | formatType == getFormatType choiceFormat -> choiceFormat
       | otherwise -> defaultForFormatType formatType
     Nothing -> defaultForFormatType DefaultFormatType
 
-  setDecimals :: String -> String -> ChoiceFormat
+  setDecimals :: String -> String -> NumberFormat
   setDecimals labelStr x =
     DecimalFormat
       ( case Int.fromString x of

--- a/marlowe-playground-client/src/MetadataTab/View.purs
+++ b/marlowe-playground-client/src/MetadataTab/View.purs
@@ -41,14 +41,17 @@ onlyDescriptionRenderer setAction deleteAction key info needed metadataAction ty
   ]
     <> if needed then [] else [ div [ classes [ ClassName "metadata-error", ClassName "metadata-prop-not-used" ] ] [ text "Not used" ] ]
 
-type FormattedNumberActions
-  = { setFormat :: String -> NumberFormat -> MetadataAction
+type FormattedNumberInfo
+  = { key :: String
+    , description :: String
+    , format :: NumberFormat
+    , setFormat :: String -> NumberFormat -> MetadataAction
     , setDescription :: String -> String -> MetadataAction
     , deleteInfo :: String -> MetadataAction
     }
 
-formattedNumberMetadataRenderer :: forall a p. String -> String -> NumberFormat -> FormattedNumberActions -> Boolean -> (MetadataAction -> a) -> String -> String -> Array (HTML p a)
-formattedNumberMetadataRenderer key description format { setFormat, setDescription, deleteInfo } needed metadataAction typeNameTitle typeNameSmall =
+formattedNumberMetadataRenderer :: forall a p. FormattedNumberInfo -> Boolean -> (MetadataAction -> a) -> String -> String -> Array (HTML p a)
+formattedNumberMetadataRenderer { key, description, format, setFormat, setDescription, deleteInfo } needed metadataAction typeNameTitle typeNameSmall =
   [ div [ class_ $ ClassName "metadata-prop-label" ]
       [ text $ typeNameTitle <> " " <> show key <> ": " ]
   , div [ class_ $ ClassName "metadata-prop-formattednum-col1" ]
@@ -132,16 +135,22 @@ formattedNumberMetadataRenderer key description format { setFormat, setDescripti
 
 choiceMetadataRenderer :: forall a p. String -> ChoiceInfo -> Boolean -> (MetadataAction -> a) -> String -> String -> Array (HTML p a)
 choiceMetadataRenderer key { choiceDescription, choiceFormat } =
-  formattedNumberMetadataRenderer key choiceDescription choiceFormat
-    { setFormat: SetChoiceFormat
+  formattedNumberMetadataRenderer
+    { key: key
+    , description: choiceDescription
+    , format: choiceFormat
+    , setFormat: SetChoiceFormat
     , setDescription: SetChoiceDescription
     , deleteInfo: DeleteChoiceInfo
     }
 
 valueParameterMetadataRenderer :: forall a p. String -> ValueParameterInfo -> Boolean -> (MetadataAction -> a) -> String -> String -> Array (HTML p a)
 valueParameterMetadataRenderer key { valueParameterDescription, valueParameterFormat } =
-  formattedNumberMetadataRenderer key valueParameterDescription valueParameterFormat
-    { setFormat: SetValueParameterFormat
+  formattedNumberMetadataRenderer
+    { key: key
+    , description: valueParameterDescription
+    , format: valueParameterFormat
+    , setFormat: SetValueParameterFormat
     , setDescription: SetValueParameterDescription
     , deleteInfo: DeleteValueParameterInfo
     }

--- a/marlowe-playground-client/src/Pretty.purs
+++ b/marlowe-playground-client/src/Pretty.purs
@@ -9,7 +9,7 @@ import Data.String as String
 import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Halogen.HTML (HTML, abbr, text)
 import Halogen.HTML.Properties (title)
-import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData)
+import Marlowe.Extended.Metadata (NumberFormat(..), MetaData)
 import Marlowe.Semantics (Party(..), Payee(..), Token(..))
 
 renderPrettyToken :: forall p i. Token -> HTML p i
@@ -63,7 +63,7 @@ showBigIntegerAsCurrency number numDecimals = fromCharArray numberStr
 
   numberStr = concat ([ prefixStr, digitsBeforeSeparator ] <> if digitsAfterSeparator /= [] then [ [ '.' ], digitsAfterSeparator ] else [])
 
-showPrettyChoice :: ChoiceFormat -> BigInteger -> String
+showPrettyChoice :: NumberFormat -> BigInteger -> String
 showPrettyChoice DefaultFormat num = showBigIntegerAsCurrency num 0
 
 showPrettyChoice (DecimalFormat numDecimals strLabel) num = strLabel <> " " <> showBigIntegerAsCurrency num numDecimals

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -450,7 +450,10 @@ inputItem metadata _ person (ChoiceInput choiceId@(ChoiceId choiceName choiceOwn
     else
       "Choice must be between " <> intercalate " or " (map boundError bounds)
 
-  boundError (Bound from to) = show from <> " and " <> show to
+  boundError (Bound from to) = showPretty from <> " and " <> showPretty to
+
+  showPretty :: BigInteger -> String
+  showPretty = showPrettyChoice (getChoiceFormat metadata choiceName)
 
 inputItem _ _ person NotifyInput =
   li

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -28,7 +28,7 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, disabled)
 import Halogen.Monaco (Settings, monacoComponent)
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
-import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData, getChoiceFormat)
+import Marlowe.Extended.Metadata (NumberFormat(..), MetaData, getChoiceFormat)
 import Marlowe.Monaco (daylightTheme, languageExtensionPoint)
 import Marlowe.Monaco as MM
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party(..), Payment(..), PubKey, Slot, SlotInterval(..), Token(..), TransactionInput(..), inBounds, timeouts)

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -7,17 +7,19 @@ module StaticAnalysis.BottomPanel
 import Prelude hiding (div)
 import Data.BigInteger (BigInteger)
 import Data.Foldable (foldMap)
-import Data.Lens ((^.))
+import Data.Lens (view, (^.))
 import Data.List (List, null, toUnfoldable)
 import Data.List as List
 import Data.List.NonEmpty (toList)
+import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
+import Data.Tuple.Nested ((/\))
 import Halogen.Classes (btn, spaceBottom, spaceRight, spaceTop, spanText)
 import Halogen.HTML (ClassName(..), HTML, b_, br_, button, div, h2, h3, li_, ol, span_, text, ul)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, enabled)
-import Marlowe.Extended.Metadata (MetaData)
+import Marlowe.Extended.Metadata (MetaData, NumberFormat(..), _valueParameterDescription)
 import Marlowe.Semantics (ChoiceId(..), Input(..), Payee(..), Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..))
 import Marlowe.Symbolic.Types.Response as R
 import Marlowe.Template (IntegerTemplateType(..))
@@ -62,8 +64,8 @@ analysisResultPane metadata actionGen state =
         explanation
           [ text ""
           , ul [ class_ (ClassName "templates") ]
-              ( integerTemplateParameters metadata.slotParameterDescriptions actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
-                  <> integerTemplateParameters metadata.valueParameterDescriptions actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+              ( integerTemplateParameters (const Nothing) (Map.lookup) metadata.slotParameterDescriptions actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
+                  <> integerTemplateParameters extractValueParameterNuberFormat lookupDescription metadata.valueParameterInfo actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
               )
           ]
       WarningAnalysis staticSubResult -> case staticSubResult of
@@ -229,6 +231,12 @@ analysisResultPane metadata actionGen state =
             [ h3 [ classes [ ClassName "analysis-result-title" ] ] [ text "Close Refund Analysis Result: No implicit refunds" ]
             , text "None of the Close constructs refunds any money, all refunds are explicit."
             ]
+  where
+  extractValueParameterNuberFormat valueParameter = case Map.lookup valueParameter metadata.valueParameterInfo of
+    Just { valueParameterFormat: DecimalFormat numDecimals currencyLabel } -> Just (currencyLabel /\ numDecimals)
+    _ -> Nothing
+
+  lookupDescription k m = view _valueParameterDescription <$> Map.lookup k m
 
 displayTransactionList :: forall p action. Array TransactionInput -> HTML p action
 displayTransactionList transactionList =

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -64,8 +64,8 @@ analysisResultPane metadata actionGen state =
         explanation
           [ text ""
           , ul [ class_ (ClassName "templates") ]
-              ( integerTemplateParameters (const Nothing) (Map.lookup) metadata.slotParameterDescriptions actionGen SlotContent "Timeout template parameters" "Slot for" (unwrap templateContent).slotContent
-                  <> integerTemplateParameters extractValueParameterNuberFormat lookupDescription metadata.valueParameterInfo actionGen ValueContent "Value template parameters" "Constant for" (unwrap templateContent).valueContent
+              ( integerTemplateParameters actionGen slotParameterDisplayInfo (unwrap templateContent).slotContent
+                  <> integerTemplateParameters actionGen valueParameterDisplayInfo (unwrap templateContent).valueContent
               )
           ]
       WarningAnalysis staticSubResult -> case staticSubResult of
@@ -232,6 +232,22 @@ analysisResultPane metadata actionGen state =
             , text "None of the Close constructs refunds any money, all refunds are explicit."
             ]
   where
+  slotParameterDisplayInfo =
+    { lookupFormat: const Nothing
+    , lookupDefinition: (flip Map.lookup) metadata.slotParameterDescriptions
+    , typeName: SlotContent
+    , title: "Timeout template parameters"
+    , prefix: "Slot for"
+    }
+
+  valueParameterDisplayInfo =
+    { lookupFormat: extractValueParameterNuberFormat
+    , lookupDefinition: (flip lookupDescription) metadata.valueParameterInfo
+    , typeName: ValueContent
+    , title: "Value template parameters"
+    , prefix: "Constant for"
+    }
+
   extractValueParameterNuberFormat valueParameter = case Map.lookup valueParameter metadata.valueParameterInfo of
     Just { valueParameterFormat: DecimalFormat numDecimals currencyLabel } -> Just (currencyLabel /\ numDecimals)
     _ -> Nothing

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -323,8 +323,8 @@ button.minus-btn:hover {
 .metadata-group-title { grid-column-start: 1; grid-column-end: 6; }
 .metadata-prop-label { margin-left: 1rem; grid-column-start: 1; grid-column-end: 2; }
 .metadata-prop-edit { grid-column-start: 2; grid-column-end: 4; }
-.metadata-prop-choice-col1 { grid-column-start: 2; grid-column-end: 3; }
-.metadata-prop-choice-col2 { grid-column-start: 3; grid-column-end: 4; }
+.metadata-prop-formattednum-col1 { grid-column-start: 2; grid-column-end: 3; }
+.metadata-prop-formattednum-col2 { grid-column-start: 3; grid-column-end: 4; }
 .metadata-prop-delete { grid-column-start: 4; grid-column-end: 5; }
 .metadata-prop-not-used { grid-column-start: 5; grid-column-end: 6; }
 .metadata-prop-not-defined { margin-left: 1rem; grid-column-start: 1; grid-column-end: 4; }

--- a/web-common-marlowe/src/Examples/Metadata.purs
+++ b/web-common-marlowe/src/Examples/Metadata.purs
@@ -52,7 +52,14 @@ escrow =
           , "Timeout for arbitrage" /\ "Deadline by which, if the *Arbiter* has not resolved the dispute, the *Buyer* will be refunded."
           ]
       )
-  , valueParameterDescriptions: (fromFoldable [ "Price" /\ "Amount of Lovelace to be paid by the *Buyer* for the item." ])
+  , valueParameterInfo:
+      ( fromFoldable
+          [ "Price"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "Amount of Lovelace to be paid by the *Buyer* for the item."
+                }
+          ]
+      )
   }
 
 escrowWithCollateral :: MetaData
@@ -95,10 +102,16 @@ escrowWithCollateral =
           , "Seller's response timeout" /\ "The deadline by which, if the *Seller* has not responded to the dispute, the *Buyer* will be refunded."
           ]
       )
-  , valueParameterDescriptions:
+  , valueParameterInfo:
       ( fromFoldable
-          [ "Collateral amount" /\ "The amount of Lovelace to be deposited by both parties at the start of the contract to serve as an incentive for collaboration."
-          , "Price" /\ "The amount of Lovelace to be paid by the *Buyer* as part of the exchange."
+          [ "Collateral amount"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "The amount of Lovelace to be deposited by both parties at the start of the contract to serve as an incentive for collaboration."
+                }
+          , "Price"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "The amount of Lovelace to be paid by the *Buyer* as part of the exchange."
+                }
           ]
       )
   }
@@ -121,10 +134,16 @@ zeroCouponBond =
           , "Maturity exchange deadline" /\ "The *Issuer* must deposit the full price of the bond before this deadline or it will default."
           ]
       )
-  , valueParameterDescriptions:
+  , valueParameterInfo:
       ( fromFoldable
-          [ "Discounted price" /\ "The price in Lovelace of the Zero Coupon Bond at the start date."
-          , "Notional price" /\ "The full price in Lovelace of the Zero Coupon Bond."
+          [ "Discounted price"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "The price in Lovelace of the Zero Coupon Bond at the start date."
+                }
+          , "Notional price"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "The full price in Lovelace of the Zero Coupon Bond."
+                }
           ]
       )
   }
@@ -143,10 +162,16 @@ couponBondGuaranteed =
           ]
       )
   , slotParameterDescriptions: empty
-  , valueParameterDescriptions:
+  , valueParameterInfo:
       ( fromFoldable
-          [ "Interest instalment" /\ "Amount of Lovelace that will be paid by the *Issuer* every 30 slots for 3 iterations."
-          , "Principal" /\ "Amount of Lovelace that will be borrowed by the *Issuer*."
+          [ "Interest instalment"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "Amount of Lovelace that will be paid by the *Issuer* every 30 slots for 3 iterations."
+                }
+          , "Principal"
+              /\ { valueParameterFormat: lovelaceFormat
+                , valueParameterDescription: "Amount of Lovelace that will be borrowed by the *Issuer*."
+                }
           ]
       )
   }
@@ -169,10 +194,16 @@ swap =
           , "Timeout for dollar deposit" /\ "Deadline by which dollar tokens must be deposited (must be after the deadline for Ada deposit)."
           ]
       )
-  , valueParameterDescriptions:
+  , valueParameterInfo:
       ( fromFoldable
-          [ "Amount of Ada" /\ "Amount of Ada to be exchanged for dollars."
-          , "Amount of dollars" /\ "Amount of dollar tokens to be exchanged for Ada."
+          [ "Amount of Ada"
+              /\ { valueParameterFormat: DecimalFormat 0 "₳"
+                , valueParameterDescription: "Amount of Ada to be exchanged for dollars."
+                }
+          , "Amount of dollars"
+              /\ { valueParameterFormat: DecimalFormat 0 "$"
+                , valueParameterDescription: "Amount of dollar tokens to be exchanged for Ada."
+                }
           ]
       )
   }
@@ -202,7 +233,7 @@ contractForDifferences =
           ]
       )
   , slotParameterDescriptions: empty
-  , valueParameterDescriptions: empty
+  , valueParameterInfo: empty
   }
 
 contractForDifferencesWithOracle :: MetaData
@@ -230,5 +261,5 @@ contractForDifferencesWithOracle =
           ]
       )
   , slotParameterDescriptions: empty
-  , valueParameterDescriptions: empty
+  , valueParameterInfo: empty
   }

--- a/web-common-marlowe/src/Examples/Metadata.purs
+++ b/web-common-marlowe/src/Examples/Metadata.purs
@@ -3,7 +3,7 @@ module Examples.Metadata where
 import Data.Map (fromFoldable, empty)
 import Data.Tuple.Nested ((/\))
 import Marlowe.Extended (ContractType(..))
-import Marlowe.Extended.Metadata (ChoiceFormat(..), MetaData, emptyContractMetadata, lovelaceFormat, oracleRatioFormat)
+import Marlowe.Extended.Metadata (NumberFormat(..), MetaData, emptyContractMetadata, lovelaceFormat, oracleRatioFormat)
 
 example :: MetaData
 example = emptyContractMetadata

--- a/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
+++ b/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
@@ -17,76 +17,76 @@ import Marlowe.HasParties (getParties)
 import Marlowe.Semantics as S
 import Marlowe.Template (Placeholders(..), getPlaceholderIds)
 
-data ChoiceFormat
+data NumberFormat
   = DefaultFormat
   | DecimalFormat Int String
 
-derive instance eqChoiceFormat :: Eq ChoiceFormat
+derive instance eqNumberFormat :: Eq NumberFormat
 
-derive instance genericChoiceFormat :: Generic ChoiceFormat _
+derive instance genericNumberFormat :: Generic NumberFormat _
 
-instance encodeChoiceFormat :: Encode ChoiceFormat where
+instance encodeNumberFormat :: Encode NumberFormat where
   encode value = genericEncode defaultOptions value
 
-instance decodeChoiceFormat :: Decode ChoiceFormat where
+instance decodeNumberFormat :: Decode NumberFormat where
   decode value = genericDecode defaultOptions value
 
-instance showChoiceFormat :: Show ChoiceFormat where
+instance showNumberFormat :: Show NumberFormat where
   show = genericShow
 
-integerFormat :: ChoiceFormat
+integerFormat :: NumberFormat
 integerFormat = DecimalFormat 0 ""
 
-lovelaceFormat :: ChoiceFormat
+lovelaceFormat :: NumberFormat
 lovelaceFormat = DecimalFormat 6 "₳"
 
-oracleRatioFormat :: String -> ChoiceFormat
+oracleRatioFormat :: String -> NumberFormat
 oracleRatioFormat str = DecimalFormat 8 str
 
-isDefaultFormat :: ChoiceFormat -> Boolean
+isDefaultFormat :: NumberFormat -> Boolean
 isDefaultFormat DefaultFormat = true
 
 isDefaultFormat _ = false
 
-isDecimalFormat :: ChoiceFormat -> Boolean
+isDecimalFormat :: NumberFormat -> Boolean
 isDecimalFormat (DecimalFormat _ _) = true
 
 isDecimalFormat _ = false
 
-data ChoiceFormatType
+data NumberFormatType
   = DefaultFormatType
   | DecimalFormatType
 
-derive instance eqChoiceFormatType :: Eq ChoiceFormatType
+derive instance eqNumberFormatType :: Eq NumberFormatType
 
-toString :: ChoiceFormatType -> String
+toString :: NumberFormatType -> String
 toString DefaultFormatType = "DefaultFormatType"
 
 toString DecimalFormatType = "DecimalFormatType"
 
-fromString :: String -> Maybe ChoiceFormatType
+fromString :: String -> Maybe NumberFormatType
 fromString "DefaultFormatType" = Just DefaultFormatType
 
 fromString "DecimalFormatType" = Just DecimalFormatType
 
 fromString _ = Nothing
 
-getFormatType :: ChoiceFormat -> ChoiceFormatType
+getFormatType :: NumberFormat -> NumberFormatType
 getFormatType DefaultFormat = DefaultFormatType
 
 getFormatType (DecimalFormat _ _) = DecimalFormatType
 
-defaultForFormatType :: ChoiceFormatType -> ChoiceFormat
+defaultForFormatType :: NumberFormatType -> NumberFormat
 defaultForFormatType DefaultFormatType = DefaultFormat
 
 defaultForFormatType DecimalFormatType = DecimalFormat 0 ""
 
 type ChoiceInfo
-  = { choiceFormat :: ChoiceFormat
+  = { choiceFormat :: NumberFormat
     , choiceDescription :: String
     }
 
-_choiceFormat :: Lens' ChoiceInfo ChoiceFormat
+_choiceFormat :: Lens' ChoiceInfo NumberFormat
 _choiceFormat = prop (SProxy :: SProxy "choiceFormat")
 
 _choiceDescription :: Lens' ChoiceInfo String
@@ -149,7 +149,7 @@ emptyContractMetadata =
   , choiceInfo: mempty
   }
 
-getChoiceFormat :: MetaData -> String -> ChoiceFormat
+getChoiceFormat :: MetaData -> String -> NumberFormat
 getChoiceFormat { choiceInfo } choiceName = maybe DefaultFormat (\choiceInfoVal -> choiceInfoVal.choiceFormat) $ Map.lookup choiceName choiceInfo
 
 type MetadataHintInfo

--- a/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
+++ b/web-common-marlowe/src/Marlowe/Extended/Metadata.purs
@@ -81,6 +81,32 @@ defaultForFormatType DefaultFormatType = DefaultFormat
 
 defaultForFormatType DecimalFormatType = DecimalFormat 0 ""
 
+type ValueParameterInfo
+  = { valueParameterFormat :: NumberFormat
+    , valueParameterDescription :: String
+    }
+
+_valueParameterFormat :: Lens' ValueParameterInfo NumberFormat
+_valueParameterFormat = prop (SProxy :: SProxy "valueParameterFormat")
+
+_valueParameterDescription :: Lens' ValueParameterInfo String
+_valueParameterDescription = prop (SProxy :: SProxy "valueParameterDescription")
+
+emptyValueParameterInfo :: ValueParameterInfo
+emptyValueParameterInfo =
+  { valueParameterFormat: DefaultFormat
+  , valueParameterDescription: mempty
+  }
+
+getValueParameterInfo :: String -> Map String ValueParameterInfo -> ValueParameterInfo
+getValueParameterInfo str = fromMaybe emptyValueParameterInfo <<< Map.lookup str
+
+updateValueParameterInfo :: (ValueParameterInfo -> ValueParameterInfo) -> String -> Map String ValueParameterInfo -> Map String ValueParameterInfo
+updateValueParameterInfo f = Map.alter updateValueParameterInfoEntry
+  where
+  updateValueParameterInfoEntry :: Maybe ValueParameterInfo -> Maybe ValueParameterInfo
+  updateValueParameterInfoEntry mValueParameterInfo = Just $ f $ fromMaybe emptyValueParameterInfo mValueParameterInfo
+
 type ChoiceInfo
   = { choiceFormat :: NumberFormat
     , choiceDescription :: String
@@ -113,7 +139,7 @@ type MetaData
     , contractDescription :: String
     , roleDescriptions :: Map S.TokenName String
     , slotParameterDescriptions :: Map String String
-    , valueParameterDescriptions :: Map String String
+    , valueParameterInfo :: Map String ValueParameterInfo
     , choiceInfo :: Map String ChoiceInfo
     }
 
@@ -132,8 +158,8 @@ _roleDescriptions = prop (SProxy :: SProxy "roleDescriptions")
 _slotParameterDescriptions :: Lens' MetaData (Map String String)
 _slotParameterDescriptions = prop (SProxy :: SProxy "slotParameterDescriptions")
 
-_valueParameterDescriptions :: Lens' MetaData (Map String String)
-_valueParameterDescriptions = prop (SProxy :: SProxy "valueParameterDescriptions")
+_valueParameterInfo :: Lens' MetaData (Map String ValueParameterInfo)
+_valueParameterInfo = prop (SProxy :: SProxy "valueParameterInfo")
 
 _choiceInfo :: Lens' MetaData (Map String ChoiceInfo)
 _choiceInfo = prop (SProxy :: SProxy "choiceInfo")
@@ -145,7 +171,7 @@ emptyContractMetadata =
   , contractDescription: ""
   , roleDescriptions: mempty
   , slotParameterDescriptions: mempty
-  , valueParameterDescriptions: mempty
+  , valueParameterInfo: mempty
   , choiceInfo: mempty
   }
 
@@ -191,12 +217,12 @@ getMetadataHintInfo contract =
 getHintsFromMetadata :: MetaData -> MetadataHintInfo
 getHintsFromMetadata { roleDescriptions
 , slotParameterDescriptions
-, valueParameterDescriptions
+, valueParameterInfo
 , choiceInfo
 } =
   { roles: keys roleDescriptions
   , slotParameters: keys slotParameterDescriptions
-  , valueParameters: keys valueParameterDescriptions
+  , valueParameters: keys valueParameterInfo
   , choiceNames: keys choiceInfo
   }
 


### PR DESCRIPTION
This PR essentially adds the formatting options to value template parameters in the same way as we added it for choices in SCP-2394, SCP-2408, and SCP-2409.

It also adds formatting to the errors when adding choices out of range (which was missing)

Probably easiest to look at the commits independently than the full diff at once

Deployed to: http://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
