### PR TITLE
Fix another let-floating bug with immovable bindings

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -278,6 +278,7 @@
           "PlutusIR/Transform/Rename"
           "PlutusIR/Transform/NonStrict"
           "PlutusIR/Transform/LetFloat"
+          "PlutusIR/Transform/LetMerge"
           "PlutusIR/Transform/Inline"
           "PlutusIR/Transform/Beta"
           "PlutusIR/Transform/Unwrap"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -278,6 +278,7 @@
           "PlutusIR/Transform/Rename"
           "PlutusIR/Transform/NonStrict"
           "PlutusIR/Transform/LetFloat"
+          "PlutusIR/Transform/LetMerge"
           "PlutusIR/Transform/Inline"
           "PlutusIR/Transform/Beta"
           "PlutusIR/Transform/Unwrap"

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -134,6 +134,7 @@ library
         PlutusIR.Transform.Rename
         PlutusIR.Transform.NonStrict
         PlutusIR.Transform.LetFloat
+        PlutusIR.Transform.LetMerge
         PlutusIR.Transform.Inline
         PlutusIR.Transform.Beta
         PlutusIR.Transform.Unwrap

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -43,6 +43,7 @@ import qualified PlutusIR.Transform.Beta            as Beta
 import qualified PlutusIR.Transform.DeadCode        as DeadCode
 import qualified PlutusIR.Transform.Inline          as Inline
 import qualified PlutusIR.Transform.LetFloat        as LetFloat
+import qualified PlutusIR.Transform.LetMerge        as LetMerge
 import qualified PlutusIR.Transform.NonStrict       as NonStrict
 import           PlutusIR.Transform.Rename          ()
 import qualified PlutusIR.Transform.ThunkRecursions as ThunkRec
@@ -127,7 +128,7 @@ simplifyTerm = runIfOpts $ DeadCode.removeDeadBindings >=> simplify'
 -- | Perform floating/merging of lets in a 'Term' to their nearest lambda/Lambda/letStrictNonValue.
 -- Note: It assumes globally unique names
 floatTerm :: (Compiling m e uni fun a, Semigroup b) => Term TyName Name uni fun b -> m (Term TyName Name uni fun b)
-floatTerm = runIfOpts $ pure . LetFloat.floatTerm
+floatTerm = runIfOpts $ pure . LetMerge.letMerge . LetFloat.floatTerm
 
 -- | Typecheck a PIR Term iff the context demands it.
 -- Note: assumes globally unique names

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetMerge.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetMerge.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+{-|
+A trivial simplification that merges adjacent non-recursive let terms.
+-}
+module PlutusIR.Transform.LetMerge (
+  letMerge
+  ) where
+
+import           PlutusIR
+
+import           Control.Lens (transformOf)
+
+{-|
+A single non-recursive application of let-merging cancellation.
+-}
+letMergeStep
+    :: Term tyname name uni fun a
+    -> Term tyname name uni fun a
+letMergeStep = \case
+    Let a NonRec bs (Let _ NonRec bs' t) -> Let a NonRec (bs <> bs') t
+    t                                    -> t
+
+{-|
+Recursively apply let merging cancellation.
+-}
+letMerge
+    :: Term tyname name uni fun a
+    -> Term tyname name uni fun a
+letMerge = transformOf termSubterms letMergeStep

--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -17,6 +17,7 @@ import qualified PlutusIR.Transform.Beta            as Beta
 import qualified PlutusIR.Transform.DeadCode        as DeadCode
 import qualified PlutusIR.Transform.Inline          as Inline
 import qualified PlutusIR.Transform.LetFloat        as LetFloat
+import qualified PlutusIR.Transform.LetMerge        as LetMerge
 import qualified PlutusIR.Transform.NonStrict       as NonStrict
 import           PlutusIR.Transform.Rename          ()
 import qualified PlutusIR.Transform.ThunkRecursions as ThunkRec
@@ -53,7 +54,7 @@ nonStrict = testNested "nonStrict"
 letFloat :: TestNested
 letFloat =
     testNested "letFloat"
