### PR TITLE
SCP-2535 - Update contract for differences examples to support two different commitments

### DIFF
--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -355,9 +355,11 @@ contractForDifferences =
     const counterparty: Party = Role("Counterparty");
     const oracle: Party = Role("Oracle");
 
-    const depositAmount: bigint = 100_000_000n;
-    const deposit: Value = Constant(depositAmount);
-    const doubleDeposit: Value = Constant(depositAmount * 2n);
+    const partyDepositAmount: bigint = 100_000_000n;
+    const counterpartyDepositAmount: bigint = 100_000_000n;
+    const partyDeposit: Value = Constant(partyDepositAmount);
+    const counterpartyDeposit: Value = Constant(counterpartyDepositAmount);
+    const bothDeposits: Value = Constant(partyDepositAmount + counterpartyDepositAmount);
 
     const priceBeginning: ChoiceId = ChoiceId("Price at beginning", oracle);
     const priceEnd: ChoiceId = ChoiceId("Price at end", oracle);
@@ -365,7 +367,7 @@ contractForDifferences =
     const decreaseInPrice: ValueId = "Decrease in price";
     const increaseInPrice: ValueId = "Increase in price";
 
-    function initialDeposit(by: Party, timeout: ETimeout, timeoutContinuation: Contract,
+    function initialDeposit(by: Party, deposit: Value, timeout: ETimeout, timeoutContinuation: Contract,
         continuation: Contract): Contract {
         return When([Case(Deposit(by, by, ada, deposit), continuation)],
             timeout,
@@ -391,12 +393,11 @@ contractForDifferences =
 
     function recordDifference(name: ValueId, choiceId1: ChoiceId, choiceId2: ChoiceId,
         continuation: Contract): Contract {
-        return Let(name, SubValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2)),
-            continuation);
+        return Let(name, SubValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2)), continuation);
     }
 
-    function transferUpToDeposit(from: Party, to: Party, amount: Value, continuation: Contract): Contract {
-        return Pay(from, Account(to), ada, Cond(ValueLT(amount, deposit), amount, deposit), continuation);
+    function transferUpToDeposit(from: Party, payerDeposit: Value, to: Party, amount: Value, continuation: Contract): Contract {
+        return Pay(from, Account(to), ada, Cond(ValueLT(amount, payerDeposit), amount, payerDeposit), continuation);
     }
 
     function refund(who: Party, amount: Value, continuation: Contract): Contract {
@@ -408,7 +409,7 @@ contractForDifferences =
         }
     }
 
-    const refundBoth: Contract = refund(party, deposit, refund(counterparty, deposit, Close));
+    const refundBoth: Contract = refund(party, partyDeposit, refund(counterparty, counterpartyDeposit, Close));
 
     function refundIfGtZero(who: Party, amount: Value, continuation: Contract): Contract {
         if (explicitRefunds) {
@@ -418,34 +419,34 @@ contractForDifferences =
         }
     }
 
