### PR TITLE
SCP-2451 - Marlowe Playground Client - Fix save a blockly project

### DIFF
--- a/marlowe-playground-client/src/MainFrame/State.purs
+++ b/marlowe-playground-client/src/MainFrame/State.purs
@@ -413,7 +413,7 @@ handleAction (HandleActusBlocklyMessage (ActusBlockly.CurrentTerms flavour terms
 handleAction (HandleActusBlocklyMessage ActusBlockly.CodeChange) = setUnsavedChangesForLanguage Actus true
 
 -- TODO: modify gist action type to take a gistid as a parameter
--- https://github.com/input-output-hk/plutus/pull/2498/files#r533478042
+-- https://github.com/input-output-hk/plutus/pull/2498#discussion_r533478042
 handleAction (ProjectsAction action@(Projects.LoadProject lang gistId)) = do
   assign _createGistResult Loading
   res <-
@@ -685,7 +685,6 @@ createFiles = do
 
 handleGistAction ::
   forall m.
-  Warn (Text "Check if the handler for LoadGist is being used") =>
   Warn (Text "SCP-1591 Saving failure does not provide enough information") =>
   MonadAff m =>
   MonadAsk Env m =>
@@ -723,10 +722,13 @@ handleGistAction (SetGistUrl url) = do
         )
     Left _ -> pure unit
 
--- TODO: I think this action is not being called.
--- > The issue is that for historical reasons, the gist actions rely on gist id stored in the state,
--- > so we need to set the appropriate state before handling the gist action. This should probably be
--- > changed to have gist action type taking gist id as a parameter.
+-- TODO: This action is only called when loading the site with a gistid param, something like
+-- https://<base_url>/#/marlowe?gistid=<gist_id>
+-- But it's not loading the gist correctly. For now I'm leaving it as it is, but we should rethink
+-- this functionality in the redesign.
+--
+-- A separate issue is that the gistid is loaded in the state instead of passing it as a parameter
+-- to the LoadGist action
 -- https://github.com/input-output-hk/plutus/pull/2498#discussion_r533478042
 handleGistAction LoadGist = do
   res <-

--- a/marlowe-playground-client/src/Marlowe/Gists.purs
+++ b/marlowe-playground-client/src/Marlowe/Gists.purs
@@ -67,7 +67,7 @@ filenames =
   { playground: "playground.marlowe.json"
   , marlowe: "playground.marlowe"
   , haskell: "Main.hs"
-  , blockly: "blockly.xml"
+  , blockly: "playground.marlowe"
   , javascript: "playground.js"
   , actus: "actus.xml"
   , metadata: "metadata.json"


### PR DESCRIPTION
This small PR solves a bug where the blockly project was saved with Marlowe format into an XML file. Now Blockly and Marlowe uses the same file, so if you save a Marlowe project you can open it as Blockly and vice-versa.

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [X] Commits have useful messages
- [x] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
