### PR TITLE
ci-plutus-benchmark: Update origin

### DIFF
--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -38,8 +38,11 @@ cabal update
 echo "[ci-plutus-benchmark]: Running benchmark for PR branch ..."
 nix-shell --run "cabal bench plutus-benchmark:validation >bench-PR.log 2>&1"
 
+echo "[ci-plutus-benchmark]: fetching origin ..."
+git fetch origin
+
 echo "[ci-plutus-benchmark]: Switching branches ..."
-git checkout "$(git merge-base HEAD master)"
+git checkout "$(git merge-base HEAD origin/master)"
 BASE_BRANCH_REF=$(git show-ref -s HEAD)
 
 echo "[ci-plutus-benchmark]: Running benchmark for base branch ..."

--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -30,7 +30,7 @@ if [ -z "$PR_NUMBER" ] ; then
    exit 1
 fi
 echo "[ci-plutus-benchmark]: Processing benchmark comparison for PR $PR_NUMBER"
-PR_BRANCH_REF=$(git show-ref -s HEAD)
+PR_BRANCH_REF=$(git rev-parse HEAD)
 
 echo "[ci-plutus-benchmark]: Updating cabal database ..."
 cabal update
@@ -43,7 +43,7 @@ git fetch origin
 
 echo "[ci-plutus-benchmark]: Switching branches ..."
 git checkout "$(git merge-base HEAD origin/master)"
-BASE_BRANCH_REF=$(git show-ref -s HEAD)
+BASE_BRANCH_REF=$(git rev-parse HEAD)
 
 echo "[ci-plutus-benchmark]: Running benchmark for base branch ..."
 nix-shell --run "cabal bench plutus-benchmark:validation >bench-base.log 2>&1"


### PR DESCRIPTION
**Summary**:
Update origin before figuring out the branch to compare to via `git merge-base`.

**Details**
@kwxm described some weird behavior with the benchmarking picking revisions that seemingly make no sense. I _think_ the issue was with not comparing with a recent revision of `master`. Hence this PR adds a `git fetch origin` in combination with using `git merge-base HEAD origin/master`.

----

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
