### PR TITLE
SCP-2445: Make playground only draw the active page

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -99,7 +99,7 @@ contractDetailsCard currentSlot state =
   in
     div
       [ classNames [ "flex", "flex-col", "items-center", "pt-5", "h-full" ]
-      , lifeCycleEvent { onInit: Just CarouselOpened, onFinilize: Just CarouselClosed }
+      , lifeCycleEvent { onInit: Just CarouselOpened, onFinalize: Just CarouselClosed }
       ]
       [ input
           [ classNames [ "text-xl", "font-semibold", "text-center", "bg-transparent" ]

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -22,7 +22,6 @@ import Halogen (Component, HalogenM, getHTMLElementRef, liftEffect, mkComponent,
 import Halogen as H
 import Halogen.BlocklyCommons (blocklyEvents, runWithoutEventSubscription, detectCodeChanges)
 import Halogen.ElementResize (elementResize)
-import Halogen.ElementVisible (elementVisible)
 import Halogen.HTML (HTML)
 import Marlowe.Blockly (buildBlocks)
 import Marlowe.Holes (Term(..), Location(..))
@@ -49,7 +48,7 @@ blocklyComponent rootBlockName blockDefinitions toolbox =
           { handleQuery
           , handleAction
           , initialize: Just $ Inject rootBlockName blockDefinitions toolbox
-          , finalize: Nothing
+          , finalize: Just Finalize
           , receive: Just <<< SetData
           }
     }
@@ -152,8 +151,6 @@ handleAction (Inject rootBlockName blockDefinitions toolbox) = do
       pure state
   -- Subscribe to the resize events on the main section to resize blockly automatically.
   for_ mElement $ H.subscribe <<< elementResize ContentBox (const ResizeWorkspace)
-  -- Subscribe to events triggered when blockly becames visible or hidden.
-  for_ mElement $ H.subscribe <<< elementVisible VisibilityChanged
   -- Subscribe to blockly events to see when the code has changed.
   eventSubscription <- H.subscribe $ blocklyEvents BlocklyEvent blocklyState.workspace
   modify_
@@ -173,6 +170,8 @@ handleAction (BlocklyEvent (BT.Select event)) = case newElementId event of
           blockType <- MaybeT $ map pure $ liftEffect $ getBlockType block
           MaybeT $ map pure $ raise $ BlockSelection $ Just { blockId, blockType }
 
+handleAction (BlocklyEvent (BT.FinishLoading _)) = raise BlocklyReady
+
 handleAction (BlocklyEvent event) = detectCodeChanges CodeChange event
 
 handleAction ResizeWorkspace = do
@@ -182,7 +181,7 @@ handleAction ResizeWorkspace = do
 
 -- When blockly becames visible or unvisible, we call hideChaff to avoid a visual glitch
 -- See PR https://github.com/input-output-hk/plutus/pull/2787
-handleAction (VisibilityChanged _) = do
+handleAction Finalize = do
   mState <- use _blocklyState
   for_ mState \{ blockly } ->
     liftEffect $ Blockly.hideChaff blockly

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -18,6 +18,10 @@ type State
     , errorMessage :: Maybe String
     , blocklyEventSubscription :: Maybe SubscriptionId
     , eventsWhileDragging :: Maybe (List BT.BlocklyEvent)
+    -- For some reason the "FinishLoading" event can be triggered when doing an UNDO in some cases
+    -- we only need to fire the BlocklyReady once in the lifetime of this component, so we
+    -- store a flag to avoid firing it multiple times.
+    , blocklyReadyFired :: Boolean
     }
 
 _blocklyState :: Lens' State (Maybe BT.BlocklyState)
@@ -29,16 +33,20 @@ _errorMessage = prop (SProxy :: SProxy "errorMessage")
 _blocklyEventSubscription :: Lens' State (Maybe SubscriptionId)
 _blocklyEventSubscription = prop (SProxy :: SProxy "blocklyEventSubscription")
 
+_blocklyReadyFired :: Lens' State Boolean
+_blocklyReadyFired = prop (SProxy :: SProxy "blocklyReadyFired")
+
 emptyState :: State
 emptyState =
   { blocklyState: Nothing
   , errorMessage: Nothing
   , blocklyEventSubscription: Nothing
   , eventsWhileDragging: Nothing
+  , blocklyReadyFired: false
   }
 
 data Query a
-  = SetCode Boolean String a
+  = SetCode String a
   | SetError String a
   | GetWorkspace (XML -> a)
   | LoadWorkspace XML a

--- a/marlowe-playground-client/src/BlocklyComponent/Types.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/Types.purs
@@ -51,11 +51,12 @@ data Action
   | SetData Unit
   | BlocklyEvent BT.BlocklyEvent
   | ResizeWorkspace
-  | VisibilityChanged Boolean
+  | Finalize
 
 data Message
   = CodeChange
   | BlockSelection (Maybe { blockId :: String, blockType :: String })
+  | BlocklyReady
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -51,7 +51,7 @@ handleAction ::
   MonadAsk Env m =>
   Action ->
   HalogenM State Action ChildSlots Void m Unit
-handleAction Init = do
+handleAction (HandleBlocklyMessage Blockly.BlocklyReady) = do
   mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
   handleAction $ InitBlocklyProject true $ fromMaybe ME.example mContents
 
@@ -67,7 +67,6 @@ handleAction (HandleBlocklyMessage (Blockly.BlockSelection selection)) = case mB
 
 handleAction (InitBlocklyProject clearUndoStack code) = do
   void $ query _blocklySlot unit $ H.tell (Blockly.SetCode clearUndoStack code)
-  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey code
   processBlocklyCode
   -- Reset the toolbox
   void $ query _blocklySlot unit $ H.tell (Blockly.SetToolbox MB.toolbox)

--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -53,7 +53,7 @@ handleAction ::
   HalogenM State Action ChildSlots Void m Unit
 handleAction (HandleBlocklyMessage Blockly.BlocklyReady) = do
   mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
-  handleAction $ InitBlocklyProject true $ fromMaybe ME.example mContents
+  handleAction $ InitBlocklyProject $ fromMaybe ME.example mContents
 
 handleAction (HandleBlocklyMessage Blockly.CodeChange) = processBlocklyCode
 
@@ -65,8 +65,8 @@ handleAction (HandleBlocklyMessage (Blockly.BlockSelection selection)) = case mB
     { blockType } <- selection
     Map.lookup blockType MB.definitionsMap
 
-handleAction (InitBlocklyProject clearUndoStack code) = do
-  void $ query _blocklySlot unit $ H.tell (Blockly.SetCode clearUndoStack code)
+handleAction (InitBlocklyProject code) = do
+  void $ query _blocklySlot unit $ H.tell $ Blockly.SetCode code
   processBlocklyCode
   -- Reset the toolbox
   void $ query _blocklySlot unit $ H.tell (Blockly.SetToolbox MB.toolbox)

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -20,7 +20,7 @@ import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 
 data Action
   = HandleBlocklyMessage Blockly.Message
-  | InitBlocklyProject Boolean String
+  | InitBlocklyProject String
   | SendToSimulator
   | ViewAsMarlowe
   | Save
@@ -38,7 +38,7 @@ defaultEvent s = (A.defaultEvent $ "BlocklyEditor." <> s) { category = Just "Blo
 
 instance blocklyActionIsEvent :: IsEvent Action where
   toEvent (HandleBlocklyMessage _) = Just $ defaultEvent "HandleBlocklyMessage"
-  toEvent (InitBlocklyProject _ _) = Just $ defaultEvent "InitBlocklyProject"
+  toEvent (InitBlocklyProject _) = Just $ defaultEvent "InitBlocklyProject"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"
   toEvent ViewAsMarlowe = Just $ defaultEvent "ViewAsMarlowe"
   toEvent Save = Just $ defaultEvent "Save"

--- a/marlowe-playground-client/src/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/Types.purs
@@ -19,8 +19,7 @@ import MetadataTab.Types (MetadataAction, showConstructor)
 import StaticAnalysis.Types (AnalysisState, initAnalysisState)
 
 data Action
-  = Init
-  | HandleBlocklyMessage Blockly.Message
+  = HandleBlocklyMessage Blockly.Message
   | InitBlocklyProject Boolean String
   | SendToSimulator
   | ViewAsMarlowe
@@ -38,7 +37,6 @@ defaultEvent :: String -> Event
 defaultEvent s = (A.defaultEvent $ "BlocklyEditor." <> s) { category = Just "Blockly" }
 
 instance blocklyActionIsEvent :: IsEvent Action where
-  toEvent Init = Just $ defaultEvent "Init"
   toEvent (HandleBlocklyMessage _) = Just $ defaultEvent "HandleBlocklyMessage"
   toEvent (InitBlocklyProject _ _) = Just $ defaultEvent "InitBlocklyProject"
   toEvent SendToSimulator = Just $ defaultEvent "SendToSimulator"

--- a/marlowe-playground-client/src/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/HaskellEditor/Types.purs
@@ -25,8 +25,7 @@ import Text.Pretty (pretty)
 import Types (WebData)
 
 data Action
-  = Init
-  | Compile
+  = Compile
   | ChangeKeyBindings KeyBindings
   | HandleEditorMessage Monaco.Message
   | BottomPanelAction (BottomPanel.Action BottomPanelView Action)
@@ -43,7 +42,6 @@ defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Haskell." <> s
 
 instance actionIsEvent :: IsEvent Action where
-  toEvent Init = Just $ defaultEvent "Init"
   toEvent Compile = Just $ defaultEvent "Compile"
   toEvent (ChangeKeyBindings _) = Just $ defaultEvent "ChangeKeyBindings"
   toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
@@ -63,6 +61,7 @@ type State
     , bottomPanelState :: BottomPanel.State BottomPanelView
     , metadataHintInfo :: MetadataHintInfo
     , analysisState :: AnalysisState
+    , editorReady :: Boolean
     }
 
 _haskellEditorKeybindings :: Lens' State KeyBindings
@@ -76,6 +75,9 @@ _metadataHintInfo = prop (SProxy :: SProxy "metadataHintInfo")
 
 _analysisState :: Lens' State AnalysisState
 _analysisState = prop (SProxy :: SProxy "analysisState")
+
+_editorReady :: Lens' State Boolean
+_editorReady = prop (SProxy :: SProxy "editorReady")
 
 --- Language.Haskell.Interpreter is missing this ---
 _result :: forall s a. Lens' { result :: a | s } a
@@ -101,6 +103,7 @@ initialState =
   , bottomPanelState: BottomPanel.initialState MetadataView
   , metadataHintInfo: mempty
   , analysisState: initAnalysisState
+  , editorReady: false
   }
 
 isCompiling :: State -> Boolean

