### PR TITLE
SCP-2398: Slot configuration now represented by milliseconds instead of seconds

### DIFF
--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -26,7 +26,7 @@
     chainIndexPort = 8083;
     signingProcessPort = 8084;
     metadataPort = 8085;
-    zeroSlotTime = 1591566291; # POSIX time of 2020-06-07T21:44:51Z (Sunday, June 7, 2020 21:44:51)
+    zeroSlotTime = 1591566291000; # POSIX time of 2020-06-07T21:44:51Z (Sunday, June 7, 2020 21:44:51)
     slotLength = 1;
   };
 

--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -167,17 +167,17 @@ in
 
     zeroSlotTime = mkOption {
       type = types.int;
-      default = 1596059091; # POSIX time of 2020-07-29T21:44:51Z (Wednesday, July 29, 2020 21:44:51) - Shelley launch time
+      default = 1596059091000; # POSIX time of 2020-07-29T21:44:51Z (Wednesday, July 29, 2020 21:44:51) - Shelley launch time
       description = ''
-        Time of slot 0. Setting this (together with the slot length) enables pure datetime-to-slot mappings.
+        POSIX time of slot 0 in milliseconds. Setting this (together with the slot length) enables pure datetime-to-slot mappings.
       '';
     };
 
     slotLength = mkOption {
       type = types.int;
-      default = 1;
+      default = 1000;
       description = ''
-        Length of a slot (in seconds).
+        Length of a slot (in milliseconds).
       '';
     };
 

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -20,7 +20,7 @@ module Plutus.Contract(
     , Request.waitNSlots
     , Request.awaitTime
     , Request.currentTime
-    , Request.waitNSeconds
+    , Request.waitNMilliSeconds
     -- * Endpoints
     , Request.HasEndpoint
     , Request.EndpointDescription(..)

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -21,7 +21,7 @@ module Plutus.Contract.Request(
     , waitNSlots
     , awaitTime
     , currentTime
-    , waitNSeconds
+    , waitNMilliSeconds
     -- ** Querying the UTXO set
     , utxoAt
     -- ** Waiting for changes to the UTXO set
@@ -77,8 +77,8 @@ import           Data.Text.Extras            (tshow)
 import           Data.Void                   (Void)
 import           GHC.Natural                 (Natural)
 import           GHC.TypeLits                (Symbol, symbolVal)
-import           Ledger                      (Address, DiffSeconds, OnChainTx (..), POSIXTime, PubKey, Slot, Tx, TxId,
-                                              TxOut (..), TxOutTx (..), Value, fromSeconds, txId)
+import           Ledger                      (Address, DiffMilliSeconds, OnChainTx (..), POSIXTime, PubKey, Slot, Tx,
+                                              TxId, TxOut (..), TxOutTx (..), Value, fromMilliSeconds, txId)
 import           Ledger.AddressMap           (UtxoMap)
 import           Ledger.Constraints          (TxConstraints)
 import           Ledger.Constraints.OffChain (ScriptLookups, UnbalancedTx)
@@ -174,21 +174,21 @@ currentTime ::
     => Contract w s e POSIXTime
 currentTime = pabReq CurrentTimeReq E._CurrentTimeResp
 
--- | Wait for a number of seconds starting at the ending time of the current
+-- | Wait for a number of milliseconds starting at the ending time of the current
 -- slot, and return the latest time we know has passed.
 --
--- Example: if starting time is 0, slot length is 3s and current slot is 0, then
--- `waitNSeconds 0` returns the value `POSIXTime 2` and `waitNSeconds 1`
+-- Example: if starting time is 0, slot length is 3000ms and current slot is 0, then
+-- `waitNMilliSeconds 0` returns the value `POSIXTime 2000` and `waitNMilliSeconds 1000`
 -- returns the value `POSIXTime 5`.
-waitNSeconds ::
+waitNMilliSeconds ::
   forall w s e.
   ( AsContractError e
   )
-  => DiffSeconds
+  => DiffMilliSeconds
   -> Contract w s e POSIXTime
-waitNSeconds n = do
+waitNMilliSeconds n = do
   t <- currentTime
-  awaitTime $ t + fromSeconds n
+  awaitTime $ t + fromMilliSeconds n
 
 -- | Get the unspent transaction outputs at an address.
 utxoAt ::

--- a/plutus-contract/src/Plutus/Trace/Effects/Waiting.hs
+++ b/plutus-contract/src/Plutus/Trace/Effects/Waiting.hs
@@ -13,7 +13,7 @@ module Plutus.Trace.Effects.Waiting(
     , waitUntilTime
     , nextSlot
     , waitNSlots
-    , waitNSeconds
+    , waitNMilliSeconds
     , handleWaiting
     ) where
 
@@ -22,7 +22,7 @@ import           Control.Monad.Freer.Coroutine (Yield)
 import           Control.Monad.Freer.TH        (makeEffect)
 import           Data.Default                  (Default (def))
 import           Ledger.Slot                   (Slot)
-import           Ledger.Time                   (DiffSeconds, POSIXTime, fromSeconds)
+import           Ledger.Time                   (DiffMilliSeconds, POSIXTime, fromMilliSeconds)
 import qualified Ledger.TimeSlot               as TimeSlot
 import           Numeric.Natural               (Natural)
 import           Plutus.Trace.Emulator.Types   (EmulatorMessage (NewSlot))
@@ -55,16 +55,17 @@ waitNSlots n
     | n > 1 = nextSlot >> waitNSlots (n - 1)
     | otherwise = nextSlot
 
--- | Convert the given 'n' seconds to a number of slots to wait.
+-- | Convert the given 'n' milliseconds to a number of slots to wait.
 --
--- Note: Currently, if n < length of a slot, then 'waitNSeconds' has no effect.
-waitNSeconds ::
+-- Note: Currently, if n < length of a slot, then 'waitNMilliSeconds' has no
+-- effect.
+waitNMilliSeconds ::
     forall effs.
     ( Member Waiting effs )
-    => DiffSeconds
+    => DiffMilliSeconds
     -> Eff effs Slot
-waitNSeconds n =
-    waitNSlots (fromIntegral $ TimeSlot.posixTimeToEnclosingSlot def $ fromSeconds n)
+waitNMilliSeconds n =
+    waitNSlots (fromIntegral $ TimeSlot.posixTimeToEnclosingSlot def $ fromMilliSeconds n)
 
 handleWaiting ::
     forall effs effs2.

--- a/plutus-contract/src/Plutus/Trace/Emulator.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator.hs
@@ -35,7 +35,7 @@ module Plutus.Trace.Emulator(
     , Waiting.waitUntilSlot
     , Waiting.waitUntilTime
     , Waiting.waitNSlots
-    , Waiting.waitNSeconds
+    , Waiting.waitNMilliSeconds
     , EmulatorControl.freezeContractInstance
     , EmulatorControl.thawContractInstance
     -- ** Inspecting the chain state

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
@@ -17,8 +17,8 @@
 module Plutus.V1.Ledger.Time(
       POSIXTime(..)
     , POSIXTimeRange
-    , DiffSeconds(..)
-    , fromSeconds
+    , DiffMilliSeconds(..)
+    , fromMilliSeconds
     ) where
 
 import           Codec.Serialise.Class     (Serialise)
@@ -37,15 +37,15 @@ import           PlutusTx.Prelude
 import qualified Prelude                   as Haskell
 
 
--- | This is a length of time, as measured by a number of seconds.
-newtype DiffSeconds = DiffSeconds Integer
+-- | This is a length of time, as measured by a number of milliseconds.
+newtype DiffMilliSeconds = DiffMilliSeconds Integer
   deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
   deriving anyclass (FromJSON, FromJSONKey, ToJSON, ToJSONKey, NFData)
   deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Haskell.Enum, Eq, Ord, Haskell.Real, Haskell.Integral, Serialise, Hashable, PlutusTx.IsData)
 
-makeLift ''DiffSeconds
+makeLift ''DiffMilliSeconds
 
--- | POSIX time is measured as the number of seconds since 1970-01-01T00:00:00Z
+-- | POSIX time is measured as the number of milliseconds since 1970-01-01T00:00:00Z
 newtype POSIXTime = POSIXTime { getPOSIXTime :: Integer }
   deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
   deriving anyclass (FromJSONKey, ToJSONKey, NFData)
@@ -79,7 +79,7 @@ instance Pretty (Interval POSIXTime) where
 -- | An 'Interval' of 'POSIXTime's.
 type POSIXTimeRange = Interval POSIXTime
 
--- | Simple conversion from 'DiffSeconds' to 'POSIXTime'.
-{-# INLINABLE fromSeconds #-}
-fromSeconds :: DiffSeconds -> POSIXTime
-fromSeconds (DiffSeconds s) = POSIXTime s
+-- | Simple conversion from 'DiffMilliSeconds' to 'POSIXTime'.
+{-# INLINABLE fromMilliSeconds #-}
+fromMilliSeconds :: DiffMilliSeconds -> POSIXTime
+fromMilliSeconds (DiffMilliSeconds s) = POSIXTime s

--- a/plutus-ledger/src/Data/Time/Units/Extra.hs
+++ b/plutus-ledger/src/Data/Time/Units/Extra.hs
@@ -5,7 +5,7 @@ module Data.Time.Units.Extra where
 
 import           Data.Aeson      (FromJSON, ToJSON, parseJSON, toJSON, withScientific)
 import           Data.Scientific (toBoundedInteger)
-import           Data.Time.Units (Second)
+import           Data.Time.Units (Millisecond, Second)
 
 instance FromJSON Second where
     parseJSON =
@@ -17,4 +17,16 @@ instance FromJSON Second where
                      Just i  -> pure (fromIntegral (i :: Int)))
 
 instance ToJSON Second where
+    toJSON = toJSON @Int . fromIntegral
+
+instance FromJSON Millisecond where
+    parseJSON =
+        withScientific
+            "millisecond"
+            (\s ->
+                 case toBoundedInteger s of
+                     Nothing -> fail "Value must be an Integer."
+                     Just i  -> pure (fromIntegral (i :: Int)))
+
+instance ToJSON Millisecond where
     toJSON = toJSON @Int . fromIntegral

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -288,8 +288,8 @@ initialSlotToTimeProp :: Property
 initialSlotToTimeProp = property $ do
   sc <- forAll slotConfigGen
   n <- forAll $ Gen.int (fromInteger <$> Range.linear 0 (fromIntegral $ scSlotLength sc))
-  let diff = DiffSeconds $ toInteger n
-  let time = TimeSlot.scZeroSlotTime sc + fromSeconds diff
+  let diff = DiffMilliSeconds $ toInteger n
+  let time = TimeSlot.scZeroSlotTime sc + fromMilliSeconds diff
   if diff >= fromIntegral (scSlotLength sc)
      then Hedgehog.assert $ TimeSlot.posixTimeToEnclosingSlot sc time == Slot 1
      else Hedgehog.assert $ TimeSlot.posixTimeToEnclosingSlot sc time == Slot 0
@@ -382,11 +382,11 @@ slotGen = Slot <$> Gen.integral (fromIntegral <$> Range.linear 0 10000)
 posixTimeGen :: (Hedgehog.MonadGen m) => SlotConfig -> m POSIXTime
 posixTimeGen sc = do
   let beginTime = getPOSIXTime $ TimeSlot.scZeroSlotTime sc
-  POSIXTime <$> Gen.integral (Range.linear beginTime (beginTime + 10000))
+  POSIXTime <$> Gen.integral (Range.linear beginTime (beginTime + 10000000))
 
--- | Generate a 'SlotConfig' where the slot length goes from 1 second to 100
--- seconds and the time of Slot 0 is the default 'scZeroSlotTime'.
+-- | Generate a 'SlotConfig' where the slot length goes from 1 to 100000
+-- ms and the time of Slot 0 is the default 'scZeroSlotTime'.
 slotConfigGen :: Hedgehog.MonadGen m => m SlotConfig
 slotConfigGen = do
-  sl <- Gen.integral (Range.linear 1 10)
+  sl <- Gen.integral (Range.linear 1 1000000)
   return $ def { TimeSlot.scSlotLength = sl }

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -27,11 +27,10 @@
   nodeServerConfig:
     mscBaseUrl: http://localhost:${ nodeserver-port }
     mscSocketPath: /tmp/node-server.sock
-    mscSlotLength: 5
     mscRandomTxInterval: 20000000
     mscSlotConfig:
-      scZeroSlotTime: 1596059091 # POSIX time of 2020-07-29T21:44:51Z (Wednesday, July 29, 2020 21:44:51) - Shelley launch time
-      scSlotLength: 1
+      scZeroSlotTime: 1596059091000 # POSIX time of 2020-07-29T21:44:51Z (Wednesday, July 29, 2020 21:44:51) - Shelley launch time
+      scSlotLength: 1000
     mscKeptBlocks: 100000
     mscInitialTxWallets:
       - getWallet: 1

--- a/plutus-pab/src/Cardano/Node/Mock.hs
+++ b/plutus-pab/src/Cardano/Node/Mock.hs
@@ -22,7 +22,7 @@ import qualified Control.Monad.Freer.Writer        as Eff
 import           Control.Monad.IO.Class            (MonadIO, liftIO)
 import           Data.Foldable                     (traverse_)
 import           Data.Function                     ((&))
-import           Data.Time.Units                   (Second, toMicroseconds)
+import           Data.Time.Units                   (Millisecond, Second, toMicroseconds)
 import           Data.Time.Units.Extra             ()
 import           Servant                           (NoContent (NoContent))
 
@@ -140,4 +140,4 @@ slotCoordinator sc@SlotConfig{scSlotLength} serverHandler = do
         void $ Server.modifySlot (const newSlot) serverHandler
         liftIO $ threadDelay
                $ fromIntegral
-               $ toMicroseconds (fromInteger scSlotLength :: Second)
+               $ toMicroseconds (fromInteger scSlotLength :: Millisecond)

--- a/plutus-pab/src/Cardano/Node/Server.hs
+++ b/plutus-pab/src/Cardano/Node/Server.hs
@@ -24,7 +24,7 @@ import           Data.Function                    ((&))
 import qualified Data.Map.Strict                  as Map
 import           Data.Proxy                       (Proxy (Proxy))
 import           Data.Time.Clock.POSIX            (posixSecondsToUTCTime)
-import           Data.Time.Units                  (Second)
+import           Data.Time.Units                  (Millisecond, Second)
 import qualified Ledger.Ada                       as Ada
 import           Ledger.TimeSlot                  (SlotConfig (SlotConfig, scSlotLength, scZeroSlotTime))
 import qualified Network.Wai.Handler.Warp         as Warp
@@ -96,8 +96,8 @@ main trace MockServerConfig { mscBaseUrl
 
             runSlotCoordinator (Ctx (Just serverHandler) _ _ _)  = do
                 let SlotConfig{scZeroSlotTime, scSlotLength} = mscSlotConfig
-                logInfo $ StartingSlotCoordination (posixSecondsToUTCTime $ realToFrac scZeroSlotTime)
-                                                   (fromInteger scSlotLength :: Second)
+                logInfo $ StartingSlotCoordination (posixSecondsToUTCTime $ realToFrac scZeroSlotTime / 1000)
+                                                   (fromInteger scSlotLength :: Millisecond)
                 void $ liftIO $ forkIO $ slotCoordinator mscSlotConfig serverHandler
             -- Don't start the coordinator if we don't start the mock server.
             runSlotCoordinator _ = pure ()

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -53,7 +53,7 @@ import qualified Data.Map                       as Map
 import           Data.Text.Prettyprint.Doc      (Pretty (..), pretty, viaShow, (<+>))
 import           Data.Time.Clock                (UTCTime)
 import qualified Data.Time.Format.ISO8601       as F
-import           Data.Time.Units                (Second)
+import           Data.Time.Units                (Millisecond, Second)
 import           Data.Time.Units.Extra          ()
 import           GHC.Generics                   (Generic)
 import           Ledger                         (Tx, txId)
@@ -140,7 +140,7 @@ data BlockReaperConfig =
 -- | Top-level logging data type for structural logging
 -- inside the Mock Node server.
 data MockServerLogMsg =
-    StartingSlotCoordination UTCTime Second
+    StartingSlotCoordination UTCTime Millisecond
     | NoRandomTxGeneration
     | StartingRandomTx
     | KeepingOldBlocks

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,24 +19,24 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx 76e78e778ef32436497b3d91d6409b6ad519b1a13d6b1223a9b0ab4c240ff0db:
+                Tx c4f33871e2d9c86fbe33b8774c39ad81376a593f76a54131dfe8d5aba8662202:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential)
+                      addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
                   signatures:
-                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059090})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
+                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059091})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                   data:
                     "9\247\DC3\208\166D%?\EOTR\148!\185\245\ESC\155\b\151\157\b)YY\196\243\153\SO\230\ETB\245\DC3\159"}
               Requires signatures:
               Utxo index:
