### PR TITLE
Split IsData into three

### DIFF
--- a/doc/plutus/tutorials/basic-apps.rst
+++ b/doc/plutus/tutorials/basic-apps.rst
@@ -34,7 +34,7 @@ The ``SplitData`` type has instances for a number of typeclasses.
 These instances enable the serialisation of ``SplitData`` to different formats.
 ``ToJSON`` and ``FromJSON`` are needed for JSON serialization.
 JSON objects are passed between the frontend (for example, the Playground) and the app instance.
-:hsobj:`PlutusTx.IsData` is used for values that are attached to transactions, for example as the <redeemer> of a script output.
+:hsobj:`PlutusTx.FromData` and :hsobj:`PlutusTx.ToData` are used for values that are attached to transactions, for example as the <redeemer> of a script output.
 This class is used by the Plutus app at runtime to construct ``Data`` values.
 Finally, :hsobj:`PlutusTx.makeLift` is a Template Haskell statement that generates an instance of the :hsobj:`PlutusTx.Lift.Class.Lift` class for ``SplitData``.
 This class is used by the Plutus compiler at compile-time to construct Plutus core programs.

--- a/doc/plutus/tutorials/basic-validators.rst
+++ b/doc/plutus/tutorials/basic-validators.rst
@@ -31,9 +31,9 @@ The answer is that we pass them as a generic structured data type :hsobj:`Plutus
 Consequently, the validator scripts we will write in this tutorial take three arguments of type ``Data``.
 
 However, you will typically not want to use ``Data`` directly in your program, rather you will want to use your own datatypes.
-We can easily convert to and from ``Data`` with the :hsobj:`PlutusTx.IsData.Class.IsData` typeclass.
+We can easily convert to and from ``Data`` with the :hsobj:`PlutusTx.IsData.Class.ToData` and :hsobj:`PlutusTx.IsData.Class.FromData` typeclasses.
 
-You usually don't need to write your own ``IsData`` instances.
+You usually don't need to write your own ``To/FromData`` instances.
 Instead, you can use the ``makeIsData`` Template Haskell function to generate one.
 
 .. literalinclude:: BasicValidators.hs

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -413,8 +413,9 @@ submitTx = submitTxConstraintsWith @Void mempty
 --   contract's own public key to solve the constraints.
 submitTxConstraints
   :: forall a w s e.
-  ( PlutusTx.IsData (RedeemerType a)
-  , PlutusTx.IsData (DatumType a)
+  ( PlutusTx.ToData (RedeemerType a)
+  , PlutusTx.FromData (DatumType a)
+  , PlutusTx.ToData (DatumType a)
   , AsContractError e
   )
   => TypedValidator a
@@ -426,8 +427,9 @@ submitTxConstraints inst = submitTxConstraintsWith (Constraints.typedValidatorLo
 --   to resolve any input constraints (see 'Ledger.Constraints.TxConstraints.InputConstraint')
 submitTxConstraintsSpending
   :: forall a w s e.
-  ( PlutusTx.IsData (RedeemerType a)
-  , PlutusTx.IsData (DatumType a)
+  ( PlutusTx.ToData (RedeemerType a)
+  , PlutusTx.FromData (DatumType a)
+  , PlutusTx.ToData (DatumType a)
   , AsContractError e
   )
   => TypedValidator a
@@ -442,8 +444,9 @@ submitTxConstraintsSpending inst utxo =
 --   network. Using the given constraints.
 submitTxConstraintsWith
   :: forall a w s e.
-  ( PlutusTx.IsData (RedeemerType a)
-  , PlutusTx.IsData (DatumType a)
+  ( PlutusTx.ToData (RedeemerType a)
+  , PlutusTx.FromData (DatumType a)
+  , PlutusTx.ToData (DatumType a)
   , AsContractError e
   )
   => ScriptLookups a
@@ -457,4 +460,3 @@ submitTxConstraintsWith sl constraints = do
 --   confirmed on the ledger before returning.
 submitTxConfirmed :: forall w s e. (AsContractError e) => UnbalancedTx -> Contract w s e ()
 submitTxConfirmed t = submitUnbalancedTx t >>= awaitTxConfirmed . txId
-

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -107,7 +107,7 @@ type OnChainState s i = (Typed.TypedScriptTxOut (SM.StateMachine s i), Typed.Typ
 
 getStates
     :: forall s i
-    . (PlutusTx.IsData s)
+    . (PlutusTx.FromData s, PlutusTx.ToData s)
     => SM.StateMachineInstance s i
     -> Map Tx.TxOutRef Tx.TxOutTx
     -> [OnChainState s i]
@@ -197,7 +197,8 @@ mkStateMachineClient inst =
 -}
 getOnChainState ::
     ( AsSMContractError e
-    , PlutusTx.IsData state
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
     )
     => StateMachineClient state i
     -> Contract w schema e (Maybe (OnChainState state i, UtxoMap))
@@ -227,7 +228,8 @@ data WaitingResult a
 waitForUpdateUntilSlot ::
     ( AsSMContractError e
     , AsContractError e
-    , PlutusTx.IsData state
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
     )
     => StateMachineClient state i
     -> Slot
@@ -259,7 +261,8 @@ waitForUpdateUntilSlot StateMachineClient{scInstance, scChooser} timeoutSlot = d
 waitForUpdateUntilTime ::
     ( AsSMContractError e
     , AsContractError e
-    , PlutusTx.IsData state
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
     )
     => StateMachineClient state i
     -> POSIXTime
@@ -275,7 +278,8 @@ waitForUpdateUntilTime sm timeoutTime = do
 waitForUpdate ::
     ( AsSMContractError e
     , AsContractError e
-    , PlutusTx.IsData state
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
     )
     => StateMachineClient state i
     -> Contract w schema e (Maybe (OnChainState state i))
@@ -293,8 +297,9 @@ waitForUpdate StateMachineClient{scInstance, scChooser} = do
 runGuardedStep ::
     forall w a e state schema input.
     ( AsSMContractError e
-    , PlutusTx.IsData state
-    , PlutusTx.IsData input
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     )
     => StateMachineClient state input              -- ^ The state machine
     -> input                                       -- ^ The input to apply to the state machine
@@ -306,8 +311,9 @@ runGuardedStep = runGuardedStepWith mempty mempty
 runStep ::
     forall w e state schema input.
     ( AsSMContractError e
-    , PlutusTx.IsData state
-    , PlutusTx.IsData input
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     )
     => StateMachineClient state input
     -- ^ The state machine
@@ -327,8 +333,9 @@ getThreadToken = mapError (review _SMContractError) $ do
 -- | Initialise a state machine
 runInitialise ::
     forall w e state schema input.
-    ( PlutusTx.IsData state
-    , PlutusTx.IsData input
+    ( PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     , AsSMContractError e
     )
     => StateMachineClient state input
@@ -352,8 +359,9 @@ data StateMachineTransition state input =
 -- | Initialise a state machine and supply additional constraints and lookups for transaction.
 runInitialiseWith ::
     forall w e state schema input.
-    ( PlutusTx.IsData state
-    , PlutusTx.IsData input
+    ( PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     , AsSMContractError e
     )
     => ScriptLookups (StateMachine state input)
@@ -390,8 +398,9 @@ runInitialiseWith customLookups customConstraints StateMachineClient{scInstance}
 runStepWith ::
     forall w e state schema input.
     ( AsSMContractError e
-    , PlutusTx.IsData state
-    , PlutusTx.IsData input
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     )
     => ScriptLookups (StateMachine state input)
     -- ^ Additional lookups
@@ -411,8 +420,9 @@ runStepWith lookups constraints smc input =
 runGuardedStepWith ::
     forall w a e state schema input.
     ( AsSMContractError e
-    , PlutusTx.IsData state
-    , PlutusTx.IsData input
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
+    , PlutusTx.ToData input
     )
     => ScriptLookups (StateMachine state input)    -- ^ Additional lookups
     -> TxConstraints input state                   -- ^ Additional constraints
@@ -438,7 +448,8 @@ runGuardedStepWith userLookups userConstraints smc input guard = mapError (revie
 mkStep ::
     forall w e state schema input.
     ( AsSMContractError e
-    , PlutusTx.IsData state
+    , PlutusTx.FromData state
+    , PlutusTx.ToData state
     )
     => StateMachineClient state input
     -> input

--- a/plutus-contract/src/Plutus/Contract/StateMachine/OnChain.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine/OnChain.hs
@@ -109,7 +109,7 @@ machineAddress = validatorAddress . typedValidator
 
 {-# INLINABLE mkValidator #-}
 -- | Turn a state machine into a validator script.
-mkValidator :: forall s i. (PlutusTx.IsData s) => StateMachine s i -> ValidatorType (StateMachine s i)
+mkValidator :: forall s i. (PlutusTx.ToData s) => StateMachine s i -> ValidatorType (StateMachine s i)
 mkValidator (StateMachine step isFinal check threadToken) currentState input ptx =
     let vl = maybe (error ()) (txOutValue . txInInfoResolved) (findOwnInput ptx)
         checkOk =

--- a/plutus-contract/src/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Plutus/Contract/Test.hs
@@ -105,7 +105,7 @@ import qualified Plutus.Contract.Request               as Request
 import           Plutus.Contract.Resumable             (Request (..), Response (..))
 import qualified Plutus.Contract.Resumable             as State
 import           Plutus.Contract.Types                 (Contract (..), ResumableResult, shrinkResumableResult)
-import           PlutusTx                              (CompiledCode, IsData (..), getPir)
+import           PlutusTx                              (CompiledCode, FromData (..), getPir)
 import qualified PlutusTx.Prelude                      as P
 
 import           Ledger                                (Validator)
@@ -339,7 +339,7 @@ valueAtAddress address check =
             tell @(Doc Void) ("Funds at address" <+> pretty address <+> "were" <+> pretty vl)
         pure result
 
-dataAtAddress :: IsData a => Address -> (a -> Bool) -> TracePredicate
+dataAtAddress :: FromData a => Address -> (a -> Bool) -> TracePredicate
 dataAtAddress address check =
     flip postMapM (L.generalize $ Folds.utxoAtAddress address) $ \utxo -> do
         let isSingletonWith p xs = length xs == 1 && all p xs

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Ada.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Ada.hs
@@ -59,7 +59,7 @@ newtype Ada = Lovelace { getLovelace :: Integer }
     deriving (Haskell.Enum)
     deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
-    deriving newtype (Eq, Ord, Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid, Haskell.Integral, Haskell.Real, Serialise, PlutusTx.IsData)
+    deriving newtype (Eq, Ord, Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid, Haskell.Integral, Haskell.Real, Serialise, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving Pretty via (Tagged "Lovelace:" Integer)
 
 instance Haskell.Semigroup Ada where

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -94,7 +94,9 @@ module Plutus.V1.Ledger.Api (
     -- * Data
     , PLC.Data (..)
     , BuiltinData (..)
-    , IsData (..)
+    , ToData (..)
+    , FromData (..)
+    , UnsafeFromData (..)
     , toData
     , fromData
     , dataToBuiltinData
@@ -137,7 +139,8 @@ import qualified PlutusCore.Evaluation.Machine.ExBudget           as PLC
 import           PlutusCore.Evaluation.Machine.ExMemory           (ExCPU (..), ExMemory (..))
 import           PlutusCore.Evaluation.Machine.MachineParameters
 import           PlutusCore.Pretty
-import           PlutusTx                                         (IsData (..), fromData, toData)
+import           PlutusTx                                         (FromData (..), ToData (..), UnsafeFromData (..),
+                                                                   fromData, toData)
 import           PlutusTx.Builtins.Internal                       (BuiltinData (..), builtinDataToData,
                                                                    dataToBuiltinData)
 import qualified UntypedPlutusCore                                as UPLC

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Bytes.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Bytes.hs
@@ -70,7 +70,7 @@ fromHex = fmap LedgerBytes . asBSLiteral
 --   type for PureScript.
 newtype LedgerBytes = LedgerBytes { getLedgerBytes :: Builtins.ByteString } -- TODO: use strict bytestring
     deriving stock (Eq, Ord, Generic)
-    deriving newtype (Serialise, P.Eq, P.Ord, PlutusTx.IsData)
+    deriving newtype (Serialise, P.Eq, P.Ord, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving anyclass (JSON.ToJSONKey, JSON.FromJSONKey, NFData)
     deriving Pretty via (PrettyShow LedgerBytes)
 

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Crypto.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Crypto.hs
@@ -63,7 +63,7 @@ import qualified PlutusTx.Prelude          as P
 newtype PubKey = PubKey { getPubKey :: LedgerBytes }
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (Newtype, ToJSON, FromJSON, NFData)
-    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
+    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving IsString via LedgerBytes
     deriving (Show, Pretty) via LedgerBytes
 makeLift ''PubKey
@@ -78,7 +78,7 @@ instance FromJSONKey PubKey where
 newtype PubKeyHash = PubKeyHash { getPubKeyHash :: BS.ByteString }
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey, NFData)
-    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData, Hashable)
+    deriving newtype (P.Eq, P.Ord, Serialise, Hashable, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving IsString via LedgerBytes
     deriving (Show, Pretty) via LedgerBytes
 makeLift ''PubKeyHash
@@ -94,7 +94,7 @@ pubKeyHash (PubKey (LedgerBytes bs)) =
 newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
-    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
+    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving (Show, Pretty) via LedgerBytes
 
 makeLift ''PrivateKey
@@ -102,7 +102,7 @@ makeLift ''PrivateKey
 -- | A message with a cryptographic signature.
 newtype Signature = Signature { getSignature :: Builtins.ByteString }
     deriving stock (Eq, Ord, Generic)
-    deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData, NFData)
+    deriving newtype (P.Eq, P.Ord, Serialise, NFData, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving (Show, Pretty) via LedgerBytes
 
 instance ToJSON Signature where

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -80,7 +80,8 @@ import qualified PlutusCore.Data                          as PLC
 import qualified PlutusCore.DeBruijn                      as PLC
 import qualified PlutusCore.Evaluation.Machine.ExBudget   as PLC
 import qualified PlutusCore.MkPlc                         as PLC
-import           PlutusTx                                 (CompiledCode, IsData (..), getPlc, makeLift)
+import           PlutusTx                                 (CompiledCode, FromData (..), ToData (..),
+                                                           UnsafeFromData (..), getPlc, makeLift)
 import           PlutusTx.Builtins                        as Builtins
 import           PlutusTx.Builtins.Internal               as BI
 import           PlutusTx.Evaluation                      (ErrorWithCause (..), EvaluationError (..), evaluateCekTrace)
@@ -244,7 +245,7 @@ instance BA.ByteArrayAccess Validator where
 -- | 'Datum' is a wrapper around 'Data' values which are used as data in transaction outputs.
 newtype Datum = Datum { getDatum :: BuiltinData  }
   deriving stock (Generic, Haskell.Show)
-  deriving newtype (Haskell.Eq, Haskell.Ord, Eq, IsData)
+  deriving newtype (Haskell.Eq, Haskell.Ord, Eq, ToData, FromData, UnsafeFromData)
   deriving (ToJSON, FromJSON, Serialise, NFData) via PLC.Data
   deriving Pretty via PLC.Data
 
@@ -287,7 +288,7 @@ newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
     deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, ToData, FromData, UnsafeFromData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, NFData)
 
 -- | Script runtime representation of a @Digest SHA256@.
@@ -295,23 +296,23 @@ newtype DatumHash =
     DatumHash Builtins.ByteString
     deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData, NFData)
-    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, ToData, FromData, UnsafeFromData)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, NFData)
 
 -- | Script runtime representation of a @Digest SHA256@.
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
     deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
-    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, ToData, FromData, UnsafeFromData)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, NFData)
 
 -- | Script runtime representation of a @Digest SHA256@.
 newtype MintingPolicyHash =
     MintingPolicyHash Builtins.ByteString
     deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, ToData, FromData, UnsafeFromData)
     deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey)
 
 datumHash :: Datum -> DatumHash

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -42,7 +42,7 @@ import           Plutus.V1.Ledger.Interval
 newtype Slot = Slot { getSlot :: Integer }
     deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
     deriving anyclass (FromJSON, FromJSONKey, ToJSON, ToJSONKey, NFData)
-    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Eq, Ord, Enum, PlutusTx.IsData)
+    deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Eq, Ord, Enum, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving newtype (Haskell.Num, Haskell.Enum, Haskell.Real, Haskell.Integral, Serialise, Hashable)
 
 makeLift ''Slot

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Time.hs
@@ -41,7 +41,7 @@ import qualified Prelude                   as Haskell
 newtype DiffMilliSeconds = DiffMilliSeconds Integer
   deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
   deriving anyclass (FromJSON, FromJSONKey, ToJSON, ToJSONKey, NFData)
-  deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Haskell.Enum, Eq, Ord, Haskell.Real, Haskell.Integral, Serialise, Hashable, PlutusTx.IsData)
+  deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Haskell.Enum, Eq, Ord, Haskell.Real, Haskell.Integral, Serialise, Hashable, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 
 makeLift ''DiffMilliSeconds
 
@@ -49,7 +49,7 @@ makeLift ''DiffMilliSeconds
 newtype POSIXTime = POSIXTime { getPOSIXTime :: Integer }
   deriving stock (Haskell.Eq, Haskell.Ord, Haskell.Show, Generic)
   deriving anyclass (FromJSONKey, ToJSONKey, NFData)
-  deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Eq, Ord, Enum, PlutusTx.IsData)
+  deriving newtype (AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Eq, Ord, Enum, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
   deriving newtype (Haskell.Num, Haskell.Enum, Haskell.Real, Haskell.Integral, Serialise, Hashable)
 
 -- | Custom `FromJSON` instance which allows to parse a JSON number to a

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
@@ -82,7 +82,7 @@ import           PlutusTx.These
 newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: Builtins.ByteString }
     deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving anyclass (Hashable, ToJSONKey, FromJSONKey,  NFData)
 
 instance ToJSON CurrencySymbol where
@@ -122,7 +122,7 @@ currencySymbol = CurrencySymbol
 newtype TokenName = TokenName { unTokenName :: Builtins.ByteString }
     deriving (Serialise) via LedgerBytes
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving anyclass (Hashable, NFData)
     deriving Pretty via (PrettyShow TokenName)
 
@@ -182,7 +182,7 @@ tokenName = TokenName
 -- | An asset class, identified by currency symbol and token name.
 newtype AssetClass = AssetClass { unAssetClass :: (CurrencySymbol, TokenName) }
     deriving stock (Generic)
-    deriving newtype (Haskell.Eq, Haskell.Ord, Haskell.Show, Eq, Ord, PlutusTx.IsData, Serialise)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Haskell.Show, Eq, Ord, Serialise, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving anyclass (Hashable, NFData, ToJSON, FromJSON)
     deriving Pretty via (PrettyShow (CurrencySymbol, TokenName))
 
@@ -210,7 +210,7 @@ makeLift ''AssetClass
 newtype Value = Value { getValue :: Map.Map CurrencySymbol (Map.Map TokenName Integer) }
     deriving stock (Generic)
     deriving anyclass (ToJSON, FromJSON, Hashable, NFData)
-    deriving newtype (Serialise, PlutusTx.IsData)
+    deriving newtype (Serialise, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving Pretty via (PrettyShow Value)
 
 instance Haskell.Show Value where

--- a/plutus-ledger/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger/src/Ledger/Constraints/OffChain.hs
@@ -56,7 +56,7 @@ import qualified Data.Set                         as Set
 import           Data.Text.Prettyprint.Doc
 import           GHC.Generics                     (Generic)
 
-import           PlutusTx                         (IsData (..))
+import           PlutusTx                         (FromData (..), ToData (..))
 import           PlutusTx.Lattice
 import qualified PlutusTx.Numeric                 as N
 
@@ -267,7 +267,7 @@ required v = ValueSpentBalances { vbsRequired = v, vbsProvided = mempty }
 -- | Some typed 'TxConstraints' and the 'ScriptLookups' needed to turn them
 --   into an 'UnbalancedTx'.
 data SomeLookupsAndConstraints where
-    SomeLookupsAndConstraints :: forall a. (IsData (DatumType a), IsData (RedeemerType a)) => ScriptLookups a -> TxConstraints (RedeemerType a) (DatumType a) -> SomeLookupsAndConstraints
+    SomeLookupsAndConstraints :: forall a. (FromData (DatumType a), ToData (DatumType a), ToData (RedeemerType a)) => ScriptLookups a -> TxConstraints (RedeemerType a) (DatumType a) -> SomeLookupsAndConstraints
 
 -- | Given a list of 'SomeLookupsAndConstraints' describing the constraints
 --   for several scripts, build a single transaction that runs all the scripts.
@@ -284,8 +284,9 @@ mkSomeTx xs =
 -- | Resolve some 'TxConstraints' by modifying the 'UnbalancedTx' in the
 --   'ConstraintProcessingState'
 processLookupsAndConstraints
-    :: ( IsData (DatumType a)
-       , IsData (RedeemerType a)
+    :: ( FromData (DatumType a)
+       , ToData (DatumType a)
+       , ToData (RedeemerType a)
        , MonadState ConstraintProcessingState m
        , MonadError MkTxError m
        )
@@ -306,8 +307,9 @@ processLookupsAndConstraints lookups TxConstraints{txConstraints, txOwnInputs, t
 --   'Plutus.Contract.submitTxConstraints'
 --   and related functions.
 mkTx
-    :: ( IsData (DatumType a)
-       , IsData (RedeemerType a))
+    :: ( FromData (DatumType a)
+       , ToData (DatumType a)
+       , ToData (RedeemerType a))
     => ScriptLookups a
     -> TxConstraints (RedeemerType a) (DatumType a)
     -> Either MkTxError UnbalancedTx
@@ -363,8 +365,9 @@ addOwnInput
     :: ( MonadReader (ScriptLookups a) m
         , MonadError MkTxError m
         , MonadState ConstraintProcessingState m
-        , IsData (DatumType a)
-        , IsData (RedeemerType a)
+        , FromData (DatumType a)
+        , ToData (DatumType a)
+        , ToData (RedeemerType a)
         )
     => InputConstraint (RedeemerType a)
     -> m ()
@@ -384,7 +387,8 @@ addOwnInput InputConstraint{icRedeemer, icTxOutRef} = do
 addOwnOutput
     :: ( MonadReader (ScriptLookups a) m
         , MonadState ConstraintProcessingState m
-        , IsData (DatumType a)
+        , FromData (DatumType a)
+        , ToData (DatumType a)
         , MonadError MkTxError m
         )
     => OutputConstraint (DatumType a)

--- a/plutus-ledger/src/Ledger/Constraints/OnChain.hs
+++ b/plutus-ledger/src/Ledger/Constraints/OnChain.hs
@@ -11,7 +11,7 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.Constraints.OnChain where
 
-import           PlutusTx                         (IsData (..))
+import           PlutusTx                         (ToData (..))
 import           PlutusTx.Prelude
 
 import           Ledger.Constraints.TxConstraints
@@ -34,7 +34,7 @@ checkOwnInputConstraint ScriptContext{scriptContextTxInfo} InputConstraint{icTxO
 
 {-# INLINABLE checkOwnOutputConstraint #-}
 checkOwnOutputConstraint
-    :: IsData o
+    :: ToData o
     => ScriptContext
     -> OutputConstraint o
     -> Bool
@@ -95,7 +95,7 @@ checkTxConstraint ScriptContext{scriptContextTxInfo} = \case
 
 {-# INLINABLE checkScriptContext #-}
 -- | Does the 'ScriptContext' satisfy the constraints?
-checkScriptContext :: forall i o. IsData o => TxConstraints i o -> ScriptContext -> Bool
+checkScriptContext :: forall i o. ToData o => TxConstraints i o -> ScriptContext -> Bool
 checkScriptContext TxConstraints{txConstraints, txOwnInputs, txOwnOutputs} ptx =
     traceIfFalse "checkScriptContext failed"
     $ all (checkTxConstraint ptx) txConstraints

--- a/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
+++ b/plutus-ledger/src/Ledger/Constraints/TxConstraints.hs
@@ -179,7 +179,7 @@ mustIncludeDatum = singleton . MustIncludeDatum
 
 {-# INLINABLE mustPayToTheScript #-}
 -- | Lock the value with a script
-mustPayToTheScript :: forall i o. PlutusTx.IsData o => o -> Value -> TxConstraints i o
+mustPayToTheScript :: forall i o. PlutusTx.ToData o => o -> Value -> TxConstraints i o
 mustPayToTheScript dt vl =
     TxConstraints
         { txConstraints = [MustIncludeDatum (Datum $ PlutusTx.toBuiltinData dt)]

--- a/plutus-ledger/src/Ledger/Oracle.hs
+++ b/plutus-ledger/src/Ledger/Oracle.hs
@@ -126,7 +126,7 @@ checkSignature datumHash pubKey signature_ =
 --   that the hash is correct. In off-chain code, where we check the hash
 --   straightforwardly, 'checkHashOffChain' can be used instead of this.
 checkHashConstraints ::
-    ( IsData a )
+    ( FromData a )
     => SignedMessage a
     -- ^ The signed message
     -> Either SignedMessageCheckError (a, TxConstraints i o)
@@ -141,7 +141,7 @@ checkHashConstraints SignedMessage{osmMessageHash, osmDatum=Datum dt} =
 --   message, producing a 'TxConstraint' value that ensures the hashes match
 --   up.
 verifySignedMessageConstraints ::
-    ( IsData a)
+    ( FromData a)
     => PubKey
     -> SignedMessage a
     -> Either SignedMessageCheckError (a, TxConstraints i o)
@@ -155,7 +155,7 @@ verifySignedMessageConstraints pk s@SignedMessage{osmSignature, osmMessageHash} 
 --   'verifySignedMessageConstraints' for a version that does not require a
 --   'ScriptContext' value.
 verifySignedMessageOnChain ::
-    ( IsData a)
+    ( FromData a)
     => ScriptContext
     -> PubKey
     -> SignedMessage a
@@ -170,7 +170,7 @@ verifySignedMessageOnChain ptx pk s@SignedMessage{osmSignature, osmMessageHash} 
 -- | The off-chain version of 'checkHashConstraints', using the hash function
 --   directly instead of obtaining the hash from a 'ScriptContext' value
 checkHashOffChain ::
-    ( IsData a )
+    ( FromData a )
     => SignedMessage a
     -> Either SignedMessageCheckError a
 checkHashOffChain SignedMessage{osmMessageHash, osmDatum=dt} = do
@@ -181,7 +181,7 @@ checkHashOffChain SignedMessage{osmMessageHash, osmDatum=dt} = do
 -- | Check the signature on a 'SignedMessage' and extract the contents of the
 --   message.
 verifySignedMessageOffChain ::
-    ( IsData a)
+    ( FromData a)
     => PubKey
     -> SignedMessage a
     -> Either SignedMessageCheckError a
@@ -191,7 +191,7 @@ verifySignedMessageOffChain pk s@SignedMessage{osmSignature, osmMessageHash} =
 
 -- | Encode a message of type @a@ as a @Data@ value and sign the
 --   hash of the datum.
-signMessage :: IsData a => a -> PrivateKey -> SignedMessage a
+signMessage :: ToData a => a -> PrivateKey -> SignedMessage a
 signMessage msg pk =
   let dt = Datum (toBuiltinData msg)
       DatumHash msgHash = Scripts.datumHash dt
@@ -203,7 +203,7 @@ signMessage msg pk =
         }
 
 -- | Encode an observation of a value of type @a@ that was made at the given time
-signObservation :: IsData a => POSIXTime -> a -> PrivateKey -> SignedMessage (Observation a)
+signObservation :: ToData a => POSIXTime -> a -> PrivateKey -> SignedMessage (Observation a)
 signObservation time vl = signMessage Observation{obsValue=vl, obsTime=time}
 
 makeLift ''SignedMessage

--- a/plutus-ledger/src/Ledger/Typed/Scripts/MonetaryPolicies.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts/MonetaryPolicies.hs
@@ -36,7 +36,7 @@ type WrappedMintingPolicyType = BuiltinData -> BuiltinData -> ()
 
 {-# INLINABLE wrapMintingPolicy #-}
 wrapMintingPolicy
-    :: IsData r
+    :: UnsafeFromData r
     => (r -> Validation.ScriptContext -> Bool)
     -> WrappedMintingPolicyType
 -- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed

--- a/plutus-ledger/src/Ledger/Typed/Scripts/Validators.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts/Validators.hs
@@ -70,7 +70,7 @@ type WrappedValidatorType = BuiltinData -> BuiltinData -> BuiltinData -> ()
 {-# INLINABLE wrapValidator #-}
 wrapValidator
     :: forall d r
-    . (IsData d, IsData r)
+    . (UnsafeFromData d, UnsafeFromData r)
     => (d -> r -> Validation.ScriptContext -> Bool)
     -> WrappedValidatorType
 -- We can use unsafeFromBuiltinData here as we would fail immediately anyway if parsing failed

--- a/plutus-ledger/src/Ledger/Typed/Tx.hs
+++ b/plutus-ledger/src/Ledger/Typed/Tx.hs
@@ -54,7 +54,7 @@ instance Eq (DatumType a) => Eq (TypedScriptTxIn a) where
         tyTxInTxIn l == tyTxInTxIn r
         && tyTxInOutRef l == tyTxInOutRef r
 
-instance (FromJSON (DatumType a), IsData (DatumType a)) => FromJSON (TypedScriptTxIn a) where
+instance (FromJSON (DatumType a), FromData (DatumType a), ToData (DatumType a)) => FromJSON (TypedScriptTxIn a) where
     parseJSON (Object v) =
         TypedScriptTxIn <$> v .: "tyTxInTxIn" <*> v .: "tyTxInOutRef"
     parseJSON invalid = typeMismatch "Object" invalid
@@ -66,7 +66,7 @@ instance (ToJSON (DatumType a)) => ToJSON (TypedScriptTxIn a) where
 -- | Create a 'TypedScriptTxIn' from a correctly-typed validator, redeemer, and output ref.
 makeTypedScriptTxIn
     :: forall inn
-    . (IsData (RedeemerType inn), IsData (DatumType inn))
+    . (ToData (RedeemerType inn), ToData (DatumType inn))
     => TypedValidator inn
     -> RedeemerType inn
     -> TypedScriptTxOutRef inn
@@ -91,14 +91,14 @@ makePubKeyTxIn :: TxOutRef -> PubKeyTxIn
 makePubKeyTxIn ref = PubKeyTxIn . TxIn ref . Just $ ConsumePublicKeyAddress
 
 -- | A 'TxOut' tagged by a phantom type: and the connection type of the output.
-data TypedScriptTxOut a = IsData (DatumType a) => TypedScriptTxOut { tyTxOutTxOut :: TxOut, tyTxOutData :: DatumType a }
+data TypedScriptTxOut a = (FromData (DatumType a), ToData (DatumType a)) => TypedScriptTxOut { tyTxOutTxOut :: TxOut, tyTxOutData :: DatumType a }
 
 instance Eq (DatumType a) => Eq (TypedScriptTxOut a) where
     l == r =
         tyTxOutTxOut l == tyTxOutTxOut r
         && tyTxOutData l == tyTxOutData r
 
-instance (FromJSON (DatumType a), IsData (DatumType a)) => FromJSON (TypedScriptTxOut a) where
+instance (FromJSON (DatumType a), FromData (DatumType a), ToData (DatumType a)) => FromJSON (TypedScriptTxOut a) where
     parseJSON (Object v) =
         TypedScriptTxOut <$> v .: "tyTxOutTxOut" <*> v .: "tyTxOutData"
     parseJSON invalid = typeMismatch "Object" invalid
@@ -110,7 +110,7 @@ instance (ToJSON (DatumType a)) => ToJSON (TypedScriptTxOut a) where
 -- | Create a 'TypedScriptTxOut' from a correctly-typed data script, an address, and a value.
 makeTypedScriptTxOut
     :: forall out
-    . (IsData (DatumType out))
+    . (ToData (DatumType out), FromData (DatumType out))
     => TypedValidator out
     -> DatumType out
     -> Value.Value
@@ -127,7 +127,7 @@ instance Eq (DatumType a) => Eq (TypedScriptTxOutRef a) where
         tyTxOutRefRef l == tyTxOutRefRef r
         && tyTxOutRefOut l == tyTxOutRefOut r
 
-instance (FromJSON (DatumType a), IsData (DatumType a)) => FromJSON (TypedScriptTxOutRef a) where
+instance (FromJSON (DatumType a), FromData (DatumType a), ToData (DatumType a)) => FromJSON (TypedScriptTxOutRef a) where
     parseJSON (Object v) =
         TypedScriptTxOutRef <$> v .: "tyTxOutRefRef" <*> v .: "tyTxOutRefOut"
     parseJSON invalid = typeMismatch "Object" invalid
@@ -192,7 +192,7 @@ checkValidatorAddress ct actualAddr = do
 -- | Checks that the given redeemer script has the right type.
 checkRedeemer
     :: forall inn m
-    . (IsData (RedeemerType inn), MonadError ConnectionError m)
+    . (FromData (RedeemerType inn), MonadError ConnectionError m)
     => TypedValidator inn
     -> Redeemer
     -> m (RedeemerType inn)
@@ -203,7 +203,7 @@ checkRedeemer _ (Redeemer d) =
 
 -- | Checks that the given datum has the right type.
 checkDatum
-    :: forall a m . (IsData (DatumType a), MonadError ConnectionError m)
+    :: forall a m . (FromData (DatumType a), MonadError ConnectionError m)
     => TypedValidator a
     -> Datum
     -> m (DatumType a)
@@ -215,8 +215,10 @@ checkDatum _ (Datum d) =
 -- | Create a 'TypedScriptTxIn' from an existing 'TxIn' by checking the types of its parts.
 typeScriptTxIn
     :: forall inn m
-    . ( IsData (RedeemerType inn)
-      , IsData (DatumType inn)
+    . ( FromData (RedeemerType inn)
+      , ToData (RedeemerType inn)
+      , FromData (DatumType inn)
+      , ToData (DatumType inn)
       , MonadError ConnectionError m)
     => (TxOutRef -> Maybe TxOutTx)
     -> TypedValidator inn
@@ -251,7 +253,8 @@ typePubKeyTxIn inn@TxIn{txInType} = do
 -- | Create a 'TypedScriptTxOut' from an existing 'TxOut' by checking the types of its parts.
 typeScriptTxOut
     :: forall out m
-    . ( IsData (DatumType out)
+    . ( FromData (DatumType out)
+      , ToData (DatumType out)
       , MonadError ConnectionError m)
     => TypedValidator out
     -> TxOutTx
@@ -272,7 +275,8 @@ typeScriptTxOut si TxOutTx{txOutTxTx=tx, txOutTxOut=TxOut{txOutAddress,txOutValu
 -- reference points.
 typeScriptTxOutRef
     :: forall out m
-    . ( IsData (DatumType out)
+    . ( FromData (DatumType out)
+      , ToData (DatumType out)
       , MonadError ConnectionError m)
     => (TxOutRef -> Maybe TxOutTx)
     -> TypedValidator out

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -41,11 +41,11 @@ import qualified Prelude               as Haskell
 
 ------------------------------------------------------------
 
-newtype HashedString = HashedString ByteString deriving newtype PlutusTx.IsData
+newtype HashedString = HashedString ByteString deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 
 PlutusTx.makeLift ''HashedString
 
-newtype ClearString = ClearString ByteString deriving newtype PlutusTx.IsData
+newtype ClearString = ClearString ByteString deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 
 PlutusTx.makeLift ''ClearString
 

--- a/plutus-playground-server/usecases/Starter.hs
+++ b/plutus-playground-server/usecases/Starter.hs
@@ -38,10 +38,10 @@ import           PlutusTx.Prelude     hiding (Applicative (..))
 
 -- | These are the data script and redeemer types. We are using an integer
 --   value for both, but you should define your own types.
-newtype MyDatum = MyDatum Integer deriving newtype PlutusTx.IsData
+newtype MyDatum = MyDatum Integer deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 PlutusTx.makeLift ''MyDatum
 
-newtype MyRedeemer = MyRedeemer Integer deriving newtype PlutusTx.IsData
+newtype MyRedeemer = MyRedeemer Integer deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
 PlutusTx.makeLift ''MyRedeemer
 
 -- | This method is the spending validator (which gets lifted to

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -54,10 +54,14 @@ unsafeDeconstructData :: CompiledCode (Builtins.BuiltinData -> Maybe (Integer, I
 unsafeDeconstructData = plc (Proxy @"deconstructData4") (\(d :: Builtins.BuiltinData) -> IsData.unsafeFromBuiltinData d)
 
 {-# INLINABLE isDataRoundtrip #-}
-isDataRoundtrip :: (IsData.IsData a, P.Eq a) => a -> Bool
-isDataRoundtrip a = case IsData.fromBuiltinData (IsData.toBuiltinData a) of
-    Just a' -> a P.== a'
-    Nothing -> False
+isDataRoundtrip :: (IsData.FromData a, IsData.UnsafeFromData a, IsData.ToData a, P.Eq a) => a -> Bool
+isDataRoundtrip a =
+    let d = IsData.toBuiltinData a
+        safeRoundtrip = case IsData.fromBuiltinData d of
+            Just a' -> a P.== a'
+            Nothing -> False
+        unsafeRoundtrip = IsData.unsafeFromBuiltinData d P.== a
+    in safeRoundtrip && unsafeRoundtrip
 
 tests :: TestNested
 tests = testNested "IsData" [

--- a/plutus-tx-plugin/test/IsData/bytestring.plc.golden
+++ b/plutus-tx-plugin/test/IsData/bytestring.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_119 (lam case_False_120 case_True_119)))
+(delay (lam case_True_107 (lam case_False_108 case_True_107)))

--- a/plutus-tx-plugin/test/IsData/deconstructData.plc.golden
+++ b/plutus-tx-plugin/test/IsData/deconstructData.plc.golden
@@ -10,6 +10,9 @@
       )
     )
     (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
+    (datatypebind
       (datatype
         (tyvardecl Maybe (fun (type) (type)))
         (tyvardecl a (type))
@@ -17,48 +20,11 @@
         (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
       )
     )
-    (datatypebind
-      (datatype
-        (tyvardecl IsData (fun (type) (type)))
-        (tyvardecl a (type))
-        IsData_match
-        (vardecl
-          CConsIsData
-          (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-        )
-      )
-    )
     (termbind
       (strict)
       (vardecl
-        fromBuiltinData
-        (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun (con data) [Maybe a]) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
-    )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2_cfromBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
+        fFromDataTuple2_cfromBuiltinData
+        (all a (type) (all b (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun [(lam a (type) (fun (con data) [Maybe a])) b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
       )
       (abs
         a
@@ -67,11 +33,11 @@
           b
           (type)
           (lam
-            dIsData
-            [IsData a]
+            dFromData
+            [(lam a (type) (fun (con data) [Maybe a])) a]
             (lam
-              dIsData
-              [IsData b]
+              dFromData
+              [(lam a (type) (fun (con data) [Maybe a])) b]
               (lam
                 d
                 (con data)
@@ -125,9 +91,7 @@
                                             [
                                               { Maybe_match a }
                                               [
-                                                [
-                                                  { fromBuiltinData a } dIsData
-                                                ]
+                                                dFromData
                                                 [
                                                   {
                                                     (builtin headList)
@@ -152,12 +116,7 @@
                                                       [
                                                         { Maybe_match b }
                                                         [
-                                                          [
-                                                            {
-                                                              fromBuiltinData b
-                                                            }
-                                                            dIsData
-                                                          ]
+                                                          dFromData
                                                           [
                                                             {
                                                               (builtin headList)
@@ -337,244 +296,8 @@
     )
     (termbind
       (strict)
-      (vardecl toBuiltinData (all a (type) (fun [IsData a] (fun a (con data)))))
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun a (con data)) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
-    )
-    (termbind
-      (strict)
       (vardecl
-        fIsDataTuple2_ctoBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun [[Tuple2 a] b] (con data))))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dIsData
-            [IsData a]
-            (lam
-              dIsData
-              [IsData b]
-              (lam
-                ds
-                [[Tuple2 a] b]
-                [
-                  { [ { { Tuple2_match a } b } ds ] (con data) }
-                  (lam
-                    arg
-                    a
-                    (lam
-                      arg
-                      b
-                      [
-                        [ (builtin constrData) (con integer 0) ]
-                        [
-                          [
-                            { (builtin mkCons) (con data) }
-                            [ [ { toBuiltinData a } dIsData ] arg ]
-                          ]
-                          [
-                            [
-                              { (builtin mkCons) (con data) }
-                              [ [ { toBuiltinData b } dIsData ] arg ]
-                            ]
-                            [ (builtin mkNilData) (con unit ()) ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                ]
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl error (all a (type) (fun (con unit) a)))
-      (abs a (type) (lam thunk (con unit) (error a)))
-    )
-    (termbind
-      (strict)
-      (vardecl
-        unsafeFromBuiltinData (all a (type) (fun [IsData a] (fun (con data) a)))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun (con data) a) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2_cunsafeFromBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [[Tuple2 a] b])))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dIsData
-            [IsData a]
-            (lam
-              dIsData
-              [IsData b]
-              (lam
-                d
-                (con data)
-                (let
-                  (nonrec)
-                  (termbind
-                    (nonstrict)
-                    (vardecl x [[Tuple2 a] b])
-                    [ { error [[Tuple2 a] b] } (con unit ()) ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      tup [[(con pair) (con integer)] [(con list) (con data)]]
-                    )
-                    [ (builtin unConstrData) d ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl t [(con list) (con data)])
-                    [
-                      {
-                        { (builtin sndPair) (con integer) }
-                        [(con list) (con data)]
-                      }
-                      tup
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl x b)
-                    [
-                      [ { unsafeFromBuiltinData b } dIsData ]
-                      [
-                        { (builtin headList) (con data) }
-                        [ { (builtin tailList) (con data) } t ]
-                      ]
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl x a)
-                    [
-                      [ { unsafeFromBuiltinData a } dIsData ]
-                      [ { (builtin headList) (con data) } t ]
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl x [[Tuple2 a] b])
-                    [ [ { { Tuple2 a } b } x ] x ]
-                  )
-                  [
-                    [
-                      [
-                        [
-                          { (builtin ifThenElse) (fun Unit [[Tuple2 a] b]) }
-                          [
-                            [
-                              (builtin equalsInteger)
-                              [
-                                {
-                                  { (builtin fstPair) (con integer) }
-                                  [(con list) (con data)]
-                                }
-                                tup
-                              ]
-                            ]
-                            (con integer 0)
-                          ]
-                        ]
-                        (lam ds Unit x)
-                      ]
-                      (lam ds Unit x)
-                    ]
-                    Unit
-                  ]
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] [IsData [[Tuple2 a] b]]))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            v
-            [IsData a]
-            (lam
-              v
-              [IsData b]
-              [
-                [
-                  [
-                    { CConsIsData [[Tuple2 a] b] }
-                    [ [ { { fIsDataTuple2_ctoBuiltinData a } b } v ] v ]
-                  ]
-                  [ [ { { fIsDataTuple2_cfromBuiltinData a } b } v ] v ]
-                ]
-                [ [ { { fIsDataTuple2_cunsafeFromBuiltinData a } b } v ] v ]
-              ]
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataInteger_cfromBuiltinData (fun (con data) [Maybe (con integer)])
+        fFromDataInteger_cfromBuiltinData (fun (con data) [Maybe (con integer)])
       )
       (lam
         d
@@ -604,34 +327,32 @@
       )
     )
     (termbind
-      (strict)
-      (vardecl fIsDataInteger_ctoBuiltinData (fun (con integer) (con data)))
-      (lam i (con integer) [ (builtin iData) i ])
-    )
-    (termbind
       (nonstrict)
-      (vardecl fIsDataInteger [IsData (con integer)])
+      (vardecl
+        dFromData
+        [(lam a (type) (fun (con data) [Maybe a])) [[Tuple2 (con integer)] (con integer)]]
+      )
       [
         [
-          [ { CConsIsData (con integer) } fIsDataInteger_ctoBuiltinData ]
-          fIsDataInteger_cfromBuiltinData
+          { { fFromDataTuple2_cfromBuiltinData (con integer) } (con integer) }
+          fFromDataInteger_cfromBuiltinData
         ]
-        (builtin unIData)
+        fFromDataInteger_cfromBuiltinData
       ]
     )
     (termbind
-      (nonstrict)
-      (vardecl dIsData [IsData [[Tuple2 (con integer)] (con integer)]])
-      [
-        [ { { fIsDataTuple2 (con integer) } (con integer) } fIsDataInteger ]
-        fIsDataInteger
-      ]
+      (strict)
+      (vardecl
+        fromBuiltinData
+        (all a (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun (con data) [Maybe a])))
+      )
+      (abs a (type) (lam v [(lam a (type) (fun (con data) [Maybe a])) a] v))
     )
     (lam
       ds
       (con data)
       [
-        [ { fromBuiltinData [[Tuple2 (con integer)] (con integer)] } dIsData ]
+        [ { fromBuiltinData [[Tuple2 (con integer)] (con integer)] } dFromData ]
         ds
       ]
     )

--- a/plutus-tx-plugin/test/IsData/int.plc.golden
+++ b/plutus-tx-plugin/test/IsData/int.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_34 (lam case_False_35 case_True_34)))
+(delay (lam case_True_28 (lam case_False_29 case_True_28)))

--- a/plutus-tx-plugin/test/IsData/list.plc.golden
+++ b/plutus-tx-plugin/test/IsData/list.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_150 (lam case_False_151 case_True_150)))
+(delay (lam case_True_135 (lam case_False_136 case_True_135)))

--- a/plutus-tx-plugin/test/IsData/mono.plc.golden
+++ b/plutus-tx-plugin/test/IsData/mono.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_260 (lam case_False_261 case_True_260)))
+(delay (lam case_True_248 (lam case_False_249 case_True_248)))

--- a/plutus-tx-plugin/test/IsData/nested.plc.golden
+++ b/plutus-tx-plugin/test/IsData/nested.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_337 (lam case_False_338 case_True_337)))
+(delay (lam case_True_304 (lam case_False_305 case_True_304)))

--- a/plutus-tx-plugin/test/IsData/poly.plc.golden
+++ b/plutus-tx-plugin/test/IsData/poly.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_236 (lam case_False_237 case_True_236)))
+(delay (lam case_True_221 (lam case_False_222 case_True_221)))

--- a/plutus-tx-plugin/test/IsData/record.plc.golden
+++ b/plutus-tx-plugin/test/IsData/record.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_156 (lam case_False_157 case_True_156)))
+(delay (lam case_True_144 (lam case_False_145 case_True_144)))

--- a/plutus-tx-plugin/test/IsData/tuple.plc.golden
+++ b/plutus-tx-plugin/test/IsData/tuple.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_166 (lam case_False_167 case_True_166)))
+(delay (lam case_True_149 (lam case_False_150 case_True_149)))

--- a/plutus-tx-plugin/test/IsData/tupleInterop.plc.golden
+++ b/plutus-tx-plugin/test/IsData/tupleInterop.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_165 (lam case_False_166 case_True_165)))
+(delay (lam case_True_102 (lam case_False_103 case_True_102)))

--- a/plutus-tx-plugin/test/IsData/unit.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unit.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_78 (lam case_False_79 case_True_78)))
+(delay (lam case_True_64 (lam case_False_65 case_True_64)))

--- a/plutus-tx-plugin/test/IsData/unitInterop.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unitInterop.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_44 (lam case_False_45 case_True_44)))
+(delay (lam case_True_48 (lam case_False_49 case_True_48)))

--- a/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
@@ -9,47 +9,10 @@
         (vardecl Tuple2 (fun a (fun b [[Tuple2 a] b])))
       )
     )
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl IsData (fun (type) (type)))
-        (tyvardecl a (type))
-        IsData_match
-        (vardecl
-          CConsIsData
-          (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-        )
-      )
-    )
     (termbind
       (strict)
-      (vardecl
-        fromBuiltinData
-        (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun (con data) [Maybe a]) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
+      (vardecl error (all a (type) (fun (con unit) a)))
+      (abs a (type) (lam thunk (con unit) (error a)))
     )
     (datatypebind
       (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
@@ -57,8 +20,8 @@
     (termbind
       (strict)
       (vardecl
-        fIsDataTuple2_cfromBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
+        fUnsafeFromDataTuple2_cunsafeFromBuiltinData
+        (all a (type) (all b (type) (fun [(lam a (type) (fun (con data) a)) a] (fun [(lam a (type) (fun (con data) a)) b] (fun (con data) [[Tuple2 a] b])))))
       )
       (abs
         a
@@ -67,393 +30,11 @@
           b
           (type)
           (lam
-            dIsData
-            [IsData a]
+            dUnsafeFromData
+            [(lam a (type) (fun (con data) a)) a]
             (lam
-              dIsData
-              [IsData b]
-              (lam
-                d
-                (con data)
-                [
-                  [
-                    [
-                      [
-                        [
-                          [
-                            [
-                              {
-                                (builtin chooseData)
-                                (fun Unit [Maybe [[Tuple2 a] b]])
-                              }
-                              (lam
-                                ds
-                                Unit
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl
-                                      tup
-                                      [[(con pair) (con integer)] [(con list) (con data)]]
-                                    )
-                                    [ (builtin unConstrData) d ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl l [(con list) (con data)])
-                                    [
-                                      {
-                                        { (builtin sndPair) (con integer) }
-                                        [(con list) (con data)]
-                                      }
-                                      tup
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl l [(con list) (con data)])
-                                    [ { (builtin tailList) (con data) } l ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl nilCase [Maybe [[Tuple2 a] b]])
-                                    [
-                                      [
-                                        [
-                                          {
-                                            [
-                                              { Maybe_match a }
-                                              [
-                                                [
-                                                  { fromBuiltinData a } dIsData
-                                                ]
-                                                [
-                                                  {
-                                                    (builtin headList)
-                                                    (con data)
-                                                  }
-                                                  l
-                                                ]
-                                              ]
-                                            ]
-                                            (fun Unit [Maybe [[Tuple2 a] b]])
-                                          }
-                                          (lam
-                                            ipv
-                                            a
-                                            (lam
-                                              thunk
-                                              Unit
-                                              [
-                                                [
-                                                  [
-                                                    {
-                                                      [
-                                                        { Maybe_match b }
-                                                        [
-                                                          [
-                                                            {
-                                                              fromBuiltinData b
-                                                            }
-                                                            dIsData
-                                                          ]
-                                                          [
-                                                            {
-                                                              (builtin headList)
-                                                              (con data)
-                                                            }
-                                                            l
-                                                          ]
-                                                        ]
-                                                      ]
-                                                      (fun Unit [Maybe [[Tuple2 a] b]])
-                                                    }
-                                                    (lam
-                                                      ipv
-                                                      b
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        [
-                                                          {
-                                                            Just [[Tuple2 a] b]
-                                                          }
-                                                          [
-                                                            [
-                                                              { { Tuple2 a } b }
-                                                              ipv
-                                                            ]
-                                                            ipv
-                                                          ]
-                                                        ]
-                                                      )
-                                                    )
-                                                  ]
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    { Nothing [[Tuple2 a] b] }
-                                                  )
-                                                ]
-                                                Unit
-                                              ]
-                                            )
-                                          )
-                                        ]
-                                        (lam
-                                          thunk Unit { Nothing [[Tuple2 a] b] }
-                                        )
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam ds Unit nilCase)
-                                          ]
-                                          (lam
-                                            ds Unit { Nothing [[Tuple2 a] b] }
-                                          )
-                                        ]
-                                        [ { (builtin tailList) (con data) } l ]
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam
-                                              ds Unit { Nothing [[Tuple2 a] b] }
-                                            )
-                                          ]
-                                          (lam ds Unit lvl)
-                                        ]
-                                        l
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl x [Maybe [[Tuple2 a] b]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam
-                                              ds Unit { Nothing [[Tuple2 a] b] }
-                                            )
-                                          ]
-                                          (lam ds Unit lvl)
-                                        ]
-                                        l
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  [
-                                    [
-                                      [
-                                        [
-                                          {
-                                            (builtin ifThenElse)
-                                            (fun Unit [Maybe [[Tuple2 a] b]])
-                                          }
-                                          [
-                                            [
-                                              (builtin equalsInteger)
-                                              [
-                                                {
-                                                  {
-                                                    (builtin fstPair)
-                                                    (con integer)
-                                                  }
-                                                  [(con list) (con data)]
-                                                }
-                                                tup
-                                              ]
-                                            ]
-                                            (con integer 0)
-                                          ]
-                                        ]
-                                        (lam ds Unit x)
-                                      ]
-                                      (lam ds Unit { Nothing [[Tuple2 a] b] })
-                                    ]
-                                    Unit
-                                  ]
-                                )
-                              )
-                            ]
-                            (lam ds Unit { Nothing [[Tuple2 a] b] })
-                          ]
-                          (lam ds Unit { Nothing [[Tuple2 a] b] })
-                        ]
-                        (lam ds Unit { Nothing [[Tuple2 a] b] })
-                      ]
-                      (lam ds Unit { Nothing [[Tuple2 a] b] })
-                    ]
-                    d
-                  ]
-                  Unit
-                ]
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl toBuiltinData (all a (type) (fun [IsData a] (fun a (con data)))))
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun a (con data)) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2_ctoBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun [[Tuple2 a] b] (con data))))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dIsData
-            [IsData a]
-            (lam
-              dIsData
-              [IsData b]
-              (lam
-                ds
-                [[Tuple2 a] b]
-                [
-                  { [ { { Tuple2_match a } b } ds ] (con data) }
-                  (lam
-                    arg
-                    a
-                    (lam
-                      arg
-                      b
-                      [
-                        [ (builtin constrData) (con integer 0) ]
-                        [
-                          [
-                            { (builtin mkCons) (con data) }
-                            [ [ { toBuiltinData a } dIsData ] arg ]
-                          ]
-                          [
-                            [
-                              { (builtin mkCons) (con data) }
-                              [ [ { toBuiltinData b } dIsData ] arg ]
-                            ]
-                            [ (builtin mkNilData) (con unit ()) ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                ]
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl error (all a (type) (fun (con unit) a)))
-      (abs a (type) (lam thunk (con unit) (error a)))
-    )
-    (termbind
-      (strict)
-      (vardecl
-        unsafeFromBuiltinData (all a (type) (fun [IsData a] (fun (con data) a)))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            { [ { IsData_match a } v ] (fun (con data) a) }
-            (lam
-              v
-              (fun a (con data))
-              (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v))
-            )
-          ]
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2_cunsafeFromBuiltinData
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [[Tuple2 a] b])))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dIsData
-            [IsData a]
-            (lam
-              dIsData
-              [IsData b]
+              dUnsafeFromData
+              [(lam a (type) (fun (con data) a)) b]
               (lam
                 d
                 (con data)
@@ -486,7 +67,7 @@
                     (nonstrict)
                     (vardecl x b)
                     [
-                      [ { unsafeFromBuiltinData b } dIsData ]
+                      dUnsafeFromData
                       [
                         { (builtin headList) (con data) }
                         [ { (builtin tailList) (con data) } t ]
@@ -496,10 +77,7 @@
                   (termbind
                     (nonstrict)
                     (vardecl x a)
-                    [
-                      [ { unsafeFromBuiltinData a } dIsData ]
-                      [ { (builtin headList) (con data) } t ]
-                    ]
+                    [ dUnsafeFromData [ { (builtin headList) (con data) } t ] ]
                   )
                   (termbind
                     (nonstrict)
@@ -539,389 +117,42 @@
       )
     )
     (termbind
-      (strict)
-      (vardecl
-        fIsDataTuple2
-        (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] [IsData [[Tuple2 a] b]]))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            v
-            [IsData a]
-            (lam
-              v
-              [IsData b]
-              [
-                [
-                  [
-                    { CConsIsData [[Tuple2 a] b] }
-                    [ [ { { fIsDataTuple2_ctoBuiltinData a } b } v ] v ]
-                  ]
-                  [ [ { { fIsDataTuple2_cfromBuiltinData a } b } v ] v ]
-                ]
-                [ [ { { fIsDataTuple2_cunsafeFromBuiltinData a } b } v ] v ]
-              ]
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataInteger_cfromBuiltinData (fun (con data) [Maybe (con integer)])
-      )
-      (lam
-        d
-        (con data)
-        [
-          [
-            [
-              [
-                [
-                  [
-                    [
-                      { (builtin chooseData) (fun Unit [Maybe (con integer)]) }
-                      (lam ds Unit { Nothing (con integer) })
-                    ]
-                    (lam ds Unit { Nothing (con integer) })
-                  ]
-                  (lam ds Unit { Nothing (con integer) })
-                ]
-                (lam ds Unit [ { Just (con integer) } [ (builtin unIData) d ] ])
-              ]
-              (lam ds Unit { Nothing (con integer) })
-            ]
-            d
-          ]
-          Unit
-        ]
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl fIsDataInteger_ctoBuiltinData (fun (con integer) (con data)))
-      (lam i (con integer) [ (builtin iData) i ])
-    )
-    (termbind
       (nonstrict)
-      (vardecl fIsDataInteger [IsData (con integer)])
+      (vardecl
+        dUnsafeFromData
+        [(lam a (type) (fun (con data) a)) [[Tuple2 (con integer)] (con integer)]]
+      )
       [
         [
-          [ { CConsIsData (con integer) } fIsDataInteger_ctoBuiltinData ]
-          fIsDataInteger_cfromBuiltinData
+          {
+            { fUnsafeFromDataTuple2_cunsafeFromBuiltinData (con integer) }
+            (con integer)
+          }
+          (builtin unIData)
         ]
         (builtin unIData)
       ]
     )
-    (termbind
-      (nonstrict)
-      (vardecl dIsData [IsData [[Tuple2 (con integer)] (con integer)]])
-      [
-        [ { { fIsDataTuple2 (con integer) } (con integer) } fIsDataInteger ]
-        fIsDataInteger
-      ]
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataMaybe_cfromBuiltinData
-        (all a (type) (fun [IsData a] (fun (con data) [Maybe [Maybe a]])))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          dIsData
-          [IsData a]
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe [Maybe a]]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe [Maybe a]])
-                                [ { Just [Maybe a] } { Nothing a } ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl args [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe [Maybe a]])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe [Maybe a]])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing [Maybe a] })
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl index (con integer))
-                                [
-                                  {
-                                    { (builtin fstPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe [Maybe a]])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          (builtin ifThenElse)
-                                          (fun Unit [Maybe [Maybe a]])
-                                        }
-                                        [
-                                          [ (builtin equalsInteger) index ]
-                                          (con integer 1)
-                                        ]
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    (lam ds Unit { Nothing [Maybe a] })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe [Maybe a]])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match a }
-                                          [
-                                            [ { fromBuiltinData a } dIsData ]
-                                            [
-                                              { (builtin headList) (con data) }
-                                              args
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe [Maybe a]])
-                                      }
-                                      (lam
-                                        ipv
-                                        a
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            { Just [Maybe a] }
-                                            [ { Just a } ipv ]
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing [Maybe a] })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe [Maybe a]])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe [Maybe a]])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing [Maybe a] })
-                                    ]
-                                    [ { (builtin tailList) (con data) } args ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe [Maybe a]])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe [Maybe a]])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing [Maybe a] })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe [Maybe a]])
-                                      }
-                                      [
-                                        [ (builtin equalsInteger) index ]
-                                        (con integer 0)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit x)
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing [Maybe a] })
-                      ]
-                      (lam ds Unit { Nothing [Maybe a] })
-                    ]
-                    (lam ds Unit { Nothing [Maybe a] })
-                  ]
-                  (lam ds Unit { Nothing [Maybe a] })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
+    (datatypebind
+      (datatype
+        (tyvardecl Maybe (fun (type) (type)))
+        (tyvardecl a (type))
+        Maybe_match
+        (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
       )
     )
     (termbind
       (strict)
       (vardecl
-        fIsDataMaybe_ctoBuiltinData
-        (all a (type) (fun [IsData a] (fun [Maybe a] (con data))))
+        fUnsafeFromDataMaybe_cunsafeFromBuiltinData
+        (all a (type) (fun [(lam a (type) (fun (con data) a)) a] (fun (con data) [Maybe a])))
       )
       (abs
         a
         (type)
         (lam
-          dIsData
-          [IsData a]
-          (lam
-            ds
-            [Maybe a]
-            [
-              [
-                [
-                  { [ { Maybe_match a } ds ] (fun Unit (con data)) }
-                  (lam
-                    arg
-                    a
-                    (lam
-                      thunk
-                      Unit
-                      [
-                        [ (builtin constrData) (con integer 0) ]
-                        [
-                          [
-                            { (builtin mkCons) (con data) }
-                            [ [ { toBuiltinData a } dIsData ] arg ]
-                          ]
-                          [ (builtin mkNilData) (con unit ()) ]
-                        ]
-                      ]
-                    )
-                  )
-                ]
-                (lam
-                  thunk
-                  Unit
-                  [
-                    [ (builtin constrData) (con integer 1) ]
-                    [ (builtin mkNilData) (con unit ()) ]
-                  ]
-                )
-              ]
-              Unit
-            ]
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fIsDataMaybe_cunsafeFromBuiltinData
-        (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-      )
-      (abs
-        a
-        (type)
-        (lam
-          dIsData
-          [IsData a]
+          dUnsafeFromData
+          [(lam a (type) (fun (con data) a)) a]
           (lam
             d
             (con data)
@@ -970,7 +201,7 @@
                 (nonstrict)
                 (vardecl x a)
                 [
-                  [ { unsafeFromBuiltinData a } dIsData ]
+                  dUnsafeFromData
                   [
                     { (builtin headList) (con data) }
                     [
@@ -1003,31 +234,26 @@
       )
     )
     (termbind
-      (strict)
-      (vardecl fIsDataMaybe (all a (type) (fun [IsData a] [IsData [Maybe a]])))
-      (abs
-        a
-        (type)
-        (lam
-          v
-          [IsData a]
-          [
-            [
-              [
-                { CConsIsData [Maybe a] }
-                [ { fIsDataMaybe_ctoBuiltinData a } v ]
-              ]
-              [ { fIsDataMaybe_cfromBuiltinData a } v ]
-            ]
-            [ { fIsDataMaybe_cunsafeFromBuiltinData a } v ]
-          ]
-        )
+      (nonstrict)
+      (vardecl
+        dUnsafeFromData
+        [(lam a (type) (fun (con data) a)) [Maybe [[Tuple2 (con integer)] (con integer)]]]
       )
+      [
+        {
+          fUnsafeFromDataMaybe_cunsafeFromBuiltinData
+          [[Tuple2 (con integer)] (con integer)]
+        }
+        dUnsafeFromData
+      ]
     )
     (termbind
-      (nonstrict)
-      (vardecl dIsData [IsData [Maybe [[Tuple2 (con integer)] (con integer)]]])
-      [ { fIsDataMaybe [[Tuple2 (con integer)] (con integer)] } dIsData ]
+      (strict)
+      (vardecl
+        unsafeFromBuiltinData
+        (all a (type) (fun [(lam a (type) (fun (con data) a)) a] (fun (con data) a)))
+      )
+      (abs a (type) (lam v [(lam a (type) (fun (con data) a)) a] v))
     )
     (lam
       ds
@@ -1037,7 +263,7 @@
           {
             unsafeFromBuiltinData [Maybe [[Tuple2 (con integer)] (con integer)]]
           }
-          dIsData
+          dUnsafeFromData
         ]
         ds
       ]

--- a/plutus-tx-plugin/test/IsData/unsafeTupleInterop.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unsafeTupleInterop.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_162 (lam case_False_163 case_True_162)))
+(delay (lam case_True_62 (lam case_False_63 case_True_62)))

--- a/plutus-tx/src/PlutusTx.hs
+++ b/plutus-tx/src/PlutusTx.hs
@@ -7,7 +7,9 @@ module PlutusTx (
     applyCode,
     BuiltinData,
     Data (..),
-    IsData (..),
+    ToData (..),
+    FromData (..),
+    UnsafeFromData (..),
     toData,
     fromData,
     builtinDataToData,
@@ -23,7 +25,8 @@ module PlutusTx (
 import           PlutusCore.Data     (Data (..))
 import           PlutusTx.Builtins   (BuiltinData, builtinDataToData, dataToBuiltinData)
 import           PlutusTx.Code       (CompiledCode, CompiledCodeIn, applyCode, getPir, getPlc)
-import           PlutusTx.IsData     (IsData (..), fromData, makeIsDataIndexed, toData, unstableMakeIsData)
+import           PlutusTx.IsData     (FromData (..), ToData (..), UnsafeFromData (..), fromData, makeIsDataIndexed,
+                                      toData, unstableMakeIsData)
 import           PlutusTx.Lift       (liftCode, makeLift, safeLiftCode)
 import           PlutusTx.Lift.Class (Lift, Typeable)
 import           PlutusTx.TH         as Export

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -53,7 +53,7 @@ import qualified Prelude          as Haskell
 -- | A 'Map' of key-value pairs.
 newtype Map k v = Map { unMap :: [(k, v)] }
     deriving stock (Generic, Haskell.Eq, Haskell.Show)
-    deriving newtype (Eq, Ord, IsData, NFData)
+    deriving newtype (Eq, Ord, ToData, FromData, UnsafeFromData, NFData)
 
 instance Functor (Map k) where
     {-# INLINABLE fmap #-}

--- a/plutus-use-cases/src/Plutus/Contracts/Future.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Future.hs
@@ -341,12 +341,12 @@ validator :: Future -> FutureAccounts -> Validator
 validator ft fos = Scripts.validatorScript (typedValidator ft fos)
 
 {-# INLINABLE verifyOracle #-}
-verifyOracle :: PlutusTx.IsData a => PubKey -> SignedMessage a -> Maybe (a, TxConstraints Void Void)
+verifyOracle :: PlutusTx.FromData a => PubKey -> SignedMessage a -> Maybe (a, TxConstraints Void Void)
 verifyOracle pubKey sm =
     either (const Nothing) pure
     $ Oracle.verifySignedMessageConstraints pubKey sm
 
-verifyOracleOffChain :: PlutusTx.IsData a => Future -> SignedMessage (Observation a) -> Maybe (POSIXTime, a)
+verifyOracleOffChain :: PlutusTx.FromData a => Future -> SignedMessage (Observation a) -> Maybe (POSIXTime, a)
 verifyOracleOffChain Future{ftPriceOracle} sm =
     case Oracle.verifySignedMessageOffChain ftPriceOracle sm of
         Left _                               -> Nothing

--- a/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/GameStateMachine.hs
@@ -55,14 +55,14 @@ import           Plutus.Contract
 import qualified Prelude                      as Haskell
 
 newtype HashedString = HashedString ByteString
-    deriving newtype (PlutusTx.IsData, Eq)
+    deriving newtype (Eq, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.makeLift ''HashedString
 
 newtype ClearString = ClearString ByteString
-    deriving newtype (PlutusTx.IsData, Eq)
+    deriving newtype (Eq, PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving stock (Haskell.Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx f7e116902bedef0b7d6e1a3509b1c9f07b5a9f3a55a0b5e33cbad7d803eaf319:
+                Tx 7f73d1fada5d48821fe6c945ccd40f03a7e55838201a928347d80c3dc76d4b36:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential)
+                      addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -34,23 +34,23 @@ Slot 1: W2: Balancing an unbalanced transaction:
                     "\151~\251\&5\171b\GS9\219\235rt\236w\149\163G\b\255M%\160\SUB\GS\240L\US'"}
               Requires signatures:
               Utxo index:
-Slot 1: W2: Finished balancing. 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
+Slot 1: W2: Finished balancing. b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
-Slot 1: W2: Submitting tx: 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
-Slot 1: W2: TxSubmit: 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
+Slot 1: W2: Submitting tx: b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
+Slot 1: W2: TxSubmit: b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 25.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx 03bdb60b56ea95095b21733ed70828638716e67a2068cada769027ae19bb0801:
+                Tx b16076be83e748b63d1134f8c3aef8fcc7da76dfdba8ee58a199a6abdac8606e:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential)
+                      addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -60,17 +60,17 @@ Slot 1: W3: Balancing an unbalanced transaction:
                     "\DEL\138v\192\235\170J\210\r\253\205Q\165\222\a\n\183q\244\191\&7\DEL,A\230\183\FS\n"}
               Requires signatures:
               Utxo index:
-Slot 1: W3: Finished balancing. 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
-Slot 1: W3: Submitting tx: 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
-Slot 1: W3: TxSubmit: 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
+Slot 1: W3: Finished balancing. ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
+Slot 1: W3: Submitting tx: ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
+Slot 1: W3: TxSubmit: ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx f9061b0bf14648e7a2a6831d50c623b41ad4735e184d85d97fc5e09413d02d3d:
+                Tx 4351e87c24df1c1bdb7fe8a3c7a1feaef5cec6abf034679ce0c9bedc5a7bcaf3:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential)
+                      addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -80,23 +80,23 @@ Slot 1: W4: Balancing an unbalanced transaction:
                     "\188\192\131\173\227\253\208\163r\203lC\239\NUL\239\STX\252\181.\149\&2\148\DC1\ETB\215`\157j"}
               Requires signatures:
               Utxo index:
