### PR TITLE
SCP-2565: Define chain index query effect types in plutus-contract

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/playground-common.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/playground-common.nix
@@ -60,6 +60,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."prometheus" or (errorHandler.buildDepError "prometheus"))
+          (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
           (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
           (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-chain-index.nix
@@ -40,13 +40,12 @@
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."fingertree" or (errorHandler.buildDepError "fingertree"))
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
-          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           ];
         buildable = true;
         modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/playground-common.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/playground-common.nix
@@ -60,6 +60,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."prometheus" or (errorHandler.buildDepError "prometheus"))
+          (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
           (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
           (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-chain-index.nix
@@ -40,13 +40,12 @@
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."fingertree" or (errorHandler.buildDepError "fingertree"))
           (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
-          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           ];
         buildable = true;
         modules = [

--- a/playground-common/playground-common.cabal
+++ b/playground-common/playground-common.cabal
@@ -65,6 +65,7 @@ library
         newtype-generics -any,
         process -any,
         prometheus >=2,
+        plutus-chain-index -any,
         plutus-contract -any,
         plutus-ledger -any,
         row-types -any,

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -47,13 +47,12 @@ library
         aeson -any,
         base >=4.7 && <5,
         containers -any,
+        data-default -any,
         fingertree -any,
         freer-simple -any,
         lens -any,
         prettyprinter >=1.1.0.1,
         semigroups -any,
-        bytestring -any,
-        data-default -any
 
 test-suite plutus-chain-index-test
     import: lang

--- a/plutus-chain-index/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE DeriveGeneric   #-}
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
@@ -21,6 +22,7 @@ module Plutus.ChainIndex.Tx(
     ) where
 
 import           Control.Lens (makeLenses)
+import           Data.Aeson   (FromJSON, ToJSON)
 import           Data.Map     (Map)
 import qualified Data.Map     as Map
 import           Data.Set     (Set)
@@ -40,7 +42,7 @@ data ChainIndexTx = ChainIndexTx {
     _citxRedeemers       :: Map RedeemerHash Redeemer,
     _citxMintingPolicies :: Map MintingPolicyHash MintingPolicy,
     _citxValidators      :: Map ValidatorHash Validator
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 makeLenses ''ChainIndexTx
 

--- a/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-| Misc. types used in this package
 -}
 module Plutus.ChainIndex.Types(
@@ -20,6 +20,7 @@ import           GHC.Generics      (Generic)
 import           Ledger.Blockchain (BlockId (..))
 import           Ledger.Slot       (Slot)
 import           Numeric.Natural   (Natural)
+import           Prettyprinter     (Pretty (..), (<+>))
 
 newtype PageSize = PageSize { getPageSize :: Natural }
     deriving stock (Eq, Ord, Show, Generic)
@@ -70,3 +71,14 @@ instance Ord Tip where
     TipAtGenesis <= _            = True
     _            <= TipAtGenesis = False
     (Tip _ _ ln) <= (Tip _ _ rn) = ln <= rn
+
+instance Pretty Tip where
+    pretty TipAtGenesis = "TipAtGenesis"
+    pretty Tip {tipSlot, tipBlockId, tipBlockNo} =
+            "Tip(slot="
+        <+> pretty tipSlot
+        <>  ", blockId="
+        <+> pretty tipBlockId
+        <> ", blockNo="
+        <+> pretty tipBlockNo
+        <>  ")"

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
+    -- * Plutus application backend request effect types
     PABReq(..),
     _AwaitSlotReq,
     _AwaitTimeReq,
@@ -15,10 +16,21 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _OwnContractInstanceIdReq,
     _OwnPublicKeyReq,
     _UtxoAtReq,
+    _ChainIndexQueryReq,
     _AddressChangeReq,
     _BalanceTxReq,
     _WriteBalancedTxReq,
     _ExposeEndpointReq,
+    -- ** Chain index query effect types
+    _DatumFromHash,
+    _ValidatorFromHash,
+    _MintingPolicyFromHash,
+    _TxOutFromRef,
+    _TxFromTxId,
+    _UtxoSetMembership,
+    _UtxoSetAtAddress,
+    _GetTip,
+    -- * Plutus application backend response effect types
     PABResp(..),
     _AwaitSlotResp,
     _AwaitTimeResp,
@@ -29,13 +41,25 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     _OwnContractInstanceIdResp,
     _OwnPublicKeyResp,
     _UtxoAtResp,
+    _ChainIndexQueryResp,
     _AddressChangeResp,
     _BalanceTxResp,
     _WriteBalancedTxResp,
     _ExposeEndpointResp,
-    matches,
+    -- ** Chain index response effect types
+    _DatumHashResponse,
+    _ValidatorHashResponse,
+    _MintingPolicyHashResponse,
+    _TxOutRefResponse,
+    _TxIdResponse,
+    _UtxoSetMembershipResponse,
+    _UtxoSetAtResponse,
+    _GetTipResponse,
 
     -- * Etc.
+    matches,
+    ChainIndexQuery(..),
+    ChainIndexResponse(..),
     UtxoAtAddress(..),
     BalanceTxResponse(..),
     balanceTxResponse,
@@ -54,14 +78,22 @@ import           Control.Lens                     (Iso', Prism', iso, makePrisms
 import           Data.Aeson                       (FromJSON, ToJSON)
 import qualified Data.Aeson                       as JSON
 import qualified Data.Map                         as Map
-import           Data.Text.Prettyprint.Doc        (Pretty (..), colon, indent, viaShow, vsep, (<+>))
+import           Data.Text.Prettyprint.Doc        (Pretty (..), colon, hsep, indent, viaShow, vsep, (<+>))
 import           Data.Text.Prettyprint.Doc.Extras (PrettyShow (..))
 import           GHC.Generics                     (Generic)
-import           Ledger                           (Address, OnChainTx, PubKey, Tx, TxId, TxOutTx (..), eitherTx, txId)
+import           Ledger                           (Address, Datum, DatumHash, MintingPolicy, MintingPolicyHash,
+                                                   OnChainTx, PubKey, Tx, TxId, TxOutRef, TxOutTx (..), ValidatorHash,
+                                                   eitherTx, txId)
 import           Ledger.AddressMap                (UtxoMap)
 import           Ledger.Constraints.OffChain      (UnbalancedTx)
+import           Ledger.Credential                (Credential)
+import           Ledger.Scripts                   (Validator)
 import           Ledger.Slot                      (Slot (..))
 import           Ledger.Time                      (POSIXTime (..))
+import           Ledger.Tx                        (TxOut)
+import           Plutus.ChainIndex                (Tip)
+import           Plutus.ChainIndex.Tx             (ChainIndexTx (_citxTxId))
+import           Plutus.ChainIndex.Types          (Page (pageItems))
 import           PlutusTx.Lattice                 (MeetSemiLattice (..))
 import           Wallet.API                       (WalletAPIError)
 import           Wallet.Types                     (AddressChangeRequest, AddressChangeResponse, ContractInstanceId,
@@ -77,6 +109,7 @@ data PABReq =
     | OwnContractInstanceIdReq
     | OwnPublicKeyReq
     | UtxoAtReq Address
+    | ChainIndexQueryReq ChainIndexQuery
     | AddressChangeReq AddressChangeRequest
     | BalanceTxReq UnbalancedTx
     | WriteBalancedTxReq Tx
@@ -94,6 +127,7 @@ instance Pretty PABReq where
     OwnContractInstanceIdReq    -> "Own contract instance ID"
     OwnPublicKeyReq             -> "Own public key"
     UtxoAtReq addr              -> "Utxo at:" <+> pretty addr
+    ChainIndexQueryReq q        -> "Chain index query:" <+> pretty q
     AddressChangeReq req        -> "Address change:" <+> pretty req
     BalanceTxReq utx            -> "Balance tx:" <+> pretty utx
     WriteBalancedTxReq tx       -> "Write balanced tx:" <+> pretty tx
@@ -109,13 +143,13 @@ data PABResp =
     | OwnContractInstanceIdResp ContractInstanceId
     | OwnPublicKeyResp PubKey
     | UtxoAtResp UtxoAtAddress
+    | ChainIndexQueryResp ChainIndexResponse
     | AddressChangeResp AddressChangeResponse
     | BalanceTxResp BalanceTxResponse
     | WriteBalancedTxResp WriteBalancedTxResponse
     | ExposeEndpointResp EndpointDescription (EndpointValue JSON.Value)
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON)
-
 
 instance Pretty PABResp where
   pretty = \case
@@ -127,6 +161,7 @@ instance Pretty PABResp where
     OwnContractInstanceIdResp i         -> "Own contract instance ID:" <+> pretty i
     OwnPublicKeyResp k                  -> "Own public key:" <+> pretty k
     UtxoAtResp rsp                      -> "Utxo at:" <+> pretty rsp
+    ChainIndexQueryResp rsp             -> pretty rsp
     AddressChangeResp rsp               -> "Address change:" <+> pretty rsp
     BalanceTxResp r                     -> "Balance tx:" <+> pretty r
     WriteBalancedTxResp r               -> "Write balanced tx:" <+> pretty r
@@ -134,20 +169,94 @@ instance Pretty PABResp where
 
 matches :: PABReq -> PABResp -> Bool
 matches a b = case (a, b) of
-  (AwaitSlotReq{}, AwaitSlotResp{})                       -> True
-  (AwaitTimeReq{}, AwaitTimeResp{})                       -> True
-  (CurrentSlotReq, CurrentSlotResp{})                     -> True
-  (CurrentTimeReq, CurrentTimeResp{})                     -> True
-  (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _)         -> i == i'
-  (OwnContractInstanceIdReq, OwnContractInstanceIdResp{}) -> True
-  (OwnPublicKeyReq, OwnPublicKeyResp{})                   -> True
-  (UtxoAtReq{}, UtxoAtResp{})                             -> True
-  (AddressChangeReq{}, AddressChangeResp{})               -> True
-  (BalanceTxReq{}, BalanceTxResp{})                       -> True
-  (WriteBalancedTxReq{}, WriteBalancedTxResp{})           -> True
+  (AwaitSlotReq{}, AwaitSlotResp{})                        -> True
+  (AwaitTimeReq{}, AwaitTimeResp{})                        -> True
+  (CurrentSlotReq, CurrentSlotResp{})                      -> True
+  (CurrentTimeReq, CurrentTimeResp{})                      -> True
+  (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _) -> i == i'
+  (OwnContractInstanceIdReq, OwnContractInstanceIdResp{})  -> True
+  (OwnPublicKeyReq, OwnPublicKeyResp{})                    -> True
+  (UtxoAtReq{}, UtxoAtResp{})                              -> True
+  (ChainIndexQueryReq r, ChainIndexQueryResp r')           -> chainIndexMatches r r'
+  (AddressChangeReq{}, AddressChangeResp{})                -> True
+  (BalanceTxReq{}, BalanceTxResp{})                        -> True
+  (WriteBalancedTxReq{}, WriteBalancedTxResp{})            -> True
   (ExposeEndpointReq ActiveEndpoint{aeDescription}, ExposeEndpointResp desc _)
     | aeDescription == desc -> True
-  _                                                       -> False
+  _                                                        -> False
+
+chainIndexMatches :: ChainIndexQuery -> ChainIndexResponse -> Bool
+chainIndexMatches q r = case (q, r) of
+    (DatumFromHash{}, DatumHashResponse{})                 -> True
+    (ValidatorFromHash{}, ValidatorHashResponse{})         -> True
+    (MintingPolicyFromHash{}, MintingPolicyHashResponse{}) -> True
+    (TxOutFromRef{}, TxOutRefResponse{})                   -> True
+    (TxFromTxId{}, TxIdResponse{})                         -> True
+    (UtxoSetMembership{}, UtxoSetMembershipResponse{})     -> True
+    (UtxoSetAtAddress{}, UtxoSetAtResponse{})              -> True
+    (GetTip{}, GetTipResponse{})                           -> True
+    _                                                      -> False
+
+-- | Represents all possible chain index queries. Each constructor contains the
+-- input(s) needed for the query. These possible queries correspond to the
+-- constructors of the data type 'Plutus.ChainIndex.Effects.ChainIndexQueryEffect'.
+data ChainIndexQuery =
+    DatumFromHash DatumHash
+  | ValidatorFromHash ValidatorHash
+  | MintingPolicyFromHash MintingPolicyHash
+  | TxOutFromRef TxOutRef
+  | TxFromTxId TxId
+  | UtxoSetMembership TxOutRef
+  | UtxoSetAtAddress Credential
+  | GetTip
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty ChainIndexQuery where
+    pretty = \case
+        DatumFromHash h            -> "requesting datum from hash" <+> pretty h
+        ValidatorFromHash h        -> "requesting validator from hash" <+> pretty h
+        MintingPolicyFromHash h    -> "requesting minting policy from hash" <+> pretty h
+        TxOutFromRef r             -> "requesting utxo from utxo reference" <+> pretty r
+        TxFromTxId i               -> "requesting chain index tx from id" <+> pretty i
+        UtxoSetMembership txOutRef -> "whether tx output is part of the utxo set" <+> pretty txOutRef
+        UtxoSetAtAddress c         -> "requesting utxos located at addresses with the credential" <+> pretty c
+        GetTip                     -> "requesting the tip of the chain index"
+
+-- | Represents all possible responses to chain index queries. Each constructor
+-- contain the output resulting for the chain index query. These possible
+-- responses come from the data type 'Plutus.ChainIndex.Effects.ChainIndexQueryEffect'.
+data ChainIndexResponse =
+    DatumHashResponse (Maybe Datum)
+  | ValidatorHashResponse (Maybe Validator)
+  | MintingPolicyHashResponse (Maybe MintingPolicy)
+  | TxOutRefResponse (Maybe TxOut)
+  | TxIdResponse (Maybe ChainIndexTx)
+  | UtxoSetMembershipResponse (Tip, Bool)
+  | UtxoSetAtResponse (Tip, Page TxOutRef)
+  | GetTipResponse Tip
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty ChainIndexResponse where
+    pretty = \case
+        DatumHashResponse d -> "Chain index datum from hash response:" <+> pretty d
+        ValidatorHashResponse v -> "Chain index validator from hash response:" <+> pretty v
+        MintingPolicyHashResponse m -> "Chain index minting policy from hash response:" <+> pretty m
+        TxOutRefResponse t -> "Chain index utxo from utxo ref response:" <+> pretty t
+        TxIdResponse t -> "Chain index tx from tx id response:" <+> pretty (_citxTxId <$> t)
+        UtxoSetMembershipResponse (tip, b) ->
+                "Chain index response whether tx output ref is part of the UTxO set:"
+            <+> pretty b
+            <+> "with tip"
+            <+> pretty tip
+        UtxoSetAtResponse (tip, txOutRefPage) ->
+                "Chain index UTxO set from address response:"
+            <+> "Current tip is"
+            <+> pretty tip
+            <+> "and utxo refs are"
+            <+> hsep (fmap pretty $ pageItems txOutRefPage)
+        GetTipResponse tip -> "Chain index get tip response:" <+> pretty tip
 
 data UtxoAtAddress =
     UtxoAtAddress
@@ -294,3 +403,7 @@ instance Pretty ActiveEndpoint where
 makePrisms ''PABReq
 
 makePrisms ''PABResp
+
+makePrisms ''ChainIndexQuery
+
+makePrisms ''ChainIndexResponse

--- a/plutus-ledger/src/Ledger/Blockchain.hs
+++ b/plutus-ledger/src/Ledger/Blockchain.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 module Ledger.Blockchain (
     OnChainTx(..),
     _Valid,
@@ -37,6 +37,7 @@ import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import           Data.Monoid              (First (..))
 import qualified Data.Set                 as Set
+import           Data.Text.Encoding       (decodeUtf8)
 import           GHC.Generics             (Generic)
 import           Ledger.Tx                (spentOutputs, txId, unspentOutputsTx, updateUtxo, validValuesTx)
 
@@ -47,11 +48,15 @@ import           Plutus.V1.Ledger.Tx      (Tx, TxIn, TxOut, TxOutRef, collateral
                                            txOutRefId, txOutRefIdx, txOutValue, txOutputs, updateUtxoCollateral)
 import           Plutus.V1.Ledger.TxId
 import           Plutus.V1.Ledger.Value   (Value)
+import           Prettyprinter            (Pretty (..))
 
 -- | Block identifier (usually a hash)
 newtype BlockId = BlockId { getBlockId :: BS.ByteString }
     deriving stock (Eq, Ord, Generic)
     deriving (ToJSON, FromJSON, Show) via LedgerBytes
+
+instance Pretty BlockId where
+    pretty (BlockId blockId) = "BlockId(" <> pretty (decodeUtf8 blockId) <> ")"
 
 -- | A transaction on the blockchain.
 -- Invalid transactions are still put on the chain to be able to collect fees.

--- a/plutus-ledger/src/Ledger/Constraints/OffChain.hs
+++ b/plutus-ledger/src/Ledger/Constraints/OffChain.hs
@@ -106,7 +106,6 @@ instance Semigroup (ScriptLookups a) where
             -- 'First' to match the semigroup instance of Map (left-biased)
             , slTypedValidator = fmap getFirst $ (First <$> slTypedValidator l) <> (First <$> slTypedValidator r)
             , slOwnPubkey = fmap getFirst $ (First <$> slOwnPubkey l) <> (First <$> slOwnPubkey r)
-
             }
 
 instance Monoid (ScriptLookups a) where

--- a/plutus-pab-client/src/View/Pretty.purs
+++ b/plutus-pab-client/src/View/Pretty.purs
@@ -98,6 +98,12 @@ instance prettyPABResp :: Pretty PABResp where
       , nbsp
       , text $ show utxoAtAddress
       ]
+  pretty (ChainIndexQueryResp chainIndexQueryResponse) =
+    span_
+      [ text "ChainIndexQueryResponse:"
+      , nbsp
+      , text $ show chainIndexQueryResponse
+      ]
   pretty (AddressChangeResp addressChangeResponse) =
     span_
       [ text "AddressChangedAtResponse:"
@@ -165,6 +171,12 @@ instance prettyContractPABRequest :: Pretty PABReq where
       [ text "UtxoAtRequest:"
       , nbsp
       , text $ show utxoAtAddress
+      ]
+  pretty (ChainIndexQueryReq chainIndexQueryRequest) =
+    span_
+      [ text "ChainIndexQueryRequest:"
+      , nbsp
+      , text $ show chainIndexQueryRequest
       ]
   pretty (AddressChangeReq addressChangeRequest) =
     span_


### PR DESCRIPTION
Defined a effect types for chain index queries and responses in plutus-contract. These effects mirror the effects in the module `Plutus.ChainIndex.Effects.ChainIndexQueryEffect`. Now it is possible to make a `PABReq` to the chain index.

Added a lot of pretty instances which can probably be improved in the future.

@raduom FYI since you're also working on the chain index

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
