### PR TITLE
SCP-2569: Await tx status change

### DIFF
--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -36,8 +36,9 @@ import           Ledger.Typed.Tx                           (ConnectionError, Wro
 import           Ledger.Value                              (AssetClass, CurrencySymbol, TokenName, Value)
 import           Playground.Types                          (ContractCall, FunctionSchema, KnownCurrency)
 import           Plutus.Contract.Checkpoint                (CheckpointError)
-import           Plutus.Contract.Effects                   (ActiveEndpoint, BalanceTxResponse, PABReq, PABResp,
-                                                            UtxoAtAddress, WriteBalancedTxResponse)
+import           Plutus.Contract.Effects                   (ActiveEndpoint, BalanceTxResponse, Depth, PABReq, PABResp,
+                                                            TxStatus, TxValidity, UtxoAtAddress,
+                                                            WriteBalancedTxResponse)
 import           Plutus.Contract.Resumable                 (IterationID, Request, RequestID, Response)
 import           Plutus.Trace.Emulator.Types               (ContractInstanceLog, ContractInstanceMsg,
                                                             ContractInstanceTag, EmulatorRuntimeError, UserThreadMsg)
@@ -335,6 +336,9 @@ ledgerTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @UtxoAtAddress)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @ActiveEndpoint)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @UnbalancedTx)
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @TxValidity)
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @TxStatus)
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @Depth)
     ]
 
 walletTypes :: [SumType 'Haskell]

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     PABReq(..),
@@ -10,7 +11,7 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitTimeReq,
     _CurrentSlotReq,
     _CurrentTimeReq,
-    _AwaitTxConfirmedReq,
+    _AwaitTxStatusChangeReq,
     _OwnContractInstanceIdReq,
     _OwnPublicKeyReq,
     _UtxoAtReq,
@@ -23,7 +24,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _AwaitTimeResp,
     _CurrentSlotResp,
     _CurrentTimeResp,
-    _AwaitTxConfirmedResp,
+    _AwaitTxStatusChangeResp,
+    _AwaitTxStatusChangeResp',
     _OwnContractInstanceIdResp,
     _OwnPublicKeyResp,
     _UtxoAtResp,
@@ -40,23 +42,30 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     WriteBalancedTxResponse(..),
     writeBalancedTxResponse,
     ActiveEndpoint(..),
-    TxConfirmed(..)
+    TxValidity(..),
+    TxStatus(..),
+    Depth(..),
+    isConfirmed,
+    increaseDepth,
+    initialStatus
     ) where
 
