### PR TITLE
SCP-2092: Implement new design of contract cards.

### DIFF
--- a/marlowe-dashboard-client/src/Bridge.purs
+++ b/marlowe-dashboard-client/src/Bridge.purs
@@ -8,7 +8,7 @@ module Bridge
 import Prelude
 import Cardano.Wallet.Types (WalletInfo(..)) as Back
 import Data.Bifunctor (bimap)
-import Data.BigInteger (BigInteger, fromInt)
+import Data.BigInteger (BigInteger)
 import Data.Either (Either)
 import Data.Json.JsonTuple (JsonTuple(..))
 import Data.Json.JsonUUID (JsonUUID(..))
@@ -85,17 +85,9 @@ instance mapBridge :: (Ord a, Ord c, Bridge a c, Bridge b d) => Bridge (Back.Map
   toFront map = Front.fromFoldable $ toFront <$> Back.toTuples map
   toBack map = Back.fromTuples $ toBack <$> Front.toUnfoldable map
 
--- The PAB has replaced slot numbers with posix timestamps, but still gives us slot numbers through
--- the websocket. However, these are now all multiplied by 1000 and increment by 1000 every second
--- (so apparently the slot conversion represents things in milliseconds). This breaks the frontend,
--- which expects slot numbers to be incremented by 1 each second. The simplest fix for now is to
--- divide by 1000 on the the way in, and multiply back by 1000 on the way out. But note that this
--- conversion is not currently applied to Marlowe contracts, so the backend will also need to do
--- some slot-to-posix conversion (either in the Marlowe contracts or the PAB itself) - something
--- for @nau to sort out.
 instance slotBridge :: Bridge Back.Slot Front.Slot where
-  toFront slot@(Back.Slot { getSlot }) = Front.Slot $ getSlot / (fromInt 1000)
-  toBack (Front.Slot slot) = Back.Slot { getSlot: slot * (fromInt 1000) }
+  toFront slot@(Back.Slot { getSlot }) = Front.Slot getSlot
+  toBack (Front.Slot slot) = Back.Slot { getSlot: slot }
 
 instance bigIntegerBridge :: Bridge BigInteger BigInteger where
   toFront = identity

--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -5,7 +5,6 @@ module Contract.Lenses
   , _pendingTransaction
   , _previousSteps
   , _mMarloweParams
-  , _followerAppId
   , _selectedStep
   , _metadata
   , _participants
@@ -23,7 +22,7 @@ import Data.Symbol (SProxy(..))
 import Marlowe.Execution.Types (NamedAction)
 import Marlowe.Execution.Types (State) as Execution
 import Marlowe.Extended.Metadata (MetaData)
-import Marlowe.PAB (PlutusAppId, MarloweParams)
+import Marlowe.PAB (MarloweParams)
 import Marlowe.Semantics (Party, TransactionInput)
 import WalletData.Types (WalletNickname)
 
@@ -44,9 +43,6 @@ _previousSteps = prop (SProxy :: SProxy "previousSteps")
 
 _mMarloweParams :: Lens' State (Maybe MarloweParams)
 _mMarloweParams = prop (SProxy :: SProxy "mMarloweParams")
-
-_followerAppId :: Lens' State PlutusAppId
-_followerAppId = prop (SProxy :: SProxy "followerAppId")
 
 _selectedStep :: Lens' State Int
 _selectedStep = prop (SProxy :: SProxy "selectedStep")

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -9,7 +9,6 @@ module Contract.Types
   ) where
 
 import Prelude
-
 import Analytics (class IsEvent, defaultEvent)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -9,6 +9,7 @@ module Contract.Types
   ) where
 
 import Prelude
+
 import Analytics (class IsEvent, defaultEvent)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))
@@ -17,7 +18,7 @@ import Halogen (RefLabel(..))
 import Marlowe.Execution.Types (NamedAction)
 import Marlowe.Execution.Types (State) as Execution
 import Marlowe.Extended.Metadata (MetaData)
-import Marlowe.PAB (PlutusAppId, MarloweParams)
+import Marlowe.PAB (MarloweParams, PlutusAppId)
 import Marlowe.Semantics (ChoiceId, ChosenNum, Party, Slot, TransactionInput, Accounts)
 import WalletData.Types (WalletDetails, WalletNickname)
 
@@ -29,7 +30,6 @@ type State
     -- can advance the contract. This enables us to show immediate feedback to the user while we wait.
     , pendingTransaction :: Maybe TransactionInput
     , previousSteps :: Array PreviousStep
-    , followerAppId :: PlutusAppId
     -- Every contract needs MarloweParams, but this is a Maybe because we want to create "placeholder"
     -- contracts when a user creates a contract, to show on the page until the blockchain settles and
     -- we get the MarloweParams back from the PAB (through the MarloweFollower app).
@@ -66,10 +66,12 @@ derive instance eqTab :: Eq Tab
 type Input
   = { currentSlot :: Slot
     , walletDetails :: WalletDetails
+    , followerAppId :: PlutusAppId
     }
 
 data Action
-  = SetNickname String
+  = SelectSelf
+  | SetNickname String
   | ConfirmAction NamedAction
   | ChangeChoice ChoiceId (Maybe ChosenNum)
   | SelectTab Int Tab
@@ -83,6 +85,7 @@ data Action
   | CarouselClosed
 
 instance actionIsEvent :: IsEvent Action where
+  toEvent SelectSelf = Nothing
   toEvent (ConfirmAction _) = Just $ defaultEvent "ConfirmAction"
   toEvent (SetNickname _) = Just $ defaultEvent "SetNickname"
   toEvent (ChangeChoice _ _) = Just $ defaultEvent "ChangeChoice"

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -1,6 +1,6 @@
 module Contract.View
-  ( contractInnerBox
-  , contractDetailsCard
+  ( contractCard
+  , contractScreen
   , actionConfirmationCard
   ) where
 
@@ -32,7 +32,7 @@ import Halogen.Extra (lifeCycleEvent)
 import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, sup_, text)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
 import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