-Slot 1: W2: Finished balancing. a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
-Slot 1: W2: Submitting tx: a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
-Slot 1: W2: TxSubmit: a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
+Slot 1: W2: Finished balancing. 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
+Slot 1: W2: Submitting tx: 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
+Slot 1: W2: TxSubmit: 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
@@ -45,58 +45,58 @@ Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx d3fe6341ecfd4ea34a47a0f71a4fe1b6103fc92c460437d3b31f14947c75a585:
+                Tx 1cecc26ceebfeee28016f76a68fc1410b10963710d5c87021b82dc8ae873e3ad:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential)
+                      addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
                   signatures:
-                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059090})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
+                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059091})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                   data:
                     "\218\192s\224\DC2;\222\165\157\217\179\189\169\207`7\246:\202\130b}z\188\213\196\172)\221t\NUL>"}
               Requires signatures:
               Utxo index:
-Slot 1: W3: Finished balancing. 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
-Slot 1: W3: Submitting tx: 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
-Slot 1: W3: TxSubmit: 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
+Slot 1: W3: Finished balancing. 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
+Slot 1: W3: Submitting tx: 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
+Slot 1: W3: TxSubmit: 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx c52c1fab4428579fc9540c8269cd25f0565757e13f23d5109ba9039abf5c1012:
+                Tx e75ad52b3ed5b5e3b76e0eccb590c8d5688535328d4bd538d425c838b2f39366:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential)
+                      addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
                   signatures:
-                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059090})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
+                  validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = -1596059091})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                   data:
                     "\237\209\195sr\247R\201z\236\b\130E/\172\172\ETB\164\253\175F\230\FS\ETX?J\246x\164\a\155\205"}
               Requires signatures:
               Utxo index:
-Slot 1: W4: Finished balancing. 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
-Slot 1: W4: Submitting tx: 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
-Slot 1: W4: TxSubmit: 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
-Slot 1: TxnValidate 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
-Slot 1: TxnValidate 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
-Slot 1: TxnValidate a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
+Slot 1: W4: Finished balancing. e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
+Slot 1: W4: Submitting tx: e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
+Slot 1: W4: TxSubmit: e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
+Slot 1: TxnValidate e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
+Slot 1: TxnValidate 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
+Slot 1: TxnValidate 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 86696fef2c2503d2fa3fb7c6be07e1e6e8ea016b80bc6db9664b617480e8094e:
+                 Tx 22d4d0fb4b5f11f8adf25b59de8c6d45e31b0a22b089edeb2c695cbcef1b0822:
                    {inputs:
-                      - 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb!1
+                      - 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e!1
                         Redeemer: <>
-                      - 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501!1
+                      - 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093!1
                         Redeemer: <>
-                      - a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717!1
+                      - e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb!1
                         Redeemer: <>
                    collateral inputs:
                    outputs:
@@ -108,18 +108,18 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    data:}
                Requires signatures:
                Utxo index:
