### PR TITLE
SCP-2600: Modified the migrate command in PAB

### DIFF
--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -219,7 +219,7 @@ in
           rm -rf ${cfg.dbFile}
 
           echo "[pab-init-cmd]: Creating new DB '${cfg.dbFile}'"
-          ${cfg.pab-setup}/bin/plutus-pab-setup migrate ${cfg.dbFile}
+          ${cfg.pab-package}/bin/plutus-pab-examples --config=${pabYaml} migrate;
         '';
       in
       {

--- a/plutus-pab-client/default.nix
+++ b/plutus-pab-client/default.nix
@@ -27,8 +27,7 @@ let
   migrate = pkgs.writeShellScriptBin "plutus-pab-migrate" ''
     # There might be local modifications so only copy when missing
     ! test -f ./plutus-pab.yaml && cp ../plutus-pab/plutus-pab.yaml.sample plutus-pab.yaml
-    # TODO: Change the migrate to read the config file instead and get the db path from there
-    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-setup-invoker)/bin/plutus-pab-setup migrate $(yq -r '.dbConfig.dbConfigFile' plutus-pab.yaml)
+    $(nix-build ../default.nix --quiet --no-build-output -A plutus-pab.server-examples-invoker)/bin/plutus-pab-examples --config=plutus-pab.yaml migrate
   '';
 
   # For dev usage

--- a/plutus-pab-client/pab-demo-scripts.nix
+++ b/plutus-pab-client/pab-demo-scripts.nix
@@ -45,11 +45,11 @@ let
     in
     runCommand "pab-setup" { } ''
       echo "Creating PAB database"
-      ${pab-setup} migrate ${conf.db-file}
-      ${sqlite-interactive}/bin/sqlite3 ${conf.db-file} '.tables'
       mkdir $out
-      cp ${conf.db-file}* $out/
       cp ${cfg} $out/plutus-pab.yaml
+      ${pab-exes.plutus-pab-examples}/bin/plutus-pab-examples --config=$out/plutus-pab.yaml migrate
+      ${sqlite-interactive}/bin/sqlite3 ${conf.db-file} '.tables'
+      cp ${conf.db-file}* $out/
     '';
 
   # mock node, needs to be the same for all PABs

--- a/plutus-pab/app/CommandParser.hs
+++ b/plutus-pab/app/CommandParser.hs
@@ -52,8 +52,7 @@ commandParser :: Parser NoConfigCommand
 commandParser =
     subparser $
     mconcat