--- a/marlowe-playground-client/src/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/JavascriptEditor/Types.purs
@@ -91,6 +91,7 @@ type State
     , decorationIds :: Maybe DecorationIds
     , metadataHintInfo :: MetadataHintInfo
     , analysisState :: AnalysisState
+    , editorReady :: Boolean
     }
 
 _keybindings :: Lens' State KeyBindings
@@ -111,6 +112,9 @@ _metadataHintInfo = prop (SProxy :: SProxy "metadataHintInfo")
 _analysisState :: Lens' State AnalysisState
 _analysisState = prop (SProxy :: SProxy "analysisState")
 
+_editorReady :: Lens' State Boolean
+_editorReady = prop (SProxy :: SProxy "editorReady")
+
 isCompiling :: State -> Boolean
 isCompiling state = case state ^. _compilationResult of
   Compiling -> true
@@ -124,6 +128,7 @@ initialState =
   , decorationIds: Nothing
   , metadataHintInfo: mempty
   , analysisState: initAnalysisState
+  , editorReady: false
   }
 
 data BottomPanelView

--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -45,9 +45,8 @@ import HaskellEditor.Types (Action(..), State, _ContractString, _metadataHintInf
 import JavascriptEditor.State as JavascriptEditor
 import JavascriptEditor.Types (Action(..), State, _ContractString, _metadataHintInfo, initialState) as JS
 import JavascriptEditor.Types (CompilationState(..))
-import Language.Haskell.Monaco as HM
 import LoginPopup (openLoginPopup, informParentAndClose)
-import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _contractMetadata, _createGistResult, _gistId, _hasUnsavedChanges, _haskellState, _javascriptState, _jsEditorSlot, _loadGistResult, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _workflow, sessionToState, stateToSession)
+import MainFrame.Types (Action(..), ChildSlots, ModalView(..), Query(..), State, View(..), _actusBlocklySlot, _authStatus, _blocklyEditorState, _contractMetadata, _createGistResult, _gistId, _hasUnsavedChanges, _haskellState, _javascriptState, _loadGistResult, _marloweEditorState, _newProject, _projectName, _projects, _rename, _saveAs, _showBottomPanel, _showModal, _simulationState, _view, _workflow, sessionToState, stateToSession)
 import MainFrame.View (render)
 import Marlowe (getApiGistsByGistId)
 import Marlowe as Server
