### PR TITLE
SCP-2334 - Marlowe Dashboard - implement new design of contract screen part 1

### DIFF
--- a/marlowe-dashboard-client/package-lock.json
+++ b/marlowe-dashboard-client/package-lock.json
@@ -74,37 +74,37 @@
       "dev": true
     },
     "@fullhuman/postcss-purgecss": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz",
-      "integrity": "sha512-kwOXw8fZ0Lt1QmeOOrd+o4Ibvp4UTEBFQbzvWldjlKv5n+G9sXfIPn1hh63IQIL8K8vbvv1oYMJiIUbuy9bGaA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.0.3.tgz",
+      "integrity": "sha512-/EnQ9UDWGGqHkn1UKAwSgh+gJHPKmD+Z+5dQ4gWT4qq2NUyez3zqAfZNwFH3eSgmgO+wjTXfhlLchx2M9/K+7Q==",
       "dev": true,
       "requires": {
-        "purgecss": "^3.1.3"
+        "purgecss": "^4.0.3"
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
     },
@@ -470,6 +470,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "arg": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
+      "integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -546,12 +552,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -897,19 +897,19 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "dependencies": {
         "braces": {
@@ -928,6 +928,15 @@
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
           }
         },
         "is-number": {
@@ -1576,9 +1585,9 @@
       }
     },
     "didyoumean": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
-      "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
     "dlv": {
@@ -2093,17 +2102,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       },
       "dependencies": {
         "braces": {
@@ -2122,6 +2130,15 @@
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
           }
         },
         "is-number": {
@@ -2164,9 +2181,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -2296,12 +2313,11 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -2372,46 +2388,10 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
+      "integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -2733,6 +2713,15 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true
     },
+    "import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "requires": {
+        "import-from": "^3.0.0"
+      }
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2747,6 +2736,23 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         }
       }
@@ -2948,12 +2954,6 @@
           "dev": true
         }
       }
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3194,6 +3194,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+      "dev": true
+    },
+    "lilconfig": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
+      "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
       "dev": true
     },
     "lines-and-columns": {
@@ -3723,9 +3729,9 @@
       }
     },
     "object-hash": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
-      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "dev": true
     },
     "object-is": {
@@ -3891,35 +3897,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4003,9 +3980,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "pify": {
@@ -4180,66 +4157,6 @@
       "integrity": "sha512-hybnScTaZM2iEA6kzVQ6Spozy7kVdLw+lGw8hftLlBEzt93uzXoltkYp9u0tI8xbfhxDLTOOzHsHQCkYdmzRUg==",
       "dev": true
     },
-    "postcss-functions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.2",
-        "object-assign": "^4.1.1",
-        "postcss": "^6.0.9",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "postcss-import": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.0.1.tgz",
@@ -4259,6 +4176,25 @@
       "requires": {
         "camelcase-css": "^2.0.1",
         "postcss": "^8.1.6"
+      }
+    },
+    "postcss-load-config": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
+      "integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+      "dev": true,
+      "requires": {
+        "import-cwd": "^3.0.0",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+          "dev": true
+        }
       }
     },
     "postcss-loader": {
@@ -4772,9 +4708,9 @@
       "dev": true
     },
     "purgecss": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.1.3.tgz",
-      "integrity": "sha512-hRSLN9mguJ2lzlIQtW4qmPS2kh6oMnA9RxdIYK8sz18QYqd6ePp4GNDl18oWHA1f2v2NEQIh51CO8s/E3YGckQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
+      "integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
       "dev": true,
       "requires": {
         "commander": "^6.0.0",
@@ -4938,9 +4874,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -5864,38 +5800,42 @@
       }
     },
     "tailwindcss": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.1.2.tgz",
