### PR TITLE
SCP-2458: Extend InputField to include number inputs (using NumberFormat).

### DIFF
--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -30,7 +30,7 @@ import Halogen.Extra (lifeCycleEvent)
 import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
-import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeToken)
+import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
 import Marlowe.Execution.Lenses (_currentState, _mNextTimeout)
 import Marlowe.Execution.State (expandBalances, getActionParticipant)
 import Marlowe.Execution.Types (NamedAction(..))
@@ -183,11 +183,11 @@ actionConfirmationCard assets state namedAction =
         , span [ classNames [ "font-semibold" ] ] amountHtml
         ]
 
-    transactionFeeItem = detailItem [ text "Transaction fee", sup_ [ text "*" ], text ":" ] [ text $ humanizeToken adaToken transactionFee ]
+    transactionFeeItem = detailItem [ text "Transaction fee", sup_ [ text "*" ], text ":" ] [ text $ humanizeValue adaToken transactionFee ]
 
     actionAmountItems = case namedAction of
       MakeDeposit _ _ token amount ->
-        [ detailItem [ text "Deposit amount:" ] [ text $ humanizeToken token amount ] false
+        [ detailItem [ text "Deposit amount:" ] [ text $ humanizeValue token amount ] false
         , transactionFeeItem true
         ]
       MakeChoice _ _ (Just option) ->
@@ -207,7 +207,7 @@ actionConfirmationCard assets state namedAction =
     div_
       [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
           [ span_ [ text "Demo wallet balance:" ]
-          , span_ [ text $ humanizeToken adaToken $ getAda assets ]
+          , span_ [ text $ humanizeValue adaToken $ getAda assets ]
           ]
       , div [ classNames [ "px-5", "pb-6", "pt-3", "md:pb-8" ] ]
           [ h2
@@ -223,7 +223,7 @@ actionConfirmationCard assets state namedAction =
               [ text "Confirm payment of:" ]
           , div
               [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
-              [ text $ humanizeToken adaToken totalToPay ]
+              [ text $ humanizeValue adaToken totalToPay ]
           , div [ classNames [ "flex", "justify-center" ] ]
               [ button
                   [ classNames $ Css.secondaryButton <> [ "mr-2", "flex-1" ]
@@ -404,7 +404,7 @@ renderPartyPastActions state { inputs, interval, party } =
                 PK publicKey -> publicKey <> " public key"
                 Role roleName -> roleName <> "'s"
         in
-          div [] [ text $ fromDescription <> " made a deposit of " <> humanizeToken token value <> " into " <> toDescription <> " account " <> intervalDescription ]
+          div [] [ text $ fromDescription <> " made a deposit of " <> humanizeValue token value <> " into " <> toDescription <> " account " <> intervalDescription ]
       IChoice (ChoiceId choiceIdKey _) chosenNum -> div [] [ text $ fromDescription <> " chose " <> show chosenNum <> " for " <> show choiceIdKey <> " " <> intervalDescription ]
       _ -> div_ []
   in
@@ -628,7 +628,7 @@ renderAction state party namedAction@(MakeDeposit intoAccountOf by token value) 
           , onClick_ $ AskConfirmation namedAction
           ]
           [ span_ [ text "Deposit:" ]
-          , span_ [ text $ humanizeToken token value ]
+          , span_ [ text $ humanizeValue token value ]
           ]
       ]
 
@@ -754,7 +754,7 @@ renderBalances state accounts =
               <#> ( \((party /\ token) /\ amount) ->
                     div [ classNames [ "flex", "justify-between", "py-3", "border-t" ] ]
                       [ span_ [ text $ participantWithNickname state party ]
-                      , span [ classNames [ "font-semibold" ] ] [ text $ humanizeToken token amount ]
+                      , span [ classNames [ "font-semibold" ] ] [ text $ humanizeValue token amount ]
                       ]
                 )
           )

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -30,7 +30,7 @@ import Halogen.Extra (lifeCycleEvent)
 import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
-import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
+import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeToken)
 import Marlowe.Execution.Lenses (_currentState, _mNextTimeout)
 import Marlowe.Execution.State (expandBalances, getActionParticipant)
 import Marlowe.Execution.Types (NamedAction(..))
@@ -183,11 +183,11 @@ actionConfirmationCard assets state namedAction =
         , span [ classNames [ "font-semibold" ] ] amountHtml
         ]
 
-    transactionFeeItem = detailItem [ text "Transaction fee", sup_ [ text "*" ], text ":" ] [ text $ humanizeValue adaToken transactionFee ]
+    transactionFeeItem = detailItem [ text "Transaction fee", sup_ [ text "*" ], text ":" ] [ text $ humanizeToken adaToken transactionFee ]
 
     actionAmountItems = case namedAction of
       MakeDeposit _ _ token amount ->