-                 ( 2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb!1
+                 ( 17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e!1
+                 , - Value (Map [(,Map [("",100)])]) addressed to
+                     addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential) )
+                 ( 662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093!1
+                 , - Value (Map [(,Map [("",100)])]) addressed to
+                     addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential) )
+                 ( e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb!1
                  , - Value (Map [(,Map [("",25)])]) addressed to
-                     addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential) )
-                 ( 52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501!1
-                 , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential) )
-                 ( a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717!1
-                 , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d (no staking credential) )
-Slot 20: W1: Finished balancing. f95e45a69bb33017e28f8783c5bac1ec8a12504bd8bc4c6458d503eae84f7bad
-Slot 20: W1: Submitting tx: f95e45a69bb33017e28f8783c5bac1ec8a12504bd8bc4c6458d503eae84f7bad
-Slot 20: W1: TxSubmit: f95e45a69bb33017e28f8783c5bac1ec8a12504bd8bc4c6458d503eae84f7bad
+                     addressed to ScriptCredential: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1 (no staking credential) )
+Slot 20: W1: Finished balancing. 34d38edc0e633e135540debca91b3ac82874b94a50a8524f4bf04d42c615aaae
+Slot 20: W1: Submitting tx: 34d38edc0e633e135540debca91b3ac82874b94a50a8524f4bf04d42c615aaae
+Slot 20: W1: TxSubmit: 34d38edc0e633e135540debca91b3ac82874b94a50a8524f4bf04d42c615aaae
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 21: TxnValidate f95e45a69bb33017e28f8783c5bac1ec8a12504bd8bc4c6458d503eae84f7bad
+Slot 21: TxnValidate 34d38edc0e633e135540debca91b3ac82874b94a50a8524f4bf04d42c615aaae

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
+TxId:       e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 58402208dfe3aaf0c21351136e58ef1a69a27157...
+              Signature: 5840fe6277f2d6eaee960e4f9a3f4ad190ad0724...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
+TxId:       17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584071088c7931ff5cfbc70eb333d573554c2a23...
+              Signature: 58406eb16f51b9e301b4a7bcdace8c4b3799613f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
+TxId:       662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584054aaa5cc4000f9fd5ed8a4847112f1b1a279...
+              Signature: 58406d8c51791430f3c9e5eaca446316f3482e39...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  100
 
