### PR TITLE
SCP-2605: Add compression to script serialization

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
@@ -48,6 +48,7 @@
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."pure-zlib" or (errorHandler.buildDepError "pure-zlib"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."base16-bytestring" or (errorHandler.buildDepError "base16-bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -55,6 +56,7 @@
           (hsPkgs."tagged" or (errorHandler.buildDepError "tagged"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
+          (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
           ];
         buildable = true;
         modules = [

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -646,6 +646,7 @@
         "hourglass".revision = (((hackage."hourglass")."0.2.12").revisions).default;
         "appar".revision = (((hackage."appar")."0.1.8").revisions).default;
         "indexed-traversable-instances".revision = (((hackage."indexed-traversable-instances")."0.1").revisions).default;
+        "pure-zlib".revision = (((hackage."pure-zlib")."0.6.7").revisions).default;
         "testing-type-modifiers".revision = (((hackage."testing-type-modifiers")."0.1.0.1").revisions).default;
         "th-desugar".revision = (((hackage."th-desugar")."1.11").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.0.9").revisions).default;
@@ -1143,6 +1144,7 @@
           "signal".components.exes."test".planned = lib.mkOverride 900 true;
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "appar".components.library.planned = lib.mkOverride 900 true;
+          "pure-zlib".components.library.planned = lib.mkOverride 900 true;
           "hspec-discover".components.exes."hspec-discover".planned = lib.mkOverride 900 true;
           "prettyprinter-configurable".components.setup.planned = lib.mkOverride 900 true;
           "MonadRandom".components.library.planned = lib.mkOverride 900 true;
@@ -1245,6 +1247,7 @@
           "auto-update".components.library.planned = lib.mkOverride 900 true;
           "http-conduit".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-consensus-byron".components.library.planned = lib.mkOverride 900 true;
+          "pure-zlib".components.exes."deflate".planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
           "criterion".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
@@ -48,6 +48,7 @@
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."pure-zlib" or (errorHandler.buildDepError "pure-zlib"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."base16-bytestring" or (errorHandler.buildDepError "base16-bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -55,6 +56,7 @@
           (hsPkgs."tagged" or (errorHandler.buildDepError "tagged"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
+          (hsPkgs."zlib" or (errorHandler.buildDepError "zlib"))
           ];
         buildable = true;
         modules = [

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -651,6 +651,7 @@
         "appar".revision = (((hackage."appar")."0.1.8").revisions).default;
         "indexed-traversable-instances".revision = (((hackage."indexed-traversable-instances")."0.1").revisions).default;
         "libsystemd-journal".revision = (((hackage."libsystemd-journal")."1.4.5").revisions).default;
+        "pure-zlib".revision = (((hackage."pure-zlib")."0.6.7").revisions).default;
         "testing-type-modifiers".revision = (((hackage."testing-type-modifiers")."0.1.0.1").revisions).default;
         "th-desugar".revision = (((hackage."th-desugar")."1.11").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.0.9").revisions).default;
@@ -1149,6 +1150,7 @@
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "libsystemd-journal".components.library.planned = lib.mkOverride 900 true;
           "appar".components.library.planned = lib.mkOverride 900 true;
+          "pure-zlib".components.library.planned = lib.mkOverride 900 true;
           "hspec-discover".components.exes."hspec-discover".planned = lib.mkOverride 900 true;
           "prettyprinter-configurable".components.setup.planned = lib.mkOverride 900 true;
           "MonadRandom".components.library.planned = lib.mkOverride 900 true;
@@ -1253,6 +1255,7 @@
           "auto-update".components.library.planned = lib.mkOverride 900 true;
           "http-conduit".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-consensus-byron".components.library.planned = lib.mkOverride 900 true;
+          "pure-zlib".components.exes."deflate".planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "process".components.library.planned = lib.mkOverride 900 true;
           "criterion".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -70,13 +70,18 @@ library
         template-haskell -any,
         text -any,
         prettyprinter -any,
+        pure-zlib -any,
         transformers -any,
         base16-bytestring >= 1,
         deepseq -any,
         newtype-generics -any,
         tagged -any,
         lens -any,
-        scientific -any
+        scientific -any,
+        zlib -any
+    mixins:
+        pure-zlib (Codec.Compression.Zlib as PureZlib.Zlib),
+        zlib (Codec.Compression.Zlib as CZlib.Zlib)
 
 test-suite plutus-ledger-api-test
     import: lang

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -54,7 +54,9 @@ module Plutus.V1.Ledger.Scripts(
 
 import qualified Prelude                                  as Haskell
 
+import           CZlib.Zlib                               as CZlib
 import           Codec.CBOR.Decoding                      (decodeBytes)
+import           Codec.CBOR.Encoding                      (encodeBytes)
 import           Codec.Serialise                          (Serialise, decode, encode, serialise)
 import           Control.DeepSeq                          (NFData)
 import           Control.Monad.Except                     (MonadError, runExceptT, throwError)
@@ -82,14 +84,15 @@ import           PlutusTx.Builtins                        as Builtins
 import           PlutusTx.Builtins.Internal               as BI
 import           PlutusTx.Evaluation                      (ErrorWithCause (..), EvaluationError (..), evaluateCekTrace)
 import           PlutusTx.Prelude
+import           PureZlib.Zlib                            as PZlib
 import qualified UntypedPlutusCore                        as UPLC
 import qualified UntypedPlutusCore.Evaluation.Machine.Cek as UPLC
 
 -- | A script on the chain. This is an opaque type as far as the chain is concerned.
 newtype Script = Script { unScript :: UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun () }
-  deriving stock Generic
+    deriving stock Generic
 
-{-| Note [Using Flat inside CBOR instance of Script]
+{- Note [Using Flat inside CBOR instance for Script]
 `plutus-ledger` uses CBOR for data serialisation and `plutus-core` uses Flat. The
 choice to use Flat was made to have a more efficient (most wins are in uncompressed
 size) data serialisation format and use less space on-chain.
@@ -103,13 +106,31 @@ Because Flat is not self-describing and it gets used in the encoding of Programs
 data structures that include scripts (for example, transactions) no-longer benefit
 for CBOR's ability to self-describe it's format.
 -}
+
+{- Note [Using compression for script serialization]
+Compression gains us 30-40% off script size, which is enough that we can't ignore it.
+Unfortunately, using compression is somewhat fraught. In particular, it is too risky
+to use a C compression library in the main line of the Cardano node, since such things
+tend to be prone to exploits.
+
+Instead we use a pure Haskell implementation of (just enough of) zlib, `pure-zlib` for
+decompression, and the Haskell C-wrapper around `zlib` for compression.
+-}
+
 instance Serialise Script where
-  encode = encode . Flat.flat . unScript
-  decode = do
-    bs <- decodeBytes
-    case Flat.unflat bs of
-      Left  err    -> Haskell.fail (Haskell.show err)
-      Right script -> return $ Script script
+    -- See Note [Using Flat inside the CBOR instance for Script]
+    -- See Note [Using compression for script serialization]
+    encode = encodeBytes . BSL.toStrict . CZlib.compressWith (CZlib.defaultCompressParams{compressLevel=CZlib.bestCompression}) . BSL.fromStrict . Flat.flat . unScript
+    decode = do
+        bs <- decodeBytes
+        -- See Note [Using compression for script serialization]
+        bs' <- case PZlib.decompress $ BSL.fromStrict bs of
+            Left err           -> Haskell.fail (Haskell.show err)
+            Right decompressed -> return decompressed
+        -- See Note [Using Flat inside the CBOR instance for Script]
+        case Flat.unflat bs' of
+            Left  err    -> Haskell.fail (Haskell.show err)
+            Right script -> return $ Script script
 
 {- Note [Eq and Ord for Scripts]
 We need `Eq` and `Ord` instances for `Script`s mostly so we can put them in `Set`s.

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -9,6 +9,7 @@ module Main(main) where
 
 import qualified Cardano.Api                    as C
 import qualified Cardano.Api.Shelley            as C
+import           Codec.Serialise                (serialise)
 import qualified Control.Foldl                  as L
 import           Control.Monad.Freer            (run)
 import           Data.Aeson                     (ToJSON (..), object, (.=))
@@ -187,9 +188,15 @@ writeScript fp prefix mode idx event@ScriptValidationEvent{sveResult} = do
     let filename = fp </> prefix <> "-" <> show idx <> filenameSuffix mode <> ".flat"
         bytes = BSL.fromStrict . flat . unScript . getScript mode $ event
         byteSize = BSL.length bytes
+    let
+        filename2 = fp </> prefix <> "-" <> show idx <> filenameSuffix mode <> ".flat.z.cbor"
+        bytes2 = serialise . getScript mode $ event
+        byteSize2 = BSL.length bytes2
     putStrLn $ "Writing script: " <> filename <> " (" <> either show (showStats byteSize . fst) sveResult <> ")"
     BSL.writeFile filename bytes
-    pure (Sum byteSize, foldMap fst sveResult)
+    putStrLn $ "Writing script: " <> filename2 <> " (" <> either show (showStats byteSize2 . fst) sveResult <> ")"
+    BSL.writeFile filename2 bytes2
+    pure (Sum byteSize2, foldMap fst sveResult)
 
 showStats :: Int64 -> ExBudget -> String
 showStats byteSize (ExBudget exCPU exMemory) = "Size: " <> size <> "kB, Cost: " <> show exCPU <> ", " <> show exMemory

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx ebbf63053f10c94d23ba99c9a6bd257f54687800da10a6747f892378e6d13a10:
+                Tx 093a96fba7231d9a0fea69381e6c4bd7a247ac89391e481fa3630b6261e31b43:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential)
+                      addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -34,23 +34,23 @@ Slot 1: W2: Balancing an unbalanced transaction:
                     "\151~\251\&5\171b\GS9\219\235rt\236w\149\163G\b\255M%\160\SUB\GS\240L\US'"}
               Requires signatures:
               Utxo index:
-Slot 1: W2: Finished balancing. bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
+Slot 1: W2: Finished balancing. b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
-Slot 1: W2: Submitting tx: bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
-Slot 1: W2: TxSubmit: bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
+Slot 1: W2: Submitting tx: b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
+Slot 1: W2: TxSubmit: b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 25.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx 8b66afb1401497930ed125aae00638d6f7bb7dc63f69ad360c5cc906bd8540f6:
+                Tx 87bb4eff431542844189fd618fe181205e053b08d660d09a0c9579de619cf93f:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential)
+                      addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -60,17 +60,17 @@ Slot 1: W3: Balancing an unbalanced transaction:
                     "\DEL\138v\192\235\170J\210\r\253\205Q\165\222\a\n\183q\244\191\&7\DEL,A\230\183\FS\n"}
               Requires signatures:
               Utxo index:
-Slot 1: W3: Finished balancing. 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
-Slot 1: W3: Submitting tx: 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
-Slot 1: W3: TxSubmit: 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
+Slot 1: W3: Finished balancing. ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
+Slot 1: W3: Submitting tx: ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
+Slot 1: W3: TxSubmit: ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx e299f59a09fe2444cc55a20589e2300970d5ba6577cdeedf0f11b7a468a70af2:
+                Tx 5a987baab0b79564db936cb640a9ebdf91701f2d248e692f618871111d57bccb:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential)
+                      addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -80,23 +80,23 @@ Slot 1: W4: Balancing an unbalanced transaction:
                     "\188\192\131\173\227\253\208\163r\203lC\239\NUL\239\STX\252\181.\149\&2\148\DC1\ETB\215`\157j"}
               Requires signatures:
               Utxo index:
-Slot 1: W4: Finished balancing. 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
-Slot 1: W4: Submitting tx: 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
-Slot 1: W4: TxSubmit: 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
-Slot 1: TxnValidate 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
-Slot 1: TxnValidate 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
-Slot 1: TxnValidate bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
+Slot 1: W4: Finished balancing. 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
+Slot 1: W4: Submitting tx: 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
+Slot 1: W4: TxSubmit: 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
+Slot 1: TxnValidate 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
+Slot 1: TxnValidate ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
+Slot 1: TxnValidate b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 961d31cf33bccaf7f96e6beff9ade00d1491e78e0ee980825e0382a7f12dbc65:
+                 Tx 3771bd51be916b543306e59dca2ee01e69ff0c63f2be55426f2c3e0bd3d842fa:
                    {inputs:
-                      - 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8!1
+                      - 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce!1
                         <>
-                      - 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf!1
+                      - b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b!1
                         <>
-                      - bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f!1
+                      - ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c!1
                         <>
                    collateral inputs:
                    outputs:
@@ -108,18 +108,18 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    data:}
                Requires signatures:
                Utxo index:
-                 ( 633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8!1
-                 , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential) )
-                 ( 8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf!1
+                 ( 085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce!1
                  , - Value (Map [(,Map [("",25)])]) addressed to
-                     addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential) )
-                 ( bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f!1
+                     addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential) )
+                 ( b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b!1
                  , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc (no staking credential) )
-Slot 20: W1: Finished balancing. 6482037d7095ab78b68500c15a6b6de1f757fbbdee7af81fac4114a24a3eaef7
-Slot 20: W1: Submitting tx: 6482037d7095ab78b68500c15a6b6de1f757fbbdee7af81fac4114a24a3eaef7
-Slot 20: W1: TxSubmit: 6482037d7095ab78b68500c15a6b6de1f757fbbdee7af81fac4114a24a3eaef7
+                     addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential) )
+                 ( ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c!1
+                 , - Value (Map [(,Map [("",100)])]) addressed to
+                     addressed to ScriptCredential: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe (no staking credential) )
+Slot 20: W1: Finished balancing. a297054f99c73da9422298fe53d743a3d0c53132b0b6228d083b259b7f06810c
+Slot 20: W1: Submitting tx: a297054f99c73da9422298fe53d743a3d0c53132b0b6228d083b259b7f06810c
+Slot 20: W1: TxSubmit: a297054f99c73da9422298fe53d743a3d0c53132b0b6228d083b259b7f06810c
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 6482037d7095ab78b68500c15a6b6de1f757fbbdee7af81fac4114a24a3eaef7
+Slot 20: TxnValidate a297054f99c73da9422298fe53d743a3d0c53132b0b6228d083b259b7f06810c

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
+TxId:       085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840e1f3af4199e6ea56a1e2dbffcde3008a27ee...
+              Signature: 5840a1fb09c2a7c5e60f0067c29af8e876dde184...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: bcc083ade3fdd0a372cb6c43ef00ef02fcb52e95... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
+TxId:       ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584024533e9c82f5f85fba592b281514e5d8c656...
+              Signature: 5840fe491557c7612592f91a03ef40634feb2eb7...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 7f8a76c0ebaa4ad20dfdcd51a5de070ab771f4bf... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
+TxId:       b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840083df4fdc3f188b61e4bd2a8f64fe4cf1dbd...
+              Signature: 5840bb232024fcf2e4f75a21e43bf4abee4f9ee6...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  100
 
@@ -318,16 +318,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       6482037d7095ab78b68500c15a6b6de1f757fbbdee7af81fac4114a24a3eaef7
+TxId:       a297054f99c73da9422298fe53d743a3d0c53132b0b6228d083b259b7f06810c
 Fee:        Ada:      Lovelace:  14038
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840da84563d99e49702ecd8aa46bc87d8a3c175...
+              Signature: 58404432dfee29648c3b69adf7e4fb8055c31ef0...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -339,31 +339,31 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     633fe898ba05bbe0e104b2231c597b7dad95b6046f63268dd95f54462e86b6d8
-    Output #1
-    Script: 590e420100003323332223232333222333222333...
-
-  ---- Input 2 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  25
   Source:
-    Tx:     8ad38d6daa7f6509810ca3f79b6ccb80a39e89b9fdec4f4382ae0d6bccdbdacf
+    Tx:     085a9ee3da393b02eb6d0ff89a8456d38cc536f098e02b961fc6cd3c2ef4dcce
     Output #1
-    Script: 590e420100003323332223232333222333222333...
+    Script: 5908a078da95566f681be7197fdef74eca9d6c27...
 
-  ---- Input 3 ----
-  Destination:  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  ---- Input 2 ----
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     bad077d0a2104d83f2507bb46c25ddea185cba3928a1b60d766e93d81745075f
+    Tx:     b194ba929b5e1b35891d5e21379df0d6f6bfc2c34013b786d2c60a736a625c0b
     Output #1
-    Script: 590e420100003323332223232333222333222333...
+    Script: 5908a078da95566f681be7197fdef74eca9d6c27...
+
+  ---- Input 3 ----
+  Destination:  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
+  Value:
+    Ada:      Lovelace:  100
+  Source:
+    Tx:     ddae8208a60f5696124b6d1c837f8f54ba77d2039c6c684d9b89debd8b22b13c
+    Output #1
+    Script: 5908a078da95566f681be7197fdef74eca9d6c27...
 
 
 Outputs:
@@ -414,6 +414,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d2d012ff2f40ceea2a795878b3fb7bb6c74e7ce62c038bcdd78350cc
+  Script: e15bd48d5549a83c657ac6f655ca11dc4b11618183834a79e2bdeebe
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       a0ef6da6ad38e0181a1ad314ac447dd49ca22b04e596dd131f3ff0e99f162ec9
+TxId:       da69b9246b8c5eb6ef58e684f60e6aa4c7b3aafced73af2c3b9bd35764dd1444
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584035f5b2ebdd54329867b0f36182b36dc2632b...
+              Signature: 58400e292e91c6cb1ca15449d555447285091b24...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999982
 
   ---- Output 1 ----
-  Destination:  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Destination:  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
 
@@ -170,34 +170,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       2b6df0a1b4f0f60fdbe00fe4476b064846e295d059368cf046d34b7882263c81
+TxId:       cdc066b97cda19f16476afa16a5547cbae84ebbe4ee3420b2468ddb2fc0d83c7
 Fee:        Ada:      Lovelace:  12612
-Mint:       a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+Mint:       9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840c45365990a86ae76131fb91af28d6f2879a9...
+              Signature: 5840a27b1c4250ca072af835670506cf0d417cff...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     a0ef6da6ad38e0181a1ad314ac447dd49ca22b04e596dd131f3ff0e99f162ec9
+    Tx:     da69b9246b8c5eb6ef58e684f60e6aa4c7b3aafced73af2c3b9bd35764dd1444
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Destination:  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     a0ef6da6ad38e0181a1ad314ac447dd49ca22b04e596dd131f3ff0e99f162ec9
+    Tx:     da69b9246b8c5eb6ef58e684f60e6aa4c7b3aafced73af2c3b9bd35764dd1444
     Output #1
-    Script: 591d8b0100003323322333222333222323233223...
+    Script: 5912cf78da95587f6c1bd77dffbee3237927d3ca...
 
 
 Outputs:
@@ -205,16 +205,16 @@ Outputs:
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987370
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  -
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Destination:  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
 
@@ -223,7 +223,7 @@ Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987370
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       b865119649ed0fd692ef17b9c71a1107dcede0bc0ee2c2137a37fcad9bc81a97
+TxId:       5cfc352363db1b055dac73fbb734258ab283ff153a7efae2c435897f8a1b586f
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58409c621e22ef89b251d3ccf988ae87fd5c0b60...
+              Signature: 58404f487e4f8d4d0f16127c81de3576174cbbf6...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987370
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  -
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  -
   Source:
-    Tx:     2b6df0a1b4f0f60fdbe00fe4476b064846e295d059368cf046d34b7882263c81
+    Tx:     cdc066b97cda19f16476afa16a5547cbae84ebbe4ee3420b2468ddb2fc0d83c7
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
     Ada:      -
   Source:
-    Tx:     2b6df0a1b4f0f60fdbe00fe4476b064846e295d059368cf046d34b7882263c81
+    Tx:     cdc066b97cda19f16476afa16a5547cbae84ebbe4ee3420b2468ddb2fc0d83c7
     Output #1
 
 
@@ -298,19 +298,19 @@ Outputs:
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987360
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    0
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987360
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    0
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -335,7 +335,7 @@ Balances Carried Forward:
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -349,16 +349,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       719f465bbefef4d42682606317cafef065f7a91510429a49e7213f05a6326e1c
+TxId:       23616e99222d1528a61c90828e433c8d36cd836cbb09922f7985550d7380c90b
 Fee:        Ada:      Lovelace:  12612
-Mint:       a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    0
+Mint:       9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 58401c613a84ba1561ec0fd13e191c3eac7ca41d...
+              Signature: 5840f7a9a5f2f52e61f4f37367a633480b997efb...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -370,22 +370,22 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
+  Value:
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
+  Source:
+    Tx:     5cfc352363db1b055dac73fbb734258ab283ff153a7efae2c435897f8a1b586f
+    Output #1
+
+
+  ---- Input 2 ----
+  Destination:  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     2b6df0a1b4f0f60fdbe00fe4476b064846e295d059368cf046d34b7882263c81
+    Tx:     cdc066b97cda19f16476afa16a5547cbae84ebbe4ee3420b2468ddb2fc0d83c7
     Output #2
-    Script: 591d8b0100003323322333222333222323233223...
-
-  ---- Input 2 ----
-  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
-  Value:
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
-  Source:
-    Tx:     b865119649ed0fd692ef17b9c71a1107dcede0bc0ee2c2137a37fcad9bc81a97
-    Output #1
-
+    Script: 5912cf78da95587f6c1bd77dffbee3237927d3ca...
 
 
 Outputs:
@@ -393,16 +393,16 @@ Outputs:
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  99987391
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    0
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Destination:  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  5
 
@@ -411,7 +411,7 @@ Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99987360
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    0
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -436,7 +436,7 @@ Balances Carried Forward:
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  99987391
-    a23e0a9b9367954bbd1a8536784cecd5c7e95d20154e54bdc7a51345:  guess:    1
+    9e75e16fea2ca1dd6b0580c0a360406193e6940949642c763ca80dcb:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -450,6 +450,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 2f42c00813badd9ec0f52c16ee9cf33ab028cedd3f06c4e8ebadbc16
+  Script: 56b747c2499e95c7c7844552eb64ea86f0bdec04d5df96891bb9d10d
   Value:
     Ada:      Lovelace:  5

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       1097d1a45d9ab5f560f5fd52ab753d12365fccc6c1ed155130bb311f5aa43d71
+TxId:       08c1a2356a69656ed92b8ae3b80729467a9af27064c6bbd4f3452973b3841d52
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 58409ce723a95596e2b0b4dc25d1460d97e54de8...
+              Signature: 5840561098972877933d30ea3f8589826610334e...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: 9d1ca204b16908257d52c29f8744c66e61aba91e558c7d6841c88169
+  Destination:  Script: 58480d8993df0a16ba23df7ab3820285e2ff848c2dbc38555bfc0b3e
   Value:
     Ada:      Lovelace:  60
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 9d1ca204b16908257d52c29f8744c66e61aba91e558c7d6841c88169
+  Script: 58480d8993df0a16ba23df7ab3820285e2ff848c2dbc38555bfc0b3e
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       73b0d4c3cc94e3f475d524b10d58990fcbf9160a5c9169b99c8b981299395107
+TxId:       f29cd3e676f5748d208489e81c83458b0dd8427acd927580d54eeb13aed0637b
 Fee:        Ada:      Lovelace:  6260
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840f55bc6c89e817cd072897503b3e48fba00b6...
+              Signature: 5840d0d458cfede3c7b8cc89734513e1c115e9d7...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -191,13 +191,13 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: 9d1ca204b16908257d52c29f8744c66e61aba91e558c7d6841c88169
+  Destination:  Script: 58480d8993df0a16ba23df7ab3820285e2ff848c2dbc38555bfc0b3e
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     1097d1a45d9ab5f560f5fd52ab753d12365fccc6c1ed155130bb311f5aa43d71
+    Tx:     08c1a2356a69656ed92b8ae3b80729467a9af27064c6bbd4f3452973b3841d52
     Output #1
-    Script: 5913110100003323322323233322233322233333...
+    Script: 590b9e78da955771681bd719ffded3493e298e73...
 
 
 Outputs:
@@ -207,7 +207,7 @@ Outputs:
     Ada:      Lovelace:  99993750
 
   ---- Output 1 ----
-  Destination:  Script: 9d1ca204b16908257d52c29f8744c66e61aba91e558c7d6841c88169
+  Destination:  Script: 58480d8993df0a16ba23df7ab3820285e2ff848c2dbc38555bfc0b3e
   Value:
     Ada:      Lovelace:  50
 
@@ -253,6 +253,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 9d1ca204b16908257d52c29f8744c66e61aba91e558c7d6841c88169
+  Script: 58480d8993df0a16ba23df7ab3820285e2ff848c2dbc38555bfc0b3e
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Simple enough to implement, I'm still unsure if we should pull the trigger.

I made `plutus-use-cases` scripts dump out both formats, both the ASTs in flat and the scripts in our odd combination of nested flat+z+cbor (hence the unwieldy filed extension). I think it's worth having both, since we can continue to use the simple flat ASTs for evaluator benchmarking.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