-        [ detailItem [ text "Deposit amount:" ] [ text $ humanizeValue token amount ] false
+        [ detailItem [ text "Deposit amount:" ] [ text $ humanizeToken token amount ] false
         , transactionFeeItem true
         ]
       MakeChoice _ _ (Just option) ->
@@ -207,7 +207,7 @@ actionConfirmationCard assets state namedAction =
     div_
       [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
           [ span_ [ text "Demo wallet balance:" ]
-          , span_ [ text $ humanizeValue adaToken $ getAda assets ]
+          , span_ [ text $ humanizeToken adaToken $ getAda assets ]
           ]
       , div [ classNames [ "px-5", "pb-6", "pt-3", "md:pb-8" ] ]
           [ h2
@@ -223,7 +223,7 @@ actionConfirmationCard assets state namedAction =
               [ text "Confirm payment of:" ]
           , div
               [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
-              [ text $ humanizeValue adaToken totalToPay ]
+              [ text $ humanizeToken adaToken totalToPay ]
           , div [ classNames [ "flex", "justify-center" ] ]
               [ button
                   [ classNames $ Css.secondaryButton <> [ "mr-2", "flex-1" ]
@@ -404,7 +404,7 @@ renderPartyPastActions state { inputs, interval, party } =
                 PK publicKey -> publicKey <> " public key"
                 Role roleName -> roleName <> "'s"
         in
-          div [] [ text $ fromDescription <> " made a deposit of " <> humanizeValue token value <> " into " <> toDescription <> " account " <> intervalDescription ]
+          div [] [ text $ fromDescription <> " made a deposit of " <> humanizeToken token value <> " into " <> toDescription <> " account " <> intervalDescription ]
       IChoice (ChoiceId choiceIdKey _) chosenNum -> div [] [ text $ fromDescription <> " chose " <> show chosenNum <> " for " <> show choiceIdKey <> " " <> intervalDescription ]
       _ -> div_ []
   in
@@ -628,7 +628,7 @@ renderAction state party namedAction@(MakeDeposit intoAccountOf by token value) 
           , onClick_ $ AskConfirmation namedAction
           ]
           [ span_ [ text "Deposit:" ]
-          , span_ [ text $ humanizeValue token value ]
+          , span_ [ text $ humanizeToken token value ]
           ]
       ]
 
@@ -754,7 +754,7 @@ renderBalances state accounts =
               <#> ( \((party /\ token) /\ amount) ->
                     div [ classNames [ "flex", "justify-between", "py-3", "border-t" ] ]
                       [ span_ [ text $ participantWithNickname state party ]
-                      , span [ classNames [ "font-semibold" ] ] [ text $ humanizeValue token amount ]
+                      , span [ classNames [ "font-semibold" ] ] [ text $ humanizeToken token amount ]
                       ]
                 )
           )

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -85,11 +85,9 @@ inputBase =
   , "outline-none"
   , "focus:outline-none"
   , "text-black"
+  , "border"
   , "border-transparent"
   , "focus:border-transparent"
-  , "shadow-sm"
-  , "focus:shadow"
-  , "hover:shadow"
   ]
 
 inputBaseFocus :: Array String
@@ -99,19 +97,31 @@ inputBaseNoFocus :: Array String
 inputBaseNoFocus = inputBase <> [ "focus:ring-0" ]
 
 input :: Boolean -> Array String
-input valid = inputBaseFocus <> [ "border", "bg-transparent" ] <> if valid then [ "border-black", "focus:border-black" ] else [ "border-red" ]
+input valid =
+  inputBaseFocus
+    <> [ "border-gray" ]
+    <> applyWhen (not valid) [ "border-red" ]
 
 inputNoFocus :: Boolean -> Array String
-inputNoFocus valid = inputBaseNoFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
+inputNoFocus valid =
+  inputBaseNoFocus
+    <> [ "border-gray" ]
+    <> applyWhen (not valid) [ "border-red" ]
 
 withNestedLabel :: Array String
-withNestedLabel = [ "border", "border-gray", "focus:border-gray" ]
+withNestedLabel = [ "border-gray", "focus:border-gray" ]
 
 inputCard :: Boolean -> Array String
-inputCard valid = inputBaseFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
+inputCard valid =
+  inputBaseFocus
+    <> [ "shadow-sm", "focus:shadow", "hover:shadow" ]
+    <> if valid then [ "border-transparent" ] else [ "border-red" ]
 
 inputCardNoFocus :: Boolean -> Array String
-inputCardNoFocus valid = inputBaseNoFocus <> if valid then [ "border-transparent" ] else [ "border-red" ]
+inputCardNoFocus valid =
+  inputBaseNoFocus
+    <> [ "shadow-sm", "focus:shadow", "hover:shadow" ]
+    <> if valid then [ "border-transparent" ] else [ "border-red" ]
 
 inputError :: Array String
 inputError = [ "px-3", "mt-1", "text-red", "text-sm" ]

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -9,6 +9,7 @@ module Css
   , whiteButton
   , input
   , inputNoFocus
+  , unstyledInput
   , inputCard
   , inputCardNoFocus
   , inputError
@@ -88,25 +89,26 @@ inputBase =
   , "border"
   , "border-transparent"
   , "focus:border-transparent"
+  , "focus-within:border-transparent"
   ]
 
+-- note we set rings on focus-within as well as focus, so that we can use these classes on divs
+-- with unstyled inputs inside them, making that whole parent div look like the input
 inputBaseFocus :: Array String
-inputBaseFocus = inputBase <> [ "focus:ring-1" ]
+inputBaseFocus = inputBase <> [ "focus:ring-1", "focus-within:ring-1" ]
 
 inputBaseNoFocus :: Array String
 inputBaseNoFocus = inputBase <> [ "focus:ring-0" ]
 
 input :: Boolean -> Array String