@@ -318,45 +318,36 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       f95e45a69bb33017e28f8783c5bac1ec8a12504bd8bc4c6458d503eae84f7bad
+TxId:       34d38edc0e633e135540debca91b3ac82874b94a50a8524f4bf04d42c615aaae
 Fee:        Ada:      Lovelace:  26839
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840b4a3ec35426cb6b133f05b093900645369f9...
+              Signature: 58408a26e259a9e5b6fc5ce5904f42b205ad116d...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
-    Ada:      Lovelace:  25
+    Ada:      Lovelace:  100
   Source:
-    Tx:     2d680eeb61ff46f86c77d5d502922b8c81fca506c38c603d5c3ae6e3cfb807bb
+    Tx:     17213b879d58a960388d656012438834353938c088600ea0017aca700cf31b9e
     Output #1
-    Script: 5918490100003323332223332223322332233322...
+    Script: 59184b0100003323332223332223322332233322...
 
   ---- Input 1 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     52c5fa8b9677a2933e5ee11b9d1f28a0fd4f3ebd274c68ab86c200d84b818501
+    Tx:     662ce190a5ae90d14862a7562e830fe6a8a07e9bf6cd454e3ebaf84069a5c093
     Output #1
-    Script: 5918490100003323332223332223322332233322...
+    Script: 59184b0100003323332223332223322332233322...
 
   ---- Input 2 ----
