### PR TITLE
SCP-2460: Wait for address changed without polling

### DIFF
--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -27,6 +27,7 @@ import           Control.Monad                (forM_, void)
 import           Control.Monad.Error.Lens     (catching, throwing)
 import           Data.Aeson                   (FromJSON, ToJSON, parseJSON, toJSON)
 import           Data.Default                 (Default (def))
+import qualified Data.List.NonEmpty           as NonEmpty
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   (isNothing, maybeToList)
@@ -34,6 +35,7 @@ import           Data.Monoid                  (First (..))
 import           Data.Semigroup.Generic       (GenericSemigroupMonoid (..))
 import qualified Data.Set                     as Set
 import qualified Data.Text                    as T
+import           Data.Void                    (absurd)
 import           GHC.Generics                 (Generic)
 import           Language.Marlowe.Semantics   hiding (Contract)
 import qualified Language.Marlowe.Semantics   as Marlowe
@@ -128,7 +130,8 @@ isEmpty :: ContractHistory -> Bool
 isEmpty = isNothing . getFirst . chParams
 
 data ContractProgress = InProgress | Finished
-  deriving (Show,Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance Semigroup ContractProgress where
     _ <> Finished     = Finished
@@ -155,32 +158,42 @@ type MarloweContractState = LastResult
 marloweFollowContract :: Contract ContractHistory MarloweFollowSchema MarloweError ()
 marloweFollowContract = awaitPromise $ endpoint @"follow" $ \params -> do
     slot <- currentSlot
-    checkpointLoop follow (0, slot, params)
-  where
-    follow (ifrom, ito, params) = do
-        let client@StateMachineClient{scInstance} = mkMarloweClient params
-        let inst = SM.typedValidator scInstance
-        let address = Scripts.validatorAddress inst
-        AddressChangeResponse{acrTxns} <- awaitPromise $ addressChangeRequest
+    let client@StateMachineClient{scInstance} = mkMarloweClient params
+    let inst = SM.typedValidator scInstance
+    let address = Scripts.validatorAddress inst
+    let go [] = pure InProgress
+        go (tx:rest) = do
+            res <- updateHistoryFromTx client params tx
+            case res of
+                Finished   -> pure Finished
+                InProgress -> go rest
+
+    AddressChangeResponse{acrTxns} <- awaitPromise $ addressChangeRequest
                 AddressChangeRequest
-                { acreqSlotRangeFrom = ifrom
-                , acreqSlotRangeTo = ito
+                { acreqSlotRangeFrom = 0
+                , acreqSlotRangeTo = slot
                 , acreqAddress = address
                 }
-        let go [] = pure InProgress
-            go (tx:rest) = do
-                res <- updateHistoryFromTx client params tx
-                case res of
-                    Finished   -> pure Finished
-                    InProgress -> go rest
-        res <- go acrTxns
-        case res of
-            Finished -> do
-                logDebug @String ("Contract finished " <> show params)
-                pure $ Left () -- close the contract
-            InProgress ->
-                let next = succ ito in
-                pure $ Right (next, next, params)
+    go acrTxns >>= checkpointLoop (follow client params)
+  where
+    follow client params = \case
+        Finished -> do
+            logDebug @String ("Contract finished " <> show params)
+            pure $ Left () -- close the contract
+        InProgress -> do
+            result <- SM.waitForUpdateTimeout @_ @MarloweInput client never >>= awaitPromise
+            case result of
+                Timeout t -> absurd t
+                ContractEnded _ (itvl, inputs) -> do
+                    tell @ContractHistory (transition $ TransactionInput itvl inputs)
+                    pure (Right Finished)
+                Transition _ (itvl, inputs) _ -> do
+                    tell @ContractHistory (transition $ TransactionInput itvl inputs)
+                    pure (Right InProgress)
+                InitialState _ SM.OnChainState{ocsTxOut} -> do
+                    let initialMarloweData = tyTxOutData ocsTxOut
+                    tell @ContractHistory (created params initialMarloweData)
+                    pure (Right InProgress)
 
     updateHistoryFromTx StateMachineClient{scInstance, scChooser} params tx = do
         logInfo @String $ "Updating history from tx" <> show (Ledger.eitherTx Ledger.txId Ledger.txId tx)
@@ -193,7 +206,7 @@ marloweFollowContract = awaitPromise $ endpoint @"follow" $ \params -> do
             -- it's a contract creation transaction, and there is Marlowe TxOut
             Nothing -> case scChooser states of
                 Left err    -> throwing _SMContractError err
-                Right (state, _) -> do
+                Right SM.OnChainState{SM.ocsTxOut=state} -> do
                     let initialMarloweData = tyTxOutData state
                     logInfo @String ("Contract created " <> show initialMarloweData)
                     tell $ created params initialMarloweData
@@ -295,16 +308,17 @@ marlowePlutusContract = do
             Nothing -> do
                 wr <- SM.waitForUpdateUntilSlot theClient untilSlot
                 case wr of
-                    ContractEnded -> do
+                    ContractEnded{} -> do
                         logInfo @String $ "Contract Ended for party " <> show party
                         tell OK
                         marlowePlutusContract
-                    Timeout _ -> do
+                    Timeout{} -> do
                         logInfo @String $ "Contract Timeout for party " <> show party
                         tell OK
                         marlowePlutusContract
-                    WaitingResult marloweData -> continueWith marloweData
-            Just ((st, _), _) -> do
+                    Transition _ _ marloweData -> continueWith marloweData
+                    InitialState _ marloweData -> continueWith marloweData
+            Just (SM.OnChainState{SM.ocsTxOut=st}, _) -> do
                 let marloweData = tyTxOutData st
                 continueWith marloweData
     close = endpoint @"close" $ \_ -> tell OK
@@ -340,14 +354,15 @@ marlowePlutusContract = do
                 logInfo @String $ "WaitOtherActionUntil " <> show timeout
                 wr <- SM.waitForUpdateUntilSlot theClient timeout
                 case wr of
-                    ContractEnded -> do
+                    ContractEnded{} -> do
                         logInfo @String $ "Contract Ended"
                         tell OK
                         marlowePlutusContract
-                    Timeout _ -> do
+                    Timeout{} -> do
                         logInfo @String $ "Contract Timeout"
                         continueWith marloweData
-                    WaitingResult marloweData -> continueWith marloweData
+                    Transition _ _ marloweData -> continueWith marloweData
+                    InitialState _ marloweData -> continueWith marloweData
 
             CloseContract -> do
                 logInfo @String $ "CloseContract"
@@ -661,7 +676,7 @@ marloweCompanionContract = contracts
         forM_ txOuts notifyOnNewContractRoles
         checkpointLoop (fmap Right <$> cont) ownAddress
     cont ownAddress = do
-        txns <- nextTransactionsAt ownAddress
+        txns <- NonEmpty.toList <$> awaitUtxoProduced ownAddress
         let txOuts = txns >>= eitherTx (const []) txOutputs
         forM_ txOuts notifyOnNewContractRoles
         pure ownAddress
@@ -699,7 +714,7 @@ findMarloweContractsOnChainByRoleCurrency curSym = do
     let client = mkMarloweClient params
     maybeState <- SM.getOnChainState client
     case maybeState of
-        Just ((st, _), _) -> do
-            let marloweData = tyTxOutData st
+        Just (SM.OnChainState{SM.ocsTxOut}, _) -> do
+            let marloweData = tyTxOutData ocsTxOut
             pure $ Just (params, marloweData)
         Nothing -> pure Nothing

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -48,6 +48,8 @@ module Plutus.Contract(
     , Request.watchAddressUntilTime
     , Request.fundsAtAddressGt
     , Request.fundsAtAddressGeq
+    , Request.awaitUtxoSpent
+    , Request.awaitUtxoProduced
     -- * UTXO set
     , UtxoMap
     , Request.utxoAt

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -49,7 +49,9 @@ module Plutus.Contract(
     , Request.fundsAtAddressGt
     , Request.fundsAtAddressGeq
     , Request.awaitUtxoSpent
+    , Request.utxoIsSpent
     , Request.awaitUtxoProduced
+    , Request.utxoIsProduced
     -- * UTXO set
     , UtxoMap
     , Request.utxoAt

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -130,21 +130,21 @@ data PABReq =
 
 instance Pretty PABReq where
   pretty = \case
-    AwaitSlotReq s              -> "Await slot:" <+> pretty s
-    AwaitTimeReq s              -> "Await time:" <+> pretty s
-    AwaitUtxoSpentReq utxo      -> "Await utxo spent:" <+> pretty utxo
-    AwaitUtxoProducedReq a      -> "Await utxo produced:" <+> pretty a
-    CurrentSlotReq              -> "Current slot"
-    CurrentTimeReq              -> "Current time"
-    AwaitTxStatusChangeReq txid -> "Await tx status change:" <+> pretty txid
-    OwnContractInstanceIdReq    -> "Own contract instance ID"
-    OwnPublicKeyReq             -> "Own public key"
-    UtxoAtReq addr              -> "Utxo at:" <+> pretty addr
-    ChainIndexQueryReq q        -> "Chain index query:" <+> pretty q
-    AddressChangeReq req        -> "Address change:" <+> pretty req
-    BalanceTxReq utx            -> "Balance tx:" <+> pretty utx
-    WriteBalancedTxReq tx       -> "Write balanced tx:" <+> pretty tx
-    ExposeEndpointReq ep        -> "Expose endpoint:" <+> pretty ep
+    AwaitSlotReq s                          -> "Await slot:" <+> pretty s
+    AwaitTimeReq s                          -> "Await time:" <+> pretty s
+    AwaitUtxoSpentReq utxo                  -> "Await utxo spent:" <+> pretty utxo
+    AwaitUtxoProducedReq a                  -> "Await utxo produced:" <+> pretty a
+    CurrentSlotReq                          -> "Current slot"
+    CurrentTimeReq                          -> "Current time"
+    AwaitTxStatusChangeReq txid             -> "Await tx status change:" <+> pretty txid
+    OwnContractInstanceIdReq                -> "Own contract instance ID"
+    OwnPublicKeyReq                         -> "Own public key"
+    UtxoAtReq addr                          -> "Utxo at:" <+> pretty addr
+    ChainIndexQueryReq q                    -> "Chain index query:" <+> pretty q
+    AddressChangeReq req                    -> "Address change:" <+> pretty req
+    BalanceTxReq utx                        -> "Balance tx:" <+> pretty utx
+    WriteBalancedTxReq tx                   -> "Write balanced tx:" <+> pretty tx
+    ExposeEndpointReq ep                    -> "Expose endpoint:" <+> pretty ep
     PosixTimeRangeToContainedSlotRangeReq r -> "Posix time range to contained slot range:" <+> pretty r
 
 -- | Responses that 'Contract's receive
@@ -170,21 +170,21 @@ data PABResp =
 
 instance Pretty PABResp where
   pretty = \case
-    AwaitSlotResp s                     -> "Slot:" <+> pretty s
-    AwaitTimeResp s                     -> "Time:" <+> pretty s
-    AwaitUtxoSpentResp utxo             -> "Utxo spent:" <+> pretty utxo
-    AwaitUtxoProducedResp addr          -> "Utxo produced:" <+> pretty addr
-    CurrentSlotResp s                   -> "Current slot:" <+> pretty s
-    CurrentTimeResp s                   -> "Current time:" <+> pretty s
-    AwaitTxStatusChangeResp txid status -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
-    OwnContractInstanceIdResp i         -> "Own contract instance ID:" <+> pretty i
-    OwnPublicKeyResp k                  -> "Own public key:" <+> pretty k
-    UtxoAtResp rsp                      -> "Utxo at:" <+> pretty rsp
-    ChainIndexQueryResp rsp             -> pretty rsp
-    AddressChangeResp rsp               -> "Address change:" <+> pretty rsp
-    BalanceTxResp r                     -> "Balance tx:" <+> pretty r
-    WriteBalancedTxResp r               -> "Write balanced tx:" <+> pretty r
-    ExposeEndpointResp desc rsp         -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
+    AwaitSlotResp s                          -> "Slot:" <+> pretty s
+    AwaitTimeResp s                          -> "Time:" <+> pretty s
+    AwaitUtxoSpentResp utxo                  -> "Utxo spent:" <+> pretty utxo
+    AwaitUtxoProducedResp addr               -> "Utxo produced:" <+> pretty addr
+    CurrentSlotResp s                        -> "Current slot:" <+> pretty s
+    CurrentTimeResp s                        -> "Current time:" <+> pretty s
+    AwaitTxStatusChangeResp txid status      -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
+    OwnContractInstanceIdResp i              -> "Own contract instance ID:" <+> pretty i
+    OwnPublicKeyResp k                       -> "Own public key:" <+> pretty k
+    UtxoAtResp rsp                           -> "Utxo at:" <+> pretty rsp
+    ChainIndexQueryResp rsp                  -> pretty rsp
+    AddressChangeResp rsp                    -> "Address change:" <+> pretty rsp
+    BalanceTxResp r                          -> "Balance tx:" <+> pretty r
+    WriteBalancedTxResp r                    -> "Write balanced tx:" <+> pretty r
+    ExposeEndpointResp desc rsp              -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
     PosixTimeRangeToContainedSlotRangeResp r -> "Slot range:" <+> pretty r
 
 matches :: PABReq -> PABResp -> Bool

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -191,8 +191,8 @@ matches :: PABReq -> PABResp -> Bool
 matches a b = case (a, b) of
   (AwaitSlotReq{}, AwaitSlotResp{})                        -> True
   (AwaitTimeReq{}, AwaitTimeResp{})                        -> True
-  (AwaitUtxoSpentReq{}, AwaitUtxoSpentResp{})            -> True
-  (AwaitUtxoProducedReq{}, AwaitUtxoProducedResp{})      -> True
+  (AwaitUtxoSpentReq{}, AwaitUtxoSpentResp{})              -> True
+  (AwaitUtxoProducedReq{}, AwaitUtxoProducedResp{})        -> True
   (CurrentSlotReq, CurrentSlotResp{})                      -> True
   (CurrentTimeReq, CurrentTimeResp{})                      -> True
   (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _) -> i == i'

--- a/plutus-contract/src/Plutus/Contract/Effects.hs
+++ b/plutus-contract/src/Plutus/Contract/Effects.hs
@@ -10,6 +10,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     PABReq(..),
     _AwaitSlotReq,
     _AwaitTimeReq,
+    _AwaitUtxoSpentReq,
+    _AwaitUtxoProducedReq,
     _CurrentSlotReq,
     _CurrentTimeReq,
     _AwaitTxStatusChangeReq,
@@ -35,6 +37,8 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
     PABResp(..),
     _AwaitSlotResp,
     _AwaitTimeResp,
+    _AwaitUtxoSpentResp,
+    _AwaitUtxoProducedResp,
     _CurrentSlotResp,
     _CurrentTimeResp,
     _AwaitTxStatusChangeResp,
@@ -79,6 +83,7 @@ module Plutus.Contract.Effects( -- TODO: Move to Requests.Internal
 import           Control.Lens                     (Iso', Prism', iso, makePrisms, prism')
 import           Data.Aeson                       (FromJSON, ToJSON)
 import qualified Data.Aeson                       as JSON
+import           Data.List.NonEmpty               (NonEmpty)
 import qualified Data.Map                         as Map
 import           Data.Text.Prettyprint.Doc        (Pretty (..), colon, hsep, indent, viaShow, vsep, (<+>))
 import           Data.Text.Prettyprint.Doc.Extras (PrettyShow (..))
@@ -106,14 +111,16 @@ import           Wallet.Types                     (AddressChangeRequest, Address
 data PABReq =
     AwaitSlotReq Slot
     | AwaitTimeReq POSIXTime
+    | AwaitUtxoSpentReq TxOutRef
+    | AwaitUtxoProducedReq Address
+    | AwaitTxStatusChangeReq TxId
     | CurrentSlotReq
     | CurrentTimeReq
-    | AwaitTxStatusChangeReq TxId
     | OwnContractInstanceIdReq
     | OwnPublicKeyReq
     | UtxoAtReq Address
     | ChainIndexQueryReq ChainIndexQuery
-    | AddressChangeReq AddressChangeRequest
+    | AddressChangeReq AddressChangeRequest -- deprecated
     | BalanceTxReq UnbalancedTx
     | WriteBalancedTxReq Tx
     | ExposeEndpointReq ActiveEndpoint
@@ -123,28 +130,32 @@ data PABReq =
 
 instance Pretty PABReq where
   pretty = \case
-    AwaitSlotReq s                          -> "Await slot:" <+> pretty s
-    AwaitTimeReq s                          -> "Await time:" <+> pretty s
-    CurrentSlotReq                          -> "Current slot"
-    CurrentTimeReq                          -> "Current time"
-    AwaitTxStatusChangeReq txid             -> "Await tx status change:" <+> pretty txid
-    OwnContractInstanceIdReq                -> "Own contract instance ID"
-    OwnPublicKeyReq                         -> "Own public key"
-    UtxoAtReq addr                          -> "Utxo at:" <+> pretty addr
-    ChainIndexQueryReq q                    -> "Chain index query:" <+> pretty q
-    AddressChangeReq req                    -> "Address change:" <+> pretty req
-    BalanceTxReq utx                        -> "Balance tx:" <+> pretty utx
-    WriteBalancedTxReq tx                   -> "Write balanced tx:" <+> pretty tx
-    ExposeEndpointReq ep                    -> "Expose endpoint:" <+> pretty ep
+    AwaitSlotReq s              -> "Await slot:" <+> pretty s
+    AwaitTimeReq s              -> "Await time:" <+> pretty s
+    AwaitUtxoSpentReq utxo      -> "Await utxo spent:" <+> pretty utxo
+    AwaitUtxoProducedReq a      -> "Await utxo produced:" <+> pretty a
+    CurrentSlotReq              -> "Current slot"
+    CurrentTimeReq              -> "Current time"
+    AwaitTxStatusChangeReq txid -> "Await tx status change:" <+> pretty txid
+    OwnContractInstanceIdReq    -> "Own contract instance ID"
+    OwnPublicKeyReq             -> "Own public key"
+    UtxoAtReq addr              -> "Utxo at:" <+> pretty addr
+    ChainIndexQueryReq q        -> "Chain index query:" <+> pretty q
+    AddressChangeReq req        -> "Address change:" <+> pretty req
+    BalanceTxReq utx            -> "Balance tx:" <+> pretty utx
+    WriteBalancedTxReq tx       -> "Write balanced tx:" <+> pretty tx
+    ExposeEndpointReq ep        -> "Expose endpoint:" <+> pretty ep
     PosixTimeRangeToContainedSlotRangeReq r -> "Posix time range to contained slot range:" <+> pretty r
 
 -- | Responses that 'Contract's receive
 data PABResp =
     AwaitSlotResp Slot
     | AwaitTimeResp POSIXTime
+    | AwaitUtxoSpentResp OnChainTx
+    | AwaitUtxoProducedResp (NonEmpty OnChainTx)
+    | AwaitTxStatusChangeResp TxId TxStatus
     | CurrentSlotResp Slot
     | CurrentTimeResp POSIXTime
-    | AwaitTxStatusChangeResp TxId TxStatus
     | OwnContractInstanceIdResp ContractInstanceId
     | OwnPublicKeyResp PubKey
     | UtxoAtResp UtxoAtAddress
@@ -159,25 +170,29 @@ data PABResp =
 
 instance Pretty PABResp where
   pretty = \case
-    AwaitSlotResp s                          -> "Slot:" <+> pretty s
-    AwaitTimeResp s                          -> "Time:" <+> pretty s
-    CurrentSlotResp s                        -> "Current slot:" <+> pretty s
-    CurrentTimeResp s                        -> "Current time:" <+> pretty s
-    AwaitTxStatusChangeResp txid status      -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
-    OwnContractInstanceIdResp i              -> "Own contract instance ID:" <+> pretty i
-    OwnPublicKeyResp k                       -> "Own public key:" <+> pretty k
-    UtxoAtResp rsp                           -> "Utxo at:" <+> pretty rsp
-    ChainIndexQueryResp rsp                  -> pretty rsp
-    AddressChangeResp rsp                    -> "Address change:" <+> pretty rsp
-    BalanceTxResp r                          -> "Balance tx:" <+> pretty r
-    WriteBalancedTxResp r                    -> "Write balanced tx:" <+> pretty r
-    ExposeEndpointResp desc rsp              -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
+    AwaitSlotResp s                     -> "Slot:" <+> pretty s
+    AwaitTimeResp s                     -> "Time:" <+> pretty s
+    AwaitUtxoSpentResp utxo             -> "Utxo spent:" <+> pretty utxo
+    AwaitUtxoProducedResp addr          -> "Utxo produced:" <+> pretty addr
+    CurrentSlotResp s                   -> "Current slot:" <+> pretty s
+    CurrentTimeResp s                   -> "Current time:" <+> pretty s
+    AwaitTxStatusChangeResp txid status -> "Status of" <+> pretty txid <+> "changed to" <+> pretty status
+    OwnContractInstanceIdResp i         -> "Own contract instance ID:" <+> pretty i
+    OwnPublicKeyResp k                  -> "Own public key:" <+> pretty k
+    UtxoAtResp rsp                      -> "Utxo at:" <+> pretty rsp
+    ChainIndexQueryResp rsp             -> pretty rsp
+    AddressChangeResp rsp               -> "Address change:" <+> pretty rsp
+    BalanceTxResp r                     -> "Balance tx:" <+> pretty r
+    WriteBalancedTxResp r               -> "Write balanced tx:" <+> pretty r
+    ExposeEndpointResp desc rsp         -> "Call endpoint" <+> pretty desc <+> "with" <+> pretty rsp
     PosixTimeRangeToContainedSlotRangeResp r -> "Slot range:" <+> pretty r
 
 matches :: PABReq -> PABResp -> Bool
 matches a b = case (a, b) of
   (AwaitSlotReq{}, AwaitSlotResp{})                        -> True
   (AwaitTimeReq{}, AwaitTimeResp{})                        -> True
+  (AwaitUtxoSpentReq{}, AwaitUtxoSpentResp{})            -> True
+  (AwaitUtxoProducedReq{}, AwaitUtxoProducedResp{})      -> True
   (CurrentSlotReq, CurrentSlotResp{})                      -> True
   (CurrentTimeReq, CurrentTimeResp{})                      -> True
   (AwaitTxStatusChangeReq i, AwaitTxStatusChangeResp i' _) -> i == i'

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -105,7 +105,7 @@ import           PlutusTx.Monoid                              (inv)
 -- makes the transition to the next state using the given input and taking care
 -- of all payments.
 
--- | Typed representation of the on-chain state of a state machine insante
+-- | Typed representation of the on-chain state of a state machine instance
 data OnChainState s i =
     OnChainState
         { ocsTxOut    :: Typed.TypedScriptTxOut (SM.StateMachine s i) -- ^ Typed transaction output

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -290,7 +290,8 @@ waitForUpdate client = waitForUpdateTimeout client never >>= awaitPromise >>= \c
     InitialState _ r -> pure (Just r)
     Transition _ _ r -> pure (Just r)
 
--- | Wait until the on-chain state of the state machine changes, or a timeout.
+-- | Construct a 'Promise' that waits for an update to the state machine's
+--   on-chain state, or a user-defined timeout (whichever happens first).
 waitForUpdateTimeout ::
     forall state i t w schema e.
     ( AsSMContractError e

--- a/plutus-contract/src/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine.hs
@@ -230,11 +230,12 @@ getOnChainState StateMachineClient{scInstance, scChooser} = mapError (review _SM
                 Left err    -> throwing _SMContractError err
                 Right state -> pure $ Just (state, utxo)
 
+-- | The outcome of 'waitForUpdateTimeout'
 data WaitingResult t i s
-    = Timeout t
-    | ContractEnded Tx.Tx i
-    | Transition Tx.Tx i s
-    | InitialState Tx.Tx s
+    = Timeout t -- ^ The timeout happened before any change of the on-chain state was detected
+    | ContractEnded Tx.Tx i -- ^ The state machine instance ended
+    | Transition Tx.Tx i s -- ^ The state machine instance transitioned to a new state
+    | InitialState Tx.Tx s -- ^ The state machine instance was initialised
   deriving stock (Show,Generic,Functor)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
+++ b/plutus-contract/src/Plutus/Trace/Emulator/ContractInstance.hs
@@ -456,7 +456,6 @@ instance Semigroup IndexedBlock where
       }
 
 instance Monoid IndexedBlock where
-  mappend = (<>)
   mempty = IndexedBlock mempty mempty
 
 indexBlock :: [OnChainTx] -> IndexedBlock

--- a/plutus-ledger/src/Ledger/Blockchain.hs
+++ b/plutus-ledger/src/Ledger/Blockchain.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Ledger.Blockchain (
@@ -14,6 +15,7 @@ module Ledger.Blockchain (
     Context(..),
     eitherTx,
     consumableInputs,
+    outputsProduced,
     transaction,
     out,
     value,
@@ -25,32 +27,34 @@ module Ledger.Blockchain (
     txOutPubKey,
     pubKeyTxo,
     validValuesTx,
+    toOutRefMap
     ) where
 
-import           Codec.Serialise          (Serialise)
-import           Control.DeepSeq          (NFData)
-import           Control.Lens             (makePrisms, view)
-import           Control.Monad            (join)
-import           Data.Aeson               (FromJSON, ToJSON)
-import qualified Data.Aeson               as JSON
-import qualified Data.Aeson.Extras        as JSON
-import qualified Data.ByteString          as BS
-import           Data.Map                 (Map)
-import qualified Data.Map                 as Map
-import           Data.Monoid              (First (..))
-import qualified Data.Set                 as Set
-import qualified Data.Text                as Text
-import           Data.Text.Encoding       (decodeUtf8)
-import           GHC.Generics             (Generic)
-import           Ledger.Tx                (spentOutputs, txId, unspentOutputsTx, updateUtxo, validValuesTx)
+import           Codec.Serialise           (Serialise)
+import           Control.DeepSeq           (NFData)
+import           Control.Lens              (makePrisms, view)
+import           Control.Monad             (join)
+import           Data.Aeson                (FromJSON, ToJSON)
+import qualified Data.Aeson                as JSON
+import qualified Data.Aeson.Extras         as JSON
+import qualified Data.ByteString           as BS
+import           Data.Map                  (Map)
+import qualified Data.Map                  as Map
+import           Data.Monoid               (First (..))
+import qualified Data.Set                  as Set
+import qualified Data.Text                 as Text
+import           Data.Text.Encoding        (decodeUtf8)
+import           Data.Text.Prettyprint.Doc (Pretty (..), (<+>))
+import           GHC.Generics              (Generic)
+import           Ledger.Tx                 (TxOutTx (..), spentOutputs, txId, unspentOutputsTx, updateUtxo,
+                                            validValuesTx)
 
 import           Plutus.V1.Ledger.Crypto
 import           Plutus.V1.Ledger.Scripts
-import           Plutus.V1.Ledger.Tx      (Tx, TxIn, TxOut, TxOutRef, collateralInputs, inputs, txOutDatum, txOutPubKey,
-                                           txOutRefId, txOutRefIdx, txOutValue, txOutputs, updateUtxoCollateral)
+import           Plutus.V1.Ledger.Tx       (Tx, TxIn, TxOut, TxOutRef (..), collateralInputs, inputs, txOutDatum,
+                                            txOutPubKey, txOutValue, txOutputs, updateUtxoCollateral)
 import           Plutus.V1.Ledger.TxId
-import           Plutus.V1.Ledger.Value   (Value)
-import           Prettyprinter            (Pretty (..))
+import           Plutus.V1.Ledger.Value    (Value)
 
 -- | Block identifier (usually a hash)
 newtype BlockId = BlockId { getBlockId :: BS.ByteString }
@@ -73,6 +77,12 @@ instance Pretty BlockId where
 data OnChainTx = Invalid Tx | Valid Tx
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, FromJSON, Serialise, NFData)
+
+instance Pretty OnChainTx where
+    pretty = \case
+        Invalid tx -> "Invalid:" <+> pretty tx
+        Valid   tx -> "Valid:"   <+> pretty tx
+
 -- | A block on the blockchain. This is just a list of transactions
 -- following on from the chain so far.
 type Block = [OnChainTx]
@@ -85,6 +95,18 @@ eitherTx _ ifValid (Valid tx)     = ifValid tx
 
 consumableInputs :: OnChainTx -> Set.Set TxIn
 consumableInputs = eitherTx (view collateralInputs) (view inputs)
+
+-- | Outputs added to the UTXO set by the 'OnChainTx'
+outputsProduced :: OnChainTx -> [TxOut]
+outputsProduced = eitherTx (const []) (txOutputs)
+
+-- | A map of UTXO refs to 'TxOutTx' values for a single on-chain
+--   transaction.
+toOutRefMap :: OnChainTx -> Map TxOutRef TxOutTx
+toOutRefMap tx =
+    let tx' = eitherTx id id tx
+        mkOutRef (idx, txOut) = (TxOutRef (txId tx') idx, TxOutTx{txOutTxTx=tx', txOutTxOut=txOut})
+    in Map.fromList . fmap mkOutRef $ zip [0..] $ outputsProduced tx
 
 -- | Lookup a transaction in a 'Blockchain' by its id.
 transaction :: Blockchain -> TxId -> Maybe OnChainTx

--- a/plutus-pab-client/src/View/Pretty.purs
+++ b/plutus-pab-client/src/View/Pretty.purs
@@ -144,6 +144,14 @@ instance prettyPABResp :: Pretty PABResp where
       , nbsp
       , pretty slotRange
       ]
+  pretty (AwaitUtxoSpentResp _) =
+    span_
+      [ text "AwaitUtxoSpentResp"
+      ]
+  pretty (AwaitUtxoProducedResp _) =
+    span_
+      [ text "AwaitUtxoProducedResp"
+      ]
 
 instance prettyContractPABRequest :: Pretty PABReq where
   pretty (AwaitSlotReq slot) =
@@ -221,6 +229,14 @@ instance prettyContractPABRequest :: Pretty PABReq where
       [ text "PosixTimeRangeToContainedSlotRangeReq:"
       , nbsp
       , pretty timeRange
+      ]
+  pretty (AwaitUtxoSpentReq _) =
+    span_
+      [ text "AwaitUtxoSpentReq"
+      ]
+  pretty (AwaitUtxoProducedReq _) =
+    span_
+      [ text "AwaitUtxoProducedReq"
       ]
 
 instance prettyBalanceTxResponse :: Pretty BalanceTxResponse where

--- a/plutus-pab/src/Plutus/PAB/App.hs
+++ b/plutus-pab/src/Plutus/PAB/App.hs
@@ -108,7 +108,7 @@ appEffectHandlers storageBackend config trace BuiltinHandler{contractHandler} =
             env <- liftIO $ mkEnv trace config
             let Config{nodeServerConfig=MockServerConfig{mscSocketPath, mscSlotConfig, mscNodeMode, mscNetworkId=NetworkIdWrapper networkId}} = config
             instancesState <- liftIO $ STM.atomically Instances.emptyInstancesState
-            blockchainEnv <- liftIO $ BlockchainEnv.startNodeClient mscSocketPath mscNodeMode mscSlotConfig networkId
+            blockchainEnv <- liftIO $ BlockchainEnv.startNodeClient mscSocketPath mscNodeMode mscSlotConfig networkId instancesState
             pure (instancesState, blockchainEnv, env)
 
         , handleLogMessages =

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -29,6 +29,7 @@ module Plutus.PAB.Core.ContractInstance(
     , AppBackendConstraints
     -- * Calling endpoints
     , callEndpointOnInstance
+    -- * Indexed block
     ) where
 
 import           Control.Applicative                              (Alternative (..))

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -157,8 +157,6 @@ processMockBlock instancesState BlockchainEnv{beAddressMap, beTxChanges, beCurre
     instEnv <- S.instancesClientEnv instancesState
     updateInstances (indexBlock transactions) instEnv
 
-  -- TODO: Update instancesClientEnv
-
 processTx :: Slot -> (AddressMap, ChainIndex) -> OnChainTx -> (AddressMap, ChainIndex)
 processTx currentSlot (addressMap, chainIndex) tx = (addressMap', chainIndex') where
   tid = eitherTx txId txId tx
@@ -166,3 +164,5 @@ processTx currentSlot (addressMap, chainIndex) tx = (addressMap', chainIndex') w
   chainIndex' =
     let itm = ChainIndexItem{ciSlot = currentSlot, ciTx = tx, ciTxId = tid } in
     Index.insert addressMap' itm chainIndex
+  -- TODO: updateInstances
+  -- We need to switch to using 'ChainIndexTx' everyhwere first, though.

--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance/BlockchainEnv.hs
@@ -9,10 +9,8 @@
 -- |
 module Plutus.PAB.Core.ContractInstance.BlockchainEnv(
   startNodeClient
-  , ClientEnv(..)
   , processMockBlock
   , processChainSyncEvent
-  , getClientEnv
   , fromCardanoTxId
   ) where
 
@@ -22,11 +20,18 @@ import           Cardano.Node.Types                   (NodeMode (..))
 import           Cardano.Protocol.Socket.Client       (ChainSyncEvent (..))
 import qualified Cardano.Protocol.Socket.Client       as Client
 import qualified Cardano.Protocol.Socket.Mock.Client  as MockClient
-import           Ledger                               (Address, Block, OnChainTx, Slot, TxId (..), eitherTx, txId)
+import           Data.List.NonEmpty                   (NonEmpty (..))
+import qualified Data.Map                             as Map
+import qualified Data.Set                             as Set
+import           Ledger                               (Address, Block, OnChainTx, Slot, TxId (..), TxIn (txInRef),
+                                                       TxOut (..), TxOutRef, consumableInputs, eitherTx,
+                                                       outputsProduced, txId)
 import           Ledger.AddressMap                    (AddressMap)
 import qualified Ledger.AddressMap                    as AddressMap
 import           Plutus.Contract.Effects              (TxStatus (..), TxValidity (..), increaseDepth)
-import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstancesState, emptyBlockchainEnv)
+import           Plutus.PAB.Core.ContractInstance.STM (BlockchainEnv (..), InstanceClientEnv (..), InstancesState,
+                                                       OpenTxOutProducedRequest (..), OpenTxOutSpentRequest (..),
+                                                       emptyBlockchainEnv)
 import qualified Plutus.PAB.Core.ContractInstance.STM as S
 import           Plutus.V1.Ledger.Api                 (toBuiltin)
 
@@ -36,7 +41,6 @@ import           Control.Lens
 import           Control.Monad                        (foldM, forM_, unless, void, when)
 import           Data.Foldable                        (foldl')
 import           Data.Map                             (Map)
-import           Data.Set                             (Set)
 import           Ledger.TimeSlot                      (SlotConfig)
 import           Wallet.Emulator.ChainIndex.Index     (ChainIndex, ChainIndexItem (..))
 import qualified Wallet.Emulator.ChainIndex.Index     as Index
@@ -48,28 +52,51 @@ startNodeClient ::
   -> NodeMode -- ^ Whether to connect to real node or mock node
   -> SlotConfig -- ^ Slot config used by the node
   -> NetworkId -- ^ Cardano network ID
+  -> InstancesState -- ^ In-memory state of running contract instances
   -> IO BlockchainEnv
-startNodeClient socket mode slotConfig networkId = do
+startNodeClient socket mode slotConfig networkId instancesState = do
     env <- STM.atomically emptyBlockchainEnv
     case mode of
       MockNode ->
         void $ MockClient.runChainSync socket slotConfig
-            (\block slot -> STM.atomically $ processMockBlock env block slot)
+            (\block slot -> STM.atomically $ processMockBlock instancesState env block slot)
       AlonzoNode -> do
           let resumePoints = []
           void $ Client.runChainSync socket slotConfig networkId resumePoints
             (\block slot -> STM.atomically $ processChainSyncEvent env block slot)
     pure env
 
--- | Interesting addresses and transactions from all the
---   active instances.
-data ClientEnv = ClientEnv{ceAddresses :: Set Address, ceTransactions :: Set TxId} deriving Eq
+data IndexedBlock =
+  IndexedBlock
+    { ibUtxoSpent    :: Map TxOutRef OnChainTx
+    , ibUtxoProduced :: Map Address (NonEmpty OnChainTx)
+    }
 
-getClientEnv :: InstancesState -> STM ClientEnv
-getClientEnv instancesState =
-  ClientEnv
-    <$> S.watchedAddresses instancesState
-    <*> S.watchedTransactions instancesState
+instance Semigroup IndexedBlock where
+  l <> r =
+    IndexedBlock
+      { ibUtxoSpent = ibUtxoSpent l <> ibUtxoSpent r
+      , ibUtxoProduced = Map.unionWith (<>) (ibUtxoProduced l) (ibUtxoProduced r)
+      }
+
+instance Monoid IndexedBlock where
+  mappend = (<>)
+  mempty = IndexedBlock mempty mempty
+
+indexBlock :: [OnChainTx] -> IndexedBlock
+indexBlock = foldMap indexTx where
+  indexTx otx =
+    IndexedBlock
+      { ibUtxoSpent = Map.fromSet (const otx) $ Set.map txInRef $ consumableInputs otx
+      , ibUtxoProduced = Map.fromListWith (<>) $ outputsProduced otx >>= (\TxOut{txOutAddress} -> [(txOutAddress, otx :| [])])
+      }
+
+updateInstances :: IndexedBlock -> InstanceClientEnv -> STM ()
+updateInstances IndexedBlock{ibUtxoSpent, ibUtxoProduced} InstanceClientEnv{ceUtxoSpentRequests, ceUtxoProducedRequests} = do
+  forM_ (Map.intersectionWith (,) ibUtxoSpent ceUtxoSpentRequests) $ \(onChainTx, requests) ->
+    traverse (\OpenTxOutSpentRequest{osrSpendingTx} -> STM.tryPutTMVar osrSpendingTx onChainTx) requests
+  forM_ (Map.intersectionWith (,) ibUtxoProduced ceUtxoProducedRequests) $ \(txns, requests) ->
+    traverse (\OpenTxOutProducedRequest{otxProducingTxns} -> STM.tryPutTMVar otxProducingTxns txns) requests
 
 -- | Process a chain sync event that we receive from the alonzo node client
 processChainSyncEvent :: BlockchainEnv -> ChainSyncEvent -> Slot -> STM ()
@@ -109,8 +136,8 @@ insertNewTx oldMap (txi, txValidity) = do
 
 -- | Go through the transactions in a block, updating the 'BlockchainEnv'
 --   when any interesting addresses or transactions have changed.
-processMockBlock :: BlockchainEnv -> Block -> Slot -> STM ()
-processMockBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} transactions slot = do
+processMockBlock :: InstancesState -> BlockchainEnv -> Block -> Slot -> STM ()
+processMockBlock instancesState BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxIndex} transactions slot = do
   changes <- STM.readTVar beTxChanges
   forM_ changes $ \tv -> STM.modifyTVar tv increaseDepth
   lastSlot <- STM.readTVar beCurrentSlot
@@ -126,6 +153,11 @@ processMockBlock BlockchainEnv{beAddressMap, beTxChanges, beCurrentSlot, beTxInd
     txStatusMap <- STM.readTVar beTxChanges
     txStatusMap' <- foldM insertNewTx txStatusMap (txMockEvent <$> transactions)
     STM.writeTVar beTxChanges txStatusMap'
+
+    instEnv <- S.instancesClientEnv instancesState
+    updateInstances (indexBlock transactions) instEnv
+
+  -- TODO: Update instancesClientEnv
 
 processTx :: Slot -> (AddressMap, ChainIndex) -> OnChainTx -> (AddressMap, ChainIndex)
 processTx currentSlot (addressMap, chainIndex) tx = (addressMap', chainIndex') where

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -235,6 +235,7 @@ mkSimulatorHandlers feeCfg slotCfg handleContractEffect =
                 $ runPABAction
                 $ handleDelayEffect
                 $ interpret (Core.handleUserEnvReader @t @(SimulatorState t))
+                $ interpret (Core.handleInstancesStateReader @t @(SimulatorState t))
                 $ interpret (Core.handleBlockchainEnvReader @t @(SimulatorState t))
                 $ advanceClock @t slotCfg
             Core.waitUntilSlot 1
@@ -340,6 +341,7 @@ makeBlock ::
     ( LastMember IO effs
     , Member (Reader (SimulatorState t)) effs
     , Member (Reader BlockchainEnv) effs
+    , Member (Reader Instances.InstancesState) effs
     , Member DelayEffect effs
     , Member TimeEffect effs
     )
@@ -432,6 +434,7 @@ handleChainControl ::
     ( LastMember IO effs
     , Member (Reader (SimulatorState t)) effs
     , Member (Reader BlockchainEnv) effs
+    , Member (Reader Instances.InstancesState) effs
     , Member (LogMsg Chain.ChainEvent) effs
     , Member (LogMsg ChainIndex.ChainIndexEvent) effs
     )
@@ -441,10 +444,11 @@ handleChainControl ::
 handleChainControl slotCfg = \case
     Chain.ProcessBlock -> do
         blockchainEnv <- ask @BlockchainEnv
+        instancesState <- ask @Instances.InstancesState
         (txns, slot) <- runChainEffects @t @_ slotCfg ((,) <$> Chain.processBlock <*> Chain.getCurrentSlot)
         runChainIndexEffects @t (ChainIndex.chainIndexNotify $ BlockValidated txns)
 
-        void $ liftIO $ STM.atomically $ BlockchainEnv.processMockBlock blockchainEnv txns slot
+        void $ liftIO $ STM.atomically $ BlockchainEnv.processMockBlock instancesState blockchainEnv txns slot
 
         pure txns
     Chain.ModifySlot f -> do
@@ -585,6 +589,7 @@ advanceClock ::
     ( LastMember IO effs
     , Member (Reader (SimulatorState t)) effs
     , Member (Reader BlockchainEnv) effs
+    , Member (Reader Instances.InstancesState) effs
     , Member DelayEffect effs
     , Member TimeEffect effs
     )

--- a/plutus-pab/test/full/Spec.hs
+++ b/plutus-pab/test/full/Spec.hs
@@ -13,9 +13,9 @@ main =
     testGroup
         "all tests"
         [
-        -- Plutus.PAB.CoreSpec.tests
+        Plutus.PAB.CoreSpec.tests
         -- TODO: To be re-instated once we resolve big delays experienced by
         -- running lots of PABs at once.
-        Plutus.PAB.CliSpec.tests
-        -- , Plutus.PAB.Effects.Contract.BuiltinSpec.tests
+        -- , Plutus.PAB.CliSpec.tests
+        , Plutus.PAB.Effects.Contract.BuiltinSpec.tests
         ]

--- a/plutus-pab/test/full/Spec.hs
+++ b/plutus-pab/test/full/Spec.hs
@@ -12,9 +12,10 @@ main =
     defaultMain $
     testGroup
         "all tests"
-        [ Plutus.PAB.CoreSpec.tests
+        [
+        -- Plutus.PAB.CoreSpec.tests
         -- TODO: To be re-instated once we resolve big delays experienced by
         -- running lots of PABs at once.
-        -- , Plutus.PAB.CliSpec.tests
-        , Plutus.PAB.Effects.Contract.BuiltinSpec.tests
+        Plutus.PAB.CliSpec.tests
+        -- , Plutus.PAB.Effects.Contract.BuiltinSpec.tests
         ]

--- a/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/PingPong.hs
@@ -124,7 +124,7 @@ run ::
     -> Promise w PingPongSchema PingPongError ()
     -> Contract w PingPongSchema PingPongError ()
 run expectedState action = do
-    let extractState = tyTxOutData . fst
+    let extractState = tyTxOutData . SM.ocsTxOut
         go Nothing = throwError StoppedUnexpectedly
         go (Just currentState)
             | extractState currentState == expectedState = awaitPromise action
@@ -158,7 +158,7 @@ combined = forever (selectList [initialise, ping, pong, runStop, wait]) where
         newState <- runWaitForUpdate
         case newState of
             Nothing -> logWarn @Haskell.String "runWaitForUpdate: Nothing"
-            Just (TypedScriptTxOut{tyTxOutData=s}, _) -> do
+            Just SM.OnChainState{SM.ocsTxOut=TypedScriptTxOut{tyTxOutData=s}} -> do
                 logInfo $ "new state: " <> Haskell.show s
                 tell (Last $ Just s)
 

--- a/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/Stablecoin.hs
@@ -95,8 +95,8 @@ import           Ledger.Typed.Tx              (TypedScriptTxOut (..))
 import           Ledger.Value                 (AssetClass, TokenName, Value)
 import qualified Ledger.Value                 as Value
 import           Plutus.Contract
-import           Plutus.Contract.StateMachine (AsSMContractError, SMContractError, State (..), StateMachine,
-                                               StateMachineClient (..), Void)
+import           Plutus.Contract.StateMachine (AsSMContractError, OnChainState (..), SMContractError, State (..),
+                                               StateMachine, StateMachineClient (..), Void)
 import qualified Plutus.Contract.StateMachine as StateMachine
 import qualified PlutusTx
 import           PlutusTx.Prelude
@@ -415,7 +415,7 @@ checkTransition theClient sc i@Input{inpConversionRate} = do
         case checkHashOffChain inpConversionRate of
             Right Observation{obsValue} -> do
                 case currentState of
-                    Just ((TypedScriptTxOut{tyTxOutData}, _), _) -> do
+                    Just (OnChainState{ocsTxOut=TypedScriptTxOut{tyTxOutData}}, _) -> do
                         case checkValidState sc tyTxOutData obsValue of
                             Right _ -> logInfo @Haskell.String "Current state OK"
                             Left w  -> logInfo $ "Current state is invalid: " <> Haskell.show w <> ". The transition may still be allowed."

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -2600,107 +2600,6 @@
                         (termbind
                           (strict)
                           (vardecl
-                            appEndo
-                            (all a (type) (fun [(lam a (type) (fun a a)) a] [(lam a (type) (fun a a)) a]))
-                          )
-                          (abs a (type) (lam ds [(lam a (type) (fun a a)) a] ds)
-                          )
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
-                            fGeneric1TYPEDual
-                            (all a (type) (fun [(lam a (type) a) a] [(lam a (type) a) a]))
-                          )
-                          (abs a (type) (lam x [(lam a (type) a) a] x))
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
-                            foldl
-                            (all t (fun (type) (type)) (all b (type) (all a (type) (fun [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t] (fun (fun b (fun a b)) (fun b (fun [t a] b)))))))
-                          )
-                          (abs
-                            t
-                            (fun (type) (type))
-                            (abs
-                              b
-                              (type)
-                              (abs
-                                a
-                                (type)
-                                (lam
-                                  dFoldable
-                                  [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t]
-                                  (let
-                                    (nonrec)
-                                    (termbind
-                                      (nonstrict)
-                                      (vardecl
-                                        dMonoid
-                                        [Monoid [(lam a (type) a) [(lam a (type) (fun a a)) b]]]
-                                      )
-                                      [
-                                        {
-                                          fMonoidDual
-                                          [(lam a (type) (fun a a)) b]
-                                        }
-                                        { fMonoidEndo b }
-                                      ]
-                                    )
-                                    (lam
-                                      f
-                                      (fun b (fun a b))
-                                      (lam
-                                        z
-                                        b
-                                        (lam
-                                          t
-                                          [t a]
-                                          [
-                                            [
-                                              { appEndo b }
-                                              [
-                                                {
-                                                  fGeneric1TYPEDual
-                                                  [(lam a (type) (fun a a)) b]
-                                                }
-                                                [
-                                                  [
-                                                    [
-                                                      {
-                                                        {
-                                                          dFoldable
-                                                          [(lam a (type) a) [(lam a (type) (fun a a)) b]]
-                                                        }
-                                                        a
-                                                      }
-                                                      dMonoid
-                                                    ]
-                                                    (lam
-                                                      x
-                                                      a
-                                                      (lam y b [ [ f y ] x ])
-                                                    )
-                                                  ]
-                                                  t
-                                                ]
-                                              ]
-                                            ]
-                                            z
-                                          ]
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
                             length
                             (all t (fun (type) (type)) (all a (type) (fun [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t] (fun [t a] (con integer)))))
                           )
@@ -2713,27 +2612,57 @@
                               (lam
                                 dFoldable
                                 [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t]
-                                [
-                                  [
-                                    [
-                                      { { { foldl t } (con integer) } a }
-                                      dFoldable
-                                    ]
-                                    (lam
-                                      c
-                                      (con integer)
-                                      (lam
-                                        ds
-                                        a
-                                        [
-                                          [ (builtin addInteger) c ]
-                                          (con integer 1)
-                                        ]
-                                      )
+                                (let
+                                  (nonrec)
+                                  (termbind
+                                    (nonstrict)
+                                    (vardecl
+                                      dMonoid
+                                      [Monoid [(lam a (type) a) [(lam a (type) (fun a a)) (con integer)]]]
                                     )
-                                  ]
-                                  (con integer 0)
-                                ]
+                                    [
+                                      {
+                                        fMonoidDual
+                                        [(lam a (type) (fun a a)) (con integer)]
+                                      }
+                                      { fMonoidEndo (con integer) }
+                                    ]
+                                  )
+                                  (lam
+                                    t
+                                    [t a]
+                                    [
+                                      [
+                                        [
+                                          [
+                                            {
+                                              {
+                                                dFoldable
+                                                [(lam a (type) a) [(lam a (type) (fun a a)) (con integer)]]
+                                              }
+                                              a
+                                            }
+                                            dMonoid
+                                          ]
+                                          (lam
+                                            x
+                                            a
+                                            (lam
+                                              y
+                                              (con integer)
+                                              [
+                                                [ (builtin addInteger) y ]
+                                                (con integer 1)
+                                              ]
+                                            )
+                                          )
+                                        ]
+                                        t
+                                      ]
+                                      (con integer 0)
+                                    ]
+                                  )
+                                )
                               )
                             )
                           )

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -2600,6 +2600,107 @@
                         (termbind
                           (strict)
                           (vardecl
+                            appEndo
+                            (all a (type) (fun [(lam a (type) (fun a a)) a] [(lam a (type) (fun a a)) a]))
+                          )
+                          (abs a (type) (lam ds [(lam a (type) (fun a a)) a] ds)
+                          )
+                        )
+                        (termbind
+                          (strict)
+                          (vardecl
+                            fGeneric1TYPEDual
+                            (all a (type) (fun [(lam a (type) a) a] [(lam a (type) a) a]))
+                          )
+                          (abs a (type) (lam x [(lam a (type) a) a] x))
+                        )
+                        (termbind
+                          (strict)
+                          (vardecl
+                            foldl
+                            (all t (fun (type) (type)) (all b (type) (all a (type) (fun [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t] (fun (fun b (fun a b)) (fun b (fun [t a] b)))))))
+                          )
+                          (abs
+                            t
+                            (fun (type) (type))
+                            (abs
+                              b
+                              (type)
+                              (abs
+                                a
+                                (type)
+                                (lam
+                                  dFoldable
+                                  [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t]
+                                  (let
+                                    (nonrec)
+                                    (termbind
+                                      (nonstrict)
+                                      (vardecl
+                                        dMonoid
+                                        [Monoid [(lam a (type) a) [(lam a (type) (fun a a)) b]]]
+                                      )
+                                      [
+                                        {
+                                          fMonoidDual
+                                          [(lam a (type) (fun a a)) b]
+                                        }
+                                        { fMonoidEndo b }
+                                      ]
+                                    )
+                                    (lam
+                                      f
+                                      (fun b (fun a b))
+                                      (lam
+                                        z
+                                        b
+                                        (lam
+                                          t
+                                          [t a]
+                                          [
+                                            [
+                                              { appEndo b }
+                                              [
+                                                {
+                                                  fGeneric1TYPEDual
+                                                  [(lam a (type) (fun a a)) b]
+                                                }
+                                                [
+                                                  [
+                                                    [
+                                                      {
+                                                        {
+                                                          dFoldable
+                                                          [(lam a (type) a) [(lam a (type) (fun a a)) b]]
+                                                        }
+                                                        a
+                                                      }
+                                                      dMonoid
+                                                    ]
+                                                    (lam
+                                                      x
+                                                      a
+                                                      (lam y b [ [ f y ] x ])
+                                                    )
+                                                  ]
+                                                  t
+                                                ]
+                                              ]
+                                            ]
+                                            z
+                                          ]
+                                        )
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (termbind
+                          (strict)
+                          (vardecl
                             length
                             (all t (fun (type) (type)) (all a (type) (fun [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t] (fun [t a] (con integer)))))
                           )
@@ -2612,57 +2713,27 @@
                               (lam
                                 dFoldable
                                 [(lam t (fun (type) (type)) (all m (type) (all a (type) (fun [Monoid m] (fun (fun a m) (fun [t a] m)))))) t]
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl
-                                      dMonoid
-                                      [Monoid [(lam a (type) a) [(lam a (type) (fun a a)) (con integer)]]]
-                                    )
+                                [
+                                  [
                                     [
-                                      {
-                                        fMonoidDual
-                                        [(lam a (type) (fun a a)) (con integer)]
-                                      }
-                                      { fMonoidEndo (con integer) }
+                                      { { { foldl t } (con integer) } a }
+                                      dFoldable
                                     ]
-                                  )
-                                  (lam
-                                    t
-                                    [t a]
-                                    [
-                                      [
+                                    (lam
+                                      c
+                                      (con integer)
+                                      (lam
+                                        ds
+                                        a
                                         [
-                                          [
-                                            {
-                                              {
-                                                dFoldable
-                                                [(lam a (type) a) [(lam a (type) (fun a a)) (con integer)]]
-                                              }
-                                              a
-                                            }
-                                            dMonoid
-                                          ]
-                                          (lam
-                                            x
-                                            a
-                                            (lam
-                                              y
-                                              (con integer)
-                                              [
-                                                [ (builtin addInteger) y ]
-                                                (con integer 1)
-                                              ]
-                                            )
-                                          )
+                                          [ (builtin addInteger) c ]
+                                          (con integer 1)
                                         ]
-                                        t
-                                      ]
-                                      (con integer 0)
-                                    ]
-                                  )
-                                )
+                                      )
+                                    )
+                                  ]
+                                  (con integer 0)
+                                ]
                               )
                             )
                           )


### PR DESCRIPTION
* Add `awaitUtxoSpent` and `awaitUtxoProduced` requests to `Plutus.Contract.Request`
  * The two requests can be handled efficiently by the PAB
* Replace most uses of `addressChangeRequest` with the new requests
  * The biggest change happened in the state machine client, where `waitForUpdate` etc now don't need to call `addressChangeRequest` once every slot
  * The last remaining use of `waitForUpdate` is in `marloweFollowContract`. The follow contract needs to know every single transaction that interacted with the marlowe contract, instead of just the last one. I asked @nau why this is necessary and if there was a way around it
* Extend `Plutus.Contract.StateMachine.waitForUpdateTimeout`:
  * The `WaitingResult` type now informs about the kind of transition that happend
  * `OnChainState` is a proper datatype

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
