### PR TITLE
SCP-2455

### DIFF
--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -1045,8 +1045,8 @@ thm1bV M (V-IΠ b {as' = x₂ ∷ as'} p₁ x₁) M' E p N V (step* refl q) | in
          V
          q
 
-... | inj₂ (_ ,, E' ,, wrap-) | I[ eq ] = {!!}
-... | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] = {!!}
+thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, wrap-) | I[ eq ] rewrite dissect-inj₂ E E' wrap- eq = thm1bV (wrap _ _ M) (V-wrap W) _ E' (trans p (extEC-[]ᴱ E' wrap- M)) N V q
+thm1bV .(wrap _ _ _) (V-wrap W) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E E' unwrap- eq = trans—↠ (ruleEC E' (β-wrap W) (trans p (extEC-[]ᴱ E' unwrap- _)) refl) (thm1b _ _ E' refl N V q)
 thm1bV M W M' E refl N V (step* refl q) | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E refl eq with box2box M N W V q
 ... | refl ,, refl = refl—↠
 

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -1031,7 +1031,20 @@ thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (VI@(V-I⇒ b {as' = x
          N
          V
          q
-... | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] = {!!}
+thm1bV .(Λ M) (V-Λ M) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq = trans—↠ (ruleEC E' β-Λ (trans p (extEC-[]ᴱ E' (-·⋆ A) (Λ M))) refl) (thm1b (M [ A ]⋆) _ E' refl N V q)
+thm1bV M (V-IΠ b {as' = []} p₁ x₁) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq = trans—↠
+  (ruleEC E' (β-sbuiltin⋆ b _ p₁ x₁ A) (trans p (extEC-[]ᴱ E' (-·⋆ A) M)) refl)
+  (thm1b (BUILTIN' b (bubble p₁) (step⋆ p₁ x₁)) _ E' refl N V q)
+thm1bV M (V-IΠ b {as' = x₂ ∷ as'} p₁ x₁) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq =
+  thm1bV (M ·⋆ A)
+         (V-I b (bubble p₁) (step⋆ p₁ x₁))
+         M'
+         E'
+         (trans p (extEC-[]ᴱ E' (-·⋆ A) M))
+         N
+         V
+         q
+
 ... | inj₂ (_ ,, E' ,, wrap-) | I[ eq ] = {!!}
 ... | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] = {!!}
 thm1bV M W M' E refl N V (step* refl q) | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E refl eq with box2box M N W V q

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -984,3 +984,56 @@ thm1 M _ E refl O V (trans—↠ q q') with focus M E _ q
 
 thm2 : ∀{A}(M N : ∅ ⊢ A)(V : Value N) → M —↠ N → ([] ▻ M) -→s ([] ◅ V)
 thm2 M N V p = thm1 M M [] refl N V p
+
+box2box : ∀{A}(M M' : ∅ ⊢ A)(V : Value M)(V' : Value M')
+  → □ V -→s □ V' → Σ (M ≡ M') λ p → subst Value p V ≡ V'
+box2box M .M V .V base = refl ,, refl
+box2box M M' V V' (step* refl p) = box2box M M' V V' p
+
+thm1b : ∀{A B}(M : ∅ ⊢ A)(M' : ∅ ⊢ B)(E : EC B A)
+  → M' ≡ E [ M ]ᴱ → (N : ∅ ⊢ B)(V : Value N)
+  → (E ▻ M) -→s (□ V)
+  → M' —↠ N
+
+thm1bV : ∀{A B}(M : ∅ ⊢ A)(W : Value M)(M' : ∅ ⊢ B)(E : EC B A)
+  → M' ≡ E [ M ]ᴱ → (N : ∅ ⊢ B)(V : Value N)
+  → (E ◅ W) -→s (□ V)
+  → M' —↠ N
+
+thm1b M M' E p N V q = {!!}
+
+-- we never have just one case, because there is always a step before box
+
+thm1bV M W M' E p N V (step* x q) with dissect E | inspect dissect E
+thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (-· N')) | I[ eq ]
+  rewrite dissect-inj₂ E E' (-· N') eq =
+  thm1b N'
+        M'
+        (extEC E' (W ·-)) -- this is making sideways progress
+        (trans p (trans (extEC-[]ᴱ E' (-· N') M)
+                        (sym (extEC-[]ᴱ E' (W ·-) N'))))
+        N
+        V
+        q -- this is smaller 
+thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (V-ƛ M₁ ·-)) | I[ eq ]
+  rewrite dissect-inj₂ E E' (V-ƛ M₁ ·-) eq = trans—↠
+    (ruleEC E' (β-ƛ W) (trans p (extEC-[]ᴱ E' (V-ƛ M₁ ·-) M)) refl)
+    (thm1b (M₁ [ M ]) _ E' refl N V q)
+thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (VI@(V-I⇒ b {as' = []} p₁ x₁) ·-)) | I[ eq ] rewrite dissect-inj₂ E E' (VI ·-) eq = trans—↠
+  (ruleEC E' (β-sbuiltin b _ p₁ x₁ M W) (trans p (extEC-[]ᴱ E' (VI ·-) M)) refl)
+  (thm1b (BUILTIN' b (bubble p₁) (step p₁ x₁ W)) _ E' refl N V q) 
+thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (VI@(V-I⇒ b {as' = x₂ ∷ as'} p₁ x₁) ·-)) | I[ eq ] rewrite dissect-inj₂ E E' (VI ·-) eq =
+  thm1bV (_ · M)
+         (V-I b (bubble p₁) (step p₁ x₁ W))
+         M'
+         E'
+         (trans p (extEC-[]ᴱ E' (VI ·-) M))
+         N
+         V
+         q
+... | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] = {!!}
+... | inj₂ (_ ,, E' ,, wrap-) | I[ eq ] = {!!}
+... | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] = {!!}
+thm1bV M W M' E refl N V (step* refl q) | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E refl eq with box2box M N W V q
+... | refl ,, refl = refl—↠
+

--- a/plutus-metatheory/src/Algorithmic/CK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CK.lagda.md
@@ -154,36 +154,83 @@ step** : ∀{A}{s : State A}{s' : State A}{s'' : State A}
 step** base q = q
 step** (step* x p) q = step* x (step** p q)
 
-thm64 : ∀{A}(E : CC.State A)(s' : CC.State A)
-  → E CC.-→s s' → cc2ck E -→s cc2ck s'
+thm64 : ∀{A}(E : CC.State A)(E' : CC.State A)
+  → E CC.-→s E' → cc2ck E -→s cc2ck E'
 thm64 E .E CC.base = base
-thm64 (E CC.▻ ƛ M) s' (CC.step* refl p) = step* refl (thm64 _ s' p)
-thm64 (E CC.▻ (M · N)) s' (CC.step* refl p) =
-  step* (cong (λ E → E ▻ M) (lemmaH E (-· N))) (thm64 _ s' p)
-thm64 (E CC.▻ Λ M) s' (CC.step* refl p) = step* refl (thm64 _ s' p)
-thm64 (E CC.▻ (M ·⋆ A)) s' (CC.step* refl p) =
-  step* (cong (λ E → E ▻ M) (lemmaH E (-·⋆ A))) (thm64 _ s' p)
-thm64 (E CC.▻ wrap A B M) s' (CC.step* refl p) =
-  step* (cong (λ E → E ▻ M) (lemmaH E wrap-)) (thm64 _ s' p)
-thm64 (E CC.▻ unwrap M) s' (CC.step* refl p) =
-  step* (cong (λ E → E ▻ M) (lemmaH E unwrap-)) (thm64 _ s' p)
-thm64 (E CC.▻ con M) s' (CC.step* refl p) =
-  step* refl (thm64 _ s' p)
-thm64 (E CC.▻ ibuiltin b) s' (CC.step* refl p) =
-  step* refl (thm64 _ s' p)
-thm64 (E CC.▻ error _) s' (CC.step* refl p) = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V) s' (CC.step* refl p) with CC.dissect E | inspect CC.dissect E
+thm64 (E CC.▻ ƛ M) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
+thm64 (E CC.▻ (M · N)) E' (CC.step* refl p) =
+  step* (cong (λ E → E ▻ M) (lemmaH E (-· N))) (thm64 _ E' p)
+thm64 (E CC.▻ Λ M) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
+thm64 (E CC.▻ (M ·⋆ A)) E' (CC.step* refl p) =
+  step* (cong (λ E → E ▻ M) (lemmaH E (-·⋆ A))) (thm64 _ E' p)
+thm64 (E CC.▻ wrap A B M) E' (CC.step* refl p) =
+  step* (cong (λ E → E ▻ M) (lemmaH E wrap-)) (thm64 _ E' p)
+thm64 (E CC.▻ unwrap M) E' (CC.step* refl p) =
+  step* (cong (λ E → E ▻ M) (lemmaH E unwrap-)) (thm64 _ E' p)
+thm64 (E CC.▻ con M) E' (CC.step* refl p) =
+  step* refl (thm64 _ E' p)
+thm64 (E CC.▻ ibuiltin b) E' (CC.step* refl p) =
+  step* refl (thm64 _ E' p)
+thm64 (E CC.▻ error _) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V) E' (CC.step* refl p) with CC.dissect E | inspect CC.dissect E
 ... | inj₁ refl | [[ eq ]] rewrite CC.dissect-inj₁ E refl eq =
-  step* refl (thm64 _ s' p)
-... | inj₂ (_ ,, E' ,, (-· N)) | [[ eq ]] =
-  step* (cong (λ p → p ▻ N) (lemmaH E' (V ·-))) (thm64 _ s' p)
-... | inj₂ (_ ,, E' ,, (V-ƛ M ·-)) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, (V-I⇒ b {as' = []} p₁ x ·-)) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, (V-I⇒ b {as' = x₁ ∷ as'} p₁ x ·-)) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V-Λ M) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V-IΠ b {as' = []} p₁ x) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V-IΠ b {as' = x₁ ∷ as'} p₁ x) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ s' p)
-... | inj₂ (_ ,, E' ,, wrap-) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (E CC.◅ V-wrap V) s' (CC.step* refl p) | inj₂ (_ ,, E' ,, unwrap-) | [[ eq ]] = step* refl (thm64 _ s' p)
-thm64 (CC.□ V) s' (CC.step* refl p) = step* refl (thm64 _ s' p)
-thm64 (CC.◆ A) s' (CC.step* refl p) = step* refl (thm64 _ s' p)
+  step* refl (thm64 _ E' p)
+... | inj₂ (_ ,, E'' ,, (-· N)) | [[ eq ]] =
+  step* (cong (λ p → p ▻ N) (lemmaH E'' (V ·-))) (thm64 _ E' p)
+... | inj₂ (_ ,, E'' ,, (V-ƛ M ·-)) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, (V-I⇒ b {as' = []} p₁ x ·-)) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, (V-I⇒ b {as' = x₁ ∷ as'} p₁ x ·-)) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V-Λ M) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V-IΠ b {as' = []} p₁ x) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V-IΠ b {as' = x₁ ∷ as'} p₁ x) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, -·⋆ A) | [[ eq ]] = step* refl (thm64 _ E' p)
+... | inj₂ (_ ,, E'' ,, wrap-) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (E CC.◅ V-wrap V) E' (CC.step* refl p) | inj₂ (_ ,, E'' ,, unwrap-) | [[ eq ]] = step* refl (thm64 _ E' p)
+thm64 (CC.□ V) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
+thm64 (CC.◆ A) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
+
+thm64b : ∀{A}(s : State A)(s' : State A)
+  → s -→s s' → ck2cc s CC.-→s ck2cc s'
+thm64b s .s base = CC.base
+thm64b (s ▻ ƛ M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ (M · M₁)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ Λ M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ (M ·⋆ A)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ wrap A B M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ unwrap M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ con c) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ ibuiltin b) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ error _) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (ε ◅ V) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b ((s , (-· M)) ◅ V) s' (step* refl p) = CC.step*
+  (cong (CC.stepV V) (CC.dissect-lemma (Stack2EvalCtx s) (-· M)))
+  (thm64b _ s' p)
+thm64b ((s , (V-ƛ M ·-)) ◅ V) s' (step* refl p) = CC.step*
+  ((cong (CC.stepV V) (CC.dissect-lemma (Stack2EvalCtx s) (V-ƛ M ·-))))
+  (thm64b _ s' p)
+thm64b ((s , (VI@(V-I⇒ b {as' = []} p₁ x) ·-)) ◅ V) s' (step* refl p) =
+  CC.step*
+    (cong (CC.stepV V) (CC.dissect-lemma (Stack2EvalCtx s) (VI ·-)))
+    (thm64b _ s' p)
+thm64b ((s , (VI@(V-I⇒ b {as' = x₁ ∷ as'} p₁ x) ·-)) ◅ V) s' (step* refl p) =
+  CC.step*
+    (cong (CC.stepV V) (CC.dissect-lemma (Stack2EvalCtx s) (VI ·-)))
+    (thm64b _ s' p)
+thm64b ((s , -·⋆ A) ◅ V-Λ M) s' (step* refl p) = CC.step*
+  (cong (CC.stepV (V-Λ M)) (CC.dissect-lemma (Stack2EvalCtx s) (-·⋆ A)))
+  (thm64b _ s' p)
+thm64b ((s , -·⋆ A) ◅ VI@(V-IΠ b {as' = []} p₁ x)) s' (step* refl p) =
+  CC.step*
+    (cong (CC.stepV VI) (CC.dissect-lemma (Stack2EvalCtx s) (-·⋆ A)))
+    (thm64b _ s' p)
+thm64b ((s , -·⋆ A) ◅ VI@(V-IΠ b {as' = x₁ ∷ as'} p₁ x)) s' (step* refl p) =
+  CC.step*
+    (cong (CC.stepV VI) (CC.dissect-lemma (Stack2EvalCtx s) (-·⋆ A)))
+    (thm64b _ s' p)
+thm64b ((s , wrap-) ◅ V) s' (step* refl p) = CC.step*
+  (cong (CC.stepV V) (CC.dissect-lemma (Stack2EvalCtx s) wrap-))
+  (thm64b _ s' p)
+thm64b ((s , unwrap-) ◅ V-wrap V) s' (step* refl p) = CC.step*
+  ((cong (CC.stepV (V-wrap V)) (CC.dissect-lemma (Stack2EvalCtx s) unwrap-)))
+  (thm64b _ s' p)
+thm64b (□ x₁) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (◆ A) s' (step* refl p) = CC.step* refl (thm64b _ s' p)

--- a/plutus-metatheory/src/Type/CC.lagda.md
+++ b/plutus-metatheory/src/Type/CC.lagda.md
@@ -365,6 +365,8 @@ thm1 A A' E refl C V (trans—↠E {B = B} q q') with lemmaE' A E B q
   (thm1 (L [ N ]) B E' (sym p'') C V q')
 
 {-# TERMINATING #-}
+-- TODO: refactor following the term version
+-- the value part below is wrong
 thm1b : (A : ∅ ⊢⋆ J)(A' : ∅ ⊢⋆ K)(E : EvalCtx K J)
   → A' ≡ closeEvalCtx E A → (B : ∅ ⊢⋆ K)(V : Value⋆ B)
   → (E ▻ A) -→s ([] ◅ V) ⊎ (∃ λ (W : Value⋆ A) → (E ◅ W) -→s ([] ◅ V)) → A' —↠E B


### PR DESCRIPTION
CK=>reduction proof.

This completes the first version of behavioural equivalence for reduction vs CK.

Subject to the following caveats:
1. The old version of reduction needs to be removed.
2. There are some omitted termination proofs.
3. I removed the optimisation that the CC and CK machine remember that something is a value after a beta-step. This is relevant to builtins and also wrap/unwrap. 
4. I have used injectivity of type constructors.
5. It only deals with computations that compute to a value, so errors are impossible.
6. It needs polishing.
7. I postulated one lemma about evaluation contexts.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