-    $ map (goldenPir (LetFloat.floatTerm . runQuote . PLC.rename) $ term @PLC.DefaultUni @PLC.DefaultFun)
+    $ map (goldenPir (LetMerge.letMerge . LetFloat.floatTerm . runQuote . PLC.rename) $ term @PLC.DefaultUni @PLC.DefaultFun)
   [ "letInLet"
   ,"listMatch"
   ,"maybe"
@@ -82,6 +83,7 @@ letFloat =
   ,"strictValueValue"
   ,"even3Eval"
   ,"strictNonValueDeep"
+  ,"regression1"
   ]
 
 instance Semigroup SourcePos where

--- a/plutus-core/plutus-ir/test/recursion/even3.golden
+++ b/plutus-core/plutus-ir/test/recursion/even3.golden
@@ -33,31 +33,42 @@
                                   (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i1) out_Nat_i1))))
                                   [
                                     (lam
-                                      tup_i0
-                                      (all r_i0 (type) (fun (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) r_i1)) r_i1))
+                                      three_i0
+                                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
                                       [
                                         (lam
-                                          even_i0
-                                          (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                          tup_i0
+                                          (all r_i0 (type) (fun (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) r_i1)) r_i1))
                                           [
                                             (lam
-                                              odd_i0
+                                              even_i0
                                               (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
                                               [
                                                 (lam
-                                                  three_i0
-                                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                                  [ even_i3 three_i1 ]
+                                                  odd_i0
+                                                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                  [ even_i2 three_i4 ]
                                                 )
                                                 [
-                                                  Suc_i5
-                                                  [ Suc_i5 [ Suc_i5 Zero_i6 ] ]
+                                                  {
+                                                    tup_i2
+                                                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                  }
+                                                  (lam
+                                                    arg_0_i0
+                                                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                    (lam
+                                                      arg_1_i0
+                                                      (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                      arg_1_i1
+                                                    )
+                                                  )
                                                 ]
                                               ]
                                             )
                                             [
                                               {
-                                                tup_i2
+                                                tup_i1
                                                 (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
                                               }
                                               (lam
@@ -66,7 +77,7 @@
                                                 (lam
                                                   arg_1_i0
                                                   (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                                  arg_1_i1
+                                                  arg_0_i2
                                                 )
                                               )
                                             ]
@@ -74,93 +85,84 @@
                                         )
                                         [
                                           {
-                                            tup_i1
-                                            (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                            {
+                                              {
+                                                {
+                                                  fix2_i8
+                                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                                }
+                                                (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                              }
+                                              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                            }
+                                            (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
                                           }
-                                          (lam
-                                            arg_0_i0
-                                            (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                          (abs
+                                            Q_i0
+                                            (type)
                                             (lam
-                                              arg_1_i0
-                                              (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                              arg_0_i2
+                                              choose_i0
+                                              (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) Q_i2))
+                                              (lam
+                                                even_i0
+                                                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                (lam
+                                                  odd_i0
+                                                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                                  [
+                                                    [
+                                                      choose_i3
+                                                      (lam
+                                                        n_i0
+                                                        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                                        [
+                                                          [
+                                                            {
+                                                              [
+                                                                match_Nat_i7
+                                                                n_i1
+                                                              ]
+                                                              (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                                            }
+                                                            True_i12
+                                                          ]
+                                                          (lam
+                                                            pred_i0
+                                                            (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                                            [ odd_i3 pred_i1 ]
+                                                          )
+                                                        ]
+                                                      )
+                                                    ]
+                                                    (lam
+                                                      n_i0
+                                                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                                      [
+                                                        [
+                                                          {
+                                                            [
+                                                              match_Nat_i7 n_i1
+                                                            ]
+                                                            (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                                          }
+                                                          False_i11
+                                                        ]
+                                                        (lam
+                                                          pred_i0
+                                                          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                                          [ even_i4 pred_i1 ]
+                                                        )
+                                                      ]
+                                                    )
+                                                  ]
+                                                )
+                                              )
                                             )
                                           )
                                         ]
                                       ]
                                     )
-                                    [
-                                      {
-                                        {
-                                          {
-                                            {
-                                              fix2_i7
-                                              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                            }
-                                            (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                                          }
-                                          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                        }
-                                        (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                                      }
-                                      (abs
-                                        Q_i0
-                                        (type)
-                                        (lam
-                                          choose_i0
-                                          (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))) Q_i2))
-                                          (lam
-                                            even_i0
-                                            (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                            (lam
-                                              odd_i0
-                                              (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                              [
-                                                [
-                                                  choose_i3
-                                                  (lam
-                                                    n_i0
-                                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                                    [
-                                                      [
-                                                        {
-                                                          [ match_Nat_i6 n_i1 ]
-                                                          (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                                                        }
-                                                        True_i11
-                                                      ]
-                                                      (lam
-                                                        pred_i0
-                                                        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                                        [ odd_i3 pred_i1 ]
-                                                      )
-                                                    ]
-                                                  )
-                                                ]
-                                                (lam
-                                                  n_i0
-                                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                                  [
-                                                    [
-                                                      {
-                                                        [ match_Nat_i6 n_i1 ]
-                                                        (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                                                      }
-                                                      False_i10
-                                                    ]
-                                                    (lam
-                                                      pred_i0
-                                                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                                      [ even_i4 pred_i1 ]
-                                                    )
-                                                  ]
-                                                )
-                                              ]
-                                            )
-                                          )
-                                        )
-                                      )
-                                    ]
+                                    [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
                                   ]
                                 )
                               )

--- a/plutus-core/plutus-ir/test/recursion/stupidZero.golden
+++ b/plutus-core/plutus-ir/test/recursion/stupidZero.golden
@@ -17,76 +17,76 @@
                   (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i1) out_Nat_i1))))
                   [
                     (lam
-                      tup_i0
-                      (all r_i0 (type) (fun (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))) r_i1) r_i1))
+                      three_i0
+                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
                       [
                         (lam
-                          stupidZero_i0
-                          (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
+                          tup_i0
+                          (all r_i0 (type) (fun (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))) r_i1) r_i1))
                           [
-                            (lam
-                              three_i0
-                              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                              [ stupidZero_i2 three_i1 ]
-                            )
-                            [ Suc_i4 [ Suc_i4 [ Suc_i4 Zero_i5 ] ] ]
-                          ]
-                        )
-                        [
-                          {
-                            tup_i1
-                            (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
-                          }
-                          (lam
-                            arg_0_i0
-                            (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
-                            arg_0_i1
-                          )
-                        ]
-                      ]
-                    )
-                    (abs
-                      r_i0
-                      (type)
-                      (lam
-                        f_i0
-                        (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))) r_i2)
-                        [
-                          f_i1
-                          [
-                            {
-                              {
-                                fix1_i6
-                                (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                              }
-                              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                            }
                             (lam
                               stupidZero_i0
                               (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
-                              (lam
-                                n_i0
-                                (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                [
-                                  [
-                                    {
-                                      [ match_Nat_i5 n_i1 ]
-                                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                    }
-                                    Zero_i7
-                                  ]
-                                  (lam
-                                    pred_i0
-                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-                                    [ stupidZero_i3 pred_i1 ]
-                                  )
-                                ]
-                              )
+                              [ stupidZero_i1 three_i3 ]
                             )
+                            [
+                              {
+                                tup_i1
+                                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
+                              }
+                              (lam
+                                arg_0_i0
+                                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
+                                arg_0_i1
+                              )
+                            ]
                           ]
-                        ]
-                      )
+                        )
+                        (abs
+                          r_i0
+                          (type)
+                          (lam
+                            f_i0
+                            (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))) r_i2)
+                            [
+                              f_i1
+                              [
+                                {
+                                  {
+                                    fix1_i7
+                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                  }
+                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                }
+                                (lam
+                                  stupidZero_i0
+                                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))))
+                                  (lam
+                                    n_i0
+                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                    [
+                                      [
+                                        {
+                                          [ match_Nat_i6 n_i1 ]
+                                          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                        }
+                                        Zero_i8
+                                      ]
+                                      (lam
+                                        pred_i0
+                                        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                                        [ stupidZero_i3 pred_i1 ]
+                                      )
+                                    ]
+                                  )
+                                )
+                              ]
+                            ]
+                          )
+                        )
+                      ]
                     )
