### PR TITLE
Increase some waiting times for the uniswap traces

### DIFF
--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -491,7 +491,7 @@ ownerEndpoint = do
     e <- mapError absurd $ runError start
     void $ waitNSlots 1
     tell $ Last $ Just e
-    void $ waitNSlots 1
+    void $ waitNSlots 50
 
 -- | Provides the following endpoints for users of a Uniswap instance:
 --

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/Trace.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/Trace.hs
@@ -78,7 +78,7 @@ setupTokens = do
 
     -- Need to wait one slot or else we will get stuck in an infinite loop
     -- when requesting the contract's observable state.
-    void $ waitNSlots 1
+    void $ waitNSlots 50
 
   where
     amount = 1000000


### PR DESCRIPTION
The emulator can't get the observable states for contract instances that have stopped, that's why we have the waiting actions at the end of some of the uniswap contracts. This PR fixes the problem that `plutus-use-cases-scripts` hangs when it gets to the uniswap examples, by increasing the timeouts.

A better solution would be to change the emulator so that it can answer requests for the observable state even after the instance has finished. I'll add a ticket for that to Jira.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
