### PR TITLE
permissive CORS policy for the pab

### DIFF
--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -15,6 +15,7 @@ let
     pabWebserverConfig = {
       baseUrl = "http://localhost:${builtins.toString cfg.webserverPort}";
       staticDir = "${cfg.staticContent}";
+      permissiveCorsPolicy = false;
     };
 
     walletServerConfig = {

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -96,6 +96,7 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
           (hsPkgs."wai-cors" or (errorHandler.buildDepError "wai-cors"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
           (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -96,6 +96,7 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."wai-cors" or (errorHandler.buildDepError "wai-cors"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
           (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
           (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -96,6 +96,7 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
           (hsPkgs."wai-cors" or (errorHandler.buildDepError "wai-cors"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
           (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -96,6 +96,7 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."wai-cors" or (errorHandler.buildDepError "wai-cors"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
           (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
           (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -174,6 +174,7 @@ library
         uuid -any,
         vector -any,
         warp -any,
+        wai-cors -any,
         Win32-network -any,
         websockets -any,
         yaml -any,

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -174,6 +174,7 @@ library
         uuid -any,
         vector -any,
         warp -any,
+        wai -any,
         wai-cors -any,
         Win32-network -any,
         websockets -any,

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -5,6 +5,7 @@ dbConfig:
 pabWebserverConfig:
   baseUrl: http://localhost:9080
   staticDir: plutus-pab-client/dist
+  permissiveCorsPolicy: False
 
 walletServerConfig:
   baseUrl: http://localhost:9081

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -109,8 +109,9 @@ newtype RequestProcessingConfig =
 
 data WebserverConfig =
     WebserverConfig
-        { baseUrl   :: BaseUrl
-        , staticDir :: FilePath
+        { baseUrl              :: BaseUrl
+        , staticDir            :: FilePath
+        , permissiveCorsPolicy :: Bool -- ^ If true; use a very permissive CORS policy (any website can interact.)
         }
     deriving (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -17,6 +17,7 @@ import           Cardano.Node.Types        (MockServerConfig (..))
 import qualified Cardano.Wallet.Types      as Wallet
 import           Control.Lens.TH           (makePrisms)
 import           Data.Aeson                (FromJSON, ToJSON (..))
+import           Data.Default              (Default, def)
 import           Data.Map.Strict           (Map)
 import qualified Data.Map.Strict           as Map
 import           Data.Text                 (Text)
@@ -29,7 +30,7 @@ import           Ledger                    (Block, Blockchain, Tx, TxId, eitherT
 import           Ledger.Index              as UtxoIndex
 import           Plutus.Contract.Types     (ContractError)
 import           Plutus.PAB.Instances      ()
-import           Servant.Client            (BaseUrl, ClientError)
+import           Servant.Client            (BaseUrl (..), ClientError, Scheme (Http))
 import           Wallet.API                (WalletAPIError)
 import           Wallet.Emulator.Wallet    (Wallet)
 import           Wallet.Types              (ContractInstanceId (..), NotificationError)
@@ -110,11 +111,23 @@ newtype RequestProcessingConfig =
 data WebserverConfig =
     WebserverConfig
         { baseUrl              :: BaseUrl
-        , staticDir            :: FilePath
+        , staticDir            :: Maybe FilePath
         , permissiveCorsPolicy :: Bool -- ^ If true; use a very permissive CORS policy (any website can interact.)
         }
     deriving (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)
+
+-- | Default config for debugging.
+defaultWebServerConfig :: WebserverConfig
+defaultWebServerConfig =
+  WebserverConfig
+    { baseUrl              = BaseUrl Http "localhost" 8080 "/"
+    , staticDir            = Nothing
+    , permissiveCorsPolicy = False
+    }
+
+instance Default WebserverConfig where
+  def = defaultWebServerConfig
 
 -- | The source of a PAB event, used for sharding of the event stream
 data Source

--- a/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
@@ -15,6 +15,7 @@ module Plutus.PAB.Webserver.Server
     ( startServer
     , startServer'
     , startServerDebug
+    , startServerDebug'
     ) where
 
 import           Control.Concurrent              (MVar, forkFinally, forkIO, newEmptyMVar, putMVar)
@@ -44,7 +45,7 @@ import           Plutus.PAB.Core                 (PABAction, PABRunner (..))
 import qualified Plutus.PAB.Core                 as Core
 import qualified Plutus.PAB.Effects.Contract     as Contract
 import qualified Plutus.PAB.Monitoring.PABLogMsg as LM
-import           Plutus.PAB.Types                (PABError, WebserverConfig (..), baseUrl)
+import           Plutus.PAB.Types                (PABError, WebserverConfig (..), baseUrl, defaultWebServerConfig)
 import           Plutus.PAB.Webserver.API        (API, NewAPI, WSAPI, WalletProxy)
 import           Plutus.PAB.Webserver.Handler    (handlerNew, handlerOld, walletProxy, walletProxyClientEnv)
 import qualified Plutus.PAB.Webserver.WebSocket  as WS
@@ -101,6 +102,7 @@ app fp walletClient pabRunner = do
                 rest = Proxy @(CombinedAPI t :<|> (WalletProxy Integer) :<|> Raw)
             Servant.serve rest (apiServer :<|> wpServer :<|> fileServer)
 
+
 -- | Start the server using the config. Returns an action that shuts it down
 --   again, and an MVar that is filled when the webserver
 --   thread exits.
@@ -118,7 +120,7 @@ startServer ::
 startServer WebserverConfig{baseUrl, staticDir, permissiveCorsPolicy} walletClient availability = do
     when permissiveCorsPolicy $
       logWarn @(LM.PABMultiAgentMsg t) (LM.UserLog "Warning: Using a very permissive CORS policy! *Any* website serving JavaScript can interact with these endpoints.")
-    startServer' mw (baseUrlPort baseUrl) walletClient (Just staticDir) availability
+    startServer' mw (baseUrlPort baseUrl) walletClient staticDir availability
       where
         mw = if permissiveCorsPolicy then simpleCors else id
 
@@ -138,7 +140,7 @@ startServer' ::
     -> Maybe FilePath -- ^ Optional file path for static assets
     -> Availability
     -> PABAction t env (MVar (), PABAction t env ())
-startServer' mw port walletClient fp availability = do
+startServer' waiMiddleware port walletClient staticPath availability = do
     simRunner <- Core.pabRunner
     shutdownVar <- liftIO $ STM.atomically $ STM.newEmptyTMVar @()
     mvar <- liftIO newEmptyMVar
@@ -156,12 +158,12 @@ startServer' mw port walletClient fp availability = do
     logInfo @(LM.PABMultiAgentMsg t) (LM.StartingPABBackendServer port)
     void $ liftIO $
         forkFinally
-            (Warp.runSettings warpSettings $ mw $ app fp walletClient simRunner)
+            (Warp.runSettings warpSettings $ waiMiddleware $ app staticPath walletClient simRunner)
             (\_ -> putMVar mvar ())
 
     pure (mvar, liftIO $ STM.atomically $ STM.putTMVar shutdownVar ())
 
--- | Start the server using default configuration for debugging.
+-- | Start the server using a default configuration for debugging.
 startServerDebug ::
     ( FromJSON (Contract.ContractDef t)
     , ToJSON (Contract.ContractDef t)
@@ -169,10 +171,21 @@ startServerDebug ::
     , Servant.MimeUnrender Servant.JSON (Contract.ContractDef t)
     )
     => Simulation t (Simulation t ())
-startServerDebug = do
+startServerDebug = startServerDebug' defaultWebServerConfig
+
+-- | Start the server using (mostly) a default configuration for debugging,
+-- but allow an optional webserver config.
+startServerDebug' ::
+    ( FromJSON (Contract.ContractDef t)
+    , ToJSON (Contract.ContractDef t)
+    , Contract.PABContract t
+    , Servant.MimeUnrender Servant.JSON (Contract.ContractDef t)
+    )
+    => WebserverConfig
+    -> Simulation t (Simulation t ())
+startServerDebug' conf = do
     tk <- newToken
     let mkWalletInfo = do
             (wllt, pk) <- Simulator.addWallet
             pure $ WalletInfo{wiWallet = wllt, wiPubKey = pk, wiPubKeyHash = pubKeyHash pk}
-    let mw = id -- default configuration middleware is a strict CORS policy; i.e. no policy.
-    snd <$> startServer' mw 8080 (Right mkWalletInfo) Nothing tk
+    snd <$> startServer conf (Right mkWalletInfo) tk

--- a/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
@@ -37,6 +37,7 @@ import           Servant.Client                  (BaseUrl (baseUrlPort), ClientE
 
 import           Cardano.Wallet.Types            (WalletInfo (..))
 import           Control.Monad.Freer.Extras.Log  (logInfo)
+import           Network.Wai.Middleware.Cors     (simpleCors)
 import           Plutus.PAB.Core                 (PABAction, PABRunner (..))
 import qualified Plutus.PAB.Core                 as Core
 import qualified Plutus.PAB.Effects.Contract     as Contract
@@ -148,7 +149,7 @@ startServer' port walletClient fp availability = do
     logInfo @(LM.PABMultiAgentMsg t) (LM.StartingPABBackendServer port)
     void $ liftIO $
         forkFinally
-            (Warp.runSettings warpSettings $ app fp walletClient simRunner)
+            (Warp.runSettings warpSettings $ simpleCors $ app fp walletClient simRunner)
             (\_ -> putMVar mvar ())
 
     pure (mvar, liftIO $ STM.atomically $ STM.putTMVar shutdownVar ())

--- a/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Server.hs
@@ -13,6 +13,7 @@
 
 module Plutus.PAB.Webserver.Server
     ( startServer
+    , startServer'
     , startServerDebug
     ) where
 


### PR DESCRIPTION
Adds a permissive CORS policy for the PAB.

It's configured in the yaml file like so:

```
pabWebserverConfig:
  ...
  permissiveCorsPolicy: False
```

The `.sample` yaml file, and the nix pab vm-tests, sets it to `False` by default.

Fixes SCP-2421

----

Before:

```
> curl -I -X OPTIONS -H "Origin: http://example.com" -H 'Access-Control-Request-Method: GET' \
  http://localhost:9080
HTTP/1.1 405 Method Not Allowed
Transfer-Encoding: chunked
Date: Wed, 07 Jul 2021 14:35:43 GMT
Server: Warp/3.3.16
Content-Type: text/plain

```

After:

```
> curl -I -X OPTIONS -H "Origin: http://example.com" -H 'Access-Control-Request-Method: GET' \
  http://localhost:9080
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Date: Wed, 07 Jul 2021 14:36:21 GMT
Server: Warp/3.3.16
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, HEAD, POST
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
