### PR TITLE
Drop `lib` from `pkgs`.

### DIFF
--- a/nix/overlays/r.nix
+++ b/nix/overlays/r.nix
@@ -9,7 +9,7 @@ self: super: {
   };
   R = super.R.overrideAttrs (oldAttrs: {
     # Backport https://github.com/NixOS/nixpkgs/pull/99570
-    prePatch = super.stdenv.lib.optionalString super.stdenv.isDarwin ''
+    prePatch = super.lib.optionalString super.stdenv.isDarwin ''
       substituteInPlace configure --replace "-install_name libRblas.dylib" "-install_name $out/lib/R/lib/libRblas.dylib"
       substituteInPlace configure --replace "-install_name libRlapack.dylib" "-install_name $out/lib/R/lib/libRlapack.dylib"
       substituteInPlace configure --replace "-install_name libR.dylib" "-install_name $out/lib/R/lib/libR.dylib"


### PR DESCRIPTION
It's deprecated and will disapper in upstream nixpkgs soon.
