### PR TITLE
PAB fixes

### DIFF
--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -36,7 +36,7 @@
       fcConstantFee:
         getLovelace: 10 # Constant fee per transaction in lovelace
       fcScriptsFeeFactor: 1.0 # Factor by which to multiply the size-dependent scripts fee in lovelace
-    mscNetworkId = "" # Empty string for Mainnet. Put a network magic number in the string to use the Testnet.
+    mscNetworkId: "" # Empty string for Mainnet. Put a network magic number in the string to use the Testnet.
     mscKeptBlocks: 100000
     mscInitialTxWallets:
       - getWallet: 1

--- a/plutus-pab-client/pab-demo-scripts.nix
+++ b/plutus-pab-client/pab-demo-scripts.nix
@@ -99,6 +99,7 @@ let
     echo "PAB database path: $DB_PATH"
     cat $CFG_PATH
     echo "-----------------------------------------------------------------------------"
+    ${pab-exes.plutus-pab-examples}/bin/plutus-pab-examples --config=$CFG_PATH ${cmd}
   '';
 
   start-all-servers = runWithContracts (mkSetup primary-config) "all-servers";

--- a/plutus-pab-client/package.json
+++ b/plutus-pab-client/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "webpack": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack --progress --bail --mode=production -p",
     "webpack:watch": "PATH=$PATH:../releases/psc-package DEBUG=purs-loader* DEBUG_DEPTH=100 webpack --progress --display-error-details --display verbose --watch",
-    "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development",
+    "webpack:server": "webpack-dev-server --progress --inline --hot --mode=development --host 0.0.0.0",
     "webpack:server:debug": "DEBUG=purs-loader* DEBUG_DEPTH=100 webpack-dev-server --progress --inline --hot",
     "purs:compile": "spago build",
     "purs:ide": "purs ide server --log-level=debug 'src/**/*.purs' 'generated/**/*.purs' 'test/**/*.purs' 'web-common/**/*.purs'",

--- a/plutus-pab-client/src/MonadApp.purs
+++ b/plutus-pab-client/src/MonadApp.purs
@@ -18,7 +18,6 @@ import Effect.Console as Console
 import Halogen (HalogenM, liftEffect, raise)
 import Network.RemoteData as RemoteData
 import Playground.Lenses (_getEndpointDescription)
-import Plutus.PAB.Effects.Contract.Builtin (Builtin)
 import Plutus.PAB.Webserver (SPParams_, getApiContractByContractinstanceidSchema, getApiFullreport, postApiContractActivate, postApiContractByContractinstanceidEndpointByEndpointname)
 import Plutus.PAB.Webserver.Types (ContractSignatureResponse, FullReport, CombinedWSStreamToServer)
 import Servant.PureScript.Ajax (AjaxError)
@@ -28,10 +27,10 @@ import ContractExample (ExampleContracts)
 
 class
   Monad m <= MonadApp m where
-  getFullReport :: m (WebData (FullReport (Builtin ExampleContracts)))
-  getContractSignature :: ContractInstanceId -> m (WebData (ContractSignatureResponse (Builtin ExampleContracts)))
+  getFullReport :: m (WebData (FullReport ExampleContracts))
+  getContractSignature :: ContractInstanceId -> m (WebData (ContractSignatureResponse ExampleContracts))
   invokeEndpoint :: RawJson -> ContractInstanceId -> EndpointDescription -> m (WebData (Maybe NotificationError))
-  activateContract :: Builtin ExampleContracts -> m Unit
+  activateContract :: ExampleContracts -> m Unit
   sendWebSocketMessage :: CombinedWSStreamToServer -> m Unit
   log :: String -> m Unit
 

--- a/plutus-pab-client/src/Types.purs
+++ b/plutus-pab-client/src/Types.purs
@@ -31,7 +31,6 @@ import Network.StreamData (StreamData)
 import Network.StreamData as Stream
 import Playground.Types (FunctionSchema)
 import Plutus.Contract.Effects (PABReq, ActiveEndpoint, _ExposeEndpointReq)
-import Plutus.PAB.Effects.Contract.Builtin (Builtin)
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
 import Plutus.PAB.Webserver.Types (ChainReport, ContractReport, ContractSignatureResponse, _ChainReport, _ContractReport, _ContractSignatureResponse, CombinedWSStreamToClient, CombinedWSStreamToServer)
 import Schema (FormSchema)
@@ -67,7 +66,7 @@ data HAction a
   = Init
   | ChangeView View
   | LoadFullReport
-  | ActivateContract (Builtin a)
+  | ActivateContract a
   | ChainAction Chain.Action
   | ClipboardAction Clipboard.Action
   | ChangeContractEndpointCall ContractInstanceId Int FormEvent
@@ -78,14 +77,14 @@ type ContractStates
 
 newtype ContractSignatures a
   = ContractSignatures