@@ -215,8 +214,6 @@ handleSubRoute Router.Blockly = selectView BlocklyEditor
 
 handleSubRoute Router.ActusBlocklyEditor = selectView ActusBlocklyEditor
 
-handleSubRoute Router.Wallets = selectView WalletEmulator
-
 -- This route is supposed to be called by the github oauth flow after a succesful login flow
 -- It is supposed to be run inside a popup window
 handleSubRoute Router.GithubAuthCallback = do
@@ -298,10 +295,6 @@ handleAction Init = do
   document <- liftEffect $ Web.document =<< Web.window
   subscribe' \sid ->
     eventListenerEventSource keyup (toEventTarget document) (map (HandleKey sid) <<< KE.fromEvent)
-  toSimulation $ Simulation.handleAction ST.Init
-  toHaskellEditor $ HaskellEditor.handleAction HE.Init
-  toMarloweEditor $ MarloweEditor.handleAction ME.Init
-  toBlocklyEditor $ BlocklyEditor.handleAction BE.Init
   checkAuthStatus
   -- Load session data if available
   void
@@ -460,13 +453,8 @@ handleAction (NewProjectAction (NewProject.CreateProject lang)) = do
         <<< set _createGistResult NotAsked
         <<< set _contractMetadata emptyContractMetadata
     )
+  -- TODO: Remove gistIdLocalStorageKey and use global session management (MainFrame.stateToSession)
   liftEffect $ SessionStorage.setItem gistIdLocalStorageKey mempty