-      "integrity": "sha512-T5t+wwd+/hsOyRw2HJuFuv0LTUm3MUdHm2DJ94GPVgzqwPPFa9XxX0KlwLWupUuiOUj6uiKURCzYPHFcuPch/w==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.4.tgz",
+      "integrity": "sha512-OdBCPgazNNsknSP+JfrPzkay9aqKjhKtFhbhgxHgvEFdHy/GuRPo2SCJ4w1SFTN8H6FPI4m6qD/Jj20NWY1GkA==",
       "dev": true,
       "requires": {
-        "@fullhuman/postcss-purgecss": "^3.1.3",
+        "@fullhuman/postcss-purgecss": "^4.0.3",
+        "arg": "^5.0.0",
         "bytes": "^3.0.0",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.5.1",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.2",
         "color": "^3.1.3",
+        "cosmiconfig": "^7.0.0",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.1",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.5",
-        "fs-extra": "^9.1.0",
+        "fs-extra": "^10.0.0",
+        "glob-parent": "^6.0.0",
         "html-tags": "^3.1.0",
+        "is-glob": "^4.0.1",
         "lodash": "^4.17.21",
         "lodash.topath": "^4.5.2",
-        "modern-normalize": "^1.0.0",
+        "modern-normalize": "^1.1.0",
         "node-emoji": "^1.8.1",
         "normalize-path": "^3.0.0",
-        "object-hash": "^2.1.1",
-        "parse-glob": "^3.0.4",
-        "postcss-functions": "^3",
+        "object-hash": "^2.2.0",
         "postcss-js": "^3.0.3",
+        "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.5",
-        "postcss-selector-parser": "^6.0.4",
+        "postcss-selector-parser": "^6.0.6",
         "postcss-value-parser": "^4.1.0",
         "pretty-hrtime": "^1.0.3",
         "quick-lru": "^5.1.1",
         "reduce-css-calc": "^2.1.8",
-        "resolve": "^1.20.0"
+        "resolve": "^1.20.0",
+        "tmp": "^0.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5943,6 +5883,16 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.6",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+          "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -6052,6 +6002,26 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/marlowe-dashboard-client/package.json
+++ b/marlowe-dashboard-client/package.json
@@ -37,7 +37,7 @@
     "purescript-psa": "^0.8.2",
     "purs-loader": "^3.7.2",
     "raw-loader": "^4.0.2",
-    "tailwindcss": "^2.1.2",
+    "tailwindcss": "^2.2.4",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.6.0",
     "webpack-dev-server": "^3.11.2"

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -29,10 +29,11 @@ import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Css (applyWhen, classNames)
 import Halogen.Extra (lifeCycleEvent)
-import Halogen.HTML (HTML, a, button, div, div_, h2, h3, input, p, span, span_, sup_, text)
+import Halogen.HTML (HTML, a, button, div, div_, h2, h3, h4_, input, p, span, span_, sup_, text)
+import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Events.Extra (onClick_, onValueInput_)
-import Halogen.HTML.Properties (InputType(..), enabled, href, placeholder, ref, target, type_, value)
-import Humanize (contractIcon, formatDate, formatTime, humanizeDuration, humanizeInterval, humanizeValue)
+import Halogen.HTML.Properties (InputType(..), enabled, href, id_, placeholder, ref, target, type_, value)
+import Humanize (contractIcon, formatDate, formatTime, humanizeDuration, humanizeValue)
 import LoadingSubmitButton.State (loadingSubmitButton)
 import LoadingSubmitButton.Types (Message(..))
 import MainFrame.Types (ChildSlots)
@@ -42,10 +43,13 @@ import Marlowe.Execution.Types (NamedAction(..))
 import Marlowe.Extended (contractTypeName)
 import Marlowe.Extended.Metadata (_contractType)
 import Marlowe.PAB (transactionFee)
-import Marlowe.Semantics (Accounts, Assets, Bound(..), ChoiceId(..), Input(..), Party(..), Slot, SlotInterval, Token, TransactionInput(..), getEncompassBound)
+import Marlowe.Semantics (Accounts, Assets, Bound(..), ChoiceId(..), Input(..), Party(..), Slot, SlotInterval(..), Token, TransactionInput(..), getEncompassBound)
 import Marlowe.Slot (secondsDiff, slotToDateTime)
 import Material.Icons (Icon(..)) as Icon
-import Material.Icons (Icon, icon)
+import Material.Icons (icon, icon_)
+import Popper (Placement(..))
+import Tooltip.State (tooltip)
+import Tooltip.Types (ReferenceId(..))
 import WalletData.State (adaToken, getAda)
 
 contractCard :: forall p. Slot -> State -> HTML p Action
@@ -106,12 +110,7 @@ timeoutString currentSlot state =
       (\nextTimeout -> humanizeDuration $ secondsDiff nextTimeout currentSlot)
       mNextTimeout
 
--- NOTE: Currently, the horizontal scrolling for this element does not match the exact desing. In the designs, the active card is always centered and you
--- can change which card is active via scrolling or the navigation buttons. To implement this we would probably need to add snap scrolling to the center of the
--- big container and create a smaller absolute positioned element of the size of a card (positioned in the middle), and with JS check that if a card enters
--- that "viewport", then we make that the selected element.
--- Current implementation just hides non active elements in mobile and makes a simple x-scrolling for larger devices.
-contractScreen :: forall p. Slot -> State -> HTML p Action
+contractScreen :: forall m. MonadAff m => Slot -> State -> ComponentHTML Action ChildSlots m
 contractScreen currentSlot state =
   let
     nickname = state ^. _nickname
@@ -131,19 +130,13 @@ contractScreen currentSlot state =
   in
     div
       [ classNames [ "flex", "flex-col", "items-center", "pt-5", "h-full" ]
+      -- FIXME: This is causing problems with the tooltips
       , lifeCycleEvent { onInit: Just CarouselOpened, onFinalize: Just CarouselClosed }
       ]
-      [ input
-          [ classNames [ "text-xl", "font-semibold", "text-center", "bg-transparent" ]
-          , placeholder "Please rename"
-          , value nickname
-          , onValueInput_ SetNickname
-          ]
-      , h2 [ classNames [ "mb-5", "text-xs", "uppercase" ] ] [ text $ contractTypeName metadata.contractType ]
-      -- NOTE: The card is allowed to grow in an h-full container and the navigation buttons are absolute positioned
-      --       because the cards x-scrolling can't coexist with a visible y-overflow. To avoid clipping the cards shadow
-      --       we need the cards container to grow (hence the flex-grow).
-      , div [ classNames [ "flex-grow", "w-full" ] ]
+      {- NOTE: The card is allowed to grow in an h-full container and the navigation buttons are absolute positioned
+               because the cards x-scrolling can't coexist with a visible y-overflow. To avoid clipping the cards shadow
+               we need the cards container to grow (hence the flex-grow). -}
+      [ div [ classNames [ "flex-grow", "w-full" ] ]
           [ div
               [ classNames [ "flex", "items-center", "overflow-x-scroll", "h-full", "scrollbar-width-none", "relative" ]
               , ref scrollContainerRef
@@ -151,45 +144,53 @@ contractScreen currentSlot state =
               (paddingElement <> pastStepsCards <> currentStepCard <> paddingElement)
           ]
       , cardNavigationButtons state
+      -- TODO: Add a status indicator for the
+      --  "Waiting for <participant>"
+      --  "Contract starting"
+      --  "Your turn"
       ]
 
-cardNavigationButtons :: forall p. State -> HTML p Action
+cardNavigationButtons :: forall m. MonadAff m => State -> ComponentHTML Action ChildSlots m
 cardNavigationButtons state =
   let
     lastStep = currentStep state
 
+    selectedStep = state ^. _selectedStep
+
     contractIsClosed = isContractClosed state
 
-    leftButton selectedStep
-      | selectedStep > 0 =
-        Just
-          $ a
-              [ classNames [ "text-purple" ]
-              , onClick_ $ MoveToStep $ selectedStep - 1
-              ]
-              [ icon Icon.ArrowLeft [ "text-2xl", "py-4" ] ]
-      | otherwise = Nothing
+    hasLeftStep = selectedStep > 0
 
-    rightButton selectedStep
-      | selectedStep == lastStep && contractIsClosed = Nothing
-      | selectedStep == lastStep =
-        Just
-          $ div
-              [ classNames [ "px-6", "py-4", "rounded-full", "bg-white", "font-semibold", "ml-auto" ] ]
-              [ text "Waiting..." ]
-      | otherwise =
-        Just
-          $ button
-              [ classNames $ Css.primaryButton <> [ "ml-auto" ] <> Css.withIcon Icon.ArrowRight
-              , onClick_ $ MoveToStep $ selectedStep + 1
-              ]
-              [ text "Next" ]
-  in
-    div [ classNames [ "mb-6", "flex", "items-center", "w-full", "px-6" ] ]
-      $ Array.catMaybes
-          [ leftButton (state ^. _selectedStep)
-          , rightButton (state ^. _selectedStep)
+    hasRightStep = selectedStep < lastStep
+
+    buttonClasses isActive = [ "leading-none", "text-xl" ] <> applyWhen (not isActive) [ "text-darkgray", "cursor-none" ]
+
+    leftButton =
+      [ button
+          [ classNames $ buttonClasses hasLeftStep
+          , onClick \_ -> if hasLeftStep then (Just $ MoveToStep $ selectedStep - 1) else Nothing
+          , enabled hasLeftStep
+          , id_ "previousStepButton"
           ]
+          [ icon_ Icon.ArrowLeft ]
+      , tooltip "Previous step" (RefId "previousStepButton") Bottom
+      ]
+
+    rightButton =
+      [ button
+          [ classNames $ buttonClasses hasRightStep
+          , onClick \_ -> if hasRightStep then (Just $ MoveToStep $ selectedStep + 1) else Nothing
+          , enabled hasRightStep
+          , id_ "nextStepButton"
+          ]
+          [ icon_ Icon.ArrowRight ]
+      , tooltip "Next step" (RefId "nextStepButton") Bottom
+      ]
+  in
+    div [ classNames [ "mb-6", "flex", "items-center", "px-6", "py-2", "bg-white", "rounded", "shadow" ] ]
+      $ leftButton
+      <> [ icon Icon.Info [ "px-4", "invisible" ] ]
+      <> rightButton
 
 -- TODO: This is a lot like the `contractSetupConfirmationCard` in `Template.View`. Consider factoring out a shared component.
 actionConfirmationCard ::
@@ -319,16 +320,16 @@ renderContractCard stepNumber state currentTab cardBody =
       --       so the perceived margins are bigger than we'd want to. To solve this we add negative margin of 4
       --       to the "not selected" cards, a positive margin of 2 to the selected one
       -- Base classes
-      [ "grid", "grid-rows-auto-1fr", "rounded", "overflow-hidden", "flex-shrink-0", "w-contract-card", "h-contract-card", "transform", "transition-transform", "duration-100", "ease-out" ]
+      [ "grid", "grid-rows-auto-1fr", "rounded", "overflow-hidden", "flex-shrink-0", "w-contract-card", "h-contract-card", "transform", "transition-transform", "duration-100", "ease-out", "mb-8", "filter" ]
         <> if (state ^. _selectedStep /= stepNumber) then
             -- Not selected card modifiers
-            [ "shadow", "scale-77", "-mx-4" ]
+            [ "drop-shadow", "scale-77", "-mx-4" ]
           else
             -- Selected card modifiers
-            [ "shadow-lg", "mx-2" ]
+            [ "drop-shadow-lg", "mx-2" ]
   in
     div [ classNames contractCardCss ]
-      [ div [ classNames [ "flex" ] ]
+      [ div [ classNames [ "flex", "select-none" ] ]
           [ a
               [ classNames (tabSelector $ currentTab == Tasks)
               , onClick_ $ SelectTab stepNumber Tasks
@@ -343,15 +344,6 @@ renderContractCard stepNumber state currentTab cardBody =
       , div [ classNames [ "bg-white", "grid", "grid-rows-auto-1fr" ] ] cardBody
       ]
 
-statusIndicator :: forall p a. Maybe Icon -> String -> Array String -> HTML p a
-statusIndicator mIcon status extraClasses =
-  div
-    [ classNames $ [ "flex-grow", "rounded-full", "h-10", "flex", "items-center" ] <> extraClasses ]
-    $ Array.catMaybes
-        [ mIcon <#> \anIcon -> icon anIcon [ "pl-3" ]
-        , Just $ span [ classNames [ "text-xs", "flex-grow", "text-center", "font-semibold" ] ] [ text status ]
-        ]
-
 renderPastStep :: forall p. State -> Int -> PreviousStep -> HTML p Action
 renderPastStep state stepNumber step =
   let
@@ -362,17 +354,32 @@ renderPastStep state stepNumber step =
     renderBody Tasks { state: TimeoutStep timeoutSlot } = renderTimeout stepNumber timeoutSlot
 
     renderBody Balances { balances } = renderBalances state balances
+
+    statusIndicator stepState =
+      div
+        [ classNames $ [ "h-10", "flex", "items-center" ] ]
+        $ case stepState of
+            TimeoutStep _ ->
+              [ span
+                  [ classNames [ "select-none", "font-semibold" ] ]
+                  [ text "Timed out" ]
+              , icon Icon.Timer [ "pl-2" ]
+              ]
+            TransactionStep _ ->
+              [ icon Icon.Done [ "text-green" ]
+              , span
+                  [ classNames [ "pl-2", "select-none", "font-semibold", "text-green" ] ]
+                  [ text "Completed" ]
+              ]
   in
     renderContractCard stepNumber state currentTab
       [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
           [ span
               [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
               [ text $ "Step " <> show (stepNumber + 1) ]
-          , case step.state of
-              TimeoutStep _ -> statusIndicator (Just Icon.Timer) "Timed out" [ "bg-red", "text-white" ]
-              TransactionStep _ -> statusIndicator (Just Icon.Done) "Completed" [ "bg-green", "text-white" ]
+          , statusIndicator step.state
           ]
-      , div [ classNames [ "overflow-y-auto", "px-4" ] ]
+      , div [ classNames [ "overflow-y-auto", "px-4", "bg-gray" ] ]
           [ renderBody currentTab step
           ]
       ]
@@ -418,41 +425,59 @@ renderPastActions state txInput =
 renderPartyPastActions :: forall p a. State -> InputsByParty -> HTML p a
 renderPartyPastActions state { inputs, interval, party } =
   let
-    participantName = participantWithNickname state party
+    -- We don't know exactly when a transaction was executed, we have an interval. But
+    -- the design asks for an exact date so we use the lower end of the interval so that
+    -- we don't show a value in the future
+    (SlotInterval intervalFrom _) = interval
 
-    userParties = state ^. _userParties
+    -- TODO: This time is in UTC, we need to localize.
+    mTransactionDateTime = slotToDateTime intervalFrom
 
-    isActiveParticipant = Set.member party userParties
+    transactionDate = maybe "-" formatDate mTransactionDateTime
 
-    fromDescription =
-      if isActiveParticipant then
-        "You"
-      else case party of
-        PK publicKey -> "Account " <> publicKey
-        Role roleName -> capitalize roleName
+    transactionTime = maybe "-" formatTime mTransactionDateTime
 
-    intervalDescription = humanizeInterval interval
+    renderPartyHeader =
+      div [ classNames [ "flex", "justify-between", "items-center", "border-b", "border-gray", "px-3", "pb-4" ] ]
+        [ renderParty [] state party
+        , div [ classNames [ "flex", "flex-col", "items-end", "text-xs" ] ]
+            [ span [] [ text $ transactionDate ]
+            , span [ classNames [ "font-semibold" ] ] [ text transactionTime ]
+            ]
+        ]
+
+    renderFeesSummary =
+      div [ classNames [ "pt-4", "px-3", "border-t", "border-gray", "flex", "items-center", "text-xs" ] ]
+        [ icon Icon.Language [ "text-lightpurple", "text-lg", "mr-1" ]
+        , span [ classNames [ "font-semibold" ] ]
+            [ text "Total fees:"
+            ]
+        , span [ classNames [ "flex-grow", "text-right" ] ] [ text $ humanizeValue adaToken transactionFee ]
+        ]
+
+    renderActionsBody =
+      div [ classNames [ "py-4", "px-3" ] ]
+        (map renderPastAction inputs)
 
     renderPastAction = case _ of
-      IDeposit intoAccountOf by token value ->
-        let
-          toDescription =
-            if Set.member intoAccountOf userParties then
-              "your"
-            else
-              if by == intoAccountOf then
-                "their"
-              else case intoAccountOf of
-                PK publicKey -> publicKey <> " public key"
-                Role roleName -> roleName <> "'s"
-        in
-          div [] [ text $ fromDescription <> " made a deposit of " <> humanizeValue token value <> " into " <> toDescription <> " account " <> intervalDescription ]
-      IChoice (ChoiceId choiceIdKey _) chosenNum -> div [] [ text $ fromDescription <> " chose " <> show chosenNum <> " for " <> show choiceIdKey <> " " <> intervalDescription ]
+      IDeposit intoAccountOf by token value -> renderDeposit state intoAccountOf by token value
+      IChoice (ChoiceId choiceIdKey _) chosenNum ->
+        div []
+          [ h4_ [ text "Chose:" ]
+          -- NOTE: It would be neat if we could use the same trick that we use in renderAction.MakeChoice
+          --       to detect if this is a single option or not, but we don't have the bounds of the choice
+          --       available here. We could later add a way to get that from the contract or rethink the
+          --       different constructs of When to properly include a single option and an enum.
+          , span_ [ text $ show chosenNum <> " for " ]
+          , span [ classNames [ "font-semibold" ] ] [ text choiceIdKey ]
+          ]
       _ -> div_ []
   in
-    div [ classNames [ "mt-4" ] ]
-      ( [ renderParty state party ] <> map renderPastAction inputs
-      )
+    div [ classNames [ "mt-4", "bg-white", "rounded", "shadow-sm", "py-4" ] ]
+      [ renderPartyHeader
+      , renderActionsBody
+      , renderFeesSummary
+      ]
 
 renderTimeout :: forall p a. Int -> Slot -> HTML p a
 renderTimeout stepNumber timeoutSlot =
@@ -483,6 +508,14 @@ renderCurrentStep currentSlot state =
     contractIsClosed = isContractClosed state
 
     mNextTimeout = state ^. (_executionState <<< _mNextTimeout)
+
+    statusIndicator mIcon status =
+      div
+        [ classNames $ [ "flex-grow", "h-10", "flex", "items-center" ] ]
+        $ Array.catMaybes
+            [ Just $ span [ classNames [ "select-none", "text-base", "flex-grow", "text-right", "font-semibold" ] ] [ text status ]
+            , mIcon <#> \anIcon -> icon anIcon [ "pl-2" ]
+            ]
   in
     renderContractCard stepNumber state currentTab
       [ div [ classNames [ "py-2.5", "px-4", "flex", "items-center", "border-b", "border-lightgray" ] ]
@@ -490,9 +523,9 @@ renderCurrentStep currentSlot state =
               [ classNames [ "text-xl", "font-semibold", "flex-grow" ] ]
               [ text $ "Step " <> show (stepNumber + 1) ]
           , case contractIsClosed, isJust pendingTransaction of
-              true, _ -> statusIndicator Nothing "Contract closed" [ "bg-lightgray" ]
-              _, true -> statusIndicator Nothing "Awaiting confirmation" [ "bg-lightgray" ]
-              _, _ -> statusIndicator (Just Icon.Timer) (timeoutString currentSlot state) [ "bg-lightgray" ]
+              true, _ -> statusIndicator Nothing "Contract closed"
+              _, true -> statusIndicator Nothing "Awaiting confirmation"
+              _, _ -> statusIndicator (Just Icon.Timer) (timeoutString currentSlot state)
           ]
       , div
           [ classNames [ "overflow-y-auto" ] ]
@@ -605,23 +638,58 @@ participantWithNickname state party =
     mNickname :: Maybe String
     mNickname = join $ Map.lookup party (state ^. _participants)
   in
-    capitalize case party /\ mNickname of
+    capitalize case party, mNickname of
       -- TODO: For the demo we wont have PK, but eventually we probably want to limit the amount of characters
-      PK publicKey /\ _ -> publicKey
-      Role roleName /\ Just nickname -> roleName <> " (" <> nickname <> ")"
-      Role roleName /\ Nothing -> roleName
+      PK publicKey, _ -> publicKey
+      Role roleName, Just nickname -> roleName <> " (" <> nickname <> ")"
+      Role roleName, Nothing -> roleName
+
+renderDeposit :: State -> Party -> Party -> Token -> BigInteger -> forall p a. HTML p a
+renderDeposit state to from token value =
+  div [ classNames [ "flex", "flex-col" ] ]
+    -- FIXME: The designs makes the distinction between Wallet and account, but a party is either
+    --        PK or Role, so we may need to rethink this part.
+    [ renderParty [] state from
+    , div [ classNames [ "flex", "justify-between", "items-center" ] ]
+        [ icon Icon.South [ "text-purple", "text-xs", "ml-1" ]
+        , span [ classNames [ "text-xs", "text-green" ] ] [ text $ humanizeValue token value ]
+        ]
+    , renderParty [] state to
+    ]
+
+firstLetterInCircle :: forall p a. Array String -> String -> HTML p a
+firstLetterInCircle colorStyles name =
+  div
+    [ classNames
+        $ [ "bg-gradient-to-r"
+          , "from-purple"
+          , "to-lightpurple"
+          , "text-white"
+          , "rounded-full"
+          , "w-5"
+          , "h-5"
+          , "text-center"
+          , "mr-1"
+          , "font-semibold"
+          ]
+        <> colorStyles
+    ]
+    [ text $ take 1 name ]
 
 -- TODO: In zeplin all participants have a different color. We need to decide how are we going to assing
 --       colors to users. For now they all have purple
-renderParty :: forall p a. State -> Party -> HTML p a
-renderParty state party =
+renderParty :: forall p a. Array String -> State -> Party -> HTML p a
+renderParty styles state party =
   let
     participantName = participantWithNickname state party
+
+    userParties = state ^. _userParties
   in
-    -- FIXME: mb-2 should not belong here
-    div [ classNames [ "text-xs", "flex", "mb-2" ] ]
-      [ div [ classNames [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white", "rounded-full", "w-5", "h-5", "text-center", "mr-1", "font-semibold" ] ] [ text $ take 1 participantName ]
-      , div [ classNames [ "font-semibold" ] ] [ text participantName ]
+    div [ classNames $ [ "text-xs", "flex" ] <> styles ]
+      [ firstLetterInCircle [ "bg-gradient-to-r", "from-purple", "to-lightpurple", "text-white" ] participantName
+      , div [ classNames [ "font-semibold" ] ]
+          [ text $ if Set.member party userParties then participantName <> " (you)" else participantName
+          ]
       ]
 
 renderPartyTasks :: forall p. State -> Party -> Array NamedAction -> HTML p Action
@@ -634,7 +702,7 @@ renderPartyTasks state party actions =
         (Array.singleton <<< renderAction state party <$> actions)
   in
     div [ classNames [ "mt-3" ] ]
-      ([ renderParty state party ] <> actionsSeparatedByOr)
+      ([ renderParty [ "mb-2" ] state party ] <> actionsSeparatedByOr)
 
 -- FIXME: This was added to allow anybody being able to do any actions for debug purposes...
 --        Remove once the PAB is connected
@@ -693,8 +761,7 @@ renderAction state party namedAction@(MakeChoice choiceId bounds mChosenNum) =
     metadata = state ^. _metadata
 
     -- NOTE': We could eventually add an heuristic that if the difference between min and max is less
-    --        than 10 elements, we could show a `select` instead of a input[number] and if the min==max
-    --        we use a button that says "Choose `min`"
+    --        than 10 elements, we could show a `select` instead of a input[number]
     Bound minBound maxBound = getEncompassBound bounds
 
     ChoiceId choiceIdKey _ = choiceId

--- a/marlowe-dashboard-client/tailwind.config.js
+++ b/marlowe-dashboard-client/tailwind.config.js
@@ -13,7 +13,7 @@ module.exports = {
       current: "currentColor",
       black: "#283346",
       lightgray: "#eeeeee",
-      gray: "#dfdfdf",
+      gray: "#f2f2f2",
       green: "#00a551",
       lightgreen: "#00e872",
       darkgray: "#b7b7b7",
@@ -48,6 +48,13 @@ module.exports = {
       lg: "25px",
       full: "9999px",
     },
+    dropShadow: {
+      DEFAULT: [
+        "0 5px 5px rgba(0, 0, 0, 0.15)",
+        "5px 5px 5px rgba(0, 0, 0, 0.06)",
+      ],
+      lg: ["0 10px 5px rgba(0, 0, 0, 0.2)", "5px 10px 5px rgba(0, 0, 0, 0.04)"],
+    },
     boxShadow: {
       none: "none",
       sm: "0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06)",
@@ -64,11 +71,12 @@ module.exports = {
         "to-bottom": "to-bottom 250ms ease-out 1",
       },
       transitionProperty: {
-        width: "width"
+        width: "width",
       },
-      backgroundImage: theme => ({
+      backgroundImage: (theme) => ({
         "background-shape": "url('/static/images/background-shape.svg')",
-        "get-started-thumbnail": "url('/static/images/get-started-thumbnail.jpg')",
+        "get-started-thumbnail":
+          "url('/static/images/get-started-thumbnail.jpg')",
         "link-highlight": "url('/static/images/link-highlight.svg')",
       }),
       keyframes: {
@@ -99,19 +107,19 @@ module.exports = {
       },
       spacing: {
         "2+2px": "calc(0.5rem + 2px)",
-        "4.5": "1.125rem",
-        "22": "5.5rem",
-        "160": "40rem",
-        "256": "64rem",
+        4.5: "1.125rem",
+        22: "5.5rem",
+        160: "40rem",
+        256: "64rem",
         "16:9": "56.25%", // this is used for video containers to maintain a 16:9 aspect ratio
-        "sidebar": "350px",
+        sidebar: "350px",
       },
       width: {
         sm: "375px",
         md: "640px",
         lg: "768px",
         "welcome-box": "400px",
-        "sidebar": "350px",
+        sidebar: "350px",
         "contracts-grid-md": "632px", // 2 cards of 300px + 1 gap of 32px
         "contracts-grid-lg": "964px", // 3 cards of 300px + 2 gaps of 32px
         "contract-card": "264px",
@@ -122,7 +130,7 @@ module.exports = {
       height: {
         "welcome-box": "227px",
         "dashboard-card-actions": "200px",
-        "contract-card": "467px",
+        "contract-card": "415px",
         "90pc": "90%",
       },
       borderWidth: {
@@ -166,6 +174,7 @@ module.exports = {
     divideColor: false,
     divideStyle: false,
     divideOpacity: false,
+    dropShadow: true,
     accessibility: false,
     appearance: false,
     backgroundAttachment: false,
@@ -232,6 +241,7 @@ module.exports = {
     ringColor: true,
     ringOpacity: false,
     fill: false,
+    filter: true,
     stroke: false,
     strokeWidth: false,
     tableLayout: false,
@@ -244,7 +254,7 @@ module.exports = {
     fontSmoothing: false,
     fontVariantNumeric: false,
     letterSpacing: false,
-    userSelect: false,
+    userSelect: true,
     verticalAlign: false,
     visibility: true,
     whitespace: true,

--- a/web-common/src/Halogen/Extra.purs
+++ b/web-common/src/Halogen/Extra.purs
@@ -64,6 +64,13 @@ mapSubmodule ::
     ~> HalogenM state action slots msg m
 mapSubmodule lens wrapper halogen = (imapState lens <<< mapAction wrapper) halogen
 
+mapComponentAction ::
+  forall m action action' slots.
+  (action' -> action) ->
+  ComponentHTML action' slots m ->
+  ComponentHTML action slots m
+mapComponentAction actionWrapper rendered = bimap (map actionWrapper) actionWrapper rendered
+
 -- Allows you to render a submodule changing the state with the provided optic and
 -- wrapping the action. If the optic cant produce a value, an empty div is inserted instead
 renderSubmodule ::
@@ -81,7 +88,7 @@ renderSubmodule optic actionWrapper render state =
       Nothing -> div_ []
       Just subState -> render subState
   in
-    bimap (map actionWrapper) actionWrapper rendered
+    mapComponentAction actionWrapper rendered
 
 -- | This lets you map the state of a submodule that may not exist,
 -- | given an affine traversal into that optional substate. It's
@@ -115,6 +122,12 @@ scrollIntoView ref = do
   mElement <- getHTMLElementRef ref
   for_ mElement (liftEffect <<< runEffectFn1 scrollIntoView_)
 
+-- FIXME: There is a problem with this implementation of lifeCycleEvent that makes the tooltips not appear
+--        in branches of the component that includes this.
+--        I think that by firing an Action and not using the RefUpdate we are "hijacking" halogen internals
+--        and not allowing the slots component Init state to kick in.
+--        To fix this one option would be to change this IProp into a proper dumb component (used with slots)
+--        and to re-use the lifecycle of that component through the output message to send an Init/Finilize message.
 -- This HTML property dispatch lifecycle actions when the element is added or removed to the DOM
 lifeCycleEvent :: forall r action. { onInit :: Maybe action, onFinalize :: Maybe action } -> IProp r action
 lifeCycleEvent handlers = (unsafeCoerce :: Prop (Input action) -> IProp r action) $ Core.ref onLifecycleEvent

--- a/web-common/src/Material/Icons.purs
+++ b/web-common/src/Material/Icons.purs
@@ -39,6 +39,8 @@ data Icon
   | HelpOutline
   | History
   | Home
+  | Info
+  | Language
   | Menu
   | Next
   | NewContact
@@ -48,6 +50,7 @@ data Icon
   | Refresh
   | Roles
   | Running
+  | South
   | TaskAlt
   | Terms
   | Timer
@@ -92,6 +95,10 @@ content History = "history"
 
 content Home = "home"
 
+content Info = "info"
+
+content Language = "language"
+
 content Menu = "short_text"
 
 content Next = "chevron_right"
@@ -109,6 +116,8 @@ content Refresh = "refresh"
 content Roles = "person_pin_circle"
 
 content Running = "directions_run"
+
+content South = "south"
 
 content TaskAlt = "task_alt"
 
@@ -157,6 +166,10 @@ iconClass History = "history"
 
 iconClass Home = "home"
 
+iconClass Info = "info"
+
+iconClass Language = "language"
+
 iconClass Menu = "menu"
 
 iconClass Next = "next"
@@ -174,6 +187,8 @@ iconClass Refresh = "refresh"
 iconClass Roles = "roles"
 
 iconClass Running = "running"
+
+iconClass South = "south"
 
 iconClass TaskAlt = "task-alt"
 


### PR DESCRIPTION
This PR makes the first part in the contract screen redesign:

![changes](https://user-images.githubusercontent.com/2634059/126712221-0333e57a-0568-461a-911b-9d7c04278bda.png)

Things to note:
* When it comes to deposits the design makes a distinction between accounts and wallet, but I'm not sure if we have this information. I think we can assume that deposits always comes from "wallet -> account", but we'll have to see when we do the transaction summary if we can always tell.
* In the choice input we don't have access to the original choice bounds, so I cant use the same hack that I used for the singleChoice and sadly the input reads "1 for Report problem" etc. 
* There is a bug with lifeCycleEvent that prevents tooltips and other halogen components from rendering
* I've changed box-shadow to drop-shadow in the step cards and now the top right corner doesn't have the "shadow artifact" 🎉

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
