### PR TITLE
Adding new necessary property to pab config.

### DIFF
--- a/marlowe-dashboard-client/plutus-pab.yaml
+++ b/marlowe-dashboard-client/plutus-pab.yaml
@@ -11,6 +11,7 @@ dbConfig:
 pabWebserverConfig:
   baseUrl: http://localhost:8080
   staticDir: plutus-pab-client/dist
+  permissiveCorsPolicy: False
 
 walletServerConfig:
   baseUrl: http://localhost:8081


### PR DESCRIPTION
#3507 added a new parameter to the pab config, so the `plutus-pab.yaml` file in `marlowe-dashboard-client` needs updating to include it. (This is only needed for local development, but needed nonetheless.)

Going to go ahead and merge without review, because there's really nothing to it. But also going to flag @silky - just so you know, for future reference.