### PR TITLE
Marlowe Playground Client: Fix actus main block type dissapear

### DIFF
--- a/marlowe-playground-client/src/Blockly/Internal.js
+++ b/marlowe-playground-client/src/Blockly/Internal.js
@@ -153,10 +153,7 @@ exports.addBlockType_ = function (blockly, name, block) {
   };
 };
 
-exports.initializeWorkspace_ = function (blockly, workspace) {
-  // QUESTION: Shouldn't we pass the id element as a parameter? this does not
-  // affect having multiple Blockly instances? (currently Actus and BlocklyEditor)
-  var workspaceBlocks = document.getElementById("workspaceBlocks");
+exports.initializeWorkspace_ = function (blockly, workspace, workspaceBlocks) {
   blockly.Xml.domToWorkspace(workspaceBlocks, workspace);
   workspace.getAllBlocks()[0].setDeletable(false);
 };

--- a/marlowe-playground-client/src/Blockly/Types.purs
+++ b/marlowe-playground-client/src/Blockly/Types.purs
@@ -14,6 +14,7 @@ type BlocklyState
   = { blockly :: Blockly
     , workspace :: Workspace
     , rootBlockName :: String
+    , blocksElementId :: String
     }
 
 data BlocklyEvent

--- a/marlowe-playground-client/src/BlocklyComponent/State.purs
+++ b/marlowe-playground-client/src/BlocklyComponent/State.purs
@@ -145,9 +145,9 @@ handleAction (Inject rootBlockName blockDefinitions toolbox) = do
     liftEffect do
       -- TODO: once we refactor ActusBlockly to use BlocklyComponent we should remove ElementId from
       --       createBlocklyInstance and receive two HTMLElements that should be handled by RefElement
-      state <- Blockly.createBlocklyInstance rootBlockName (ElementId "blocklyWorkspace") toolbox
+      state <- Blockly.createBlocklyInstance rootBlockName (ElementId "blocklyWorkspace") (ElementId "workspaceBlocks") toolbox
       Blockly.addBlockTypes state.blockly blockDefinitions
-      Blockly.initializeWorkspace state.blockly state.workspace
+      Blockly.initializeWorkspace state
       pure state
   -- Subscribe to the resize events on the main section to resize blockly automatically.
   for_ mElement $ H.subscribe <<< elementResize ContentBox (const ResizeWorkspace)

--- a/marlowe-playground-client/src/Halogen/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Halogen/ActusBlockly.purs
@@ -142,9 +142,9 @@ handleAction :: forall m. MonadAff m => Action -> DSL m Unit
 handleAction (Inject rootBlockName blockDefinitions toolbox) = do
   blocklyState /\ generator <-
     liftEffect do
-      state <- Blockly.createBlocklyInstance rootBlockName (ElementId "actusBlocklyWorkspace") toolbox
+      state <- Blockly.createBlocklyInstance rootBlockName (ElementId "actusBlocklyWorkspace") (ElementId "actusWorkspaceBlocks") toolbox
       Blockly.addBlockTypes state.blockly blockDefinitions
-      Blockly.initializeWorkspace state.blockly state.workspace
+      Blockly.initializeWorkspace state
       generator <- buildGenerator state.blockly
       pure $ Tuple state generator
   void $ H.subscribe $ blocklyEvents BlocklyEvent blocklyState.workspace

--- a/marlowe-playground-client/src/Marlowe/ActusBlockly.purs
+++ b/marlowe-playground-client/src/Marlowe/ActusBlockly.purs
@@ -520,7 +520,7 @@ toolbox =
 
 workspaceBlocks :: forall a b. HTML a b
 workspaceBlocks =
-  xml [ id_ "actusBlocklyWorkspace", style "display:none" ]
+  xml [ id_ "actusWorkspaceBlocks", style "display:none" ]
     [ block [ blockType (show BaseContractType), x "13", y "187", id_ rootBlockName ] []
     ]
 

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -1441,9 +1441,8 @@ instance blockToTermBound :: BlockToTerm Bound where
 ---------------------------------------------------------------------------------------------------
 buildBlocks :: NewBlockFunction -> BlocklyState -> Term Contract -> Effect Unit
 buildBlocks newBlock bs contract = do
-  workspaceWasEmpty <- isWorkspaceEmpty bs.workspace
   clearWorkspace bs.workspace
-  initializeWorkspace bs.blockly bs.workspace
+  initializeWorkspace bs
   -- Get or create rootBlock
   mRootBlock <- getBlockById bs.workspace bs.rootBlockName
   rootBlock <- case mRootBlock of

--- a/marlowe-playground-client/test/Blockly/Headless.purs
+++ b/marlowe-playground-client/test/Blockly/Headless.purs
@@ -20,7 +20,7 @@ createBlocklyInstance :: String -> Effect BlocklyState
 createBlocklyInstance rootBlockName = do
   blockly <- createBlocklyInstance_
   workspace <- runEffectFn1 createWorkspace_ blockly
-  pure { blockly, workspace, rootBlockName }
+  pure { blockly, workspace, rootBlockName, blocksElementId: "workspaceBlocks" }
 
 newBlock :: Workspace -> String -> Effect Block
 newBlock = runEffectFn2 newBlock_


### PR DESCRIPTION
This PR fixes a problem in the BlocklyActus component were the BaseContract type was not appearing.

The main functionality still needs some work as now we have the following response from the BE

```
ACTUS Term Validation Failed:
    Missing required term: At least one of the conditional terms in group ["cycle anchor date of fee","cycle of fee"] must be defined when fee rate is defined for contract type 'PAM'
    Missing required term: Contract term 'nominal interest rate' is required for contract type 'PAM'
    Missing required term: At least one of the conditional terms in group ["cycle anchor date of scaling index","cycle of scaling index"] must be defined when scaling effect is defined for contract type 'PAM'
    Missing required term: The unconditional terms ["cycle anchor date of rate reset","cycle of rate reset"] must be defined when any of ["next reset rate","rate spread","rate multiplier","period floor","period cap","life cap","life floor"] are defined for contract type 'PAM'

```

<img width="1129" alt="Screen Shot 2021-07-14 at 11 04 08" src="https://user-images.githubusercontent.com/2634059/125635698-3a2dd892-115b-4f65-b867-f1633f61af96.png">

<img width="1127" alt="Screen Shot 2021-07-14 at 11 02 54" src="https://user-images.githubusercontent.com/2634059/125635506-f60cff3a-4c88-4843-90f3-0c2e643d5930.png">

Other related bugs:
* The Edit source in the simulation doesn't seem to be working if it came from Actus.
* If we reload on Actus the contract is not saved.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
