### PR TITLE
Hide flake-enabled Nix behind an alias.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -144,6 +144,8 @@ actually use flakes for normal Nix builds. To manage the dependencies,
 see https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html#flake-inputs[the Nix flake inputs documentation]
 and https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake-update.html[the Nix flake update command].
 
+Inside of the project nix-shell, a version of Nix with flakes is available under the alias `nix-flakes`.
+
 [[update-index-state]]
 === How to update the Hackage index state
 

--- a/shell.nix
+++ b/shell.nix
@@ -51,13 +51,18 @@ let
     };
   };
 
+  nixFlakesAlias = pkgs.runCommand "nix-flakes-alias" { } ''
+    mkdir -p $out/bin
+    ln -sv ${pkgs.nixFlakes}/bin/nix $out/bin/nix-flakes
+  '';
+
   # build inputs from nixpkgs ( -> ./nix/default.nix )
   nixpkgsInputs = (with pkgs; [
     cacert
     ghcid
     jq
     morph
-    nixFlakes
+    nixFlakesAlias
     nixpkgs-fmt
     nodejs
     shellcheck


### PR DESCRIPTION
Nix 2.4pre is unstable and segfaults often.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
