### PR TITLE
More documentation for getting started in Plutus Playground

### DIFF
--- a/plutus-playground-client/README.md
+++ b/plutus-playground-client/README.md
@@ -33,7 +33,7 @@ The `start` script will:
 
 Once the `start` script completes you can access the frontend via [http://localhost:8009](http://localhost:8009)
 
-> __NOTE__: You may need to adjust `webpack.config.js` to serve non-SSL content; set
+> **NOTE**: You may need to adjust `webpack.config.js` to serve non-SSL content; set
 > `module.exports.devServer.https` to `false`.
 
 ## Development Workflow

--- a/plutus-playground-client/README.md
+++ b/plutus-playground-client/README.md
@@ -33,6 +33,9 @@ The `start` script will:
 
 Once the `start` script completes you can access the frontend via [http://localhost:8009](http://localhost:8009)
 
+> __NOTE__: You may need to adjust `webpack.config.js` to serve non-SSL content; set
+> `module.exports.devServer.https` to `false`.
+
 ## Development Workflow
 
 The following outlines some essentials for actually working on the plutus playground code.

--- a/plutus-playground-server/README.md
+++ b/plutus-playground-server/README.md
@@ -16,6 +16,11 @@ stack exec -- plutus-playground-server webserver
 $(nix-build -A plutus-playground.server)/bin/plutus-playground-server webserver
 ```
 
+> __NOTE__: You may notice that the executable that nix exposes does not accept
+> arguments; that's because the exposed command is actually a script run by
+> [this attribute](https://github.com/input-output-hk/plutus/blob/master/plutus-playground-client/default.nix#L43).
+> Use the above `nix-build` sub-command to expose the actual haskell executable.
+
 ## Testing
 
 Tests should be run with nix:

--- a/plutus-playground-server/README.md
+++ b/plutus-playground-server/README.md
@@ -16,7 +16,7 @@ stack exec -- plutus-playground-server webserver
 $(nix-build -A plutus-playground.server)/bin/plutus-playground-server webserver
 ```
 
-> __NOTE__: You may notice that the executable that nix exposes does not accept
+> **NOTE**: You may notice that the executable that nix exposes does not accept
 > arguments; that's because the exposed command is actually a script run by
 > [this attribute](https://github.com/input-output-hk/plutus/blob/master/plutus-playground-client/default.nix#L43).
 > Use the above `nix-build` sub-command to expose the actual haskell executable.


### PR DESCRIPTION
Hello everyone - I had some trouble earlier in getting the plutus-playground to cooperate from a fresh clone of the plutus repository. My issue is described fully in #3484 - I had no idea that `webpack.config.js` would need to be adjusted in order to view the playground on my local machine.

This PR just adds two separate notes - one regarding the `https` field in `webpack.config.js`, and the other noting how the `plutus-playground-server` command exposed by `nix-shell` isn't the bona-fide executable built from haskell, but rather a wrapper script identified by the attribute referenced in the notes.

I believe these extra notes will help newcomers find some clues as to why their fresh clone of the plutus repository isn't operating as they expect.

------------------------------------

Pre-submit checklist:
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