-  -- We reset all editors and then initialize the selected language.
-  toHaskellEditor $ HaskellEditor.handleAction $ HE.InitHaskellProject mempty mempty
-  toJavascriptEditor $ JavascriptEditor.handleAction $ JS.InitJavascriptProject mempty mempty
-  toMarloweEditor $ MarloweEditor.handleAction $ ME.InitMarloweProject mempty
-  toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true mempty
-  -- TODO: implement ActusBlockly.SetCode
   case lang of
     Haskell ->
       for_ (Map.lookup "Example" StaticData.demoFiles) \contents -> do
@@ -491,6 +479,15 @@ handleAction (NewProjectAction (NewProject.CreateProject lang)) = do
 handleAction (NewProjectAction NewProject.Cancel) = fullHandleAction CloseModal
 
 handleAction (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
+  modify_
+    ( set _showModal Nothing
+        <<< set _workflow (Just lang)
+        <<< set _hasUnsavedChanges false
+        <<< set _gistId Nothing
+        <<< set _projectName metadata.contractName
+        <<< set _contractMetadata metadata
+    )
+  selectView $ selectLanguageView lang
   case lang of
     Haskell ->
       for_ (Map.lookup key StaticData.demoFiles) \contents ->
@@ -505,15 +502,6 @@ handleAction (DemosAction action@(Demos.LoadDemo lang (Demos.Demo key))) = do
       for_ (preview (ix key) StaticData.marloweContracts) \contents -> do
         toBlocklyEditor $ BlocklyEditor.handleAction $ BE.InitBlocklyProject true contents
     Actus -> pure unit
-  modify_
-    ( set _showModal Nothing
-        <<< set _workflow (Just lang)
-        <<< set _hasUnsavedChanges false
-        <<< set _gistId Nothing
-        <<< set _projectName metadata.contractName
-        <<< set _contractMetadata metadata
-    )
-  selectView $ selectLanguageView lang
   where
   metadata = fromMaybe emptyContractMetadata $ Map.lookup key StaticData.demoFilesMetadata
 
@@ -617,7 +605,6 @@ routeToView { subroute } = case subroute of
   Router.JSEditor -> Just JSEditor
   Router.ActusBlocklyEditor -> Just ActusBlocklyEditor
   Router.Blockly -> Just BlocklyEditor
-  Router.Wallets -> Just WalletEmulator
   Router.GithubAuthCallback -> Nothing
 
 viewToRoute :: View -> Router.SubRoute
@@ -628,7 +615,6 @@ viewToRoute = case _ of
   HaskellEditor -> Router.HaskellEditor
   JSEditor -> Router.JSEditor
   BlocklyEditor -> Router.Blockly
-  WalletEmulator -> Router.Wallets
   ActusBlocklyEditor -> Router.ActusBlocklyEditor
 
 ------------------------------------------------------------
@@ -886,18 +872,9 @@ selectView view = do
     Window.scroll 0 0 window
   case view of
     HomePage -> modify_ (set _workflow Nothing <<< set _hasUnsavedChanges false)
-    Simulation -> do
-      Simulation.editorSetTheme
-    MarloweEditor -> do
-      MarloweEditor.editorSetTheme
-    HaskellEditor -> do
-      HaskellEditor.editorSetTheme
-    JSEditor -> do
-      void $ query _jsEditorSlot unit (Monaco.SetTheme HM.daylightTheme.name unit)
-    BlocklyEditor -> pure unit
-    WalletEmulator -> pure unit
     ActusBlocklyEditor -> do
       void $ query _actusBlocklySlot unit (ActusBlockly.Resize unit)
+    _ -> pure unit
 
 ------------------------------------------------------------
 withSessionStorage ::

--- a/marlowe-playground-client/src/MainFrame/Types.purs
+++ b/marlowe-playground-client/src/MainFrame/Types.purs
@@ -130,7 +130,6 @@ data View
   | Simulation
   | BlocklyEditor
   | ActusBlocklyEditor
-  | WalletEmulator
 
 derive instance eqView :: Eq View
 

--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -3,7 +3,7 @@ module MainFrame.View where
 import Prelude hiding (div)
 import Auth (_GithubUser, authStatusAuthRole)
 import BlocklyEditor.View as BlocklyEditor
-import Data.Lens (has, to, (^.))
+import Data.Lens (has, (^.))
 import Data.Maybe (Maybe(..), isNothing)
 import Effect.Aff.Class (class MonadAff)
 import Gists.Types (GistAction(..))
@@ -49,18 +49,47 @@ render state =
           , topBar
           ]
       , main []