-Slot 1: W4: Finished balancing. b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
-Slot 1: W4: Submitting tx: b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
-Slot 1: W4: TxSubmit: b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
-Slot 1: TxnValidate b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
-Slot 1: TxnValidate 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
-Slot 1: TxnValidate 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
+Slot 1: W4: Finished balancing. ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
+Slot 1: W4: Submitting tx: ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
+Slot 1: W4: TxSubmit: ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
+Slot 1: TxnValidate ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
+Slot 1: TxnValidate ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
+Slot 1: TxnValidate b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 87645bfa73a065f613bad27f09449e88c28f23346430f1057d35c3f3e9d14235:
+                 Tx 6914abaaa987faee7fce680b8fbd83b33a1b855249726bb8d2d8620788895428:
                    {inputs:
-                      - 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58!1
+                      - ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3!1
                         <>
-                      - 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4!1
+                      - b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79!1
                         <>
-                      - b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450!1
+                      - ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259!1
                         <>
                    collateral inputs:
                    outputs:
@@ -108,18 +108,18 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    data:}
                Requires signatures:
                Utxo index:
-                 ( 576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58!1
+                 ( ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3!1
                  , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential) )
-                 ( 737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4!1
+                     addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential) )
+                 ( b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79!1
                  , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential) )
