### PR TITLE
SCP-2484: Extend plutus-use-cases-scripts to produce partial txns

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-use-cases.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-use-cases.nix
@@ -123,6 +123,11 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-use-cases.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-use-cases.nix
@@ -123,6 +123,11 @@
             (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
             (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
             (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [

--- a/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
@@ -33,6 +33,9 @@ module Plutus.Contract.CardanoAPI(
   , toCardanoValidityRange
   , toCardanoExtraScriptData
   , toCardanoScriptInEra
+  , toCardanoPaymentKeyHash
+  , toCardanoScriptHash
+  , ToCardanoError(..)
 ) where
 
 import qualified Cardano.Api                 as C

--- a/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
@@ -48,7 +48,7 @@ import qualified Data.ByteString.Lazy        as BSL
 import           Data.ByteString.Short       as BSS
 import qualified Data.Map                    as Map
 import qualified Data.Set                    as Set
-import           Data.Text.Prettyprint.Doc   (Pretty (..))
+import           Data.Text.Prettyprint.Doc   (Pretty (..), colon, (<+>))
 import qualified Ledger                      as P
 import qualified Ledger.Ada                  as Ada
 import qualified Plutus.V1.Ledger.Api        as Api
@@ -112,7 +112,9 @@ fromCardanoTxId :: C.TxId -> P.TxId
 fromCardanoTxId txId = P.TxId $ C.serialiseToRawBytes txId
 
 toCardanoTxId :: P.TxId -> Either ToCardanoError C.TxId
-toCardanoTxId (P.TxId bs) = deserialiseFromRawBytes C.AsTxId bs
+toCardanoTxId (P.TxId bs) =
+    tag "toCardanoTxId"
+    $ deserialiseFromRawBytes C.AsTxId bs
 
 fromCardanoTxInsCollateral :: C.TxInsCollateral era -> Set.Set P.TxIn
 fromCardanoTxInsCollateral C.TxInsCollateralNone       = mempty
@@ -193,13 +195,13 @@ fromCardanoPaymentKeyHash :: C.Hash C.PaymentKey -> P.PubKeyHash
 fromCardanoPaymentKeyHash paymentKeyHash = P.PubKeyHash $ C.serialiseToRawBytes paymentKeyHash
 
 toCardanoPaymentKeyHash :: P.PubKeyHash -> Either ToCardanoError (C.Hash C.PaymentKey)
-toCardanoPaymentKeyHash (P.PubKeyHash bs) = deserialiseFromRawBytes (C.AsHash C.AsPaymentKey) bs
+toCardanoPaymentKeyHash (P.PubKeyHash bs) = tag "toCardanoPaymentKeyHash" $ _ (C.AsHash C.AsPaymentKey) $ _ bs
 
 fromCardanoScriptHash :: C.ScriptHash -> P.ValidatorHash
 fromCardanoScriptHash scriptHash = P.ValidatorHash $ C.serialiseToRawBytes scriptHash
 
 toCardanoScriptHash :: P.ValidatorHash -> Either ToCardanoError C.ScriptHash
-toCardanoScriptHash (P.ValidatorHash bs) = deserialiseFromRawBytes C.AsScriptHash bs
+toCardanoScriptHash (P.ValidatorHash bs) = tag "toCardanoScriptHash" $ deserialiseFromRawBytes C.AsScriptHash bs
 
 fromCardanoStakeAddressReference :: C.StakeAddressReference -> Either FromCardanoError (Maybe Credential.StakingCredential)
 fromCardanoStakeAddressReference C.NoStakeAddress = pure Nothing
@@ -225,7 +227,7 @@ fromCardanoStakeKeyHash :: C.Hash C.StakeKey -> P.PubKeyHash
 fromCardanoStakeKeyHash stakeKeyHash = P.PubKeyHash $ C.serialiseToRawBytes stakeKeyHash
 
 toCardanoStakeKeyHash :: P.PubKeyHash -> Either ToCardanoError (C.Hash C.StakeKey)
-toCardanoStakeKeyHash (P.PubKeyHash bs) = deserialiseFromRawBytes (C.AsHash C.AsStakeKey) bs
+toCardanoStakeKeyHash (P.PubKeyHash bs) = tag "toCardanoStakeKeyHash" $ deserialiseFromRawBytes (C.AsHash C.AsStakeKey) bs
 
 fromCardanoTxOutValue :: C.TxOutValue era -> P.Value
 fromCardanoTxOutValue (C.TxOutAdaOnly _ lovelace) = fromCardanoLovelace lovelace
@@ -240,7 +242,7 @@ fromCardanoTxOutDatumHash (C.TxOutDatumHash _ h) = Just $ P.DatumHash (C.seriali
 
 toCardanoTxOutDatumHash :: Maybe P.DatumHash -> Either ToCardanoError (C.TxOutDatumHash C.AlonzoEra)
 toCardanoTxOutDatumHash Nothing = pure C.TxOutDatumHashNone
-toCardanoTxOutDatumHash (Just (P.DatumHash bs)) = C.TxOutDatumHash C.ScriptDataInAlonzoEra <$> deserialiseFromRawBytes (C.AsHash C.AsScriptData) bs
+toCardanoTxOutDatumHash (Just (P.DatumHash bs)) = C.TxOutDatumHash C.ScriptDataInAlonzoEra <$> tag "toCardanoTxOutDatumHash" (deserialiseFromRawBytes (C.AsHash C.AsScriptData) bs)
 
 fromCardanoMintValue :: C.TxMintValue build era -> P.Value
 fromCardanoMintValue C.TxMintNone              = mempty
@@ -269,7 +271,7 @@ fromCardanoPolicyId :: C.PolicyId -> P.MintingPolicyHash
 fromCardanoPolicyId (C.PolicyId scriptHash) = P.MintingPolicyHash (C.serialiseToRawBytes scriptHash)
 
 toCardanoPolicyId :: P.MintingPolicyHash -> Either ToCardanoError C.PolicyId
-toCardanoPolicyId (P.MintingPolicyHash bs) = C.PolicyId <$> deserialiseFromRawBytes C.AsScriptHash bs
+toCardanoPolicyId (P.MintingPolicyHash bs) = C.PolicyId <$> tag "toCardanoPolicyId" (deserialiseFromRawBytes C.AsScriptHash bs)
 
 fromCardanoAssetName :: C.AssetName -> Value.TokenName
 fromCardanoAssetName (C.AssetName bs) = Value.TokenName bs
@@ -349,7 +351,9 @@ fromCardanoPlutusScript :: C.HasTypeProxy lang => C.PlutusScript lang -> P.Scrip
 fromCardanoPlutusScript = Codec.deserialise . BSL.fromStrict . C.serialiseToRawBytes
 
 toCardanoPlutusScript :: P.Script -> Either ToCardanoError (C.PlutusScript C.PlutusScriptV1)
-toCardanoPlutusScript = deserialiseFromRawBytes (C.AsPlutusScript C.AsPlutusScriptV1) . BSL.toStrict . Codec.serialise
+toCardanoPlutusScript =
+    tag "toCardanoPlutusScript"
+    . deserialiseFromRawBytes (C.AsPlutusScript C.AsPlutusScriptV1) . BSL.toStrict . Codec.serialise
 
 toCardanoExecutionUnits :: P.Script -> [Data.Data] -> Either ToCardanoError C.ExecutionUnits
 toCardanoExecutionUnits script datum = do
@@ -362,6 +366,9 @@ toCardanoExecutionUnits script datum = do
 
 deserialiseFromRawBytes :: C.SerialiseAsRawBytes t => C.AsType t -> ByteString -> Either ToCardanoError t
 deserialiseFromRawBytes asType = maybe (Left DeserialisationError) Right . C.deserialiseFromRawBytes asType
+
+tag :: String -> Either ToCardanoError t -> Either ToCardanoError t
+tag s = first (Tag s)
 
 data FromCardanoError
     = SimpleScriptsNotSupported
@@ -382,6 +389,7 @@ data ToCardanoError
     | NoDefaultCostModelParams
     | StakingPointersNotSupported
     | MissingTxInType
+    | Tag String ToCardanoError
 
 instance Pretty ToCardanoError where
     pretty (EvaluationError err)       = pretty err
@@ -392,3 +400,4 @@ instance Pretty ToCardanoError where
     pretty NoDefaultCostModelParams    = "Extracting default cost model failed"
     pretty StakingPointersNotSupported = "Staking pointers are not supported"
     pretty MissingTxInType             = "Missing TxInType"
+    pretty (Tag t err)                 = pretty t <> colon <+> pretty err

--- a/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
@@ -195,7 +195,7 @@ fromCardanoPaymentKeyHash :: C.Hash C.PaymentKey -> P.PubKeyHash
 fromCardanoPaymentKeyHash paymentKeyHash = P.PubKeyHash $ C.serialiseToRawBytes paymentKeyHash
 
 toCardanoPaymentKeyHash :: P.PubKeyHash -> Either ToCardanoError (C.Hash C.PaymentKey)
-toCardanoPaymentKeyHash (P.PubKeyHash bs) = tag "toCardanoPaymentKeyHash" $ _ (C.AsHash C.AsPaymentKey) $ _ bs
+toCardanoPaymentKeyHash (P.PubKeyHash bs) = tag "toCardanoPaymentKeyHash" $ deserialiseFromRawBytes (C.AsHash C.AsPaymentKey) bs
 
 fromCardanoScriptHash :: C.ScriptHash -> P.ValidatorHash
 fromCardanoScriptHash scriptHash = P.ValidatorHash $ C.serialiseToRawBytes scriptHash

--- a/plutus-contract/src/Wallet/Emulator/LogMessages.hs
+++ b/plutus-contract/src/Wallet/Emulator/LogMessages.hs
@@ -9,6 +9,7 @@ module Wallet.Emulator.LogMessages(
   RequestHandlerLogMsg(..)
   , TxBalanceMsg(..)
   , _ValidationFailed
+  , _BalancingUnbalancedTx
   ) where
 
 import           Control.Lens.TH             (makePrisms)

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -219,7 +219,12 @@ executable plutus-use-cases-scripts
         plutus-tx -any,
         plutus-contract -any,
         plutus-ledger -any,
-        plutus-use-cases -any
+        plutus-use-cases -any,
+        optparse-applicative -any,
+        aeson-pretty -any,
+        cardano-api -any,
+        cardano-binary -any,
+        cborg -any
 
     if !(impl(ghcjs) || os(ghcjs))
         build-depends: plutus-tx-plugin -any

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -1,24 +1,42 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeFamilies       #-}
 module Main(main) where
 
+import qualified Cardano.Api                    as C
+import qualified Cardano.Binary                 as Binary
 import qualified Control.Foldl                  as L
+import           Control.Monad                  (when)
 import           Control.Monad.Freer            (run)
+import qualified Data.Aeson                     as Aeson
+import           Data.Aeson.Encode.Pretty       (encodePretty)
+import           Data.Bitraversable             (bitraverse)
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Default                   (Default (..))
 import           Data.Foldable                  (traverse_)
+import           Data.Map                       (Map)
+import qualified Data.Map                       as Map
+import           Data.Proxy                     (Proxy (..))
+import           Data.Set                       (Set)
+import qualified Data.Set                       as Set
+import           Data.Text.Prettyprint.Doc      (Pretty (..))
+import           Data.Typeable                  (Typeable)
 import           Flat                           (flat)
+import           GHC.Generics                   (Generic)
+import qualified Ledger                         as Plutus
+import           Ledger.Constraints.OffChain    (UnbalancedTx (..))
 import           Ledger.Index                   (ScriptValidationEvent (sveScript))
+import           Options.Applicative
+import qualified Plutus.Contract.CardanoAPI     as CardanoAPI
+import qualified Plutus.Contracts.Crowdfunding  as Crowdfunding
+import qualified Plutus.Contracts.Uniswap.Trace as Uniswap
 import           Plutus.Trace.Emulator          (EmulatorConfig, EmulatorTrace)
 import qualified Plutus.Trace.Emulator          as Trace
 import           Plutus.V1.Ledger.Scripts       (Script (..))
-import qualified Streaming.Prelude              as S
-import           System.Directory               (createDirectoryIfMissing)
-import           System.Environment             (getArgs)
-import           System.FilePath                ((</>))
-import qualified Wallet.Emulator.Folds          as Folds
-import           Wallet.Emulator.Stream         (foldEmulatorStreamM)
-
-import qualified Plutus.Contracts.Crowdfunding  as Crowdfunding
-import qualified Plutus.Contracts.Uniswap.Trace as Uniswap
 import qualified Spec.Auction                   as Auction
 import qualified Spec.Currency                  as Currency
 import qualified Spec.Escrow                    as Escrow
@@ -32,21 +50,46 @@ import qualified Spec.PubKey                    as PubKey
 import qualified Spec.Stablecoin                as Stablecoin
 import qualified Spec.TokenAccount              as TokenAccount
 import qualified Spec.Vesting                   as Vesting
+import qualified Streaming.Prelude              as S
+import           System.Directory               (createDirectoryIfMissing)
+import           System.FilePath                ((</>))
+import qualified Wallet.Emulator.Folds          as Folds
+import           Wallet.Emulator.Stream         (foldEmulatorStreamM)
+
+data Mode = Scripts | Transactions | Both
+    deriving stock (Read, Show, Eq)
+
+instance Ord Mode where
+    x <= y = x == y || y == Both
+
+writeWhat :: Mode -> String
+writeWhat Scripts      = "scripts"
+writeWhat Both         = "scripts and partial transactions"
+writeWhat Transactions = "partial transactions"
+
+pathParser :: Parser FilePath
+pathParser = strArgument (metavar "SCRIPT_PATH" <> help "output path")
+
+modeParser :: Parser Mode
+modeParser = option auto (long "mode" <> showDefault <> value Scripts)
+
+progParser :: ParserInfo (FilePath, Mode)
+progParser =
+    let p = (,) <$> pathParser <*> modeParser
+    in info
+        (p <**> helper)
+        (fullDesc
+        <> progDesc "Run a number of emulator traces and write all validator scripts and/or partial transactions to SCRIPT_PATH"
+        <> header "plutus-use-cases-scripts - extract applied validators and partial transactions from emulator traces"
+        )
 
 main :: IO ()
-main = do
-    args <- getArgs
-    case args of
-        [script_path] -> writeScripts script_path
-        _             -> traverse_ putStrLn [
-            "usage: plutus-use-cases-scripts SCRIPT_PATH",
-            "Run a number of emulator traces and write all fully applied validator scripts to SCRIPT_PATH"
-            ]
+main = execParser progParser >>= uncurry writeScripts
 
-writeScripts :: FilePath -> IO ()
-writeScripts fp = do
-    putStrLn $ "Writing scripts to: " <> fp
-    traverse_ (uncurry3 (writeScriptsTo fp))
+writeScripts :: FilePath -> Mode -> IO ()
+writeScripts fp mode = do
+    putStrLn $ "Writing " <> writeWhat mode <> " to: " <> fp
+    traverse_ (uncurry3 (writeScriptsTo mode fp))
         [ ("auction_1", Auction.auctionTrace1, Auction.auctionEmulatorCfg)
         , ("auction_2", Auction.auctionTrace2, Auction.auctionEmulatorCfg)
         , ("crowdfunding-success", Crowdfunding.successfulCampaign, def)
@@ -74,31 +117,99 @@ writeScripts fp = do
         ]
 
 {-| Run an emulator trace and write the applied scripts to a file in Flat format
-    using the name as a prefix.  There's an instance of Codec.Serialise for
+    using the name as a prefix.
+-}
+writeScriptsTo
+    :: Mode
+    -> FilePath
+    -> String
+    -> EmulatorTrace a
+    -> EmulatorConfig
+    -> IO ()
+writeScriptsTo mode fp prefix trace emulatorCfg = do
+    let (scriptEvents, balanceEvents) =
+            S.fst'
+            $ run
+            $ foldEmulatorStreamM (L.generalize theFold)
+            $ Trace.runEmulatorStream emulatorCfg def trace
+
+    createDirectoryIfMissing True fp
+    when (Scripts <= mode) $
+        traverse_ (uncurry $ writeScript fp prefix) (zip [1::Int ..] (sveScript <$> scriptEvents))
+    when (Transactions <= mode) $
+        traverse_ (uncurry $ writeTransaction fp prefix) (zip [1::Int ..] balanceEvents)
+
+{- There's an instance of Codec.Serialise for
     Script in Scripts.hs (see Note [Using Flat inside CBOR instance of Script]),
     which wraps Flat-encoded bytestings in CBOR, but that's not used here: we
     just use unwrapped Flat because that's more convenient for use with the
     `plc` command, for example.
 -}
-writeScriptsTo
-    :: FilePath
-    -> String
-    -> EmulatorTrace a
-    -> EmulatorConfig
-    -> IO ()
-writeScriptsTo fp prefix trace emulatorCfg = do
-    let events =
-            S.fst'
-            $ run
-            $ foldEmulatorStreamM (L.generalize Folds.scriptEvents)
-            $ Trace.runEmulatorStream emulatorCfg def trace
-        writeScript idx script = do
-            let filename = fp </> prefix <> "-" <> show idx <> ".flat"
-            putStrLn $ "Writing script: " <> filename
-            BSL.writeFile filename (BSL.fromStrict . flat . unScript $ script)
-    createDirectoryIfMissing True fp
-    traverse_ (uncurry writeScript) (zip [1::Int ..] (sveScript <$> events))
+writeScript :: FilePath -> String -> Int -> Script -> IO ()
+writeScript fp prefix idx script = do
+    let filename = fp </> prefix <> "-" <> show idx <> ".flat"
+    putStrLn $ "Writing script: " <> filename
+    BSL.writeFile filename (BSL.fromStrict . flat . unScript $ script)
+
+writeTransaction :: FilePath -> String -> Int -> UnbalancedTx -> IO ()
+writeTransaction fp prefix idx tx = do
+    let filename1 = fp </> prefix <> "-" <> show idx <> ".json"
+    putStrLn $ "Writing partial transaction JSON: " <> filename1
+    BSL.writeFile filename1 (encodePretty tx)
+    case export tx of
+        Left err -> putStrLn $ "Export tx failed for " <> filename1 <> ". Reason: " <> show (pretty err)
+        Right exportTx -> do
+            let filename2 = fp </> prefix <> "-" <> show idx <> ".cbor"
+            putStrLn $ "Writing partial transaction CBOR: " <> filename2
+            BSL.writeFile filename2 $ BSL.fromStrict (Binary.serialize' exportTx)
 
 -- | `uncurry3` converts a curried function to a function on triples.
 uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
 uncurry3 f (a, b, c) = f a b c
+
+theFold :: Folds.EmulatorEventFold ([ScriptValidationEvent], [UnbalancedTx])
+theFold = (,) <$> Folds.scriptEvents <*> Folds.walletTxBalanceEvents
+
+-- | Partial transaction that can be balanced by the wallet backend.
+data ExportTx =
+        ExportTx
+            { partialTx   :: C.Tx C.AlonzoEra -- ^ The transaction itself
+            , lookups     :: [(C.TxIn, C.TxOut C.AlonzoEra)] -- ^ The tx outputs for all inputs spent by the partial tx
+            , signatories :: [C.Hash C.PaymentKey] -- ^ Key(s) that we expect to be used for balancing & signing. (Advisory)
+            }
+    deriving stock (Generic, Typeable)
+
+instance Binary.ToCBOR ExportTx where
+    toCBOR ExportTx{partialTx, lookups, signatories} =
+        Binary.toCBOR
+            -- This is the best I could do, the types in Cardano.API all seem to have different serialisation
+            -- formats (ToCBOR, SerialiseAsCBOR, ToJSON)
+            ( C.serialiseToCBOR partialTx
+            , Aeson.encode lookups -- TODO: Missing CBOR instance(s) for TxOut AlonzoEra :(
+            , Binary.serialize' signatories
+            )
+
+    encodedSizeExpr size _ =
+        Binary.encodedSizeExpr
+            size
+            (Proxy @(Binary.LengthOf BSL.ByteString, Binary.LengthOf BSL.ByteString, Binary.LengthOf BSL.ByteString))
+
+instance C.HasTypeProxy ExportTx where
+    data AsType ExportTx = AsExportTx
+    proxyToAsType _ = AsExportTx
+
+export :: UnbalancedTx -> Either CardanoAPI.ToCardanoError ExportTx
+export UnbalancedTx{unBalancedTxTx, unBalancedTxUtxoIndex, unBalancedTxRequiredSignatories} =
+    ExportTx
+        <$> mkTx unBalancedTxTx
+        <*> mkLookups unBalancedTxUtxoIndex
+        <*> mkSignatories unBalancedTxRequiredSignatories
+
+mkTx :: Plutus.Tx -> Either CardanoAPI.ToCardanoError (C.Tx C.AlonzoEra)
+mkTx = fmap (C.makeSignedTransaction []) . CardanoAPI.toCardanoTxBody
+
+mkLookups :: Map Plutus.TxOutRef Plutus.TxOut -> Either CardanoAPI.ToCardanoError [(C.TxIn, C.TxOut C.AlonzoEra)]
+mkLookups = traverse (bitraverse CardanoAPI.toCardanoTxIn CardanoAPI.toCardanoTxOut) . Map.toList
+
+mkSignatories :: Set Plutus.PubKeyHash -> Either CardanoAPI.ToCardanoError [C.Hash C.PaymentKey]
+mkSignatories = traverse CardanoAPI.toCardanoPaymentKeyHash . Set.toList


### PR DESCRIPTION
* Extend the `plutus-use-cases-scripts` program to also print out some partial transactions (if desired)
* The partial transactions are produced in two different formats: JSON (from our `UnbalancedTx` type) and CBOR (using a new `ExportTx` type).
* The CBOR serialisation isn't working yet. One reason is that address hashes in the emulator are 32 bytes, but in the network they are 28 bytes
* Sorting this out should be done in a separate PR.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