-          [ section [ id_ "main-panel" ]
-              [ tabContents HomePage [ Home.render state ]
-              , tabContents Simulation [ renderSubmodule _simulationState SimulationAction (Simulation.render (state ^. _contractMetadata)) state ]
-              , tabContents MarloweEditor [ renderSubmodule _marloweEditorState MarloweEditorAction (MarloweEditor.render (state ^. _contractMetadata)) state ]
-              , tabContents HaskellEditor [ renderSubmodule _haskellState HaskellAction (HaskellEditor.render (state ^. _contractMetadata)) state ]
-              , tabContents JSEditor [ renderSubmodule _javascriptState JavascriptAction (JSEditor.render (state ^. _contractMetadata)) state ]
-              , tabContents BlocklyEditor [ renderSubmodule _blocklyEditorState BlocklyEditorAction (BlocklyEditor.render (state ^. _contractMetadata)) state ]
-              , tabContents ActusBlocklyEditor
-                  [ slot _actusBlocklySlot unit (ActusBlockly.blockly AMB.rootBlockName AMB.blockDefinitions AMB.toolbox) unit (Just <<< HandleActusBlocklyMessage)
-                  , AMB.workspaceBlocks
-                  ]
-              ]
+          [ section [ id_ "main-panel" ] case state ^. _view of
+              HomePage -> [ Home.render state ]
+              Simulation ->
+                [ renderSubmodule
+                    _simulationState
+                    SimulationAction
+                    (Simulation.render (state ^. _contractMetadata))
+                    state
+                ]
+              MarloweEditor ->
+                [ renderSubmodule
+                    _marloweEditorState
+                    MarloweEditorAction
+                    (MarloweEditor.render (state ^. _contractMetadata))
+                    state
+                ]
+              HaskellEditor ->
+                [ renderSubmodule
+                    _haskellState
+                    HaskellAction
+                    (HaskellEditor.render (state ^. _contractMetadata))
+                    state
+                ]
+              JSEditor ->
+                [ renderSubmodule
+                    _javascriptState
+                    JavascriptAction
+                    (JSEditor.render (state ^. _contractMetadata))
+                    state
+                ]
+              BlocklyEditor ->
+                [ renderSubmodule
+                    _blocklyEditorState
+                    BlocklyEditorAction
+                    (BlocklyEditor.render (state ^. _contractMetadata))
+                    state
+                ]
+              ActusBlocklyEditor ->
+                [ slot _actusBlocklySlot unit (ActusBlockly.blockly AMB.rootBlockName AMB.blockDefinitions AMB.toolbox) unit (Just <<< HandleActusBlocklyMessage)
+                , AMB.workspaceBlocks
+                ]
           ]
       , modal state
       , globalLoadingOverlay
@@ -100,14 +129,6 @@ render state =
               ]
           , spinner
           ]
-
-  isActiveView activeView = state ^. _view <<< to (eq activeView)
-
-  tabContents activeView contents =
-    div
-      [ classNames $ if isActiveView activeView then [ "h-full" ] else [ "hidden" ]
-      ]
-      contents
 
   topBar =
     if showtopBar then

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -38,7 +38,7 @@ import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
 import Marlowe.Template (TemplateContent)
 import Marlowe.Template as Template
-import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _comesFromBlockly, _editorErrors, _editorReady, _editorWarnings, _hasHoles, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
+import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _editorErrors, _editorReady, _editorWarnings, _hasHoles, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
 import Monaco (isError, isWarning)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
@@ -123,7 +123,6 @@ handleAction ViewAsBlockly = pure unit
 
 handleAction (InitMarloweProject contents) = do
   editorSetValue contents
-  assign (_comesFromBlockly) false
   liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey contents
 
 handleAction (SelectHole hole) = assign _selectedHole hole

--- a/marlowe-playground-client/src/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/MarloweEditor/State.purs
@@ -1,7 +1,6 @@
 module MarloweEditor.State
   ( handleAction
   , editorGetValue
-  , editorSetTheme
   ) where
 
 import Prelude hiding (div)
@@ -32,14 +31,14 @@ import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import MainFrame.Types (ChildSlots, _marloweEditorPageSlot)
 import Marlowe.Extended as Extended
 import Marlowe.Extended.Metadata (MetadataHintInfo)
-import Marlowe.Template (TemplateContent)
-import Marlowe.Template as Template
 import Marlowe.Holes as Holes
 import Marlowe.LinterText as Linter
 import Marlowe.Monaco (updateAdditionalContext)
 import Marlowe.Monaco as MM
 import Marlowe.Parser (parseContract)
-import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _comesFromBlockly, _editorErrors, _editorWarnings, _hasHoles, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
+import Marlowe.Template (TemplateContent)
+import Marlowe.Template as Template
+import MarloweEditor.Types (Action(..), BottomPanelView, State, _bottomPanelState, _comesFromBlockly, _editorErrors, _editorReady, _editorWarnings, _hasHoles, _keybindings, _metadataHintInfo, _selectedHole, _showErrorDetail)
 import Monaco (isError, isWarning)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
@@ -66,19 +65,29 @@ handleAction ::
   MonadAsk Env m =>
   Action ->
   HalogenM State Action ChildSlots Void m Unit
