### PR TITLE
Remove generic ExMemory instances

### DIFF
--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -19,7 +19,6 @@ module PlutusCore.Examples.Builtins where
 import           PlutusCore
 import           PlutusCore.Constant
 import           PlutusCore.Evaluation.Machine.ExBudget
-import           PlutusCore.Evaluation.Machine.ExMemory
 import           PlutusCore.Evaluation.Machine.Exception
 import           PlutusCore.Pretty
 
@@ -112,7 +111,6 @@ data ExtensionFun
     | SwapEls  -- For checking that nesting polymorphic built-in types and instantiating them with
                -- a mix of monomorphic types and type variables works correctly.
     deriving (Show, Eq, Ord, Enum, Bounded, Ix, Generic, Hashable)
-    deriving (ExMemoryUsage) via (GenericExMemoryUsage ExtensionFun)
 
 instance Pretty ExtensionFun where pretty = viaShow
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -24,11 +24,10 @@ module UntypedPlutusCore.Core.Type
 import           Data.Functor.Identity
 import           PlutusPrelude
 
-import qualified PlutusCore.Constant                    as TPLC
-import qualified PlutusCore.Core                        as TPLC
-import           PlutusCore.Evaluation.Machine.ExMemory
+import qualified PlutusCore.Constant   as TPLC
+import qualified PlutusCore.Core       as TPLC
 import           PlutusCore.MkPlc
