### PR TITLE
SCP-2580: Execute migrate command before starting dev servers and better logging

### DIFF
--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -27,7 +27,8 @@ let
   migrate = pkgs.writeShellScriptBin "plutus-pab-migrate" ''
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
-    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-setup-invoker)/bin/plutus-pab-setup migrate
+    # TODO: Change the migrate to read the config file instead and get the db path from there
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-setup-invoker)/bin/plutus-pab-setup migrate $(yq -r '.dbConfig.dbConfigFile' plutus-pab.yaml)
   '';
 
   # For dev usage
@@ -36,6 +37,8 @@ let
     export WEBGHC_URL=http://localhost:8080
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
+    # Only execute the migration when the database file does not exist
+    ! test -f ./$(yq -r '.dbConfig.dbConfigFile' plutus-pab.yaml) && plutus-pab-migrate
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-examples-invoker)/bin/plutus-pab-examples --config=plutus-pab.yaml webserver
   '';
 
@@ -45,6 +48,8 @@ let
     export WEBGHC_URL=http://localhost:8080
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
+    # Only execute the migration when the database file does not exist
+    ! test -f ./$(yq -r '.dbConfig.dbConfigFile' plutus-pab.yaml) && plutus-pab-migrate
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-examples-invoker)/bin/plutus-pab-examples --config=plutus-pab.yaml all-servers
   '';
 
@@ -54,6 +59,8 @@ let
     export WEBGHC_URL=http://localhost:8080
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
+    # Only execute the migration when the database file does not exist
+    ! test -f ./$(yq -r '.dbConfig.dbConfigFile' plutus-pab.yaml) && plutus-pab-migrate
     $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-examples-invoker)/bin/plutus-pab-examples --config=plutus-pab.yaml -m all-servers
   '';
 

--- a/plutus-pab/src/Plutus/PAB/Run.hs
+++ b/plutus-pab/src/Plutus/PAB/Run.hs
@@ -35,7 +35,7 @@ import           Plutus.PAB.Run.Cli
 import           Plutus.PAB.Run.CommandParser
 import           Plutus.PAB.Run.PSGenerator          (HasPSTypes)
 import           Plutus.PAB.Types                    (PABError (MissingConfigFileOption))
-import           Prettyprinter                       (Pretty)
+import           Prettyprinter                       (Pretty (pretty))
 import qualified Servant
 import           System.Exit                         (ExitCode (ExitFailure), exitSuccess, exitWith)
 
@@ -85,5 +85,5 @@ runWith userContractHandler = do
         where
 
             handleError (err :: PABError) = do
-                runStdoutLoggingT $ (logErrorN . tshow) err
+                runStdoutLoggingT $ (logErrorN . tshow . pretty) err
                 exitWith (ExitFailure 1)

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -21,7 +21,7 @@ import           Data.Default              (Default, def)
 import           Data.Map.Strict           (Map)
 import qualified Data.Map.Strict           as Map
 import           Data.Text                 (Text)
-import           Data.Text.Prettyprint.Doc (Pretty, pretty, viaShow, (<+>))
+import           Data.Text.Prettyprint.Doc (Pretty, line, pretty, viaShow, (<+>))
 import           Data.Time.Units           (Second)
 import           Data.UUID                 (UUID)
 import qualified Data.UUID.Extras          as UUID
@@ -55,6 +55,7 @@ data PABError
     | MissingConfigFileOption
     | ContractStateNotFound ContractInstanceId
     | AesonDecodingError Text Text
+    | MigrationNotDoneError Text
     deriving stock (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
@@ -76,9 +77,13 @@ instance Pretty PABError where
         EndpointCallError n        -> "Endpoint call failed:" <+> pretty n
         InstanceAlreadyStopped i   -> "Instance already stopped:" <+> pretty i
         WalletNotFound w           -> "Wallet not found:" <+> pretty w
-        MissingConfigFileOption    -> "The --config-file option is required"
+        MissingConfigFileOption    -> "The --config option is required"
         ContractStateNotFound i    -> "State for contract instance not found:" <+> pretty i
         AesonDecodingError msg o   -> "Error while Aeson decoding: " <+> pretty msg <+> pretty o
+        MigrationNotDoneError msg  -> pretty msg
+                                   <> line
+                                   <> "Did you forget to run the 'migrate' command ?"
+                                   <+> "(ex. 'plutus-pab-migrate' or 'plutus-pab-setup migrate pab-core.db')"
 
 data DbConfig =
     DbConfig

--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,7 @@ let
   nixpkgsInputs = (with pkgs; [
     cacert
     ghcid
+    jq
     morph
     niv
     nixpkgs-fmt
@@ -62,6 +63,7 @@ let
     shellcheck
     sqlite-interactive
     stack
+    yq
     z3
     zlib
   ] ++ (lib.optionals (!stdenv.isDarwin) [ rPackages.plotly R ]));


### PR DESCRIPTION
Execute `migrate` command before starting dev servers and better logging

* Execute the `migrate` command which creates the database file before launching the `PAB` dev servers.

* Read the db file from the `YAML` file using `yq` when launching `PAB` dev servers

* Log an error message when we get `no such table: instances` when running `runBeamSqliteDebug` in the `PAB`

Here's the log output when running the `PAB` without running the `migrate` command first:

```
$ cabal run plutus-pab:exe:plutus-pab-examples -- --config plutus-pab/plutus-pab.yaml all-servers
Starting: MockNode WithMockServer
Started: MockNode WithMockServer
[pab:Info:13] [2021-07-29 22:08:38.59 UTC] Starting slot coordination thread. Initial slot time: 2020-06-07T21:44:51Z Slot length: 1000ms
[pab:Info:13] [2021-07-29 22:08:38.59 UTC] Starting random transaction generation thread
[pab:Info:13] [2021-07-29 22:08:38.59 UTC] Starting Mock Node Server on port  9082
Starting: ChainIndex
Started: ChainIndex
[pab:Info:15] [2021-07-29 22:08:38.59 UTC] Processing chain event  TxnValidate 75913a01d9e6ff0da3b4e54ba4c78feeddb9fb74340c4aaf3cf434564abb36fe
[pab:Info:37] [2021-07-29 22:08:38.59 UTC] Starting node client thread
Starting: Metadata
Started: Metadata
Starting: MockWallet
Started: MockWallet
[pab:Info:37] [2021-07-29 22:08:38.59 UTC] Starting chain index on port: 9083
[pab:Info:41] [2021-07-29 22:08:38.59 UTC] Starting Metadata Server: 9085
Starting: PABWebserver
Started: PABWebserver
[pab:Info:43] [2021-07-29 22:08:38.64 UTC] Starting wallet server on port  9081
[Error] SQLite3 returned ErrorError while attempting to perform prepare "SELECT \"t0\".\"instance_id\" AS \"res0\", \"t0\".\"instance_contract_id\" AS \"res1\", \"t0\".\"instance_wallet\" AS \"res2\", \"t0\".\"instance_state\" AS \"res3\", \"t0\".\"instance_active\" AS \"res4\" FROM \"instances\" AS \"t0\" WHERE \"t0\".\"instance_active\"": no such table: instances
Did you forget to run the 'migrate' command ? (ex. 'plutus-pab-migrate' or 'plutus-pab-setup migrate pab-core.db')
$
```

Also, when running the scripts `plutus-pab-all-servers`, `plutus-pab-all-servers-m` and `plutus-pab-server`, they execute the `migrate` command if the file `pab-core.db` does not exist.

@merivale This should solve the issue you reported

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