-handleAction Init = do
-  editorSetTheme
-  mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
-  editorSetValue $ fromMaybe ME.example mContents
-
 handleAction (ChangeKeyBindings bindings) = do
   assign _keybindings bindings
   void $ query _marloweEditorPageSlot unit (Monaco.SetKeyBindings bindings unit)
 
+handleAction (HandleEditorMessage Monaco.EditorReady) = do
+  editorSetTheme
+  mContents <- liftEffect $ SessionStorage.getItem marloweBufferLocalStorageKey
+  editorSetValue $ fromMaybe ME.example mContents
+  for_ mContents processMarloweCode
+  assign _editorReady true
+
 handleAction (HandleEditorMessage (Monaco.TextChanged text)) = do
-  assign _selectedHole Nothing
-  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey text
-  processMarloweCode text
+  -- When the Monaco component start it fires two messages at the same time, an EditorReady
+  -- and TextChanged. Because of how Halogen works, it interwines the handleActions calls which
+  -- can cause problems while setting and getting the values of the session storage. To avoid
+  -- starting with an empty text editor we use an editorReady flag to ignore the text changes until
+  -- we are ready to go. Eventually we could remove the initial TextChanged event, but we need to check
+  -- that it doesn't break the plutus playground.
+  editorReady <- use _editorReady
+  when editorReady do
+    assign _selectedHole Nothing
+    liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey text
+    processMarloweCode text
 
 handleAction (HandleDragEvent event) = liftEffect $ preventDefault event
 
@@ -132,7 +141,7 @@ handleAction AnalyseContractForCloseRefund = runAnalysis $ analyseClose
 handleAction ClearAnalysisResults = do
   assign (_analysisState <<< _analysisExecutionState) NoneAsked
   mContents <- editorGetValue
-  for_ mContents \contents -> processMarloweCode contents
+  for_ mContents processMarloweCode
 
 handleAction Save = pure unit
 

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -92,7 +92,6 @@ type State
     , editorErrors :: Array IMarkerData
     , editorWarnings :: Array IMarkerData
     , hasHoles :: Boolean
-    , comesFromBlockly :: Boolean
     , editorReady :: Boolean
     }
 
@@ -120,9 +119,6 @@ _bottomPanelState = prop (SProxy :: SProxy "bottomPanelState")
 _hasHoles :: Lens' State Boolean
 _hasHoles = prop (SProxy :: SProxy "hasHoles")
 
-_comesFromBlockly :: Lens' State Boolean
-_comesFromBlockly = prop (SProxy :: SProxy "comesFromBlockly")
-
 _editorReady :: Lens' State Boolean
 _editorReady = prop (SProxy :: SProxy "editorReady")
 
@@ -137,7 +133,6 @@ initialState =
   , editorErrors: mempty
   , editorWarnings: mempty
   , hasHoles: false
-  , comesFromBlockly: false
   , editorReady: false
   }
 

--- a/marlowe-playground-client/src/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/MarloweEditor/Types.purs
@@ -23,8 +23,7 @@ import Text.Parsing.StringParser (Pos)
 import Web.HTML.Event.DragEvent (DragEvent)
 
 data Action
-  = Init
-  | ChangeKeyBindings KeyBindings
+  = ChangeKeyBindings KeyBindings
   | HandleEditorMessage Monaco.Message
   | HandleDragEvent DragEvent
   | HandleDropEvent DragEvent
@@ -49,7 +48,6 @@ defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "MarloweEditor." <> s
 
 instance actionIsEvent :: IsEvent Action where
-  toEvent Init = Just $ defaultEvent "Init"
   toEvent (ChangeKeyBindings _) = Just $ defaultEvent "ChangeKeyBindings"
   toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
   toEvent (HandleDragEvent _) = Just $ defaultEvent "HandleDragEvent"
@@ -95,6 +93,7 @@ type State
     , editorWarnings :: Array IMarkerData
     , hasHoles :: Boolean
     , comesFromBlockly :: Boolean
+    , editorReady :: Boolean
     }
 
 _keybindings :: Lens' State KeyBindings
@@ -124,6 +123,9 @@ _hasHoles = prop (SProxy :: SProxy "hasHoles")
 _comesFromBlockly :: Lens' State Boolean
 _comesFromBlockly = prop (SProxy :: SProxy "comesFromBlockly")
 
+_editorReady :: Lens' State Boolean
+_editorReady = prop (SProxy :: SProxy "editorReady")
+
 initialState :: State
 initialState =
   { keybindings: DefaultBindings
@@ -136,6 +138,7 @@ initialState =
   , editorWarnings: mempty
   , hasHoles: false
   , comesFromBlockly: false
+  , editorReady: false
   }
 
 contractHasHoles :: State -> Boolean

