### PR TITLE
Add 'never' promise

### DIFF
--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -21,6 +21,7 @@ module Plutus.Contract(
     , selectEither
     , select
     , selectList
+    , never
     -- * Dealing with time
     , Request.awaitSlot
     , Request.isSlot
@@ -98,7 +99,7 @@ import qualified Plutus.Contract.Schema         as Schema
 import           Plutus.Contract.Typed.Tx       as Tx
 import           Plutus.Contract.Types          (AsCheckpointError (..), AsContractError (..), CheckpointError (..),
                                                  Contract (..), ContractError (..), IsContract (..), Promise (..),
-                                                 checkpoint, checkpointLoop, handleError, mapError, promiseBind,
+                                                 checkpoint, checkpointLoop, handleError, mapError, never, promiseBind,
                                                  promiseMap, runError, select, selectEither, selectList, throwError)
 
 import qualified Control.Monad.Freer.Extras.Log as L

--- a/plutus-contract/src/Plutus/Contract/Resumable.hs
+++ b/plutus-contract/src/Plutus/Contract/Resumable.hs
@@ -56,6 +56,7 @@ module Plutus.Contract.Resumable(
     Resumable(..)
     , prompt
     , select
+    , never
     -- * Handling the 'Resumable' effect
     , Request(..)
     , Response(..)
@@ -114,8 +115,10 @@ and 'suspendNonDet'.
 -- | A data type for representing non-deterministic prompts.
 data Resumable i o r where
     RRequest :: o -> Resumable i o i
+
     -- See https://hackage.haskell.org/package/freer-simple-1.2.1.1/docs/src/Control.Monad.Freer.Internal.html#NonDet
     RSelect :: Resumable i o Bool
+    RZero   :: Resumable i o a
 
 prompt :: Member (Resumable i o) effs => o -> Eff effs i
 prompt o = send (RRequest o)
@@ -127,6 +130,12 @@ select ::
     -> Eff effs a
     -> Eff effs a
 select l r = send @(Resumable i o) RSelect >>= \b -> if b then l else r
+
+never ::
+    forall i o effs a.
+    Member (Resumable i o) effs
+    => Eff effs a
+never = send @(Resumable i o) RZero
 
 -- | A value that uniquely identifies requests made during the execution of
 --   'Resumable' programs.
@@ -269,6 +278,7 @@ handleResumable ::
 handleResumable = interpret $ \case
     RRequest o -> yield o id
     RSelect    -> send MPlus
+    RZero      -> send MZero
 
 -- | Status of a suspended 'MultiRequestContinuation'.
 data MultiRequestContStatus i o effs a =

--- a/plutus-contract/src/Plutus/Contract/Types.hs
+++ b/plutus-contract/src/Plutus/Contract/Types.hs
@@ -30,6 +30,7 @@ module Plutus.Contract.Types(
     , select
     , selectEither
     , selectList
+    , never
     -- * Error handling
     , ContractError(..)
     , AsContractError(..)
@@ -94,7 +95,7 @@ import           Plutus.Contract.Checkpoint        (AsCheckpointError (..), Chec
                                                     CheckpointKey, CheckpointLogMsg, CheckpointStore,
                                                     completedIntervals, handleCheckpoint, jsonCheckpoint,
                                                     jsonCheckpointLoop)
-import           Plutus.Contract.Resumable         hiding (responses, select)
+import           Plutus.Contract.Resumable         hiding (never, responses, select)
 import qualified Plutus.Contract.Resumable         as Resumable
 
 import           Plutus.Contract.Effects           (PABReq, PABResp)
@@ -216,6 +217,10 @@ newtype Promise w (s :: Row *) e a = Promise { awaitPromise :: Contract w s e a 
 
 instance Apply (Promise w s e) where
   liftF2 f (Promise a) (Promise b) = Promise (f <$> a <*> b)
+
+-- | A `Promise` that is never fulfilled. This is the identity of `select`.
+never :: Promise w s e a
+never = Promise (Contract $ Resumable.never @PABResp @PABReq)
 
 -- | Run more `Contract` code after the `Promise`.
 promiseBind :: Promise w s e a -> (a -> Contract w s e b) -> Promise w s e b


### PR DESCRIPTION
This was deliberately left out in earlier versions, to avoid users accidentally writing `Contract`s that get stuck. But now that we have the promise API we should put it back in because it's convenient and the risk of suprises is lower. What do you think @sjoerdvisscher ?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