-input valid =
-  inputBaseFocus
-    <> [ "border-gray" ]
-    <> applyWhen (not valid) [ "border-red" ]
+input valid = inputBaseFocus <> if valid then [ "border-gray" ] else [ "border-red" ]
 
 inputNoFocus :: Boolean -> Array String
-inputNoFocus valid =
-  inputBaseNoFocus
-    <> [ "border-gray" ]
-    <> applyWhen (not valid) [ "border-red" ]
+inputNoFocus valid = inputBaseNoFocus <> if valid then [ "border-gray" ] else [ "border-red" ]
+
+-- use this on an input inside a div styled like an input
+unstyledInput :: Array String
+unstyledInput = [ "p-0", "border-0", "focus:ring-0" ]
 
 withNestedLabel :: Array String
 withNestedLabel = [ "border-gray", "focus:border-gray" ]

--- a/marlowe-dashboard-client/src/Dashboard/State.purs
+++ b/marlowe-dashboard-client/src/Dashboard/State.purs
@@ -77,8 +77,8 @@ mkInitialState walletLibrary walletDetails contracts contractNicknames currentSl
     , status: Running
     , contracts: mapMaybeWithKey mkInitialContractState contracts
     , selectedContractIndex: Nothing
-    , walletNicknameInput: InputField.initialState
-    , walletIdInput: InputField.initialState
+    , walletNicknameInput: InputField.initialState Nothing
+    , walletIdInput: InputField.initialState Nothing
     , remoteWalletInfo: NotAsked
     , timezoneOffset
     , templateState: Template.dummyState

--- a/marlowe-dashboard-client/src/Humanize.purs
+++ b/marlowe-dashboard-client/src/Humanize.purs
@@ -3,7 +3,6 @@ module Humanize
   , formatDate
   , formatTime
   , humanizeInterval
-  , humanizeValue
   , humanizeToken
   ) where
 
@@ -12,7 +11,7 @@ import Data.BigInteger (BigInteger, toNumber)
 import Data.DateTime (DateTime)
 import Data.Formatter.DateTime (FormatterCommand(..), format) as DateTime
 import Data.Formatter.Number (Formatter(..), format) as Number
-import Data.Int (floor, pow, round)
+import Data.Int (floor, round)
 import Data.Int (toNumber) as Int
 import Data.List as List
 import Data.Maybe (Maybe(..))
@@ -84,20 +83,6 @@ formatTime =
         , DateTime.Placeholder ":"
         , DateTime.MinutesTwoDigits
         ]
-
-humanizeValue :: Int -> BigInteger -> String
-humanizeValue decimals value =
-  let
-    numericValue = toNumber value
-
-    -- we display the number as the actual value divided by 10^decimals - this is useful for e.g.
-    -- displaying lovelace values as ada (decimals == 6), or cents as dollars (decimals == 2)
-    correctedValue = numericValue / (Int.toNumber $ pow 10 decimals)
-  in
-    -- we don't include the comma in this case, because this function is used to format the values
-    -- in number inputs, where browsers natively disallow commas (the value is a string, but it
-    -- must be one that can be parsed directly as a number)
-    Number.format (numberFormatter false decimals) correctedValue
 
 humanizeToken :: Token -> BigInteger -> String
 -- TODO: use a different currencyFormatter with no decimal places when they're all zero

--- a/marlowe-dashboard-client/src/Humanize.purs
+++ b/marlowe-dashboard-client/src/Humanize.purs
@@ -3,7 +3,7 @@ module Humanize
   , formatDate
   , formatTime
   , humanizeInterval
-  , humanizeToken
+  , humanizeValue
   ) where
 
 import Prelude
@@ -84,13 +84,13 @@ formatTime =
         , DateTime.MinutesTwoDigits
         ]
 
-humanizeToken :: Token -> BigInteger -> String
+humanizeValue :: Token -> BigInteger -> String
 -- TODO: use a different currencyFormatter with no decimal places when they're all zero
-humanizeToken (Token "" "") value = "₳ " <> Number.format (numberFormatter true 6) (toAda value)
+humanizeValue (Token "" "") value = "₳ " <> Number.format (numberFormatter true 6) (toAda value)
 
-humanizeToken (Token "" "dollar") value = "$ " <> Number.format (numberFormatter true 2) (toNumber value)
+humanizeValue (Token "" "dollar") value = "$ " <> Number.format (numberFormatter true 2) (toNumber value)
 
-humanizeToken (Token _ name) value = Number.format (numberFormatter true 0) (toNumber value) <> " " <> name
+humanizeValue (Token _ name) value = Number.format (numberFormatter true 0) (toNumber value) <> " " <> name
 
 toAda :: BigInteger -> Number
 toAda lovelace = (toNumber lovelace) / 1000000.0

--- a/marlowe-dashboard-client/src/Humanize.purs
+++ b/marlowe-dashboard-client/src/Humanize.purs
@@ -86,21 +86,21 @@ formatTime =
 
 humanizeValue :: Token -> BigInteger -> String
 -- TODO: use a different currencyFormatter with no decimal places when they're all zero
-humanizeValue (Token "" "") value = "₳ " <> Number.format (numberFormatter true 6) (toAda value)
+humanizeValue (Token "" "") value = "₳ " <> Number.format (numberFormatter 6) (toAda value)
 