--- a/marlowe-playground-client/src/Router.purs
+++ b/marlowe-playground-client/src/Router.purs
@@ -24,7 +24,6 @@ data SubRoute
   | JSEditor
   | ActusBlocklyEditor
   | Blockly
-  | Wallets
   | GithubAuthCallback
 
 derive instance eqRoute :: Eq SubRoute
@@ -45,7 +44,6 @@ route =
         , "JSEditor": "javascript" / noArgs
         , "Blockly": "blockly" / noArgs
         , "ActusBlocklyEditor": "actus" / noArgs
-        , "Wallets": "wallets" / noArgs
         , "GithubAuthCallback": "gh-oauth-cb" / noArgs
         }
   where

--- a/marlowe-playground-client/src/SimulationPage/State.purs
+++ b/marlowe-playground-client/src/SimulationPage/State.purs
@@ -1,6 +1,5 @@
 module SimulationPage.State
   ( handleAction
-  , editorSetTheme
   , editorGetValue
   , getCurrentContract
   , mkState
@@ -38,7 +37,7 @@ import Foreign.Generic (ForeignError, decode)
 import Foreign.JSON (parseJSON)
 import Halogen (HalogenM, get, query, tell)
 import Halogen.Extra (mapSubmodule)
-import Halogen.Monaco (Query(..)) as Monaco
+import Halogen.Monaco (Message(..), Query(..)) as Monaco
 import Help (HelpContext(..))
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe as Server
@@ -88,10 +87,12 @@ handleAction ::
   MonadAsk Env m =>
   Action ->
   HalogenM State Action ChildSlots Void m Unit
-handleAction Init = do
-  editorSetTheme
+handleAction (HandleEditorMessage Monaco.EditorReady) = do
   contents <- fromMaybe "" <$> (liftEffect $ SessionStorage.getItem simulatorBufferLocalStorageKey)
   handleAction $ LoadContract contents
+  editorSetTheme
+
+handleAction (HandleEditorMessage (Monaco.TextChanged _)) = pure unit
 
 handleAction (SetInitialSlot initialSlot) = do
   assign (_currentMarloweState <<< _executionState <<< _SimulationNotStarted <<< _initialSlot) initialSlot

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -10,6 +10,7 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.List.Types (NonEmptyList)
 import Data.Maybe (Maybe(..))
+import Halogen.Monaco as Monaco
 import Help (HelpContext)
 import Marlowe.Template (IntegerTemplateType)
 import Marlowe.Semantics (Bound, ChoiceId, ChosenNum, Input, Slot)
@@ -28,7 +29,7 @@ type State
     }
 
 data Action
-  = Init
+  = HandleEditorMessage Monaco.Message
   -- marlowe actions
   | SetInitialSlot Slot
   | SetIntegerTemplateParam IntegerTemplateType String BigInteger
@@ -54,7 +55,6 @@ defaultEvent :: String -> Event
 defaultEvent s = A.defaultEvent $ "Simulation." <> s
 
 instance isEventAction :: IsEvent Action where
-  toEvent Init = Just $ defaultEvent "Init"
   toEvent (SetInitialSlot _) = Just $ defaultEvent "SetInitialSlot"
   toEvent (SetIntegerTemplateParam templateType key value) = Just $ defaultEvent "SetIntegerTemplateParam"
   toEvent StartSimulation = Just $ defaultEvent "StartSimulation"
@@ -69,6 +69,7 @@ instance isEventAction :: IsEvent Action where
   toEvent (ShowRightPanel _) = Just $ defaultEvent "ShowRightPanel"
   toEvent (BottomPanelAction action) = A.toEvent action
   toEvent EditSource = Just $ defaultEvent "EditSource"
+  toEvent (HandleEditorMessage _) = Just $ defaultEvent "HandleEditorMessage"
 
 data Query a
   = WebsocketResponse (RemoteData String Result) a

--- a/marlowe-playground-client/src/SimulationPage/View.purs
+++ b/marlowe-playground-client/src/SimulationPage/View.purs
@@ -18,7 +18,6 @@ import Data.Tuple (Tuple(..), snd)
 import Data.Tuple.Nested (type (/\), (/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
-import Halogen (RefLabel(..))
 import Halogen.Classes (aHorizontal, bold, btn, flex, flexCol, flexGrow, flexShrink0, fontBold, fullHeight, fullWidth, grid, gridColsDescriptionLocation, group, justifyBetween, justifyCenter, justifyEnd, maxH70p, minH0, noMargins, overflowHidden, overflowScroll, paddingX, plusBtn, smallBtn, smallSpaceBottom, spaceBottom, spaceLeft, spaceRight, spanText, spanTextBreakWord, textSecondaryColor, textXs, uppercase, w30p)
 import Halogen.Css (classNames)
 import Halogen.CurrencyInput (currencyInput)
@@ -26,14 +25,13 @@ import Halogen.Extra (renderSubmodule)
 import Halogen.HTML (ClassName(..), ComponentHTML, HTML, aside, b_, button, div, div_, em_, h6, h6_, li, li_, p, p_, section, slot, span, span_, strong_, text, ul)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, disabled)
-import Halogen.Monaco (Settings, monacoComponent)
+import Halogen.Monaco (monacoComponent)
 import MainFrame.Types (ChildSlots, _simulatorEditorSlot)
 import Marlowe.Extended.Metadata (MetaData, NumberFormat(..), getChoiceFormat)
 import Marlowe.Monaco (daylightTheme, languageExtensionPoint)
 import Marlowe.Monaco as MM
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), Input(..), Party(..), Payment(..), PubKey, Slot, SlotInterval(..), Token(..), TransactionInput(..), inBounds, timeouts)
 import Marlowe.Template (IntegerTemplateType(..))