-  { unContractSignatures :: Array (ContractSignatureResponse (Builtin a))
+  { unContractSignatures :: Array (ContractSignatureResponse a)
   }
 
 derive instance genericContractSignatures :: Generic (ContractSignatures a) _
 
 derive instance newtypeContractSignatures :: Newtype (ContractSignatures a) _
 
-_ContractSignatures :: forall a. Iso' (ContractSignatures a) { unContractSignatures :: Array (ContractSignatureResponse (Builtin a)) }
+_ContractSignatures :: forall a. Iso' (ContractSignatures a) { unContractSignatures :: Array (ContractSignatureResponse a) }
 _ContractSignatures = _Newtype
 
 data WebSocketStatus
@@ -172,7 +171,7 @@ _crActiveContractStates = _ContractReport <<< prop (SProxy :: SProxy "crActiveCo
 _csrDefinition :: forall t. Lens' (ContractSignatureResponse t) t
 _csrDefinition = _ContractSignatureResponse <<< prop (SProxy :: SProxy "csrDefinition")
 
-_unContractSignatures :: forall t. Lens' (ContractSignatures t) (Array (ContractSignatureResponse (Builtin t)))
+_unContractSignatures :: forall t. Lens' (ContractSignatures t) (Array (ContractSignatureResponse t))
 _unContractSignatures = _ContractSignatures <<< prop (SProxy :: SProxy "unContractSignatures")
 
 -- _csContract :: forall t. Lens' (ContractInstanceState t) ContractInstanceId

--- a/plutus-pab-client/src/View/Contracts.purs
+++ b/plutus-pab-client/src/View/Contracts.purs
@@ -21,7 +21,6 @@ import Icons (Icon(..), icon)
 import Network.StreamData as Stream
 import Playground.Lenses (_endpointDescription, _getEndpointDescription, _schema)
 import Playground.Types (_FunctionSchema)
-import Plutus.PAB.Effects.Contract.Builtin (Builtin)
 import Plutus.Contract.Effects (PABReq)
 import Plutus.PAB.Events.ContractInstanceState (PartiallyDecodedResponse)
 import Schema.Types (FormEvent)
@@ -36,7 +35,7 @@ installedContractsPane ::
   forall p a.
   Show a =>
   Boolean ->
-  Array (Builtin a) ->
+  Array a ->
   HTML p (HAction a)
 installedContractsPane buttonsDisabled installedContracts =
   card_
@@ -55,7 +54,7 @@ installedContractPane ::
   forall p a.
   Show a =>
   Boolean ->
-  Builtin a ->
+  a ->
   HTML p (HAction a)
 installedContractPane buttonsDisabled installedContract =
   row_

--- a/plutus-pab/src/Plutus/PAB/Effects/Contract/Builtin.hs
+++ b/plutus-pab/src/Plutus/PAB/Effects/Contract/Builtin.hs
@@ -151,7 +151,7 @@ fromResponse cid (SomeBuiltin contract) ContractResponse{newState=State{record}}
   let runUpdate (SomeBuiltinState oldS oldW) n = do
         case fromJSON (rspResponse (snd <$> n)) of
           Error e      -> throwError . OtherError $ "Couldn't decode JSON response when reconstruting state: " <> Text.pack e
-          Success resp -> updateBuiltin @effs @a cid oldS oldW resp
+          Success resp -> updateBuiltin @effs @a cid oldS oldW (resp <$ n)
 
   foldlM runUpdate initialState (responses record)
 

--- a/plutus-pab/src/Plutus/PAB/Run/PSGenerator.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/PSGenerator.hs
@@ -38,6 +38,7 @@ import qualified PSGenerator.Common
 import           Plutus.Contract.Checkpoint                 (CheckpointKey, CheckpointStore, CheckpointStoreItem)
 import           Plutus.Contract.Effects                    (TxConfirmed)
 import           Plutus.Contract.Resumable                  (Responses)
+import qualified Plutus.PAB.Effects.Contract                as Contract
 import           Plutus.PAB.Effects.Contract.Builtin        (Builtin)
 import           Plutus.PAB.Events.ContractInstanceState    (PartiallyDecodedResponse)
 import qualified Plutus.PAB.Webserver.API                   as API
@@ -150,8 +151,8 @@ generateAPIModule _ outputDir = do
         mySettings
         outputDir
         pabBridgeProxy
-        (    Proxy @(API.API (Builtin a)
-        :<|> API.NewAPI (Builtin a) Text.Text
+        (    Proxy @(API.API (Contract.ContractDef (Builtin a))
+        :<|> API.NewAPI (Contract.ContractDef (Builtin a)) Text.Text
         :<|> API.WalletProxy Text.Text)
         )
 


### PR DESCRIPTION
Issues I ran into while working on reinstating the pab client contract pane.


- Fix response decoding when retrieving from contract store this was originally trying to decode a `PABResp` into a `Response PABResp`. This was a tricky one to track 
- Fix type of the generated pab api client to match with the backend handlers
- Fix demo scripts
- set the devolopment host in webpack to 0.0.0.0

Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