-import Humanize (formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
+import Humanize (contractIcon, formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
 import LoadingSubmitButton.State (loadingSubmitButton)
 import LoadingSubmitButton.Types (Message(..))
 import MainFrame.Types (ChildSlots)
@@ -40,16 +40,62 @@ import Marlowe.Execution.Lenses (_semanticState, _mNextTimeout)
 import Marlowe.Execution.State (expandBalances, getActionParticipant)
 import Marlowe.Execution.Types (NamedAction(..))
 import Marlowe.Extended (contractTypeName)
+import Marlowe.Extended.Metadata (_contractType)
 import Marlowe.PAB (transactionFee)
 import Marlowe.Semantics (Accounts, Assets, Bound(..), ChoiceId(..), Input(..), Party(..), Slot, SlotInterval, Token, TransactionInput(..), getEncompassBound)
 import Marlowe.Slot (secondsDiff, slotToDateTime)
-import Material.Icons (Icon(..), icon)
+import Material.Icons (Icon(..)) as Icon
+import Material.Icons (Icon, icon)
 import WalletData.State (adaToken, getAda)
 
--- I'm moving this view here so that we can easily call Contract.Actions from inside it. I'm not
--- actually calling any Contract.Actions from here yet, but that's a TODO for the next PR...
-contractInnerBox :: forall p. Slot -> State -> HTML p Action
-contractInnerBox currentSlot state =
+contractCard :: forall p. Slot -> State -> HTML p Action
+contractCard currentSlot state =
+  let
+    currentStepNumber = (currentStep state) + 1
+
+    nickname = state ^. _nickname
+
+    contractType = state ^. (_metadata <<< _contractType)
+  in
+    div
+      [ classNames [ "shadow", "bg-white", "rounded" ] ]
+      [ div
+          [ classNames [ "flex", "gap-2", "px-4", "py-2", "border-gray", "border-b" ] ]
+          [ div
+              [ classNames [ "flex-1" ] ]
+              [ h3
+                  [ classNames [ "flex", "gap-2", "items-center" ] ]
+                  [ contractIcon contractType
+                  , text $ contractTypeName contractType
+                  ]
+              , input
+                  [ classNames [ "text-lg" ]
+                  , type_ InputText
+                  , value nickname
+                  , onValueInput_ SetNickname
+                  , placeholder "Please rename"
+                  ]
+              ]
+          , a
+              [ classNames [ "flex", "items-center" ]
+              , onClick_ SelectSelf
+              ]
+              [ icon Icon.ArrowRight [ "text-28px" ] ]
+          ]
+      , div
+          [ classNames [ "px-4", "py-2", "border-gray", "border-b" ] ]
+          [ p
+              [ classNames [ "text-sm", "font-semibold" ] ]
+              [ text $ "Current step:" <> show currentStepNumber ]
+          , p
+              [ classNames [ "font-semibold" ] ]
+              [ text "time left..." ]
+          ]
+      , contractCardInner currentSlot state
+      ]
+
+contractCardInner :: forall p. Slot -> State -> HTML p Action
+contractCardInner currentSlot state =
   let
     nickname = state ^. _nickname
 
@@ -84,8 +130,8 @@ contractInnerBox currentSlot state =
 -- big container and create a smaller absolute positioned element of the size of a card (positioned in the middle), and with JS check that if a card enters
 -- that "viewport", then we make that the selected element.
 -- Current implementation just hides non active elements in mobile and makes a simple x-scrolling for larger devices.
-contractDetailsCard :: forall p. Slot -> State -> HTML p Action
-contractDetailsCard currentSlot state =
+contractScreen :: forall p. Slot -> State -> HTML p Action
+contractScreen currentSlot state =
   let
     nickname = state ^. _nickname
 
@@ -140,7 +186,7 @@ cardNavigationButtons state =
               [ classNames [ "text-purple" ]
               , onClick_ $ MoveToStep $ selectedStep - 1
               ]
-              [ icon ArrowLeft [ "text-2xl", "py-4" ] ]
+              [ icon Icon.ArrowLeft [ "text-2xl", "py-4" ] ]
       | otherwise = Nothing
 
     rightButton selectedStep
@@ -153,7 +199,7 @@ cardNavigationButtons state =
       | otherwise =
         Just
           $ button
-              [ classNames $ Css.primaryButton <> [ "ml-auto" ] <> Css.withIcon ArrowRight
+              [ classNames $ Css.primaryButton <> [ "ml-auto" ] <> Css.withIcon Icon.ArrowRight
               , onClick_ $ MoveToStep $ selectedStep + 1
               ]
               [ text "Next" ]
@@ -271,7 +317,7 @@ actionConfirmationCard assets namedAction state =
                       , target "_blank"
                       ]
                       [ text "Read more in Docs" ]
-                  , icon ArrowRight [ "text-2xl" ]
+                  , icon Icon.ArrowRight [ "text-2xl" ]
                   ]
               ]
           ]
