### PR TITLE
SCP-2447 - Implement outline of new designs.

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -8,7 +8,6 @@ import Prelude hiding (div)
 import Contract.Lenses (_executionState, _mMarloweParams, _metadata, _namedActions, _nickname, _participants, _pendingTransaction, _previousSteps, _selectedStep, _tab, _userParties)
 import Contract.State (currentStep, isContractClosed)
 import Contract.Types (Action(..), PreviousStep, PreviousStepState(..), State, Tab(..), scrollContainerRef)
-import Css (applyWhen, classNames, toggleWhen)
 import Css as Css
 import Data.Array (foldr, intercalate, length)
 import Data.Array as Array
@@ -26,6 +25,7 @@ import Data.String (null, take, trim)
 import Data.String.Extra (capitalize)
 import Data.Tuple (Tuple(..), fst, uncurry)
 import Data.Tuple.Nested ((/\))
+import Halogen.Css (applyWhen, classNames)
 import Halogen.Extra (lifeCycleEvent)
 import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
@@ -278,9 +278,10 @@ renderContractCard stepNumber state currentTab cardBody =
       --       to the "not selected" cards, a positive margin of 2 to the selected one
       -- Base classes
       [ "grid", "grid-rows-contract-step-card", "rounded", "overflow-hidden", "flex-shrink-0", "w-contract-card", "h-contract-card", "transform", "transition-transform", "duration-100", "ease-out" ]
-        <> toggleWhen (state ^. _selectedStep /= stepNumber)
+        <> if (state ^. _selectedStep /= stepNumber) then
             -- Not selected card modifiers
             [ "shadow", "scale-77", "-mx-4" ]
+          else
             -- Selected card modifiers
             [ "shadow-lg", "mx-2" ]
   in

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -153,7 +153,7 @@ cardNavigationButtons state =
               ]
               [ text "Next" ]
   in