-import Monaco (Editor)
 import Monaco as Monaco
 import Pretty (renderPrettyParty, renderPrettyToken, showPrettyChoice, showPrettyMoney)
 import SimulationPage.BottomPanel (panelContents)
@@ -171,35 +169,11 @@ marloweEditor ::
   MonadAff m =>
   State ->
   ComponentHTML Action ChildSlots m
-marloweEditor state = slot _simulatorEditorSlot unit component unit (const Nothing)
+marloweEditor state = slot _simulatorEditorSlot unit component unit (Just <<< HandleEditorMessage)
   where
-  setup editor = do
-    model <- liftEffect $ Monaco.getModel editor
-    liftEffect do
-      -- Since the Simulation Tab is viewed before the Haskell tab we need to set the correct editor theme when things have been loaded
-      monaco <- Monaco.getMonaco
-      Monaco.setTheme monaco MM.daylightTheme.name
-      Monaco.setReadOnly editor true
+  setup editor = liftEffect $ Monaco.setReadOnly editor true
 
-  component = monacoComponent $ settings setup
-
-refLabel :: RefLabel
-refLabel = RefLabel "simulatorEditor"
-
-settings :: forall m. (Editor -> m Unit) -> Settings m
-settings setup =
-  { languageExtensionPoint
-  , theme: Just daylightTheme
-  , monarchTokensProvider: Nothing
-  , tokensProvider: Nothing
-  , hoverProvider: Nothing
-  , completionItemProvider: Nothing
-  , codeActionProvider: Nothing
-  , documentFormattingEditProvider: Nothing
-  , refLabel
-  , owner: "marloweEditor"
-  , setup
-  }
+  component = monacoComponent $ MM.settings setup
 
 ------------------------------------------------------------
 sidebar ::

--- a/plutus-playground-client/src/Editor/State.purs
+++ b/plutus-playground-client/src/Editor/State.purs
@@ -54,6 +54,8 @@ handleAction bufferLocalStorageKey Init = do
   assign _keyBindings binding
   handleAction bufferLocalStorageKey (SetKeyBindings binding)
 
+handleAction _ (HandleEditorMessage Monaco.EditorReady) = pure unit
+
 handleAction bufferLocalStorageKey (HandleEditorMessage (Monaco.TextChanged text)) = do
   lastCompiledCode <- use _lastCompiledCode
   case lastCompiledCode of

--- a/web-common/src/Halogen/Extra.purs
+++ b/web-common/src/Halogen/Extra.purs
@@ -116,9 +116,9 @@ scrollIntoView ref = do
   for_ mElement (liftEffect <<< runEffectFn1 scrollIntoView_)
 
 -- This HTML property dispatch lifecycle actions when the element is added or removed to the DOM
-lifeCycleEvent :: forall r action. { onInit :: Maybe action, onFinilize :: Maybe action } -> IProp r action
+lifeCycleEvent :: forall r action. { onInit :: Maybe action, onFinalize :: Maybe action } -> IProp r action
 lifeCycleEvent handlers = (unsafeCoerce :: Prop (Input action) -> IProp r action) $ Core.ref onLifecycleEvent
   where
   onLifecycleEvent (Just _) = Input.Action <$> handlers.onInit
 
-  onLifecycleEvent Nothing = Input.Action <$> handlers.onFinilize
+  onLifecycleEvent Nothing = Input.Action <$> handlers.onFinalize

--- a/web-common/src/Web/DOM/ResizeObserver.js
+++ b/web-common/src/Web/DOM/ResizeObserver.js
@@ -24,7 +24,7 @@ exports._observe = function (element) {
 exports.unobserve = function (element) {
     return function (observer) {
       return function () {
-        return observer.observe(element, config);
+        return observer.unobserve(element);
       };
     };
 };


### PR DESCRIPTION
This PR solves a long-standing issue in the playground where all the components were drawn at the same time even if they weren't in view. This issue was a blocker for adding the hints widget, as halogen requires the slots components id's to be unique, and if we reutilize a component in a different view it collides, resulting in weird errors.

Changes are deployed to https://hernan.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [X] Commits have useful messages
- [ ] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