@@ -342,8 +388,8 @@ renderPastStep state stepNumber step =
               [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
               [ text $ "Step " <> show (stepNumber + 1) ]
           , case step.state of
-              TimeoutStep _ -> statusIndicator (Just Timer) "Timed out" [ "bg-red", "text-white" ]
-              TransactionStep _ -> statusIndicator (Just Done) "Completed" [ "bg-green", "text-white" ]
+              TimeoutStep _ -> statusIndicator (Just Icon.Timer) "Timed out" [ "bg-red", "text-white" ]
+              TransactionStep _ -> statusIndicator (Just Icon.Done) "Completed" [ "bg-green", "text-white" ]
           ]
       , div [ classNames [ "overflow-y-auto", "px-4" ] ]
           [ renderBody currentTab step
@@ -439,7 +485,7 @@ renderTimeout stepNumber timeoutSlot =
     div [ classNames [ "flex", "flex-col", "items-center" ] ]
       -- NOTE: we use pt-16 instead of making the parent justify-center because in the design it's not actually
       --       centered and it has more space above than below.
-      [ icon Timer [ "pb-2", "pt-16", "text-red", "text-big-icon" ]
+      [ icon Icon.Timer [ "pb-2", "pt-16", "text-red", "text-big-icon" ]
       , span [ classNames [ "font-semibold", "text-center", "text-sm" ] ]
           [ text $ "Step " <> show (stepNumber + 1) <> " timed out on " <> timedOutDate ]
       ]
@@ -476,7 +522,7 @@ renderCurrentStep currentSlot state =
           , case contractIsClosed, isJust pendingTransaction of
               true, _ -> statusIndicator Nothing "Contract closed" [ "bg-lightgray" ]
               _, true -> statusIndicator Nothing "Awaiting confirmation" [ "bg-lightgray" ]
-              _, _ -> statusIndicator (Just Timer) timeoutStr [ "bg-lightgray" ]
+              _, _ -> statusIndicator (Just Icon.Timer) timeoutStr [ "bg-lightgray" ]
           ]
       , div [ classNames [ "overflow-y-auto", "px-4" ] ]
           [ case currentTab, contractIsClosed, isJust pendingTransaction of
@@ -492,7 +538,7 @@ renderContractClose =
   div [ classNames [ "flex", "flex-col", "items-center" ] ]
     -- NOTE: we use pt-16 instead of making the parent justify-center because in the design it's not actually
     --       centered and it has more space above than below.
-    [ icon TaskAlt [ "pb-2", "pt-16", "text-green", "text-big-icon" ]
+    [ icon Icon.TaskAlt [ "pb-2", "pt-16", "text-green", "text-big-icon" ]
     , div
         [ classNames [ "text-center", "text-sm" ] ]
         [ div [ classNames [ "font-semibold" ] ]

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -5,7 +5,7 @@ module Contract.View
   ) where
 
 import Prelude hiding (div)
-import Contract.Lenses (_executionState, _mMarloweParams, _metadata, _namedActions, _nickname, _participants, _pendingTransaction, _previousSteps, _selectedStep, _tab, _userParties)
+import Contract.Lenses (_executionState, _metadata, _namedActions, _nickname, _participants, _pendingTransaction, _previousSteps, _selectedStep, _tab, _userParties)
 import Contract.State (currentStep, isContractClosed)
 import Contract.Types (Action(..), PreviousStep, PreviousStepState(..), State, Tab(..), scrollContainerRef)
 import Css as Css
@@ -21,7 +21,7 @@ import Data.Map (keys, lookup, toUnfoldable) as Map
 import Data.Maybe (Maybe(..), isJust, maybe, maybe')
 import Data.Set (Set)
 import Data.Set as Set
-import Data.String (null, take, trim)
+import Data.String (take, trim)
 import Data.String.Extra (capitalize)
 import Data.Tuple (Tuple(..), fst, uncurry)
 import Data.Tuple.Nested ((/\))
@@ -69,7 +69,7 @@ contractCard currentSlot state =
                   , text $ contractTypeName contractType
                   ]
               , input
-                  [ classNames [ "text-lg" ]
+                  [ classNames $ Css.inputNoBorder <> [ "-ml-2", "text-lg" ]
                   , type_ InputText
                   , value nickname
                   , onValueInput_ SetNickname
@@ -89,41 +89,22 @@ contractCard currentSlot state =
               [ text $ "Current step:" <> show currentStepNumber ]
           , p
               [ classNames [ "font-semibold" ] ]
-              [ text "time left..." ]
+              [ text $ timeoutString currentSlot state ]
           ]
-      , contractCardInner currentSlot state
-      ]
-
-contractCardInner :: forall p. Slot -> State -> HTML p Action
-contractCardInner currentSlot state =
-  let
-    nickname = state ^. _nickname
-
-    mMarloweParams = state ^. _mMarloweParams
-
-    stepNumber = currentStep state + 1
-
-    mNextTimeout = state ^. (_executionState <<< _mNextTimeout)
-
-    timeoutStr =
-      maybe'
-        (\_ -> if isContractClosed state then "Contract closed" else "Timed out")
-        (\nextTimeout -> humanizeDuration $ secondsDiff nextTimeout currentSlot)
-        mNextTimeout
-  in
-    div_
-      [ div
-          [ classNames [ "flex-1", "px-4", "py-2", "text-lg" ] ]
-          -- TODO: make (new) nicknames editable directly from here
-          [ text if null nickname then "My new contract" else nickname ]
       , div
-          [ classNames [ "bg-lightgray", "flex", "flex-col", "px-4", "py-2" ] ] case mMarloweParams of
-          Nothing -> [ text "pending confirmation" ]
-          _ ->
-            [ span [ classNames [ "text-xs", "font-semibold" ] ] [ text $ "Step " <> show stepNumber <> ":" ]
-            , span [ classNames [ "text-xl" ] ] [ text timeoutStr ]
-            ]
+          [ classNames [ "h-dashboard-card-actions", "overflow-y-auto" ] ]
+          [ currentStepActions currentSlot state ]
       ]
+
+timeoutString :: Slot -> State -> String
+timeoutString currentSlot state =
+  let
+    mNextTimeout = state ^. (_executionState <<< _mNextTimeout)
+  in
+    maybe'
+      (\_ -> if isContractClosed state then "Contract closed" else "Timed out")
+      (\nextTimeout -> humanizeDuration $ secondsDiff nextTimeout currentSlot)
+      mNextTimeout
 
 -- NOTE: Currently, the horizontal scrolling for this element does not match the exact desing. In the designs, the active card is always centered and you
 -- can change which card is active via scrolling or the navigation buttons. To implement this we would probably need to add snap scrolling to the center of the
@@ -502,17 +483,6 @@ renderCurrentStep currentSlot state =
     contractIsClosed = isContractClosed state
 
     mNextTimeout = state ^. (_executionState <<< _mNextTimeout)
-
-    participants = state ^. _participants
-
-    semanticState = state ^. (_executionState <<< _semanticState)
-
-    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] semanticState
-
-    timeoutStr =
-      maybe "timed out"
-        (\nextTimeout -> humanizeDuration $ secondsDiff nextTimeout currentSlot)
-        mNextTimeout
   in
     renderContractCard stepNumber state currentTab
       [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
@@ -522,25 +492,41 @@ renderCurrentStep currentSlot state =
           , case contractIsClosed, isJust pendingTransaction of
               true, _ -> statusIndicator Nothing "Contract closed" [ "bg-lightgray" ]
               _, true -> statusIndicator Nothing "Awaiting confirmation" [ "bg-lightgray" ]
-              _, _ -> statusIndicator (Just Icon.Timer) timeoutStr [ "bg-lightgray" ]
+              _, _ -> statusIndicator (Just Icon.Timer) (timeoutString currentSlot state) [ "bg-lightgray" ]
           ]
-      , div [ classNames [ "overflow-y-auto", "px-4" ] ]
-          [ case currentTab, contractIsClosed, isJust pendingTransaction of
-              Tasks, true, _ -> renderContractClose
-              Tasks, _, true -> renderPendingStep
-              Tasks, _, _ -> renderTasks state
-              Balances, _, _ -> renderBalances state balances
-          ]
+      , div
+          [ classNames [ "overflow-y-auto" ] ]
+          [ currentStepActions currentSlot state ]
       ]
+
+currentStepActions :: forall p. Slot -> State -> HTML p Action
+currentStepActions currentSlot state =
+  let
+    currentTab = state ^. _tab
+
+    pendingTransaction = state ^. _pendingTransaction
+
+    participants = state ^. _participants
+
+    semanticState = state ^. (_executionState <<< _semanticState)
+
+    balances = expandBalances (Set.toUnfoldable $ Map.keys participants) [ adaToken ] semanticState
+  in
+    case currentTab, isContractClosed state, isJust pendingTransaction of
+      Tasks, true, _ -> renderContractClose
+      Tasks, _, true -> renderPendingStep
+      Tasks, _, _ -> renderTasks state
+      Balances, _, _ -> renderBalances state balances
 
 renderContractClose :: forall p a. HTML p a
 renderContractClose =
-  div [ classNames [ "flex", "flex-col", "items-center" ] ]
-    -- NOTE: we use pt-16 instead of making the parent justify-center because in the design it's not actually
-    --       centered and it has more space above than below.
-    [ icon Icon.TaskAlt [ "pb-2", "pt-16", "text-green", "text-big-icon" ]
+  div [ classNames [ "h-full", "flex", "flex-col", "justify-center", "items-center", "p-4" ] ]
+    [ icon Icon.TaskAlt [ "text-green", "text-big-icon" ]
     , div
-        [ classNames [ "text-center", "text-sm" ] ]
+        -- The bottom margin on this div means the whole thing isn't perfectly centered vertically.
+        -- Because there's an image on top and text below, being perfectly centered vertically
+        -- looks wrong.
+        [ classNames [ "text-center", "text-sm", "mb-4" ] ]
         [ div [ classNames [ "font-semibold" ] ]
             [ text "This contract is now closed" ]
         , div_ [ text "There are no tasks to complete" ]
@@ -551,7 +537,7 @@ renderContractClose =
 -- the past step card)
 renderPendingStep :: forall p a. HTML p a
 renderPendingStep =
-  div [ classNames [ "mt-4" ] ]
+  div [ classNames [ "px-4", "mt-4" ] ]
     [ text "Your transaction has been submitted. You will be notified when confirmation is received." ]
 
 -- This helper function expands actions that can be taken by anybody,
@@ -604,9 +590,14 @@ renderTasks state =
         actions
   in
     if length expandedActions > 0 then
-      div [ classNames [ "pb-4" ] ] $ expandedActions <#> uncurry (renderPartyTasks state)
+      div
+        [ classNames [ "px-4", "pb-4" ] ]
+        $ expandedActions
+        <#> uncurry (renderPartyTasks state)
     else
-      div [ classNames [ "my-4" ] ] [ text "There are no tasks to perform at this step. The contract will progress automatically when the timeout has passed." ]
+      div
+        [ classNames [ "p-4" ] ]
+        [ text "There are no tasks to perform at this step. The contract will progress automatically when the timeout has passed." ]
 
 participantWithNickname :: State -> Party -> String
 participantWithNickname state party =

--- a/marlowe-dashboard-client/src/Css.purs
+++ b/marlowe-dashboard-client/src/Css.purs
@@ -10,6 +10,7 @@ module Css
   , whiteButton
   , input
   , inputNoFocus
+  , inputNoBorder
   , unstyledInput
   , inputError
   , hasNestedLabel
@@ -104,6 +105,20 @@ inputNoFocus valid =
   inputBase
     <> [ "focus:ring-0", "focus:border-gray" ]
     <> if valid then [ "border-gray" ] else [ "border-red" ]
+
+inputNoBorder :: Array String
+inputNoBorder =
+  [ "block"
+  , "w-full"
+  , "p-2"
+  , "rounded"
+  , "transition-all"
+  , "duration-200"
+  , "outline-none"
+  , "focus:outline-none"
+  , "text-black"
+  , "border-0"
+  ]
 
 -- use this on an input inside a div styled like an input
 unstyledInput :: Array String

--- a/marlowe-dashboard-client/src/Dashboard/Lenses.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Lenses.purs
@@ -5,8 +5,9 @@ module Dashboard.Lenses
   , _card
   , _cardOpen
   , _contracts
+  , _contract
   , _contractFilter
-  , _selectedContractIndex
+  , _selectedContractFollowerAppId
   , _selectedContract
   , _walletNicknameInput
   , _walletIdInput
@@ -18,6 +19,8 @@ import Prelude
 import Contract.Types (State) as Contract
 import Dashboard.Types (Card, ContractFilter, State)
 import Data.Lens (Lens', Traversal', set, wander)
+import Data.Lens.At (at)
+import Data.Lens.Prism.Maybe (_Just)
 import Data.Lens.Record (prop)
 import Data.Map (Map, insert, lookup)
 import Data.Maybe (Maybe(..))
@@ -47,16 +50,19 @@ _cardOpen = prop (SProxy :: SProxy "cardOpen")
 _contracts :: Lens' State (Map PlutusAppId Contract.State)
 _contracts = prop (SProxy :: SProxy "contracts")
 
+_contract :: PlutusAppId -> Traversal' State Contract.State
+_contract followerAppId = _contracts <<< at followerAppId <<< _Just
+
 _contractFilter :: Lens' State ContractFilter
 _contractFilter = prop (SProxy :: SProxy "contractFilter")
 
-_selectedContractIndex :: Lens' State (Maybe PlutusAppId)
-_selectedContractIndex = prop (SProxy :: SProxy "selectedContractIndex")
+_selectedContractFollowerAppId :: Lens' State (Maybe PlutusAppId)
+_selectedContractFollowerAppId = prop (SProxy :: SProxy "selectedContractFollowerAppId")
 
 -- This traversal focus on a specific contract indexed by another property of the state
 _selectedContract :: Traversal' State Contract.State
 _selectedContract =
-  wander \f state -> case state.selectedContractIndex of
+  wander \f state -> case state.selectedContractFollowerAppId of
     Just ix
       | Just contract <- lookup ix state.contracts ->
         let

--- a/marlowe-dashboard-client/src/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Types.purs
@@ -2,7 +2,6 @@ module Dashboard.Types
   ( State
   , Card(..)
   , ContractFilter(..)
-  , PartitionedContracts
   , Input
   , Action(..)
   ) where
@@ -30,7 +29,7 @@ type State
     , cardOpen :: Boolean -- see note [CardOpen] in Welcome.State (the same applies here)
     , contracts :: Map PlutusAppId Contract.State
     , contractFilter :: ContractFilter
-    , selectedContractIndex :: Maybe PlutusAppId
+    , selectedContractFollowerAppId :: Maybe PlutusAppId
     , walletNicknameInput :: InputField.State WalletNicknameError
     , walletIdInput :: InputField.State WalletIdError
     , remoteWalletInfo :: WebData WalletInfo
@@ -45,7 +44,7 @@ data Card
   | SaveWalletCard (Maybe String)
   | ViewWalletCard WalletDetails
   | ContractTemplateCard
-  | ContractActionConfirmationCard NamedAction
+  | ContractActionConfirmationCard PlutusAppId NamedAction
 
 derive instance eqCard :: Eq Card
 
@@ -54,9 +53,6 @@ data ContractFilter
   | Completed
 
 derive instance eqContractFilter :: Eq ContractFilter
-
-type PartitionedContracts
-  = { completed :: Array Contract.State, running :: Array Contract.State }
 
 type Input
   = { currentSlot :: Slot
@@ -79,7 +75,7 @@ data Action
   | RedeemPayments PlutusAppId
   | AdvanceTimedoutSteps
   | TemplateAction Template.Action
-  | ContractAction Contract.Action
+  | ContractAction PlutusAppId Contract.Action
 
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
@@ -100,4 +96,4 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (RedeemPayments _) = Nothing
   toEvent AdvanceTimedoutSteps = Nothing
   toEvent (TemplateAction templateAction) = toEvent templateAction
-  toEvent (ContractAction contractAction) = toEvent contractAction
+  toEvent (ContractAction _ contractAction) = toEvent contractAction

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -203,7 +203,7 @@ dashboardBreadcrumb mSelectedContractState =
         <> case mSelectedContractState of
             Just { nickname } ->
               [ span_ [ text ">" ]
-              , span_ [ text nickname ]
+              , span_ [ text if nickname == mempty then "My new contract" else nickname ]
               ]
             Nothing -> []
     ]
@@ -365,7 +365,8 @@ contractGrid :: forall p. Slot -> Map PlutusAppId Contract.State -> HTML p Actio
 contractGrid currentSlot contracts =
   div
     [ classNames [ "grid", "pt-4", "pb-20", "lg:pb-4", "gap-4", "auto-rows-min", "md:grid-cols-2", "lg:grid-cols-3", "lg:px-16" ] ]
-    $ dashboardContractCard <$> toUnfoldable contracts
+    $ dashboardContractCard
+    <$> toUnfoldable contracts
   where
   dashboardContractCard (followerAppId /\ contractState) = ContractAction followerAppId <$> contractCard currentSlot contractState
 

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -4,17 +4,17 @@ module Dashboard.View
   ) where
 
 import Prelude hiding (div)
-import Contract.Lenses (_followerAppId, _mMarloweParams, _metadata)
+import Contract.State (isContractClosed)
 import Contract.Types (State) as Contract
-import Contract.View (actionConfirmationCard, contractDetailsCard, contractInnerBox)
+import Contract.View (actionConfirmationCard, contractCard, contractScreen)
 import Css as Css
-import Dashboard.Lenses (_card, _cardOpen, _contractFilter, _contracts, _menuOpen, _remoteWalletInfo, _selectedContract, _templateState, _walletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput)
-import Dashboard.State (partitionContracts)
-import Dashboard.Types (Action(..), Card(..), ContractFilter(..), PartitionedContracts, State)
-import Data.Array (length)
+import Dashboard.Lenses (_card, _cardOpen, _contractFilter, _contract, _contracts, _menuOpen, _remoteWalletInfo, _selectedContract, _selectedContractFollowerAppId, _templateState, _walletDetails, _walletIdInput, _walletLibrary, _walletNicknameInput)
+import Dashboard.Types (Action(..), Card(..), ContractFilter(..), State)
 import Data.Lens (preview, view, (^.))
+import Data.Map (Map, filter, isEmpty, toUnfoldable)
 import Data.Maybe (Maybe(..))
 import Data.String (take)
+import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Css (applyWhen, classNames)
@@ -24,7 +24,7 @@ import Halogen.HTML.Events.Extra (onClick_)
 import Halogen.HTML.Properties (href, id_, src)
 import Images (marloweRunNavLogo, marloweRunNavLogoDark)
 import MainFrame.Types (ChildSlots)
-import Marlowe.Extended (contractTypeInitials, contractTypeName)
+import Marlowe.PAB (PlutusAppId)
 import Marlowe.Semantics (PubKey, Slot)
 import Material.Icons (Icon(..)) as Icon
 import Material.Icons (icon, icon_)
@@ -39,15 +39,17 @@ import WalletData.View (currentWalletCard, saveWalletCard, walletDetailsCard, wa
 dashboardScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
 dashboardScreen currentSlot state =
   let
-    walletNickname = view (_walletDetails <<< _walletNickname) state
+    walletNickname = state ^. (_walletDetails <<< _walletNickname)
 
-    menuOpen = view _menuOpen state
+    menuOpen = state ^. _menuOpen
 
-    card = view _card state
+    card = state ^. _card
 
-    cardOpen = view _cardOpen state
+    cardOpen = state ^. _cardOpen
 
-    contractFilter = view _contractFilter state
+    contractFilter = state ^. _contractFilter
+
+    selectedContractFollowerAppId = state ^. _selectedContractFollowerAppId
 
     selectedContract = preview _selectedContract state
   in
@@ -62,9 +64,9 @@ dashboardScreen currentSlot state =
           , div [ classNames [ "h-full", "grid", "grid-rows-auto-1fr" ] ]
               [ dashboardBreadcrumb selectedContract
               , main
-                  [ classNames [ "relative" ] ] case selectedContract of
-                  Just contractState -> [ ContractAction <$> contractDetailsCard currentSlot contractState ]
-                  Nothing -> [ contractsScreen currentSlot state ]
+                  [ classNames [ "relative" ] ] case selectedContractFollowerAppId, selectedContract of
+                  Just followerAppId, Just contractState -> [ ContractAction followerAppId <$> contractScreen currentSlot contractState ]
+                  _, _ -> [ contractsScreen currentSlot state ]
               ]
           ]
       , dashboardFooter
@@ -92,6 +94,10 @@ dashboardCard currentSlot state = case view _card state of
       walletIdInput = view _walletIdInput state
 
       remoteWalletInfo = view _remoteWalletInfo state
+
+      contracts = view _contracts state
+
+      templateState = view _templateState state
     in
       div
         [ classNames $ Css.sidebarCardOverlay cardOpen ]
@@ -109,7 +115,7 @@ dashboardCard currentSlot state = case view _card state of
                   SaveWalletCard mTokenName -> saveWalletCard walletLibrary walletNicknameInput walletIdInput remoteWalletInfo mTokenName
                   ViewWalletCard walletDetails -> walletDetailsCard walletDetails
                   ContractTemplateCard -> renderSubmodule _templateState TemplateAction (contractTemplateCard walletLibrary assets) state
-                  ContractActionConfirmationCard action -> renderSubmodule _selectedContract ContractAction (actionConfirmationCard assets action) state
+                  ContractActionConfirmationCard followerAppId action -> renderSubmodule (_contract followerAppId) (ContractAction followerAppId) (actionConfirmationCard assets action) state
               ]
         ]
   Nothing -> div_ []
@@ -245,10 +251,6 @@ link label url =
 contractsScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
 contractsScreen currentSlot state =
   let
-    -- TODO: This is going to be called every second, if we have a performance issue
-    -- see if we can use Lazy or to store the partition result in the state
-    contracts = partitionContracts $ view _contracts state
-
     contractFilter = view _contractFilter state
   in
     -- This convoluted combination of absolute and relative elements is the only way I could find
@@ -262,7 +264,7 @@ contractsScreen currentSlot state =
           [ classNames [ "absolute", "z-10", "inset-0", "h-full", "overflow-y-auto" ] ]
           [ div
               [ classNames $ Css.maxWidthContainer <> [ "relative", "h-full" ] ]
-              [ contractCards currentSlot state contracts ]
+              [ contractCards currentSlot state ]
           ]
       , div
           [ classNames [ "absolute", "inset-0" ] ]
@@ -315,14 +317,24 @@ contractNavigation contractFilter =
           ]
       ]
 
