### PR TITLE
ci-plutus-benchmark: use separate nix-shells

### DIFF
--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -36,14 +36,14 @@ echo "[ci-plutus-benchmark]: Updating cabal database ..."
 cabal update
 
 echo "[ci-plutus-benchmark]: Running benchmark for PR branch ..."
-cabal bench plutus-benchmark:validation >bench-PR.log 2>&1
+nix-shell --run "cabal bench plutus-benchmark:validation >bench-PR.log 2>&1"
 
 echo "[ci-plutus-benchmark]: Switching branches ..."
 git checkout "$(git merge-base HEAD master)"
 BASE_BRANCH_REF=$(git show-ref -s HEAD)
 
 echo "[ci-plutus-benchmark]: Running benchmark for base branch ..."
-cabal bench plutus-benchmark:validation >bench-base.log 2>&1
+nix-shell --run "cabal bench plutus-benchmark:validation >bench-base.log 2>&1"
 
 echo "[ci-plutus-benchmark]: Comparing results ..."
 echo -e "Comparing benchmark results of '$BASE_BRANCH_REF' (base) and '$PR_BRANCH_REF' (PR)\n" >bench-compare-result.log


### PR DESCRIPTION
Run the 'cabal bench' commands in nix-shells to ensure that potentially
different haskell dependencies are being actually used.


--------

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