-                 ( b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450!1
+                     addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential) )
+                 ( ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259!1
                  , - Value (Map [(,Map [("",25)])]) addressed to
-                     addressed to ScriptCredential: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497 (no staking credential) )
-Slot 20: W1: Finished balancing. 0a0d18c83da9410f0e8d99daa46b4a4847737dbd224d6fc7ff63624ba17c8cdb
-Slot 20: W1: Submitting tx: 0a0d18c83da9410f0e8d99daa46b4a4847737dbd224d6fc7ff63624ba17c8cdb
-Slot 20: W1: TxSubmit: 0a0d18c83da9410f0e8d99daa46b4a4847737dbd224d6fc7ff63624ba17c8cdb
+                     addressed to ScriptCredential: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3 (no staking credential) )
+Slot 20: W1: Finished balancing. 28820ea4e0bc500571b4ec322f273b3cbce775cfe271be3ac7011a9aaf3fcd7e
+Slot 20: W1: Submitting tx: 28820ea4e0bc500571b4ec322f273b3cbce775cfe271be3ac7011a9aaf3fcd7e
+Slot 20: W1: TxSubmit: 28820ea4e0bc500571b4ec322f273b3cbce775cfe271be3ac7011a9aaf3fcd7e
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 21: TxnValidate 0a0d18c83da9410f0e8d99daa46b4a4847737dbd224d6fc7ff63624ba17c8cdb
+Slot 21: TxnValidate 28820ea4e0bc500571b4ec322f273b3cbce775cfe271be3ac7011a9aaf3fcd7e

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -2284,7 +2284,7 @@
                   )
                   (termbind
                     (strict)
-                    (vardecl fIsDataUnit_ctoBuiltinData (fun Unit (con data)))
+                    (vardecl fToDataUnit_ctoBuiltinData (fun Unit (con data)))
                     (lam
                       ds
                       Unit
@@ -2300,7 +2300,7 @@
                   (termbind
                     (nonstrict)
                     (vardecl unitDatum (con data))
-                    [ fIsDataUnit_ctoBuiltinData Unit ]
+                    [ fToDataUnit_ctoBuiltinData Unit ]
                   )
                   (termbind
                     (strict)
@@ -2416,7 +2416,179 @@
                   (termbind
                     (strict)
                     (vardecl
-                      fIsDataInteger_cfromBuiltinData
+                      fMonoidTxConstraints_cmempty
+                      (all i (type) (all o (type) [[TxConstraints i] o]))
+                    )
+                    (abs
+                      i
+                      (type)
+                      (abs
+                        o
+                        (type)
+                        [
+                          [
+                            [ { { TxConstraints i } o } { Nil TxConstraint } ]
+                            { Nil [InputConstraint i] }
+                          ]
+                          { Nil [OutputConstraint o] }
+                        ]
+                      )
+                    )
+                  )
+                  (datatypebind
+                    (datatype
+                      (tyvardecl Observation (fun (type) (type)))
+                      (tyvardecl a (type))
+                      Observation_match
+                      (vardecl
+                        Observation (fun a (fun (con integer) [Observation a]))
+                      )
+                    )
+                  )
+                  (datatypebind
+                    (datatype
+                      (tyvardecl SignedMessage (fun (type) (type)))
+                      (tyvardecl a (type))
+                      SignedMessage_match
+                      (vardecl
+                        SignedMessage
+                        (fun (con bytestring) (fun (con bytestring) (fun (con data) [SignedMessage a])))
+                      )
+                    )
+                  )
+                  (datatypebind
+                    (datatype
+                      (tyvardecl Role (type))
+
+                      Role_match
+                      (vardecl Long Role) (vardecl Short Role)
+                    )
+                  )
+                  (datatypebind
+                    (datatype
+                      (tyvardecl FutureAction (type))
+
+                      FutureAction_match
+                      (vardecl
+                        AdjustMargin
+                        (fun Role (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] FutureAction))
+                      )
+                      (vardecl
+                        Settle
+                        (fun [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] FutureAction)
+                      )
+                      (vardecl
+                        SettleEarly
+                        (fun [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] FutureAction)
+                      )
+                    )
+                  )
+                  (datatypebind
+                    (datatype
+                      (tyvardecl FutureState (type))
+
+                      FutureState_match
+                      (vardecl Finished FutureState)
+                      (vardecl Running (fun Margins FutureState))
+                    )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl
+                      adjustMargin
+                      (fun Role (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun Margins Margins)))
+                    )
+                    (lam
+                      role
+                      Role
+                      (lam
+                        value
+                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                        (lam
+                          accounts
+                          Margins
+                          [
+                            [
+                              [
+                                { [ Role_match role ] (fun Unit Margins) }
+                                (lam
+                                  thunk
+                                  Unit
+                                  [
+                                    { [ Margins_match accounts ] Margins }
+                                    (lam
+                                      ds
+                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                      (lam
+                                        ds
+                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                        [
+                                          [ Margins ds ]
+                                          [
+                                            [ [ unionWith addInteger ] ds ]
+                                            value
+                                          ]
+                                        ]
+                                      )
+                                    )
+                                  ]
+                                )
+                              ]
+                              (lam
+                                thunk
+                                Unit
+                                [
+                                  { [ Margins_match accounts ] Margins }
+                                  (lam
+                                    ds
+                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                    (lam
+                                      ds
+                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                      [
+                                        [
+                                          Margins
+                                          [
+                                            [ [ unionWith addInteger ] ds ]
+                                            value
+                                          ]
+                                        ]
+                                        ds
+                                      ]
+                                    )
+                                  )
+                                ]
+                              )
+                            ]
+                            Unit
+                          ]
+                        )
+                      )
+                    )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl from (all a (type) (fun a [Interval a])))
+                    (abs
+                      a
+                      (type)
+                      (lam
+                        s
+                        a
+                        [
+                          [
+                            { Interval a }
+                            [ [ { LowerBound a } [ { Finite a } s ] ] True ]
+                          ]
+                          [ [ { UpperBound a } { PosInf a } ] True ]
+                        ]
+                      )
+                    )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl
+                      fFromDataInteger_cfromBuiltinData
                       (fun (con data) [Maybe (con integer)])
                     )
                     (lam
@@ -2455,68 +2627,18 @@
                       ]
                     )
                   )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl Observation (fun (type) (type)))