-humanizeValue (Token "" "dollar") value = "$ " <> Number.format (numberFormatter true 2) (toNumber value)
+humanizeValue (Token "" "dollar") value = "$ " <> Number.format (numberFormatter 2) (toNumber value)
 
-humanizeValue (Token _ name) value = Number.format (numberFormatter true 0) (toNumber value) <> " " <> name
+humanizeValue (Token _ name) value = Number.format (numberFormatter 0) (toNumber value) <> " " <> name
 
 toAda :: BigInteger -> Number
 toAda lovelace = (toNumber lovelace) / 1000000.0
 
-numberFormatter :: Boolean -> Int -> Number.Formatter
-numberFormatter comma decimals =
+numberFormatter :: Int -> Number.Formatter
+numberFormatter decimals =
   Number.Formatter
     { sign: false
     , before: 0
-    , comma
+    , comma: true
     , after: decimals
     , abbreviations: false
     }

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -2,31 +2,44 @@ module InputField.State
   ( dummyState
   , initialState
   , handleAction
+  , getBigIntegerValue
   , validate
   ) where
 
 import Prelude
 import Control.Monad.Reader (class MonadAsk)
-import Data.Lens (assign, set, view)
-import Data.Maybe (Maybe(..))
+import Data.Array (head, last, length, take)
+import Data.BigInteger (BigInteger)
+import Data.BigInteger (fromInt, fromString) as BigInteger
+import Data.Int (pow)
+import Data.Lens (assign, set, use, view)
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String (Pattern(..), split)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, modify_)
+import Humanize (humanizeValue)
 import InputField.Lenses (_dropdownLocked, _dropdownOpen, _pristine, _validator, _value)
 import InputField.Types (class InputFieldError, Action(..), State)
+import Marlowe.Extended.Metadata (NumberFormat(..))
 
 -- see note [dummyState] in MainFrame.State
 dummyState :: forall e. InputFieldError e => State e
-dummyState = initialState
+dummyState = initialState Nothing
 
-initialState :: forall e. InputFieldError e => State e
-initialState =
-  { value: mempty
-  , pristine: true
-  , validator: const Nothing
-  , dropdownOpen: false
-  , dropdownLocked: false
-  }
+initialState :: forall e. InputFieldError e => Maybe NumberFormat -> State e
+initialState mNumberFormat =
+  let
+    initialValue = case mNumberFormat of
+      Just (DecimalFormat decimals _) -> humanizeValue decimals zero
+      _ -> mempty
+  in
+    { value: initialValue
+    , pristine: true
+    , validator: const Nothing
+    , dropdownOpen: false
+    , dropdownLocked: false
+    }
 
 handleAction ::
   forall m e slots msg.
@@ -38,6 +51,33 @@ handleAction (SetValue value) =
   modify_
     $ set _value value
     <<< set _pristine false
+
+-- This handler is used for number inputs instead of SetValue. Since `getBigIntegerValue` and
+-- `humanizeValue` are essentially inverses of each other, you might think it doesn't do anything
+-- differently from what plain old SetValue does. But the difference is that this version sanitizes
+-- the user input, replacing empty strings with "0" and enforcing the right number of decimal
+-- places.
+handleAction (SetFormattedValue numberFormat value) =
+  let
+    decimals = case numberFormat of
+      DefaultFormat -> zero
+      DecimalFormat d _ -> d
+
+    bigIntegerValue = getBigIntegerValue decimals value
+
+    newValue = humanizeValue decimals bigIntegerValue
+  in
+    modify_
+      $ set _value newValue
+      <<< set _pristine false
+
+-- This seemingly pointless action is used to force an update onKeyUp for number inputs. This is
+-- needed because some edits to numeric inputs don't trigger the onValueChange handler. I *think*
+-- this is because Halogen doesn't bubble the event up if the result of `parseFloat(value)` doesn't
+-- change or is `NaN` - but I haven't investigated it thoroughly.
+handleAction RefreshFormattedValue = do
+  value <- use _value
+  assign _value value
 
 handleAction (SetValueFromDropdown value) = do
   handleAction $ SetValue value
@@ -55,6 +95,34 @@ handleAction Reset =
     <<< set _pristine true
     <<< set _validator (const Nothing)
     <<< set _dropdownOpen false
+
+------------------------------------------------------------
+-- This function is essentially the inverse of humanizeValue, except that it doesn't mind if the
+-- format of the input string is incorrect (e.g. with the wrong number of decimal places), and it
+-- returns zero in the case of input that can't be parsed as a number. Since we store the value in
+-- the state as a string (the output of humanizeValue), we need this function to extract the
+-- BigInteger value from that string. Now, since humanizeValue divides the value by decimals^10,
+-- here we need to multiply by the same. But the process is a bit more involved than just parsing
+-- as a Number and then multplying and converting to a BigInteger, because after the multiplication
+-- the value can easily get too large to handle as a Number. So instead we split the string into
+-- the decimal and fractional part, and parse both separately as BigIntegers before stitching it
+-- all back together.
+getBigIntegerValue :: Int -> String -> BigInteger
+getBigIntegerValue decimals value =
+  let
+    valueBits = take 2 $ split (Pattern ".") value
+
+    decimalString = if value /= "" then fromMaybe "0" $ head valueBits else "0"
+
+    fractionalString = if length valueBits > 1 then fromMaybe "0" $ last valueBits else "0"
+
+    multiplier = BigInteger.fromInt $ pow 10 decimals
+
+    dec = fromMaybe zero $ BigInteger.fromString decimalString
+
+    frac = fromMaybe zero $ BigInteger.fromString fractionalString
+  in
+    (dec * multiplier) + frac
 
 validate :: forall e. InputFieldError e => State e -> Maybe e
 validate state =

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -124,7 +124,10 @@ getBigIntegerValue decimals value =
 
     frac = fromMaybe zero $ BigInteger.fromString $ String.take decimals $ fractionalString
   in
