### PR TITLE
use-cases-scripts: Extract unapplied validators

### DIFF
--- a/nix/tests/vm-tests/web-ghc.nix
+++ b/nix/tests/vm-tests/web-ghc.nix
@@ -26,7 +26,7 @@ makeTest {
         enable = true;
         port = 80;
         web-ghc-package = web-ghc;
-        timeout = 180;
+        timeout = 360;
       };
     };
   testScript = ''

--- a/plutus-ledger/src/Ledger/Index.hs
+++ b/plutus-ledger/src/Ledger/Index.hs
@@ -399,16 +399,17 @@ mkIn TxIn{txInRef} = do
     txOut <- lkpTxOut txInRef
     pure $ Validation.TxInInfo{Validation.txInInfoOutRef = txInRef, Validation.txInInfoResolved=txOut}
 
-data ScriptType = ValidatorScript | MintingPolicyScript
+data ScriptType = ValidatorScript Validator Datum | MintingPolicyScript MintingPolicy
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
 -- | A script (MPS or validator) that was run during transaction validation
 data ScriptValidationEvent =
     ScriptValidationEvent
-        { sveScript :: Script -- ^ The script applied to all arguments
-        , sveResult :: Either ScriptError (Api.ExBudget, [String]) -- ^ Result of running the script: an error or the 'ExBudget' and trace logs
-        , sveType   :: ScriptType -- ^ What type of script it was
+        { sveScript   :: Script -- ^ The script applied to all arguments
+        , sveResult   :: Either ScriptError (Api.ExBudget, [String]) -- ^ Result of running the script: an error or the 'ExBudget' and trace logs
+        , sveRedeemer :: Redeemer
+        , sveType     :: ScriptType -- ^ What type of script it was
         }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
@@ -424,7 +425,8 @@ validatorScriptValidationEvent ctx validator datum redeemer result =
     ScriptValidationEvent
         { sveScript = applyValidator ctx validator datum redeemer
         , sveResult = result
-        , sveType = ValidatorScript
+        , sveRedeemer = redeemer
+        , sveType = ValidatorScript validator datum
         }
 
 mpsValidationEvent
@@ -437,5 +439,6 @@ mpsValidationEvent ctx mps red result =
     ScriptValidationEvent
         { sveScript = applyMintingPolicyScript ctx mps red
         , sveResult = result
-        , sveType = MintingPolicyScript
+        , sveRedeemer = red
+        , sveType = MintingPolicyScript mps
         }

--- a/plutus-use-cases/default.nix
+++ b/plutus-use-cases/default.nix
@@ -7,6 +7,7 @@ let
     mkdir -p $out/transactions
     ln -s ${haskell.packages.plutus-use-cases.src}/scripts/protocol-parameters.json protocol-parameters.json
     ${puc-scripts-invoker}/bin/plutus-use-cases-scripts $out/scripts scripts
+    ${puc-scripts-invoker}/bin/plutus-use-cases-scripts $out/scripts scripts -u
     # Mainnet address is used because no networkid is specified (with the '-n' flag)
     ${puc-scripts-invoker}/bin/plutus-use-cases-scripts $out/transactions transactions -p protocol-parameters.json
     tar zcf $out/all-outputs.tar.gz -C $out scripts transactions

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -28,7 +28,7 @@ import           Flat                           (flat)
 import           GHC.Generics                   (Generic)
 import qualified Ledger                         as Plutus
 import           Ledger.Constraints.OffChain    (UnbalancedTx (..))
-import           Ledger.Index                   (ScriptValidationEvent (..))
+import           Ledger.Index                   (ScriptType (..), ScriptValidationEvent (..))
 import           Options.Applicative
 import qualified Plutus.Contract.CardanoAPI     as CardanoAPI
 import qualified Plutus.Contracts.Crowdfunding  as Crowdfunding
@@ -57,13 +57,14 @@ import qualified Wallet.Emulator.Folds          as Folds
 import           Wallet.Emulator.Stream         (foldEmulatorStreamM)
 
 data Command =
-    Scripts
+    Scripts{ unappliedValidators :: ValidatorMode }
     | Transactions{ networkId :: C.NetworkId, protocolParamsJSON :: FilePath }
     deriving stock (Show, Eq)
 
 writeWhat :: Command -> String
-writeWhat Scripts        = "scripts"
-writeWhat Transactions{} = "transactions"
+writeWhat (Scripts FullyAppliedValidators) = "scripts (fully applied)"
+writeWhat (Scripts UnappliedValidators)    = "scripts (unapplied)"
+writeWhat Transactions{}                   = "transactions"
 
 pathParser :: Parser FilePath
 pathParser = strArgument (metavar "SCRIPT_PATH" <> help "output path")
@@ -83,7 +84,7 @@ scriptsParser :: Mod CommandFields Command
 scriptsParser =
     command "scripts" $
     info
-        (pure Scripts)
+        (Scripts <$> flag FullyAppliedValidators UnappliedValidators (long "unapplied-validators" <> short 'u' <> help "Write the unapplied validator scripts" <> showDefault))
         (fullDesc <> progDesc "Write fully applied validator scripts")
 
 transactionsParser :: Mod CommandFields Command
@@ -160,8 +161,8 @@ writeScriptsTo ScriptsConfig{scPath, scCommand} prefix trace emulatorCfg = do
 
     createDirectoryIfMissing True scPath
     case scCommand of
-        Scripts -> do
-            traverse_ (uncurry $ writeScript scPath prefix) (zip [1::Int ..] scriptEvents)
+        Scripts mode -> do
+            traverse_ (uncurry $ writeScript scPath prefix mode) (zip [1::Int ..] scriptEvents)
         Transactions{networkId, protocolParamsJSON} -> do
             bs <- BSL.readFile protocolParamsJSON
             case Aeson.eitherDecode bs of
@@ -174,11 +175,12 @@ writeScriptsTo ScriptsConfig{scPath, scCommand} prefix trace emulatorCfg = do
     just use unwrapped Flat because that's more convenient for use with the
     `plc` command, for example.
 -}