-                      (tyvardecl a (type))
-                      Observation_match
-                      (vardecl
-                        Observation (fun a (fun (con integer) [Observation a]))
-                      )
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl IsData (fun (type) (type)))
-                      (tyvardecl a (type))
-                      IsData_match
-                      (vardecl
-                        CConsIsData
-                        (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-                      )
-                    )
-                  )
                   (termbind
                     (strict)
                     (vardecl
-                      fromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
+                      fFromDataObservation_cfromBuiltinData
+                      (all a (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun (con data) [Maybe [Observation a]])))
                     )
                     (abs
                       a
                       (type)
                       (lam
-                        v
-                        [IsData a]
-                        [
-                          {
-                            [ { IsData_match a } v ] (fun (con data) [Maybe a])
-                          }
-                          (lam
-                            v
-                            (fun a (con data))
-                            (lam
-                              v
-                              (fun (con data) [Maybe a])
-                              (lam v (fun (con data) a) v)
-                            )
-                          )
-                        ]
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataObservation_cfromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) [Maybe [Observation a]])))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        dIsData
-                        [IsData a]
+                        dFromData
+                        [(lam a (type) (fun (con data) [Maybe a])) a]
                         (lam
                           d
                           (con data)
@@ -2582,12 +2704,7 @@
                                                       [
                                                         { Maybe_match a }
                                                         [
-                                                          [
-                                                            {
-                                                              fromBuiltinData a
-                                                            }
-                                                            dIsData
-                                                          ]
+                                                          dFromData
                                                           [
                                                             {
                                                               (builtin headList)
@@ -2615,7 +2732,7 @@
                                                                     (con integer)
                                                                   }
                                                                   [
-                                                                    fIsDataInteger_cfromBuiltinData
+                                                                    fFromDataInteger_cfromBuiltinData
                                                                     [
                                                                       {
                                                                         (builtin
@@ -2834,401 +2951,8 @@
                   (termbind
                     (strict)
                     (vardecl
-                      toBuiltinData
-                      (all a (type) (fun [IsData a] (fun a (con data))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        v
-                        [IsData a]
-                        [
-                          { [ { IsData_match a } v ] (fun a (con data)) }
-                          (lam
-                            v
-                            (fun a (con data))
-                            (lam
-                              v
-                              (fun (con data) [Maybe a])
-                              (lam v (fun (con data) a) v)
-                            )
-                          )
-                        ]
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataObservation_ctoBuiltinData
-                      (all a (type) (fun [IsData a] (fun [Observation a] (con data))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        dIsData
-                        [IsData a]
-                        (lam
-                          ds
-                          [Observation a]
-                          [
-                            { [ { Observation_match a } ds ] (con data) }
-                            (lam
-                              arg
-                              a
-                              (lam
-                                arg
-                                (con integer)
-                                [
-                                  [ (builtin constrData) (con integer 0) ]
-                                  [
-                                    [
-                                      { (builtin mkCons) (con data) }
-                                      [ [ { toBuiltinData a } dIsData ] arg ]
-                                    ]
-                                    [
-                                      [
-                                        { (builtin mkCons) (con data) }
-                                        [ (builtin iData) arg ]
-                                      ]
-                                      [ (builtin mkNilData) (con unit ()) ]
-                                    ]
-                                  ]
-                                ]
-                              )
-                            )
-                          ]
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl error (all a (type) (fun (con unit) a)))
-                    (abs a (type) (lam thunk (con unit) (error a)))
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      unsafeFromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) a)))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        v
-                        [IsData a]
-                        [
-                          { [ { IsData_match a } v ] (fun (con data) a) }
-                          (lam
-                            v
-                            (fun a (con data))
-                            (lam
-                              v
-                              (fun (con data) [Maybe a])
-                              (lam v (fun (con data) a) v)
-                            )
-                          )
-                        ]
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataObservation_cunsafeFromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) [Observation a])))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        dIsData
-                        [IsData a]
-                        (lam
-                          d
-                          (con data)
-                          (let
-                            (nonrec)
-                            (termbind
-                              (nonstrict)
-                              (vardecl x [Observation a])
-                              [ { error [Observation a] } (con unit ()) ]
-                            )
-                            (termbind
-                              (nonstrict)
-                              (vardecl
-                                tup
-                                [[(con pair) (con integer)] [(con list) (con data)]]
-                              )
-                              [ (builtin unConstrData) d ]
-                            )
-                            (termbind
-                              (nonstrict)
-                              (vardecl t [(con list) (con data)])
-                              [
-                                {
-                                  { (builtin sndPair) (con integer) }
-                                  [(con list) (con data)]
-                                }
-                                tup
-                              ]
-                            )
-                            (termbind
-                              (nonstrict)
-                              (vardecl x (con integer))
-                              [
-                                (builtin unIData)
-                                [
-                                  { (builtin headList) (con data) }
-                                  [ { (builtin tailList) (con data) } t ]
-                                ]
-                              ]
-                            )
-                            (termbind
-                              (nonstrict)
-                              (vardecl x a)
-                              [
-                                [ { unsafeFromBuiltinData a } dIsData ]
-                                [ { (builtin headList) (con data) } t ]
-                              ]
-                            )
-                            (termbind
-                              (nonstrict)
-                              (vardecl x [Observation a])
-                              [ [ { Observation a } x ] x ]
-                            )
-                            [
-                              [
-                                [
-                                  [
-                                    {
-                                      (builtin ifThenElse)
-                                      (fun Unit [Observation a])
-                                    }
-                                    [
-                                      [
-                                        (builtin equalsInteger)
-                                        [
-                                          {
-                                            { (builtin fstPair) (con integer) }
-                                            [(con list) (con data)]
-                                          }
-                                          tup
-                                        ]
-                                      ]
-                                      (con integer 0)
-                                    ]
-                                  ]
-                                  (lam ds Unit x)
-                                ]
-                                (lam ds Unit x)
-                              ]
-                              Unit
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataObservation
-                      (all a (type) (fun [IsData a] [IsData [Observation a]]))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        v
-                        [IsData a]
-                        [
-                          [
-                            [
-                              { CConsIsData [Observation a] }
-                              [ { fIsDataObservation_ctoBuiltinData a } v ]
-                            ]
-                            [ { fIsDataObservation_cfromBuiltinData a } v ]
-                          ]
-                          [ { fIsDataObservation_cunsafeFromBuiltinData a } v ]
-                        ]
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataByteString_cfromBuiltinData
-                      (fun (con data) [Maybe (con bytestring)])
-                    )
-                    (lam
-                      d
-                      (con data)
-                      [
-                        [
-                          [
-                            [
-                              [
-                                [
-                                  [
-                                    {
-                                      (builtin chooseData)
-                                      (fun Unit [Maybe (con bytestring)])
-                                    }
-                                    (lam ds Unit { Nothing (con bytestring) })
-                                  ]
-                                  (lam ds Unit { Nothing (con bytestring) })
-                                ]
-                                (lam ds Unit { Nothing (con bytestring) })
-                              ]
-                              (lam ds Unit { Nothing (con bytestring) })
-                            ]
-                            (lam
-                              ds
-                              Unit
-                              [
-                                { Just (con bytestring) }
-                                [ (builtin unBData) d ]
-                              ]
-                            )
-                          ]
-                          d
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataByteString_ctoBuiltinData
-                      (fun (con bytestring) (con data))
-                    )
-                    (lam b (con bytestring) [ (builtin bData) b ])
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl fIsDataCurrencySymbol [IsData (con bytestring)])
-                    [
-                      [
-                        [
-                          { CConsIsData (con bytestring) }
-                          fIsDataByteString_ctoBuiltinData
-                        ]
-                        fIsDataByteString_cfromBuiltinData
-                      ]
-                      (builtin unBData)
-                    ]
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataInteger_ctoBuiltinData
-                      (fun (con integer) (con data))
-                    )
-                    (lam i (con integer) [ (builtin iData) i ])
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl fIsDataInteger [IsData (con integer)])
-                    [
-                      [
-                        [
-                          { CConsIsData (con integer) }
-                          fIsDataInteger_ctoBuiltinData
-                        ]
-                        fIsDataInteger_cfromBuiltinData
-                      ]
-                      (builtin unIData)
-                    ]
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataNil_cunsafeFromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) [List a])))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        dIsData
-                        [IsData a]
-                        (lam
-                          d
-                          (con data)
-                          (let
-                            (rec)
-                            (termbind
-                              (strict)
-                              (vardecl go (fun [(con list) (con data)] [List a])
-                              )
-                              (lam
-                                l
-                                [(con list) (con data)]
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [List a])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nil a })
-                                      ]
-                                      (lam
-                                        ds
-                                        Unit
-                                        [
-                                          [
-                                            { Cons a }
-                                            [
-                                              [
-                                                { unsafeFromBuiltinData a }
-                                                dIsData
-                                              ]
-                                              [
-                                                {
-                                                  (builtin headList) (con data)
-                                                }
-                                                l
-                                              ]
-                                            ]
-                                          ]
-                                          [
-                                            go
-                                            [
-                                              { (builtin tailList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                      )
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                            )
-                            [ go [ (builtin unListData) d ] ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataTuple2_cfromBuiltinData
-                      (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
+                      fFromDataTuple2_cfromBuiltinData
+                      (all a (type) (all b (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun [(lam a (type) (fun (con data) [Maybe a])) b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
                     )
                     (abs
                       a
@@ -3237,11 +2961,11 @@
                         b
                         (type)
                         (lam
-                          dIsData
-                          [IsData a]
+                          dFromData
+                          [(lam a (type) (fun (con data) [Maybe a])) a]
                           (lam
-                            dIsData
-                            [IsData b]
+                            dFromData
+                            [(lam a (type) (fun (con data) [Maybe a])) b]
                             (lam
                               d
                               (con data)
@@ -3311,13 +3035,7 @@
                                                           [
                                                             { Maybe_match a }
                                                             [
-                                                              [
-                                                                {
-                                                                  fromBuiltinData
-                                                                  a
-                                                                }
-                                                                dIsData
-                                                              ]
+                                                              dFromData
                                                               [
                                                                 {
                                                                   (builtin
@@ -3347,13 +3065,7 @@
                                                                         b
                                                                       }
                                                                       [
-                                                                        [
-                                                                          {
-                                                                            fromBuiltinData
-                                                                            b
-                                                                          }
-                                                                          dIsData
-                                                                        ]
+                                                                        dFromData
                                                                         [
                                                                           {
                                                                             (builtin
@@ -3593,263 +3305,75 @@
                   (termbind
                     (strict)
                     (vardecl
-                      fIsDataTuple2_ctoBuiltinData
-                      (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun [[Tuple2 a] b] (con data))))))
+                      fFromDataByteString_cfromBuiltinData
+                      (fun (con data) [Maybe (con bytestring)])
                     )
-                    (abs
-                      a
-                      (type)
-                      (abs
-                        b
-                        (type)
-                        (lam
-                          dIsData
-                          [IsData a]
-                          (lam
-                            dIsData
-                            [IsData b]
-                            (lam
-                              ds
-                              [[Tuple2 a] b]
+                    (lam
+                      d
+                      (con data)
+                      [
+                        [
+                          [
+                            [
                               [
-                                { [ { { Tuple2_match a } b } ds ] (con data) }
-                                (lam
-                                  arg
-                                  a
-                                  (lam
-                                    arg
-                                    b
-                                    [
-                                      [ (builtin constrData) (con integer 0) ]
-                                      [
-                                        [
-                                          { (builtin mkCons) (con data) }
-                                          [
-                                            [ { toBuiltinData a } dIsData ] arg
-                                          ]
-                                        ]
-                                        [
-                                          [
-                                            { (builtin mkCons) (con data) }
-                                            [
-                                              [ { toBuiltinData b } dIsData ]
-                                              arg
-                                            ]
-                                          ]
-                                          [ (builtin mkNilData) (con unit ()) ]
-                                        ]
-                                      ]
-                                    ]
-                                  )
-                                )
-                              ]
-                            )
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataTuple2_cunsafeFromBuiltinData
-                      (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [[Tuple2 a] b])))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (abs
-                        b
-                        (type)
-                        (lam
-                          dIsData
-                          [IsData a]
-                          (lam
-                            dIsData
-                            [IsData b]
-                            (lam
-                              d
-                              (con data)
-                              (let
-                                (nonrec)
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl x [[Tuple2 a] b])
-                                  [ { error [[Tuple2 a] b] } (con unit ()) ]
-                                )
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl
-                                    tup
-                                    [[(con pair) (con integer)] [(con list) (con data)]]
-                                  )
-                                  [ (builtin unConstrData) d ]
-                                )
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl t [(con list) (con data)])
+                                [
                                   [
                                     {
-                                      { (builtin sndPair) (con integer) }
-                                      [(con list) (con data)]
+                                      (builtin chooseData)
+                                      (fun Unit [Maybe (con bytestring)])
                                     }
-                                    tup
+                                    (lam ds Unit { Nothing (con bytestring) })
                                   ]
-                                )
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl x b)
-                                  [
-                                    [ { unsafeFromBuiltinData b } dIsData ]
-                                    [
-                                      { (builtin headList) (con data) }
-                                      [ { (builtin tailList) (con data) } t ]
-                                    ]
-                                  ]
-                                )
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl x a)
-                                  [
-                                    [ { unsafeFromBuiltinData a } dIsData ]
-                                    [ { (builtin headList) (con data) } t ]
-                                  ]
-                                )
-                                (termbind
-                                  (nonstrict)
-                                  (vardecl x [[Tuple2 a] b])
-                                  [ [ { { Tuple2 a } b } x ] x ]
-                                )
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          (builtin ifThenElse)
-                                          (fun Unit [[Tuple2 a] b])
-                                        }
-                                        [
-                                          [
-                                            (builtin equalsInteger)
-                                            [
-                                              {
-                                                {
-                                                  (builtin fstPair)
-                                                  (con integer)
-                                                }
-                                                [(con list) (con data)]
-                                              }
-                                              tup
-                                            ]
-                                          ]
-                                          (con integer 0)
-                                        ]
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  Unit
+                                  (lam ds Unit { Nothing (con bytestring) })
                                 ]
-                              )
+                                (lam ds Unit { Nothing (con bytestring) })
+                              ]
+                              (lam ds Unit { Nothing (con bytestring) })
+                            ]
+                            (lam
+                              ds
+                              Unit
+                              [
+                                { Just (con bytestring) }
+                                [ (builtin unBData) d ]
+                              ]
                             )
-                          )
-                        )
-                      )
+                          ]
+                          d
+                        ]
+                        Unit
+                      ]
                     )
+                  )
+                  (termbind
+                    (nonstrict)
+                    (vardecl
+                      fFromDataValue
+                      (fun (con data) [Maybe [[Tuple2 (con bytestring)] (con integer)]])
+                    )
+                    [
+                      [
+                        {
+                          { fFromDataTuple2_cfromBuiltinData (con bytestring) }
+                          (con integer)
+                        }
+                        fFromDataByteString_cfromBuiltinData
+                      ]
+                      fFromDataInteger_cfromBuiltinData
+                    ]
                   )
                   (termbind
                     (strict)
                     (vardecl
-                      fIsDataTuple2
-                      (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] [IsData [[Tuple2 a] b]]))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (abs
-                        b
-                        (type)
-                        (lam
-                          v
-                          [IsData a]
-                          (lam
-                            v
-                            [IsData b]
-                            [
-                              [
-                                [
-                                  { CConsIsData [[Tuple2 a] b] }
-                                  [
-                                    [
-                                      { { fIsDataTuple2_ctoBuiltinData a } b } v
-                                    ]
-                                    v
-                                  ]
-                                ]
-                                [
-                                  [
-                                    { { fIsDataTuple2_cfromBuiltinData a } b } v
-                                  ]
-                                  v
-                                ]
-                              ]
-                              [
-                                [
-                                  {
-                                    { fIsDataTuple2_cunsafeFromBuiltinData a } b
-                                  }
-                                  v
-                                ]
-                                v
-                              ]
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataMap
-                      (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun (con data) [List [[Tuple2 k] v]])))))
-                    )
-                    (abs
-                      k
-                      (type)
-                      (abs
-                        v
-                        (type)
-                        (lam
-                          dIsData
-                          [IsData k]
-                          (lam
-                            dIsData
-                            [IsData v]
-                            [
-                              {
-                                fIsDataNil_cunsafeFromBuiltinData [[Tuple2 k] v]
-                              }
-                              [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataNil_cfromBuiltinData
-                      (all a (type) (fun [IsData a] (fun (con data) [Maybe [List a]])))
+                      fFromDataNil_cfromBuiltinData
+                      (all a (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun (con data) [Maybe [List a]])))
                     )
                     (abs
                       a
                       (type)
                       (lam
-                        dIsData
-                        [IsData a]
+                        dFromData
+                        [(lam a (type) (fun (con data) [Maybe a])) a]
                         (lam
                           d
                           (con data)
@@ -3894,10 +3418,7 @@
                                                   [
                                                     { Maybe_match a }
                                                     [
-                                                      [
-                                                        { fromBuiltinData a }
-                                                        dIsData
-                                                      ]
+                                                      dFromData
                                                       [
                                                         {
                                                           (builtin headList)
@@ -4022,445 +3543,75 @@
                   (termbind
                     (strict)
                     (vardecl
-                      fIsDataMap
-                      (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun (con data) [Maybe [List [[Tuple2 k] v]]])))))
+                      fFromDataValue
+                      (fun (con data) [Maybe [List [[Tuple2 (con bytestring)] (con integer)]]])
                     )
-                    (abs
-                      k
-                      (type)
-                      (abs
-                        v
-                        (type)
-                        (lam
-                          dIsData
-                          [IsData k]
-                          (lam
-                            dIsData
-                            [IsData v]
-                            [
-                              { fIsDataNil_cfromBuiltinData [[Tuple2 k] v] }
-                              [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataNil_ctoBuiltinData
-                      (all a (type) (fun [IsData a] (fun [List a] (con data))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        dIsData
-                        [IsData a]
-                        (lam
-                          l
-                          [List a]
-                          (let
-                            (rec)
-                            (termbind
-                              (strict)
-                              (vardecl go (fun [List a] [(con list) (con data)])
-                              )
-                              (lam
-                                ds
-                                [List a]
-                                [
-                                  [
-                                    [
-                                      {
-                                        [ { Nil_match a } ds ]
-                                        (fun Unit [(con list) (con data)])
-                                      }
-                                      (lam
-                                        thunk
-                                        Unit
-                                        [ (builtin mkNilData) (con unit ()) ]
-                                      )
-                                    ]
-                                    (lam
-                                      x
-                                      a
-                                      (lam
-                                        xs
-                                        [List a]
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              { (builtin mkCons) (con data) }
-                                              [
-                                                [ { toBuiltinData a } dIsData ]
-                                                x
-                                              ]
-                                            ]
-                                            [ go xs ]
-                                          ]
-                                        )
-                                      )
-                                    )
-                                  ]
-                                  Unit
-                                ]
-                              )
-                            )
-                            [ (builtin listData) [ go l ] ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataMap
-                      (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun [List [[Tuple2 k] v]] (con data))))))
-                    )
-                    (abs
-                      k
-                      (type)
-                      (abs
-                        v
-                        (type)
-                        (lam
-                          dIsData
-                          [IsData k]
-                          (lam
-                            dIsData
-                            [IsData v]
-                            [
-                              { fIsDataNil_ctoBuiltinData [[Tuple2 k] v] }
-                              [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataMap
-                      (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] [IsData [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]]))))
-                    )
-                    (abs
-                      k
-                      (type)
-                      (abs
-                        v
-                        (type)
-                        (lam
-                          v
-                          [IsData k]
-                          (lam
-                            v
-                            [IsData v]
-                            [
-                              [
-                                [
-                                  {
-                                    CConsIsData
-                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
-                                  }
-                                  [ [ { { fIsDataMap k } v } v ] v ]
-                                ]
-                                [ [ { { fIsDataMap k } v } v ] v ]
-                              ]
-                              [ [ { { fIsDataMap k } v } v ] v ]
-                            ]
-                          )
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl fIsDataTokenName [IsData (con bytestring)])
-                    [
+                    (lam
+                      eta
+                      (con data)
                       [
                         [
-                          { CConsIsData (con bytestring) }
-                          fIsDataByteString_ctoBuiltinData
+                          {
+                            fFromDataNil_cfromBuiltinData
+                            [[Tuple2 (con bytestring)] (con integer)]
+                          }
+                          fFromDataValue
                         ]
-                        fIsDataByteString_cfromBuiltinData
+                        eta
                       ]
-                      (builtin unBData)
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      fIsDataValue
-                      [IsData [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                     )
-                    [
-                      [
-                        { { fIsDataMap (con bytestring) } (con integer) }
-                        fIsDataTokenName
-                      ]
-                      fIsDataInteger
-                    ]
                   )
                   (termbind
                     (nonstrict)
                     (vardecl
-                      fIsDataValue
-                      [IsData [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                      fFromDataValue
+                      (fun (con data) [Maybe [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
                     )
                     [
                       [
                         {
-                          { fIsDataTuple2 (con bytestring) }
+                          { fFromDataTuple2_cfromBuiltinData (con bytestring) }
                           [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                         }
-                        fIsDataCurrencySymbol
+                        fFromDataByteString_cfromBuiltinData
                       ]
-                      fIsDataValue
+                      fFromDataValue
                     ]
                   )
                   (termbind
-                    (nonstrict)
+                    (strict)
                     (vardecl
-                      fIsDataValue
-                      (fun (con data) [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
-                    )
-                    [
-                      {
-                        fIsDataNil_cunsafeFromBuiltinData
-                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                      }
-                      fIsDataValue
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      fIsDataValue
+                      fFromDataValue
                       (fun (con data) [Maybe [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
                     )
-                    [
-                      {
-                        fIsDataNil_cfromBuiltinData
-                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                      }
-                      fIsDataValue
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      fIsDataValue
-                      (fun [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]] (con data))
-                    )
-                    [
-                      {
-                        fIsDataNil_ctoBuiltinData
-                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                      }
-                      fIsDataValue
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      fIsDataValue
-                      [IsData [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                    )
-                    [
+                    (lam
+                      eta
+                      (con data)
                       [
                         [
                           {
-                            CConsIsData
-                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                            fFromDataNil_cfromBuiltinData
+                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                           }
-                          fIsDataValue
+                          fFromDataValue
                         ]
-                        fIsDataValue
+                        eta
                       ]
-                      fIsDataValue
-                    ]
+                    )
                   )
                   (termbind
                     (nonstrict)
                     (vardecl
-                      fIsDataFutureAction
-                      [IsData [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                      futureStateMachine
+                      (fun (con data) [Maybe [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
                     )
                     [
                       {
-                        fIsDataObservation
+                        fFromDataObservation_cfromBuiltinData
                         [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                       }
-                      fIsDataValue
+                      fFromDataValue
                     ]
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fMonoidTxConstraints_cmempty
-                      (all i (type) (all o (type) [[TxConstraints i] o]))
-                    )
-                    (abs
-                      i
-                      (type)
-                      (abs
-                        o
-                        (type)
-                        [
-                          [
-                            [ { { TxConstraints i } o } { Nil TxConstraint } ]
-                            { Nil [InputConstraint i] }
-                          ]
-                          { Nil [OutputConstraint o] }
-                        ]
-                      )
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl SignedMessage (fun (type) (type)))
-                      (tyvardecl a (type))
-                      SignedMessage_match
-                      (vardecl
-                        SignedMessage
-                        (fun (con bytestring) (fun (con bytestring) (fun (con data) [SignedMessage a])))
-                      )
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl Role (type))
-
-                      Role_match
-                      (vardecl Long Role) (vardecl Short Role)
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl FutureAction (type))
-
-                      FutureAction_match
-                      (vardecl
-                        AdjustMargin
-                        (fun Role (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] FutureAction))
-                      )
-                      (vardecl
-                        Settle
-                        (fun [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] FutureAction)
-                      )
-                      (vardecl
-                        SettleEarly
-                        (fun [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] FutureAction)
-                      )
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl FutureState (type))
-
-                      FutureState_match
-                      (vardecl Finished FutureState)
-                      (vardecl Running (fun Margins FutureState))
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      adjustMargin
-                      (fun Role (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun Margins Margins)))
-                    )
-                    (lam
-                      role
-                      Role
-                      (lam
-                        value
-                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                        (lam
-                          accounts
-                          Margins
-                          [
-                            [
-                              [
-                                { [ Role_match role ] (fun Unit Margins) }
-                                (lam
-                                  thunk
-                                  Unit
-                                  [
-                                    { [ Margins_match accounts ] Margins }
-                                    (lam
-                                      ds
-                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                      (lam
-                                        ds
-                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                        [
-                                          [ Margins ds ]
-                                          [
-                                            [ [ unionWith addInteger ] ds ]
-                                            value
-                                          ]
-                                        ]
-                                      )
-                                    )
-                                  ]
-                                )
-                              ]
-                              (lam
-                                thunk
-                                Unit
-                                [
-                                  { [ Margins_match accounts ] Margins }
-                                  (lam
-                                    ds
-                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                    (lam
-                                      ds
-                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                      [
-                                        [
-                                          Margins
-                                          [
-                                            [ [ unionWith addInteger ] ds ]
-                                            value
-                                          ]
-                                        ]
-                                        ds
-                                      ]
-                                    )
-                                  )
-                                ]
-                              )
-                            ]
-                            Unit
-                          ]
-                        )
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl from (all a (type) (fun a [Interval a])))
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        s
-                        a
-                        [
-                          [
-                            { Interval a }
-                            [ [ { LowerBound a } [ { Finite a } s ] ] True ]
-                          ]
-                          [ [ { UpperBound a } { PosInf a } ] True ]
-                        ]
-                      )
-                    )
                   )
                   (termbind
                     (strict)
@@ -4568,7 +3719,7 @@
                     (strict)
                     (vardecl
                       checkHashConstraints
-                      (all a (type) (all i (type) (all o (type) (fun [IsData a] (fun [SignedMessage a] [[Either SignedMessageCheckError] [[Tuple2 a] [[TxConstraints i] o]]])))))
+                      (all a (type) (all i (type) (all o (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun [SignedMessage a] [[Either SignedMessageCheckError] [[Tuple2 a] [[TxConstraints i] o]]])))))
                     )
                     (abs
                       a
@@ -4580,8 +3731,8 @@
                           o
                           (type)
                           (lam
-                            dIsData
-                            [IsData a]
+                            dFromData
+                            [(lam a (type) (fun (con data) [Maybe a])) a]
                             (lam
                               ds
                               [SignedMessage a]
@@ -4605,13 +3756,7 @@
                                             {
                                               [
                                                 { Maybe_match a }
-                                                [
-                                                  [
-                                                    { fromBuiltinData a }
-                                                    dIsData
-                                                  ]
-                                                  ds
-                                                ]
+                                                [ dFromData ds ]
                                               ]
                                               (fun Unit [[Either SignedMessageCheckError] [[Tuple2 a] [[TxConstraints i] o]]])
                                             }
@@ -4693,7 +3838,7 @@
                     (strict)
                     (vardecl
                       verifySignedMessageConstraints
-                      (all a (type) (all i (type) (all o (type) (fun [IsData a] (fun (con bytestring) (fun [SignedMessage a] [[Either SignedMessageCheckError] [[Tuple2 a] [[TxConstraints i] o]]]))))))
+                      (all a (type) (all i (type) (all o (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun (con bytestring) (fun [SignedMessage a] [[Either SignedMessageCheckError] [[Tuple2 a] [[TxConstraints i] o]]]))))))
                     )
                     (abs
                       a
@@ -4705,8 +3850,8 @@
                           o
                           (type)
                           (lam
-                            dIsData
-                            [IsData a]
+                            dFromData
+                            [(lam a (type) (fun (con data) [Maybe a])) a]
                             (lam
                               pk
                               (con bytestring)
@@ -4774,7 +3919,7 @@
                                                       }
                                                       o
                                                     }
-                                                    dIsData
+                                                    dFromData
                                                   ]
                                                   s
                                                 ]
@@ -5733,7 +4878,7 @@
                                                                               }
                                                                               Void
                                                                             }
-                                                                            fIsDataFutureAction
+                                                                            futureStateMachine
                                                                           ]
                                                                           ds
                                                                         ]
@@ -6187,7 +5332,7 @@
                                                                             }
                                                                             Void
                                                                           }
-                                                                          fIsDataFutureAction
+                                                                          futureStateMachine
                                                                         ]
                                                                         ds
                                                                       ]

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -44,54 +44,6 @@
         )
         (datatypebind
           (datatype
-            (tyvardecl Maybe (fun (type) (type)))
-            (tyvardecl a (type))
-            Maybe_match
-            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataByteString_cfromBuiltinData
-            (fun (con data) [Maybe (con bytestring)])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          {
-                            (builtin chooseData)
-                            (fun Unit [Maybe (con bytestring)])
-                          }
-                          (lam ds Unit { Nothing (con bytestring) })
-                        ]
-                        (lam ds Unit { Nothing (con bytestring) })
-                      ]
-                      (lam ds Unit { Nothing (con bytestring) })
-                    ]
-                    (lam ds Unit { Nothing (con bytestring) })
-                  ]
-                  (lam
-                    ds
-                    Unit
-                    [ { Just (con bytestring) } [ (builtin unBData) d ] ]
-                  )
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (datatypebind
-          (datatype
             (tyvardecl GameState (type))
 
             GameState_match
@@ -107,572 +59,7 @@
         )
         (termbind
           (strict)
-          (vardecl
-            fIsDataGameState_cfromBuiltinData (fun (con data) [Maybe GameState])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe GameState]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl args [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } args ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match (con bytestring) }
-                                          [
-                                            fIsDataByteString_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              args
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe GameState])
-                                      }
-                                      (lam
-                                        ipv
-                                        (con bytestring)
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      (con bytestring)
-                                                    }
-                                                    [
-                                                      fIsDataByteString_cfromBuiltinData
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe GameState])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  (con bytestring)
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                Maybe_match
-                                                                (con bytestring)
-                                                              }
-                                                              [
-                                                                fIsDataByteString_cfromBuiltinData
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      headList
-                                                                    )
-                                                                    (con data)
-                                                                  }
-                                                                  l
-                                                                ]
-                                                              ]
-                                                            ]
-                                                            (fun Unit [Maybe GameState])
-                                                          }
-                                                          (lam
-                                                            ipv
-                                                            (con bytestring)
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                {
-                                                                  Just GameState
-                                                                }
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      Initialised
-                                                                      ipv
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                  ipv
-                                                                ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          { Nothing GameState }
-                                                        )
-                                                      ]
-                                                      Unit
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing GameState }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing GameState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing GameState })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl index (con integer))
-                                [
-                                  {
-                                    { (builtin fstPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          (builtin ifThenElse)
-                                          (fun Unit [Maybe GameState])
-                                        }
-                                        [
-                                          [ (builtin equalsInteger) index ]
-                                          (con integer 0)
-                                        ]
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    (lam ds Unit { Nothing GameState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } args ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match (con bytestring) }
-                                          [
-                                            fIsDataByteString_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              args
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe GameState])
-                                      }
-                                      (lam
-                                        ipv
-                                        (con bytestring)
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      (con bytestring)
-                                                    }
-                                                    [
-                                                      fIsDataByteString_cfromBuiltinData
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe GameState])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  (con bytestring)
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                Maybe_match
-                                                                (con bytestring)
-                                                              }
-                                                              [
-                                                                fIsDataByteString_cfromBuiltinData
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      headList
-                                                                    )
-                                                                    (con data)
-                                                                  }
-                                                                  l
-                                                                ]
-                                                              ]
-                                                            ]
-                                                            (fun Unit [Maybe GameState])
-                                                          }
-                                                          (lam
-                                                            ipv
-                                                            (con bytestring)
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                {
-                                                                  Just GameState
-                                                                }
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      Locked ipv
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                  ipv
-                                                                ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          { Nothing GameState }
-                                                        )
-                                                      ]
-                                                      Unit
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing GameState }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing GameState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing GameState })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe GameState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GameState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GameState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe GameState])
-                                      }
-                                      [
-                                        [ (builtin equalsInteger) index ]
-                                        (con integer 1)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit x)
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing GameState })
-                      ]
-                      (lam ds Unit { Nothing GameState })
-                    ]
-                    (lam ds Unit { Nothing GameState })
-                  ]
-                  (lam ds Unit { Nothing GameState })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataGameState_ctoBuiltinData (fun GameState (con data)))
+          (vardecl fToDataGameState_ctoBuiltinData (fun GameState (con data)))
           (lam
             ds
             GameState
@@ -750,176 +137,6 @@
               )
             ]
           )
