### PR TITLE
SCP-2446: Marlowe Dashboard: Add LoadingSubmit button with animation

### DIFF
--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -2,6 +2,7 @@ module Css
   ( maxWidthContainer
   , bgBlueGradient
   , button
+  , withAnimation
   , withIcon
   , withShadow
   , primaryButton
@@ -47,9 +48,8 @@ button =
   , "font-bold"
   , "leading-none"
   , "whitespace-nowrap"
-  , "transition-all"
-  , "duration-200"
   , "outline-none"
+  , "select-none"
   , "focus:outline-none"
   , "disabled:bg-none"
   , "disabled:bg-lightgray"
@@ -60,14 +60,17 @@ button =
 withShadow :: Array String
 withShadow = [ "shadow", "hover:shadow-lg" ]
 
+withAnimation :: Array String
+withAnimation = [ "transition-all", "duration-200" ]
+
 primaryButton :: Array String
-primaryButton = button <> bgBlueGradient <> withShadow
+primaryButton = button <> bgBlueGradient <> withShadow <> withAnimation
 
 secondaryButton :: Array String
-secondaryButton = button <> [ "bg-lightgray", "text-black", "hover:shadow" ]
+secondaryButton = button <> withAnimation <> [ "bg-lightgray", "text-black", "hover:shadow" ]
 
 whiteButton :: Array String
-whiteButton = button <> withShadow <> [ "bg-white" ]
+whiteButton = button <> withShadow <> withAnimation <> [ "bg-white" ]
 
 withIcon :: Icon -> Array String
 withIcon icon = [ "with-icon", "with-icon-" <> iconClass icon ]

--- a/marlowe-dashboard-client/src/LoadingSubmitButton/Lenses.purs
+++ b/marlowe-dashboard-client/src/LoadingSubmitButton/Lenses.purs
@@ -1,0 +1,20 @@
+module LoadingSubmitButton.Lenses where
+
+import Data.Lens (Lens')
+import Data.Lens.Record (prop)
+import Data.Symbol (SProxy(..))
+
+_caption :: forall s a. Lens' { caption :: a | s } a
+_caption = prop (SProxy :: SProxy "caption")
+
+_buttonHeight :: forall s a. Lens' { buttonHeight :: a | s } a
+_buttonHeight = prop (SProxy :: SProxy "buttonHeight")
+
+_styles :: forall s a. Lens' { styles :: a | s } a
+_styles = prop (SProxy :: SProxy "styles")
+
+_status :: forall s a. Lens' { status :: a | s } a
+_status = prop (SProxy :: SProxy "status")
+
+_enabled :: forall s a. Lens' { enabled :: a | s } a
+_enabled = prop (SProxy :: SProxy "enabled")

--- a/marlowe-dashboard-client/src/LoadingSubmitButton/State.purs
+++ b/marlowe-dashboard-client/src/LoadingSubmitButton/State.purs
@@ -1,0 +1,134 @@
+module LoadingSubmitButton.State (loadingSubmitButton) where
+
+import Prelude
+import Control.Monad.Cont (lift)
+import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
+import Data.Int (round)
+import Data.Lens (assign, set, use)
+import Data.Maybe (Maybe(..))
+import Effect.Aff as Aff
+import Effect.Aff.Class (class MonadAff, liftAff)
+import Halogen (Component, HalogenM, Slot, getHTMLElementRef, liftEffect, mkComponent, modify_, raise)
+import Halogen as H
+import Halogen.Animation (waitForAllAnimations)
+import Halogen.HTML (ComponentHTML, HTML, slot)
+import LoadingSubmitButton.Lenses (_buttonHeight, _caption, _enabled, _status, _styles)
+import LoadingSubmitButton.Types (Action(..), Input, Message(..), Query(..), State, _submitButtonSlot, buttonRef)
+import LoadingSubmitButton.View (render)
+import Network.RemoteData (RemoteData(..), fromEither)
+import Web.DOM.DOMTokenList as DOMTokenList
+import Web.DOM.Element (removeAttribute, setAttribute)
+import Web.HTML.HTMLElement (classList, offsetHeight, toElement)
+
+loadingSubmitButton ::
+  forall slots m action.
+  MonadAff m =>
+  { ref :: String
+  , styles :: Array String
+  , enabled :: Boolean
+  , caption :: String
+  , handler :: (Message -> Maybe action)
+  } ->
+  ComponentHTML action ( submitButtonSlot :: Slot Query Message String | slots ) m
+loadingSubmitButton { ref, styles, enabled, caption, handler } =
+  slot
+    _submitButtonSlot
+    ref
+    component
+    { styles, caption, enabled }
+    handler
+
+initialState :: Input -> State
+initialState { caption
+, styles
+, enabled
+} =
+  { caption
+  , styles
+  , enabled
+  , status: NotAsked
+  , buttonHeight: 0.0
+  }
+
+component ::
+  forall m.
+  MonadAff m =>
+  Component HTML Query Input Message m
+component =
+  mkComponent
+    { initialState
+    , render
+    , eval:
+        H.mkEval
+          $ H.defaultEval
+              { handleAction = handleAction
+              , handleQuery = handleQuery
+              , receive = Just <<< OnNewInput
+              }
+    }
+
+roundShow :: Number -> String
+roundShow = show <<< round
+
+handleAction ::
+  forall m slots.
+  MonadAff m =>
+  Action ->
+  HalogenM State Action slots Message m Unit
+handleAction Submit = do
+  void
+    $ runMaybeT do
+        -- When the user clicks on the submit button we set the Loading state,
+        -- which will prepare the DOM to be a circle. We measure the height
+        -- before this happens so that it stays consistent before loading, while
+        -- loading and when showing the result. The final tweak that makes it a
+        -- circule is to then set the same width and height via the style property.
+        buttonElem <- MaybeT $ getHTMLElementRef buttonRef
+        buttonHeight <- MaybeT $ map pure $ liftEffect $ offsetHeight buttonElem
+        modify_
+          $ set _status Loading
+          <<< set _buttonHeight buttonHeight
+        let
+          styleStr = "width: " <> roundShow buttonHeight <> "px; height: " <> roundShow buttonHeight <> "px"
+        liftEffect $ setAttribute "style" styleStr $ toElement buttonElem
+        -- After we set the width of the property we are going to have a transition animation
+        -- so we wait for that before adding the animate-spin. If both are set at the same time
+        -- it will rotate as it shrinks.
+        liftAff $ waitForAllAnimations buttonElem
+        -- NOTE: We manually add the CSS to the DOM element but we never manually remove it.
+        --       This is because Halogen will clear it for us when it recomputes the classes
+        --       when we call handleQuery.SubmitResult
+        classes <- MaybeT $ map pure $ liftEffect $ classList buttonElem
+        liftEffect $ DOMTokenList.add classes "animate-spin"
+  raise OnSubmit
+
+handleAction (OnNewInput { enabled, styles, caption }) =
+  modify_
+    $ set _enabled enabled
+    <<< set _styles styles
+    <<< set _caption caption
+
+handleQuery ::
+  forall slots a m.
+  MonadAff m =>
+  Query a ->
+  HalogenM State Action slots Message m (Maybe a)
+handleQuery (SubmitResult timeout result next) =
+  runMaybeT do
+    assign _status $ fromEither result
+    buttonHeight <- use _buttonHeight
+    buttonElem <- MaybeT $ getHTMLElementRef buttonRef
+    let
+      styleStr = "height: " <> roundShow buttonHeight <> "px"
+    -- We keep the original height for the Result message, but
+    -- we remove the width (so that is no longer a circle)
+    liftEffect $ setAttribute "style" styleStr $ toElement buttonElem
+    -- We pause the execution of this "thread/handler" so we give enough
+    -- time for the user to see the result before continuing. Because of
+    -- how Halogen works, it will pause the execution of the handleAction
+    -- that makes this query without affecting other handleActions
+    liftAff $ Aff.delay timeout
+    assign _status NotAsked
+    liftEffect $ removeAttribute "style" $ toElement buttonElem
+    lift $ raise OnResultAnimationFinish
+    MaybeT $ pure $ Just next

--- a/marlowe-dashboard-client/src/LoadingSubmitButton/Types.purs
+++ b/marlowe-dashboard-client/src/LoadingSubmitButton/Types.purs
@@ -1,0 +1,38 @@
+module LoadingSubmitButton.Types where
+
+import Data.Either (Either)
+import Data.Symbol (SProxy(..))
+import Data.Time.Duration (Milliseconds)
+import Halogen (RefLabel(..))
+import Network.RemoteData (RemoteData)
+
+_submitButtonSlot :: SProxy "submitButtonSlot"
+_submitButtonSlot = SProxy
+
+type State
+  = { caption :: String
+    , styles :: Array String
+    , enabled :: Boolean
+    , status :: RemoteData String String
+    , buttonHeight :: Number
+    }
+
+type Input
+  = { caption :: String
+    , styles :: Array String
+    , enabled :: Boolean
+    }
+
+data Query a
+  = SubmitResult Milliseconds (Either String String) a
+
+data Message
+  = OnSubmit
+  | OnResultAnimationFinish
+
+data Action
+  = Submit
+  | OnNewInput Input
+
+buttonRef :: RefLabel
+buttonRef = RefLabel "button"

--- a/marlowe-dashboard-client/src/LoadingSubmitButton/View.purs
+++ b/marlowe-dashboard-client/src/LoadingSubmitButton/View.purs
@@ -1,0 +1,53 @@
+module LoadingSubmitButton.View (render) where
+
+import Prelude hiding (div)
+import Css as Css
+import Data.Maybe (Maybe(..))
+import Halogen.Css (classNames)
+import Halogen.HTML (HTML, div, text, button)
+import Halogen.HTML.Events (onClick)
+import Halogen.HTML.Properties (disabled, ref)
+import LoadingSubmitButton.Types (Action(..), State, buttonRef)
+import Material.Icons as Icon
+import Network.RemoteData (RemoteData(..))
+
+render :: forall p. State -> HTML p Action
+render { caption, styles, status, enabled } =
+  let
+    withWidthAnimation = [ "transition-width", "duration-200" ]
+
+    resultClasses = Css.button <> withWidthAnimation <> [ "w-full", "border-2", "flex", "items-center", "justify-center", "cursor-default" ]
+
+    classes = case status of
+      NotAsked -> Css.button <> Css.bgBlueGradient <> Css.withShadow <> withWidthAnimation <> [ "w-full" ]
+      Loading ->
+        [ "border-4"
+        , "border-gray"
+        , "border-left-green"
+        , "rounded-full"
+        , "cursor-default"
+        , "outline-none"
+        , "focus:outline-none"
+        ]
+          <> withWidthAnimation
+      Success msg -> resultClasses <> [ "border-green", "text-green" ]
+      Failure msg -> resultClasses <> [ "border-red", "text-red" ]
+
+    content = case status of
+      NotAsked -> [ text caption ]
+      Loading -> []
+      Success msg -> [ Icon.icon Icon.TaskAlt [ "font-normal", "mr-2" ], text msg ]
+      Failure msg -> [ text msg ]
+  in
+    div
+      [ classNames $ styles <> [ "flex", "justify-center" ] ]
+      [ button
+          [ classNames classes
+          , ref buttonRef
+          , disabled $ not enabled
+          , onClick \_ -> case status of
+              NotAsked -> Just Submit
+              _ -> Nothing
+          ]
+          content
+      ]

--- a/marlowe-dashboard-client/src/MainFrame/Types.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Types.purs
@@ -22,6 +22,7 @@ import Plutus.PAB.Webserver.Types (CombinedWSStreamToClient)
 import Toast.Types (Action, State) as Toast
 import Tooltip.Types (ReferenceId)
 import WalletData.Types (WalletDetails, WalletLibrary)
+import LoadingSubmitButton.Types as LoadingSubmitButton
 import Web.Socket.Event.CloseEvent (CloseEvent, reason) as WS
 import WebSocket.Support (FromSocket) as WS
 import Welcome.Types (Action, State) as Welcome
@@ -50,6 +51,7 @@ instance showWebSocketStatus :: Show WebSocketStatus where
 ------------------------------------------------------------
 type ChildSlots
   = ( tooltipSlot :: forall query. H.Slot query Void ReferenceId
+    , submitButtonSlot :: H.Slot LoadingSubmitButton.Query LoadingSubmitButton.Message String
     )
 
 ------------------------------------------------------------

--- a/marlowe-dashboard-client/src/Toast/State.purs
+++ b/marlowe-dashboard-client/src/Toast/State.purs
@@ -13,7 +13,7 @@ import Effect.Aff (error)
 import Effect.Aff as Aff
 import Effect.Aff.Class (class MonadAff)
 import Halogen (HalogenM, RefLabel(..), getHTMLElementRef, subscribe, unsubscribe)
-import Halogen.Animation (animateAndWaitUntilFinish)
+import Halogen.Animation (animateAndWaitUntilFinishSubscription)
 import Halogen.Query.EventSource (EventSource)
 import Halogen.Query.EventSource as EventSource
 import Toast.Lenses (_expanded, _mToast, _timeoutSubscription)
@@ -56,4 +56,4 @@ handleAction CloseToast = assign _mToast Nothing
 
 handleAction ToastTimeout = do
   mElement <- getHTMLElementRef (RefLabel "collapsed-toast")
-  for_ mElement $ subscribe <<< animateAndWaitUntilFinish "to-bottom" CloseToast
+  for_ mElement $ subscribe <<< animateAndWaitUntilFinishSubscription "to-bottom" CloseToast

--- a/marlowe-dashboard-client/src/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Welcome/State.purs
@@ -33,7 +33,7 @@ import WalletData.Validation (WalletIdError, WalletNicknameError, WalletNickname
 import Web.HTML (window)
 import Web.HTML.Location (reload)
 import Web.HTML.Window (location)
-import Welcome.Lenses (_card, _cardOpen, _enteringDashboardState, _remoteWalletDetails, _walletLibrary, _walletIdInput, _walletNicknameInput, _walletNicknameOrIdInput)
+import Welcome.Lenses (_card, _cardOpen, _enteringDashboardState, _remoteWalletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput, _walletNicknameOrIdInput)
 import Welcome.Types (Action(..), Card(..), State)
 
 -- see note [dummyState] in MainFrame.State

--- a/marlowe-dashboard-client/static/css/main.css
+++ b/marlowe-dashboard-client/static/css/main.css
@@ -29,3 +29,10 @@ hr {
 .scrollbar-width-none::-webkit-scrollbar {
   display: none;
 }
+
+/* This "utility" is used by the loading submit button. Tailwind does not
+  generate the directional-border utility colors as they would generate a lot
+  of clases, so we manually define the one we use.  */
+.border-left-green {
+  border-left-color: #00a551;
+}

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -62,6 +62,9 @@ module.exports = {
         "from-below": "from-below 250ms ease-out 1",
         "to-bottom": "to-bottom 250ms ease-out 1",
       },
+      transitionProperty: {
+        width: "width"
+      },
       backgroundImage: theme => ({
         "background-shape": "url('/static/images/background-shape.svg')",
         "get-started-thumbnail": "url('/static/images/get-started-thumbnail.jpg')",

--- a/plutus-pab-client/spago-packages.nix
+++ b/plutus-pab-client/spago-packages.nix
@@ -17,6 +17,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "aff-promise" = pkgs.stdenv.mkDerivation {
+        name = "aff-promise";
+        version = "v2.1.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/nwolverson/purescript-aff-promise.git";
+          rev = "033d6b90252e0390b0de7845e21de919bc4c3a0e";
+          sha256 = "0khm53lvxgvc7fbsvcr2h2wlhcgay8vq45755f0w8vpk1441dvww";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "affjax" = pkgs.stdenv.mkDerivation {
         name = "affjax";
         version = "v10.0.0";

--- a/plutus-pab-client/spago.dhall
+++ b/plutus-pab-client/spago.dhall
@@ -6,6 +6,7 @@ You can edit this file as you like.
 , dependencies =
   [ "prelude"
   , "aff"
+  , "aff-promise"
   , "avar"
   , "bigints"
   , "console"

--- a/plutus-playground-client/spago-packages.nix
+++ b/plutus-playground-client/spago-packages.nix
@@ -29,6 +29,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "aff-promise" = pkgs.stdenv.mkDerivation {
+        name = "aff-promise";
+        version = "v2.1.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/nwolverson/purescript-aff-promise.git";
+          rev = "033d6b90252e0390b0de7845e21de919bc4c3a0e";
+          sha256 = "0khm53lvxgvc7fbsvcr2h2wlhcgay8vq45755f0w8vpk1441dvww";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "affjax" = pkgs.stdenv.mkDerivation {
         name = "affjax";
         version = "v10.0.0";

--- a/plutus-playground-client/spago.dhall
+++ b/plutus-playground-client/spago.dhall
@@ -6,6 +6,7 @@ You can edit this file as you like.
 , dependencies =
   [ "prelude"
   , "aff"
+  , "aff-promise"
   , "bigints"
   , "concurrent-queues"
   , "console"

--- a/web-common/src/Halogen/Animation.js
+++ b/web-common/src/Halogen/Animation.js
@@ -15,3 +15,7 @@ exports.getAnimationName = function (animation) {
 exports.setOnFinishHandler_ = function (animation, cb) {
   animation.onfinish = cb;
 };
+
+exports.animationFinished_ = function (animation) {
+  return animation.finished;
+};

--- a/web-common/src/Halogen/Animation.purs
+++ b/web-common/src/Halogen/Animation.purs
@@ -3,9 +3,13 @@
 module Halogen.Animation where
 
 import Prelude
+import Control.Promise (Promise, toAffE)
 import Data.Array (filter)
+import Data.Traversable (traverse)
 import Effect (Effect)
+import Effect.Aff (Aff)
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class (liftEffect)
 import Effect.Uncurried (EffectFn1, EffectFn2, runEffectFn1, runEffectFn2)
 import Halogen.Query.EventSource (EventSource)
 import Halogen.Query.EventSource as EventSource
@@ -21,25 +25,35 @@ foreign import getAnimationName :: CSSAnimation -> String
 
 foreign import setOnFinishHandler_ :: EffectFn2 CSSAnimation (Effect Unit) Unit
 
+foreign import animationFinished_ :: EffectFn1 CSSAnimation (Promise Unit)
+
 getAnimations :: HTMLElement -> Effect (Array CSSAnimation)
 getAnimations = runEffectFn1 getAnimations_
 
+-- The feautre is experimental and is not supported on Internet Explorer.
+-- https://developer.mozilla.org/en-US/docs/Web/API/Animation/onfinish
 setOnFinishHandler :: CSSAnimation -> Effect Unit -> Effect Unit
 setOnFinishHandler = runEffectFn2 setOnFinishHandler_
+
+-- The Animation.finished returns a Promise which resolves once the animation has finished playing.
+-- The feautre is experimental and is not supported on Internet Explorer.
+-- https://developer.mozilla.org/en-US/docs/Web/API/Animation/finished
+animationFinished :: CSSAnimation -> Aff Unit
+animationFinished = toAffE <<< runEffectFn1 animationFinished_
 
 -- This function adds a tailwind animation `animationName` (which can be customized using CSS Animations)
 -- to an element, and calls an `action` once it finished. The only way to call HalogenM from the Effect world
 -- is via the subscriptions mechanism, so you need to subscribe to this EventSource.
 -- You don't need to unsubscribe as the EventSource closes itself after firing the action.
 -- https://tailwindcss.com/docs/animation
-animateAndWaitUntilFinish ::
+animateAndWaitUntilFinishSubscription ::
   forall m action.
   MonadAff m =>
   String ->
   action ->
   HTMLElement ->
   EventSource m action
-animateAndWaitUntilFinish animationName action element =
+animateAndWaitUntilFinishSubscription animationName action element =
   EventSource.effectEventSource \emitter -> do
     let
       className = "animate-" <> animationName
@@ -58,3 +72,30 @@ animateAndWaitUntilFinish animationName action element =
       [ animation ] -> setOnFinishHandler animation cb
       _ -> cb
     pure $ EventSource.Finalizer mempty
+
+-- same as `animateAndWaitUntilFinishSubscription` but works with Aff instead of subscriptions so it allows
+-- to sequence animations.
+animateAndWaitUntilFinish ::
+  String ->
+  HTMLElement ->
+  Aff Unit
+animateAndWaitUntilFinish animationName element = do
+  let
+    className = "animate-" <> animationName
+
+    getAnimations' = liftEffect <<< getAnimations
+  -- Adding the class to the element starts the animation
+  classes <- liftEffect $ classList element
+  liftEffect $ DOMTokenList.add classes className
+  animations <- getAnimations' element <#> filter (\animation -> animationName == getAnimationName animation)
+  -- TODO: Try to use `finally` to make sure the class is removed even if we kill the Aff ("cancel animation")
+  case animations of
+    [ animation ] -> animationFinished animation
+    _ -> pure unit
+  -- We remove the css class so we can redo the animation if necessary
+  liftEffect $ DOMTokenList.remove classes className
+
+waitForAllAnimations :: HTMLElement -> Aff Unit
+waitForAllAnimations element = do
+  animations <- liftEffect $ getAnimations element
+  void $ traverse animationFinished animations


### PR DESCRIPTION
This PR adds a new submit button that has a loading/success/error animation.

![loading-submit2](https://user-images.githubusercontent.com/2634059/125533883-a4fa4afc-92c6-4406-8d78-51e6640ac537.gif)

Deployed to https://hernan.marlowe-dash.iohkdev.io/

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [X] Commits have useful messages
- [ ] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