-contractCards :: forall p. Slot -> State -> PartitionedContracts -> HTML p Action
-contractCards currentSlot { contractFilter: Running } { running }
-  | length running == 0 = noContractsMessage Running
-  | otherwise = contractGrid currentSlot running
+contractCards :: forall p. Slot -> State -> HTML p Action
+contractCards currentSlot { contractFilter: Running, contracts } =
+  let
+    runningContracts = filter (not isContractClosed) contracts
+  in
+    if isEmpty runningContracts then
+      noContractsMessage Running
+    else
+      contractGrid currentSlot runningContracts
 
-contractCards currentSlot { contractFilter: Completed } { completed }
-  | length completed == 0 = noContractsMessage Completed
-  | otherwise = contractGrid currentSlot completed
+contractCards currentSlot { contractFilter: Completed, contracts } =
+  let
+    completedContracts = filter isContractClosed contracts
+  in
+    if isEmpty completedContracts then
+      noContractsMessage Running
+    else
+      contractGrid currentSlot completedContracts
 
 noContractsMessage :: forall p. ContractFilter -> HTML p Action
 noContractsMessage contractFilter =
@@ -349,41 +361,13 @@ noContractsMessage contractFilter =
               [ text "You have no completed contracts." ]
           ]
 
-contractGrid :: forall p. Slot -> Array Contract.State -> HTML p Action
+contractGrid :: forall p. Slot -> Map PlutusAppId Contract.State -> HTML p Action
 contractGrid currentSlot contracts =
   div
     [ classNames [ "grid", "pt-4", "pb-20", "lg:pb-4", "gap-4", "auto-rows-min", "md:grid-cols-2", "lg:grid-cols-3", "lg:px-16" ] ]
