### PR TITLE
SCP-2491: Emulator can answer observable state queries even after a contract instance has stopped

### DIFF
--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -188,7 +188,7 @@ tests =
               matchLogs :: [EM.EmulatorTimeEvent ContractInstanceLog] -> Bool
               matchLogs lgs =
                   case _cilMessage . EM._eteEvent <$> lgs of
-                            [ Started, ContractLog "waiting for endpoint 1", CurrentRequests [_], ReceiveEndpointCall{}, ContractLog "Received value: 27", HandledRequest _, CurrentRequests [], StoppedNoError] -> True
+                            [ Started, ContractLog "waiting for endpoint 1", CurrentRequests [_], ReceiveEndpointCall{}, ContractLog "Received value: 27", HandledRequest _, CurrentRequests [], StoppedNoError ] -> True
                             _ -> False
 
           in run 1 "contract logs"

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeFamilies       #-}
 module Main(main) where
 

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/OffChain.hs
@@ -491,7 +491,6 @@ ownerEndpoint = do
     e <- mapError absurd $ runError start
     void $ waitNSlots 1
     tell $ Last $ Just e
-    void $ waitNSlots 50
 
 -- | Provides the following endpoints for users of a Uniswap instance:
 --

--- a/plutus-use-cases/src/Plutus/Contracts/Uniswap/Trace.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Uniswap/Trace.hs
@@ -12,7 +12,7 @@ module Plutus.Contracts.Uniswap.Trace(
     , wallets
     ) where
 
-import           Control.Monad                     (forM_, void, when)
+import           Control.Monad                     (forM_, when)
 import           Control.Monad.Freer.Error         (throwError)
 import qualified Data.Map                          as Map
 import qualified Data.Monoid                       as Monoid
@@ -75,10 +75,6 @@ setupTokens = do
             awaitTxConfirmed $ txId tx
 
     tell $ Just $ Semigroup.Last cur
-
-    -- Need to wait one slot or else we will get stuck in an infinite loop
-    -- when requesting the contract's observable state.
-    void $ waitNSlots 50
 
   where
     amount = 1000000

--- a/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Vesting.hs
@@ -113,9 +113,9 @@ availableFrom (VestingTranche d v) range =
     in if validRange `Interval.contains` range then v else zero
 
 availableAt :: VestingParams -> POSIXTime -> Value
-availableAt VestingParams{vestingTranche1, vestingTranche2} sl =
+availableAt VestingParams{vestingTranche1, vestingTranche2} time =
     let f VestingTranche{vestingTrancheDate, vestingTrancheAmount} =
-            if sl >= vestingTrancheDate then vestingTrancheAmount else mempty
+            if time >= vestingTrancheDate then vestingTrancheAmount else mempty
     in foldMap f [vestingTranche1, vestingTranche2]
 
 {-# INLINABLE remainingFrom #-}


### PR DESCRIPTION
Emulator can answer observable state queries even after a contract instance has stopped.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
