### PR TITLE
SCP-2500 - Remove need for Eq instance for `Contract` in Marlowe semantics

### DIFF
--- a/marlowe-dashboard-client/src/Marlowe/Execution/State.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Execution/State.purs
@@ -81,7 +81,7 @@ timeoutState currentSlot { semanticState, contract, history, mPendingTimeouts, m
         let
           { txOutState, txOutContract } = case reduceContractUntilQuiescent env state' contract' of
             -- TODO: SCP-2088 We need to discuss how to display the warnings that computeTransaction may give
-            ContractQuiescent _ _ txOutState txOutContract -> { txOutState, txOutContract }
+            ContractQuiescent _ _ _ txOutState txOutContract -> { txOutState, txOutContract }
             -- FIXME: Change timeoutState to return an Either
             RRAmbiguousSlotIntervalError -> { txOutState: state', txOutContract: contract' }
 

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -568,7 +568,7 @@ executeAndInterpret sta ((l, h, v, b):t) cont
   | b == 0 = computeAndContinue transaction [] sta cont t
   | otherwise =
        case reduceContractUntilQuiescent env sta cont of
-         ContractQuiescent _ _ _ tempCont ->
+         ContractQuiescent _ _ _ _ tempCont ->
            case tempCont of
              When cases _ _ -> computeAndContinue transaction
                                   [caseToInput cases b v] sta cont t

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -390,7 +389,7 @@ setupMarloweParams owners contract = mapError (review _MarloweError) $ do
         pure (params, mempty)
     else if roles `Set.isSubsetOf` Set.fromList (AssocMap.keys owners)
     then do
-        let tokens = fmap (, 1) $ Set.toList roles
+        let tokens = fmap (\role -> (role, 1)) $ Set.toList roles
         cur <- mapError RolesCurrencyError $ Currency.mintContract creator tokens
         let rolesSymbol = Currency.currencySymbol cur
         let giveToParty (role, pkh) = Constraints.mustPayToPubKey pkh (Val.singleton rolesSymbol role 1)
@@ -422,7 +421,7 @@ getAction slotRange party MarloweData{marloweContract,marloweState} = let
                 When [] timeout _ -> WaitForTimeout timeout
                 Close -> CloseContract
                 _ -> NotSure
-        -- When's timeout is in the slot range
+        -- When timeout is in the slot range
         RRAmbiguousSlotIntervalError ->
             {- FIXME
                 Consider contract:


### PR DESCRIPTION
This PR removes the need for comparing the type `Contract` (using the `Eq` instance), which hopefully should translate into a smaller and faster validator for Marlowe.

This covers the semantics of Marlowe in Haskel/Plutus and Purescript

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
