### PR TITLE
SCP-2545 - Marlowe Run Client - Implement transaction summary

### DIFF
--- a/marlowe-dashboard-client/src/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Contract/Lenses.purs
@@ -10,6 +10,8 @@ module Contract.Lenses
   , _participants
   , _userParties
   , _namedActions
+  , _expandPayments
+  , _resultingPayments
   ) where
 
 import Contract.Types (PreviousStep, State, Tab)
@@ -24,7 +26,7 @@ import Marlowe.Execution.Types (NamedAction)
 import Marlowe.Execution.Types (State) as Execution
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.PAB (MarloweParams)
-import Marlowe.Semantics (Party, TransactionInput)
+import Marlowe.Semantics (Party, Payment, TransactionInput)
 import WalletData.Types (WalletNickname)
 
 _nickname :: Lens' State String
@@ -59,3 +61,9 @@ _userParties = prop (SProxy :: SProxy "userParties")
 
 _namedActions :: Lens' State (Array (Tuple Party (Array NamedAction)))
 _namedActions = prop (SProxy :: SProxy "namedActions")
+
+_expandPayments :: Lens' PreviousStep Boolean
+_expandPayments = prop (SProxy :: SProxy "expandPayments")
+
+_resultingPayments :: Lens' PreviousStep (Array Payment)
+_resultingPayments = prop (SProxy :: SProxy "resultingPayments")

--- a/marlowe-dashboard-client/src/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Contract/Types.purs
@@ -84,9 +84,9 @@ type Input
     }
 
 data Movement
-  = PayIn AccountId Party Token BigInteger -- a.k.a deposit
+  = PayIn Party AccountId Token BigInteger -- a.k.a deposit
   | Transfer Party Party Token BigInteger
-  | PayOut Party AccountId Token BigInteger
+  | PayOut AccountId Party Token BigInteger
 
 data Action
   = SelectSelf

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -986,7 +986,7 @@ renderBalances stepNumber state stepBalance =
           , span [ classNames [ "font-semibold" ] ] [ text "Balances of contract accounts" ]
           , hint [ "relative", "-top-1" ] ("balances-" <> show stepNumber) Auto
               -- FIXME: Revisit copy
-
+              
               $ div_ [ text "This tab shows the amount of tokens that each role has in the contract account. A deposit is needed to get tokens from a wallet into the contract account, and a payment is needed to redeem tokens from the contract account into a user's wallet" ]
           ]
       , div [ classNames [ "px-4" ] ]

--- a/marlowe-dashboard-client/src/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Contract/View.purs
@@ -473,9 +473,9 @@ renderPaymentSummary stepNumber state step =
 
     -- TODO: This function is currently hard-coded to ADA, we should rethink how to deal with this
     --       when we support multiple tokens
-    paymentToMovement (Payment from (Account to) money) = Transfer to from adaToken $ getAda money
+    paymentToMovement (Payment from (Account to) money) = Transfer from to adaToken $ getAda money
 
-    paymentToMovement (Payment from (Party to) money) = PayOut to from adaToken $ getAda money
+    paymentToMovement (Payment from (Party to) money) = PayOut from to adaToken $ getAda money
 
     movements = paymentToMovement <$> step ^. _resultingPayments
 
@@ -558,7 +558,7 @@ renderPartyPastActions stepNumber { tzOffset } state { inputs, interval, party }
         (map renderPastAction inputs)
 
     renderPastAction = case _ of