-        [ migrationParser
-        , psGeneratorCommandParser
+        [ psGeneratorCommandParser
         , defaultConfigParser
         ]
 
@@ -78,14 +77,3 @@ psGeneratorCommandParser =
                 (metavar "OUTPUT_DIR" <>
                  help "Output directory to write PureScript files to.")
         pure $ PSGenerator {psGenOutputDir}
-
-migrationParser :: Mod CommandFields NoConfigCommand
-migrationParser =
-    command "migrate" $
-    flip info (fullDesc <> progDesc "Update the database with the latest schema.") $ do
-        dbPath <-
-            argument
-                str
-                (metavar "DATABASE" <>
-                 help "The sqlite database file.")
-        pure $ Migrate{dbPath}

--- a/plutus-pab/app/Main.hs
+++ b/plutus-pab/app/Main.hs
@@ -12,34 +12,20 @@ module Main
     ( main
     ) where
 
-import           CommandParser
-import           Plutus.PAB.Run.Cli
+import           CommandParser        (AppOpts (..), parseOptions)
+import           Plutus.PAB.Run.Cli   (runNoConfigCommand)
 
-import qualified Cardano.BM.Configuration.Model      as CM
-import           Cardano.BM.Data.Trace               (Trace)
-import           Cardano.BM.Setup                    (setupTrace_)
-import           Control.Monad.Logger                (logErrorN, runStdoutLoggingT)
-import           Data.Foldable                       (for_)
-import           Data.Text.Extras                    (tshow)
-import           Data.Void                           (Void)
-import           Plutus.PAB.Effects.Contract.Builtin (Builtin)
-import           Plutus.PAB.Monitoring.Config        (defaultConfig, loadConfig)
-import           Plutus.PAB.Monitoring.PABLogMsg     (AppMsg (..))
-import           Plutus.PAB.Monitoring.Util          (PrettyObject (..), convertLog)
-import           Plutus.PAB.Types                    (PABError)
-import           System.Exit                         (ExitCode (ExitFailure), exitSuccess, exitWith)
+import           Control.Monad.Logger (logErrorN, runStdoutLoggingT)
+import           Data.Text.Extras     (tshow)
+import           Plutus.PAB.Types     (PABError)
+import           System.Exit          (ExitCode (ExitFailure), exitSuccess, exitWith)
 
 main :: IO ()
 main = do
-    AppOpts { minLogLevel, logConfigPath, cmd } <- parseOptions
-
-    -- Parse config files and initialize logging
-    logConfig <- maybe defaultConfig loadConfig logConfigPath
-    for_ minLogLevel $ \ll -> CM.setMinSeverity logConfig ll
-    (trace :: Trace IO (PrettyObject (AppMsg (Builtin Void))), _) <- setupTrace_ logConfig "pab"
+    AppOpts { cmd } <- parseOptions
 
     -- execute parsed pab command and handle errors on failure
-    result <- Right <$> runNoConfigCommand (convertLog PrettyObject trace) cmd
+    result <- Right <$> runNoConfigCommand cmd
     either handleError (const exitSuccess) result
 
     where

--- a/plutus-pab/src/Plutus/PAB/Run/Command.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Command.hs
@@ -21,7 +21,8 @@ import           Wallet.Types       (ContractInstanceId)
 
 -- | A command for which a config.yaml file is required
 data ConfigCommand =
-    MockNode MockServerMode -- ^ Run the mock node service without starting the server
+    Migrate
+    | MockNode MockServerMode -- ^ Run the mock node service without starting the server
     | MockWallet -- ^ Run the mock wallet service
     | ChainIndex -- ^ Run the chain index service
     | Metadata -- ^ Run the mock meta-data service
@@ -38,8 +39,7 @@ data ConfigCommand =
     deriving anyclass JSON.ToJSON
 
 data NoConfigCommand =
-    Migrate { dbPath :: !FilePath } -- ^ Execute a database migration
-    | PSGenerator -- ^ Generate purescript bridge code
+    PSGenerator -- ^ Generate purescript bridge code
           { psGenOutputDir :: !FilePath -- ^ Path to write generated code to
           }
     | WriteDefaultConfig -- ^ Write default logging configuration

--- a/plutus-pab/src/Plutus/PAB/Run/CommandParser.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/CommandParser.hs
@@ -83,7 +83,8 @@ commandParser :: Parser ConfigCommand
 commandParser =
     subparser $
     mconcat
-        [ allServersParser
+        [ migrationParser
+        , allServersParser
         , clientServicesParser
         , mockWalletParser
         , pabWebserverParser
@@ -103,6 +104,12 @@ commandParser =
                    (fullDesc <> progDesc "Manage your smart contracts."))
         , psGeneratorCommandParser
         ]
+
+migrationParser :: Mod CommandFields ConfigCommand
+migrationParser =
+    command "migrate" $
+    flip info (fullDesc <> progDesc "Update the database with the latest schema.") $
+        pure Migrate
 
 psGeneratorCommandParser :: Mod CommandFields ConfigCommand
 psGeneratorCommandParser =

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -83,7 +83,7 @@ instance Pretty PABError where
         MigrationNotDoneError msg  -> pretty msg
                                    <> line
                                    <> "Did you forget to run the 'migrate' command ?"
-                                   <+> "(ex. 'plutus-pab-migrate' or 'plutus-pab-setup migrate pab-core.db')"
+                                   <+> "(ex. 'plutus-pab-migrate' or 'plutus-pab-examples --config <CONFIG_FILE> migrate')"
 
 data DbConfig =
     DbConfig


### PR DESCRIPTION
Modified the migrate command in plutus-pab to use the database filepath from the config file instead of the CLI.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
