### PR TITLE
SCP-1759: Marlowe playground Client - Add warnings and errors tab to the simulation

### DIFF
--- a/marlowe-playground-client/src/Marlowe/ViewPartials.purs
+++ b/marlowe-playground-client/src/Marlowe/ViewPartials.purs
@@ -1,0 +1,114 @@
+module Marlowe.ViewPartials where
+
+import Prelude hiding (div)
+import Data.Array (mapWithIndex)
+import Effect.Aff.Class (class MonadAff)
+import Halogen (ComponentHTML)
+import Halogen.Css (classNames)
+import Halogen.HTML (ClassName(..), b_, div_, h4, li_, ol, text)
+import Halogen.HTML.Properties (classes)
+import Hint.State (hint)
+import MainFrame.Types (ChildSlots)
+import Marlowe.Semantics (Payee(..), TransactionWarning(..))
+import Popper (Placement(..))
+import Pretty (showPrettyToken)
+
+displayWarningList ::
+  forall m action.
+  MonadAff m =>
+  Array TransactionWarning ->
+  ComponentHTML action ChildSlots m
+displayWarningList transactionWarnings =
+  ol [ classes [ ClassName "indented-enum" ] ]
+    $ mapWithIndex
+        (\index warning -> li_ $ displayWarning index warning)
+        transactionWarnings
+
+warningHint ::
+  forall m action.
+  MonadAff m =>
+  Int ->
+  String ->
+  ComponentHTML action ChildSlots m
+warningHint index msg =
+  hint [ "ml-1", "relative", "-top-1" ] ("warning-" <> show index) Auto
+    $ div_
+        [ h4 [ classNames [ "no-margins", "text-lg", "font-semibold", "pb-2", "min-w-max" ] ]
+            [ text "Warning" ]
+        , text msg
+        ]
+
+displayWarning ::
+  forall m action.
+  MonadAff m =>
+  Int ->
+  TransactionWarning ->
+  Array (ComponentHTML action ChildSlots m)
+displayWarning index (TransactionNonPositiveDeposit party owner tok amount) =
+  [ b_ [ text "Non-positive deposit" ]
+  , warningHint index "A non-positive deposit is when the contract asks a participant to make a deposit of a value which is 0 or lower."
+  , text " - Party "
+  , b_ [ text $ show party ]
+  , text " is asked to deposit "
+  , b_ [ text $ show amount ]
+  , text " units of "
+  , b_ [ text $ showPrettyToken tok ]
+  , text " into account of "
+  , b_ [ text (show owner) ]
+  , text "."
+  ]
+
+displayWarning index (TransactionNonPositivePay owner payee tok amount) =
+  [ b_ [ text "Non-positive pay" ]
+  , warningHint index "A non-positive pay is when the contract needs to pay a participant a value which is 0 or lower."
+  , text " - The contract is supposed to make a payment of "
+  , b_ [ text $ show amount ]
+  , text " units of "
+  , b_ [ text $ showPrettyToken tok ]
+  , text " from account of "
+  , b_ [ text (show owner) ]
+  , text " to "
+  , b_
+      [ text case payee of
+          (Account owner2) -> ("account of " <> (show owner2))
+          (Party dest) -> ("party " <> (show dest))
+      ]
+  , text "."
+  ]
+
+displayWarning index (TransactionPartialPay owner payee tok amount expected) =
+  [ b_ [ text "Partial pay" ]
+  , warningHint index "A partial pay is when the contract needs to pay a participant a value grater than the funds available in the origin account."
+  , text " - The contract is supposed to make a payment of "
+  , b_ [ text $ show expected ]
+  , text " units of "
+  , b_ [ text $ showPrettyToken tok ]
+  , text " from account of "
+  , b_ [ text (show owner) ]
+  , text " to "
+  , b_
+      [ text case payee of
+          (Account owner2) -> ("account of " <> (show owner2))
+          (Party dest) -> ("party " <> (show dest))
+      ]
+  , text " but there is only "
+  , b_ [ text $ show amount ]
+  , text "."
+  ]
+
+displayWarning index (TransactionShadowing valId oldVal newVal) =
+  [ b_ [ text "Shadowing" ]
+  , warningHint index "Shadowing is when a value is re-assigned to the same identifier, which means that we lose the reference to the previous value."
+  , text " - The contract defined the value with id "
+  , b_ [ text (show valId) ]
+  , text " before, it was assigned the value "
+  , b_ [ text (show oldVal) ]
+  , text " and now it is being assigned the value "
+  , b_ [ text (show newVal) ]
+  , text "."
+  ]
+
+displayWarning index TransactionAssertionFailed =
+  [ b_ [ text "Assertion failed" ]
+  , text " - An assertion in the contract did not hold."
+  ]

--- a/marlowe-playground-client/src/SimulationPage/Types.purs
+++ b/marlowe-playground-client/src/SimulationPage/Types.purs
@@ -76,6 +76,7 @@ data Query a
 
 data BottomPanelView
   = CurrentStateView
+  | WarningsAndErrorsView
 
 derive instance eqBottomPanelView :: Eq BottomPanelView
 