-  Destination:  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     a4c2a24b243459b086469a9a24f1459fa0ce39a459ef0239c5a04eb57ba37717
-    Output #1
-    Script: 5918490100003323332223332223322332233322...
-
-  ---- Input 3 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  100000000
@@ -364,6 +355,15 @@ Inputs:
     Tx:     af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
     Output #6
 
+
+  ---- Input 3 ----
+  Destination:  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
+  Value:
+    Ada:      Lovelace:  25
+  Source:
+    Tx:     e489dd3b737c6af6faead78406c84f6d40300d7c2291d1f7592d9a4112e17adb
+    Output #1
+    Script: 59184b0100003323332223332223322332233322...
 
 
 Outputs:
@@ -414,6 +414,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  99999965
 
-  Script: 27d54c8c5718da681247f4d68139391a11abcfbee564ba5c67cda5712ee2184d
+  Script: 6af175a97f95c9b0b0a31e5fd30f60edf7ba995a6781b73d3be4ec01ec7b0ab1
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       dd05d430d7f6255a5e97a362a086586e44b55dd3d94283fb3926174c9857baa3
+TxId:       433d9ffe7a6ecd0d2a8777ab277c3303569a78dee776df799ca22db49534470f
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 58405ef95a93c3ea6b11ae96c4d24ce2ee672988...
+              Signature: 58405d56f326a6b0c66a39d63e846aa8b9385498...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: 89c046f6d4265448ca5d296262215480d4741ebe27868fb094e014b5dede669c
+  Destination:  Script: 121b34ac841ac87c98e6df2297dfc6365b21258346c8e5608f4823d36474f772
   Value:
     Ada:      Lovelace:  60
 
