### PR TITLE
docs: Fix quick-jump.css search scroll

### DIFF
--- a/nix/lib/haddock-combine.nix
+++ b/nix/lib/haddock-combine.nix
@@ -63,6 +63,12 @@ runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
     ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
     "''${interfaceOpts[@]}"
 
+  # TODO: remove patch when haddock > 2.24.0
+  # patch quick-jump.css to fix scrolling in search for chromium
+  for f in $(find $out -name "quick-jump.css"); do
+    sed -i -r "s,^\#search-results \{,\#search-results \{ max-height:80%;overflow-y:scroll;," "$f"
+  done
+
   # Following: https://github.com/input-output-hk/ouroboros-network/blob/2068d091bc7dcd3f4538fb76f1b598f219d1e0c8/scripts/haddocs.sh#L87
   # Assemble a toplevel `doc-index.json` from package level ones.
   shopt -s globstar


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/plutus/issues/3541

locally for chromium based browsers. This patch can be dropped once
haddock is > 2.24.0.

based on https://github.com/haskell/haddock/pull/1235

This can be tested locally using:
```sh
nix-shell
build-and-serve-docs
# and navigating to http://localhost:8002/haddock/ once done
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
