### PR TITLE
Fixing resolution of slots from relative to absolute.

### DIFF
--- a/marlowe-dashboard-client/src/Template/State.purs
+++ b/marlowe-dashboard-client/src/Template/State.purs
@@ -166,8 +166,6 @@ instantiateExtendedContract currentSlot state =
   let
     extendedContract = view (_contractTemplate <<< _extendedContract) state
 
-    relativeContract = resolveRelativeTimes currentSlot extendedContract
-
     slotContentInputs = view _slotContentInputs state
 
     valueContentInputs = view _valueContentInputs state
@@ -183,8 +181,12 @@ instantiateExtendedContract currentSlot state =
     valueContent = mapMaybeWithKey getBigIntegerValueWithDecimals valueContentInputs
 
     templateContent = TemplateContent { slotContent, valueContent }
+
+    filledContract = fillTemplate templateContent extendedContract
+
+    absoluteFilledContract = resolveRelativeTimes currentSlot filledContract
   in
-    toCore $ fillTemplate templateContent relativeContract
+    toCore absoluteFilledContract
 
 ------------------------------------------------------------
 toContractNicknameInput ::


### PR DESCRIPTION
I broke the way slot resolution works in #3578. Or possibly it was already broken, but the bug was masked by the fact that we were pre-filling slot parameters before instantiating contracts. Either way, this fixes it. The code is probably self-explanatory - basically the resolution was being done too soon (before filling the contract with the parameters).