-    (dec * multiplier) + frac
+    if dec < zero then
+      (dec * multiplier) - frac
+    else
+      (dec * multiplier) + frac
 
 validate :: forall e. InputFieldError e => State e -> Maybe e
 validate state =

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -17,7 +17,7 @@ import Data.Lens (assign, set, use, view)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (Pattern(..), split, splitAt)
 import Data.String (length, take) as String
-import Data.String.Extra (rightPadTo)
+import Data.String.Extra (leftPadTo, rightPadTo)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, modify_)
@@ -125,15 +125,13 @@ getBigIntegerValue decimals value =
 formatBigIntegerValue :: Int -> BigInteger -> String
 formatBigIntegerValue decimals value =
   let
-    string = show value
+    string = leftPadTo decimals "0" $ show value
 
     len = String.length string
 
-    { after, before } = splitAt (len - decimals) string
+    { after: fractionalString, before } = splitAt (len - decimals) string
 
     decimalString = if before == "" then "0" else before
-
-    fractionalString = rightPadTo decimals "0" after
   in
     decimalString <> "." <> fractionalString
 

--- a/marlowe-dashboard-client/src/InputField/State.purs
+++ b/marlowe-dashboard-client/src/InputField/State.purs
@@ -16,7 +16,7 @@ import Data.Int (pow) as Int
 import Data.Lens (assign, set, use, view)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (Pattern(..), split, splitAt)
-import Data.String (length, take) as String
+import Data.String (drop, length, take) as String
 import Data.String.Extra (leftPadTo, rightPadTo)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
@@ -102,11 +102,17 @@ handleAction Reset =
 getBigIntegerValue :: Int -> String -> BigInteger
 getBigIntegerValue decimals value =
   let
-    valueBits = Array.take 2 $ split (Pattern ".") value
+    { isNegative, absoluteValue } =
+      if String.take 1 value == "-" then
+        { isNegative: true, absoluteValue: String.drop 1 value }
+      else
+        { isNegative: false, absoluteValue: value }
 
-    decimalString = if value /= "" then fromMaybe "0" $ head valueBits else "0"
+    valueBits = Array.take 2 $ split (Pattern ".") absoluteValue
 
-    fractionalString = if Array.length valueBits > 1 then fromMaybe "0" $ last valueBits else "0"
+    decimalString = if absoluteValue == "" then "0" else fromMaybe "0" $ head valueBits
+
+    fractionalString = if Array.length valueBits < 2 then "0" else fromMaybe "0" $ last valueBits
 
     -- if zeros have been deleted from the end of the string, the fractional part will be wrong
     correctedFractionalString = String.take decimals $ rightPadTo decimals "0" fractionalString
@@ -117,21 +123,38 @@ getBigIntegerValue decimals value =
 
     frac = fromMaybe zero $ BigInteger.fromString $ String.take decimals $ correctedFractionalString
   in
-    if dec < zero then
-      (dec * multiplier) - frac
+    if isNegative then
+      -((dec * multiplier) + frac)
     else
       (dec * multiplier) + frac
 
+-- The basic idea of this function is to take the default string representation (`show value`),
+-- split it where the decimal point is supposed to go, and join the two parts with a decimal point
+-- in the middle. Simple enough, but there are a few things to watch out for:
+-- 1. The default string representation needs left zero padding to a minimum length of `decimals`,
+--    otherwise small values (i.e where the absolute value of `value / (decimals ^ 10)` is less
+--    than 1) get the wrong fractionalString.
+-- 2. If the value is negative, the minus sign needs to go to the left of the left zero padding.
+-- 3. Small positive values will have no decimalString following the split, and the decimal string
+--    for small negative values will just be a minus sign, so a zero needs to be added in these
+--    cases.
 formatBigIntegerValue :: Int -> BigInteger -> String
 formatBigIntegerValue decimals value =
   let
-    string = leftPadTo decimals "0" $ show value
+    string =
+      if value < zero then
+        "-" <> (leftPadTo decimals "0" $ String.drop 1 $ show value)
+      else
+        leftPadTo decimals "0" $ show value
 
     len = String.length string
 
     { after: fractionalString, before } = splitAt (len - decimals) string
 
-    decimalString = if before == "" then "0" else before
+    decimalString = case before of
+      "" -> "0"
+      "-" -> "-0"
+      _ -> before
   in
     decimalString <> "." <> fractionalString
 

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -43,7 +43,6 @@ type InputDisplayOptions
 data Action error
   = SetValue String
   | SetFormattedValue NumberFormat String
