### PR TITLE
Fix “open project” button

### DIFF
--- a/marlowe-playground-client/src/Home.purs
+++ b/marlowe-playground-client/src/Home.purs
@@ -1,14 +1,17 @@
 module Home where
 
 import Prelude hiding (div)
+import Auth (_GithubUser, authStatusAuthRole)
+import Data.Lens (has)
 import Data.Maybe (Maybe(..))
-import Halogen (ClassName(..), ComponentHTML)
-import Halogen.Classes (arrowLeftDown, arrowLeftUp, arrowRightDown, arrowRightUp, flex, marloweLogo, newProjectBlocklyIcon, newProjectHaskellIcon, newProjectJavascriptIcon, primaryButton, secondaryButton, simulationIcon, simulationIconBlack, vl)
+import Halogen (ComponentHTML)
+import Halogen.Classes (arrowLeftDown, arrowLeftUp, arrowRightDown, arrowRightUp, marloweLogo, newProjectBlocklyIcon, newProjectHaskellIcon, newProjectJavascriptIcon, primaryButton, secondaryButton, simulationIconBlack)
 import Halogen.Css (classNames)
-import Halogen.HTML (a, button, div, h1, h2_, hr_, img, p_, span, span_, text)
+import Halogen.HTML (a, button, div, h1, img, span, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (href, src, target)
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State)
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), State, _authStatus)
+import Network.RemoteData (_Success)
 import NewProject.Types as NewProject
 import Projects.Types (Lang(..))
 
@@ -19,7 +22,11 @@ render state =
     , div [ classNames [ "mb-6" ] ]
         [ button
             [ classNames (secondaryButton <> [ "mr-small", "w-56", "text-base", "cursor-pointer" ])
-            , onClick ((const <<< Just <<< OpenModal) NewProject)
+            , onClick \_ ->
+                if has (_authStatus <<< _Success <<< authStatusAuthRole <<< _GithubUser) state then
+                  Just $ OpenModal OpenProject
+                else
+                  Just $ OpenModal $ GithubLogin (OpenModal OpenProject)
             ]
             [ text "Open existing project" ]
         , button


### PR DESCRIPTION
This small PR fixes the "open existing project" in the Marlowe playground home. It was opening the new project modal instead.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [X] Commits have useful messages
- [ ] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