-import qualified PlutusCore.Name                        as TPLC
+import qualified PlutusCore.Name       as TPLC
 import           Universe
 
 {- Note [Term constructor ordering and numbers]
@@ -105,11 +104,6 @@ instance TPLC.FromConstant (Term name uni fun ()) where
 
 type instance TPLC.HasUniques (Term name uni fun ann) = TPLC.HasUnique name TPLC.TermUnique
 type instance TPLC.HasUniques (Program name uni fun ann) = TPLC.HasUniques (Term name uni fun ann)
-
-deriving via GenericExMemoryUsage (Term name uni fun ann) instance
-    ( ExMemoryUsage name, ExMemoryUsage fun, ExMemoryUsage ann
-    , Closed uni, uni `Everywhere` ExMemoryUsage
-    ) => ExMemoryUsage (Term name uni fun ann)
 
 toTerm :: Program name uni fun ann -> Term name uni fun ann
 toTerm (Program _ _ term) = term

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -3,7 +3,7 @@
 
 module Evaluation.Machines
     ( test_machines
-    , test_memory
+    --, test_memory
     , test_budget
     , test_tallying
     ) where
@@ -15,7 +15,6 @@ import           UntypedPlutusCore.Evaluation.Machine.Cek        as Cek
 import qualified PlutusCore                                      as Plc
 import           PlutusCore.Constant
 import           PlutusCore.Default
-import           PlutusCore.Evaluation.Machine.ExMemory
 import           PlutusCore.Evaluation.Machine.Exception
 import           PlutusCore.Evaluation.Machine.MachineParameters
 import           PlutusCore.FsTree
@@ -24,14 +23,11 @@ import           PlutusCore.MkPlc
 import           PlutusCore.Pretty
 
 import           PlutusCore.Examples.Builtins
-import           PlutusCore.Examples.Everything                  (examples)
 import qualified PlutusCore.StdLib.Data.Nat                      as Plc
-import           PlutusCore.StdLib.Everything                    (stdLib)
 import           PlutusCore.StdLib.Meta
 import           PlutusCore.StdLib.Meta.Data.Function            (etaExpand)
 
 import           Common
-import           Data.String
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Text
 import           GHC.Ix
@@ -60,22 +56,6 @@ test_machines =
         [ testMachine "CEK"  $ evaluateCekNoEmit Plc.defaultCekParameters
         , testMachine "HOAS" $ evaluateHoas Plc.defaultBuiltinsRuntime
         ]
-
-testMemory :: ExMemoryUsage a => TestName -> a -> TestNested
-testMemory name = nestedGoldenVsText name . fromString . show . memoryUsage
-
-test_memory :: TestTree
-test_memory =
-    testGroup "Bundles"
-        [ folder stdLib
-        , folder examples
-        ]
-  where
-    folder :: ExMemoryUsage fun => PlcFolderContents DefaultUni fun -> TestTree
-    folder
-        = runTestNestedIn ["untyped-plutus-core", "test", "Evaluation", "Machines"]
-        . testNested "Memory"
-        . foldPlcFolderContents testNested testMemory testMemory
 
 testBudget
     :: (Ix fun, Show fun, Hashable fun, PrettyUni DefaultUni fun)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Data/ofoldrData.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Data/ofoldrData.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2170

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/FoldrInterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/FoldrInterList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 1036

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterCons.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 482

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 137

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/InterList/InterNil.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 310

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/List/omapList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/List/omapList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 483

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Pair/obothPair.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Pair/obothPair.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 75

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/RecUnit/recUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/RecUnit/recUnit.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 32

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/RecUnit/runRecUnit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/RecUnit/runRecUnit.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 51

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Shad/mkShad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Shad/mkShad.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 62

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Shad/shad.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Shad/shad.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 38

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/Forest.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/Forest.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 333

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/ForestCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/ForestCons.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 1124

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/ForestNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/ForestNil.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 676

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/Tree.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/Tree.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 333

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/TreeNode.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/TreeForest/TreeNode.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 690

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchConcat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchConcat.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 561

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchCons.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 275

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchNil.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 107

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchVec.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/churchVec.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 117

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/plusT.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/plusT.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 49

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottCons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottCons.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 622

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottHead.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottHead.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 426

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottNil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottNil.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 406

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottSumHeadsOr0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottSumHeadsOr0.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2146

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottVec.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/scottVec.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 151

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/succT.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/succT.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 35

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/zeroT.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/Examples/Vec/zeroT.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 13

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/Bool.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/Bool.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/False.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/False.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/IfThenElse.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/IfThenElse.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 51

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/True.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Bool/True.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchNat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchNat.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 19

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchSucc.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchSucc.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 61

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchZero.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ChurchNat/ChurchZero.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 23

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Data/Data.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Data/Data.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Data/caseData.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Data/caseData.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 236

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Apply.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Apply.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 31

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Const.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Const.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 23

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Fix.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Fix.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 226

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Fix2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Fix2.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 660

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Self.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Self.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 29

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Unroll.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Function/Unroll.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 48

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Integer/SuccInteger.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Integer/SuccInteger.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 14

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Integer/integer.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Integer/integer.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/CaseList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/CaseList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 146

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/FoldrList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/FoldrList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 481

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/List.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/List/List.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/FoldNat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/FoldNat.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 497

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/FoldrNat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/FoldrNat.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 485

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Nat.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Nat.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 49

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/NatToInteger.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/NatToInteger.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 509

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Succ.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Succ.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 174

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Zero.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Nat/Zero.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 118

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Fst.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Fst.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Pair.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Pair.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Snd.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Snd.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Uncurry.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Pair/Uncurry.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 72

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Cons.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Cons.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 184

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/EnumFromTo.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/EnumFromTo.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 810

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/FoldList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/FoldList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 515

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/FoldrList.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/FoldrList.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 503

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/List.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/List.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 45

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Nil.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Nil.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 118

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Product.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Product.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 527

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Reverse.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Reverse.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 1007

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Sum.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/ScottList/Sum.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 527

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Left.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Left.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 45

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Right.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Right.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 45

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Sum.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Sum/Sum.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 31

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Unit/Unit.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Unit/Unit.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Unit/Unitval.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Data/Unit/Unitval.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 2

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/MkProdN2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/MkProdN2.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 49

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 27

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2_0.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2_0.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 69

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2_1.plc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines/Memory/StdLib/Meta/Data/Tuple/ProdN2_1.plc.golden
@@ -1,1 +1,0 @@
-ExMemory 69

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -11,7 +11,6 @@ main :: IO ()
 main = defaultMain $ testGroup "Untyped Plutus Core"
     [ test_machines
     , test_builtins
-    , test_memory
     , test_budget
     , test_golden
     , test_tallying


### PR DESCRIPTION
These are dangerous and largely unnecessary. We do need an instance for
tuples because they appear in the builtin universes.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
