### PR TITLE
SCP-2590: Fix a bug in the let-floater

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -73,6 +73,11 @@ typeCheckTerm t = do
         Just tcconfig -> void . runTypeCheckM tcconfig $ inferTypeM t
         Nothing       -> pure ()
 
+check :: Compiling m e uni fun b => Term TyName Name uni fun (Provenance b) -> m ()
+check arg = do
+    shouldCheck <- view (ccOpts . coParanoidTypechecking)
+    if shouldCheck then typeCheckTerm arg else pure ()
+
 -- | The 1st half of the PIR compiler pipeline up to floating/merging the lets.
 -- We stop momentarily here to give a chance to the tx-plugin
 -- to dump a "readable" version of pir (i.e. floated).
@@ -85,8 +90,11 @@ compileToReadable =
     >=> PLC.rename
     >=> through typeCheckTerm
     >=> simplifyTerm
+    >=> through check
     >=> (pure . ThunkRec.thunkRecursions)
+    >=> through check
     >=> floatTerm
+    >=> through check
 
 -- | The 2nd half of the PIR compiler pipeline.
 -- Compiles a 'Term' into a PLC Term, by removing/translating step-by-step the PIR's language construsts to PLC.
@@ -94,8 +102,13 @@ compileToReadable =
 compileReadableToPlc :: Compiling m e uni fun a => Term TyName Name uni fun (Provenance a) -> m (PLCTerm uni fun a)
 compileReadableToPlc =
     NonStrict.compileNonStrictBindings
+    >=> through check
     >=> Let.compileLets Let.DataTypes
+    >=> through check
     >=> Let.compileLets Let.RecTerms
+    -- TODO: add 'check' steps from here on. Can't do this since we seem to generate a wrong type
+    -- somewhere in the recursive binding compilation step
+    >=> through check
     -- We introduce some non-recursive let bindings while eliminating recursive let-bindings, so we
     -- can eliminate any of them which are unused here.
     >=> simplifyTerm

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -40,14 +40,15 @@ makeLenses ''PirTCConfig
 instance PLC.HasTypeCheckConfig (PirTCConfig uni fun) uni fun where
     typeCheckConfig = pirConfigTCConfig
 
-newtype CompilationOpts = CompilationOpts {
-    _coOptimize :: Bool
+data CompilationOpts = CompilationOpts {
+    _coOptimize               :: Bool
+    , _coParanoidTypechecking :: Bool
     } deriving (Eq, Show)
 
 makeLenses ''CompilationOpts
 
 defaultCompilationOpts :: CompilationOpts
-defaultCompilationOpts = CompilationOpts True
+defaultCompilationOpts = CompilationOpts True False
 
 data CompilationCtx uni fun a = CompilationCtx {
     _ccOpts              :: CompilationOpts

--- a/plutus-core/plutus-ir/test/transform/letFloat/listMatch.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/listMatch.golden
@@ -3,6 +3,11 @@
   (con integer)
   (let
     (rec)
+    (termbind
+      (strict)
+      (vardecl j (con integer))
+      [ [ (builtin addInteger) (con integer 3) ] x ]
+    )
     (datatypebind
       (datatype
         (tyvardecl List (fun (type) (type)))
@@ -11,30 +16,22 @@
         (vardecl Nil [List a]) (vardecl Cons (fun a (fun [List a] [List a])))
       )
     )
-    (let
-      (rec)
-      (termbind
-        (strict)
-        (vardecl j (con integer))
-        [ [ (builtin addInteger) (con integer 3) ] x ]
-      )
+    [
       [
-        [
-          {
-            [
-              { match_List (all a (type) (fun a a)) }
-              { Nil (all a (type) (fun a a)) }
-            ]
-            (all a (type) (fun a a))
-          }
-          (abs a (type) (lam x a x))
-        ]
-        (lam
-          head
+        {
+          [
+            { match_List (all a (type) (fun a a)) }
+            { Nil (all a (type) (fun a a)) }
+          ]
           (all a (type) (fun a a))
-          (lam tail [List (all a (type) (fun a a))] head)
-        )
+        }
+        (abs a (type) (lam x a x))
       ]
-    )
+      (lam
+        head
+        (all a (type) (fun a a))
+        (lam tail [List (all a (type) (fun a a))] head)
+      )
+    ]
   )
 )

--- a/plutus-core/plutus-ir/test/transform/letFloat/mutuallyRecursiveValues.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/mutuallyRecursiveValues.golden
@@ -1,9 +1,10 @@
 (let
   (rec)
+  (termbind (strict) (vardecl x (all a (type) (fun a a))) y)
   (termbind
     (strict)
     (vardecl y (all a (type) (fun a a)))
     (abs a (type) (lam z a [ { x a } z ]))
   )
-  (let (rec) (termbind (strict) (vardecl x (all a (type) (fun a a))) y) x)
+  x
 )


### PR DESCRIPTION
This came up in my other branch, but was clearly pre-existing (we even had a wrong testcase!). I think this is a reasonable fix, but @bezirg should think about it when he's back.

Fortunately, this case doesn't come up that often in practice! 

I also added a paranoid typechecking mode like "core lint" in GHC, that runs the typechecker after every stage. This is helpful for debugging. I had to stop after recursive binding elimination since we apparently generate a wrong type signature somewhere, which is concerning even though apparently it somehow sorts itself out by the time we get to PLC typechecking...

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