-  | RefreshFormattedValue
   | SetValueFromDropdown String
   | SetValidator (String -> Maybe error)
   | SetDropdownOpen Boolean

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -42,8 +42,8 @@ type InputDisplayOptions
 
 data Action error
   = SetValue String
-  | SetFormattedValue NumberFormat String
   | SetValueFromDropdown String
+  | FormatValue NumberFormat
   | SetValidator (String -> Maybe error)
   | SetDropdownOpen Boolean
   | SetDropdownLocked Boolean

--- a/marlowe-dashboard-client/src/InputField/Types.purs
+++ b/marlowe-dashboard-client/src/InputField/Types.purs
@@ -8,9 +8,10 @@ module InputField.Types
 
 import Analytics (class IsEvent)
 import Data.Maybe (Maybe(..))
+import Marlowe.Extended.Metadata (NumberFormat)
 
 type State error
-  = { value :: String
+  = { value :: String -- all values are strings in JavaScript; embrace it
     , pristine :: Boolean
     , validator :: String -> Maybe error
     , dropdownOpen :: Boolean
@@ -28,17 +29,21 @@ type State error
 class InputFieldError e where
   inputErrorToString :: e -> String
 
+-- TODO: should the validator be in the InputDisplayOptions instead of the State?
 type InputDisplayOptions
   = { baseCss :: Boolean -> Array String
     , additionalCss :: Array String
     , id_ :: String
     , placeholder :: String
     , readOnly :: Boolean
-    , valueOptions :: Array String
+    , numberFormat :: Maybe NumberFormat -- set to nothing for string inputs
+    , valueOptions :: Array String -- non-empty for select inputs
     }
 
 data Action error
   = SetValue String
+  | SetFormattedValue NumberFormat String
+  | RefreshFormattedValue
   | SetValueFromDropdown String
   | SetValidator (String -> Maybe error)
   | SetDropdownOpen Boolean
@@ -48,9 +53,4 @@ data Action error
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
 instance actionIsEvent :: IsEvent (Action e) where
-  toEvent (SetValue _) = Nothing
-  toEvent (SetValueFromDropdown _) = Nothing
-  toEvent (SetValidator _) = Nothing
-  toEvent (SetDropdownOpen _) = Nothing
-  toEvent (SetDropdownLocked _) = Nothing
-  toEvent Reset = Nothing
+  toEvent action = Nothing

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -166,7 +166,6 @@ renderInput options@{ numberFormat: Just (DecimalFormat decimals label) } state 
               , id_ $ view _id_ options
               , value currentValue
               , readOnly $ view _readOnly options
-              , min zero
               , onValueInput_ $ SetFormattedValue $ DecimalFormat decimals label
               ]
           ]

--- a/marlowe-dashboard-client/src/InputField/View.purs
+++ b/marlowe-dashboard-client/src/InputField/View.purs
@@ -9,7 +9,7 @@ import Data.Maybe (Maybe(..), isJust)
 import Data.String (Pattern(..), contains, toLower)
 import Halogen.Css (classNames)
 import Halogen.HTML (HTML, a, div, div_, input, span, text)
-import Halogen.HTML.Events (onBlur, onKeyUp, onMouseEnter, onMouseLeave)
+import Halogen.HTML.Events (onBlur, onMouseEnter, onMouseLeave)
 import Halogen.HTML.Events.Extra (onClick_, onFocus_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), autocomplete, id_, min, placeholder, readOnly, type_, value)
 import InputField.Lenses (_additionalCss, _baseCss, _dropdownLocked, _dropdownOpen, _id_, _placeholder, _pristine, _readOnly, _value)
@@ -168,7 +168,6 @@ renderInput options@{ numberFormat: Just (DecimalFormat decimals label) } state 
               , readOnly $ view _readOnly options
               , min zero
               , onValueInput_ $ SetFormattedValue $ DecimalFormat decimals label
-              , onKeyUp $ const $ Just RefreshFormattedValue
               ]
           ]
       , div

--- a/marlowe-dashboard-client/src/Template/Lenses.purs
+++ b/marlowe-dashboard-client/src/Template/Lenses.purs
@@ -5,6 +5,7 @@ module Template.Lenses
   , _roleWalletInput
   , _templateContent
   , _slotContentStrings
+  , _dummyNumberInput
   ) where
 
 import Prelude
@@ -38,3 +39,6 @@ _templateContent = prop (SProxy :: SProxy "templateContent")
 
 _slotContentStrings :: Lens' State (Map String String)
 _slotContentStrings = prop (SProxy :: SProxy "slotContentStrings")
+
+_dummyNumberInput :: Lens' State (InputField.State RoleError)
+_dummyNumberInput = prop (SProxy :: SProxy "dummyNumberInput")

--- a/marlowe-dashboard-client/src/Template/Types.purs
+++ b/marlowe-dashboard-client/src/Template/Types.purs
@@ -21,6 +21,7 @@ type State
     , roleWalletInputs :: Map TokenName (InputField.State RoleError)
     , templateContent :: TemplateContent
     , slotContentStrings :: Map String String
+    , dummyNumberInput :: InputField.State RoleError -- FIXME: temporary, just for testing
     }
 
 data Action
@@ -34,6 +35,7 @@ data Action
   | RoleWalletInputAction TokenName (InputField.Action RoleError)
   | SetSlotContent String String -- slot input comes from the HTML as a dateTimeString
   | SetValueContent String (Maybe BigInteger)
