### PR TITLE
Expand the exports of plutus-ledger-api to cover the needs of the ledger better

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -5,30 +5,30 @@
 The interface to Plutus V1 for the ledger.
 -}
 module Plutus.V1.Ledger.Api (
+    -- * Scripts
     SerializedScript
+    , Script
+    , fromCompiledCode
     -- * Validating scripts
     , validateScript
-    -- * Cost model
-    , validateCostModelParams
-    , defaultCostModelParams
-    , CostModelParams
     -- * Running scripts
     , evaluateScriptRestricting
     , evaluateScriptCounting
+    -- ** Verbose mode and log output
+    , VerboseMode (..)
+    , LogOutput
     -- * Serialising scripts
     , plutusScriptEnvelopeType
     , plutusDatumEnvelopeType
     , plutusRedeemerEnvelopeType
-    -- * Data
-    , Data (..)
-    , IsData (..)
-    -- ** Costing-related types
+    -- * Costing-related types
     , ExBudget (..)
     , ExCPU (..)
     , ExMemory (..)
-    -- ** Verbose mode and log output
-    , VerboseMode (..)
-    , LogOutput
+    -- ** Cost model
+    , validateCostModelParams
+    , defaultCostModelParams
+    , CostModelParams
     -- * Context types
     , ScriptContext(..)
     , ScriptPurpose(..)
@@ -41,30 +41,58 @@ module Plutus.V1.Ledger.Api (
     -- *** Credentials
     , StakingCredential(..)
     , Credential(..)
+    -- *** Value
+    , Value (..)
+    , CurrencySymbol (..)
+    , TokenName (..)
+    , singleton
+    , unionWith
+    , adaSymbol
+    , adaToken
+    -- *** Time
+    , POSIXTime (..)
+    , POSIXTimeRange
     -- *** Types for representing transactions
     , Address (..)
     , PubKeyHash (..)
+    , TxId (..)
     , TxInfo (..)
     , TxOut(..)
     , TxOutRef(..)
     , TxInInfo(..)
-    , Slot (..)
-    , SlotRange
     -- *** Intervals
     , Interval (..)
     , Extended (..)
     , Closure
     , UpperBound (..)
     , LowerBound (..)
+    , always
+    , from
+    , to
+    , lowerBound
+    , upperBound
+    , strictLowerBound
+    , strictUpperBound
     -- *** Newtypes for script/datum types and hash types
     , Validator (..)
+    , mkValidatorScript
+    , unValidatorScript
     , ValidatorHash (..)
+    , validatorHash
     , MintingPolicy (..)
+    , mkMintingPolicyScript
+    , unMintingPolicyScript
     , MintingPolicyHash (..)
+    , mintingPolicyHash
     , Redeemer (..)
     , RedeemerHash (..)
+    , redeemerHash
     , Datum (..)
     , DatumHash (..)
+    , datumHash
+    -- * Data
+    , Data (..)
+    , IsData (..)
     -- * Errors
     , EvaluationError (..)
 ) where
@@ -81,15 +109,18 @@ import           Data.Text                                        (Text)
 import qualified Data.Text                                        as Text
 import           Data.Text.Prettyprint.Doc
 import           Data.Tuple
+import           Plutus.V1.Ledger.Ada
 import           Plutus.V1.Ledger.Address
 import           Plutus.V1.Ledger.Bytes
 import           Plutus.V1.Ledger.Contexts
 import           Plutus.V1.Ledger.Credential
 import           Plutus.V1.Ledger.Crypto
 import           Plutus.V1.Ledger.DCert
-import           Plutus.V1.Ledger.Interval
+import           Plutus.V1.Ledger.Interval                        hiding (singleton)
 import           Plutus.V1.Ledger.Scripts
-import           Plutus.V1.Ledger.Slot
+import           Plutus.V1.Ledger.Time
+import           Plutus.V1.Ledger.TxId
+import           Plutus.V1.Ledger.Value
 import           PlutusCore                                       as PLC
 import qualified PlutusCore.DeBruijn                              as PLC
 import           PlutusCore.Evaluation.Machine.CostModelInterface (CostModelParams, applyCostModelParams)

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Examples.hs
@@ -2,7 +2,7 @@
 {-|
 This module contains example values to be used for testing. These should NOT be used in non-test code!
 -}
-module Plutus.V1.Ledger.Examples where
+module Plutus.V1.Ledger.Examples (alwaysSucceedingNAryFunction, alwaysFailingNAryFunction) where
 
 import           Codec.Serialise
 import           Data.ByteString.Lazy     (toStrict)

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
@@ -33,6 +33,8 @@ module Plutus.V1.Ledger.Interval(
     , isEmpty
     , before
     , after
+    , lowerBound
+    , upperBound
     , strictLowerBound
     , strictUpperBound
     ) where


### PR DESCRIPTION
My goal is to *only* expose `Plutus.V1.Ledger.Api` and
`Plutus.V1.Ledger.Examples`, which means they'd better export everything
the ledger uses.

Steps:
1. This PR
2. Update ledger to use this commit
3. Bump us to use new ledger
4. Remove access to other things (now that the ledger won't use them)
5. Update the ledger again
6. Update us again (optional)

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
