### PR TITLE
Fix playground decoding errors

### DIFF
--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -18,9 +18,9 @@ import           Language.PureScript.Bridge                (BridgePart, Language
 import           Language.PureScript.Bridge.Builder        (BridgeData)
 import           Language.PureScript.Bridge.PSTypes        (psArray, psInt, psNumber, psString)
 import           Language.PureScript.Bridge.TypeParameters (A)
-import           Ledger                                    (Address, Datum, DatumHash, MintingPolicy, OnChainTx, PubKey,
-                                                            PubKeyHash, Redeemer, RedeemerPtr, ScriptTag, Signature, Tx,
-                                                            TxId, TxIn, TxInType, TxOut, TxOutRef, TxOutTx, UtxoIndex,
+import           Ledger                                    (Address, DatumHash, MintingPolicy, OnChainTx, PubKey,
+                                                            PubKeyHash, RedeemerPtr, ScriptTag, Signature, Tx, TxId,
+                                                            TxIn, TxInType, TxOut, TxOutRef, TxOutTx, UtxoIndex,
                                                             ValidationPhase, Validator)
 import           Ledger.Ada                                (Ada)
 import           Ledger.Constraints.OffChain               (MkTxError, UnbalancedTx)
@@ -189,6 +189,18 @@ scriptBridge = do
     typeModule ^== "Plutus.V1.Ledger.Scripts"
     pure psString
 
+datumBridge :: BridgePart
+datumBridge = do
+    typeName ^== "Datum"
+    typeModule ^== "Plutus.V1.Ledger.Scripts"
+    pure psString
+
+redeemerBridge :: BridgePart
+redeemerBridge = do
+    typeName ^== "Redeemer"
+    typeModule ^== "Plutus.V1.Ledger.Scripts"
+    pure psString
+
 validatorHashBridge :: BridgePart
 validatorHashBridge = do
     typeName ^== "ValidatorHash"
@@ -209,7 +221,7 @@ ledgerBytesBridge = do
 
 ledgerBridge :: BridgePart
 ledgerBridge =
-    scriptBridge <|> validatorHashBridge <|> mpsHashBridge <|> ledgerBytesBridge
+    scriptBridge <|> redeemerBridge <|> datumBridge <|> validatorHashBridge <|> mpsHashBridge <|> ledgerBytesBridge
 
 ------------------------------------------------------------
 headersBridge :: BridgePart
@@ -255,7 +267,6 @@ ledgerTypes =
           (Proxy @(UpperBound A))
     , (genericShow <*> (order <*> mkSumType)) (Proxy @CurrencySymbol)
     , (genericShow <*> (order <*> mkSumType)) (Proxy @MintingPolicy)
-    , (genericShow <*> (order <*> mkSumType)) (Proxy @Redeemer)
     , (genericShow <*> (order <*> mkSumType)) (Proxy @RedeemerPtr)
     , (genericShow <*> (order <*> mkSumType)) (Proxy @ScriptTag)
     , (genericShow <*> (order <*> mkSumType)) (Proxy @Signature)
@@ -266,7 +277,6 @@ ledgerTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ValidationError)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ValidationPhase)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @Address)
-    , (order <*> (genericShow <*> mkSumType)) (Proxy @Datum)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @DatumHash)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @PubKey)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @PubKeyHash)

--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -26,8 +26,8 @@ import           Ledger.Ada                                (Ada)
 import           Ledger.Constraints.OffChain               (MkTxError, UnbalancedTx)
 import           Ledger.Credential                         (Credential, StakingCredential)
 import           Ledger.DCert                              (DCert)
-import           Ledger.Index                              (ExBudget, ExCPU, ExMemory, SatInt, ScriptType,
-                                                            ScriptValidationEvent, ValidationError)
+import           Ledger.Index                              (ExCPU, ExMemory, ScriptType, ScriptValidationEvent,
+                                                            ValidationError)
 import           Ledger.Interval                           (Extended, Interval, LowerBound, UpperBound)
 import           Ledger.Scripts                            (ScriptError)
 import           Ledger.Slot                               (Slot)
@@ -153,9 +153,21 @@ naturalBridge = do
     typeModule ^== "GHC.Natural"
     pure psInt
 
+satIntBridge :: BridgePart
+satIntBridge = do
+    typeName ^== "SatInt"
+    typeModule ^== "Data.SatInt" <|> typeModule ^== "Ledger.Index"
+    pure psInt
+
+exBudgetBridge :: BridgePart
+exBudgetBridge = do
+    typeName ^== "ExBudget"
+    typeModule ^== "PlutusCore.Evaluation.Machine.ExBudget"
+    pure psJson
+
 miscBridge :: BridgePart
 miscBridge =
-    byteStringBridge <|> integerBridge <|> scientificBridge <|> digestBridge <|> naturalBridge
+    byteStringBridge <|> integerBridge <|> scientificBridge <|> digestBridge <|> naturalBridge <|> satIntBridge <|> exBudgetBridge
 
 ------------------------------------------------------------
 
@@ -309,10 +321,8 @@ ledgerTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @StopReason)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @IterationID)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ScriptValidationEvent)
-    , (equal <*> (genericShow <*> mkSumType)) (Proxy @ExBudget)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ExCPU)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ExMemory)
-    , (equal <*> (genericShow <*> mkSumType)) (Proxy @SatInt)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ScriptType)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @PABReq)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @PABResp)


### PR DESCRIPTION
Fixes #3563

- Fix purescript decoding for `Datum` and `Redeemer` matching with the encoding in haskell
  Fixup from aeson instance changes in #3539

- Fix purescript decoding for `ExBudget` by treating it as json. The haskell side is not using the generic aeson instance which is what the generated purescript expects. This is ok as the value is not used in the playground and maintains consistency in hs. Also fixed purescript decoding for `SatInt`
  Fixup bridges from #3502

Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
