### PR TITLE
SCP-2575 - Move static analysis end-point to /api/*

### DIFF
--- a/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/StaticTools.purs
@@ -65,7 +65,7 @@ analyseContract extendedContract = do
   where
   emptySemanticState = emptyState zero
 
-  checkContractForWarnings settings state contract = traverse logAndStripDuration =<< (runAjax $ (flip runReaderT) settings (Server.postMarloweanalysis (MSReq.Request { onlyAssertions: false, contract, state })))
+  checkContractForWarnings settings state contract = traverse logAndStripDuration =<< (runAjax $ (flip runReaderT) settings (Server.postApiMarloweanalysis (MSReq.Request { onlyAssertions: false, contract, state })))
 
 splitArray :: forall a. List a -> List (List a /\ a /\ List a)
 splitArray x = splitArrayAux Nil x
@@ -221,7 +221,7 @@ checkContractForFailedAssertions ::
   HalogenM state action slots Void m (WebData Result)
 checkContractForFailedAssertions contract state = do
   settings <- asks _.ajaxSettings
-  traverse logAndStripDuration =<< (runAjax $ (flip runReaderT) settings (Server.postMarloweanalysis (MSReq.Request { onlyAssertions: true, contract: contract, state: state })))
+  traverse logAndStripDuration =<< (runAjax $ (flip runReaderT) settings (Server.postApiMarloweanalysis (MSReq.Request { onlyAssertions: true, contract: contract, state: state })))
 
 startMultiStageAnalysis ::
   forall m state action slots.

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -37,9 +37,6 @@ module.exports = {
             "/runghc": {
                 target: "http://localhost:8080"
             },
-            "/marlowe-analysis": {
-                target: "http://localhost:8080"
-            }
         }
     },
     entry: "./entry.js",

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
@@ -31,7 +31,7 @@ import           System.Clock                          (Clock (Monotonic), diffT
 import           System.Process                        (system)
 import           Text.PrettyPrint.Leijen               (displayS, renderCompact)
 
-type API = "marlowe-analysis" :> ReqBody '[JSON] Request :> Post '[JSON] Response
+type API = "api" :> "marlowe-analysis" :> ReqBody '[JSON] Request :> Post '[JSON] Response
 
 makeResult ::
   Either String (Maybe (Slot, [TransactionInput], [TransactionWarning])) ->


### PR DESCRIPTION
Moves the static analysis endpoint so that it is under `/api`

Deployed to http://pablo.marlowe.iohkdev.io/

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [x] Someone approved it
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
- [x] History is moderately tidy; or going to squash-merge