--- a/marlowe-playground-client/src/Simulator/State.purs
+++ b/marlowe-playground-client/src/Simulator/State.purs
@@ -216,7 +216,7 @@ applyPendingInputs oldState@{ executionState: SimulationRunning executionState }
 
         newExecutionState =
           ( set _transactionError Nothing
-              <<< set _transactionWarnings (fromFoldable txOutWarnings)
+              <<< over _transactionWarnings (flip append $ fromFoldable txOutWarnings)
               <<< set _pendingInputs mempty
               <<< set _state txOutState
               <<< set _moneyInContract (moneyInContract txOutState)

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -6,7 +6,6 @@ module StaticAnalysis.BottomPanel
 
 import Prelude hiding (div)
 import Data.BigInteger (BigInteger)
-import Data.Foldable (foldMap)
 import Data.Lens (view, (^.))
 import Data.List (List, null, toUnfoldable)
 import Data.List as List
@@ -18,14 +17,15 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Classes (btn, spaceBottom, spaceRight, spaceTop, spanText)
-import Halogen.HTML (ClassName(..), HTML, b_, br_, button, div, h2, h3, li_, ol, span_, text, ul)
+import Halogen.HTML (ClassName(..), HTML, b_, br_, button, div, h3, li_, ol, span_, text, ul)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, enabled)
 import MainFrame.Types (ChildSlots)
 import Marlowe.Extended.Metadata (MetaData, NumberFormat(..), _valueParameterDescription)
-import Marlowe.Semantics (ChoiceId(..), Input(..), Payee(..), Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..))
+import Marlowe.Semantics (ChoiceId(..), Input(..), Slot(..), SlotInterval(..), TransactionInput(..))
 import Marlowe.Symbolic.Types.Response as R
 import Marlowe.Template (IntegerTemplateType(..))
+import Marlowe.ViewPartials (displayWarningList)
 import Network.RemoteData (RemoteData(..))
 import Pretty (showPrettyToken)
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
@@ -329,94 +329,4 @@ displayInput (INotify) =
   [ b_ [ text "INotify" ]
   , text " - The contract is notified that an observation became "
   , b_ [ text "True" ]
-  ]
-
-displayWarningList :: forall p action. Array TransactionWarning -> HTML p action
-displayWarningList transactionWarnings =
-  ol [ classes [ ClassName "indented-enum" ] ]
-    ( do
-        warning <- transactionWarnings
-        pure (li_ (displayWarning warning))
-    )
-
-displayWarnings :: forall p action. Array TransactionWarning -> HTML p action
-displayWarnings [] = text mempty
-
-displayWarnings warnings =
-  div
-    [ classes
-        [ ClassName "invalid-transaction"
-        , ClassName "input-composer"
-        ]
-    ]
-    [ h2 [] [ text "Warnings" ]
-    , ol
-        []
-        $ foldMap (\warning -> [ li_ (displayWarning warning) ]) warnings
-    ]
-
-displayWarning :: forall p action. TransactionWarning -> Array (HTML p action)
-displayWarning (TransactionNonPositiveDeposit party owner tok amount) =
-  [ b_ [ text "TransactionNonPositiveDeposit" ]
-  , text " - Party "
-  , b_ [ text $ show party ]
-  , text " is asked to deposit "
-  , b_ [ text $ show amount ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
-  , text " into account of "
-  , b_ [ text (show owner) ]
-  , text "."
-  ]
-
-displayWarning (TransactionNonPositivePay owner payee tok amount) =
-  [ b_ [ text "TransactionNonPositivePay" ]
-  , text " - The contract is supposed to make a payment of "
-  , b_ [ text $ show amount ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
-  , text " from account of "
-  , b_ [ text (show owner) ]
-  , text " to "
-  , b_
-      [ text case payee of
-          (Account owner2) -> ("account of " <> (show owner2))
-          (Party dest) -> ("party " <> (show dest))
-      ]
-  , text "."
-  ]
-
-displayWarning (TransactionPartialPay owner payee tok amount expected) =
-  [ b_ [ text "TransactionPartialPay" ]
-  , text " - The contract is supposed to make a payment of "
-  , b_ [ text $ show expected ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
-  , text " from account of "
-  , b_ [ text (show owner) ]
-  , text " to "
-  , b_
-      [ text case payee of
-          (Account owner2) -> ("account of " <> (show owner2))
-          (Party dest) -> ("party " <> (show dest))
-      ]
-  , text " but there is only "
-  , b_ [ text $ show amount ]
-  , text "."
-  ]
-
-displayWarning (TransactionShadowing valId oldVal newVal) =
-  [ b_ [ text "TransactionShadowing" ]
-  , text " - The contract defined the value with id "
-  , b_ [ text (show valId) ]
-  , text " before, it was assigned the value "
-  , b_ [ text (show oldVal) ]
-  , text " and now it is being assigned the value "
-  , b_ [ text (show newVal) ]
-  , text "."
-  ]
-
-displayWarning TransactionAssertionFailed =
-  [ b_ [ text "TransactionAssertionFailed" ]
-  , text " - An assertion in the contract did not hold."
   ]


### PR DESCRIPTION
This PR adds warnings and errors to the Marlowe Playground simulator.

NOTE: I wasn't sure how to explain to an end-user the possible Errors (and not sure how to reach that point). @palas, I appreciate your input in that regard. 

Changes are deployed to https://hernan.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [X] Commits have useful messages
- [ ] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
