### PR TITLE
Fixed issue with POSIXTime in endpoint parameter.

### DIFF
--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -373,6 +373,9 @@ instance ToSchema LedgerBytes where
 instance ToSchema UUID where
     toSchema = toSchema @String
 
+instance ToSchema POSIXTime where
+    toSchema = FormSchemaInteger
+
 instance ToSchema POSIXTimeRange where
     toSchema = FormSchemaPOSIXTimeRange
 
@@ -389,8 +392,6 @@ deriving anyclass instance ToSchema PubKeyHash
 deriving anyclass instance ToSchema RedeemerHash
 
 deriving anyclass instance ToSchema Signature
-
-deriving anyclass instance ToSchema POSIXTime
 
 deriving anyclass instance ToSchema TokenName
 

--- a/plutus-playground-client/src/MainFrame/State.purs
+++ b/plutus-playground-client/src/MainFrame/State.purs
@@ -80,7 +80,7 @@ mkSimulatorWallet :: Array KnownCurrency -> BigInteger -> SimulatorWallet
 mkSimulatorWallet currencies walletId =
   SimulatorWallet
     { simulatorWalletWallet: Wallet { getWallet: walletId }
-    , simulatorWalletBalance: mkInitialValue currencies (BigInteger.fromInt 10)
+    , simulatorWalletBalance: mkInitialValue currencies (BigInteger.fromInt 100_000_000)
     }
 
 mkSimulation :: Array KnownCurrency -> Int -> Simulation


### PR DESCRIPTION
Fixed issue with POSIXTime in endpoint parameter. ToSchema POSIXTime now uses a number field. Also, added higher opening balances in playground.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