-    $ map (contractCard currentSlot) contracts
-
-contractCard :: forall p. Slot -> Contract.State -> HTML p Action
-contractCard currentSlot contractState =
-  let
-    mMarloweParams = contractState ^. _mMarloweParams
-
-    metadata = contractState ^. _metadata
-
-    contractInstanceId = contractState ^. _followerAppId
-
-    attributes = case mMarloweParams of
-      Just _ ->
-        -- NOTE: The overflow hidden helps fix a visual bug in which the background color eats away the border-radius
-        [ classNames [ "flex", "flex-col", "cursor-pointer", "shadow-sm", "hover:shadow", "active:shadow-lg", "bg-white", "rounded", "overflow-hidden" ]
-        , onClick_ $ SelectContract $ Just contractInstanceId
-        ]
-      -- in this case the box shouldn't be clickable
-      Nothing -> [ classNames [ "flex", "flex-col", "shadow-sm", "bg-white", "rounded", "overflow-hidden" ] ]
-  in
-    div
-      attributes
-      -- TODO: This part is really similar to contractTitle in Template.View, see if it makes sense to factor a component out
-      [ div
-          [ classNames [ "flex", "px-4", "pt-4", "items-center" ] ]
-          [ span [ classNames [ "text-2xl", "leading-none", "font-semibold" ] ] [ text $ contractTypeInitials metadata.contractType ]
-          , span [ classNames [ "flex-grow", "ml-2", "self-start", "text-xs", "uppercase" ] ] [ text $ contractTypeName metadata.contractType ]
-          , icon Icon.ArrowRight [ "text-28px" ]
-          ]
-      , ContractAction <$> contractInnerBox currentSlot contractState
-      ]
+    $ dashboardContractCard <$> toUnfoldable contracts
+  where
+  dashboardContractCard (followerAppId /\ contractState) = ContractAction followerAppId <$> contractCard currentSlot contractState
 
 -- FIXME: add a proper tutorials card (possibly a whole tutorials module)
 tutorialsCard :: forall p. HTML p Action

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -334,16 +334,16 @@ contractCards currentSlot { contractFilter: Running, contracts } =
     if isEmpty runningContracts then
       noContractsMessage Running
     else