+                    [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
                   ]
                 )
               )

--- a/plutus-core/plutus-ir/test/transform/letFloat/even3Eval.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/even3Eval.golden
@@ -19,28 +19,28 @@
       )
     )
     (let
-      (rec)
-      (termbind
-        (strict)
-        (vardecl even (fun Nat Bool))
-        (lam
-          n
-          Nat
-          [ [ { [ match_Nat n ] Bool } True ] (lam pred Nat [ odd pred ]) ]
-        )
-      )
-      (termbind
-        (strict)
-        (vardecl odd (fun Nat Bool))
-        (lam
-          n
-          Nat
-          [ [ { [ match_Nat n ] Bool } False ] (lam pred Nat [ even pred ]) ]
-        )
-      )
+      (nonrec)
+      (termbind (strict) (vardecl three Nat) [ Suc [ Suc [ Suc Zero ] ] ])
       (let
-        (nonrec)
-        (termbind (strict) (vardecl three Nat) [ Suc [ Suc [ Suc Zero ] ] ])
+        (rec)
+        (termbind
+          (strict)
+          (vardecl even (fun Nat Bool))
+          (lam
+            n
+            Nat
+            [ [ { [ match_Nat n ] Bool } True ] (lam pred Nat [ odd pred ]) ]
+          )
+        )
+        (termbind
+          (strict)
+          (vardecl odd (fun Nat Bool))
+          (lam
+            n
+            Nat
+            [ [ { [ match_Nat n ] Bool } False ] (lam pred Nat [ even pred ]) ]
+          )
+        )
         [ even three ]
       )
     )

