### PR TITLE
recip should not produce a number with a negative denominator

### DIFF
--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -189,7 +189,7 @@ x % y = reduce (x P.* signum y) (abs y)
 
 -- | Reciprocal fraction
 recip :: Ratio Integer -> Ratio Integer
-recip (x :% y) = (y :% x)
+recip (x :% y) = ((y P.* signum x) :% abs x)
 
 -- | Convert an 'Interger' to a 'Rational'
 fromInteger :: Integer -> Ratio Integer


### PR DESCRIPTION
recip should not produce a number with a negative denominator because this will mess with the ordering relation, violating the law tested in reciprocal ordering 3, one of the tests added by this commit.