-      contractGrid currentSlot runningContracts
+      contractGrid currentSlot Running runningContracts
 
 contractCards currentSlot { contractFilter: Completed, contracts } =
   let
     completedContracts = filter isContractClosed contracts
   in
     if isEmpty completedContracts then
-      noContractsMessage Running
+      noContractsMessage Completed
     else
-      contractGrid currentSlot completedContracts
+      contractGrid currentSlot Completed completedContracts
 
 noContractsMessage :: forall p. ContractFilter -> HTML p Action
 noContractsMessage contractFilter =
@@ -370,11 +370,13 @@ noContractsMessage contractFilter =
               [ text "You have no completed contracts." ]
           ]
 
-contractGrid :: forall p. Slot -> Map PlutusAppId Contract.State -> HTML p Action
-contractGrid currentSlot contracts =
+contractGrid :: forall p. Slot -> ContractFilter -> Map PlutusAppId Contract.State -> HTML p Action
+contractGrid currentSlot contractFilter contracts =
   div
     [ classNames [ "grid", "pt-4", "pb-20", "lg:pb-4", "gap-8", "auto-rows-min", "mx-auto", "max-w-contracts-grid-sm", "md:max-w-none", "md:w-contracts-grid-md", "md:grid-cols-2", "lg:w-contracts-grid-lg", "lg:grid-cols-3" ] ]
