### PR TITLE
Fix documentation of Interval to (upper bound included)

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Interval.hs
@@ -217,7 +217,7 @@ from s = Interval (lowerBound s) (UpperBound PosInf True)
 
 {-# INLINABLE to #-}
 -- | @to a@ is an 'Interval' that includes all values that are
---  smaller than @a@.
+--  smaller than or equal to @a@.
 to :: a -> Interval a
 to s = Interval (LowerBound NegInf True) (upperBound s)
 


### PR DESCRIPTION
There was an incorrect documentation for the `to` function of `Interval`. The upper bound is inclusive.

```
> member 20 (to (20 :: Integer))
True
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
