### PR TITLE
Add dumping flat pir

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -257,6 +257,7 @@
           "PlutusIR"
           "PlutusIR/Core"
           "PlutusIR/Core/Instance"
+          "PlutusIR/Core/Instance/Flat"
           "PlutusIR/Core/Instance/Pretty"
           "PlutusIR/Core/Instance/Scoping"
           "PlutusIR/Core/Plated"
@@ -362,6 +363,20 @@
           modules = [ "Common" "Parsers" ];
           hsSourceDirs = [ "executables" ];
           mainPath = [ "uplc/Main.hs" ];
+          };
+        "pir" = {
+          depends = [
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "executables" ];
+          mainPath = [ "pir/Main.hs" ];
           };
         };
       tests = {

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1337,6 +1337,7 @@
           "cardano-crypto-wrapper".components.library.planned = lib.mkOverride 900 true;
           "ansi-terminal".components.library.planned = lib.mkOverride 900 true;
           "typed-protocols".components.library.planned = lib.mkOverride 900 true;
+          "plutus-core".components.exes."pir".planned = lib.mkOverride 900 true;
           "Stream".components.library.planned = lib.mkOverride 900 true;
           "wai-websockets".components.library.planned = lib.mkOverride 900 true;
           "cardano-api".components.sublibs."gen".planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -257,6 +257,7 @@
           "PlutusIR"
           "PlutusIR/Core"
           "PlutusIR/Core/Instance"
+          "PlutusIR/Core/Instance/Flat"
           "PlutusIR/Core/Instance/Pretty"
           "PlutusIR/Core/Instance/Scoping"
           "PlutusIR/Core/Plated"
@@ -362,6 +363,20 @@
           modules = [ "Common" "Parsers" ];
           hsSourceDirs = [ "executables" ];
           mainPath = [ "uplc/Main.hs" ];
+          };
+        "pir" = {
+          depends = [
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "executables" ];
+          mainPath = [ "pir/Main.hs" ];
           };
         };
       tests = {

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1346,6 +1346,7 @@
           "cardano-crypto-wrapper".components.library.planned = lib.mkOverride 900 true;
           "ansi-terminal".components.library.planned = lib.mkOverride 900 true;
           "typed-protocols".components.library.planned = lib.mkOverride 900 true;
+          "plutus-core".components.exes."pir".planned = lib.mkOverride 900 true;
           "Stream".components.library.planned = lib.mkOverride 900 true;
           "wai-websockets".components.library.planned = lib.mkOverride 900 true;
           "cardano-api".components.sublibs."gen".planned = lib.mkOverride 900 true;

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE RankNTypes #-}
+module Main where
+
+import qualified PlutusCore                 as PLC
+import           PlutusCore.Quote           (runQuoteT)
+import qualified PlutusIR                   as PIR
+import qualified PlutusIR.Compiler          as PIR
+
+import           Control.Lens               (Lens', set, (&))
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Reader
+import qualified Data.ByteString            as BS
+import           Flat                       (unflat)
+import           Options.Applicative
+
+
+data Options = Options
+  { opPath     :: FilePath
+  , opOptimize :: Bool
+  }
+
+options :: Parser Options
+options = Options
+            <$> argument str (metavar "FILE.flat")
+            <*> switch' (long "dont-optimize"
+                        <> help "Don't optimize"
+                        )
+  where
+    switch' :: Mod FlagFields Bool -> Parser Bool
+    switch' = fmap not . switch
+
+type PIRTerm  = PIR.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ()
+type PLCTerm  = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
+type PIRError = PIR.Error PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
+type PIRCompilationCtx a = PIR.CompilationCtx PLC.DefaultUni PLC.DefaultFun a
+
+compile
+  :: Options -> PIRTerm -> Either PIRError PLCTerm
+compile opts pirT = do
+  plcTcConfig <- PLC.getDefTypeCheckConfig PIR.noProvenance
+  let pirCtx = defaultCompilationCtx plcTcConfig
+  runExcept $ flip runReaderT pirCtx $ runQuoteT $ PIR.compileTerm pirT
+
+  where
+    set' :: Lens' PIR.CompilationOpts b -> (Options -> b) -> PIRCompilationCtx a -> PIRCompilationCtx a
+    set' pirOpt opt = set (PIR.ccOpts . pirOpt) (opt opts)
+
+    defaultCompilationCtx :: PLC.TypeCheckConfig PLC.DefaultUni PLC.DefaultFun -> PIRCompilationCtx a
+    defaultCompilationCtx plcTcConfig =
+      PIR.toDefaultCompilationCtx plcTcConfig
+      & set' PIR.coOptimize                     opOptimize
+
+loadPirAndCompile :: Options -> IO ()
+loadPirAndCompile opts = do
+  let path = opPath opts
+  putStrLn $ "!!! Loading file " ++ path
+  bs <- BS.readFile path
+  case unflat bs of
+    Left decodeErr -> error $ show decodeErr
+    Right pirT -> do
+      putStrLn "!!! Compiling"
+      case compile opts pirT of
+        Left pirError -> error $ show pirError
+        Right _       -> putStrLn "!!! Compilation successful"
+
+main :: IO ()
+main = loadPirAndCompile =<< execParser opts
+  where
+    opts =
+      info (options <**> helper)
+           ( fullDesc
+           <> progDesc "Load a flat pir term from file and run the compiler on it"
+           <> header "pir - a small tool for loading pir from flat representation and compiling it")

--- a/plutus-core/executables/pir/README.md
+++ b/plutus-core/executables/pir/README.md
@@ -1,0 +1,41 @@
+A small tool to help with rapid interation when working with Plutus IR compiler.
+
+For instance, when debugging an issue when compiling a file from the `marlowe`
+package, we can:
+
+- dump the PIR of the troublesome Plutus IR term,
+- modify the compiler, and
+- re-run the compiler on the dumped PIR term, without the need to rebuild
+  `marlowe` and all of its dependencies.
+
+# Dumping PIR
+
+Plutus plugin supports dumping binary representation of the PIR via `dump-pir-flat`:
+
+```haskell
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:dump-pir-flat #-}
+```
+
+Ideally, we would want to use the module when naming the PIR binary dump file,
+but for the time being it received a random name.
+
+# Debugging PIR Compilation
+
+When dealing with issues with PIR compilation, we can simply re-run the
+compiler on the dumped PIR flat file:
+
+```bash
+cabal run plutus-core:pir -- FILE.flat
+```
+
+`cabal run` should take care of rebuilding the compiler, so the issue of stale
+plugin does not arise.
+
+# Profiling PIR -> PLC Compilation
+
+We can also profile the evaluation.
+
+```bash
+cabal run plutus-core:pir --enable-profiling -- FILE.flat
+```
+

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -113,6 +113,7 @@ library
         PlutusIR
         PlutusIR.Core
         PlutusIR.Core.Instance
+        PlutusIR.Core.Instance.Flat
         PlutusIR.Core.Instance.Pretty
         PlutusIR.Core.Instance.Scoping
         PlutusIR.Core.Plated
@@ -456,6 +457,18 @@ executable uplc
         text -any,
         transformers -any
 
+executable pir
+    import: lang
+    main-is: pir/Main.hs
+    hs-source-dirs: executables
+    build-depends:
+        plutus-core -any,
+        base <5,
+        bytestring -any,
+        flat -any,
+        lens -any,
+        optparse-applicative -any,
+        transformers -any
 
 -- This runs the microbenchmarks used to generate the cost models for built-in functions,
 -- saving the results in cost-model/data/benching.csv.  It will take several hours.

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance.hs
@@ -1,4 +1,5 @@
 module PlutusIR.Core.Instance () where
 
+import           PlutusIR.Core.Instance.Flat    ()
 import           PlutusIR.Core.Instance.Pretty  ()
 import           PlutusIR.Core.Instance.Scoping ()

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Flat.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Flat.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans       #-}
+module PlutusIR.Core.Instance.Flat () where
+
+import           PlutusIR.Core.Type
+
+import qualified PlutusCore         as PLC
+import           PlutusCore.Flat    ()
+
+import           Flat               (Flat)
+
+{- Note: [Serialization of PIR]
+The serialized version of Plutus-IR will be included in  the final
+executable for helping debugging and testing and providing better error
+reporting. It is not meant to be stored on the chain, which means that
+the underlying representation can vary. The `Generic` instances of the
+terms can thus be used as backwards compatibility is not required.
+-}
+
+instance ( PLC.Closed uni
+         , uni `PLC.Everywhere` Flat
+         , Flat a
+         , Flat tyname
+         , Flat name
+         -- This was needed only for the Flat instance
+         , Flat fun
+         ) => Flat (Datatype tyname name uni fun a)
+
+instance Flat Recursivity
+
+instance Flat Strictness
+
+instance ( PLC.Closed uni
+         , uni `PLC.Everywhere` Flat
+         , Flat fun
+         , Flat a
+         , Flat tyname
+         , Flat name
+         ) => Flat (Binding tyname name uni fun a)
+
+instance ( PLC.Closed uni
+         , uni `PLC.Everywhere` Flat
+         , Flat fun
+         , Flat a
+         , Flat tyname
+         , Flat name
+         ) => Flat (Term tyname name uni fun a)
+
+instance ( PLC.Closed uni
+         , uni `PLC.Everywhere` Flat
+         , Flat fun
+         , Flat a
+         , Flat tyname
+         , Flat name
+         ) => Flat (Program tyname name uni fun a)

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 module PlutusIR.Core.Type (
     TyName (..),
@@ -33,7 +32,6 @@ import qualified PlutusCore.Name     as PLC
 
 
 import qualified Data.Text           as T
-import           Flat                (Flat)
 
 -- Datatypes
 
@@ -47,15 +45,6 @@ terms can thus be used as backwards compatibility is not required.
 
 data Datatype tyname name uni fun a = Datatype a (TyVarDecl tyname a) [TyVarDecl tyname a] name [VarDecl tyname name uni fun a]
     deriving (Functor, Show, Generic)
-
-instance ( PLC.Closed uni
-         , uni `PLC.Everywhere` Flat
-         , Flat a
-         , Flat tyname
-         , Flat name
-         -- This was needed only for the Flat instance
-         , Flat fun
-         ) => Flat (Datatype tyname name uni fun a)
 
 varDeclNameString :: VarDecl tyname Name uni fun a -> String
 varDeclNameString = T.unpack . PLC.nameString . varDeclName
@@ -82,25 +71,13 @@ instance Semigroup Recursivity where
   NonRec <> x = x
   Rec <> _    = Rec
 
-instance Flat Recursivity
-
 data Strictness = NonStrict | Strict
     deriving (Show, Eq, Generic)
-
-instance Flat Strictness
 
 data Binding tyname name uni fun a = TermBind a Strictness (VarDecl tyname name uni fun a) (Term tyname name uni fun a)
                            | TypeBind a (TyVarDecl tyname a) (Type tyname uni a)
                            | DatatypeBind a (Datatype tyname name uni fun a)
     deriving (Functor, Show, Generic)
-
-instance ( PLC.Closed uni
-         , uni `PLC.Everywhere` Flat
-         , Flat fun
-         , Flat a
-         , Flat tyname
-         , Flat name
-         ) => Flat (Binding tyname name uni fun a)
 
 -- Terms
 
@@ -154,14 +131,6 @@ instance AsConstant (Term tyname name uni fun ann) where
 instance FromConstant (Term tyname name uni fun ()) where
     fromConstant = Constant ()
 
-instance ( PLC.Closed uni
-         , uni `PLC.Everywhere` Flat
-         , Flat fun
-         , Flat a
-         , Flat tyname
-         , Flat name
-         ) => Flat (Term tyname name uni fun a)
-
 instance TermLike (Term tyname name uni fun) tyname name uni fun where
     var      = Var
     tyAbs    = TyAbs
@@ -178,14 +147,6 @@ instance TermLike (Term tyname name uni fun) tyname name uni fun where
 
 -- no version as PIR is not versioned
 data Program tyname name uni fun a = Program a (Term tyname name uni fun a) deriving Generic
-
-instance ( PLC.Closed uni
-         , uni `PLC.Everywhere` Flat
-         , Flat fun
-         , Flat a
-         , Flat tyname
-         , Flat name
-         ) => Flat (Program tyname name uni fun a)
 
 type instance PLC.HasUniques (Term tyname name uni fun ann) = (PLC.HasUnique tyname PLC.TypeUnique, PLC.HasUnique name PLC.TermUnique)
 type instance PLC.HasUniques (Program tyname name uni fun ann) = PLC.HasUniques (Term tyname name uni fun ann)

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -6,6 +6,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 
+
 module Plugin.Basic.Spec where
 
 import           Common


### PR DESCRIPTION
- Move flat instances for PlutusIR to PlutusIR.Core.Instance.Flat,
- Change dump-pir option to dump binary PlutusIR representation, and
- Add a small cli tool for loading and compiling binary PlutusIR files.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested

Pre-merge checklist:
- [X] Someone approved it
- [X] Commits have useful messages
- [X] Review clarifications made it into the code
- [X] History is moderately tidy; or going to squash-merge