@@ -170,18 +170,27 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 89c046f6d4265448ca5d296262215480d4741ebe27868fb094e014b5dede669c
+  Script: 121b34ac841ac87c98e6df2297dfc6365b21258346c8e5608f4823d36474f772
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       91924443e6676ef1f405caa86d5f033fbb1683dd56ede8485057f22b4b72e54b
+TxId:       d90bee45d8c8cfa2256a06add23b5c94e6b42f527438d0a1f1b01e9453f0ea95
 Fee:        Ada:      Lovelace:  10436
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58405062cdf75e3441e133a40aef7d35e6812ee9...
+              Signature: 5840b1efabe5ab4f2ccb3e2e4c1121a727cfe064...
 Inputs:
   ---- Input 0 ----
+  Destination:  Script: 121b34ac841ac87c98e6df2297dfc6365b21258346c8e5608f4823d36474f772
+  Value:
+    Ada:      Lovelace:  60
+  Source:
+    Tx:     433d9ffe7a6ecd0d2a8777ab277c3303569a78dee776df799ca22db49534470f
+    Output #1
+    Script: 591d820100003323332223322332233322233333...
+
+  ---- Input 1 ----
   Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 1)
   Value:
     Ada:      Lovelace:  100000000
@@ -189,15 +198,6 @@ Inputs:
     Tx:     af5e6d25b5ecb26185289a03d50786b7ac4425b21849143ed7e18bcd70dc4db8
     Output #6
 
-
-  ---- Input 1 ----
-  Destination:  Script: 89c046f6d4265448ca5d296262215480d4741ebe27868fb094e014b5dede669c
-  Value:
-    Ada:      Lovelace:  60
-  Source:
-    Tx:     dd05d430d7f6255a5e97a362a086586e44b55dd3d94283fb3926174c9857baa3
-    Output #1
-    Script: 591d800100003323332223322332233322233333...
 
 
 Outputs:
@@ -207,7 +207,7 @@ Outputs:
     Ada:      Lovelace:  99989574
 
   ---- Output 1 ----
-  Destination:  Script: 89c046f6d4265448ca5d296262215480d4741ebe27868fb094e014b5dede669c
+  Destination:  Script: 121b34ac841ac87c98e6df2297dfc6365b21258346c8e5608f4823d36474f772
   Value:
     Ada:      Lovelace:  50
 
@@ -253,6 +253,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 89c046f6d4265448ca5d296262215480d4741ebe27868fb094e014b5dede669c
+  Script: 121b34ac841ac87c98e6df2297dfc6365b21258346c8e5608f4823d36474f772
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Slot configuration now represented by milliseconds instead of seconds. POSIXTime is also now in ms.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
