### PR TITLE
SCP-2404: PAB updates its internal state with txns from Alonzo node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ node.sock
 .pre-commit-config.yaml
 secrets/*/.gpg-id
 ghcid.txt
+plutus-pab/test-node/testnet/db

--- a/marlowe-dashboard-client/plutus-pab.yaml
+++ b/marlowe-dashboard-client/plutus-pab.yaml
@@ -34,6 +34,7 @@ nodeServerConfig:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
+  mscNodeMode: MockNode
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083

--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -46,6 +46,7 @@ let
         { getWallet = 2; }
         { getWallet = 3; }
       ];
+      mscNodeMode = "MockNode";
     };
 
     chainIndexConfig = {

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -258,7 +258,6 @@
             (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
             (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -258,13 +258,14 @@
             (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
             (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             ];
           buildable = true;
           modules = [
-            "ContractExample"
             "ContractExample/AtomicSwap"
             "ContractExample/PayToWallet"
             "ContractExample/WaitForTx"
+            "ContractExample"
             ];
           hsSourceDirs = [ "examples" ];
           mainPath = [ "Main.hs" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -258,7 +258,6 @@
             (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
             (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -258,13 +258,14 @@
             (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
             (hsPkgs."servant-purescript" or (errorHandler.buildDepError "servant-purescript"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             ];
           buildable = true;
           modules = [
-            "ContractExample"
             "ContractExample/AtomicSwap"
             "ContractExample/PayToWallet"
             "ContractExample/WaitForTx"
+            "ContractExample"
             ];
           hsSourceDirs = [ "examples" ];
           mainPath = [ "Main.hs" ];

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -42,6 +42,7 @@
       - getWallet: 1
       - getWallet: 2
       - getWallet: 3
+    mscNodeMode = "MockNode";
 
   chainIndexConfig:
     ciBaseUrl: http://localhost:${ chain-index-port }

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -42,7 +42,7 @@
       - getWallet: 1
       - getWallet: 2
       - getWallet: 3
-    mscNodeMode: "MockNode";
+    mscNodeMode: MockNode
 
   chainIndexConfig:
     ciBaseUrl: http://localhost:${ chain-index-port }

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -42,7 +42,7 @@
       - getWallet: 1
       - getWallet: 2
       - getWallet: 3
-    mscNodeMode = "MockNode";
+    mscNodeMode: "MockNode";
 
   chainIndexConfig:
     ciBaseUrl: http://localhost:${ chain-index-port }

--- a/plutus-pab/examples/ContractExample.hs
+++ b/plutus-pab/examples/ContractExample.hs
@@ -28,6 +28,7 @@ import           Data.Data                                 (Proxy (Proxy))
 import           Data.Row
 import           Language.PureScript.Bridge                (equal, genericShow, mkSumType)
 import           Language.PureScript.Bridge.TypeParameters (A)
+import           Ledger                                    (TxId)
 import           Playground.Types                          (FunctionSchema)
 import qualified Plutus.Contracts.Currency                 as Contracts.Currency
 import qualified Plutus.Contracts.GameStateMachine         as Contracts.GameStateMachine
@@ -55,8 +56,8 @@ data ExampleContracts = UniswapInit
                       | PrismMirror
                       | PrismUnlockExchange
                       | PrismUnlockSto
-                      | WaitForTx
                       | PingPong
+                      | WaitForTx TxId
     deriving (Eq, Ord, Show, Generic)
     deriving anyclass (FromJSON, ToJSON)
 
@@ -82,7 +83,6 @@ instance HasDefinitions ExampleContracts where
                      , PrismMirror
                      , PrismUnlockExchange
                      , PrismUnlockSto
-                     , WaitForTx
                      , PingPong
                      ]
     getContract = getExampleContracts
@@ -100,8 +100,8 @@ getExampleContractsSchema = \case
     PrismMirror         -> Builtin.endpointsToSchemas @Contracts.Prism.MirrorSchema
     PrismUnlockExchange -> Builtin.endpointsToSchemas @Contracts.Prism.UnlockExchangeSchema
     PrismUnlockSto      -> Builtin.endpointsToSchemas @Contracts.Prism.STOSubscriberSchema
-    WaitForTx           -> Builtin.endpointsToSchemas @Contracts.WaitForTx.WaitForTxSchema
     PingPong            -> Builtin.endpointsToSchemas @Contracts.PingPong.PingPongSchema
+    WaitForTx{}         -> Builtin.endpointsToSchemas @Empty
 
 getExampleContracts :: ExampleContracts -> SomeBuiltin
 getExampleContracts = \case
@@ -115,8 +115,8 @@ getExampleContracts = \case
     PrismMirror         -> SomeBuiltin (Contracts.Prism.mirror @Contracts.Prism.MirrorSchema @())
     PrismUnlockExchange -> SomeBuiltin (Contracts.Prism.unlockExchange @() @Contracts.Prism.UnlockExchangeSchema)
     PrismUnlockSto      -> SomeBuiltin (Contracts.Prism.subscribeSTO @() @Contracts.Prism.STOSubscriberSchema)
-    WaitForTx           -> SomeBuiltin Contracts.WaitForTx.waitForTx
     PingPong            -> SomeBuiltin Contracts.PingPong.simplePingPong
+    WaitForTx txi       -> SomeBuiltin (Contracts.WaitForTx.waitForTx txi)
 
 handlers :: SimulatorEffectHandlers (Builtin ExampleContracts)
 handlers =

--- a/plutus-pab/examples/ContractExample/WaitForTx.hs
+++ b/plutus-pab/examples/ContractExample/WaitForTx.hs
@@ -3,16 +3,13 @@
 
 module ContractExample.WaitForTx (
     waitForTx
-    , WaitForTxSchema
     ) where
 
 import           Ledger          (TxId)
-import           Plutus.Contract (ContractError, Endpoint, Promise, awaitTxConfirmed, endpoint, logInfo)
+import           Plutus.Contract (Contract, ContractError, EmptySchema, awaitTxConfirmed, logInfo)
 
-type WaitForTxSchema = Endpoint "tx-id" TxId
-
-waitForTx :: Promise () WaitForTxSchema ContractError ()
-waitForTx = endpoint @"tx-id" $ \txid -> do
+waitForTx :: TxId -> Contract () EmptySchema ContractError ()
+waitForTx txid = do
     logInfo @String $ "Waiting for transaction " <> show txid
     awaitTxConfirmed txid
     logInfo @String "CONFIRMED"

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -267,10 +267,10 @@ executable plutus-pab-examples
     main-is:          Main.hs
     hs-source-dirs:   examples
     other-modules:
-        ContractExample
         ContractExample.AtomicSwap
         ContractExample.PayToWallet
         ContractExample.WaitForTx
+        ContractExample
     default-language: Haskell2010
     ghc-options:
         -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -20,7 +20,7 @@ nodeServerConfig:
   mscBaseUrl: http://localhost:9082
   mscSocketPath: ./node-server.sock
   mscKeptBlocks: 100
-  mscNetworkId: "1"
+  mscNetworkId: "1097911063" # Testnet network ID (main net = empty string)
   mscSlotConfig:
     scSlotZeroTime: 1591566291000 # Wednesday, July 29, 2020 21:44:51 - shelley launch time in milliseconds
     scSlotLength: 1000 # In milliseconds
@@ -33,6 +33,7 @@ nodeServerConfig:
     - getWallet: 1
     - getWallet: 2
     - getWallet: 3
+  mscNodeMode: MockNode
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083

--- a/plutus-pab/src/Cardano/Node/Types.hs
+++ b/plutus-pab/src/Cardano/Node/Types.hs
@@ -37,7 +37,7 @@ module Cardano.Node.Types
 
     -- * Config types
     , MockServerConfig (..)
-    , MockServerMode (..)
+    , NodeMode (..)
 
     -- * newtype wrappers
     , NodeUrl (..)
@@ -99,13 +99,12 @@ We use this approach for the "proper" pab executable.
 newtype NodeUrl = NodeUrl BaseUrl
     deriving (Show, Eq) via BaseUrl
 
--- | The mock node server can be replaced with a cardano node, in which case
---   we don't want to start it.
-data MockServerMode =
-      WithMockServer
-    | WithoutMockServer
-    deriving (Show, Eq, Generic)
-    deriving anyclass ToJSON
+-- | Which node we're connecting to
+data NodeMode =
+    MockNode -- ^ Connect to the PAB mock node.
+    | AlonzoNode -- ^ Connect to an Alonzo node
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass (FromJSON, ToJSON)
 
 -- | Mock Node server configuration
 data MockServerConfig =
@@ -127,8 +126,11 @@ data MockServerConfig =
         -- multiply size-dependent scripts fee.
         , mscNetworkId        :: NetworkIdWrapper
         -- ^ NetworkId that's used with the CardanoAPI.
+        , mscNodeMode         :: NodeMode
+        -- ^ Whether to connect to an Alonzo node or a mock node
         }
-    deriving (Show, Eq, Generic, FromJSON)
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass (FromJSON)
 
 
 defaultMockServerConfig :: MockServerConfig
@@ -147,6 +149,7 @@ defaultMockServerConfig =
       , mscSlotConfig = def
       , mscFeeConfig  = def
       , mscNetworkId = testnetNetworkId
+      , mscNodeMode  = MockNode
       }
 
 instance Default MockServerConfig where

--- a/plutus-pab/src/Cardano/Protocol/Socket/Client.hs
+++ b/plutus-pab/src/Cardano/Protocol/Socket/Client.hs
@@ -17,7 +17,7 @@ import           Cardano.Api                                 (BlockInMode (..), 
                                                               ChainTip (..), ConsensusModeParams (..),
                                                               LocalChainSyncClient (..), LocalNodeClientProtocols (..),
                                                               LocalNodeClientProtocolsInMode, LocalNodeConnectInfo (..),
-                                                              connectToLocalNode)
+                                                              NetworkId, connectToLocalNode)
 import           Ledger.TimeSlot                             (SlotConfig, currentSlot)
 import           Ouroboros.Network.IOManager
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
@@ -54,18 +54,20 @@ getCurrentSlot = cshCurrentSlot
 runChainSync'
   :: FilePath
   -> SlotConfig
+  -> NetworkId
   -> [ChainPoint]
   -> IO (ChainSyncHandle ChainSyncEvent)
-runChainSync' socketPath slotConfig resumePoints =
-  runChainSync socketPath slotConfig resumePoints (\_ _ -> pure ())
+runChainSync' socketPath slotConfig networkId resumePoints =
+  runChainSync socketPath slotConfig networkId resumePoints (\_ _ -> pure ())
 
 runChainSync
   :: FilePath
   -> SlotConfig
+  -> NetworkId
   -> [ChainPoint]
   -> ChainSyncCallback
   -> IO (ChainSyncHandle ChainSyncEvent)
-runChainSync socketPath slotConfig resumePoints chainSyncEventHandler = do
+runChainSync socketPath slotConfig networkId resumePoints chainSyncEventHandler = do
     let handle = ChainSyncHandle {
           cshCurrentSlot = currentSlot slotConfig,
           cshHandler = chainSyncEventHandler }
@@ -75,7 +77,7 @@ runChainSync socketPath slotConfig resumePoints chainSyncEventHandler = do
     where
       localNodeConnectInfo = LocalNodeConnectInfo {
         localConsensusModeParams = CardanoModeParams epochSlots,
-        localNodeNetworkId = cfgNetworkId,
+        localNodeNetworkId = networkId,
         localNodeSocketPath = socketPath }
       localNodeClientProtocols :: LocalNodeClientProtocolsInMode CardanoMode
       localNodeClientProtocols = LocalNodeClientProtocols {

--- a/plutus-pab/src/Cardano/Wallet/Mock.hs
+++ b/plutus-pab/src/Cardano/Wallet/Mock.hs
@@ -21,7 +21,6 @@ module Cardano.Wallet.Mock
 import           Cardano.BM.Data.Trace               (Trace)
 import qualified Cardano.ChainIndex.Client           as ChainIndexClient
 import qualified Cardano.Node.Client                 as NodeClient
-import qualified Cardano.Protocol.Socket.Client      as Client
 import qualified Cardano.Protocol.Socket.Mock.Client as MockClient
 import           Cardano.Wallet.Types                (MultiWalletEffect (..), WalletEffects, WalletInfo (..),
                                                       WalletMsg (..), Wallets)
@@ -50,7 +49,6 @@ import           Data.Function                       ((&))
 import qualified Data.Map                            as Map
 import           Data.Text.Encoding                  (encodeUtf8)
 import           Data.Text.Prettyprint.Doc           (pretty)
-import           Ledger                              (Block)
 import qualified Ledger.Ada                          as Ada
 import           Ledger.Address                      (pubKeyAddress)
 import           Ledger.Crypto                       (PrivateKey (..), PubKeyHash (..), privateKey2, pubKeyHash,
@@ -171,7 +169,7 @@ processWalletEffects ::
     (MonadIO m, MonadError ServerError m)
     => Trace IO WalletMsg -- ^ trace for logging
     -> MockClient.TxSendHandle -- ^ node client
-    -> Client.ChainSyncHandle Block -- ^ node client
+    -> NodeClient.ChainSyncHandle -- ^ node client
     -> ClientEnv          -- ^ chain index client
     -> MVar Wallets   -- ^ wallets state
     -> FeeConfig
@@ -200,7 +198,7 @@ processWalletEffects trace txSendHandle chainSyncHandle chainIndexEnv mVarState 
 runWalletEffects ::
     Trace IO WalletMsg -- ^ trace for logging
     -> MockClient.TxSendHandle -- ^ node client
-    -> Client.ChainSyncHandle Block -- ^ node client
+    -> NodeClient.ChainSyncHandle -- ^ node client
     -> ClientEnv -- ^ chain index client
     -> Wallets -- ^ current state
     -> FeeConfig

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -28,6 +28,7 @@ import qualified Ledger.AddressMap                    as AddressMap
 import           Plutus.Contract.Effects              (TxStatus (..), TxValidity (..), increaseDepth)
 import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstancesState, emptyBlockchainEnv)
 import qualified Plutus.PAB.Core.ContractInstance.STM as S
+import           Plutus.V1.Ledger.Api                 (toBuiltin)
 
 import           Control.Concurrent.STM               (STM)
 import qualified Control.Concurrent.STM               as STM
@@ -84,7 +85,7 @@ txEvent (C.Tx body _) _ =
   in (txi, TxValid)  -- TODO: Validity for Alonzo transactions (not available in cardano-api yet (?))
 
 fromCardanoTxId :: C.TxId -> TxId
-fromCardanoTxId = TxId . C.serialiseToRawBytes
+fromCardanoTxId = TxId . toBuiltin . C.serialiseToRawBytes
 
 -- | Get transaction ID and validity from an emulator transaction
 txMockEvent :: OnChainTx -> (TxId, TxValidity)

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -1,28 +1,38 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE MonoLocalBinds   #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators    #-}
 -- |
 module Plutus.PAB.Core.ContractInstance.BlockchainEnv(
   startNodeClient
   , ClientEnv(..)
-  , processBlock
+  , processMockBlock
+  , processChainSyncEvent
   , getClientEnv
+  , fromCardanoTxId
   ) where
 
-import qualified Cardano.Protocol.Socket.Mock.Client  as Client
-import           Ledger                               (Address, Block, OnChainTx, Slot, TxId, eitherTx, txId)
+import           Cardano.Api                          (BlockInMode (..), NetworkId)
+import qualified Cardano.Api                          as C
+import           Cardano.Node.Types                   (NodeMode (..))
+import           Cardano.Protocol.Socket.Client       (ChainSyncEvent (..))
+import qualified Cardano.Protocol.Socket.Client       as Client
+import qualified Cardano.Protocol.Socket.Mock.Client  as MockClient
+import           Ledger                               (Address, Block, OnChainTx, Slot, TxId (..), eitherTx, txId)
 import           Ledger.AddressMap                    (AddressMap)
 import qualified Ledger.AddressMap                    as AddressMap
-import           Plutus.Contract.Effects              (TxStatus (..), increaseDepth, initialStatus)
+import           Plutus.Contract.Effects              (TxStatus (..), TxValidity (..), increaseDepth)
 import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstancesState, emptyBlockchainEnv)
 import qualified Plutus.PAB.Core.ContractInstance.STM as S
 
 import           Control.Concurrent.STM               (STM)
 import qualified Control.Concurrent.STM               as STM
 import           Control.Lens
-import           Control.Monad                        (foldM, forM_, unless, when)
+import           Control.Monad                        (foldM, forM_, unless, void, when)
 import           Data.Foldable                        (foldl')
 import           Data.Map                             (Map)
 import           Data.Set                             (Set)
@@ -34,12 +44,20 @@ import qualified Wallet.Emulator.ChainIndex.Index     as Index
 --   env.
 startNodeClient ::
   FilePath -- ^ Socket to connect to node
+  -> NodeMode -- ^ Whether to connect to real node or mock node
   -> SlotConfig -- ^ Slot config used by the node
+  -> NetworkId -- ^ Cardano network ID
   -> IO BlockchainEnv
-startNodeClient socket slotConfig = do
+startNodeClient socket mode slotConfig networkId = do
     env <- STM.atomically emptyBlockchainEnv
-    _ <- Client.runChainSync socket slotConfig
-            (\block slot -> STM.atomically $ processBlock env block slot)
+    case mode of
+      MockNode ->
+        void $ MockClient.runChainSync socket slotConfig
+            (\block slot -> STM.atomically $ processMockBlock env block slot)
+      AlonzoNode -> do
+          let resumePoints = []
+          void $ Client.runChainSync socket slotConfig networkId resumePoints
+            (\block slot -> STM.atomically $ processChainSyncEvent env block slot)
     pure env
 
 -- | Interesting addresses and transactions from all the
@@ -52,10 +70,46 @@ getClientEnv instancesState =
     <$> S.watchedAddresses instancesState
     <*> S.watchedTransactions instancesState
 
+-- | Process a chain sync event that we receive from the alonzo node client
+processChainSyncEvent :: BlockchainEnv -> ChainSyncEvent -> Slot -> STM ()
+processChainSyncEvent blockchainEnv event _slot = case event of
+  Resume _                                                -> pure () -- TODO: Handle resume
+  RollForward  (BlockInMode (C.Block _ transactions) era) -> processBlock blockchainEnv transactions era
+  RollBackward _cp                                        -> pure () -- TODO: Handle rollbacks
+
+-- | Get transaction ID and validity from a cardano transaction in any era
+txEvent :: forall era. C.Tx era -> C.EraInMode era C.CardanoMode -> (TxId, TxValidity)
+txEvent (C.Tx body _) _ =
+  let txi = fromCardanoTxId (C.getTxId @era body)
+  in (txi, TxValid)  -- TODO: Validity for Alonzo transactions (not available in cardano-api yet (?))
+
+fromCardanoTxId :: C.TxId -> TxId
+fromCardanoTxId = TxId . C.serialiseToRawBytes
+
+-- | Get transaction ID and validity from an emulator transaction
+txMockEvent :: OnChainTx -> (TxId, TxValidity)
+txMockEvent = eitherTx (\t -> (txId t, TxValid)) (\t -> (txId t, TxInvalid))
+
+-- | Update the blockchain env. with changes from a new block of cardano
+--   transactions in any era
+processBlock :: forall era. BlockchainEnv -> [C.Tx era] -> C.EraInMode era C.CardanoMode -> STM ()
+processBlock BlockchainEnv{beTxChanges} transactions era = do
+  changes <- STM.readTVar beTxChanges
+  forM_ changes $ \tv -> STM.modifyTVar tv increaseDepth
+  unless (null transactions) $ do
+    txStatusMap <- STM.readTVar beTxChanges
+    txStatusMap' <- foldM insertNewTx txStatusMap (flip txEvent era <$> transactions)
+    STM.writeTVar beTxChanges txStatusMap'
+
+insertNewTx :: Map TxId (STM.TVar TxStatus) -> (TxId, TxValidity) -> STM (Map TxId (STM.TVar TxStatus))
+insertNewTx oldMap (txi, txValidity) = do
+  newV <- STM.newTVar (TentativelyConfirmed 0 txValidity)
+  pure $ oldMap & at txi ?~ newV
+
 -- | Go through the transactions in a block, updating the 'BlockchainEnv'
 --   when any interesting addresses or transactions have changed.
-processBlock :: BlockchainEnv -> Block -> Slot -> STM ()
-processBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} transactions slot = do
+processMockBlock :: BlockchainEnv -> Block -> Slot -> STM ()
+processMockBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} transactions slot = do
   changes <- STM.readTVar beTxChanges
   forM_ changes $ \tv -> STM.modifyTVar tv increaseDepth
   lastSlot <- STM.readTVar beCurrentSlot
@@ -69,14 +123,8 @@ processBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} 
     STM.writeTVar beTxIndex chainIndex'
 
     txStatusMap <- STM.readTVar beTxChanges
-    txStatusMap' <- foldM insertNewTx txStatusMap transactions
+    txStatusMap' <- foldM insertNewTx txStatusMap (txMockEvent <$> transactions)
     STM.writeTVar beTxChanges txStatusMap'
-
-insertNewTx :: Map TxId (STM.TVar TxStatus) -> OnChainTx -> STM (Map TxId (STM.TVar TxStatus))
-insertNewTx mp tx = do
-  tv <- STM.newTVar (initialStatus tx)
-  let tid = eitherTx txId txId tx
-  pure $ mp & at tid ?~ tv
 
 processTx :: Slot -> (AddressMap, ChainIndex) -> OnChainTx -> (AddressMap, ChainIndex)
 processTx currentSlot (addressMap, chainIndex) tx = (addressMap', chainIndex') where

--- a/plutus-pab/src/Plutus/PAB/Monitoring/PABLogMsg.hs
+++ b/plutus-pab/src/Plutus/PAB/Monitoring/PABLogMsg.hs
@@ -181,6 +181,7 @@ instance Pretty (ContractDef t) => Pretty (PABMultiAgentMsg t) where
 data CoreMsg t =
     FindingContract ContractInstanceId
     | FoundContract (Maybe (ContractResponse Value Value PABResp PABReq))
+    | ConnectingToAlonzoNode
     deriving stock Generic
 
 deriving stock instance (Show (ContractDef t)) => Show (CoreMsg t)
@@ -189,8 +190,9 @@ deriving anyclass instance (FromJSON (ContractDef t)) => FromJSON (CoreMsg t)
 
 instance Pretty (ContractDef t) => Pretty (CoreMsg t) where
     pretty = \case
-        FindingContract i -> "Finding contract" <+> pretty i
-        FoundContract c   -> "Found contract" <+> viaShow c
+        FindingContract i      -> "Finding contract" <+> pretty i
+        FoundContract c        -> "Found contract" <+> viaShow c
+        ConnectingToAlonzoNode -> "Connecting to Alonzo node"
 
 instance (StructuredLog (ContractDef t), ToJSON (ContractDef t)) => ToObject (CoreMsg t) where
     toObject v = \case
@@ -201,6 +203,7 @@ instance (StructuredLog (ContractDef t), ToJSON (ContractDef t)) => ToObject (Co
                 case v of
                     MaximalVerbosity -> Left (Tagged @"contract" state)
                     _                -> Right ()
+        ConnectingToAlonzoNode -> mkObjectStr "Connecting to Alonzo node" ()
 
 newtype RequestSize = RequestSize Int
     deriving stock (Show)

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -139,6 +139,11 @@ runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig = Config {nodeServer
                 ccaAvailability
         AlonzoNode -> do
             available ccaAvailability
+            runM
+                $ interpret (LM.handleLogMsgTrace ccaTrace)
+                $ logInfo @(LM.AppMsg (Builtin a))
+                $ LM.PABMsg
+                $ LM.SCoreMsg LM.ConnectingToAlonzoNode
             pure () -- TODO: Log message that we're connecting to the real Alonzo node
 
 -- Run mock metadata server

--- a/plutus-pab/src/Plutus/PAB/Run/Command.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Command.hs
@@ -11,18 +11,16 @@
 module Plutus.PAB.Run.Command
     ( ConfigCommand(..)
     , NoConfigCommand(..)
-    , MockServerMode(..)
     ) where
 
-import           Cardano.Node.Types (MockServerMode (..))
-import qualified Data.Aeson         as JSON
-import           GHC.Generics       (Generic)
-import           Wallet.Types       (ContractInstanceId)
+import qualified Data.Aeson   as JSON
+import           GHC.Generics (Generic)
+import           Wallet.Types (ContractInstanceId)
 
 -- | A command for which a config.yaml file is required
 data ConfigCommand =
     Migrate
-    | MockNode MockServerMode -- ^ Run the mock node service without starting the server
+    | StartMockNode -- ^ Run the mock node service
     | MockWallet -- ^ Run the mock wallet service
     | ChainIndex -- ^ Run the chain index service
     | Metadata -- ^ Run the mock meta-data service

--- a/plutus-pab/src/Plutus/PAB/Run/CommandParser.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/CommandParser.hs
@@ -125,10 +125,9 @@ psGeneratorCommandParser =
 mockNodeParser :: Mod CommandFields ConfigCommand
 mockNodeParser =
     command "node-server" $
-    flip info (fullDesc <> progDesc "Run a mock version of the Cardano node API server.") $ do
-        withoutMockServer <- flag WithMockServer WithoutMockServer
-                                  (long "without-mock-node")
-        pure $ MockNode withoutMockServer
+        info
+            (pure StartMockNode)
+            (fullDesc <> progDesc "Run a mock version of the Cardano node API server.")
 
 mockWalletParser :: Mod CommandFields ConfigCommand
 mockWalletParser =
@@ -152,10 +151,8 @@ allServersParser :: Mod CommandFields ConfigCommand
 allServersParser =
     command "all-servers" $
     flip info (fullDesc <> progDesc "Run all the mock servers needed.") $ do
-        withoutMockServer <- flag WithMockServer WithoutMockServer
-                                  (long "without-mock-node")
         pure  (ForkCommands
-                   [ MockNode withoutMockServer
+                   [ StartMockNode
                    , ChainIndex
                    , Metadata
                    , MockWallet

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -444,7 +444,7 @@ handleChainControl slotCfg = \case
         (txns, slot) <- runChainEffects @t @_ slotCfg ((,) <$> Chain.processBlock <*> Chain.getCurrentSlot)
         runChainIndexEffects @t (ChainIndex.chainIndexNotify $ BlockValidated txns)
 
-        void $ liftIO $ STM.atomically $ BlockchainEnv.processBlock blockchainEnv txns slot
+        void $ liftIO $ STM.atomically $ BlockchainEnv.processMockBlock blockchainEnv txns slot
 
         pure txns
     Chain.ModifySlot f -> do

--- a/plutus-pab/sync-client/Main.hs
+++ b/plutus-pab/sync-client/Main.hs
@@ -15,6 +15,7 @@ import           Cardano.Api                    (Block (..), BlockHeader (..), B
                                                  HasTypeProxy (..), deserialiseFromRawBytesHex,
                                                  serialiseToRawBytesHexText)
 import           Cardano.Protocol.Socket.Client (ChainSyncEvent (..), runChainSync)
+import           Cardano.Protocol.Socket.Type   (cfgNetworkId)
 import           Cardano.Slotting.Slot          (SlotNo (..))
 import           Ledger                         (Slot)
 import           Ledger.TimeSlot                (SlotConfig (..))
@@ -88,6 +89,7 @@ main = do
   print    cfg
   _ <- runChainSync (cSocketPath cfg)
                     slotConfig
+                    cfgNetworkId
                     [(cResumeHash cfg)]
                     processBlock
   _ <- forever $ threadDelay 1000000

--- a/plutus-pab/test-node/activate-contract.sh
+++ b/plutus-pab/test-node/activate-contract.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl -H "Content-Type: application/json" -d @activation.json localhost:9080/api/new/contract/activate

--- a/plutus-pab/test-node/activation.json
+++ b/plutus-pab/test-node/activation.json
@@ -1,0 +1,9 @@
+{
+    "caID": {
+        "contents": "e828c6c644870a15e09ee1ac511d31a2d4d484d1e5032762f576699ae7f5c881",
+        "tag": "WaitForTx"
+    },
+    "caWallet": {
+        "getWallet": 1
+    }
+}

--- a/plutus-pab/test/full/Plutus/PAB/CliSpec.hs
+++ b/plutus-pab/test/full/Plutus/PAB/CliSpec.hs
@@ -23,6 +23,7 @@ import           Cardano.BM.Data.Trace               (Trace)
 import           Cardano.BM.Setup                    (setupTrace_)
 import qualified Cardano.ChainIndex.Types            as ChainIndex.Types
 import qualified Cardano.Metadata.Types              as Metadata.Types
+import           Cardano.Node.Types                  (NodeMode (..))
 import qualified Cardano.Node.Types                  as Node.Types
 import qualified Cardano.Wallet.Client               as Wallet.Client
 import           Cardano.Wallet.Types                (WalletInfo (..))
@@ -54,7 +55,7 @@ import qualified Plutus.PAB.Monitoring.Monitoring    as LM
 import           Plutus.PAB.Monitoring.PABLogMsg     (AppMsg (..))
 import           Plutus.PAB.Monitoring.Util          (PrettyObject (..), convertLog)
 import           Plutus.PAB.Run.Cli                  (ConfigCommandArgs (..), runConfigCommand)
-import           Plutus.PAB.Run.Command              (ConfigCommand (..), MockServerMode (..))
+import           Plutus.PAB.Run.Command              (ConfigCommand (..))
 import           Plutus.PAB.Run.PSGenerator          (HasPSTypes (..))
 import           Plutus.PAB.Types                    (Config (..))
 import qualified Plutus.PAB.Types                    as PAB.Types
@@ -143,7 +144,7 @@ startPab pabConfig = do
 
   -- Spin up the servers
   let cmd = ForkCommands
-              [ MockNode WithMockServer
+              [ StartMockNode
               , ChainIndex
               , Metadata
               , MockWallet

--- a/plutus-pab/tx-inject/config.yaml
+++ b/plutus-pab/tx-inject/config.yaml
@@ -35,6 +35,7 @@ nodeServerConfig:
     - getWallet: 8
     - getWallet: 9
     - getWallet: 10
+  mscNodeMode: MockNode
 
 chainIndexConfig:
   ciBaseUrl: http://localhost:9083


### PR DESCRIPTION
The main change is in `Plutus.PAB.Core.ContractInstance.BlockchainEnv`:
* Add a `NodeMode` argument
* Use the "real" chain sync client when `AlonzoNode` is specified
* Update the set of validated transactions when a new block is received

Other changes:
* Add `mscNodeMode :: NodeMode` to the node config. If it is set to `AlonzoNode` then the mock node is not started at all.
* Configurable network ID
* Add a `TxId` parameter to the `WaitForTx` example.

I tested this against a local test-net node.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