-import           Control.Lens                (Iso', iso, makePrisms)
-import           Data.Aeson                  (FromJSON, ToJSON)
-import qualified Data.Aeson                  as JSON
-import qualified Data.Map                    as Map
-import           Data.Text.Prettyprint.Doc   (Pretty (..), colon, indent, viaShow, vsep, (<+>))
-import           GHC.Generics                (Generic)
-import           Ledger                      (Address, PubKey, Tx, TxId, TxOutTx (..), txId)
-import           Ledger.AddressMap           (UtxoMap)
-import           Ledger.Constraints.OffChain (UnbalancedTx)
-import           Ledger.Slot                 (Slot (..))
-import           Ledger.Time                 (POSIXTime (..))
-import           Wallet.API                  (WalletAPIError)
-import           Wallet.Types                (AddressChangeRequest, AddressChangeResponse, ContractInstanceId,
-                                              EndpointDescription, EndpointValue)
+import           Control.Lens                     (Iso', Prism', iso, makePrisms, prism')
+import           Data.Aeson                       (FromJSON, ToJSON)
+import qualified Data.Aeson                       as JSON
+import qualified Data.Map                         as Map
+import           Data.Text.Prettyprint.Doc        (Pretty (..), colon, indent, viaShow, vsep, (<+>))
+import           Data.Text.Prettyprint.Doc.Extras (PrettyShow (..))
+import           GHC.Generics                     (Generic)
+import           Ledger                           (Address, OnChainTx, PubKey, Tx, TxId, TxOutTx (..), eitherTx, txId)
+import           Ledger.AddressMap                (UtxoMap)
+import           Ledger.Constraints.OffChain      (UnbalancedTx)
+import           Ledger.Slot                      (Slot (..))
+import           Ledger.Time                      (POSIXTime (..))
+import           PlutusTx.Lattice                 (MeetSemiLattice (..))
+import           Wallet.API                       (WalletAPIError)
+import           Wallet.Types                     (AddressChangeRequest, AddressChangeResponse, ContractInstanceId,
+                                                   EndpointDescription, EndpointValue)
 
 -- | Requests that 'Contract's can make
 data PABReq =
@@ -64,7 +73,7 @@ data PABReq =
     | AwaitTimeReq POSIXTime
     | CurrentSlotReq
     | CurrentTimeReq
-    | AwaitTxConfirmedReq TxId
+    | AwaitTxStatusChangeReq TxId
     | OwnContractInstanceIdReq
     | OwnPublicKeyReq
     | UtxoAtReq Address
@@ -77,18 +86,18 @@ data PABReq =
 
 instance Pretty PABReq where
   pretty = \case
-    AwaitSlotReq s           -> "Await slot:" <+> pretty s
-    AwaitTimeReq s           -> "Await time:" <+> pretty s
-    CurrentSlotReq           -> "Current slot"
-    CurrentTimeReq           -> "Current time"
-    AwaitTxConfirmedReq txid -> "Await tx confirmed:" <+> pretty txid
-    OwnContractInstanceIdReq -> "Own contract instance ID"
-    OwnPublicKeyReq          -> "Own public key"
-    UtxoAtReq addr           -> "Utxo at:" <+> pretty addr
-    AddressChangeReq req     -> "Address change:" <+> pretty req
-    BalanceTxReq utx         -> "Balance tx:" <+> pretty utx
-    WriteBalancedTxReq tx    -> "Write balanced tx:" <+> pretty tx
-    ExposeEndpointReq ep     -> "Expose endpoint:" <+> pretty ep
+    AwaitSlotReq s              -> "Await slot:" <+> pretty s
+    AwaitTimeReq s              -> "Await time:" <+> pretty s
+    CurrentSlotReq              -> "Current slot"
+    CurrentTimeReq              -> "Current time"
+    AwaitTxStatusChangeReq txid -> "Await tx status change:" <+> pretty txid
+    OwnContractInstanceIdReq    -> "Own contract instance ID"
+    OwnPublicKeyReq             -> "Own public key"
+    UtxoAtReq addr              -> "Utxo at:" <+> pretty addr
+    AddressChangeReq req        -> "Address change:" <+> pretty req
+    BalanceTxReq utx            -> "Balance tx:" <+> pretty utx
+    WriteBalancedTxReq tx       -> "Write balanced tx:" <+> pretty tx
+    ExposeEndpointReq ep        -> "Expose endpoint:" <+> pretty ep
 
 -- | Responses that 'Contract's receive
 data PABResp =
@@ -96,7 +105,7 @@ data PABResp =
     | AwaitTimeResp POSIXTime
     | CurrentSlotResp Slot
     | CurrentTimeResp POSIXTime
-    | AwaitTxConfirmedResp TxId
+    | AwaitTxStatusChangeResp TxId TxStatus
     | OwnContractInstanceIdResp ContractInstanceId
     | OwnPublicKeyResp PubKey
     | UtxoAtResp UtxoAtAddress
@@ -110,18 +119,18 @@ data PABResp =
 
 instance Pretty PABResp where
   pretty = \case
-    AwaitSlotResp s             -> "Slot:" <+> pretty s
-    AwaitTimeResp s             -> "Time:" <+> pretty s
-    CurrentSlotResp s           -> "Current slot:" <+> pretty s
-    CurrentTimeResp s           -> "Current time:" <+> pretty s
-    AwaitTxConfirmedResp txid   -> "Tx confirmed:" <+> pretty txid
-    OwnContractInstanceIdResp i -> "Own contract instance ID:" <+> pretty i
-    OwnPublicKeyResp k          -> "Own public key:" <+> pretty k
-    UtxoAtResp rsp              -> "Utxo at:" <+> pretty rsp
-    AddressChangeResp rsp       -> "Address change:" <+> pretty rsp
-    BalanceTxResp r             -> "Balance tx:" <+> pretty r
-    WriteBalancedTxResp r       -> "Write balanced tx:" <+> pretty r
-    ExposeEndpointResp desc rsp -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
+    AwaitSlotResp s                     -> "Slot:" <+> pretty s
+    AwaitTimeResp s                     -> "Time:" <+> pretty s
+    CurrentSlotResp s                   -> "Current slot:" <+> pretty s
+    CurrentTimeResp s                   -> "Current time:" <+> pretty s
+    AwaitTxStatusChangeResp txid status -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
+    OwnContractInstanceIdResp i         -> "Own contract instance ID:" <+> pretty i
+    OwnPublicKeyResp k                  -> "Own public key:" <+> pretty k
+    UtxoAtResp rsp                      -> "Utxo at:" <+> pretty rsp
+    AddressChangeResp rsp               -> "Address change:" <+> pretty rsp
+    BalanceTxResp r                     -> "Balance tx:" <+> pretty r
+    WriteBalancedTxResp r               -> "Write balanced tx:" <+> pretty r
+    ExposeEndpointResp desc rsp         -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
 
 matches :: PABReq -> PABResp -> Bool
 matches a b = case (a, b) of
@@ -129,7 +138,7 @@ matches a b = case (a, b) of
   (AwaitTimeReq{}, AwaitTimeResp{})                       -> True
   (CurrentSlotReq, CurrentSlotResp{})                     -> True
   (CurrentTimeReq, CurrentTimeResp{})                     -> True
-  (AwaitTxConfirmedReq{}, AwaitTxConfirmedResp{})         -> True
+  (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _)         -> i == i'
   (OwnContractInstanceIdReq, OwnContractInstanceIdResp{}) -> True
   (OwnPublicKeyReq, OwnPublicKeyResp{})                   -> True
   (UtxoAtReq{}, UtxoAtResp{})                             -> True
@@ -156,6 +165,80 @@ instance Pretty UtxoAtAddress where
       utxos = vsep $ fmap prettyTxOutPair (Map.toList utxo)
     in vsep ["Utxo at" <+> pretty address <+> "=", indent 2 utxos]
 
+-- | Validity of a transaction that has been added to the ledger
+data TxValidity = TxValid | TxInvalid | UnknownValidity
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+  deriving Pretty via (PrettyShow TxValidity)
+
+instance MeetSemiLattice TxValidity where
+  TxValid /\ TxValid     = TxValid
+  TxInvalid /\ TxInvalid = TxInvalid
+  _ /\ _                 = UnknownValidity
+
+{- Note [TxStatus state machine]
+
+The status of a transaction is described by the following state machine.
+
+Current state | Next state(s)
+-----------------------------------------------------
+Unknown       | OnChain
+OnChain       | OnChain, Unknown, Committed
+Committed     | -
+
+The initial state after submitting the transaction is Unknown.
+
+-}
+
+-- | How many blocks deep the tx is on the chain
+newtype Depth = Depth Int
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (Num, Real, Enum, Integral, Pretty, ToJSON, FromJSON)
+
+instance MeetSemiLattice Depth where
+  Depth a /\ Depth b = Depth (max a b)
+
+-- | The status of a Cardano transaction
+data TxStatus =
+  Unknown -- ^ The transaction is not on the chain. That's all we can say.
+  | TentativelyConfirmed Depth TxValidity -- ^ The transaction is on the chain, n blocks deep. It can still be rolled back.
+  | Committed TxValidity -- ^ The transaction is on the chain. It cannot be rolled back anymore.
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+  deriving Pretty via (PrettyShow TxStatus)
+
+instance MeetSemiLattice TxStatus where
+  Unknown /\ a                                             = a
+  a /\ Unknown                                             = a
+  TentativelyConfirmed d1 v1 /\ TentativelyConfirmed d2 v2 = TentativelyConfirmed (d1 /\ d2) (v1 /\ v2)
+  TentativelyConfirmed _ v1 /\ Committed v2                = Committed (v1 /\ v2)
+  Committed v1 /\ TentativelyConfirmed _ v2                = Committed (v1 /\ v2)
+  Committed v1 /\ Committed v2                             = Committed (v1 /\ v2)
+
+-- | The 'TxStatus' of a transaction right after it was added to the chain
+initialStatus :: OnChainTx -> TxStatus
+initialStatus =
+  TentativelyConfirmed 0 . eitherTx (const TxInvalid) (const TxValid)
+
+-- | Whether a 'TxStatus' counts as confirmed given the minimum depth
+isConfirmed :: Depth -> TxStatus -> Bool
+isConfirmed minDepth = \case
+    TentativelyConfirmed d _ | d >= minDepth -> True
+    Committed{}                              -> True
+    _                                        -> False
+
+-- | Increase the depth of a tentatively confirmed transaction
+increaseDepth :: TxStatus -> TxStatus
+increaseDepth (TentativelyConfirmed d s)
+  | d < succ chainConstant = TentativelyConfirmed (d + 1) s
+  | otherwise              = Committed s
+increaseDepth e                        = e
+
+-- TODO: Configurable!
+-- | The depth (in blocks) after which a transaction cannot be rolled back anymore
+chainConstant :: Depth
+chainConstant = Depth 8
+
 data BalanceTxResponse =
   BalanceTxFailed WalletAPIError
   | BalanceTxSuccess Tx
@@ -166,6 +249,12 @@ instance Pretty BalanceTxResponse where
   pretty = \case
     BalanceTxFailed e  -> "BalanceTxFailed:" <+> pretty e
     BalanceTxSuccess i -> "BalanceTxSuccess:" <+> pretty (txId i)
+
+_AwaitTxStatusChangeResp' :: TxId -> Prism' PABResp TxStatus
+_AwaitTxStatusChangeResp' i =
+  prism'
+    (AwaitTxStatusChangeResp i)
+    (\case { AwaitTxStatusChangeResp i' s | i == i' -> Just s; _ -> Nothing })
 
 balanceTxResponse :: Iso' BalanceTxResponse (Either WalletAPIError Tx)
 balanceTxResponse = iso f g where
@@ -201,12 +290,6 @@ instance Pretty ActiveEndpoint where
       [ "Endpoint:" <+> pretty aeDescription
       , "Metadata:" <+> viaShow aeMetadata
       ]
-
-newtype TxConfirmed =
-    TxConfirmed { unTxConfirmed :: TxId }
-        deriving stock (Eq, Ord, Generic, Show)
-        deriving anyclass (ToJSON, FromJSON)
-        deriving Pretty via TxId
 
 makePrisms ''PABReq
 

--- a/plutus-contract/src/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace.hs
@@ -33,7 +33,6 @@ module Plutus.Contract.Trace
     , handleUnbalancedTransactions
     , handlePendingTransactions
     , handleUtxoQueries
-    , handleTxConfirmedQueries
     , handleAddressChangedAtQueries
     , handleOwnInstanceIdQueries
     -- * Initial distributions of emulated chains
@@ -142,7 +141,6 @@ handleBlockchainQueries =
     handleUnbalancedTransactions
     <> handlePendingTransactions
     <> handleUtxoQueries
-    <> handleTxConfirmedQueries
     <> handleOwnPubKeyQueries
     <> handleAddressChangedAtQueries
     <> handleOwnInstanceIdQueries
@@ -189,14 +187,6 @@ handleUtxoQueries ::
     => RequestHandler effs PABReq PABResp
 handleUtxoQueries =
     generalise (preview E._UtxoAtReq) E.UtxoAtResp RequestHandler.handleUtxoQueries
-
-handleTxConfirmedQueries ::
-    ( Member (LogObserve (LogMessage Text)) effs
-    , Member ChainIndexEffect effs
-    )
-    => RequestHandler effs PABReq PABResp
-handleTxConfirmedQueries =
-    generalise (preview E._AwaitTxConfirmedReq) (E.AwaitTxConfirmedResp . E.unTxConfirmed) RequestHandler.handleTxConfirmedQueries
 
 handleAddressChangedAtQueries ::
     ( Member (LogObserve (LogMessage Text)) effs

--- a/plutus-contract/src/Wallet/Effects.hs
+++ b/plutus-contract/src/Wallet/Effects.hs
@@ -30,12 +30,11 @@ module Wallet.Effects(
     , startWatching
     , watchedAddresses
     , confirmedBlocks
-    , transactionConfirmed
     , addressChanged
     ) where
 
 import           Control.Monad.Freer.TH      (makeEffect)
-import           Ledger                      (Address, Block, PubKey, Slot, Tx, TxId, Value)
+import           Ledger                      (Address, Block, PubKey, Slot, Tx, Value)
 import           Ledger.AddressMap           (AddressMap)
 import           Ledger.Constraints.OffChain (UnbalancedTx)
 import           Wallet.Emulator.Error       (WalletAPIError)
@@ -63,8 +62,6 @@ data ChainIndexEffect r where
     StartWatching :: Address -> ChainIndexEffect ()
     WatchedAddresses :: ChainIndexEffect AddressMap
     ConfirmedBlocks :: ChainIndexEffect [Block]
-    -- TODO: In the future we should have degrees of confirmation
-    TransactionConfirmed :: TxId -> ChainIndexEffect Bool
     AddressChanged :: AddressChangeRequest -> ChainIndexEffect AddressChangeResponse
 makeEffect ''ChainIndexEffect
 

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
@@ -108,8 +108,6 @@ handleChainIndex = interpret $ \case
         s & idxWatchedAddresses %~ AM.addAddress addr)
     WatchedAddresses -> gets _idxWatchedAddresses
     ConfirmedBlocks -> gets _idxConfirmedBlocks
-    TransactionConfirmed txid ->
-        Map.member txid <$> gets _idxConfirmedTransactions
     AddressChanged r@AddressChangeRequest{acreqAddress} -> do
         idx <- gets _idxIdx
         let itms = Index.transactionsAt idx (slotRange r) acreqAddress

--- a/plutus-pab-client/src/View/Pretty.purs
+++ b/plutus-pab-client/src/View/Pretty.purs
@@ -70,11 +70,13 @@ instance prettyPABResp :: Pretty PABResp where
       , nbsp
       , text $ show time
       ]
-  pretty (AwaitTxConfirmedResp txConfirmed) =
+  pretty (AwaitTxStatusChangeResp txConfirmed txStatus) =
     span_
-      [ text "AwaitTxConfirmedResponse:"
+      [ text "AwaitTxStatusChangeResponse:"
       , nbsp
       , text $ view _txId txConfirmed
+      , nbsp
+      , text $ show txStatus
       ]
   pretty (ExposeEndpointResp endpointDescription endpointValue) =
     span_
@@ -142,9 +144,9 @@ instance prettyContractPABRequest :: Pretty PABReq where
     span_
       [ text "CurrentTimeRequest"
       ]
-  pretty (AwaitTxConfirmedReq txId) =
+  pretty (AwaitTxStatusChangeReq txId) =
     span_
-      [ text "AwaitTxConfirmedRequest:"
+      [ text "AwaitTxStatusChangeReq:"
       , nbsp
       , text $ view _txId txId
       ]

--- a/plutus-pab/src/Cardano/ChainIndex/API.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/API.hs
@@ -3,7 +3,7 @@
 
 module Cardano.ChainIndex.API where
 
-import           Ledger            (Address, TxId)
+import           Ledger            (Address)
 import           Ledger.AddressMap (AddressMap)
 import           Ledger.Blockchain (Block)
 import           Servant.API       (Get, JSON, NoContent, Post, ReqBody, (:<|>), (:>))
@@ -14,5 +14,4 @@ type API
      :<|> "start-watching" :> ReqBody '[ JSON] Address :> Post '[ JSON] NoContent
      :<|> "watched-addresses" :> Get '[ JSON] AddressMap
      :<|> "confirmed-blocks" :> Get '[ JSON] [Block]
-     :<|> "transaction-confirmed" :> ReqBody '[ JSON] TxId :> Post '[ JSON] Bool
      :<|> "next-tx" :> ReqBody '[ JSON] AddressChangeRequest :> Post '[ JSON] AddressChangeResponse

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -48,7 +48,7 @@ app trace stateVar =
     hoistServer
         (Proxy @API)
         (liftIO . processIndexEffects trace stateVar)
-        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.addressChanged)
+        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.addressChanged)
 
 main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> SlotConfig -> Availability -> IO ()
 main trace ChainIndexConfig{ciBaseUrl} socketPath slotConfig availability = runLogEffects trace $ do

--- a/plutus-pab/src/Plutus/PAB/Arbitrary.hs
+++ b/plutus-pab/src/Plutus/PAB/Arbitrary.hs
@@ -173,7 +173,6 @@ instance Arbitrary PABReq where
         oneof
             [ AwaitSlotReq <$> arbitrary
             , pure CurrentSlotReq
-            , AwaitTxConfirmedReq <$> arbitrary
             , pure OwnContractInstanceIdReq
             , ExposeEndpointReq <$> arbitrary
             , UtxoAtReq <$> arbitrary
@@ -215,8 +214,7 @@ instance Arbitrary ActiveEndpoint where
 -- 'Maybe' because we can't (yet) create a generator for every request
 -- type.
 genResponse :: PABReq -> Maybe (Gen PABResp)
-genResponse (AwaitSlotReq slot)        = Just . pure . AwaitSlotResp $ slot
-genResponse (AwaitTxConfirmedReq txId) = Just . pure . AwaitTxConfirmedResp $ txId
-genResponse (ExposeEndpointReq _)      = Just $ ExposeEndpointResp <$> arbitrary <*> (EndpointValue <$> arbitrary)
-genResponse OwnPublicKeyReq            = Just $ OwnPublicKeyResp <$> arbitrary
-genResponse _                          = Nothing
+genResponse (AwaitSlotReq slot)   = Just . pure . AwaitSlotResp $ slot
+genResponse (ExposeEndpointReq _) = Just $ ExposeEndpointResp <$> arbitrary <*> (EndpointValue <$> arbitrary)
+genResponse OwnPublicKeyReq       = Just $ OwnPublicKeyResp <$> arbitrary
+genResponse _                     = Nothing

--- a/plutus-pab/src/Plutus/PAB/Core.hs
+++ b/plutus-pab/src/Plutus/PAB/Core.hs
@@ -56,7 +56,7 @@ module Plutus.PAB.Core
     , instanceState
     , observableState
     , waitForState
-    , waitForTxConfirmed
+    , waitForTxStatusChange
     , activeEndpoints
     , waitForEndpoint
     , currentSlot
@@ -103,7 +103,7 @@ import           Data.Text                               (Text)
 import           Ledger.Tx                               (Address, Tx)
 import           Ledger.TxId                             (TxId)
 import           Ledger.Value                            (Value)
-import           Plutus.Contract.Effects                 (ActiveEndpoint (..), PABReq, TxConfirmed)
+import           Plutus.Contract.Effects                 (ActiveEndpoint (..), PABReq, TxStatus (Unknown))
 import           Plutus.PAB.Core.ContractInstance        (ContractInstanceMsg, ContractInstanceState)
 import qualified Plutus.PAB.Core.ContractInstance        as ContractInstance
 import           Plutus.PAB.Core.ContractInstance.STM    (Activity (Active), BlockchainEnv, InstancesState,
@@ -466,10 +466,10 @@ waitForState extract instanceId = do
         maybe STM.retry pure (extract state)
 
 -- | Wait for the transaction to be confirmed on the blockchain.
-waitForTxConfirmed :: forall t env. TxId -> PABAction t env TxConfirmed
-waitForTxConfirmed t = do
+waitForTxStatusChange :: forall t env. TxId -> PABAction t env TxStatus
+waitForTxStatusChange t = do
     env <- asks @(PABEnvironment t env) blockchainEnv
-    liftIO $ STM.atomically $ Instances.waitForTxConfirmed t env
+    liftIO $ STM.atomically $ Instances.waitForTxStatusChange Unknown t env
 
 -- | The list of endpoints that are currently open
 activeEndpoints :: forall t env. ContractInstanceId -> PABAction t env (STM [OpenEndpoint])

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -15,14 +15,14 @@ import qualified Cardano.Protocol.Socket.Mock.Client  as Client
 import           Ledger                               (Address, Block, OnChainTx, Slot, TxId, eitherTx, txId)
 import           Ledger.AddressMap                    (AddressMap)
 import qualified Ledger.AddressMap                    as AddressMap
-import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstancesState, TxStatus (..),
-                                                       emptyBlockchainEnv)
+import           Plutus.Contract.Effects              (TxStatus (..), increaseDepth, initialStatus)
+import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstancesState, emptyBlockchainEnv)
 import qualified Plutus.PAB.Core.ContractInstance.STM as S
 
 import           Control.Concurrent.STM               (STM)
 import qualified Control.Concurrent.STM               as STM
 import           Control.Lens
-import           Control.Monad                        (unless, when)
+import           Control.Monad                        (foldM, forM_, unless, when)
 import           Data.Foldable                        (foldl')
 import           Data.Map                             (Map)
 import           Data.Set                             (Set)
@@ -56,25 +56,32 @@ getClientEnv instancesState =
 --   when any interesting addresses or transactions have changed.
 processBlock :: BlockchainEnv -> Block -> Slot -> STM ()
 processBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} transactions slot = do
+  changes <- STM.readTVar beTxChanges
+  forM_ changes $ \tv -> STM.modifyTVar tv increaseDepth
   lastSlot <- STM.readTVar beCurrentSlot
   when (slot > lastSlot) $ do
-    STM.modifyTVar beTxChanges (fmap S.increaseDepth)
     STM.writeTVar beCurrentSlot slot
   unless (null transactions) $ do
     addressMap <- STM.readTVar beAddressMap
     chainIndex <- STM.readTVar beTxIndex
-    txStatusMap <- STM.readTVar beTxChanges
-    let (addressMap', txStatusMap', chainIndex') = foldl' (processTx slot) (addressMap, txStatusMap, chainIndex) transactions
+    let (addressMap', chainIndex') = foldl' (processTx slot) (addressMap, chainIndex) transactions
     STM.writeTVar beAddressMap addressMap'
-    STM.writeTVar beTxChanges txStatusMap'
     STM.writeTVar beTxIndex chainIndex'
 
+    txStatusMap <- STM.readTVar beTxChanges
+    txStatusMap' <- foldM insertNewTx txStatusMap transactions
+    STM.writeTVar beTxChanges txStatusMap'
 
-processTx :: Slot -> (AddressMap, Map TxId TxStatus, ChainIndex) -> OnChainTx -> (AddressMap, Map TxId TxStatus, ChainIndex)
-processTx currentSlot (addressMap, txStatusMap, chainIndex) tx = (addressMap', txStatusMap', chainIndex') where
+insertNewTx :: Map TxId (STM.TVar TxStatus) -> OnChainTx -> STM (Map TxId (STM.TVar TxStatus))
+insertNewTx mp tx = do
+  tv <- STM.newTVar (initialStatus tx)
+  let tid = eitherTx txId txId tx
+  pure $ mp & at tid ?~ tv
+
+processTx :: Slot -> (AddressMap, ChainIndex) -> OnChainTx -> (AddressMap, ChainIndex)
+processTx currentSlot (addressMap, chainIndex) tx = (addressMap', chainIndex') where
   tid = eitherTx txId txId tx
   addressMap' = AddressMap.updateAllAddresses tx addressMap
   chainIndex' =
     let itm = ChainIndexItem{ciSlot = currentSlot, ciTx = tx, ciTxId = tid } in
     Index.insert addressMap' itm chainIndex
-  txStatusMap' = txStatusMap & at tid .~ Just (TentativelyConfirmed 0)

--- a/plutus-pab/src/Plutus/PAB/Run/PSGenerator.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/PSGenerator.hs
@@ -36,7 +36,6 @@ import           Language.PureScript.Bridge.CodeGenSwitches (ForeignOptions (For
 import           Language.PureScript.Bridge.TypeParameters  (A)
 import qualified PSGenerator.Common
 import           Plutus.Contract.Checkpoint                 (CheckpointKey, CheckpointStore, CheckpointStoreItem)
-import           Plutus.Contract.Effects                    (TxConfirmed)
 import           Plutus.Contract.Resumable                  (Responses)
 import           Plutus.PAB.Effects.Contract.Builtin        (Builtin)
 import           Plutus.PAB.Events.ContractInstanceState    (PartiallyDecodedResponse)
@@ -104,7 +103,6 @@ pabTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(PartiallyDecodedResponse A))
 
     -- Contract request / response types
-    , (equal <*> (genericShow <*> mkSumType)) (Proxy @TxConfirmed)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @CheckpointStore)
     , (order <*> (genericShow <*> mkSumType)) (Proxy @CheckpointKey)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(CheckpointStoreItem A))


### PR DESCRIPTION
Change "awaitTxConfirmed" to "awaitTxStatusChange". The `TxStatus` type reflects the different degrees of confirmation that transactions can have.

* When handling `AwaitTxStatusChangeReq` in the emulator, we previously queried the chain index every time to see if the transaction had been added to it. I changed `Plutus.Trace.Emulator.ContractInstance.runInstance` to "push" notifications about new blocks to the threads instead. This is much closer to the way `AwaitTxStatusChangeReq` is handled in the PAB, and it allows us to get rid of one of the constructors of the old chain index effect.
  * The emulator still doesn't support rollbacks, so all transactions are immediately committed.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