-        )
-        (termbind
-          (strict)
-          (vardecl error (all a (type) (fun (con unit) a)))
-          (abs a (type) (lam thunk (con unit) (error a)))
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataGameState_cunsafeFromBuiltinData (fun (con data) GameState)
-          )
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x GameState)
-                [ { error GameState } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [ { (builtin tailList) (con data) } t ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [
-                  (builtin unBData)
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict) (vardecl x GameState) [ [ [ Initialised x ] x ] x ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl index (con integer))
-                [
-                  {
-                    { (builtin fstPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x GameState)
-                [
-                  [
-                    [
-                      [
-                        { (builtin ifThenElse) (fun Unit GameState) }
-                        [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                      ]
-                      (lam ds Unit x)
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  Unit
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [ { (builtin tailList) (con data) } t ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [
-                  (builtin unBData)
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict) (vardecl x GameState) [ [ [ Locked x ] x ] x ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit GameState) }
-                      [ [ (builtin equalsInteger) index ] (con integer 1) ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl IsData (fun (type) (type)))
-            (tyvardecl a (type))
-            IsData_match
-            (vardecl
-              CConsIsData
-              (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataGameState [IsData GameState])
-          [
-            [
-              [ { CConsIsData GameState } fIsDataGameState_ctoBuiltinData ]
-              fIsDataGameState_cfromBuiltinData
-            ]
-            fIsDataGameState_cunsafeFromBuiltinData
-          ]
         )
         (datatypebind
           (datatype
@@ -1019,6 +236,14 @@
             (vardecl
               Interval (fun [LowerBound a] (fun [UpperBound a] [Interval a]))
             )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Maybe (fun (type) (type)))
+            (tyvardecl a (type))
+            Maybe_match
+            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
           )
         )
         (datatypebind
@@ -2806,7 +2031,7 @@
                   )
                   (termbind
                     (strict)
-                    (vardecl fIsDataUnit_ctoBuiltinData (fun Unit (con data)))
+                    (vardecl fToDataUnit_ctoBuiltinData (fun Unit (con data)))
                     (lam
                       ds
                       Unit
@@ -3020,7 +2245,7 @@
                                                                               mph
                                                                             ]
                                                                             [
-                                                                              fIsDataUnit_ctoBuiltinData
+                                                                              fToDataUnit_ctoBuiltinData
                                                                               Unit
                                                                             ]
                                                                           ]
@@ -3201,7 +2426,7 @@
                                                                                                 mph
                                                                                               ]
                                                                                               [
-                                                                                                fIsDataUnit_ctoBuiltinData
+                                                                                                fToDataUnit_ctoBuiltinData
                                                                                                 Unit
                                                                                               ]
                                                                                             ]
@@ -3393,33 +2618,8 @@
                   )
                   (termbind
                     (strict)
-                    (vardecl
-                      fIsDataVoid_cfromBuiltinData (fun (con data) [Maybe Void])
-                    )
-                    (lam ds (con data) { Nothing Void })
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataVoid_cunsafeFromBuiltinData (fun (con data) Void)
-                    )
-                    (lam ds (con data) [ { error Void } (con unit ()) ])
-                  )
-                  (termbind
-                    (strict)
                     (vardecl absurd (all a (type) (fun Void a)))
                     (abs a (type) (lam a Void { [ Void_match a ] a }))
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl fIsDataVoid [IsData Void])
-                    [
-                      [
-                        [ { CConsIsData Void } { absurd (con data) } ]
-                        fIsDataVoid_cfromBuiltinData
-                      ]
-                      fIsDataVoid_cunsafeFromBuiltinData
-                    ]
                   )
                   (datatypebind
                     (datatype
@@ -4077,33 +3277,6 @@
                   (termbind
                     (strict)
                     (vardecl
-                      toBuiltinData
-                      (all a (type) (fun [IsData a] (fun a (con data))))
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        v
-                        [IsData a]
-                        [
-                          { [ { IsData_match a } v ] (fun a (con data)) }
-                          (lam
-                            v
-                            (fun a (con data))
-                            (lam
-                              v
-                              (fun (con data) [Maybe a])
-                              (lam v (fun (con data) a) v)
-                            )
-                          )
-                        ]
-                      )
-                    )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
                       fEqCredential_c (fun Credential (fun Credential Bool))
                     )
                     (lam
@@ -4560,6 +3733,11 @@
                         ]
                       )
                     )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl error (all a (type) (fun (con unit) a)))
+                    (abs a (type) (lam thunk (con unit) (error a)))
                   )
                   (termbind
                     (strict)
@@ -5266,14 +4444,14 @@
                     (strict)
                     (vardecl
                       checkOwnOutputConstraint
-                      (all o (type) (fun [IsData o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
+                      (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
                     )
                     (abs
                       o
                       (type)
                       (lam
-                        dIsData
-                        [IsData o]
+                        dToData
+                        [(lam a (type) (fun a (con data))) o]
                         (lam
                           ctx
                           ScriptContext
@@ -5304,15 +4482,7 @@
                                               hsh [Maybe (con bytestring)]
                                             )
                                             [
-                                              [
-                                                findDatumHash
-                                                [
-                                                  [
-                                                    { toBuiltinData o } dIsData
-                                                  ]
-                                                  ds
-                                                ]
-                                              ]
+                                              [ findDatumHash [ dToData ds ] ]
                                               ds
                                             ]
                                           )
@@ -10226,7 +9396,7 @@
                     (strict)
                     (vardecl
                       checkScriptContext
-                      (all i (type) (all o (type) (fun [IsData o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
+                      (all i (type) (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
                     )
                     (abs
                       i
@@ -10235,8 +9405,8 @@
                         o
                         (type)
                         (lam
-                          dIsData
-                          [IsData o]
+                          dToData
+                          [(lam a (type) (fun a (con data))) o]
                           (lam
                             ds
                             [[TxConstraints i] o]
@@ -10376,7 +9546,7 @@
                                                                             checkOwnOutputConstraint
                                                                             o
                                                                           }
-                                                                          dIsData
+                                                                          dToData
                                                                         ]
                                                                         ptx
                                                                       ]
@@ -10908,7 +10078,7 @@
                     (strict)
                     (vardecl
                       wmkValidator
-                      (all s (type) (all i (type) (fun [IsData s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
+                      (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
                     )
                     (abs
                       s
@@ -10918,7 +10088,7 @@
                         (type)
                         (lam
                           w
-                          [IsData s]
+                          [(lam a (type) (fun a (con data))) s]
                           (lam
                             ww
                             (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]]))
@@ -11126,7 +10296,10 @@
                                                                                                 }
                                                                                                 Void
                                                                                               }
-                                                                                              fIsDataVoid
+                                                                                              {
+                                                                                                absurd
+                                                                                                (con data)
+                                                                                              }
                                                                                             ]
                                                                                             newConstraints
                                                                                           ]
@@ -11643,7 +10816,7 @@
                     (strict)
                     (vardecl
                       mkValidator
-                      (all s (type) (all i (type) (fun [IsData s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
+                      (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
                     )
                     (abs
                       s
@@ -11653,7 +10826,7 @@
                         (type)
                         (lam
                           w
-                          [IsData s]
+                          [(lam a (type) (fun a (con data))) s]
                           (lam
                             w
                             [[StateMachine s] i]
@@ -11731,7 +10904,8 @@
                     )
                     [
                       [
-                        { { mkValidator GameState } GameInput } fIsDataGameState
+                        { { mkValidator GameState } GameInput }
+                        fToDataGameState_ctoBuiltinData
                       ]
                       machine
                     ]

--- a/plutus-use-cases/test/Spec/governance.pir
+++ b/plutus-use-cases/test/Spec/governance.pir
@@ -42,1558 +42,9 @@
             (vardecl True Bool) (vardecl False Bool)
           )
         )
-        (datatypebind
-          (datatype
-            (tyvardecl Maybe (fun (type) (type)))
-            (tyvardecl a (type))
-            Maybe_match
-            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl IsData (fun (type) (type)))
-            (tyvardecl a (type))
-            IsData_match
-            (vardecl
-              CConsIsData
-              (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-            )
-          )
-        )
         (termbind
           (strict)
-          (vardecl
-            fromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun (con data) [Maybe a]) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMaybe_cfromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe [Maybe a]])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                [
-                  [
-                    [
-                      [
-                        [
-                          [
-                            [
-                              {
-                                (builtin chooseData)
-                                (fun Unit [Maybe [Maybe a]])
-                              }
-                              (lam
-                                ds
-                                Unit
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl nilCase [Maybe [Maybe a]])
-                                    [ { Just [Maybe a] } { Nothing a } ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl
-                                      tup
-                                      [[(con pair) (con integer)] [(con list) (con data)]]
-                                    )
-                                    [ (builtin unConstrData) d ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl args [(con list) (con data)])
-                                    [
-                                      {
-                                        { (builtin sndPair) (con integer) }
-                                        [(con list) (con data)]
-                                      }
-                                      tup
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl x [Maybe [Maybe a]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [Maybe a]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam ds Unit nilCase)
-                                          ]
-                                          (lam ds Unit { Nothing [Maybe a] })
-                                        ]
-                                        args
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl index (con integer))
-                                    [
-                                      {
-                                        { (builtin fstPair) (con integer) }
-                                        [(con list) (con data)]
-                                      }
-                                      tup
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl x [Maybe [Maybe a]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              (builtin ifThenElse)
-                                              (fun Unit [Maybe [Maybe a]])
-                                            }
-                                            [
-                                              [ (builtin equalsInteger) index ]
-                                              (con integer 1)
-                                            ]
-                                          ]
-                                          (lam ds Unit x)
-                                        ]
-                                        (lam ds Unit { Nothing [Maybe a] })
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl nilCase [Maybe [Maybe a]])
-                                    [
-                                      [
-                                        [
-                                          {
-                                            [
-                                              { Maybe_match a }
-                                              [
-                                                [
-                                                  { fromBuiltinData a } dIsData
-                                                ]
-                                                [
-                                                  {
-                                                    (builtin headList)
-                                                    (con data)
-                                                  }
-                                                  args
-                                                ]
-                                              ]
-                                            ]
-                                            (fun Unit [Maybe [Maybe a]])
-                                          }
-                                          (lam
-                                            ipv
-                                            a
-                                            (lam
-                                              thunk
-                                              Unit
-                                              [
-                                                { Just [Maybe a] }
-                                                [ { Just a } ipv ]
-                                              ]
-                                            )
-                                          )
-                                        ]
-                                        (lam thunk Unit { Nothing [Maybe a] })
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl lvl [Maybe [Maybe a]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [Maybe a]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam ds Unit nilCase)
-                                          ]
-                                          (lam ds Unit { Nothing [Maybe a] })
-                                        ]
-                                        [
-                                          { (builtin tailList) (con data) } args
-                                        ]
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl x [Maybe [Maybe a]])
-                                    [
-                                      [
-                                        [
-                                          [
-                                            {
-                                              {
-                                                (builtin chooseList)
-                                                (fun Unit [Maybe [Maybe a]])
-                                              }
-                                              (con data)
-                                            }
-                                            (lam ds Unit { Nothing [Maybe a] })
-                                          ]
-                                          (lam ds Unit lvl)
-                                        ]
-                                        args
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                  [
-                                    [
-                                      [
-                                        [
-                                          {
-                                            (builtin ifThenElse)
-                                            (fun Unit [Maybe [Maybe a]])
-                                          }
-                                          [
-                                            [ (builtin equalsInteger) index ]
-                                            (con integer 0)
-                                          ]
-                                        ]
-                                        (lam ds Unit x)
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    Unit
-                                  ]
-                                )
-                              )
-                            ]
-                            (lam ds Unit { Nothing [Maybe a] })
-                          ]
-                          (lam ds Unit { Nothing [Maybe a] })
-                        ]
-                        (lam ds Unit { Nothing [Maybe a] })
-                      ]
-                      (lam ds Unit { Nothing [Maybe a] })
-                    ]
-                    d
-                  ]
-                  Unit
-                ]
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataInteger_cfromBuiltinData
-            (fun (con data) [Maybe (con integer)])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          {
-                            (builtin chooseData)
-                            (fun Unit [Maybe (con integer)])
-                          }
-                          (lam ds Unit { Nothing (con integer) })
-                        ]
-                        (lam ds Unit { Nothing (con integer) })
-                      ]
-                      (lam ds Unit { Nothing (con integer) })
-                    ]
-                    (lam
-                      ds Unit [ { Just (con integer) } [ (builtin unIData) d ] ]
-                    )
-                  ]
-                  (lam ds Unit { Nothing (con integer) })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataByteString_cfromBuiltinData
-            (fun (con data) [Maybe (con bytestring)])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          {
-                            (builtin chooseData)
-                            (fun Unit [Maybe (con bytestring)])
-                          }
-                          (lam ds Unit { Nothing (con bytestring) })
-                        ]
-                        (lam ds Unit { Nothing (con bytestring) })
-                      ]
-                      (lam ds Unit { Nothing (con bytestring) })
-                    ]
-                    (lam ds Unit { Nothing (con bytestring) })
-                  ]
-                  (lam
-                    ds
-                    Unit
-                    [ { Just (con bytestring) } [ (builtin unBData) d ] ]
-                  )
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl Proposal (type))
-
-            Proposal_match
-            (vardecl
-              Proposal
-              (fun (con bytestring) (fun (con bytestring) (fun (con integer) Proposal)))
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataGovInput_cfromBuiltinData (fun (con data) [Maybe Proposal])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe Proposal]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe Proposal])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match (con bytestring) }
-                                          [
-                                            fIsDataByteString_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe Proposal])
-                                      }
-                                      (lam
-                                        ipv
-                                        (con bytestring)
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      (con bytestring)
-                                                    }
-                                                    [
-                                                      fIsDataByteString_cfromBuiltinData
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe Proposal])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  (con bytestring)
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                Maybe_match
-                                                                (con integer)
-                                                              }
-                                                              [
-                                                                fIsDataInteger_cfromBuiltinData
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      headList
-                                                                    )
-                                                                    (con data)
-                                                                  }
-                                                                  l
-                                                                ]
-                                                              ]
-                                                            ]
-                                                            (fun Unit [Maybe Proposal])
-                                                          }
-                                                          (lam
-                                                            ipv
-                                                            (con integer)
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                {
-                                                                  Just Proposal
-                                                                }
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      Proposal
-                                                                      ipv
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                  ipv
-                                                                ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          { Nothing Proposal }
-                                                        )
-                                                      ]
-                                                      Unit
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing Proposal }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing Proposal })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Proposal])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Proposal])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing Proposal })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Proposal])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Proposal])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Proposal })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Proposal])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Proposal])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Proposal })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Proposal])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Proposal])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Proposal })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe Proposal])
-                                      }
-                                      [
-                                        [
-                                          (builtin equalsInteger)
-                                          [
-                                            {
-                                              {
-                                                (builtin fstPair) (con integer)
-                                              }
-                                              [(con list) (con data)]
-                                            }
-                                            tup
-                                          ]
-                                        ]
-                                        (con integer 0)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit { Nothing Proposal })
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing Proposal })
-                      ]
-                      (lam ds Unit { Nothing Proposal })
-                    ]
-                    (lam ds Unit { Nothing Proposal })
-                  ]
-                  (lam ds Unit { Nothing Proposal })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataNil_cfromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe [List a]])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [(con list) (con data)] [Maybe [List a]]))
-                    (lam
-                      l
-                      [(con list) (con data)]
-                      (let
-                        (nonrec)
-                        (termbind
-                          (nonstrict)
-                          (vardecl x [Maybe [List a]])
-                          [ { Just [List a] } { Nil a } ]
-                        )
-                        [
-                          [
-                            [
-                              [
-                                {
-                                  {
-                                    (builtin chooseList)
-                                    (fun Unit [Maybe [List a]])
-                                  }
-                                  (con data)
-                                }
-                                (lam ds Unit x)
-                              ]
-                              (lam
-                                ds
-                                Unit
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match a }
-                                          [
-                                            [ { fromBuiltinData a } dIsData ]
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe [List a]])
-                                      }
-                                      (lam
-                                        a
-                                        a
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    { Maybe_match [List a] }
-                                                    [
-                                                      go
-                                                      [
-                                                        {
-                                                          (builtin tailList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe [List a]])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  [List a]
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      { Just [List a] }
-                                                      [ [ { Cons a } a ] ipv ]
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing [List a] }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing [List a] })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                            ]
-                            l
-                          ]
-                          Unit
-                        ]
-                      )
-                    )
-                  )
-                  [
-                    [
-                      [
-                        [
-                          [
-                            [
-                              [
-                                {
-                                  (builtin chooseData)
-                                  (fun Unit [Maybe [List a]])
-                                }
-                                (lam ds Unit { Nothing [List a] })
-                              ]
-                              (lam ds Unit { Nothing [List a] })
-                            ]
-                            (lam ds Unit [ go [ (builtin unListData) d ] ])
-                          ]
-                          (lam ds Unit { Nothing [List a] })
-                        ]
-                        (lam ds Unit { Nothing [List a] })
-                      ]
-                      d
-                    ]
-                    Unit
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_cfromBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                dIsData
-                [IsData a]
-                (lam
-                  dIsData
-                  [IsData b]
-                  (lam
-                    d
-                    (con data)
-                    [
-                      [
-                        [
-                          [
-                            [
-                              [
-                                [
-                                  {
-                                    (builtin chooseData)
-                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                  }
-                                  (lam
-                                    ds
-                                    Unit
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl
-                                          tup
-                                          [[(con pair) (con integer)] [(con list) (con data)]]
-                                        )
-                                        [ (builtin unConstrData) d ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl l [(con list) (con data)])
-                                        [
-                                          {
-                                            { (builtin sndPair) (con integer) }
-                                            [(con list) (con data)]
-                                          }
-                                          tup
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl l [(con list) (con data)])
-                                        [ { (builtin tailList) (con data) } l ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl nilCase [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              {
-                                                [
-                                                  { Maybe_match a }
-                                                  [
-                                                    [
-                                                      { fromBuiltinData a }
-                                                      dIsData
-                                                    ]
-                                                    [
-                                                      {
-                                                        (builtin headList)
-                                                        (con data)
-                                                      }
-                                                      l
-                                                    ]
-                                                  ]
-                                                ]
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              (lam
-                                                ipv
-                                                a
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [
-                                                    [
-                                                      [
-                                                        {
-                                                          [
-                                                            { Maybe_match b }
-                                                            [
-                                                              [
-                                                                {
-                                                                  fromBuiltinData
-                                                                  b
-                                                                }
-                                                                dIsData
-                                                              ]
-                                                              [
-                                                                {
-                                                                  (builtin
-                                                                    headList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                l
-                                                              ]
-                                                            ]
-                                                          ]
-                                                          (fun Unit [Maybe [[Tuple2 a] b]])
-                                                        }
-                                                        (lam
-                                                          ipv
-                                                          b
-                                                          (lam
-                                                            thunk
-                                                            Unit
-                                                            [
-                                                              {
-                                                                Just
-                                                                [[Tuple2 a] b]
-                                                              }
-                                                              [
-                                                                [
-                                                                  {
-                                                                    { Tuple2 a }
-                                                                    b
-                                                                  }
-                                                                  ipv
-                                                                ]
-                                                                ipv
-                                                              ]
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        {
-                                                          Nothing [[Tuple2 a] b]
-                                                        }
-                                                      )
-                                                    ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
-                                            ]
-                                            (lam
-                                              thunk
-                                              Unit
-                                              { Nothing [[Tuple2 a] b] }
-                                            )
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam ds Unit nilCase)
-                                              ]
-                                              (lam
-                                                ds
-                                                Unit
-                                                { Nothing [[Tuple2 a] b] }
-                                              )
-                                            ]
-                                            [
-                                              { (builtin tailList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam
-                                                  ds
-                                                  Unit
-                                                  { Nothing [[Tuple2 a] b] }
-                                                )
-                                              ]
-                                              (lam ds Unit lvl)
-                                            ]
-                                            l
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl x [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam
-                                                  ds
-                                                  Unit
-                                                  { Nothing [[Tuple2 a] b] }
-                                                )
-                                              ]
-                                              (lam ds Unit lvl)
-                                            ]
-                                            l
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      [
-                                        [
-                                          [
-                                            [
-                                              {
-                                                (builtin ifThenElse)
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              [
-                                                [
-                                                  (builtin equalsInteger)
-                                                  [
-                                                    {
-                                                      {
-                                                        (builtin fstPair)
-                                                        (con integer)
-                                                      }
-                                                      [(con list) (con data)]
-                                                    }
-                                                    tup
-                                                  ]
-                                                ]
-                                                (con integer 0)
-                                              ]
-                                            ]
-                                            (lam ds Unit x)
-                                          ]
-                                          (lam
-                                            ds Unit { Nothing [[Tuple2 a] b] }
-                                          )
-                                        ]
-                                        Unit
-                                      ]
-                                    )
-                                  )
-                                ]
-                                (lam ds Unit { Nothing [[Tuple2 a] b] })
-                              ]
-                              (lam ds Unit { Nothing [[Tuple2 a] b] })
-                            ]
-                            (lam ds Unit { Nothing [[Tuple2 a] b] })
-                          ]
-                          (lam ds Unit { Nothing [[Tuple2 a] b] })
-                        ]
-                        d
-                      ]
-                      Unit
-                    ]
-                  )
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            toBuiltinData (all a (type) (fun [IsData a] (fun a (con data))))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun a (con data)) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_ctoBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun [[Tuple2 a] b] (con data))))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                dIsData
-                [IsData a]
-                (lam
-                  dIsData
-                  [IsData b]
-                  (lam
-                    ds
-                    [[Tuple2 a] b]
-                    [
-                      { [ { { Tuple2_match a } b } ds ] (con data) }
-                      (lam
-                        arg
-                        a
-                        (lam
-                          arg
-                          b
-                          [
-                            [ (builtin constrData) (con integer 0) ]
-                            [
-                              [
-                                { (builtin mkCons) (con data) }
-                                [ [ { toBuiltinData a } dIsData ] arg ]
-                              ]
-                              [
-                                [
-                                  { (builtin mkCons) (con data) }
-                                  [ [ { toBuiltinData b } dIsData ] arg ]
-                                ]
-                                [ (builtin mkNilData) (con unit ()) ]
-                              ]
-                            ]
-                          ]
-                        )
-                      )
-                    ]
-                  )
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl error (all a (type) (fun (con unit) a)))
-          (abs a (type) (lam thunk (con unit) (error a)))
-        )
-        (termbind
-          (strict)
-          (vardecl
-            unsafeFromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) a)))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun (con data) a) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_cunsafeFromBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [[Tuple2 a] b])))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                dIsData
-                [IsData a]
-                (lam
-                  dIsData
-                  [IsData b]
-                  (lam
-                    d
-                    (con data)
-                    (let
-                      (nonrec)
-                      (termbind
-                        (nonstrict)
-                        (vardecl x [[Tuple2 a] b])
-                        [ { error [[Tuple2 a] b] } (con unit ()) ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl
-                          tup
-                          [[(con pair) (con integer)] [(con list) (con data)]]
-                        )
-                        [ (builtin unConstrData) d ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl t [(con list) (con data)])
-                        [
-                          {
-                            { (builtin sndPair) (con integer) }
-                            [(con list) (con data)]
-                          }
-                          tup
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x b)
-                        [
-                          [ { unsafeFromBuiltinData b } dIsData ]
-                          [
-                            { (builtin headList) (con data) }
-                            [ { (builtin tailList) (con data) } t ]
-                          ]
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x a)
-                        [
-                          [ { unsafeFromBuiltinData a } dIsData ]
-                          [ { (builtin headList) (con data) } t ]
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x [[Tuple2 a] b])
-                        [ [ { { Tuple2 a } b } x ] x ]
-                      )
-                      [
-                        [
-                          [
-                            [
-                              { (builtin ifThenElse) (fun Unit [[Tuple2 a] b]) }
-                              [
-                                [
-                                  (builtin equalsInteger)
-                                  [
-                                    {
-                                      { (builtin fstPair) (con integer) }
-                                      [(con list) (con data)]
-                                    }
-                                    tup
-                                  ]
-                                ]
-                                (con integer 0)
-                              ]
-                            ]
-                            (lam ds Unit x)
-                          ]
-                          (lam ds Unit x)
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] [IsData [[Tuple2 a] b]]))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                v
-                [IsData a]
-                (lam
-                  v
-                  [IsData b]
-                  [
-                    [
-                      [
-                        { CConsIsData [[Tuple2 a] b] }
-                        [ [ { { fIsDataTuple2_ctoBuiltinData a } b } v ] v ]
-                      ]
-                      [ [ { { fIsDataTuple2_cfromBuiltinData a } b } v ] v ]
-                    ]
-                    [ [ { { fIsDataTuple2_cunsafeFromBuiltinData a } b } v ] v ]
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataBool_cfromBuiltinData (fun (con data) [Maybe Bool]))
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe Bool]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe Bool])
-                                [ { Just Bool } False ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl args [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Bool])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Bool])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing Bool })
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl index (con integer))
-                                [
-                                  {
-                                    { (builtin fstPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Bool])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          (builtin ifThenElse)
-                                          (fun Unit [Maybe Bool])
-                                        }
-                                        [
-                                          [ (builtin equalsInteger) index ]
-                                          (con integer 0)
-                                        ]
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    (lam ds Unit { Nothing Bool })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe Bool])
-                                [ { Just Bool } True ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Bool])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Bool])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing Bool })
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe Bool])
-                                      }
-                                      [
-                                        [ (builtin equalsInteger) index ]
-                                        (con integer 1)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit x)
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing Bool })
-                      ]
-                      (lam ds Unit { Nothing Bool })
-                    ]
-                    (lam ds Unit { Nothing Bool })
-                  ]
-                  (lam ds Unit { Nothing Bool })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataBool_ctoBuiltinData (fun Bool (con data)))
+          (vardecl fToDataBool_ctoBuiltinData (fun Bool (con data)))
           (lam
             ds
             Bool
@@ -1625,356 +76,25 @@
         )
         (termbind
           (strict)
-          (vardecl fIsDataBool_cunsafeFromBuiltinData (fun (con data) Bool))
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict) (vardecl x Bool) [ { error Bool } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl index (con integer))
-                [
-                  {
-                    { (builtin fstPair) (con integer) } [(con list) (con data)]
-                  }
-                  [ (builtin unConstrData) d ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x Bool)
-                [
-                  [
-                    [
-                      [
-                        { (builtin ifThenElse) (fun Unit Bool) }
-                        [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                      ]
-                      (lam ds Unit False)
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  Unit
-                ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit Bool) }
-                      [ [ (builtin equalsInteger) index ] (con integer 1) ]
-                    ]
-                    (lam ds Unit True)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataBool [IsData Bool])
-          [
-            [
-              [ { CConsIsData Bool } fIsDataBool_ctoBuiltinData ]
-              fIsDataBool_cfromBuiltinData
-            ]
-            fIsDataBool_cunsafeFromBuiltinData
-          ]
-        )
-        (termbind
-          (strict)
           (vardecl
-            fIsDataByteString_ctoBuiltinData (fun (con bytestring) (con data))
+            fToDataByteString_ctoBuiltinData (fun (con bytestring) (con data))
           )
           (lam b (con bytestring) [ (builtin bData) b ])
         )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataTokenName [IsData (con bytestring)])