-    $ [ newContractCard ]
+    $ case contractFilter of
+        Running -> [ newContractCard ]
+        Completed -> []
     <> (dashboardContractCard <$> toUnfoldable contracts)
   where
   newContractCard =

--- a/marlowe-dashboard-client/src/Humanize.purs
+++ b/marlowe-dashboard-client/src/Humanize.purs
@@ -28,7 +28,7 @@ import Marlowe.Slot (slotToDateTime)
 
 humanizeDuration :: Seconds -> String
 humanizeDuration (Seconds seconds)
-  | seconds <= 0.0 = "timed out"
+  | seconds <= 0.0 = "Timed out"
   | seconds <= 60.0 = show (floor seconds) <> "sec left"
   | seconds <= (60.0 * 60.0) =
     let

--- a/marlowe-dashboard-client/src/Humanize.purs
+++ b/marlowe-dashboard-client/src/Humanize.purs
@@ -4,6 +4,7 @@ module Humanize
   , formatTime
   , humanizeInterval
   , humanizeValue
+  , contractIcon
   ) where
 
 import Prelude
@@ -18,6 +19,10 @@ import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Seconds(..))
 import Data.Tuple (Tuple)
 import Data.Tuple.Nested ((/\))
+import Halogen.HTML (HTML, img)
+import Halogen.HTML.Properties (src)
+import Images (cfdIcon, loanIcon, purchaseIcon)
+import Marlowe.Extended (ContractType(..))
 import Marlowe.Semantics (Slot, SlotInterval(..), Token(..))
 import Marlowe.Slot (slotToDateTime)
 
@@ -104,3 +109,12 @@ numberFormatter decimals =
     , after: decimals
     , abbreviations: false
     }