+  | DummyNumberInputAction (InputField.Action RoleError)
   | StartContract
 
 -- | Here we decide which top-level queries to track as GA events, and
@@ -49,4 +51,5 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (RoleWalletInputAction _ inputFieldAction) = toEvent inputFieldAction
   toEvent (SetSlotContent _ _) = Just $ defaultEvent "SetSlotContent"
   toEvent (SetValueContent _ _) = Just $ defaultEvent "SetValueContent"
+  toEvent (DummyNumberInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent StartContract = Just $ defaultEvent "StartContract"

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -19,7 +19,7 @@ import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, a, br_, button, div, div_, h2, hr, input, label, li, p, p_, span, span_, text, ul, ul_)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, for, id_, placeholder, type_, value)
-import Humanize (humanizeToken)
+import Humanize (humanizeValue)
 import InputField.Types (State) as InputField
 import InputField.Types (inputErrorToString)
 import InputField.View (renderInput)
@@ -273,7 +273,7 @@ reviewAndPay accessible metaData =
                 [ text "Fee to pay:" ]
             , p
                 [ classNames Css.funds ]
-                [ text $ humanizeToken adaToken contractCreationFee ]
+                [ text $ humanizeValue adaToken contractCreationFee ]
             ]
         ]
     , div
@@ -340,7 +340,7 @@ contractSetupConfirmationCard assets =
     div_
       [ div [ classNames [ "flex", "font-semibold", "justify-between", "bg-lightgray", "p-5" ] ]
           [ span_ [ text "Demo wallet balance:" ]
-          , span_ [ text $ humanizeToken adaToken $ getAda assets ]
+          , span_ [ text $ humanizeValue adaToken $ getAda assets ]
           ]
       , div [ classNames [ "px-5", "pb-6", "md:pb-8" ] ]
           [ p
@@ -348,7 +348,7 @@ contractSetupConfirmationCard assets =
               [ text "Confirm payment of:" ]
           , p
               [ classNames [ "mb-4", "text-purple", "font-semibold", "text-2xl" ] ]
-              [ text $ humanizeToken adaToken contractCreationFee ]
+              [ text $ humanizeValue adaToken contractCreationFee ]
           , div
               [ classNames [ "flex" ] ]
               [ button

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -20,7 +20,7 @@ import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, button, div, h2, h3, h4, input, label, li, p, p_, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (InputType(..), disabled, for, readOnly, type_, value)
-import Humanize (humanizeToken)
+import Humanize (humanizeValue)
 import InputField.Lenses (_value)
 import InputField.State (validate)
 import InputField.Types (State) as InputField
@@ -155,7 +155,7 @@ putdownWalletCard walletDetails =
               [ text "Balance:" ]
           , p
               [ classNames Css.funds ]
-              [ text $ humanizeToken adaToken $ getAda assets ]
+              [ text $ humanizeValue adaToken $ getAda assets ]
           ]
       , div
           [ classNames [ "flex" ] ]

--- a/marlowe-dashboard-client/src/WalletData/View.purs
+++ b/marlowe-dashboard-client/src/WalletData/View.purs
@@ -20,7 +20,7 @@ import Halogen.Css (applyWhen, classNames, hideWhen)
 import Halogen.HTML (HTML, button, div, h2, h3, h4, input, label, li, p, p_, text, ul_)
 import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (InputType(..), disabled, for, readOnly, type_, value)
-import Humanize (humanizeValue)
+import Humanize (humanizeToken)
 import InputField.Lenses (_value)
 import InputField.State (validate)
 import InputField.Types (State) as InputField
@@ -45,6 +45,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , id_: "newWalletNickname"
       , placeholder: "Nickname"
       , readOnly: false
+      , numberFormat: Nothing
       , valueOptions: mempty
       }
 
@@ -54,6 +55,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
       , id_: "newWalletId"
       , placeholder: "Wallet ID"
       , readOnly: false
+      , numberFormat: Nothing
       , valueOptions: mempty
       }
   in
@@ -69,7 +71,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
               , for walletNicknameInputDisplayOptions.id_
               ]
               [ text "Nickname" ]
-          , WalletNicknameInputAction <$> renderInput walletNicknameInput walletNicknameInputDisplayOptions
+          , WalletNicknameInputAction <$> renderInput walletNicknameInputDisplayOptions walletNicknameInput
           ]
       , div
           [ classNames $ [ "mb-4" ] <> (applyWhen (not null walletIdString) Css.hasNestedLabel) ]
@@ -78,7 +80,7 @@ saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo 
               , for walletIdInputDisplayOptions.id_
               ]
               [ text "Wallet ID" ]
-          , WalletIdInputAction <$> renderInput walletIdInput walletIdInputDisplayOptions
+          , WalletIdInputAction <$> renderInput walletIdInputDisplayOptions walletIdInput
           ]
       , div
           [ classNames [ "flex" ] ]
@@ -153,7 +155,7 @@ putdownWalletCard walletDetails =
               [ text "Balance:" ]
           , p
               [ classNames Css.funds ]
-              [ text $ humanizeValue adaToken $ getAda assets ]
+              [ text $ humanizeToken adaToken $ getAda assets ]
           ]
       , div
           [ classNames [ "flex" ] ]