-          [
-            [
-              [
-                { CConsIsData (con bytestring) }
-                fIsDataByteString_ctoBuiltinData
-              ]
-              fIsDataByteString_cfromBuiltinData
-            ]
-            (builtin unBData)
-          ]
-        )
         (datatypebind
           (datatype
-            (tyvardecl Voting (type))
+            (tyvardecl Proposal (type))
 
-            Voting_match
+            Proposal_match
             (vardecl
-              Voting
-              (fun Proposal (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] Bool] Voting))
+              Proposal
+              (fun (con bytestring) (fun (con bytestring) (fun (con integer) Proposal)))
             )
           )
         )
         (termbind
           (strict)
-          (vardecl
-            fIsDataVoting_cfromBuiltinData (fun (con data) [Maybe Voting])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe Voting]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe Voting])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match Proposal }
-                                          [
-                                            fIsDataGovInput_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe Voting])
-                                      }
-                                      (lam
-                                        ipv
-                                        Proposal
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] Bool]
-                                                    }
-                                                    [
-                                                      [
-                                                        {
-                                                          fIsDataNil_cfromBuiltinData
-                                                          [[Tuple2 (con bytestring)] Bool]
-                                                        }
-                                                        [
-                                                          [
-                                                            {
-                                                              {
-                                                                fIsDataTuple2
-                                                                (con bytestring)
-                                                              }
-                                                              Bool
-                                                            }
-                                                            fIsDataTokenName
-                                                          ]
-                                                          fIsDataBool
-                                                        ]
-                                                      ]
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe Voting])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] Bool]
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      { Just Voting }
-                                                      [ [ Voting ipv ] ipv ]
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam thunk Unit { Nothing Voting }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing Voting })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Voting])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Voting])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing Voting })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Voting])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Voting])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Voting })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Voting])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Voting])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Voting })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe Voting])
-                                      }
-                                      [
-                                        [
-                                          (builtin equalsInteger)
-                                          [
-                                            {
-                                              {
-                                                (builtin fstPair) (con integer)
-                                              }
-                                              [(con list) (con data)]
-                                            }
-                                            tup
-                                          ]
-                                        ]
-                                        (con integer 0)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit { Nothing Voting })
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing Voting })
-                      ]
-                      (lam ds Unit { Nothing Voting })
-                    ]
-                    (lam ds Unit { Nothing Voting })
-                  ]
-                  (lam ds Unit { Nothing Voting })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataGovInput_ctoBuiltinData (fun Proposal (con data)))
+          (vardecl fToDataGovInput_ctoBuiltinData (fun Proposal (con data)))
           (lam
             ds
             Proposal
@@ -2020,70 +140,161 @@
         (termbind
           (strict)
           (vardecl
-            fIsDataNil_ctoBuiltinData
-            (all a (type) (fun [IsData a] (fun [List a] (con data))))
+            fToDataTuple2_ctoBuiltinData
+            (all a (type) (all b (type) (fun [(lam a (type) (fun a (con data))) a] (fun [(lam a (type) (fun a (con data))) b] (fun [[Tuple2 a] b] (con data))))))
           )
           (abs
             a
             (type)
-            (lam
-              dIsData
-              [IsData a]
+            (abs
+              b
+              (type)
               (lam
-                l
-                [List a]
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [List a] [(con list) (con data)]))
-                    (lam
-                      ds
-                      [List a]
-                      [
-                        [
+                dToData
+                [(lam a (type) (fun a (con data))) a]
+                (lam
+                  dToData
+                  [(lam a (type) (fun a (con data))) b]
+                  (lam
+                    ds
+                    [[Tuple2 a] b]
+                    [
+                      { [ { { Tuple2_match a } b } ds ] (con data) }
+                      (lam
+                        arg
+                        a
+                        (lam
+                          arg
+                          b
                           [
-                            {
-                              [ { Nil_match a } ds ]
-                              (fun Unit [(con list) (con data)])
-                            }
-                            (lam
-                              thunk Unit [ (builtin mkNilData) (con unit ()) ]
-                            )
-                          ]
-                          (lam
-                            x
-                            a
-                            (lam
-                              xs
-                              [List a]
-                              (lam
-                                thunk
-                                Unit
+                            [ (builtin constrData) (con integer 0) ]
+                            [
+                              [
+                                { (builtin mkCons) (con data) } [ dToData arg ]
+                              ]
+                              [
                                 [
-                                  [
-                                    { (builtin mkCons) (con data) }
-                                    [ [ { toBuiltinData a } dIsData ] x ]
-                                  ]
-                                  [ go xs ]
+                                  { (builtin mkCons) (con data) }
+                                  [ dToData arg ]
                                 ]
-                              )
-                            )
-                          )
-                        ]
-                        Unit
-                      ]
-                    )
+                                [ (builtin mkNilData) (con unit ()) ]
+                              ]
+                            ]
+                          ]
+                        )
+                      )
+                    ]
                   )
-                  [ (builtin listData) [ go l ] ]
                 )
               )
             )
           )
         )
         (termbind
+          (nonstrict)
+          (vardecl fToDataMap [(con list) (con data)])
+          [ (builtin mkNilData) (con unit ()) ]
+        )
+        (termbind
           (strict)
-          (vardecl fIsDataVoting_ctoBuiltinData (fun Voting (con data)))
+          (vardecl
+            fToDataMap_ctoBuiltinData
+            (all k (type) (all v (type) (fun [(lam a (type) (fun a (con data))) k] (fun [(lam a (type) (fun a (con data))) v] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v] (con data))))))
+          )
+          (abs
+            k
+            (type)
+            (abs
+              v
+              (type)
+              (lam
+                dToData
+                [(lam a (type) (fun a (con data))) k]
+                (lam
+                  dToData
+                  [(lam a (type) (fun a (con data))) v]
+                  (lam
+                    eta
+                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
+                    (let
+                      (rec)
+                      (termbind
+                        (strict)
+                        (vardecl
+                          go (fun [List [[Tuple2 k] v]] [(con list) (con data)])
+                        )
+                        (lam
+                          ds
+                          [List [[Tuple2 k] v]]
+                          [
+                            [
+                              [
+                                {
+                                  [ { Nil_match [[Tuple2 k] v] } ds ]
+                                  (fun Unit [(con list) (con data)])
+                                }
+                                (lam thunk Unit fToDataMap)
+                              ]
+                              (lam
+                                x
+                                [[Tuple2 k] v]
+                                (lam
+                                  xs
+                                  [List [[Tuple2 k] v]]
+                                  (lam
+                                    thunk
+                                    Unit
+                                    [
+                                      [
+                                        { (builtin mkCons) (con data) }
+                                        [
+                                          [
+                                            [
+                                              {
+                                                {
+                                                  fToDataTuple2_ctoBuiltinData k
+                                                }
+                                                v
+                                              }
+                                              dToData
+                                            ]
+                                            dToData
+                                          ]
+                                          x
+                                        ]
+                                      ]
+                                      [ go xs ]
+                                    ]
+                                  )
+                                )
+                              )
+                            ]
+                            Unit
+                          ]
+                        )
+                      )
+                      [ (builtin listData) [ go eta ] ]
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Voting (type))
+
+            Voting_match
+            (vardecl
+              Voting
+              (fun Proposal (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] Bool] Voting))
+            )
+          )
+        )
+        (termbind
+          (strict)
+          (vardecl fToDataGovState_ctoBuiltinData (fun Voting (con data)))
           (lam
             ds
             Voting
@@ -2100,24 +311,21 @@
                     [
                       [
                         { (builtin mkCons) (con data) }
-                        [ fIsDataGovInput_ctoBuiltinData arg ]
+                        [ fToDataGovInput_ctoBuiltinData arg ]
                       ]
                       [
                         [
                           { (builtin mkCons) (con data) }
                           [
                             [
-                              {
-                                fIsDataNil_ctoBuiltinData
-                                [[Tuple2 (con bytestring)] Bool]
-                              }
                               [
-                                [
-                                  { { fIsDataTuple2 (con bytestring) } Bool }
-                                  fIsDataTokenName
-                                ]
-                                fIsDataBool
+                                {
+                                  { fToDataMap_ctoBuiltinData (con bytestring) }
+                                  Bool
+                                }
+                                fToDataByteString_ctoBuiltinData
                               ]
+                              fToDataBool_ctoBuiltinData
                             ]
                             arg
                           ]
@@ -2131,600 +339,26 @@
             ]
           )
         )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataNil_cunsafeFromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [List a])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [(con list) (con data)] [List a]))
-                    (lam
-                      l
-                      [(con list) (con data)]
-                      [
-                        [
-                          [
-                            [
-                              {
-                                { (builtin chooseList) (fun Unit [List a]) }
-                                (con data)
-                              }
-                              (lam ds Unit { Nil a })
-                            ]
-                            (lam
-                              ds
-                              Unit
-                              [
-                                [
-                                  { Cons a }
-                                  [
-                                    [ { unsafeFromBuiltinData a } dIsData ]
-                                    [ { (builtin headList) (con data) } l ]
-                                  ]
-                                ]
-                                [ go [ { (builtin tailList) (con data) } l ] ]
-                              ]
-                            )
-                          ]
-                          l
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                  [ go [ (builtin unListData) d ] ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataGovInput_cunsafeFromBuiltinData (fun (con data) Proposal)
-          )
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x Proposal)
-                [ { error Proposal } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [ { (builtin tailList) (con data) } t ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con integer))
-                [
-                  (builtin unIData)
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict) (vardecl x Proposal) [ [ [ Proposal x ] x ] x ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit Proposal) }
-                      [
-                        [
-                          (builtin equalsInteger)
-                          [
-                            {
-                              { (builtin fstPair) (con integer) }
-                              [(con list) (con data)]
-                            }
-                            tup
-                          ]
-                        ]
-                        (con integer 0)
-                      ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataVoting_cunsafeFromBuiltinData (fun (con data) Voting))
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x Voting)
-                [ { error Voting } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x [List [[Tuple2 (con bytestring)] Bool]])
-                [
-                  [
-                    {
-                      fIsDataNil_cunsafeFromBuiltinData
-                      [[Tuple2 (con bytestring)] Bool]
-                    }
-                    [
-                      [
-                        { { fIsDataTuple2 (con bytestring) } Bool }
-                        fIsDataTokenName
-                      ]
-                      fIsDataBool
-                    ]
-                  ]
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x Proposal)
-                [
-                  fIsDataGovInput_cunsafeFromBuiltinData
-                  [ { (builtin headList) (con data) } t ]
-                ]
-              )
-              (termbind (nonstrict) (vardecl x Voting) [ [ Voting x ] x ])
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit Voting) }
-                      [
-                        [
-                          (builtin equalsInteger)
-                          [
-                            {
-                              { (builtin fstPair) (con integer) }
-                              [(con list) (con data)]
-                            }
-                            tup
-                          ]
-                        ]
-                        (con integer 0)
-                      ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataVoting [IsData Voting])
-          [
-            [
-              [ { CConsIsData Voting } fIsDataVoting_ctoBuiltinData ]
-              fIsDataVoting_cfromBuiltinData
-            ]
-            fIsDataVoting_cunsafeFromBuiltinData
-          ]
-        )
         (datatypebind
           (datatype
-            (tyvardecl GovState (type))
-
-            GovState_match
-            (vardecl
-              GovState
-              (fun (con bytestring) (fun (con bytestring) (fun [Maybe Voting] GovState)))
-            )
+            (tyvardecl Maybe (fun (type) (type)))
+            (tyvardecl a (type))
+            Maybe_match
+            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
           )
         )
         (termbind
           (strict)
           (vardecl
-            fIsDataGovState_cfromBuiltinData (fun (con data) [Maybe GovState])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe GovState]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe GovState])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match (con bytestring) }
-                                          [
-                                            fIsDataByteString_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe GovState])
-                                      }
-                                      (lam
-                                        ipv
-                                        (con bytestring)
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      (con bytestring)
-                                                    }
-                                                    [
-                                                      fIsDataByteString_cfromBuiltinData
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe GovState])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  (con bytestring)
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                Maybe_match
-                                                                [Maybe Voting]
-                                                              }
-                                                              [
-                                                                [
-                                                                  {
-                                                                    fIsDataMaybe_cfromBuiltinData
-                                                                    Voting
-                                                                  }
-                                                                  fIsDataVoting
-                                                                ]
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      headList
-                                                                    )
-                                                                    (con data)
-                                                                  }
-                                                                  l
-                                                                ]
-                                                              ]
-                                                            ]
-                                                            (fun Unit [Maybe GovState])
-                                                          }
-                                                          (lam
-                                                            ipv
-                                                            [Maybe Voting]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                {
-                                                                  Just GovState
-                                                                }
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      GovState
-                                                                      ipv
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                  ipv
-                                                                ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          { Nothing GovState }
-                                                        )
-                                                      ]
-                                                      Unit
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing GovState }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing GovState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GovState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GovState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing GovState })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GovState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GovState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GovState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe GovState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GovState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GovState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe GovState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe GovState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing GovState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe GovState])
-                                      }
-                                      [
-                                        [
-                                          (builtin equalsInteger)
-                                          [
-                                            {
-                                              {
-                                                (builtin fstPair) (con integer)
-                                              }
-                                              [(con list) (con data)]
-                                            }
-                                            tup
-                                          ]
-                                        ]
-                                        (con integer 0)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit { Nothing GovState })
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing GovState })
-                      ]
-                      (lam ds Unit { Nothing GovState })
-                    ]
-                    (lam ds Unit { Nothing GovState })
-                  ]
-                  (lam ds Unit { Nothing GovState })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMaybe_ctoBuiltinData
-            (all a (type) (fun [IsData a] (fun [Maybe a] (con data))))
+            fToDataMaybe_ctoBuiltinData
+            (all a (type) (fun [(lam a (type) (fun a (con data))) a] (fun [Maybe a] (con data))))
           )
           (abs
             a
             (type)
             (lam
-              dIsData
-              [IsData a]
+              dToData
+              [(lam a (type) (fun a (con data))) a]
               (lam
                 ds
                 [Maybe a]
@@ -2742,8 +376,7 @@
                             [ (builtin constrData) (con integer 0) ]
                             [
                               [
-                                { (builtin mkCons) (con data) }
-                                [ [ { toBuiltinData a } dIsData ] arg ]
+                                { (builtin mkCons) (con data) } [ dToData arg ]
                               ]
                               [ (builtin mkNilData) (con unit ()) ]
                             ]
@@ -2766,9 +399,20 @@
             )
           )
         )