-writeScript :: FilePath -> String -> Int -> ScriptValidationEvent -> IO ()
-writeScript fp prefix idx ScriptValidationEvent{sveScript, sveResult} = do
-    let filename = fp </> prefix <> "-" <> show idx <> ".flat"
+writeScript :: FilePath -> String -> ValidatorMode -> Int -> ScriptValidationEvent -> IO ()
+writeScript fp prefix mode idx event@ScriptValidationEvent{sveResult} = do
+    let filename = fp </> prefix <> "-" <> show idx <> filenameSuffix mode <> ".flat"
     putStrLn $ "Writing script: " <> filename <> " (Cost: " <> either show (showBudget . fst) sveResult <> ")"
-    BSL.writeFile filename (BSL.fromStrict . flat . unScript $ sveScript)
+
+    BSL.writeFile filename (BSL.fromStrict . flat . unScript . getScript mode $ event)
     where
         showBudget (ExBudget exCPU exMemory) = show exCPU <> ", " <> show exMemory
 
@@ -235,3 +237,17 @@ mkLookups networkId = fmap (fmap $ uncurry ExportTxInput) . traverse (bitraverse
 
 mkSignatories :: Set Plutus.PubKeyHash -> Either CardanoAPI.ToCardanoError [C.Hash C.PaymentKey]
 mkSignatories = traverse CardanoAPI.toCardanoPaymentKeyHash . Set.toList
+
+data ValidatorMode = FullyAppliedValidators | UnappliedValidators
+    deriving (Eq, Ord, Show)
+
+getScript :: ValidatorMode -> ScriptValidationEvent -> Script
+getScript FullyAppliedValidators ScriptValidationEvent{sveScript} = sveScript
+getScript UnappliedValidators ScriptValidationEvent{sveType} =
+    case sveType of
+        ValidatorScript (Plutus.Validator script) _    -> script
+        MintingPolicyScript (Plutus.MintingPolicy mps) -> mps
+
+filenameSuffix :: ValidatorMode -> String
+filenameSuffix FullyAppliedValidators = ""
+filenameSuffix UnappliedValidators    = "-unapplied"


### PR DESCRIPTION
Add a flag `--unapplied-validators|-u` that, when set, causes the program to write out the unapplied validator scripts. If the flag is not set, fully applied validators are produced.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