-    function refundUpToDoubleOfDeposit(who: Party, amount: Value, continuation: Contract): Contract {
+    function refundUpToBothDeposits(who: Party, amount: Value, continuation: Contract): Contract {
         if (explicitRefunds) {
-            return refund(who, Cond(ValueGT(amount, doubleDeposit), doubleDeposit, amount),
+            return refund(who, Cond(ValueGT(amount, bothDeposits), bothDeposits, amount),
                 continuation);
         } else {
             return continuation;
         }
     }
 
-    function refundAfterDifference(payer: Party, payee: Party, difference: Value): Contract {
-        return refundIfGtZero(payer, SubValue(deposit, difference),
-            refundUpToDoubleOfDeposit(payee, AddValue(deposit, difference),
+    function refundAfterDifference(payer: Party, payerDeposit: Value, payee: Party, payeeDeposit: Value, difference: Value): Contract {
+        return refundIfGtZero(payer, SubValue(payerDeposit, difference),
+            refundUpToBothDeposits(payee, AddValue(payeeDeposit, difference),
                 Close));
     }
 
     const contract: Contract =
-        initialDeposit(party, 300n, Close,
-            initialDeposit(counterparty, 600n, refund(party, deposit, Close),
+        initialDeposit(party, partyDeposit, 300n, Close,
+            initialDeposit(counterparty, counterpartyDeposit, 600n, refund(party, partyDeposit, Close),
                 oracleInput(priceBeginning, 900n, refundBoth,
                     wait(1500n,
                         oracleInput(priceEnd, 1800n, refundBoth,
                             gtLtEq(ChoiceValue(priceBeginning), ChoiceValue(priceEnd),
                                 recordDifference(decreaseInPrice, priceBeginning, priceEnd,
-                                    transferUpToDeposit(counterparty, party, UseValue(decreaseInPrice),
-                                        refundAfterDifference(counterparty, party, UseValue(decreaseInPrice)))),
+                                    transferUpToDeposit(counterparty, counterpartyDeposit, party, UseValue(decreaseInPrice),
+                                        refundAfterDifference(counterparty, counterpartyDeposit, party, partyDeposit, UseValue(decreaseInPrice)))),
                                 recordDifference(increaseInPrice, priceEnd, priceBeginning,
-                                    transferUpToDeposit(party, counterparty, UseValue(increaseInPrice),
-                                        refundAfterDifference(party, counterparty, UseValue(increaseInPrice)))),
+                                    transferUpToDeposit(party, partyDeposit, counterparty, UseValue(increaseInPrice),
+                                        refundAfterDifference(party, partyDeposit, counterparty, counterpartyDeposit, UseValue(increaseInPrice)))),
                                 refundBoth
                             ))))));
 

--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -465,9 +465,11 @@ contractForDifferencesWithOracle =
     const counterparty: Party = Role("Counterparty");
     const oracle: Party = Role("kraken");
 
-    const depositAmount: bigint = 100_000_000n;
-    const deposit: Value = Constant(depositAmount);
-    const doubleDeposit: Value = Constant(depositAmount * 2n);
+    const partyDepositAmount: bigint = 100_000_000n;
+    const counterpartyDepositAmount: bigint = 100_000_000n;
+    const partyDeposit: Value = Constant(partyDepositAmount);
+    const counterpartyDeposit: Value = Constant(counterpartyDepositAmount);
+    const bothDeposits: Value = Constant(partyDepositAmount + counterpartyDepositAmount);
 
     const priceBeginning: Value = Constant(100_000_000n);
     const priceEnd: ValueId = ValueId("Price at end");
@@ -478,7 +480,7 @@ contractForDifferencesWithOracle =
     const decreaseInPrice: ValueId = "Decrease in price";
     const increaseInPrice: ValueId = "Increase in price";
 
-    function initialDeposit(by: Party, timeout: ETimeout, timeoutContinuation: Contract,
+    function initialDeposit(by: Party, deposit: Value, timeout: ETimeout, timeoutContinuation: Contract,
         continuation: Contract): Contract {
         return When([Case(Deposit(by, by, ada, deposit), continuation)],
             timeout,
@@ -502,9 +504,9 @@ contractForDifferencesWithOracle =
                 eqContinuation))
     }
 
-    function recordDelta(name: ValueId, choiceId1: ChoiceId, choiceId2: ChoiceId,
+    function recordEndPrice(name: ValueId, choiceId1: ChoiceId, choiceId2: ChoiceId,
         continuation: Contract): Contract {
-        return Let(name, Scale(1n, 100_000_000n, MulValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2))),
+        return Let(name, Scale(1n, 10_000_000_000_000_000n, MulValue(priceBeginning, MulValue(ChoiceValue(choiceId1), ChoiceValue(choiceId2)))),
             continuation);
     }
 
@@ -513,8 +515,8 @@ contractForDifferencesWithOracle =
         return Let(name, SubValue(val1, val2), continuation);
     }
 
-    function transferUpToDeposit(from: Party, to: Party, amount: Value, continuation: Contract): Contract {
-        return Pay(from, Account(to), ada, Cond(ValueLT(amount, deposit), amount, deposit), continuation);
+    function transferUpToDeposit(from: Party, payerDeposit: Value, to: Party, amount: Value, continuation: Contract): Contract {
+        return Pay(from, Account(to), ada, Cond(ValueLT(amount, payerDeposit), amount, payerDeposit), continuation);
     }
 
     function refund(who: Party, amount: Value, continuation: Contract): Contract {
@@ -526,7 +528,7 @@ contractForDifferencesWithOracle =
         }
     }
 
-    const refundBoth: Contract = refund(party, deposit, refund(counterparty, deposit, Close));
+    const refundBoth: Contract = refund(party, partyDeposit, refund(counterparty, counterpartyDeposit, Close));
 
     function refundIfGtZero(who: Party, amount: Value, continuation: Contract): Contract {
         if (explicitRefunds) {
@@ -536,35 +538,35 @@ contractForDifferencesWithOracle =
         }
     }
 
-    function refundUpToDoubleOfDeposit(who: Party, amount: Value, continuation: Contract): Contract {
+    function refundUpToBothDeposits(who: Party, amount: Value, continuation: Contract): Contract {
         if (explicitRefunds) {
-            return refund(who, Cond(ValueGT(amount, doubleDeposit), doubleDeposit, amount),
+            return refund(who, Cond(ValueGT(amount, bothDeposits), bothDeposits, amount),
                 continuation);
         } else {
             return continuation;
         }
     }
 
-    function refundAfterDifference(payer: Party, payee: Party, difference: Value): Contract {
-        return refundIfGtZero(payer, SubValue(deposit, difference),
-            refundUpToDoubleOfDeposit(payee, AddValue(deposit, difference),
+    function refundAfterDifference(payer: Party, payerDeposit: Value, payee: Party, payeeDeposit: Value, difference: Value): Contract {
+        return refundIfGtZero(payer, SubValue(payerDeposit, difference),
+            refundUpToBothDeposits(payee, AddValue(payeeDeposit, difference),
                 Close));
     }
 
     const contract: Contract =
-        initialDeposit(party, 300n, Close,
-            initialDeposit(counterparty, 600n, refund(party, deposit, Close),
+        initialDeposit(party, partyDeposit, 300n, Close,
+            initialDeposit(counterparty, counterpartyDeposit, 600n, refund(party, partyDeposit, Close),
                 oracleInput(exchangeBeginning, 900n, refundBoth,
                     wait(1500n,
                         oracleInput(exchangeEnd, 1800n, refundBoth,
-                            recordDelta(priceEnd, exchangeBeginning, exchangeEnd,
+                            recordEndPrice(priceEnd, exchangeBeginning, exchangeEnd,
                                 gtLtEq(priceBeginning, UseValue(priceEnd),
                                     recordDifference(decreaseInPrice, priceBeginning, UseValue(priceEnd),
-                                        transferUpToDeposit(counterparty, party, UseValue(decreaseInPrice),
-                                            refundAfterDifference(counterparty, party, UseValue(decreaseInPrice)))),
+                                        transferUpToDeposit(counterparty, counterpartyDeposit, party, UseValue(decreaseInPrice),
+                                            refundAfterDifference(counterparty, counterpartyDeposit, party, partyDeposit, UseValue(decreaseInPrice)))),
                                     recordDifference(increaseInPrice, UseValue(priceEnd), priceBeginning,
-                                        transferUpToDeposit(party, counterparty, UseValue(increaseInPrice),
-                                            refundAfterDifference(party, counterparty, UseValue(increaseInPrice)))),
+                                        transferUpToDeposit(party, partyDeposit, counterparty, UseValue(increaseInPrice),
+                                            refundAfterDifference(party, partyDeposit, counterparty, counterpartyDeposit, UseValue(increaseInPrice)))),
                                     refundBoth
                                 )))))));
 

--- a/marlowe-playground-server/contracts/ContractForDifferences.hs
+++ b/marlowe-playground-server/contracts/ContractForDifferences.hs
@@ -17,12 +17,14 @@ party = Role "Party"
 counterparty = Role "Counterparty"
 oracle = Role "Oracle"
 
-depositAmount :: Integer
-depositAmount = 100_000_000
+partyDepositAmount, counterpartyDepositAmount :: Integer
+partyDepositAmount = 100_000_000
+counterpartyDepositAmount = 100_000_000
 
-deposit, doubleDeposit :: Value
-deposit = Constant depositAmount
-doubleDeposit = Constant (depositAmount * 2)
+partyDeposit, counterpartyDeposit, bothDeposits :: Value
+partyDeposit = Constant partyDepositAmount
+counterpartyDeposit = Constant counterpartyDepositAmount
+bothDeposits = Constant (partyDepositAmount + counterpartyDepositAmount)
 
 priceBeginning, priceEnd :: ChoiceId
 priceBeginning = ChoiceId "Price at beginning" oracle
@@ -32,8 +34,8 @@ decreaseInPrice, increaseInPrice :: ValueId
 decreaseInPrice = "Decrease in price"
 increaseInPrice = "Increase in price"
 
-initialDeposit :: Party -> Timeout -> Contract -> Contract -> Contract
-initialDeposit by timeout timeoutContinuation continuation =
+initialDeposit :: Party -> Value -> Timeout -> Contract -> Contract -> Contract
+initialDeposit by deposit timeout timeoutContinuation continuation =
   When [Case (Deposit by by ada deposit) continuation]
        timeout
        timeoutContinuation
@@ -57,9 +59,9 @@ recordDifference :: ValueId -> ChoiceId -> ChoiceId -> Contract -> Contract
 recordDifference name choiceId1 choiceId2 =
    Let name (SubValue (ChoiceValue choiceId1) (ChoiceValue choiceId2))
 
-transferUpToDeposit :: Party -> Party -> Value -> Contract -> Contract
-transferUpToDeposit from to amount =
-   Pay from (Account to) ada (Cond (ValueLT amount deposit) amount deposit)
+transferUpToDeposit :: Party -> Value -> Party -> Value -> Contract -> Contract
+transferUpToDeposit from payerDeposit to amount =
+   Pay from (Account to) ada (Cond (ValueLT amount payerDeposit) amount payerDeposit)
 
 refund :: Party -> Value -> Contract -> Contract
 refund who amount
@@ -67,37 +69,37 @@ refund who amount
   | otherwise = id
 
 refundBoth :: Contract
-refundBoth = refund party deposit (refund counterparty deposit Close)
+refundBoth = refund party partyDeposit (refund counterparty counterpartyDeposit Close)
 
 refundIfGtZero :: Party -> Value -> Contract -> Contract
 refundIfGtZero who amount continuation
   | explicitRefunds = If (ValueGT amount (Constant 0)) (refund who amount continuation) continuation
   | otherwise = continuation
 
-refundUpToDoubleOfDeposit :: Party -> Value -> Contract -> Contract
-refundUpToDoubleOfDeposit who amount
-  | explicitRefunds = refund who $ Cond (ValueGT amount doubleDeposit) doubleDeposit amount
+refundUpToBothDeposits :: Party -> Value -> Contract -> Contract
+refundUpToBothDeposits who amount
+  | explicitRefunds = refund who $ Cond (ValueGT amount bothDeposits) bothDeposits amount
   | otherwise = id
 
-refundAfterDifference :: Party -> Party -> Value -> Contract
-refundAfterDifference payer payee difference =
-    refundIfGtZero payer (SubValue deposit difference)
-  $ refundUpToDoubleOfDeposit payee (AddValue deposit difference)
+refundAfterDifference :: Party -> Value -> Party -> Value -> Value -> Contract
+refundAfterDifference payer payerDeposit payee payeeDeposit difference =
+    refundIfGtZero payer (SubValue payerDeposit difference)
+  $ refundUpToBothDeposits payee (AddValue payeeDeposit difference)
     Close
 
 contract :: Contract
-contract = initialDeposit party 300 Close
-         $ initialDeposit counterparty 600 (refund party deposit Close)
+contract = initialDeposit party partyDeposit 300 Close
+         $ initialDeposit counterparty counterpartyDeposit 600 (refund party partyDeposit Close)
          $ oracleInput priceBeginning 900 refundBoth
          $ wait 1500
          $ oracleInput priceEnd 1800 refundBoth
          $ gtLtEq (ChoiceValue priceBeginning) (ChoiceValue priceEnd)
                   ( recordDifference decreaseInPrice priceBeginning priceEnd
-                  $ transferUpToDeposit counterparty party (UseValue decreaseInPrice)
-                  $ refundAfterDifference counterparty party (UseValue decreaseInPrice)
+                  $ transferUpToDeposit counterparty counterpartyDeposit party (UseValue decreaseInPrice)
+                  $ refundAfterDifference counterparty counterpartyDeposit party partyDeposit (UseValue decreaseInPrice)
                   )
                   ( recordDifference increaseInPrice priceEnd priceBeginning
-                  $ transferUpToDeposit party counterparty (UseValue increaseInPrice)
-                  $ refundAfterDifference party counterparty (UseValue increaseInPrice)
+                  $ transferUpToDeposit party partyDeposit counterparty (UseValue increaseInPrice)
+                  $ refundAfterDifference party partyDeposit counterparty counterpartyDeposit (UseValue increaseInPrice)
                   )
                   refundBoth

--- a/web-common-marlowe/src/Examples/PureScript/ContractForDifferencesWithOracle.purs
+++ b/web-common-marlowe/src/Examples/PureScript/ContractForDifferencesWithOracle.purs
@@ -29,14 +29,20 @@ counterparty = Role "Counterparty"
 oracle :: Party
 oracle = Role "kraken"
 
-depositAmount :: BigInteger
-depositAmount = fromInt 100000000
+partyDepositAmount :: BigInteger
+partyDepositAmount = (fromInt 100000000)
 
-deposit :: Value
-deposit = Constant depositAmount
+counterpartyDepositAmount :: BigInteger
+counterpartyDepositAmount = (fromInt 100000000)
 
-doubleDeposit :: Value
-doubleDeposit = Constant (depositAmount * fromInt 2)
+partyDeposit :: Value
+partyDeposit = Constant partyDepositAmount
+
+counterpartyDeposit :: Value
+counterpartyDeposit = Constant counterpartyDepositAmount
+
+bothDeposits :: Value
+bothDeposits = Constant (partyDepositAmount + counterpartyDepositAmount)
 
 priceBeginning :: Value
 priceBeginning = Constant (fromInt 100000000)
@@ -56,8 +62,8 @@ decreaseInPrice = ValueId "Decrease in price"
 increaseInPrice :: ValueId
 increaseInPrice = ValueId "Increase in price"
 
-initialDeposit :: Party -> Timeout -> Contract -> Contract -> Contract
-initialDeposit by timeout timeoutContinuation continuation =
+initialDeposit :: Party -> Value -> Timeout -> Contract -> Contract -> Contract
+initialDeposit by deposit timeout timeoutContinuation continuation =
   When [ Case (Deposit by by ada deposit) continuation ]
     timeout
     timeoutContinuation
@@ -78,29 +84,29 @@ gtLtEq value1 value2 gtContinuation ltContinuation eqContinuation =
         eqContinuation
 
 recordEndPrice :: ValueId -> ChoiceId -> ChoiceId -> Contract -> Contract
-recordEndPrice name choiceId1 choiceId2 = Let name (Scale (Rational one (fromInt 100000000)) (MulValue (ChoiceValue choiceId1) (ChoiceValue choiceId2)))
+recordEndPrice name choiceId1 choiceId2 = Let name (Scale (Rational one ((fromInt 100000000) * (fromInt 100000000))) (MulValue priceBeginning (MulValue (ChoiceValue choiceId1) (ChoiceValue choiceId2))))
 
 recordDifference :: ValueId -> Value -> Value -> Contract -> Contract
 recordDifference name val1 val2 = Let name (SubValue val1 val2)
 
-transferUpToDeposit :: Party -> Party -> Value -> Contract -> Contract
-transferUpToDeposit from to amount = Pay from (Account to) ada (Cond (ValueLT amount deposit) amount deposit)
+transferUpToDeposit :: Party -> Value -> Party -> Value -> Contract -> Contract
+transferUpToDeposit from payerDeposit to amount = Pay from (Account to) ada (Cond (ValueLT amount payerDeposit) amount payerDeposit)
 
 extendedContract :: Contract
 extendedContract =
-  initialDeposit party (Slot $ fromInt 300) Close
-    $ initialDeposit counterparty (Slot $ fromInt 600) Close
+  initialDeposit party partyDeposit (Slot $ fromInt 300) Close
+    $ initialDeposit counterparty counterpartyDeposit (Slot $ fromInt 600) Close
     $ oracleInput exchangeBeginning (Slot $ fromInt 900) Close
     $ wait (Slot $ fromInt 1500)
     $ oracleInput exchangeEnd (Slot $ fromInt 1800) Close
     $ recordEndPrice priceEnd exchangeBeginning exchangeEnd
     $ gtLtEq priceBeginning (UseValue priceEnd)
         ( recordDifference decreaseInPrice priceBeginning (UseValue priceEnd)
-            $ transferUpToDeposit counterparty party (UseValue decreaseInPrice)
+            $ transferUpToDeposit counterparty counterpartyDeposit party (UseValue decreaseInPrice)
                 Close
         )
         ( recordDifference increaseInPrice (UseValue priceEnd) priceBeginning
-            $ transferUpToDeposit party counterparty (UseValue increaseInPrice)
+            $ transferUpToDeposit party partyDeposit counterparty (UseValue increaseInPrice)
                 Close
         )
         Close


### PR DESCRIPTION
This PR modifies the contract for differences examples logic to support two different commitments (it removes assumptions on the amounts committed). So far this is just a refactoring, I will make some of the parameters part of the template in a separate PR (when metadata is clear)

Deployed to `pablo` environment

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
