### PR TITLE
SCP-2587 - Marlowe Playground Client - Fix new blockly project

### DIFF
--- a/marlowe-playground-client/src/BlocklyEditor/State.purs
+++ b/marlowe-playground-client/src/BlocklyEditor/State.purs
@@ -66,6 +66,14 @@ handleAction (HandleBlocklyMessage (Blockly.BlockSelection selection)) = case mB
     Map.lookup blockType MB.definitionsMap
 
 handleAction (InitBlocklyProject code) = do
+  -- NOTE: We already save the code in session storage as part of the processBlocklyCode.
+  --       The reason to also add it here was to solve a small bug introduced in PR 3478.
+  --       The problem is that when we create a new project, the BlocklyReady event is
+  --       fired some time between the first InitBlocklyProject and processBlocklyCode, so
+  --       a second InitBlocklyProject was called with the previous code.
+  --       Saving the code twice solves the problem but we are still firing 2 InitBlocklyProject
+  --       when we start a new project, so we might want to revisit this later.
+  liftEffect $ SessionStorage.setItem marloweBufferLocalStorageKey code
   void $ query _blocklySlot unit $ H.tell $ Blockly.SetCode code
   processBlocklyCode
   -- Reset the toolbox


### PR DESCRIPTION
This PR solves an issue introduced by [PR-3478](https://github.com/input-output-hk/plutus/pull/3478) in which when we create and modify a marlowe/blockly project and then create a new blockly project, instead of getting a clean project, we started with the previous code. 

Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
