### PR TITLE
Fix findConsumptionPoint for inputs with same txid

### DIFF
--- a/web-common-plutus/src/Chain/Types.purs
+++ b/web-common-plutus/src/Chain/Types.purs
@@ -5,7 +5,7 @@ import Clipboard (Action) as Clipboard
 import Data.BigInteger (BigInteger)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Lens (Fold', Iso', Lens', Prism', Traversal', filtered, preview, prism', traversed)
+import Data.Lens (Fold', Iso', Lens', Prism', Traversal', anyOf, filtered, preview, prism', traversed)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Map (Map)
@@ -141,7 +141,7 @@ findConsumptionPoint :: BigInteger -> TxId -> AnnotatedBlockchain -> Maybe Annot
 findConsumptionPoint outputIndex txId = preview (_AnnotatedBlocks <<< filtered isMatchingTx)
   where
   isMatchingTx :: AnnotatedTx -> Boolean
-  isMatchingTx tx = preview (_tx <<< _txInputs <<< traversed <<< _txInRef) tx == Just txOutRef
+  isMatchingTx tx = anyOf (_tx <<< _txInputs <<< traversed <<< _txInRef) ((==) txOutRef) tx
 
   txOutRef :: TxOutRef
   txOutRef =


### PR DESCRIPTION
but different output index.

Fixes #3487

The issue was that inputs with different output index but same txid were wrongly being marked as unspent given that the check was only comparing against the first matching txid regardless of output index. This pr fixes this.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