+
+contractIcon :: forall p a. ContractType -> HTML p a
+contractIcon contractType =
+  img
+    [ src case contractType of
+        Escrow -> purchaseIcon
+        ZeroCouponBond -> loanIcon
+        _ -> cfdIcon
+    ]

--- a/marlowe-dashboard-client/src/Template/View.purs
+++ b/marlowe-dashboard-client/src/Template/View.purs
@@ -10,15 +10,13 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple (Tuple)
 import Data.Tuple.Nested ((/\))
 import Halogen.Css (classNames)
-import Halogen.HTML (HTML, a, button, div, div_, h2, h3, h4, img, label, li, p, p_, span, span_, text, ul, ul_)
+import Halogen.HTML (HTML, a, button, div, div_, h2, h3, h4, label, li, p, p_, span, span_, text, ul, ul_)
 import Halogen.HTML.Events.Extra (onClick_)
-import Halogen.HTML.Properties (enabled, for, src)
-import Humanize (humanizeValue)
-import Images (cfdIcon, loanIcon, purchaseIcon)
+import Halogen.HTML.Properties (enabled, for)
+import Humanize (contractIcon, humanizeValue)
 import InputField.Lenses (_value)
 import InputField.Types (State) as InputField
 import InputField.View (renderInput)
-import Marlowe.Extended (ContractType(..))
 import Marlowe.Extended.Metadata (ContractTemplate, MetaData, NumberFormat(..), _contractName, _metaData, _slotParameterDescriptions, _valueParameterDescription, _valueParameterFormat, _valueParameterInfo)
 import Marlowe.Market (contractTemplates)
 import Marlowe.PAB (contractCreationFee)
@@ -276,15 +274,6 @@ contractReview assets state =
       ]
 
 ------------------------------------------------------------
-contractIcon :: forall p. ContractType -> HTML p Action
-contractIcon contractType =
-  img
-    [ src case contractType of
-        Escrow -> purchaseIcon
-        ZeroCouponBond -> loanIcon
-        _ -> cfdIcon
-    ]
-
 slotParameter :: forall p. MetaData -> Tuple String (InputField.State SlotError) -> HTML p Action
 slotParameter metaData (key /\ slotContentInput) =
   let

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -111,6 +111,8 @@ module.exports = {
         lg: "768px",
         "welcome-box": "400px",
         "sidebar": "350px",
+        "contracts-grid-md": "632px", // 2 cards of 300px + 1 gap of 32px
+        "contracts-grid-lg": "964px", // 3 cards of 300px + 2 gaps of 32px
         "contract-card": "264px",
         /* This width is used by a padding element in both sides of the carousel and is enough
            to push the first and last card to the center */
@@ -130,6 +132,7 @@ module.exports = {
         md: "640px",
         lg: "768px",
         xl: "1440px",
+        "contracts-grid-sm": "300px", // 1 card of 300px
         "90pc": "90%",
       },
       minWidth: {
@@ -176,7 +179,7 @@ module.exports = {
     borderColor: true,
     borderOpacity: false,
     borderRadius: true,
-    borderStyle: false,
+    borderStyle: true,
     borderWidth: true,
     boxSizing: false,
     cursor: true,

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -118,6 +118,7 @@ module.exports = {
       },
       height: {
         "welcome-box": "227px",
+        "dashboard-card-actions": "200px",
         "contract-card": "467px",
         "90pc": "90%",
       },

--- a/web-common/src/Material/Icons.purs
+++ b/web-common/src/Material/Icons.purs
@@ -57,7 +57,7 @@ content Add = "add"
 
 content AddBox = "add_box"
 
-content AddCircle = "add_circle_outline"
+content AddCircle = "add_circle"
 
 content ArrowRight = "east"
 

--- a/web-common/src/Tooltip/View.purs
+++ b/web-common/src/Tooltip/View.purs
@@ -13,7 +13,7 @@ render state =
     [ ref tooltipRef
     , role "tooltip"
     , classNames
-        ( [ "tooltip", "bg-black", "p-2", "rounded-sm", "text-white", "text-sm", "z-50" ]
+        ( [ "tooltip", "bg-black", "p-2", "rounded-sm", "text-white", "text-sm", "whitespace-nowrap", "z-50" ]
             <> hideWhen (not state.active)
         )
     ]

--- a/web-common/static/icons.css
+++ b/web-common/static/icons.css
@@ -23,7 +23,7 @@
 }
 
 .with-icon-add-circle::after {
-  content: "add_circle_outline";
+  content: "add_circle";
 }
 
 .with-icon-arrow-right::after {


### PR DESCRIPTION
This implements the new designs for the dashboard, with the contract summary cards including the actions possible at the current step. I haven't changed the style of the actions themselves, since that change also applies to the current step card on the contract screen - and I'll attack the contract screen in the next PR. This PR already feels quite big enough, especially the diff of the Contract.View module.

Until now, the `selectedContractIndex` in the `Dashboard.State` was doing two things: determining which contract screen was visible, and also which contract any `Contract.Action` applied to. In the new designs, a `Contract.Action` for any contract can be called from the dashboard, without the need to first go into the screen for that contract, so these two things needed to come apart. I left the `selectedContractIndex` to determine which contract screen is visible, and added an contract index (`PlutusAppId`) parameter to `ContractAction`.

While I was at it, I deleted the `followerAppId` from the `Contract.State`, which is duplicate information already available as the key of the contract map in the `Dashboard.State`. Instead I'm passing this as `input` to the contract action handlers, which feels nicer. And because the contract view needs to know about this, I changed the partitioned arrays of contracts (running / completed) to maps. Since the filter functions are being called every second, we might want to store these as separate maps in the sate - but I haven't noticed any performance issues yet, so I'm not too worried about it.

![localhost_8009_ (10)](https://user-images.githubusercontent.com/380759/125777676-64ac722c-d65a-4143-a11e-9a01c95102aa.png)