--- a/marlowe-dashboard-client/src/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Welcome/State.purs
@@ -45,9 +45,9 @@ mkInitialState walletLibrary =
   { walletLibrary
   , card: Nothing
   , cardOpen: false
-  , walletNicknameOrIdInput: InputField.initialState
-  , walletNicknameInput: InputField.initialState
-  , walletIdInput: InputField.initialState
+  , walletNicknameOrIdInput: InputField.initialState Nothing
+  , walletNicknameInput: InputField.initialState Nothing
+  , walletIdInput: InputField.initialState Nothing
   , remoteWalletDetails: NotAsked
   , enteringDashboardState: false
   }

--- a/marlowe-dashboard-client/src/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Welcome/View.purs
@@ -84,6 +84,7 @@ useWalletBox state =
       , id_: "existingWallet"
       , placeholder: "Choose wallet or paste key"
       , readOnly: false
+      , numberFormat: Nothing
       , valueOptions: List.toUnfoldable $ values $ view _walletNickname <$> walletLibrary
       }
   in
@@ -110,7 +111,7 @@ useWalletBox state =
       , p
           [ classNames [ "mb-4", "text-center" ] ]
           [ text "Or select an existing demo wallet from the list or paste in a demo wallet key." ]
-      , WalletNicknameOrIdInputAction <$> renderInput walletNicknameOrIdInput walletNicknameOrIdInputDisplayOptions
+      , WalletNicknameOrIdInputAction <$> renderInput walletNicknameOrIdInputDisplayOptions walletNicknameOrIdInput
       , div
           [ classNames [ "mt-6", "flex", "justify-between" ] ]
           [ a
@@ -245,7 +246,7 @@ useNewWalletCard state =
                   , for "walletNickname"
                   ]
                   [ text "Nickname" ]
-              , WalletNicknameInputAction <$> renderInput walletNicknameInput (walletNicknameInputDisplayOptions false)
+              , WalletNicknameInputAction <$> renderInput (walletNicknameInputDisplayOptions false) walletNicknameInput
               ]
         , div
             [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
@@ -254,7 +255,7 @@ useNewWalletCard state =
                 , for "walletID"
                 ]
                 [ text "Wallet ID" ]
-            , WalletIdInputAction <$> renderInput walletIdInput walletIdInputDisplayOptions
+            , WalletIdInputAction <$> renderInput walletIdInputDisplayOptions walletIdInput
             , walletIdTip
             ]
         , div
@@ -301,7 +302,7 @@ useWalletCard state =
                   , for "walletNickname"
                   ]
                   [ text "Nickname" ]
-              , WalletNicknameInputAction <$> renderInput walletNicknameInput (walletNicknameInputDisplayOptions true)
+              , WalletNicknameInputAction <$> renderInput (walletNicknameInputDisplayOptions true) walletNicknameInput
               ]
         , div
             [ classNames $ Css.hasNestedLabel <> [ "mb-4" ] ]
@@ -310,7 +311,7 @@ useWalletCard state =
                 , for "walletId"
                 ]
                 [ text "Wallet ID" ]
-            , WalletIdInputAction <$> renderInput walletIdInput walletIdInputDisplayOptions
+            , WalletIdInputAction <$> renderInput walletIdInputDisplayOptions walletIdInput
             , walletIdTip
             ]
         , div
@@ -337,6 +338,7 @@ walletNicknameInputDisplayOptions readOnly =
   , id_: "walletNickname"
   , placeholder: if readOnly then mempty else "Give your wallet a nickname"
   , readOnly
+  , numberFormat: Nothing
   , valueOptions: mempty
   }
 
@@ -347,6 +349,7 @@ walletIdInputDisplayOptions =
   , id_: "walletId"
   , placeholder: "Wallet ID"
   , readOnly: true
+  , numberFormat: Nothing
   , valueOptions: mempty
   }
 

--- a/web-common/src/Data/String/Extra.purs
+++ b/web-common/src/Data/String/Extra.purs
@@ -2,6 +2,7 @@ module Data.String.Extra
   ( abbreviate
   , toHex
   , leftPadTo
+  , rightPadTo
   , repeat
   , unlines
   , capitalize
@@ -38,6 +39,11 @@ toHex =
 
 leftPadTo :: Int -> String -> String -> String
 leftPadTo length prefix str = repeat (max 0 (length - strlen)) prefix <> str
+  where
+  strlen = String.length str
+
+rightPadTo :: Int -> String -> String -> String
+rightPadTo length suffix str = str <> repeat (max 0 (length - strlen)) suffix
   where
   strlen = String.length str
 


### PR DESCRIPTION
I tried several things before settling on this solution, which I think is quite neat - some of the other things I tried were certainly a lot more complicated... :sweat_smile: Explanations of the various things are in the comments.

I've thrown in a dummy number input in the contract setup card, just for testing. Don't look too closely at the contract setup card itself, which continues to be visually broken - making that look like the new designs is the very next thing on my list.

Here's a screenshot showing the dummy number input (but you probably need to try it for yourself to get the full idea):

![localhost_8009_ (3)](https://user-images.githubusercontent.com/380759/124589824-b4ff8680-de5a-11eb-8fab-afa6e6a03f81.png)