--- a/plutus-core/plutus-ir/test/transform/letFloat/nonrec2.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/nonrec2.golden
@@ -3,7 +3,6 @@
   (con integer)
   (let
     (nonrec)
-    (termbind (strict) (vardecl j1 (con integer)) (con integer 0))
     (termbind (strict) (vardecl i2 (con integer)) (con integer 2))
     (termbind
       (strict)
@@ -22,6 +21,7 @@
         ]
       )
     )
+    (termbind (strict) (vardecl j1 (con integer)) (con integer 0))
     [ [ (builtin addInteger) i ] j1 ]
   )
 )

--- a/plutus-core/plutus-ir/test/transform/letFloat/regression1
+++ b/plutus-core/plutus-ir/test/transform/letFloat/regression1
@@ -1,0 +1,7 @@
+(let (nonrec)
+     (termbind (strict) (vardecl a (con integer)) [ [ (builtin addInteger) (con integer 1) ] (con integer 1) ])
+     (let (nonrec)
+          (termbind (nonstrict) (vardecl b (con integer)) a)
+          b
+     )
+)

--- a/plutus-core/plutus-ir/test/transform/letFloat/regression1.golden
+++ b/plutus-core/plutus-ir/test/transform/letFloat/regression1.golden
@@ -1,0 +1,10 @@
+(let
+  (nonrec)
+  (termbind
+    (strict)
+    (vardecl a (con integer))
+    [ [ (builtin addInteger) (con integer 1) ] (con integer 1) ]
+  )
+  (termbind (nonstrict) (vardecl b (con integer)) a)
+  b
+)

--- a/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
@@ -24,11 +24,8 @@
             (let
               (nonrec)
               (termbind (strict) (vardecl dt a) dt)
-              (let
-                (nonrec)
-                (termbind (strict) (vardecl dt a) dt)
-                [ [ { StrictPattern a } dt ] dt ]
-              )
+              (termbind (strict) (vardecl dt a) dt)
+              [ [ { StrictPattern a } dt ] dt ]
             )
           )
         )


### PR DESCRIPTION
Immovable let bindings did *not* act as anchors for lets inside the
*body* of the let. This let the let-floater produce ill-scoped terms.

The fix is:
- Do create anchors for the lets in the body of a let with immovable
bindings, by picking a single binding to be the representative.
- Distinguish different kinds of anchors in order to avoid this getting
confused with the existing anchors which can be created from bindings
(for their RHSs).

I did some simplification while I was at it. I couldn't resist moving
out let-merging into its own pass, given how simple it is...

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