-    div [ classNames [ "mb-6", "flex", "items-center", "w-full", "px-6", "md:px-5pc" ] ]
+    div [ classNames [ "mb-6", "flex", "items-center", "w-full", "px-6" ] ]
       $ Array.catMaybes
           [ leftButton (state ^. _selectedStep)
           , rightButton (state ^. _selectedStep)

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -1,9 +1,5 @@
 module Css
-  ( classNames
-  , toggleWhen
-  , applyWhen
-  , hideWhen
-  , bgBlueGradient
+  ( bgBlueGradient
   , button
   , withIcon
   , withShadow
@@ -30,24 +26,8 @@ module Css
   ) where
 
 import Prelude
-import Halogen (ClassName(ClassName))
-import Halogen.HTML.Properties (IProp, classes)
+import Halogen.Css (applyWhen)
 import Material.Icons (Icon, iconClass)
-
-classNames :: forall r i. Array String -> IProp ( class :: String | r ) i
-classNames = classes <<< map ClassName
-
---- utilities
-toggleWhen :: Boolean -> Array String -> Array String -> Array String
-toggleWhen condition classes1 classes2 = if condition then classes1 else classes2
-
--- TODO: classNames, applyWhen and hideWhen were copy-pasted to Halogen.Css web-common.
---       In a future PR we should remove them from here.
-applyWhen :: Boolean -> Array String -> Array String
-applyWhen condition classes = toggleWhen condition classes []
-
-hideWhen :: Boolean -> Array String
-hideWhen = flip applyWhen [ "hidden" ]
 
 --- color gradients
 bgBlueGradient :: Array String
@@ -113,19 +93,19 @@ inputBaseNoFocus :: Array String
 inputBaseNoFocus = inputBase <> [ "focus:ring-0" ]
 
 input :: Boolean -> Array String
-input invalid = inputBaseFocus <> [ "border" ] <> [ "bg-transparent" ] <> toggleWhen invalid [ "border-red" ] [ "border-black", "focus:border-black" ]
+input invalid = inputBaseFocus <> [ "border", "bg-transparent" ] <> if invalid then [ "border-red" ] else [ "border-black", "focus:border-black" ]
 
 inputNoFocus :: Boolean -> Array String
-inputNoFocus invalid = inputBaseNoFocus <> toggleWhen invalid [ "border-red" ] [ "border-transparent" ]
+inputNoFocus invalid = inputBaseNoFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
 
 withNestedLabel :: Array String
 withNestedLabel = [ "border", "border-gray", "focus:border-gray" ]
 
 inputCard :: Boolean -> Array String
-inputCard invalid = inputBaseFocus <> toggleWhen invalid [ "border-red" ] [ "border-transparent" ]
+inputCard invalid = inputBaseFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
 
 inputCardNoFocus :: Boolean -> Array String
-inputCardNoFocus invalid = inputBaseNoFocus <> toggleWhen invalid [ "border-red" ] [ "border-transparent" ]
+inputCardNoFocus invalid = inputBaseNoFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
 
 inputError :: Array String
 inputError = [ "px-3", "mt-1", "text-red", "text-sm" ]
@@ -138,7 +118,7 @@ nestedLabel = [ "relative", "z-10", "left-2", "top-2.5", "px-1", "bg-white", "te
 
 --- cards
 overlay :: Boolean -> Array String
-overlay invisible = [ "overflow-hidden", "absolute", "inset-0", "z-20", "flex", "justify-center", "content-end", "md:content-center", "last:bg-overlay", "transition-opacity", "duration-400" ] <> toggleWhen invisible [ "opacity-0", "pointer-events-none" ] [ "opacity-1" ]
+overlay invisible = [ "overflow-hidden", "absolute", "inset-0", "z-20", "flex", "justify-center", "content-end", "md:content-center", "last:bg-overlay", "transition-opacity", "duration-400" ] <> if invisible then [ "opacity-0", "pointer-events-none" ] else [ "opacity-1" ]
 
 card :: Boolean -> Array String
 card invisible = [ "overflow-hidden", "bg-white", "flex-grow", "max-w-sm", "mx-2", "shadow", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400", "self-end", "md:self-center" ] <> applyWhen invisible [ "translate-y-20" ]
@@ -158,7 +138,7 @@ embeddedVideo = [ "absolute", "top-0", "left-0", "w-full", "h-full" ]
 
 --- miscellaneous
 iconCircle :: Boolean -> Array String
-iconCircle enabled = [ "inline-flex", "items-center", "justify-center", "w-8", "h-8", "rounded-full" ] <> toggleWhen enabled bgBlueGradient [ "bg-lightgray", "text-darkgray" ]
+iconCircle enabled = [ "inline-flex", "items-center", "justify-center", "w-8", "h-8", "rounded-full" ] <> if enabled then bgBlueGradient else [ "bg-lightgray", "text-darkgray" ]
 
 fixedBottomRight :: Array String
 fixedBottomRight = [ "absolute", "bottom-4", "right-4", "md:right-5pc" ]

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -1,5 +1,6 @@
 module Css
-  ( bgBlueGradient
+  ( container
+  , bgBlueGradient
   , button
   , withIcon
   , withShadow
@@ -14,10 +15,11 @@ module Css
   , hasNestedLabel
   , nestedLabel
   , withNestedLabel
-  , overlay
+  , cardOverlay
+  , sidebarCardOverlay
   , card
-  , largeCard
   , videoCard
+  , sidebarCard
   , embeddedVideoContainer
   , embeddedVideo
   , iconCircle
@@ -28,6 +30,10 @@ module Css
 import Prelude
 import Halogen.Css (applyWhen)
 import Material.Icons (Icon, iconClass)
+
+-- max-width container
+container :: Array String
+container = [ "max-w-xl", "mx-auto", "px-4" ]
 
 --- color gradients
 bgBlueGradient :: Array String
@@ -117,17 +123,76 @@ nestedLabel :: Array String
 nestedLabel = [ "relative", "z-10", "left-2", "top-2.5", "px-1", "bg-white", "text-xs", "font-semibold" ]
 
 --- cards
-overlay :: Boolean -> Array String
-overlay visible = [ "overflow-hidden", "absolute", "inset-0", "z-20", "flex", "justify-center", "content-end", "md:content-center", "last:bg-overlay", "transition-opacity", "duration-400" ] <> if visible then [ "opacity-1" ] else [ "opacity-0", "pointer-events-none" ]
+cardOverlay :: Boolean -> Array String
+cardOverlay visible =
+  [ "overflow-hidden"
+  , "absolute"
+  , "inset-0"
+  , "z-20"
+  , "flex"
+  , "justify-center"
+  , "content-end"
+  , "md:content-center"
+  , "bg-overlay"
+  , "transition-opacity"
+  , "duration-400"
+  ]
+    <> if visible then [ "opacity-1" ] else [ "opacity-0", "pointer-events-none" ]
+
+sidebarCardOverlay :: Boolean -> Array String
+sidebarCardOverlay visible = cardOverlay visible <> [ "lg:justify-end", "lg:duration-500" ]
+
+cardBase :: Boolean -> Array String
+cardBase visible =
+  [ "relative" -- this is because (some) cards contain an absoutely positioned close icon
+  , "bg-white"
+  , "flex-grow"
+  , "max-w-sm"
+  , "max-h-full"
+  , "mx-2"
+  , "shadow"
+  , "transform"
+  , "transition-transform"
+  , "duration-400"
+  ]
+    <> applyWhen (not visible) [ "translate-y-20" ]
 
 card :: Boolean -> Array String
-card visible = [ "overflow-hidden", "bg-white", "flex-grow", "max-w-sm", "mx-2", "shadow", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400", "self-end", "md:self-center" ] <> applyWhen (not visible) [ "translate-y-20" ]
-
-largeCard :: Boolean -> Array String
-largeCard visible = [ "bg-grayblue", "shadow", "overflow-auto", "flex-grow", "mt-2", "md:mb-2", "mx-2", "lg:my-4", "md:mx-5pc", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400" ] <> applyWhen (not visible) [ "translate-y-20" ]
+card visible =
+  [ "overflow-hidden"
+  , "rounded-t"
+  , "md:rounded-b"
+  , "self-end"
+  , "md:self-center"
+  ]
+    <> cardBase visible
 
 videoCard :: Boolean -> Array String
-videoCard visible = [ "relative", "bg-white", "flex-grow", "max-w-sm", "lg:max-w-md", "mx-2", "shadow", "rounded", "transform", "transition-transform", "duration-400", "self-center" ] <> applyWhen (not visible) [ "translate-y-20" ]
+videoCard visible =
+  [ "relative"
+  , "lg:max-w-md"
+  , "rounded"
+  , "self-center"
+  ]
+    <> cardBase visible
+
+sidebarCard :: Boolean -> Array String
+sidebarCard visible =
+  [ "overflow-hidden"
+  , "rounded-t"
+  , "md:rounded-b"
+  , "self-end"
+  , "md:self-center"
+  , "lg:rounded-none"
+  , "lg:mx-0"
+  , "lg:flex-none"
+  , "lg:w-sidebar"
+  , "lg:h-full"
+  , "lg:justify-self-end"
+  , "lg:duration-500"
+  ]
+    <> cardBase visible
+    <> applyWhen (not visible) [ "lg:translate-y-0", "lg:translate-x-80" ]
 
 -- embedded videos
 embeddedVideoContainer :: Array String
@@ -141,7 +206,7 @@ iconCircle :: Boolean -> Array String
 iconCircle enabled = [ "inline-flex", "items-center", "justify-center", "w-8", "h-8", "rounded-full" ] <> if enabled then bgBlueGradient else [ "bg-lightgray", "text-darkgray" ]
 
 fixedBottomRight :: Array String
-fixedBottomRight = [ "absolute", "bottom-4", "right-4", "md:right-5pc" ]
+fixedBottomRight = [ "absolute", "bottom-4", "right-4" ]
 
 funds :: Array String
 funds = [ "text-2xl", "text-purple", "font-semibold" ]

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -93,19 +93,19 @@ inputBaseNoFocus :: Array String
 inputBaseNoFocus = inputBase <> [ "focus:ring-0" ]
 
 input :: Boolean -> Array String
-input invalid = inputBaseFocus <> [ "border", "bg-transparent" ] <> if invalid then [ "border-red" ] else [ "border-black", "focus:border-black" ]
+input valid = inputBaseFocus <> [ "border", "bg-transparent" ] <> if valid then [ "border-black", "focus:border-black" ] else [ "border-red" ]
 
 inputNoFocus :: Boolean -> Array String
-inputNoFocus invalid = inputBaseNoFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
+inputNoFocus valid = inputBaseNoFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
 
 withNestedLabel :: Array String
 withNestedLabel = [ "border", "border-gray", "focus:border-gray" ]
 
 inputCard :: Boolean -> Array String
-inputCard invalid = inputBaseFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
+inputCard valid = inputBaseFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
 
 inputCardNoFocus :: Boolean -> Array String
-inputCardNoFocus invalid = inputBaseNoFocus <> if invalid then [ "border-red" ] else [ "border-transparent" ]
+inputCardNoFocus valid = inputBaseNoFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
 
 inputError :: Array String
 inputError = [ "px-3", "mt-1", "text-red", "text-sm" ]
@@ -118,16 +118,16 @@ nestedLabel = [ "relative", "z-10", "left-2", "top-2.5", "px-1", "bg-white", "te
 
 --- cards
 overlay :: Boolean -> Array String
-overlay invisible = [ "overflow-hidden", "absolute", "inset-0", "z-20", "flex", "justify-center", "content-end", "md:content-center", "last:bg-overlay", "transition-opacity", "duration-400" ] <> if invisible then [ "opacity-0", "pointer-events-none" ] else [ "opacity-1" ]
+overlay visible = [ "overflow-hidden", "absolute", "inset-0", "z-20", "flex", "justify-center", "content-end", "md:content-center", "last:bg-overlay", "transition-opacity", "duration-400" ] <> if visible then [ "opacity-1" ] else [ "opacity-0", "pointer-events-none" ]
 
 card :: Boolean -> Array String
-card invisible = [ "overflow-hidden", "bg-white", "flex-grow", "max-w-sm", "mx-2", "shadow", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400", "self-end", "md:self-center" ] <> applyWhen invisible [ "translate-y-20" ]
+card visible = [ "overflow-hidden", "bg-white", "flex-grow", "max-w-sm", "mx-2", "shadow", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400", "self-end", "md:self-center" ] <> applyWhen (not visible) [ "translate-y-20" ]
 
 largeCard :: Boolean -> Array String
-largeCard invisible = [ "bg-grayblue", "shadow", "overflow-auto", "flex-grow", "mt-2", "md:mb-2", "mx-2", "lg:my-4", "md:mx-5pc", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400" ] <> applyWhen invisible [ "translate-y-20" ]
+largeCard visible = [ "bg-grayblue", "shadow", "overflow-auto", "flex-grow", "mt-2", "md:mb-2", "mx-2", "lg:my-4", "md:mx-5pc", "rounded-t", "md:rounded-b", "transform", "transition-transform", "duration-400" ] <> applyWhen (not visible) [ "translate-y-20" ]
 
 videoCard :: Boolean -> Array String
-videoCard invisible = [ "relative", "bg-white", "flex-grow", "max-w-sm", "lg:max-w-md", "mx-2", "shadow", "rounded", "transform", "transition-transform", "duration-400", "self-center" ] <> applyWhen invisible [ "translate-y-20" ]
+videoCard visible = [ "relative", "bg-white", "flex-grow", "max-w-sm", "lg:max-w-md", "mx-2", "shadow", "rounded", "transform", "transition-transform", "duration-400", "self-center" ] <> applyWhen (not visible) [ "translate-y-20" ]
 
 -- embedded videos
 embeddedVideoContainer :: Array String

--- a/marlowe-dashboard-client/src/Dashboard/Lenses.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Lenses.purs
@@ -2,8 +2,8 @@ module Dashboard.Lenses
   ( _walletLibrary
   , _walletDetails
   , _menuOpen
-  , _screen
-  , _cards
+  , _card
+  , _cardOpen
   , _status
   , _contracts
   , _selectedContractIndex
@@ -16,7 +16,7 @@ module Dashboard.Lenses
 
 import Prelude
 import Contract.Types (State) as Contract
-import Dashboard.Types (Card, ContractStatus, Screen, State)
+import Dashboard.Types (Card, ContractStatus, State)
 import Data.Lens (Lens', Traversal', set, wander)
 import Data.Lens.Record (prop)
 import Data.Map (Map, insert, lookup)
@@ -38,11 +38,11 @@ _walletDetails = prop (SProxy :: SProxy "walletDetails")
 _menuOpen :: Lens' State Boolean
 _menuOpen = prop (SProxy :: SProxy "menuOpen")
 
-_screen :: Lens' State Screen
-_screen = prop (SProxy :: SProxy "screen")
+_card :: Lens' State (Maybe Card)
+_card = prop (SProxy :: SProxy "card")
 
-_cards :: Lens' State (Array Card)
-_cards = prop (SProxy :: SProxy "cards")
+_cardOpen :: Lens' State Boolean
+_cardOpen = prop (SProxy :: SProxy "cardOpen")
 
 _status :: Lens' State ContractStatus
 _status = prop (SProxy :: SProxy "status")

--- a/marlowe-dashboard-client/src/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Types.purs
@@ -1,6 +1,5 @@
 module Dashboard.Types
   ( State
-  , Screen(..)
   , Card(..)
   , ContractStatus(..)
   , PartitionedContracts
@@ -27,8 +26,8 @@ type State
   = { walletLibrary :: WalletLibrary
     , walletDetails :: WalletDetails
     , menuOpen :: Boolean
-    , screen :: Screen
-    , cards :: Array Card
+    , card :: Maybe Card
+    , cardOpen :: Boolean -- see note [CardOpen] in Welcome.State (the same applies here)
     , status :: ContractStatus
     , contracts :: Map PlutusAppId Contract.State
     , selectedContractIndex :: Maybe PlutusAppId
@@ -39,20 +38,14 @@ type State
     , templateState :: Template.State
     }
 
-data Screen
-  = ContractsScreen
-  | WalletLibraryScreen
-  | TemplateScreen
-
-derive instance eqScreen :: Eq Screen
-
 data Card
   = SaveWalletCard (Maybe String)
   | ViewWalletCard WalletDetails
   | PutdownWalletCard
+  | WalletLibraryCard
   | TemplateLibraryCard
+  | ContractSetupCard
   | ContractSetupConfirmationCard
-  | ContractCard
   | ContractActionConfirmationCard NamedAction
 
 derive instance eqCard :: Eq Card
@@ -77,11 +70,10 @@ data Action
   | SetRemoteWalletInfo (WebData WalletInfo)
   | SaveNewWallet (Maybe TokenName)
   | ToggleMenu
-  | SetScreen Screen
   | OpenCard Card
-  | CloseCard Card
+  | CloseCard
   | SelectView ContractStatus
-  | OpenContract PlutusAppId
+  | SelectContract (Maybe PlutusAppId)
   | UpdateFromStorage
   | UpdateFollowerApps (Map MarloweParams MarloweData)
   | UpdateContract PlutusAppId ContractHistory
@@ -98,11 +90,10 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (SetRemoteWalletInfo _) = Nothing
   toEvent (SaveNewWallet _) = Just $ defaultEvent "SaveNewWallet"
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
-  toEvent (SetScreen _) = Just $ defaultEvent "SetScreen"
   toEvent (OpenCard _) = Nothing
-  toEvent (CloseCard _) = Nothing
+  toEvent CloseCard = Nothing
   toEvent (SelectView _) = Just $ defaultEvent "SelectView"
-  toEvent (OpenContract _) = Just $ defaultEvent "OpenContract"
+  toEvent (SelectContract _) = Just $ defaultEvent "OpenContract"
   toEvent UpdateFromStorage = Nothing
   toEvent (UpdateFollowerApps _) = Nothing
   toEvent (UpdateContract _ _) = Nothing

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -302,9 +302,9 @@ renderCard currentSlot state card =
     mSelectedContractState = preview _selectedContract state
 
     cardClasses = case card of
-      TemplateLibraryCard -> Css.largeCard false
-      ContractCard -> Css.largeCard false
-      _ -> Css.card false
+      TemplateLibraryCard -> Css.largeCard true
+      ContractCard -> Css.largeCard true
+      _ -> Css.card true
 
     hasCloseButton = case card of
       (ContractActionConfirmationCard _) -> false
@@ -323,7 +323,7 @@ renderCard currentSlot state card =
         []
   in
     div
-      [ classNames $ Css.overlay false ]
+      [ classNames $ Css.overlay true ]
       [ div
           [ classNames cardClasses ]
           $ closeButton

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -1,22 +1,24 @@
-module Dashboard.View (renderDashboardState) where
+module Dashboard.View
+  ( dashboardScreen
+  , dashboardCard
+  ) where
 
 import Prelude hiding (div)
 import Contract.Lenses (_followerAppId, _mMarloweParams, _metadata)
 import Contract.Types (State) as Contract
 import Contract.View (actionConfirmationCard, contractDetailsCard, contractInnerBox)
 import Css as Css
-import Dashboard.Lenses (_cards, _menuOpen, _remoteWalletInfo, _screen, _selectedContract, _status, _templateState, _walletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput)
+import Dashboard.Lenses (_card, _cardOpen, _menuOpen, _remoteWalletInfo, _selectedContract, _status, _templateState, _walletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput)
 import Dashboard.State (partitionContracts)
-import Dashboard.Types (Action(..), Card(..), ContractStatus(..), Screen(..), State, PartitionedContracts)
+import Dashboard.Types (Action(..), Card(..), ContractStatus(..), State, PartitionedContracts)
 import Data.Array (length)
 import Data.Lens (preview, view, (^.))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), isJust)
 import Data.String (take)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
-import Halogen.Css (applyWhen, classNames, hideWhen)
-import Halogen.Extra (renderSubmodule)
-import Halogen.HTML (HTML, a, div, div_, footer, h2, header, img, main, nav, p_, span, text)
+import Halogen.Css (applyWhen, classNames)
+import Halogen.HTML (HTML, a, div, div_, footer, header, img, main, nav, p_, span, span_, text)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (href, id_, src)
 import Images (marloweRunNavLogo, marloweRunNavLogoDark)
@@ -32,74 +34,131 @@ import Tooltip.Types (ReferenceId(..))
 import WalletData.Lenses (_assets, _walletNickname)
 import WalletData.View (putdownWalletCard, saveWalletCard, walletDetailsCard, walletLibraryScreen)
 
-renderDashboardState :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
-renderDashboardState currentSlot state =
+dashboardScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
+dashboardScreen currentSlot state =
   let
     walletNickname = view (_walletDetails <<< _walletNickname) state
 
     menuOpen = view _menuOpen state
 
-    screen = view _screen state
+    card = view _card state
 
-    cards = view _cards state
+    cardOpen = view _cardOpen state
+
+    mSelectedContractState = preview _selectedContract state
   in
     div
-      [ classNames $ [ "grid", "h-full", "grid-rows-main" ] <> applyWhen menuOpen [ "bg-black" ] ]
-      [ renderHeader walletNickname menuOpen
-      , main
-          [ classNames [ "relative", "px-4", "md:px-5pc" ] ]
-          [ renderMobileMenu menuOpen
-          , div_ $ renderCard currentSlot state <$> cards
-          , renderScreen currentSlot state
+      [ classNames
+          $ [ "h-full", "grid", "grid-rows-dashboard-outer", "transition-all", "duration-500" ]
+          <> applyWhen cardOpen [ "lg:mr-sidebar" ]
+      ]
+      [ dashboardHeader walletNickname menuOpen
+      , div [ classNames [ "relative" ] ] -- this wrapper is relative because the mobile menu is absolutely positioned inside it
+          [ mobileMenu menuOpen
+          , div [ classNames [ "h-full", "grid", "grid-rows-dashboard-inner" ] ]
+              [ dashboardBreadcrumb mSelectedContractState
+              , main
+                  [ classNames $ [ "w-full" ] <> if isJust mSelectedContractState then [] else Css.container ] case mSelectedContractState of
+                  Just contractState -> [ ContractAction <$> contractDetailsCard currentSlot contractState ]
+                  Nothing -> [ contractsScreen currentSlot state ]
+              ]
           ]
-      , renderFooter
+      , dashboardFooter
       ]
 
+dashboardCard :: forall p. Slot -> State -> HTML p Action
+dashboardCard currentSlot state = case view _card state of
+  Just card ->
+    let
+      cardOpen = view _cardOpen state
+
+      walletLibrary = view _walletLibrary state
+
+      currentWalletDetails = view _walletDetails state
+
+      assets = view _assets currentWalletDetails
+
+      walletNicknameInput = view _walletNicknameInput state
+
+      walletIdInput = view _walletIdInput state
+
+      remoteWalletInfo = view _remoteWalletInfo state
+
+      mSelectedContractState = preview _selectedContract state
+
+      templateState = view _templateState state
+    in
+      div
+        [ classNames $ Css.sidebarCardOverlay cardOpen ]
+        [ div
+            [ classNames $ Css.sidebarCard cardOpen ]
+            $ [ a
+                  [ classNames [ "absolute", "top-4", "right-4" ]
+                  , onClick_ CloseCard
+                  ]
+                  [ icon_ Close ]
+              ]
+            <> case card of
+                SaveWalletCard mTokenName -> [ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo mTokenName ]
+                ViewWalletCard walletDetails -> [ walletDetailsCard walletDetails ]
+                PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
+                WalletLibraryCard -> [ walletLibraryScreen walletLibrary ]
+                TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard ]
+                ContractSetupCard -> [ TemplateAction <$> contractSetupScreen walletLibrary currentSlot templateState ]
+                ContractSetupConfirmationCard -> [ TemplateAction <$> contractSetupConfirmationCard assets ]
+                ContractActionConfirmationCard action -> case mSelectedContractState of
+                  Just contractState -> [ ContractAction <$> actionConfirmationCard assets contractState action ]
+                  Nothing -> []
+        ]
+  Nothing -> div_ []
+
 ------------------------------------------------------------
-renderHeader :: forall m. MonadAff m => PubKey -> Boolean -> ComponentHTML Action ChildSlots m
-renderHeader walletNickname menuOpen =
+dashboardHeader :: forall m. MonadAff m => PubKey -> Boolean -> ComponentHTML Action ChildSlots m
+dashboardHeader walletNickname menuOpen =
   header
     [ classNames
-        $ [ "relative", "flex", "justify-between", "items-center", "leading-none", "py-3", "md:py-1", "px-4", "md:px-5pc" ]
-        -- in case the menu is open when the user makes their window wider, we make sure the menuOpen styles only apply on small screens ...
-        
-        <> if menuOpen then [ "border-0", "bg-black", "text-white", "md:border-b", "md:bg-transparent", "md:text-black" ] else [ "border-b", "border-gray" ]
+        $ [ "relative", "border-gray", "transition-colors", "duration-200" ]
+        <> if menuOpen then [ "border-0", "bg-black", "text-white", "md:border-b", "md:bg-transparent", "md:text-black" ] else [ "border-b", "text-black" ]
+    -- ^ in case the menu is open when the user makes their window wider, we make sure the menuOpen styles only apply on small screens ...
     ]
-    [ img
-        [ classNames [ "w-16", "md:hidden" ]
-        , src if menuOpen then marloweRunNavLogoDark else marloweRunNavLogo
-        ]
-    -- ... and provide an alternative logo for wider screens that always has black text
-    , img
-        [ classNames [ "w-16", "hidden", "md:inline" ]
-        , src marloweRunNavLogo
-        ]
-    , nav
-        [ classNames [ "flex", "items-center" ] ]
-        [ navigation (SetScreen ContractsScreen) Home "Home"
-        , navigation (SetScreen WalletLibraryScreen) Contacts "Contacts"
-        , a
-            [ classNames [ "ml-6", "font-bold", "text-sm" ]
-            , id_ "dropWalletHeader"
-            , onClick_ $ OpenCard PutdownWalletCard
+    [ div
+        [ classNames $ Css.container <> [ "flex", "justify-between", "items-center", "leading-none", "py-3", "md:py-1" ] ]
+        [ img
+            [ classNames [ "w-16", "md:hidden" ]
+            , src if menuOpen then marloweRunNavLogoDark else marloweRunNavLogo
             ]
-            [ span
-                [ classNames [ "md:hidden" ] ]
-                [ icon_ Wallet ]
-            , span
-                [ classNames $ [ "hidden", "md:flex", "md:items-baseline" ] <> Css.button <> [ "bg-white" ] ]
-                [ span
-                    [ classNames $ [ "-m-1", "mr-2", "rounded-full", "text-white", "w-5", "h-5", "flex", "justify-center", "items-center", "uppercase", "font-semibold" ] <> Css.bgBlueGradient ]
-                    [ text $ take 1 walletNickname ]
-                , span [ classNames [ "truncate", "max-w-16" ] ] [ text walletNickname ]
+        -- ... and provide an alternative logo for wider screens that always has black text
+        , img
+            [ classNames [ "w-16", "hidden", "md:inline" ]
+            , src marloweRunNavLogo
+            ]
+        , nav
+            [ classNames [ "flex", "items-center" ] ]
+            [ navigation (SelectContract Nothing) Home "Home"
+            , navigation (OpenCard WalletLibraryCard) Contacts "Contacts"
+            , a
+                [ classNames [ "ml-6", "font-bold", "text-sm" ]
+                , id_ "dropWalletHeader"
+                , onClick_ $ OpenCard PutdownWalletCard
                 ]
+                [ span
+                    [ classNames [ "md:hidden" ] ]
+                    [ icon_ Wallet ]
+                , span
+                    [ classNames $ [ "hidden", "md:flex", "md:items-baseline" ] <> Css.button <> [ "bg-white" ] ]
+                    [ span
+                        [ classNames $ [ "-m-1", "mr-2", "rounded-full", "text-white", "w-5", "h-5", "flex", "justify-center", "items-center", "uppercase", "font-semibold" ] <> Css.bgBlueGradient ]
+                        [ text $ take 1 walletNickname ]
+                    , span [ classNames [ "truncate", "max-w-16" ] ] [ text walletNickname ]
+                    ]
+                ]
+            , tooltip "Drop wallet" (RefId "dropWalletHeader") Bottom
+            , a
+                [ classNames [ "ml-4", "md:hidden" ]
+                , onClick_ ToggleMenu
+                ]
+                [ if menuOpen then icon_ Close else icon_ Menu ]
             ]
-        , tooltip "Drop wallet" (RefId "dropWalletHeader") Bottom
-        , a
-            [ classNames [ "ml-4", "md:hidden" ]
-            , onClick_ ToggleMenu
-            ]
-            [ if menuOpen then icon_ Close else icon_ Menu ]
         ]
     ]
   where
@@ -116,10 +175,13 @@ renderHeader walletNickname menuOpen =
           [ text label ]
       ]
 
-renderMobileMenu :: forall p. Boolean -> HTML p Action
-renderMobileMenu menuOpen =
+mobileMenu :: forall p. Boolean -> HTML p Action
+mobileMenu menuOpen =
   nav
-    [ classNames $ [ "md:hidden", "absolute", "inset-0", "z-30", "bg-black", "text-white", "text-lg", "overflow-auto", "flex", "flex-col", "justify-between", "pt-8", "pb-4" ] <> hideWhen (not menuOpen) ]
+    [ classNames
+        $ [ "md:hidden", "absolute", "inset-0", "z-30", "bg-black", "text-white", "text-lg", "overflow-auto", "flex", "flex-col", "justify-between", "pt-8", "pb-4", "transition-all", "duration-200" ]
+        <> if menuOpen then [ "opacity-100" ] else [ "opacity-0", "pointer-events-none" ]
+    ]
     [ div
         [ classNames [ "flex", "flex-col" ] ]
         dashboardLinks
@@ -128,16 +190,32 @@ renderMobileMenu menuOpen =
         iohkLinks
     ]
 
-renderFooter :: forall p. HTML p Action
-renderFooter =
+dashboardBreadcrumb :: forall p. (Maybe Contract.State) -> HTML p Action
+dashboardBreadcrumb mSelectedContractState =
+  div [ classNames [ "border-b", "border-gray" ] ]
+    [ nav [ classNames $ Css.container <> [ "flex", "gap-2", "py-2" ] ]
+        $ [ a [ onClick_ $ SelectContract Nothing ] [ text "Dashboard" ] ]
+        <> case mSelectedContractState of
+            Just { nickname } ->
+              [ span_ [ text ">" ]
+              , span_ [ text nickname ]
+              ]
+            Nothing -> []
+    ]
+
+dashboardFooter :: forall p. HTML p Action
+dashboardFooter =
   footer
-    [ classNames [ "hidden", "md:flex", "py-2", "px-4", "md:px-5pc", "justify-between", "border-t", "border-gray", "text-sm" ] ]
-    [ nav
-        [ classNames [ "flex", "-ml-4" ] ] -- -ml-4 to offset the padding of the first link
-        dashboardLinks
-    , nav
-        [ classNames [ "flex", "-mr-4" ] ] -- -mr-4 to offset the padding of the last link
-        iohkLinks
+    [ classNames [ "hidden", "md:block", "border-t", "border-gray" ] ]
+    [ div
+        [ classNames $ Css.container <> [ "flex", "justify-between", "py-2", "text-sm" ] ]
+        [ nav
+            [ classNames [ "flex", "-ml-4" ] ] -- -ml-4 to offset the padding of the first link
+            dashboardLinks
+        , nav
+            [ classNames [ "flex", "-mr-4" ] ] -- -mr-4 to offset the padding of the last link
+            iohkLinks
+        ]
     ]
 
 dashboardLinks :: forall p. Warn (Text "We need to add the dashboard links.") => Array (HTML p Action)
@@ -165,21 +243,6 @@ link label url =
     [ text label ]
 
 ------------------------------------------------------------
-renderScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
-renderScreen currentSlot state =
-  let
-    walletLibrary = view _walletLibrary state
-  in
-    div
-      -- TODO: Revisit the overflow-auto... I think the scrolling should be set at the screen level and not here.
-      --       this should have overflow-hidden to avoid the main div to occupy more space than available.
-      [ classNames [ "absolute", "inset-0", "overflow-auto", "z-0" ] ]
-      [ case state ^. _screen of
-          ContractsScreen -> contractsScreen currentSlot state
-          WalletLibraryScreen -> walletLibraryScreen walletLibrary
-          TemplateScreen -> renderSubmodule _templateState TemplateAction (contractSetupScreen walletLibrary currentSlot) state
-      ]
-
 contractsScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
 contractsScreen currentSlot state =
   let
@@ -213,14 +276,11 @@ contractsScreen currentSlot state =
   in
     div
       [ classNames [ "pt-4", "flex", "flex-col", "h-full" ] ]
-      [ h2
-          [ classNames [ "font-semibold", "text-lg", "mb-4", "px-4", "md:px-5pc" ] ]
-          [ text "Home" ]
-      , viewSelector
+      [ viewSelector
       -- NOTE: This extra div is necesary to make the scroll only to work for the contract area.
       --       The parent flex with h-full and this element flex-grow makes the div to occupy the remaining
       --       vertical space.
-      , div [ classNames [ "overflow-y-auto", "flex-grow", "px-4", "md:px-5pc" ] ]
+      , div [ classNames [ "overflow-y-auto", "flex-grow", "px-4" ] ]
           [ renderContracts currentSlot state contracts
           ]
       , a
@@ -266,7 +326,7 @@ contractBox currentSlot contractState =
       Just _ ->
         -- NOTE: The overflow hidden helps fix a visual bug in which the background color eats away the border-radius
         [ classNames [ "flex", "flex-col", "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
-        , onClick_ $ OpenContract contractInstanceId
+        , onClick_ $ SelectContract $ Just contractInstanceId
         ]
       -- in this case the box shouldn't be clickable
       Nothing -> [ classNames [ "flex", "flex-col", "shadow-sm", "bg-white", "rounded", "overflow-hidden" ] ]
@@ -281,65 +341,4 @@ contractBox currentSlot contractState =
           , icon ArrowRight [ "text-28px" ]
           ]
       , ContractAction <$> contractInnerBox currentSlot contractState
-      ]
-
-------------------------------------------------------------
-renderCard :: forall p. Slot -> State -> Card -> HTML p Action
-renderCard currentSlot state card =
-  let
-    walletLibrary = view _walletLibrary state
-
-    currentWalletDetails = view _walletDetails state
-
-    assets = view _assets currentWalletDetails
-
-    walletNicknameInput = view _walletNicknameInput state
-
-    walletIdInput = view _walletIdInput state
-
-    remoteWalletInfo = view _remoteWalletInfo state
-
-    mSelectedContractState = preview _selectedContract state
-
-    cardClasses = case card of
-      TemplateLibraryCard -> Css.largeCard true
-      ContractCard -> Css.largeCard true
-      _ -> Css.card true
-
-    hasCloseButton = case card of
-      (ContractActionConfirmationCard _) -> false
-      ContractSetupConfirmationCard -> false
-      _ -> true
-
-    closeButton =
-      if hasCloseButton then
-        [ a
-            [ classNames [ "absolute", "top-4", "right-4" ]
-            , onClick_ $ CloseCard card
-            ]
-            [ icon_ Close ]
-        ]
-      else
-        []
-  in
-    div
-      [ classNames $ Css.overlay true ]
-      [ div
-          [ classNames cardClasses ]
-          $ closeButton
-          <> case card of
-              SaveWalletCard mTokenName -> [ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo mTokenName ]
-              ViewWalletCard walletDetails -> [ walletDetailsCard walletDetails ]
-              PutdownWalletCard -> [ putdownWalletCard currentWalletDetails ]
-              TemplateLibraryCard -> [ TemplateAction <$> templateLibraryCard ]
-              ContractSetupConfirmationCard -> [ TemplateAction <$> contractSetupConfirmationCard assets ]
-              -- FIXME: We need to pattern match on the Maybe because the selectedContractState
-              --        could be Nothing. We could add the state as part of the view, but is not ideal
-              --        Will have to rethink how to deal with this once the overall state is more mature.
-              ContractCard -> case mSelectedContractState of
-                Just contractState -> [ ContractAction <$> contractDetailsCard currentSlot contractState ]
-                Nothing -> []
-              ContractActionConfirmationCard action -> case mSelectedContractState of
-                Just contractState -> [ ContractAction <$> actionConfirmationCard assets contractState action ]
-                Nothing -> []
       ]

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -4,7 +4,6 @@ import Prelude hiding (div)
 import Contract.Lenses (_followerAppId, _mMarloweParams, _metadata)
 import Contract.Types (State) as Contract
 import Contract.View (actionConfirmationCard, contractDetailsCard, contractInnerBox)
-import Css (applyWhen, classNames, hideWhen, toggleWhen)
 import Css as Css
 import Dashboard.Lenses (_cards, _menuOpen, _remoteWalletInfo, _screen, _selectedContract, _status, _templateState, _walletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput)
 import Dashboard.State (partitionContracts)
@@ -15,6 +14,7 @@ import Data.Maybe (Maybe(..))
 import Data.String (take)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
+import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.Extra (renderSubmodule)
 import Halogen.HTML (HTML, a, div, div_, footer, h2, header, img, main, nav, p_, span, text)
 import Halogen.HTML.Events.Extra (onClick_)
@@ -63,7 +63,7 @@ renderHeader walletNickname menuOpen =
         $ [ "relative", "flex", "justify-between", "items-center", "leading-none", "py-3", "md:py-1", "px-4", "md:px-5pc" ]
         -- in case the menu is open when the user makes their window wider, we make sure the menuOpen styles only apply on small screens ...
         
-        <> toggleWhen menuOpen [ "border-0", "bg-black", "text-white", "md:border-b", "md:bg-transparent", "md:text-black" ] [ "border-b", "border-gray" ]
+        <> if menuOpen then [ "border-0", "bg-black", "text-white", "md:border-b", "md:bg-transparent", "md:text-black" ] else [ "border-b", "border-gray" ]
     ]
     [ img
         [ classNames [ "w-16", "md:hidden" ]

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -1,13 +1,13 @@
 module InputField.View (renderInput) where
 
 import Prelude hiding (div)
-import Css (classNames, toggleWhen)
 import Css as Css
 import Data.Array (filter)
 import Data.Foldable (foldMap)
 import Data.Lens (view)
 import Data.Maybe (Maybe(..), isJust)
 import Data.String (Pattern(..), contains, toLower)
+import Halogen.Css (classNames)
 import Halogen.HTML (HTML, a, div, input, text)
 import Halogen.HTML.Events (onBlur, onMouseEnter, onMouseLeave)
 import Halogen.HTML.Events.Extra (onClick_, onFocus_, onValueInput_)
@@ -61,7 +61,7 @@ renderInput state options =
       , div
           [ classNames
               $ [ "absolute", "z-20", "w-full", "max-h-56", "overflow-x-hidden", "overflow-y-auto", "-mt-2", "pt-2", "bg-white", "shadow", "rounded-b", "transition-all", "duration-200" ]
-              <> toggleWhen (not dropdownOpen || matchingValueOptions == mempty) [ "hidden", "opacity-0" ] [ "opacity-100" ]
+              <> if (not dropdownOpen || matchingValueOptions == mempty) then [ "hidden", "opacity-0" ] else [ "opacity-100" ]
           , onMouseEnter $ const $ Just $ SetDropdownLocked true
           , onMouseLeave $ const $ Just $ SetDropdownLocked false
           ]

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -43,7 +43,7 @@ renderInput state options =
       [ classNames [ "relative" ] ]
       [ input
           $ [ type_ InputText
-            , classNames $ (baseCss showError) <> additionalCss
+            , classNames $ (baseCss $ not showError) <> additionalCss
             , id_ $ view _id_ options
             , placeholder $ view _placeholder options
             , value currentValue

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -40,7 +40,7 @@ import WalletData.Lenses (_assets, _companionAppId, _marloweAppId, _previousComp
 import WebSocket.Support as WS
 import Welcome.Lenses (_walletLibrary)
 import Welcome.State (handleAction, dummyState, mkInitialState) as Welcome
-import Welcome.Types (Action(..), Card(..), State) as Welcome
+import Welcome.Types (Action(..), State) as Welcome
 
 mkMainFrame ::
   forall m.
@@ -195,10 +195,7 @@ handleAction (EnterDashboardState walletLibrary walletDetails) = do
   ajaxFollowerApps <- getFollowerApps walletDetails
   currentSlot <- use _currentSlot
   case ajaxFollowerApps of
-    Left decodedAjaxError -> do
-      handleAction $ WelcomeAction $ Welcome.CloseCard Welcome.UseWalletCard
-      handleAction $ WelcomeAction $ Welcome.CloseCard Welcome.UseNewWalletCard
-      addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
+    Left decodedAjaxError -> addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
     Right followerApps -> do
       { dataProvider } <- ask
       let
@@ -215,8 +212,7 @@ handleAction (EnterDashboardState walletLibrary walletDetails) = do
       ajaxRoleContracts <- getRoleContracts walletDetails
       case ajaxRoleContracts of
         Left decodedAjaxError -> do
-          handleAction $ WelcomeAction $ Welcome.CloseCard Welcome.UseWalletCard
-          handleAction $ WelcomeAction $ Welcome.CloseCard Welcome.UseNewWalletCard
+          handleAction $ WelcomeAction Welcome.CloseCard
           addToast $ decodedAjaxErrorToast "Failed to load wallet contracts." decodedAjaxError
         Right companionState -> handleAction $ DashboardAction $ Dashboard.UpdateFollowerApps companionState
 

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -1,7 +1,7 @@
 module MainFrame.View where
 
 import Prelude hiding (div)
-import Dashboard.View (renderDashboardState)
+import Dashboard.View (dashboardCard, dashboardScreen)
 import Data.Either (Either(..))
 import Data.Lens (view)
 import Effect.Aff.Class (class MonadAff)
@@ -12,7 +12,7 @@ import Halogen.HTML (div)
 import MainFrame.Lenses (_currentSlot, _dashboardState, _subState, _toast, _welcomeState)
 import MainFrame.Types (Action(..), ChildSlots, State)
 import Toast.View (renderToast)
-import Welcome.View (renderWelcomeState)
+import Welcome.View (welcomeCard, welcomeScreen)
 
 render :: forall m. MonadAff m => State -> ComponentHTML Action ChildSlots m
 render state =
@@ -20,8 +20,13 @@ render state =
     currentSlot = view _currentSlot state
   in
     div [ classNames [ "h-full" ] ]
-      [ case view _subState state of
-          Left _ -> renderSubmodule _welcomeState WelcomeAction renderWelcomeState state
-          Right _ -> renderSubmodule _dashboardState DashboardAction (renderDashboardState currentSlot) state
-      , renderSubmodule _toast ToastAction renderToast state
-      ]
+      $ case view _subState state of
+          Left _ ->
+            [ renderSubmodule _welcomeState WelcomeAction welcomeScreen state
+            , renderSubmodule _welcomeState WelcomeAction welcomeCard state
+            ]
+          Right _ ->
+            [ renderSubmodule _dashboardState DashboardAction (dashboardScreen currentSlot) state
+            , renderSubmodule _dashboardState DashboardAction (dashboardCard currentSlot) state
+            ]
+      <> [ renderSubmodule _toast ToastAction renderToast state ]

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -1,12 +1,12 @@
 module MainFrame.View where
 
 import Prelude hiding (div)
-import Css (classNames)
 import Dashboard.View (renderDashboardState)
 import Data.Either (Either(..))
 import Data.Lens (view)
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
+import Halogen.Css (classNames)
 import Halogen.Extra (renderSubmodule)
 import Halogen.HTML (div)
 import MainFrame.Lenses (_currentSlot, _dashboardState, _subState, _toast, _welcomeState)

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -11,9 +11,9 @@ import Data.BigInteger (fromString) as BigInteger
 import Data.Lens (view)
 import Data.List (toUnfoldable) as List
 import Data.Map (Map, lookup, values)
-import Data.Map (lookup, toUnfoldable) as Map
-import Data.Maybe (Maybe(..), fromMaybe, isJust)
-import Data.String (null, trim)
+import Data.Map (toUnfoldable) as Map
+import Data.Maybe (Maybe(..), fromMaybe, isNothing)
+import Data.String (trim)
 import Data.Tuple.Nested ((/\))
 import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, p, p_, span, span_, text, ul, ul_)
@@ -24,7 +24,7 @@ import InputField.Types (State) as InputField
 import InputField.Types (inputErrorToString)
 import InputField.View (renderInput)
 import Marlowe.Extended (contractTypeInitials)
-import Marlowe.Extended.Metadata (MetaData, _contractName, _metaData, _valueParameterDescription)
+import Marlowe.Extended.Metadata (MetaData, _contractName, _metaData)
 import Marlowe.Market (contractTemplates)
 import Marlowe.PAB (contractCreationFee)
 import Marlowe.Semantics (Assets, Slot, TokenName)
@@ -208,7 +208,7 @@ parameterInputs currentSlot metaData templateContent slotContentStrings accessib
             , span_ $ formatText description
             ]
         , input
-            [ classNames $ Css.inputCard (isJust mParameterError)
+            [ classNames $ Css.inputCard (isNothing mParameterError)
             , id_ $ "slot-" <> key
             , type_ InputDatetimeLocal
             , onValueInput_ $ SetSlotContent key
@@ -225,9 +225,9 @@ parameterInputs currentSlot metaData templateContent slotContentStrings accessib
     let
       description =
         fromMaybe "no description available"
-          ( case Map.lookup key metaData.valueParameterInfo of
-              Just { valueParameterDescription: description }
-                | trim description /= "" -> Just description
+          ( case lookup key metaData.valueParameterInfo of
+              Just { valueParameterDescription }
+                | trim valueParameterDescription /= "" -> Just valueParameterDescription
               _ -> Nothing
           )
 
@@ -246,7 +246,7 @@ parameterInputs currentSlot metaData templateContent slotContentStrings accessib
             , span_ $ formatText description
             ]
         , input
-            [ classNames $ Css.inputCard (isJust mParameterError)
+            [ classNames $ Css.inputCard (isNothing mParameterError)
             , id_ $ "value-" <> key
             , type_ InputNumber
             , onValueInput_ $ SetValueContent key <<< BigInteger.fromString

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -5,7 +5,6 @@ module Template.View
   ) where
 
 import Prelude hiding (div)
-import Css (applyWhen, classNames, hideWhen)
 import Css as Css
 import Data.Array (mapWithIndex)
 import Data.BigInteger (fromString) as BigInteger
@@ -16,6 +15,7 @@ import Data.Map (lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.String (null, trim)
 import Data.Tuple.Nested ((/\))
+import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, p, p_, span, span_, text, ul, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, for, id_, placeholder, type_, value)
@@ -102,7 +102,7 @@ contractNicknameDisplay contractName contractNickname =
         [ div
             [ classNames [ "max-w-sm", "mx-auto", "px-4", "pt-2" ] ]
             [ input
-                [ classNames $ (Css.input $ null contractNickname) <> [ "font-semibold" ]
+                [ classNames $ (Css.input $ contractNickname /= mempty) <> [ "font-semibold" ]
                 , type_ InputText
                 , placeholder "Contract name *"
                 , value contractNickname

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -62,7 +62,7 @@ contractSetupScreen walletLibrary currentSlot state =
       [ navigationBar contractName
       , contractNicknameDisplay contractName contractNickname
       , div -- the containing grid sets the height of this div
-          [ classNames [ "px-4", "md:px-5pc" ] ]
+          [ classNames [ "px-4" ] ]
           [ div -- and then this fills that height fully
               [ classNames [ "h-full", "overflow-y-auto" ] ]
               [ subHeader "top-0" true Roles "Roles" true
@@ -78,7 +78,7 @@ contractSetupScreen walletLibrary currentSlot state =
 navigationBar :: forall p. String -> HTML p Action
 navigationBar contractName =
   div
-    [ classNames [ "flex", "justify-between", "items-center", "px-4", "py-2", "border-b", "border-gray", "md:px-5pc" ] ]
+    [ classNames [ "flex", "justify-between", "items-center", "px-4", "py-2", "border-b", "border-gray" ] ]
     [ a
         -- "-ml-1" makes the icon line up properly
         [ classNames [ "flex", "items-center", "font-semibold", "-ml-1" ]
@@ -96,7 +96,7 @@ navigationBar contractName =
 contractNicknameDisplay :: forall p. String -> String -> HTML p Action
 contractNicknameDisplay contractName contractNickname =
   div
-    [ classNames [ "px-4", "md:px-5pc" ] ]
+    [ classNames [ "px-4" ] ]
     [ div
         [ classNames [ "ml-5", "border-l", "border-gray", "pt-2" ] ]
         [ div
@@ -298,13 +298,11 @@ subSection accessible border content =
 templateLibraryCard :: forall p. HTML p Action
 templateLibraryCard =
   div
-    [ classNames [ "md:px-5pc", "p-4" ] ]
+    [ classNames [ "p-4", "h-full", "overflow-y-auto" ] ]
     [ h2
         [ classNames [ "text-lg", "font-semibold", "mb-4" ] ]
         [ text "Choose a contract template" ]
-    , div
-        [ classNames [ "grid", "gap-4", "md:grid-cols-2", "xl:grid-cols-3" ] ]
-        (templateBox <$> contractTemplates)
+    , div_ (templateBox <$> contractTemplates)
     ]
   where
   templateBox template =

--- a/marlowe-dashboard-client/src/Toast/View.purs
+++ b/marlowe-dashboard-client/src/Toast/View.purs
@@ -31,9 +31,9 @@ renderExpanded ::
   HTML p Action
 renderExpanded toast =
   div
-    [ classNames $ Css.overlay false ]
+    [ classNames $ Css.overlay true ]
     [ div
-        [ classNames $ Css.card false ]
+        [ classNames $ Css.card true ]
         [ a
             [ classNames [ "absolute", "top-4", "right-4", toast.textColor ]
             , onClick_ CloseToast

--- a/marlowe-dashboard-client/src/Toast/View.purs
+++ b/marlowe-dashboard-client/src/Toast/View.purs
@@ -31,7 +31,7 @@ renderExpanded ::
   HTML p Action
 renderExpanded toast =
   div
-    [ classNames $ Css.overlay true ]
+    [ classNames $ Css.cardOverlay true ]
     [ div
         [ classNames $ Css.card true ]
         [ a
@@ -60,17 +60,15 @@ renderCollapsed toast =
       Just _ ->
         div [ classNames [ "ml-4", "font-semibold", "underline", "flex-shrink-0" ] ]
           [ a
-              [ onClick_ ExpandToast
-              ]
+              [ onClick_ ExpandToast ]
               [ text "Read more" ]
           ]
   in
     div
       [ classNames [ "fixed", "bottom-6", "md:bottom-10", "left-0", "right-0", "flex", "justify-center", "z-50" ] ]
       [ div
-          [ classNames [ "px-4", "py-2", "rounded", "shadow-lg", "min-w-90p", "max-w-90p", "sm:min-w-sm", "flex", "justify-between", "animate-from-below", toast.bgColor, toast.textColor ]
-          , ref
-              (RefLabel "collapsed-toast")
+          [ classNames [ "px-4", "py-2", "rounded", "shadow-lg", "min-w-90pc", "max-w-90pc", "sm:min-w-sm", "flex", "justify-between", "animate-from-below", toast.bgColor, toast.textColor ]
+          , ref $ RefLabel "collapsed-toast"
           ]
           [ div [ classNames [ "flex", "overflow-hidden" ] ]
               [ icon toast.icon [ "mr-2", toast.iconColor ]

--- a/marlowe-dashboard-client/src/Toast/View.purs
+++ b/marlowe-dashboard-client/src/Toast/View.purs
@@ -1,11 +1,11 @@
 module Toast.View (renderToast) where
 
 import Prelude hiding (div)
-import Css (classNames)
 import Css as Css
 import Data.Lens (preview)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Halogen (RefLabel(..))
+import Halogen.Css (classNames)
 import Halogen.HTML (HTML, a, div, div_, span, span_, text)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (ref)

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -6,7 +6,6 @@ module WalletData.View
   ) where
 
 import Prelude hiding (div)
-import Css (applyWhen, classNames, hideWhen)
 import Css as Css
 import Dashboard.Types (Action(..), Card(..))
 import Data.Foldable (foldMap)
@@ -17,6 +16,7 @@ import Data.Newtype (unwrap)
 import Data.String (null)
 import Data.Tuple (Tuple(..))
 import Data.UUID (toString) as UUID
+import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, button, div, h2, h3, h4, input, label, li, p, p_, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (InputType(..), disabled, for, readOnly, type_, value)

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -114,7 +114,7 @@ walletDetailsCard walletDetails =
               [ text "Wallet ID" ]
           , input
               [ type_ InputText
-              , classNames $ Css.input false <> [ "mb-4" ]
+              , classNames $ Css.input true <> [ "mb-4" ]
               , value $ UUID.toString $ unwrap companionAppId
               , readOnly true
               ]
@@ -141,7 +141,7 @@ putdownWalletCard walletDetails =
               [ text "Wallet ID" ]
           , input
               [ type_ InputText
-              , classNames $ Css.input false <> [ "mb-4" ]
+              , classNames $ Css.input true <> [ "mb-4" ]
               , value $ UUID.toString $ unwrap companionAppId
               , readOnly true
               ]

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -84,7 +84,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
           [ classNames [ "flex" ] ]
           [ button
               [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ $ CloseCard $ SaveWalletCard Nothing
+              , onClick_ CloseCard
               ]
               [ text "Cancel" ]
           , button
@@ -159,7 +159,7 @@ putdownWalletCard walletDetails =
           [ classNames [ "flex" ] ]
           [ button
               [ classNames $ Css.secondaryButton <> [ "flex-1", "mr-4" ]
-              , onClick_ $ CloseCard PutdownWalletCard
+              , onClick_ CloseCard
               ]
               [ text "Cancel" ]
           , button
@@ -173,7 +173,7 @@ putdownWalletCard walletDetails =
 walletLibraryScreen :: forall p. WalletLibrary -> HTML p Action
 walletLibraryScreen library =
   div
-    [ classNames [ "p-4", "md:px-5pc" ] ]
+    [ classNames [ "p-4" ] ]
     [ h2
         [ classNames [ "font-semibold", "text-lg", "mb-4" ] ]
         [ text "Contacts" ]

--- a/marlowe-dashboard-client/src/Welcome/Lenses.purs
+++ b/marlowe-dashboard-client/src/Welcome/Lenses.purs
@@ -1,5 +1,6 @@
 module Welcome.Lenses
   ( _card
+  , _cardOpen
   , _walletLibrary
   , _walletNicknameOrIdInput
   , _walletNicknameInput
@@ -20,6 +21,9 @@ import Welcome.Types (Card, State)
 
 _card :: Lens' State (Maybe Card)
 _card = prop (SProxy :: SProxy "card")
+
+_cardOpen :: Lens' State Boolean
+_cardOpen = prop (SProxy :: SProxy "cardOpen")
 
 _walletLibrary :: Lens' State WalletLibrary
 _walletLibrary = prop (SProxy :: SProxy "walletLibrary")

--- a/marlowe-dashboard-client/src/Welcome/Types.purs
+++ b/marlowe-dashboard-client/src/Welcome/Types.purs
@@ -14,6 +14,14 @@ import WalletData.Validation (WalletIdError, WalletNicknameError, WalletNickname
 
 type State
   = { card :: Maybe Card
+    -- Note [CardOpen]: As well as making the card a Maybe, we add an additional cardOpen flag.
+    -- When closing a card we set this to false instead of setting the card to Nothing, and that
+    -- way we can use CSS transitions to animate it on the way out as well as the way in. This is
+    -- preferable to using the Halogen.Animation module (used for toasts), because in this case we
+    -- need to simultaneously animate (fade in/out) the overlay, and because the animation for
+    -- cards has to be different for different screen sizes (on large screens some cards slide in
+    -- from the right) - and that's much easier to do with media queries.
+    , cardOpen :: Boolean
     , walletLibrary :: WalletLibrary
     , walletNicknameOrIdInput :: InputField.State WalletNicknameOrIdError
     , walletNicknameInput :: InputField.State WalletNicknameError
@@ -33,7 +41,7 @@ derive instance eqCard :: Eq Card
 
 data Action
   = OpenCard Card
-  | CloseCard Card
+  | CloseCard
   | GenerateWallet
   | WalletNicknameOrIdInputAction (InputField.Action WalletNicknameOrIdError)
   | OpenUseWalletCardWithDetails WalletDetails
@@ -46,7 +54,7 @@ data Action
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
   toEvent (OpenCard _) = Nothing
-  toEvent (CloseCard _) = Nothing
+  toEvent CloseCard = Nothing
   toEvent GenerateWallet = Just $ defaultEvent "GenerateWallet"
   toEvent (WalletNicknameOrIdInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (OpenUseWalletCardWithDetails _) = Nothing

--- a/marlowe-dashboard-client/src/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Welcome/View.purs
@@ -6,7 +6,7 @@ import Data.Lens (view)
 import Data.List (foldMap)
 import Data.List (toUnfoldable) as List
 import Data.Map (values)
-import Data.Maybe (Maybe(..), isJust, isNothing)
+import Data.Maybe (Maybe(..), isJust)
 import Halogen.Css (classNames)
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, iframe, img, label, main, p, span_, text)
 import Halogen.HTML.Events.Extra (onClick_)
@@ -155,9 +155,9 @@ renderWelcomeCard state =
     cardClasses = if card == Just GetStartedHelpCard then Css.videoCard else Css.card
   in
     div
-      [ classNames $ Css.overlay $ isNothing card ]
+      [ classNames $ Css.overlay $ isJust card ]
       [ div
-          [ classNames $ cardClasses $ isNothing card ]
+          [ classNames $ cardClasses $ isJust card ]
           $ (flip foldMap card) \cardType -> case cardType of
               GetStartedHelpCard -> getStartedHelpCard
               GenerateWalletHelpCard -> generateWalletHelpCard
@@ -360,7 +360,7 @@ walletIdTip =
 localWalletMissingCard :: forall p. Array (HTML p Action)
 localWalletMissingCard =
   [ div
-      [ classNames $ Css.card false ]
+      [ classNames $ Css.card true ]
       [ a
           [ classNames [ "absolute", "top-4", "right-4" ]
           , onClick_ $ CloseCard LocalWalletMissingCard

--- a/marlowe-dashboard-client/src/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Welcome/View.purs
@@ -1,13 +1,13 @@
 module Welcome.View (renderWelcomeState) where
 
 import Prelude hiding (div)
-import Css (bgBlueGradient, classNames)
 import Css as Css
 import Data.Lens (view)
 import Data.List (foldMap)
 import Data.List (toUnfoldable) as List
 import Data.Map (values)
 import Data.Maybe (Maybe(..), isJust, isNothing)
+import Halogen.Css (classNames)
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, iframe, img, label, main, p, span_, text)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (disabled, for, href, src, title)
@@ -126,7 +126,7 @@ gettingStartedBox =
         [ classNames [ "text-purple", "text-center", "lg:hidden" ]
         , onClick_ $ OpenCard GetStartedHelpCard
         ]
-        [ icon Play $ bgBlueGradient <> [ "text-3xl", "text-white", "rounded-full" ]
+        [ icon Play $ Css.bgBlueGradient <> [ "text-3xl", "text-white", "rounded-full" ]
         , br_
         , text "Watch our get started tutorial"
         ]
@@ -136,7 +136,7 @@ gettingStartedBox =
             [ classNames [ "block", "relative", "rounded-lg", "shadow-lg", "bg-get-started-thumbnail", "bg-cover", "w-full", "h-welcome-box", "mb-6" ]
             , onClick_ $ OpenCard GetStartedHelpCard
             ]
-            [ icon Play $ bgBlueGradient <> [ "absolute", "bottom-4", "right-4", "text-3xl", "text-white", "rounded-full" ] ]
+            [ icon Play $ Css.bgBlueGradient <> [ "absolute", "bottom-4", "right-4", "text-3xl", "text-white", "rounded-full" ] ]
         , p
             [ classNames [ "font-semibold", "text-lg", "text-center" ] ]
             [ text "New to Marlowe Run?" ]

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
       77: ".77",
     },
     borderRadius: {
+      none: "0",
       sm: "5px",
       DEFAULT: "10px",
       lg: "25px",
@@ -62,6 +63,7 @@ module.exports = {
         "to-bottom": "to-bottom 250ms ease-out 1",
       },
       backgroundImage: theme => ({
+        "background-shape": "url('/static/images/background-shape.svg')",
         "get-started-thumbnail": "url('/static/images/get-started-thumbnail.jpg')",
         "link-highlight": "url('/static/images/link-highlight.svg')",
       }),
@@ -76,13 +78,15 @@ module.exports = {
         },
       },
       gridTemplateRows: {
-        welcome: "1fr auto auto 1fr",
-        main: "auto minmax(0, 1fr) auto",
+        "welcome": "1fr auto auto 1fr",
+        "dashboard-outer": "auto minmax(0, 1fr) auto",
+        "dashboard-inner": "auto minmax(0, 1fr)",
         "contract-setup": "auto auto minmax(0, 1fr)",
         "contract-step-card": "auto minmax(0, 1fr)",
       },
       gridTemplateColumns: {
-        welcome: "1fr auto auto 1fr",
+        "welcome": "1fr auto auto 1fr",
+        "dashboard-container": "1fr auto",
         "2-contract-home-card": "repeat(2, minmax(240px, 1fr))",
         "auto-fill-contract-home-card": "repeat(auto-fill, minmax(240px, 1fr))",
       },
@@ -90,14 +94,15 @@ module.exports = {
         "22": "5.5rem",
         "160": "40rem",
         "256": "64rem",
-        "5pc": "5%",
         "16:9": "56.25%", // this is used for video containers to maintain a 16:9 aspect ratio
+        "sidebar": "305px",
       },
       width: {
         sm: "375px",
         md: "640px",
         lg: "768px",
         "welcome-box": "400px",
+        "sidebar": "305px",
         "contract-card": "264px",
         /* This width is used by a padding element in both sides of the carousel and is enough
            to push the first and last card to the center */
@@ -107,7 +112,6 @@ module.exports = {
         "welcome-box": "227px",
         "contract-card": "467px",
       },
-
       borderWidth: {
         half: "0.5px",
       },
@@ -115,11 +119,12 @@ module.exports = {
         sm: "375px",
         md: "640px",
         lg: "768px",
-        "90p": "90%",
+        xl: "1440px",
+        "90pc": "90%",
       },
       minWidth: {
         button: "120px",
-        "90p": "90%",
+        "90pc": "90%",
         sm: "375px",
       },
     },
@@ -135,6 +140,7 @@ module.exports = {
       // spacing: ['first', 'last'],
       textColor: ["hover", "disabled"],
       margin: ["first", "last"],
+      borderRadius: ["responsive"],
     },
   },
   plugins: [require("@tailwindcss/forms")],


### PR DESCRIPTION
I've tried to do as little as possible in this PR, to make things easier to review. The aim is to move things a step closer to the new designs by implementing the new sidebar card/modal, and putting things on that that were previously in separate screens. And also putting things that were on cards (notably the contract card) onto their own screens. On top of that, I did the minimum required to keep things basically functional - but the result is a lot of stuff looking a bit weird or ugly.

The next step(s), obviously, will be making all the component parts look pretty. As I do that, I'll also tidy up the names of the various view functions (some cards are still called screens here, and vice versa).

I don't think there's much point including screenshots (since I'd have to include loads). I think this is probably one you'll have to try out locally (sorry).