+        (datatypebind
+          (datatype
+            (tyvardecl GovState (type))
+
+            GovState_match
+            (vardecl
+              GovState
+              (fun (con bytestring) (fun (con bytestring) (fun [Maybe Voting] GovState)))
+            )
+          )
+        )
         (termbind
           (strict)
-          (vardecl fIsDataGovState_ctoBuiltinData (fun GovState (con data)))
+          (vardecl fToDataGovState_ctoBuiltinData (fun GovState (con data)))
           (lam
             ds
             GovState
@@ -2800,8 +444,8 @@
                               { (builtin mkCons) (con data) }
                               [
                                 [
-                                  { fIsDataMaybe_ctoBuiltinData Voting }
-                                  fIsDataVoting
+                                  { fToDataMaybe_ctoBuiltinData Voting }
+                                  fToDataGovState_ctoBuiltinData
                                 ]
                                 arg
                               ]
@@ -2816,203 +460,6 @@
               )
             ]
           )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMaybe_cunsafeFromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                (let
-                  (nonrec)
-                  (termbind
-                    (nonstrict)
-                    (vardecl x [Maybe a])
-                    [ { error [Maybe a] } (con unit ()) ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      tup [[(con pair) (con integer)] [(con list) (con data)]]
-                    )
-                    [ (builtin unConstrData) d ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl index (con integer))
-                    [
-                      {
-                        { (builtin fstPair) (con integer) }
-                        [(con list) (con data)]
-                      }
-                      tup
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl x [Maybe a])
-                    [
-                      [
-                        [
-                          [
-                            { (builtin ifThenElse) (fun Unit [Maybe a]) }
-                            [
-                              [ (builtin equalsInteger) index ] (con integer 1)
-                            ]
-                          ]
-                          (lam ds Unit { Nothing a })
-                        ]
-                        (lam ds Unit x)
-                      ]
-                      Unit
-                    ]
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl x a)
-                    [
-                      [ { unsafeFromBuiltinData a } dIsData ]
-                      [
-                        { (builtin headList) (con data) }
-                        [
-                          {
-                            { (builtin sndPair) (con integer) }
-                            [(con list) (con data)]
-                          }
-                          tup
-                        ]
-                      ]
-                    ]
-                  )
-                  (termbind (nonstrict) (vardecl x [Maybe a]) [ { Just a } x ])
-                  [
-                    [
-                      [
-                        [
-                          { (builtin ifThenElse) (fun Unit [Maybe a]) }
-                          [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                        ]
-                        (lam ds Unit x)
-                      ]
-                      (lam ds Unit x)
-                    ]
-                    Unit
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataGovState_cunsafeFromBuiltinData (fun (con data) GovState)
-          )
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x GovState)
-                [ { error GovState } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [ { (builtin tailList) (con data) } t ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x [Maybe Voting])
-                [
-                  [
-                    { fIsDataMaybe_cunsafeFromBuiltinData Voting } fIsDataVoting
-                  ]
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict) (vardecl x GovState) [ [ [ GovState x ] x ] x ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit GovState) }
-                      [
-                        [
-                          (builtin equalsInteger)
-                          [
-                            {
-                              { (builtin fstPair) (con integer) }
-                              [(con list) (con data)]
-                            }
-                            tup
-                          ]
-                        ]
-                        (con integer 0)
-                      ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataGovState [IsData GovState])
-          [
-            [
-              [ { CConsIsData GovState } fIsDataGovState_ctoBuiltinData ]
-              fIsDataGovState_cfromBuiltinData
-            ]
-            fIsDataGovState_cunsafeFromBuiltinData
-          ]
         )
         (datatypebind
           (datatype
@@ -5652,7 +3099,7 @@
                       (termbind
                         (strict)
                         (vardecl
-                          fIsDataUnit_ctoBuiltinData (fun Unit (con data))
+                          fToDataUnit_ctoBuiltinData (fun Unit (con data))
                         )
                         (lam
                           ds
@@ -5861,7 +3308,7 @@
                             (type)
                             [
                               { { mustMintValueWithRedeemer i } o }
-                              [ fIsDataUnit_ctoBuiltinData Unit ]
+                              [ fToDataUnit_ctoBuiltinData Unit ]
                             ]
                           )
                         )
@@ -8701,35 +6148,8 @@
                       )
                       (termbind
                         (strict)
-                        (vardecl
-                          fIsDataVoid_cfromBuiltinData
-                          (fun (con data) [Maybe Void])
-                        )
-                        (lam ds (con data) { Nothing Void })
-                      )
-                      (termbind
-                        (strict)
-                        (vardecl
-                          fIsDataVoid_cunsafeFromBuiltinData
-                          (fun (con data) Void)
-                        )
-                        (lam ds (con data) [ { error Void } (con unit ()) ])
-                      )
-                      (termbind
-                        (strict)
                         (vardecl absurd (all a (type) (fun Void a)))
                         (abs a (type) (lam a Void { [ Void_match a ] a }))
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl fIsDataVoid [IsData Void])
-                        [
-                          [
-                            [ { CConsIsData Void } { absurd (con data) } ]
-                            fIsDataVoid_cfromBuiltinData
-                          ]
-                          fIsDataVoid_cunsafeFromBuiltinData
-                        ]
                       )
                       (datatypebind
                         (datatype
@@ -9883,6 +7303,11 @@
                       )
                       (termbind
                         (strict)
+                        (vardecl error (all a (type) (fun (con unit) a)))
+                        (abs a (type) (lam thunk (con unit) (error a)))
+                      )
+                      (termbind
+                        (strict)
                         (vardecl
                           findOwnInput (fun ScriptContext [Maybe TxInInfo])
                         )
@@ -10599,14 +8024,14 @@
                         (strict)
                         (vardecl
                           checkOwnOutputConstraint
-                          (all o (type) (fun [IsData o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
+                          (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
                         )
                         (abs
                           o
                           (type)
                           (lam
-                            dIsData
-                            [IsData o]
+                            dToData
+                            [(lam a (type) (fun a (con data))) o]
                             (lam
                               ctx
                               ScriptContext
@@ -10641,14 +8066,7 @@
                                                 )
                                                 [
                                                   [
-                                                    findDatumHash
-                                                    [
-                                                      [
-                                                        { toBuiltinData o }
-                                                        dIsData
-                                                      ]
-                                                      ds
-                                                    ]
+                                                    findDatumHash [ dToData ds ]
                                                   ]
                                                   ds
                                                 ]
@@ -15665,7 +13083,7 @@
                         (strict)
                         (vardecl
                           checkScriptContext
-                          (all i (type) (all o (type) (fun [IsData o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
+                          (all i (type) (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
                         )
                         (abs
                           i
@@ -15674,8 +13092,8 @@
                             o
                             (type)
                             (lam
-                              dIsData
-                              [IsData o]
+                              dToData
+                              [(lam a (type) (fun a (con data))) o]
                               (lam
                                 ds
                                 [[TxConstraints i] o]
@@ -15822,7 +13240,7 @@
                                                                                 checkOwnOutputConstraint
                                                                                 o
                                                                               }
-                                                                              dIsData
+                                                                              dToData
                                                                             ]
                                                                             ptx
                                                                           ]
@@ -16374,7 +13792,7 @@
                         (strict)
                         (vardecl
                           wmkValidator
-                          (all s (type) (all i (type) (fun [IsData s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
+                          (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
                         )
                         (abs
                           s
@@ -16384,7 +13802,7 @@
                             (type)
                             (lam
                               w
-                              [IsData s]
+                              [(lam a (type) (fun a (con data))) s]
                               (lam
                                 ww
                                 (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]]))
@@ -16600,7 +14018,10 @@
                                                                                                     }
                                                                                                     Void
                                                                                                   }
-                                                                                                  fIsDataVoid
+                                                                                                  {
+                                                                                                    absurd
+                                                                                                    (con data)
+                                                                                                  }
                                                                                                 ]
                                                                                                 newConstraints
                                                                                               ]
@@ -17124,7 +14545,7 @@
                         (strict)
                         (vardecl
                           mkValidator
-                          (all s (type) (all i (type) (fun [IsData s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
+                          (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
                         )
                         (abs
                           s
@@ -17134,7 +14555,7 @@
                             (type)
                             (lam
                               w
-                              [IsData s]
+                              [(lam a (type) (fun a (con data))) s]
                               (lam
                                 w
                                 [[StateMachine s] i]
@@ -17220,7 +14641,7 @@
                           [
                             [
                               { { mkValidator GovState } GovInput }
-                              fIsDataGovState
+                              fToDataGovState_ctoBuiltinData
                             ]
                             [ machine params ]
                           ]

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -42,192 +42,23 @@
             (vardecl This (fun a [[These a] b]))
           )
         )
-        (datatypebind
-          (datatype
-            (tyvardecl Payment (type))
-
-            Payment_match
-            (vardecl
-              Payment
-              (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun (con bytestring) (fun (con integer) Payment)))
-            )
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl MSState (type))
-
-            MSState_match
-            (vardecl
-              CollectingSignatures
-              (fun Payment (fun [List (con bytestring)] MSState))
-            )
-            (vardecl Holding MSState)
-          )
-        )
-        (datatypebind
-          (datatype
-            (tyvardecl Maybe (fun (type) (type)))
-            (tyvardecl a (type))
-            Maybe_match
-            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-          )
-        )
         (termbind
           (strict)
           (vardecl
-            fIsDataByteString_cfromBuiltinData
-            (fun (con data) [Maybe (con bytestring)])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          {
-                            (builtin chooseData)
-                            (fun Unit [Maybe (con bytestring)])
-                          }
-                          (lam ds Unit { Nothing (con bytestring) })
-                        ]
-                        (lam ds Unit { Nothing (con bytestring) })
-                      ]
-                      (lam ds Unit { Nothing (con bytestring) })
-                    ]
-                    (lam ds Unit { Nothing (con bytestring) })
-                  ]
-                  (lam
-                    ds
-                    Unit
-                    [ { Just (con bytestring) } [ (builtin unBData) d ] ]
-                  )
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataByteString_ctoBuiltinData (fun (con bytestring) (con data))
+            fToDataByteString_ctoBuiltinData (fun (con bytestring) (con data))
           )
           (lam b (con bytestring) [ (builtin bData) b ])
         )
-        (datatypebind
-          (datatype
-            (tyvardecl IsData (fun (type) (type)))
-            (tyvardecl a (type))
-            IsData_match
-            (vardecl
-              CConsIsData
-              (fun (fun a (con data)) (fun (fun (con data) [Maybe a]) (fun (fun (con data) a) [IsData a])))
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataCurrencySymbol [IsData (con bytestring)])
-          [
-            [
-              [
-                { CConsIsData (con bytestring) }
-                fIsDataByteString_ctoBuiltinData
-              ]
-              fIsDataByteString_cfromBuiltinData
-            ]
-            (builtin unBData)
-          ]
-        )
         (termbind
           (strict)
-          (vardecl
-            fIsDataInteger_cfromBuiltinData
-            (fun (con data) [Maybe (con integer)])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          {
-                            (builtin chooseData)
-                            (fun Unit [Maybe (con integer)])
-                          }
-                          (lam ds Unit { Nothing (con integer) })
-                        ]
-                        (lam ds Unit { Nothing (con integer) })
-                      ]
-                      (lam ds Unit { Nothing (con integer) })
-                    ]
-                    (lam
-                      ds Unit [ { Just (con integer) } [ (builtin unIData) d ] ]
-                    )
-                  ]
-                  (lam ds Unit { Nothing (con integer) })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataInteger_ctoBuiltinData (fun (con integer) (con data)))
+          (vardecl fToDataInteger_ctoBuiltinData (fun (con integer) (con data)))
           (lam i (con integer) [ (builtin iData) i ])
         )
         (termbind
-          (nonstrict)
-          (vardecl fIsDataInteger [IsData (con integer)])
-          [
-            [
-              [ { CConsIsData (con integer) } fIsDataInteger_ctoBuiltinData ]
-              fIsDataInteger_cfromBuiltinData
-            ]
-            (builtin unIData)
-          ]
-        )
-        (termbind
           (strict)
           (vardecl
-            fromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe a])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun (con data) [Maybe a]) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_cfromBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
+            fToDataTuple2_ctoBuiltinData
+            (all a (type) (all b (type) (fun [(lam a (type) (fun a (con data))) a] (fun [(lam a (type) (fun a (con data))) b] (fun [[Tuple2 a] b] (con data))))))
           )
           (abs
             a
@@ -236,338 +67,11 @@
               b
               (type)
               (lam
-                dIsData
-                [IsData a]
+                dToData
+                [(lam a (type) (fun a (con data))) a]
                 (lam
-                  dIsData
-                  [IsData b]
-                  (lam
-                    d
-                    (con data)
-                    [
-                      [
-                        [
-                          [
-                            [
-                              [
-                                [
-                                  {
-                                    (builtin chooseData)
-                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                  }
-                                  (lam
-                                    ds
-                                    Unit
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl
-                                          tup
-                                          [[(con pair) (con integer)] [(con list) (con data)]]
-                                        )
-                                        [ (builtin unConstrData) d ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl l [(con list) (con data)])
-                                        [
-                                          {
-                                            { (builtin sndPair) (con integer) }
-                                            [(con list) (con data)]
-                                          }
-                                          tup
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl l [(con list) (con data)])
-                                        [ { (builtin tailList) (con data) } l ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl nilCase [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              {
-                                                [
-                                                  { Maybe_match a }
-                                                  [
-                                                    [
-                                                      { fromBuiltinData a }
-                                                      dIsData
-                                                    ]
-                                                    [
-                                                      {
-                                                        (builtin headList)
-                                                        (con data)
-                                                      }
-                                                      l
-                                                    ]
-                                                  ]
-                                                ]
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              (lam
-                                                ipv
-                                                a
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [
-                                                    [
-                                                      [
-                                                        {
-                                                          [
-                                                            { Maybe_match b }
-                                                            [
-                                                              [
-                                                                {
-                                                                  fromBuiltinData
-                                                                  b
-                                                                }
-                                                                dIsData
-                                                              ]
-                                                              [
-                                                                {
-                                                                  (builtin
-                                                                    headList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                l
-                                                              ]
-                                                            ]
-                                                          ]
-                                                          (fun Unit [Maybe [[Tuple2 a] b]])
-                                                        }
-                                                        (lam
-                                                          ipv
-                                                          b
-                                                          (lam
-                                                            thunk
-                                                            Unit
-                                                            [
-                                                              {
-                                                                Just
-                                                                [[Tuple2 a] b]
-                                                              }
-                                                              [
-                                                                [
-                                                                  {
-                                                                    { Tuple2 a }
-                                                                    b
-                                                                  }
-                                                                  ipv
-                                                                ]
-                                                                ipv
-                                                              ]
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        {
-                                                          Nothing [[Tuple2 a] b]
-                                                        }
-                                                      )
-                                                    ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
-                                            ]
-                                            (lam
-                                              thunk
-                                              Unit
-                                              { Nothing [[Tuple2 a] b] }
-                                            )
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam ds Unit nilCase)
-                                              ]
-                                              (lam
-                                                ds
-                                                Unit
-                                                { Nothing [[Tuple2 a] b] }
-                                              )
-                                            ]
-                                            [
-                                              { (builtin tailList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl lvl [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam
-                                                  ds
-                                                  Unit
-                                                  { Nothing [[Tuple2 a] b] }
-                                                )
-                                              ]
-                                              (lam ds Unit lvl)
-                                            ]
-                                            l
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      (termbind
-                                        (nonstrict)
-                                        (vardecl x [Maybe [[Tuple2 a] b]])
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  (con data)
-                                                }
-                                                (lam
-                                                  ds
-                                                  Unit
-                                                  { Nothing [[Tuple2 a] b] }
-                                                )
-                                              ]
-                                              (lam ds Unit lvl)
-                                            ]
-                                            l
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      [
-                                        [
-                                          [
-                                            [
-                                              {
-                                                (builtin ifThenElse)
-                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                              }
-                                              [
-                                                [
-                                                  (builtin equalsInteger)
-                                                  [
-                                                    {
-                                                      {
-                                                        (builtin fstPair)
-                                                        (con integer)
-                                                      }
-                                                      [(con list) (con data)]
-                                                    }
-                                                    tup
-                                                  ]
-                                                ]
-                                                (con integer 0)
-                                              ]
-                                            ]
-                                            (lam ds Unit x)
-                                          ]
-                                          (lam
-                                            ds Unit { Nothing [[Tuple2 a] b] }
-                                          )
-                                        ]
-                                        Unit
-                                      ]
-                                    )
-                                  )
-                                ]
-                                (lam ds Unit { Nothing [[Tuple2 a] b] })
-                              ]
-                              (lam ds Unit { Nothing [[Tuple2 a] b] })
-                            ]
-                            (lam ds Unit { Nothing [[Tuple2 a] b] })
-                          ]
-                          (lam ds Unit { Nothing [[Tuple2 a] b] })
-                        ]
-                        d
-                      ]
-                      Unit
-                    ]
-                  )
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            toBuiltinData (all a (type) (fun [IsData a] (fun a (con data))))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun a (con data)) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_ctoBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun [[Tuple2 a] b] (con data))))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                dIsData
-                [IsData a]
-                (lam
-                  dIsData
-                  [IsData b]
+                  dToData
+                  [(lam a (type) (fun a (con data))) b]
                   (lam
                     ds
                     [[Tuple2 a] b]
@@ -583,13 +87,12 @@
                             [ (builtin constrData) (con integer 0) ]
                             [
                               [
-                                { (builtin mkCons) (con data) }
-                                [ [ { toBuiltinData a } dIsData ] arg ]
+                                { (builtin mkCons) (con data) } [ dToData arg ]
                               ]
                               [
                                 [
                                   { (builtin mkCons) (con data) }
-                                  [ [ { toBuiltinData b } dIsData ] arg ]
+                                  [ dToData arg ]
                                 ]
                                 [ (builtin mkNilData) (con unit ()) ]
                               ]
@@ -605,558 +108,91 @@
           )
         )
         (termbind
-          (strict)
-          (vardecl error (all a (type) (fun (con unit) a)))
-          (abs a (type) (lam thunk (con unit) (error a)))
+          (nonstrict)
+          (vardecl fToDataMap [(con list) (con data)])
+          [ (builtin mkNilData) (con unit ()) ]
         )
         (termbind
           (strict)
           (vardecl
-            unsafeFromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) a)))
+            fToDataMap_ctoBuiltinData
+            (all k (type) (all v (type) (fun [(lam a (type) (fun a (con data))) k] (fun [(lam a (type) (fun a (con data))) v] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v] (con data))))))
           )
           (abs
-            a
-            (type)
-            (lam
-              v
-              [IsData a]
-              [
-                { [ { IsData_match a } v ] (fun (con data) a) }
-                (lam
-                  v
-                  (fun a (con data))
-                  (lam v (fun (con data) [Maybe a]) (lam v (fun (con data) a) v)
-                  )
-                )
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2_cunsafeFromBuiltinData
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] (fun (con data) [[Tuple2 a] b])))))
-          )
-          (abs
-            a
+            k
             (type)
             (abs
-              b
+              v
               (type)
               (lam
-                dIsData
-                [IsData a]
+                dToData
+                [(lam a (type) (fun a (con data))) k]
                 (lam
-                  dIsData
-                  [IsData b]
+                  dToData
+                  [(lam a (type) (fun a (con data))) v]
                   (lam
-                    d
-                    (con data)
+                    eta
+                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
                     (let
-                      (nonrec)
+                      (rec)
                       (termbind
-                        (nonstrict)
-                        (vardecl x [[Tuple2 a] b])
-                        [ { error [[Tuple2 a] b] } (con unit ()) ]
-                      )
-                      (termbind
-                        (nonstrict)
+                        (strict)
                         (vardecl
-                          tup
-                          [[(con pair) (con integer)] [(con list) (con data)]]
+                          go (fun [List [[Tuple2 k] v]] [(con list) (con data)])
                         )
-                        [ (builtin unConstrData) d ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl t [(con list) (con data)])
-                        [
-                          {
-                            { (builtin sndPair) (con integer) }
-                            [(con list) (con data)]
-                          }
-                          tup
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x b)
-                        [
-                          [ { unsafeFromBuiltinData b } dIsData ]
-                          [
-                            { (builtin headList) (con data) }
-                            [ { (builtin tailList) (con data) } t ]
-                          ]
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x a)
-                        [
-                          [ { unsafeFromBuiltinData a } dIsData ]
-                          [ { (builtin headList) (con data) } t ]
-                        ]
-                      )
-                      (termbind
-                        (nonstrict)
-                        (vardecl x [[Tuple2 a] b])
-                        [ [ { { Tuple2 a } b } x ] x ]
-                      )
-                      [
-                        [
-                          [
-                            [
-                              { (builtin ifThenElse) (fun Unit [[Tuple2 a] b]) }
-                              [
-                                [
-                                  (builtin equalsInteger)
-                                  [
-                                    {
-                                      { (builtin fstPair) (con integer) }
-                                      [(con list) (con data)]
-                                    }
-                                    tup
-                                  ]
-                                ]
-                                (con integer 0)
-                              ]
-                            ]
-                            (lam ds Unit x)
-                          ]
-                          (lam ds Unit x)
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataTuple2
-            (all a (type) (all b (type) (fun [IsData a] (fun [IsData b] [IsData [[Tuple2 a] b]]))))
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                v
-                [IsData a]
-                (lam
-                  v
-                  [IsData b]
-                  [
-                    [
-                      [
-                        { CConsIsData [[Tuple2 a] b] }
-                        [ [ { { fIsDataTuple2_ctoBuiltinData a } b } v ] v ]
-                      ]
-                      [ [ { { fIsDataTuple2_cfromBuiltinData a } b } v ] v ]
-                    ]
-                    [ [ { { fIsDataTuple2_cunsafeFromBuiltinData a } b } v ] v ]
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataNil_cunsafeFromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [List a])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [(con list) (con data)] [List a]))
-                    (lam
-                      l
-                      [(con list) (con data)]
-                      [
-                        [
-                          [
-                            [
-                              {
-                                { (builtin chooseList) (fun Unit [List a]) }
-                                (con data)
-                              }
-                              (lam ds Unit { Nil a })
-                            ]
-                            (lam
-                              ds
-                              Unit
-                              [
-                                [
-                                  { Cons a }
-                                  [
-                                    [ { unsafeFromBuiltinData a } dIsData ]
-                                    [ { (builtin headList) (con data) } l ]
-                                  ]
-                                ]
-                                [ go [ { (builtin tailList) (con data) } l ] ]
-                              ]
-                            )
-                          ]
-                          l
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                  [ go [ (builtin unListData) d ] ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMap
-            (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun (con data) [List [[Tuple2 k] v]])))))
-          )
-          (abs
-            k
-            (type)
-            (abs
-              v
-              (type)
-              (lam
-                dIsData
-                [IsData k]
-                (lam
-                  dIsData
-                  [IsData v]
-                  [
-                    { fIsDataNil_cunsafeFromBuiltinData [[Tuple2 k] v] }
-                    [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataNil_cfromBuiltinData
-            (all a (type) (fun [IsData a] (fun (con data) [Maybe [List a]])))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                d
-                (con data)
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [(con list) (con data)] [Maybe [List a]]))
-                    (lam
-                      l
-                      [(con list) (con data)]
-                      (let
-                        (nonrec)
-                        (termbind
-                          (nonstrict)
-                          (vardecl x [Maybe [List a]])
-                          [ { Just [List a] } { Nil a } ]
-                        )
-                        [
+                        (lam
+                          ds
+                          [List [[Tuple2 k] v]]
                           [
                             [
                               [
                                 {
-                                  {
-                                    (builtin chooseList)
-                                    (fun Unit [Maybe [List a]])
-                                  }
-                                  (con data)
+                                  [ { Nil_match [[Tuple2 k] v] } ds ]
+                                  (fun Unit [(con list) (con data)])
                                 }
-                                (lam ds Unit x)
+                                (lam thunk Unit fToDataMap)
                               ]
                               (lam
-                                ds
-                                Unit
-                                [
-                                  [
+                                x
+                                [[Tuple2 k] v]
+                                (lam
+                                  xs
+                                  [List [[Tuple2 k] v]]
+                                  (lam
+                                    thunk
+                                    Unit
                                     [
-                                      {
+                                      [
+                                        { (builtin mkCons) (con data) }
                                         [
-                                          { Maybe_match a }
-                                          [
-                                            [ { fromBuiltinData a } dIsData ]
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe [List a]])
-                                      }
-                                      (lam
-                                        a
-                                        a
-                                        (lam
-                                          thunk
-                                          Unit
                                           [
                                             [
-                                              [
+                                              {
                                                 {
-                                                  [
-                                                    { Maybe_match [List a] }
-                                                    [
-                                                      go
-                                                      [
-                                                        {
-                                                          (builtin tailList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe [List a]])
+                                                  fToDataTuple2_ctoBuiltinData k
                                                 }
-                                                (lam
-                                                  ipv
-                                                  [List a]
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      { Just [List a] }
-                                                      [ [ { Cons a } a ] ipv ]
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing [List a] }
-                                              )
+                                                v
+                                              }
+                                              dToData
                                             ]
-                                            Unit
+                                            dToData
                                           ]
-                                        )
-                                      )
+                                          x
+                                        ]
+                                      ]
+                                      [ go xs ]
                                     ]
-                                    (lam thunk Unit { Nothing [List a] })
-                                  ]
-                                  Unit
-                                ]
+                                  )
+                                )
                               )
                             ]
-                            l
+                            Unit
                           ]
-                          Unit
-                        ]
+                        )
                       )
+                      [ (builtin listData) [ go eta ] ]
                     )
                   )
-                  [
-                    [
-                      [
-                        [
-                          [
-                            [
-                              [
-                                {
-                                  (builtin chooseData)
-                                  (fun Unit [Maybe [List a]])
-                                }
-                                (lam ds Unit { Nothing [List a] })
-                              ]
-                              (lam ds Unit { Nothing [List a] })
-                            ]
-                            (lam ds Unit [ go [ (builtin unListData) d ] ])
-                          ]
-                          (lam ds Unit { Nothing [List a] })
-                        ]
-                        (lam ds Unit { Nothing [List a] })
-                      ]
-                      d
-                    ]
-                    Unit
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMap
-            (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun (con data) [Maybe [List [[Tuple2 k] v]]])))))
-          )
-          (abs
-            k
-            (type)
-            (abs
-              v
-              (type)
-              (lam
-                dIsData
-                [IsData k]
-                (lam
-                  dIsData
-                  [IsData v]
-                  [
-                    { fIsDataNil_cfromBuiltinData [[Tuple2 k] v] }
-                    [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataNil_ctoBuiltinData
-            (all a (type) (fun [IsData a] (fun [List a] (con data))))
-          )
-          (abs
-            a
-            (type)
-            (lam
-              dIsData
-              [IsData a]
-              (lam
-                l
-                [List a]
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl go (fun [List a] [(con list) (con data)]))
-                    (lam
-                      ds
-                      [List a]
-                      [
-                        [
-                          [
-                            {
-                              [ { Nil_match a } ds ]
-                              (fun Unit [(con list) (con data)])
-                            }
-                            (lam
-                              thunk Unit [ (builtin mkNilData) (con unit ()) ]
-                            )
-                          ]
-                          (lam
-                            x
-                            a
-                            (lam
-                              xs
-                              [List a]
-                              (lam
-                                thunk
-                                Unit
-                                [
-                                  [
-                                    { (builtin mkCons) (con data) }
-                                    [ [ { toBuiltinData a } dIsData ] x ]
-                                  ]
-                                  [ go xs ]
-                                ]
-                              )
-                            )
-                          )
-                        ]
-                        Unit
-                      ]
-                    )
-                  )
-                  [ (builtin listData) [ go l ] ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMap
-            (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] (fun [List [[Tuple2 k] v]] (con data))))))
-          )
-          (abs
-            k
-            (type)
-            (abs
-              v
-              (type)
-              (lam
-                dIsData
-                [IsData k]
-                (lam
-                  dIsData
-                  [IsData v]
-                  [
-                    { fIsDataNil_ctoBuiltinData [[Tuple2 k] v] }
-                    [ [ { { fIsDataTuple2 k } v } dIsData ] dIsData ]
-                  ]
-                )
-              )
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMap
-            (all k (type) (all v (type) (fun [IsData k] (fun [IsData v] [IsData [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]]))))
-          )
-          (abs
-            k
-            (type)
-            (abs
-              v
-              (type)
-              (lam
-                v
-                [IsData k]
-                (lam
-                  v
-                  [IsData v]
-                  [
-                    [
-                      [
-                        {
-                          CConsIsData
-                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
-                        }
-                        [ [ { { fIsDataMap k } v } v ] v ]
-                      ]
-                      [ [ { { fIsDataMap k } v } v ] v ]
-                    ]
-                    [ [ { { fIsDataMap k } v } v ] v ]
-                  ]
                 )
               )
             )
@@ -1164,685 +200,32 @@
         )
         (termbind
           (nonstrict)
-          (vardecl fIsDataTokenName [IsData (con bytestring)])
-          [
-            [
-              [
-                { CConsIsData (con bytestring) }
-                fIsDataByteString_ctoBuiltinData
-              ]
-              fIsDataByteString_cfromBuiltinData
-            ]
-            (builtin unBData)
-          ]
-        )
-        (termbind
-          (nonstrict)
           (vardecl
-            fIsDataValue
-            [IsData [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+            fToDataValue
+            (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)] (con data))
           )
           [
             [
-              { { fIsDataMap (con bytestring) } (con integer) } fIsDataTokenName
+              { { fToDataMap_ctoBuiltinData (con bytestring) } (con integer) }
+              fToDataByteString_ctoBuiltinData
             ]
-            fIsDataInteger
+            fToDataInteger_ctoBuiltinData
           ]
         )
-        (termbind
-          (nonstrict)
-          (vardecl
-            fIsDataValue
-            [IsData [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-          )
-          [
-            [
-              {
-                { fIsDataTuple2 (con bytestring) }
-                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-              }
-              fIsDataCurrencySymbol
-            ]
-            fIsDataValue
-          ]
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataInput_cfromBuiltinData (fun (con data) [Maybe Payment])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe Payment]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } l ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe Payment])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          {
-                                            Maybe_match
-                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                          }
-                                          [
-                                            [
-                                              {
-                                                fIsDataNil_cfromBuiltinData
-                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                              }
-                                              fIsDataValue
-                                            ]
-                                            [
-                                              { (builtin headList) (con data) }
-                                              l
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe Payment])
-                                      }
-                                      (lam
-                                        ipv
-                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      (con bytestring)
-                                                    }
-                                                    [
-                                                      fIsDataByteString_cfromBuiltinData
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe Payment])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  (con bytestring)
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                Maybe_match
-                                                                (con integer)
-                                                              }
-                                                              [
-                                                                fIsDataInteger_cfromBuiltinData
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      headList
-                                                                    )
-                                                                    (con data)
-                                                                  }
-                                                                  l
-                                                                ]
-                                                              ]
-                                                            ]
-                                                            (fun Unit [Maybe Payment])
-                                                          }
-                                                          (lam
-                                                            ipv
-                                                            (con integer)
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                { Just Payment }
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      Payment
-                                                                      ipv
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                  ipv
-                                                                ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          { Nothing Payment }
-                                                        )
-                                                      ]
-                                                      Unit
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing Payment }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing Payment })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Payment])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Payment])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing Payment })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Payment])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Payment])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Payment })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe Payment])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Payment])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Payment })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe Payment])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe Payment])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing Payment })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe Payment])
-                                      }
-                                      [
-                                        [
-                                          (builtin equalsInteger)
-                                          [
-                                            {
-                                              {
-                                                (builtin fstPair) (con integer)
-                                              }
-                                              [(con list) (con data)]
-                                            }
-                                            tup
-                                          ]
-                                        ]
-                                        (con integer 0)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit { Nothing Payment })
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing Payment })
-                      ]
-                      (lam ds Unit { Nothing Payment })
-                    ]
-                    (lam ds Unit { Nothing Payment })
-                  ]
-                  (lam ds Unit { Nothing Payment })
-                ]
-                d
-              ]
-              Unit
-            ]
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataPubKeyHash [IsData (con bytestring)])
-          [
-            [
-              [
-                { CConsIsData (con bytestring) }
-                fIsDataByteString_ctoBuiltinData
-              ]
-              fIsDataByteString_cfromBuiltinData
-            ]
-            (builtin unBData)
-          ]
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMSState_cfromBuiltinData (fun (con data) [Maybe MSState])
-          )
-          (lam
-            d
-            (con data)
-            [
-              [
-                [
-                  [
-                    [
-                      [
-                        [
-                          { (builtin chooseData) (fun Unit [Maybe MSState]) }
-                          (lam
-                            ds
-                            Unit
-                            (let
-                              (nonrec)
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe MSState])
-                                [ { Just MSState } Holding ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl
-                                  tup
-                                  [[(con pair) (con integer)] [(con list) (con data)]]
-                                )
-                                [ (builtin unConstrData) d ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl args [(con list) (con data)])
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe MSState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing MSState })
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl index (con integer))
-                                [
-                                  {
-                                    { (builtin fstPair) (con integer) }
-                                    [(con list) (con data)]
-                                  }
-                                  tup
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          (builtin ifThenElse)
-                                          (fun Unit [Maybe MSState])
-                                        }
-                                        [
-                                          [ (builtin equalsInteger) index ]
-                                          (con integer 0)
-                                        ]
-                                      ]
-                                      (lam ds Unit x)
-                                    ]
-                                    (lam ds Unit { Nothing MSState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl l [(con list) (con data)])
-                                [ { (builtin tailList) (con data) } args ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl nilCase [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          { Maybe_match Payment }
-                                          [
-                                            fIsDataInput_cfromBuiltinData
-                                            [
-                                              { (builtin headList) (con data) }
-                                              args
-                                            ]
-                                          ]
-                                        ]
-                                        (fun Unit [Maybe MSState])
-                                      }
-                                      (lam
-                                        ipv
-                                        Payment
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Maybe_match
-                                                      [List (con bytestring)]
-                                                    }
-                                                    [
-                                                      [
-                                                        {
-                                                          fIsDataNil_cfromBuiltinData
-                                                          (con bytestring)
-                                                        }
-                                                        fIsDataPubKeyHash
-                                                      ]
-                                                      [
-                                                        {
-                                                          (builtin headList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (fun Unit [Maybe MSState])
-                                                }
-                                                (lam
-                                                  ipv
-                                                  [List (con bytestring)]
-                                                  (lam
-                                                    thunk
-                                                    Unit
-                                                    [
-                                                      { Just MSState }
-                                                      [
-                                                        [
-                                                          CollectingSignatures
-                                                          ipv
-                                                        ]
-                                                        ipv
-                                                      ]
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                thunk Unit { Nothing MSState }
-                                              )
-                                            ]
-                                            Unit
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (lam thunk Unit { Nothing MSState })
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe MSState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit nilCase)
-                                      ]
-                                      (lam ds Unit { Nothing MSState })
-                                    ]
-                                    [ { (builtin tailList) (con data) } l ]
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl lvl [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe MSState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing MSState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    l
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl x [Maybe MSState])
-                                [
-                                  [
-                                    [
-                                      [
-                                        {
-                                          {
-                                            (builtin chooseList)
-                                            (fun Unit [Maybe MSState])
-                                          }
-                                          (con data)
-                                        }
-                                        (lam ds Unit { Nothing MSState })
-                                      ]
-                                      (lam ds Unit lvl)
-                                    ]
-                                    args
-                                  ]
-                                  Unit
-                                ]
-                              )
-                              [
-                                [
-                                  [
-                                    [
-                                      {
-                                        (builtin ifThenElse)
-                                        (fun Unit [Maybe MSState])
-                                      }
-                                      [
-                                        [ (builtin equalsInteger) index ]
-                                        (con integer 1)
-                                      ]
-                                    ]
-                                    (lam ds Unit x)
-                                  ]
-                                  (lam ds Unit x)
-                                ]
-                                Unit
-                              ]
-                            )
-                          )
-                        ]
-                        (lam ds Unit { Nothing MSState })
-                      ]
-                      (lam ds Unit { Nothing MSState })
-                    ]
-                    (lam ds Unit { Nothing MSState })
-                  ]
-                  (lam ds Unit { Nothing MSState })
-                ]
-                d
-              ]
-              Unit
-            ]
+        (datatypebind
+          (datatype
+            (tyvardecl Payment (type))
+
+            Payment_match
+            (vardecl
+              Payment
+              (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun (con bytestring) (fun (con integer) Payment)))
+            )
           )
         )
         (termbind
           (strict)
-          (vardecl fIsDataInput_ctoBuiltinData (fun Payment (con data)))
+          (vardecl fToDataInput_ctoBuiltinData (fun Payment (con data)))
           (lam
             ds
             Payment
@@ -1864,11 +247,14 @@
                           { (builtin mkCons) (con data) }
                           [
                             [
-                              {
-                                fIsDataNil_ctoBuiltinData
-                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                              }
-                              fIsDataValue
+                              [
+                                {
+                                  { fToDataMap_ctoBuiltinData (con bytestring) }
+                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                }
+                                fToDataByteString_ctoBuiltinData
+                              ]
+                              fToDataValue
                             ]
                             arg
                           ]
@@ -1894,9 +280,21 @@
             ]
           )
         )