-      S.IDeposit intoAccountOf by token value -> renderMovement state (PayIn intoAccountOf by token value)
+      S.IDeposit intoAccountOf by token value -> renderMovement state (PayIn by intoAccountOf token value)
       S.IChoice (ChoiceId choiceIdKey _) chosenNum ->
         div []
           [ h4_ [ text "Chose:" ]
@@ -710,14 +710,14 @@ renderMovement :: State -> Movement -> forall p a. HTML p a
 renderMovement state movement =
   let
     fromParty = case movement of
-      PayIn _ from _ _ -> renderParty [] state from
-      Transfer _ from _ _ -> renderPartyAccount [] state from
-      PayOut _ from _ _ -> renderPartyAccount [] state from
+      PayIn from _ _ _ -> renderParty [] state from
+      Transfer from _ _ _ -> renderPartyAccount [] state from
+      PayOut from _ _ _ -> renderPartyAccount [] state from
 
     toParty = case movement of
-      PayIn to _ _ _ -> renderPartyAccount [] state to
-      Transfer to _ _ _ -> renderPartyAccount [] state to
-      PayOut to _ _ _ -> renderParty [] state to
+      PayIn _ to _ _ -> renderPartyAccount [] state to
+      Transfer _ to _ _ -> renderPartyAccount [] state to
+      PayOut _ to _ _ -> renderParty [] state to
 
     token = case movement of
       PayIn _ _ t _ -> t

--- a/web-common/src/Material/Icons.purs
+++ b/web-common/src/Material/Icons.purs
@@ -35,6 +35,8 @@ data Icon
   | Done
   | DoneWithCircle
   | ErrorOutline
+  | ExpandMore
+  | ExpandLess
   | Help
   | HelpOutline
   | History
@@ -87,6 +89,10 @@ content Done = "done"
 content DoneWithCircle = "check_circle_outline"
 
 content ErrorOutline = "error_outline"
+
+content ExpandMore = "expand_more"
+
+content ExpandLess = "expand_less"
 
 content Help = "help"
 
@@ -163,6 +169,10 @@ iconClass Done = "done"
 iconClass DoneWithCircle = "check-circle-outline"
 
 iconClass ErrorOutline = "error-outline"
+
+iconClass ExpandMore = "expand-more"
+
+iconClass ExpandLess = "expand-less"
 
 iconClass Help = "help"
 

--- a/web-common/src/Tooltip/State.purs
+++ b/web-common/src/Tooltip/State.purs
@@ -13,7 +13,7 @@ import Halogen (Component, HalogenM, Slot, get, getHTMLElementRef, liftEffect, m
 import Halogen as H
 import Halogen.HTML (ComponentHTML, HTML, slot)
 import Halogen.Query.EventSource (eventListenerEventSource)
-import Popper (OffsetOption(..), PaddingOption(..), Placement, PositioningStrategy(..), arrow, createPopper, defaultModifiers, defaultPreventOverflow, destroyPopper, forceUpdate, offset, pAll, preventOverflow)
+import Popper (OffsetOption(..), PaddingOption(..), Placement, PositioningStrategy(..), arrow, createPopper, defaultFlip, defaultModifiers, defaultPreventOverflow, destroyPopper, flipPlacement, forceUpdate, offset, pAll, preventOverflow)
 import Tooltip.Lenses (_active, _mPopperInstance, _message, _placement)
 import Tooltip.Types (Action(..), Input, ReferenceId(..), State, arrowRef, tooltipRef)
 import Tooltip.View (render)
@@ -83,6 +83,7 @@ handleAction Init = do
             <> [ arrow arrowElem (PaddingValue $ pAll 0.0)
               , offset (OffsetValue { skidding: 0.0, distance: 8.0 })
               , preventOverflow defaultPreventOverflow
+              , flipPlacement defaultFlip
               ]
       refElem <- MaybeT $ liftEffect $ getElementById' refId
       tooltipElem <- MaybeT $ getHTMLElementRef tooltipRef

--- a/web-common/static/icons.css
+++ b/web-common/static/icons.css
@@ -75,6 +75,14 @@
   content: "error_outline";
 }
 
+.with-icon-expand-more::after {
+  content: "expand_more";
+}
+
+.with-icon-expand-less::after {
+  content: "expand_less";
+}
+
 .with-icon-help::after {
   content: "help";
 }


### PR DESCRIPTION
This PR adds a tooltip to the past actions card with the timezone information and includes an initial version of the transaction/payment summary.

![time-tooltip](https://user-images.githubusercontent.com/2634059/127722318-f042a5f4-6ade-4610-b6c3-222f3c891a4b.png)

![payment_summary](https://user-images.githubusercontent.com/2634059/127722325-f49308ae-e9e5-4252-9409-f9ac745d7f6e.png)


While I was implementing this feature, I discovered a bug in the balance tab of the simple escrow example. When the buyer deposits and chooses to report a problem, there is a payment from the Sellers account to the Buyers account (which is shown by the new payment summary). But in the balances tab the money is removed from the Sellers account but is not added to the Buyers.


Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