+        (datatypebind
+          (datatype
+            (tyvardecl MSState (type))
+
+            MSState_match
+            (vardecl
+              CollectingSignatures
+              (fun Payment (fun [List (con bytestring)] MSState))
+            )
+            (vardecl Holding MSState)
+          )
+        )
         (termbind
           (strict)
-          (vardecl fIsDataMSState_ctoBuiltinData (fun MSState (con data)))
+          (vardecl fToDataMSState_ctoBuiltinData (fun MSState (con data)))
           (lam
             ds
             MSState
@@ -1913,30 +311,71 @@
                       (lam
                         thunk
                         Unit
-                        [
-                          [ (builtin constrData) (con integer 1) ]
-                          [
-                            [
-                              { (builtin mkCons) (con data) }
-                              [ fIsDataInput_ctoBuiltinData arg ]
-                            ]
-                            [
+                        (let
+                          (rec)
+                          (termbind
+                            (strict)
+                            (vardecl
+                              go
+                              (fun [List (con bytestring)] [(con list) (con data)])
+                            )
+                            (lam
+                              ds
+                              [List (con bytestring)]
                               [
-                                { (builtin mkCons) (con data) }
                                 [
                                   [
                                     {
-                                      fIsDataNil_ctoBuiltinData (con bytestring)
+                                      [ { Nil_match (con bytestring) } ds ]
+                                      (fun Unit [(con list) (con data)])
                                     }
-                                    fIsDataPubKeyHash
+                                    (lam
+                                      thunk
+                                      Unit
+                                      [ (builtin mkNilData) (con unit ()) ]
+                                    )
                                   ]
-                                  arg
+                                  (lam
+                                    x
+                                    (con bytestring)
+                                    (lam
+                                      xs
+                                      [List (con bytestring)]
+                                      (lam
+                                        thunk
+                                        Unit
+                                        [
+                                          [
+                                            { (builtin mkCons) (con data) }
+                                            [ (builtin bData) x ]
+                                          ]
+                                          [ go xs ]
+                                        ]
+                                      )
+                                    )
+                                  )
                                 ]
+                                Unit
                               ]
-                              [ (builtin mkNilData) (con unit ()) ]
+                            )
+                          )
+                          [
+                            [ (builtin constrData) (con integer 1) ]
+                            [
+                              [
+                                { (builtin mkCons) (con data) }
+                                [ fToDataInput_ctoBuiltinData arg ]
+                              ]
+                              [
+                                [
+                                  { (builtin mkCons) (con data) }
+                                  [ (builtin listData) [ go arg ] ]
+                                ]
+                                [ (builtin mkNilData) (con unit ()) ]
+                              ]
                             ]
                           ]
-                        ]
+                        )
                       )
                     )
                   )
@@ -1953,216 +392,6 @@
               Unit
             ]
           )
-        )
-        (termbind
-          (strict)
-          (vardecl fIsDataInput_cunsafeFromBuiltinData (fun (con data) Payment))
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x Payment)
-                [ { error Payment } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [ { (builtin tailList) (con data) } t ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con integer))
-                [
-                  (builtin unIData)
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x (con bytestring))
-                [ (builtin unBData) [ { (builtin headList) (con data) } t ] ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  x
-                  [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                )
-                [
-                  [
-                    {
-                      fIsDataNil_cunsafeFromBuiltinData
-                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                    }
-                    fIsDataValue
-                  ]
-                  [ { (builtin headList) (con data) } t ]
-                ]
-              )
-              (termbind
-                (nonstrict) (vardecl x Payment) [ [ [ Payment x ] x ] x ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit Payment) }
-                      [
-                        [
-                          (builtin equalsInteger)
-                          [
-                            {
-                              { (builtin fstPair) (con integer) }
-                              [(con list) (con data)]
-                            }
-                            tup
-                          ]
-                        ]
-                        (con integer 0)
-                      ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (strict)
-          (vardecl
-            fIsDataMSState_cunsafeFromBuiltinData (fun (con data) MSState)
-          )
-          (lam
-            d
-            (con data)
-            (let
-              (nonrec)
-              (termbind
-                (nonstrict)
-                (vardecl x MSState)
-                [ { error MSState } (con unit ()) ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl
-                  tup [[(con pair) (con integer)] [(con list) (con data)]]
-                )
-                [ (builtin unConstrData) d ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl index (con integer))
-                [
-                  {
-                    { (builtin fstPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x MSState)
-                [
-                  [
-                    [
-                      [
-                        { (builtin ifThenElse) (fun Unit MSState) }
-                        [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                      ]
-                      (lam ds Unit Holding)
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  Unit
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl t [(con list) (con data)])
-                [
-                  {
-                    { (builtin sndPair) (con integer) } [(con list) (con data)]
-                  }
-                  tup
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x [List (con bytestring)])
-                [
-                  [
-                    { fIsDataNil_cunsafeFromBuiltinData (con bytestring) }
-                    fIsDataPubKeyHash
-                  ]
-                  [
-                    { (builtin headList) (con data) }
-                    [ { (builtin tailList) (con data) } t ]
-                  ]
-                ]
-              )
-              (termbind
-                (nonstrict)
-                (vardecl x Payment)
-                [
-                  fIsDataInput_cunsafeFromBuiltinData
-                  [ { (builtin headList) (con data) } t ]
-                ]
-              )
-              (termbind
-                (nonstrict) (vardecl x MSState) [ [ CollectingSignatures x ] x ]
-              )
-              [
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) (fun Unit MSState) }
-                      [ [ (builtin equalsInteger) index ] (con integer 1) ]
-                    ]
-                    (lam ds Unit x)
-                  ]
-                  (lam ds Unit x)
-                ]
-                Unit
-              ]
-            )
-          )
-        )
-        (termbind
-          (nonstrict)
-          (vardecl fIsDataMSState [IsData MSState])
-          [
-            [
-              [ { CConsIsData MSState } fIsDataMSState_ctoBuiltinData ]
-              fIsDataMSState_cfromBuiltinData
-            ]
-            fIsDataMSState_cunsafeFromBuiltinData
-          ]
         )
         (datatypebind
           (datatype
@@ -2262,6 +491,14 @@
             (vardecl
               Interval (fun [LowerBound a] (fun [UpperBound a] [Interval a]))
             )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Maybe (fun (type) (type)))
+            (tyvardecl a (type))
+            Maybe_match
+            (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
           )
         )
         (datatypebind
@@ -5669,33 +3906,8 @@
                   )
                   (termbind
                     (strict)
-                    (vardecl
-                      fIsDataVoid_cfromBuiltinData (fun (con data) [Maybe Void])
-                    )
-                    (lam ds (con data) { Nothing Void })
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      fIsDataVoid_cunsafeFromBuiltinData (fun (con data) Void)
-                    )
-                    (lam ds (con data) [ { error Void } (con unit ()) ])
-                  )
-                  (termbind
-                    (strict)
                     (vardecl absurd (all a (type) (fun Void a)))
                     (abs a (type) (lam a Void { [ Void_match a ] a }))
-                  )
-                  (termbind
-                    (nonstrict)
-                    (vardecl fIsDataVoid [IsData Void])
-                    [
-                      [
-                        [ { CConsIsData Void } { absurd (con data) } ]
-                        fIsDataVoid_cfromBuiltinData
-                      ]
-                      fIsDataVoid_cunsafeFromBuiltinData
-                    ]
                   )
                   (datatypebind
                     (datatype
@@ -6812,6 +5024,11 @@
                   )
                   (termbind
                     (strict)
+                    (vardecl error (all a (type) (fun (con unit) a)))
+                    (abs a (type) (lam thunk (con unit) (error a)))
+                  )
+                  (termbind
+                    (strict)
                     (vardecl findOwnInput (fun ScriptContext [Maybe TxInInfo]))
                     (lam
                       ds
@@ -7216,14 +5433,14 @@
                     (strict)
                     (vardecl
                       checkOwnOutputConstraint
-                      (all o (type) (fun [IsData o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
+                      (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun ScriptContext (fun [OutputConstraint o] Bool))))
                     )
                     (abs
                       o
                       (type)
                       (lam
-                        dIsData
-                        [IsData o]
+                        dToData
+                        [(lam a (type) (fun a (con data))) o]
                         (lam
                           ctx
                           ScriptContext
@@ -7254,15 +5471,7 @@
                                               hsh [Maybe (con bytestring)]
                                             )
                                             [
-                                              [
-                                                findDatumHash
-                                                [
-                                                  [
-                                                    { toBuiltinData o } dIsData
-                                                  ]
-                                                  ds
-                                                ]
-                                              ]
+                                              [ findDatumHash [ dToData ds ] ]
                                               ds
                                             ]
                                           )
@@ -12151,7 +10360,7 @@
                     (strict)
                     (vardecl
                       checkScriptContext
-                      (all i (type) (all o (type) (fun [IsData o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
+                      (all i (type) (all o (type) (fun [(lam a (type) (fun a (con data))) o] (fun [[TxConstraints i] o] (fun ScriptContext Bool)))))
                     )
                     (abs
                       i
@@ -12160,8 +10369,8 @@
                         o
                         (type)
                         (lam
-                          dIsData
-                          [IsData o]
+                          dToData
+                          [(lam a (type) (fun a (con data))) o]
                           (lam
                             ds
                             [[TxConstraints i] o]
@@ -12301,7 +10510,7 @@
                                                                             checkOwnOutputConstraint
                                                                             o
                                                                           }
-                                                                          dIsData
+                                                                          dToData
                                                                         ]
                                                                         ptx
                                                                       ]
@@ -12833,7 +11042,7 @@
                     (strict)
                     (vardecl
                       wmkValidator
-                      (all s (type) (all i (type) (fun [IsData s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
+                      (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]])) (fun (fun s Bool) (fun (fun s (fun i (fun ScriptContext Bool))) (fun [Maybe ThreadToken] (fun s (fun i (fun ScriptContext Bool))))))))))
                     )
                     (abs
                       s
@@ -12843,7 +11052,7 @@
                         (type)
                         (lam
                           w
-                          [IsData s]
+                          [(lam a (type) (fun a (con data))) s]
                           (lam
                             ww
                             (fun [State s] (fun i [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State s]]]))
@@ -13051,7 +11260,10 @@
                                                                                                 }
                                                                                                 Void
                                                                                               }
-                                                                                              fIsDataVoid
+                                                                                              {
+                                                                                                absurd
+                                                                                                (con data)
+                                                                                              }
                                                                                             ]
                                                                                             newConstraints
                                                                                           ]
@@ -13568,7 +11780,7 @@
                     (strict)
                     (vardecl
                       mkValidator
-                      (all s (type) (all i (type) (fun [IsData s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
+                      (all s (type) (all i (type) (fun [(lam a (type) (fun a (con data))) s] (fun [[StateMachine s] i] (fun s (fun i (fun ScriptContext Bool)))))))
                     )
                     (abs
                       s
@@ -13578,7 +11790,7 @@
                         (type)
                         (lam
                           w
-                          [IsData s]
+                          [(lam a (type) (fun a (con data))) s]
                           (lam
                             w
                             [[StateMachine s] i]
@@ -13658,7 +11870,10 @@
                       params
                       Params
                       [
-                        [ { { mkValidator MSState } Input } fIsDataMSState ]
+                        [
+                          { { mkValidator MSState } Input }
+                          fToDataMSState_ctoBuiltinData
+                        ]
                         [ machine params ]
                       ]
                     )

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
+TxId:       ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840e8c8449bc30c7150e09a78f0502e9e36dd2b...
+              Signature: 5840b919337f10541d9702a14c0672907b70758c...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: bcc083ade3fdd0a372cb6c43ef00ef02fcb52e95... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
+TxId:       ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5840976acda2bac505bdd0b79ddbe94b95743933...
+              Signature: 58400b5aff9fb2b70e3eeb28af0aaa299713e443...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 7f8a76c0ebaa4ad20dfdcd51a5de070ab771f4bf... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
+TxId:       b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840fd555bf56908b24c722265dcacedfa0c59ca...
+              Signature: 584047dd5a8e0db74d59ede6b620596017f53a0f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  100
 
@@ -318,16 +318,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       0a0d18c83da9410f0e8d99daa46b4a4847737dbd224d6fc7ff63624ba17c8cdb
-Fee:        Ada:      Lovelace:  31093
+TxId:       28820ea4e0bc500571b4ec322f273b3cbce775cfe271be3ac7011a9aaf3fcd7e
+Fee:        Ada:      Lovelace:  17455
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840517a34465c4e8f9808e79909988f3414093b...
+              Signature: 5840735e43035e8b1bd6d090dbf3cb85b2afc621...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -339,44 +339,44 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     576592db5168efbf2628466c0b599e2ccaf34a5c95c3a1c198f6f36072b10b58
+    Tx:     ad7d68099b12b718d5823e5a10263a823e65e97dd7847355b5b39ccca0b4c3b3
     Output #1
-    Script: 5920510100003323332223332223322323232323...
+    Script: 5911f10100003323332223233223233322233322...
 
   ---- Input 2 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     737e7fd3bce43054c2639b087102df423d2a7f3674d616f63e20cb73b93bdbb4
+    Tx:     b6ed57dc0ed05b8f77f5bdec227ae81e41810e90ed0f823b605fdb42fcd79c79
     Output #1
-    Script: 5920510100003323332223332223322323232323...
+    Script: 5911f10100003323332223233223233322233322...
 
   ---- Input 3 ----
-  Destination:  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Destination:  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  25
   Source:
-    Tx:     b02f9d6fc50c150486ea9337fbcc47de0b72a4c56f4b294091b59dc9ab5da450
+    Tx:     ba45e97a19d20c5ed0e08fcebd182a9374e82b62baf1a88de07cd9d3ae0cd259
     Output #1
-    Script: 5920510100003323332223332223322323232323...
+    Script: 5911f10100003323332223233223233322233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99969132
+    Ada:      Lovelace:  99982770
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99969132
+    Ada:      Lovelace:  99982770
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -414,6 +414,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f852e1db1dfbf3af1036f89a8f819472d8b4161bcd9d032f96c9c497
+  Script: bcedca7f4b18957a0725a579e581ef695c13a6ebac5c7bdeed06b7c3
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       0664f2bbda4f2e649e0ee68c21a40c445217459ef00a3a56c71218116022cd27
+TxId:       390a696698092ba91031089e44ec1b1b594805f9b75025e5faec4ce2effac5d2
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840896e0485e78d3ffa1203b1cbd2234f77fd10...
+              Signature: 5840bc9526975d2b83b6a38bf67ca618b564599a...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999982
 
   ---- Output 1 ----
-  Destination:  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Destination:  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
 
@@ -170,51 +170,51 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       c0cf330ba0126822e1ee5900e99929982f23cc75e0ec60be5b3a548001c9e02c
-Fee:        Ada:      Lovelace:  25909
-Mint:       6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+TxId:       6313ad37d213389270cc9d3f2269444612d5d369a5f1f32ba3ebdc1ee0b3fb39
+Fee:        Ada:      Lovelace:  15052
+Mint:       1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840f77ca7147bab912b932a670b7ff9cef18399...
+              Signature: 5840f1fb0541b70fbb1cef85e3abdd0570ad9aff...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     0664f2bbda4f2e649e0ee68c21a40c445217459ef00a3a56c71218116022cd27
+    Tx:     390a696698092ba91031089e44ec1b1b594805f9b75025e5faec4ce2effac5d2
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Destination:  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     0664f2bbda4f2e649e0ee68c21a40c445217459ef00a3a56c71218116022cd27
+    Tx:     390a696698092ba91031089e44ec1b1b594805f9b75025e5faec4ce2effac5d2
     Output #1
-    Script: 593b370100003323322333222333222333222332...
+    Script: 5926ac0100003323322333222333222323322323...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974073
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  -
+    Ada:      Lovelace:  99984930
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Destination:  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
 
@@ -222,8 +222,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974073
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    Ada:      Lovelace:  99984930
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       33ad8a0a16bc318cbe3dfe5d4d4b131972f60707b56f246e4cad8300e751a964
+TxId:       bb63552f20a96837a52a6aa617bca5260420cb0a56c828195548fc50c70e510c
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58400dc6bf4939ae7053057ed4b776b1a7e9c938...
+              Signature: 58406b136bce3d3e2bcf8ff7d4b335f3d8b839e7...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974073
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  -
+    Ada:      Lovelace:  99984930
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  -
   Source:
-    Tx:     c0cf330ba0126822e1ee5900e99929982f23cc75e0ec60be5b3a548001c9e02c
+    Tx:     6313ad37d213389270cc9d3f2269444612d5d369a5f1f32ba3ebdc1ee0b3fb39
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
     Ada:      -
   Source:
-    Tx:     c0cf330ba0126822e1ee5900e99929982f23cc75e0ec60be5b3a548001c9e02c
+    Tx:     6313ad37d213389270cc9d3f2269444612d5d369a5f1f32ba3ebdc1ee0b3fb39
     Output #1
 
 
@@ -297,20 +297,20 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974063
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    0
+    Ada:      Lovelace:  99984920
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974063
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    0
+    Ada:      Lovelace:  99984920
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -335,7 +335,7 @@ Balances Carried Forward:
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -349,16 +349,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       c862395eeb3eb8c45918fe8e1dee93d1b73e43614b9d8d0efd36965756ab4544
-Fee:        Ada:      Lovelace:  25909
-Mint:       6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    0
+TxId:       50c73affe93a1f4e8f5e9f69ad62cb825b91c5f226482c54627b5ec82126927c
+Fee:        Ada:      Lovelace:  15052
+Mint:       1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584077c969ee3299511e03ece294b5bf364a78a6...
+              Signature: 58403b2e21e7e9ba3842bf0686c88d96bb6e651b...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -370,39 +370,39 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
-  Value:
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
-  Source:
-    Tx:     33ad8a0a16bc318cbe3dfe5d4d4b131972f60707b56f246e4cad8300e751a964
-    Output #1
-
-
-  ---- Input 2 ----
-  Destination:  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Destination:  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     c0cf330ba0126822e1ee5900e99929982f23cc75e0ec60be5b3a548001c9e02c
+    Tx:     6313ad37d213389270cc9d3f2269444612d5d369a5f1f32ba3ebdc1ee0b3fb39
     Output #2
-    Script: 593b370100003323322333222333222333222332...
+    Script: 5926ac0100003323322333222333222323322323...
+
+  ---- Input 2 ----
+  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
+  Value:
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
+  Source:
+    Tx:     bb63552f20a96837a52a6aa617bca5260420cb0a56c828195548fc50c70e510c
+    Output #1
+
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99974094
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    0
+    Ada:      Lovelace:  99984951
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Destination:  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  5
 
@@ -410,8 +410,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99974063
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    0
+    Ada:      Lovelace:  99984920
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -435,8 +435,8 @@ Balances Carried Forward:
 
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99974094
-    6567e62712ab95170c37c61ccc0ccee6d22749f401a209e3ced24414:  guess:    1
+    Ada:      Lovelace:  99984951
+    1afb7ea74727462881e68db4bd463535755e14f41ffb41c7543e0329:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -450,6 +450,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 7ea37110168a489537a31b2c544e35eb3c102b9a407c69311f4624d6
+  Script: 092522599dba0231444b599491755b928b900ccd04f69a681f91d49c
   Value:
     Ada:      Lovelace:  5

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       00caa3dc25f69fca19484a0a31e0bb94831926011542b2365d1166e7c76ce01d
+TxId:       037ad447e93fead53a18bdea507ffe55bfb4dea260af376a8c38a270186c9e25
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840e219b6c415cf32ea0a3be49bd4dffe72bda4...
+              Signature: 5840ec0464a38e6c538f40487079bf3692aa89e9...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: 367a38e427a04ad12b7730aaa6560ac8ea72da9031c9cc19f73f225c
+  Destination:  Script: 035466b4c3ebbb36c2afc35e11ee5807e19083297588222ca752143b
   Value:
     Ada:      Lovelace:  60
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 367a38e427a04ad12b7730aaa6560ac8ea72da9031c9cc19f73f225c
+  Script: 035466b4c3ebbb36c2afc35e11ee5807e19083297588222ca752143b
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       fc76a892fcccd5df58790c5ad0ce8377f9ff1bb5f6ca8881f25fbc03a0f038d4
-Fee:        Ada:      Lovelace:  11959
+TxId:       6c68efc8c3a093ecae4f9676e6fd12bb2b02d7e6cb80a1b8cc3a79663cfe855f
+Fee:        Ada:      Lovelace:  7504
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840743f3586e9ed7c2458ace0def64fdf551c35...
+              Signature: 5840e09d52f7b56aebd93bbecb8c7da719377da6...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 367a38e427a04ad12b7730aaa6560ac8ea72da9031c9cc19f73f225c
+  Destination:  Script: 035466b4c3ebbb36c2afc35e11ee5807e19083297588222ca752143b
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     00caa3dc25f69fca19484a0a31e0bb94831926011542b2365d1166e7c76ce01d
+    Tx:     037ad447e93fead53a18bdea507ffe55bfb4dea260af376a8c38a270186c9e25
     Output #1
-    Script: 5925470100003323322333222323232323322323...
+    Script: 59172f0100003323322323233322233322233333...
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -204,10 +204,10 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99988051
+    Ada:      Lovelace:  99992506
 
   ---- Output 1 ----
-  Destination:  Script: 367a38e427a04ad12b7730aaa6560ac8ea72da9031c9cc19f73f225c
+  Destination:  Script: 035466b4c3ebbb36c2afc35e11ee5807e19083297588222ca752143b
   Value:
     Ada:      Lovelace:  50
 
@@ -215,7 +215,7 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99988051
+    Ada:      Lovelace:  99992506
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -253,6 +253,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 367a38e427a04ad12b7730aaa6560ac8ea72da9031c9cc19f73f225c
+  Script: 035466b4c3ebbb36c2afc35e11ee5807e19083297588222ca752143b
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
The recent changes to `IsData` introduced a much faster alternative to
`fromBuiltinData`, namely `unsafeFromBuiltinData`. It's also *much*
smaller. Or rather, `fromBuiltinData` is really very big!

However, both of these are typeclass methods of `IsData`, and so even if
we onyl use one of them, GHC can't prune away the others. It still
constructs the typeclass dictionary with all three. This doesn't cost us
much runtime but *does* cost us lots of space usage.

The simplest solution I could think of was just to split up `IsData`
into a class per function. This allows us to only use the constraints
that we really need, which cuts down on size a lot. In particular,
`wrapValidator` and friends only require an `UnsafeFromData` constraint.

There are still some places where we incur the other constraints, but
they're mostly off-chain. Main offenders are:
- `Oracle`: uses `fromBuiltinData` and returns a specific error if it
fails. It *might* be okay to use `unsafeFromBuiltinData` here, I'm not
sure.
- `StateMachine`: uses `toBuiltinData` to compare the expected state to
the new state. I'm not sure we can get away from this, unfortunately.

I *hope* that this will help with the Marlowe OOMs.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
