### PR TITLE
Delete TakeByteString and DropByteString builtins

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Bench.hs
+++ b/plutus-core/cost-model/budgeting-bench/Bench.hs
@@ -379,7 +379,7 @@ main = do
                                                        , LessThanEqualsInteger
                                                        ])
                       <> (benchTwoByteStrings <$> [AppendByteString])
-                      <> (benchBytestringOperations <$> [TakeByteString, DropByteString, ConsByteString])
+                      <> (benchBytestringOperations <$> [ConsByteString])
                       <> [benchIndexBytestring gen]
                       <> [benchSliceByteString gen]
                       <> (benchByteStringNoArgOperations <$> [LengthOfByteString, Sha2_256, Sha3_256])

--- a/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
+++ b/plutus-core/cost-model/create-cost-model/CostModelCreation.hs
@@ -56,8 +56,6 @@ builtinCostModelNames = BuiltinCostModelBase
   , paramGreaterThanInteger       = "greaterThanIntegerModel"
   , paramGreaterThanEqualsInteger = "greaterThanEqualsIntegerModel"
   , paramAppendByteString         = "appendByteStringModel"
-  , paramTakeByteString           = "takeByteStringModel"
-  , paramDropByteString           = "dropByteStringModel"
   , paramSha2_256                 = "sha2_256Model"
   , paramSha3_256                 = "sha3_256Model"
   , paramVerifySignature          = "verifySignatureModel"
@@ -101,8 +99,6 @@ createBuiltinCostModel =
     paramGreaterThanEqualsInteger <- getParams greaterThanEqualsInteger paramGreaterThanEqualsInteger
     paramEqualsInteger            <- getParams equalsInteger            paramEqualsInteger
     paramAppendByteString         <- getParams appendByteString         paramAppendByteString
-    paramTakeByteString           <- getParams takeByteString           paramTakeByteString
-    paramDropByteString           <- getParams dropByteString           paramDropByteString
     paramSha2_256                 <- getParams sha2_256                 paramSha2_256
     paramSha3_256                 <- getParams sha3_256                 paramSha3_256
     paramVerifySignature          <- getParams verifySignature          paramVerifySignature

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -105,14 +105,6 @@ prop_appendByteString :: Property
 prop_appendByteString =
     testPredictTwo appendByteString (getConst . paramAppendByteString)
 
-prop_takeByteString :: Property
-prop_takeByteString =
-    testPredictTwo takeByteString (getConst . paramTakeByteString)
-
-prop_dropByteString :: Property
-prop_dropByteString =
-    testPredictTwo dropByteString (getConst . paramDropByteString)
-
 prop_sha2_256 :: Property
 prop_sha2_256 =
     testPredictOne sha2_256 (getConst . paramSha2_256)

--- a/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
@@ -123,8 +123,6 @@ typedBuiltins
     . insertBuiltin GreaterThanEqualsInteger
     . insertBuiltin EqualsInteger
     . insertBuiltin AppendByteString
-    . insertBuiltin TakeByteString
-    . insertBuiltin DropByteString
     . insertBuiltin Sha2_256
     . insertBuiltin Sha3_256
 --     . insertBuiltin VerifySignature

--- a/plutus-core/generators/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/generators/PlutusCore/Generators/NEAT/Term.hs
@@ -374,8 +374,6 @@ defaultFunTypes = Map.fromList [(TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuilt
                    ,[LessThanInteger,LessThanEqualsInteger,GreaterThanInteger,GreaterThanEqualsInteger,EqualsInteger])
                   ,(TyFunG (TyBuiltinG TyByteStringG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG))
                    ,[AppendByteString])
-                  ,(TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG))
-                   ,[TakeByteString,DropByteString])
                   ,(TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyIntegerG) (TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG)))
                    ,[SliceByteString])
                   ,(TyFunG (TyBuiltinG TyByteStringG) (TyBuiltinG TyByteStringG)

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -54,8 +54,6 @@ data DefaultFun
     | EqualsInteger
     | AppendByteString
     | ConsByteString
-    | TakeByteString
-    | DropByteString
     | SliceByteString
     | LengthOfByteString
     | IndexByteString
@@ -179,14 +177,6 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
         makeBuiltinMeaning
             (\n xs -> BS.cons (fromIntegral @Integer n) xs)
             mempty -- TODO: budget. To be replace with: (runCostingFunOneArgument . paramConsByteString)
-    toBuiltinMeaning TakeByteString =
-        makeBuiltinMeaning
-            BS.take
-            (runCostingFunTwoArguments . paramTakeByteString)
-    toBuiltinMeaning DropByteString =
-        makeBuiltinMeaning
-            BS.drop
-            (runCostingFunTwoArguments . paramDropByteString)
     toBuiltinMeaning SliceByteString =
         makeBuiltinMeaning
             (\from to xs -> BS.take (to - from + 1) (BS.drop from xs))
@@ -407,8 +397,8 @@ instance Flat DefaultFun where
               GreaterThanEqualsInteger -> 8
               EqualsInteger            -> 9
               AppendByteString         -> 10
-              TakeByteString           -> 11
-              DropByteString           -> 12
+              -- 11 unused
+              -- 12 unused
               Sha2_256                 -> 13
               Sha3_256                 -> 14
               VerifySignature          -> 15
@@ -467,8 +457,7 @@ instance Flat DefaultFun where
               go 8  = pure GreaterThanEqualsInteger
               go 9  = pure EqualsInteger
               go 10 = pure AppendByteString
-              go 11 = pure TakeByteString
-              go 12 = pure DropByteString
+              -- 11-12 unused
               go 13 = pure Sha2_256
               go 14 = pure Sha3_256
               go 15 = pure VerifySignature

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -70,8 +70,6 @@ data BuiltinCostModelBase f =
     , paramGreaterThanEqualsInteger :: f ModelTwoArguments
     , paramEqualsInteger            :: f ModelTwoArguments
     , paramAppendByteString         :: f ModelTwoArguments
-    , paramTakeByteString           :: f ModelTwoArguments
-    , paramDropByteString           :: f ModelTwoArguments
     , paramSha2_256                 :: f ModelOneArgument
     , paramSha3_256                 :: f ModelOneArgument
     , paramVerifySignature          :: f ModelThreeArguments

--- a/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -76,8 +76,6 @@ test_applyDefaultBuiltin =
         , test_applyBuiltinFunction GreaterThanEqInteger
         , test_applyBuiltinFunction EqInteger
         , test_applyBuiltinFunction AppendByteString
-        , test_applyBuiltinFunction TakeByteString
-        , test_applyBuiltinFunction DropByteString
         , test_applyBuiltinFunction EqByteString
         , test_applyBuiltinFunction SHA2
         , test_applyBuiltinFunction SHA3

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -25,7 +25,6 @@ import qualified UntypedPlutusCore                        as UPLC
 import           UntypedPlutusCore.Evaluation.Machine.Cek
 
 import           Data.Bifunctor
-import qualified Data.ByteString                          as BS
 import qualified Data.ByteString.Lazy                     as BSL
 import           Data.Text                                (Text)
 import           Data.Text.Encoding                       (encodeUtf8)
@@ -301,11 +300,6 @@ mulInstError2 = Apply () (TyInst () (Apply () mul eleven) string) twentytwo
 mulInstError3 :: Term TyName Name DefaultUni DefaultFun ()
 mulInstError3 = TyInst () (Apply () (Apply () mul eleven) twentytwo) string
 
-takeTooMuch :: Term TyName Name DefaultUni DefaultFun ()
-takeTooMuch = mkIterApp () (Builtin () TakeByteString)
-    [ mkConstant () $ (2 :: Integer) ^ (150 :: Integer)
-    , mkConstant () ("whatever" :: BS.ByteString)
-    ]
 
 -- Running the tests
 
@@ -379,7 +373,6 @@ namesAndTests =
    , ("mulInstError1", mulInstError1)
    , ("mulInstError2", mulInstError2)
    , ("mulInstError3", mulInstError3)
-   , ("takeTooMuch", takeTooMuch)
    ]
 
 test_golden :: TestTree

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -160,8 +160,6 @@ builtinNames = [
       ''Builtins.BuiltinByteString
     , 'Builtins.appendByteString
     , 'Builtins.consByteString
-    , 'Builtins.takeByteString
-    , 'Builtins.dropByteString
     , 'Builtins.sliceByteString
     , 'Builtins.lengthOfByteString
     , 'Builtins.indexByteString
@@ -282,8 +280,6 @@ defineBuiltinTerms = do
     -- Bytestring builtins
     defineBuiltinTerm 'Builtins.appendByteString $ mkBuiltin PLC.AppendByteString
     defineBuiltinTerm 'Builtins.consByteString $ mkBuiltin PLC.ConsByteString
-    defineBuiltinTerm 'Builtins.takeByteString $ mkBuiltin PLC.TakeByteString
-    defineBuiltinTerm 'Builtins.dropByteString $ mkBuiltin PLC.DropByteString
     defineBuiltinTerm 'Builtins.sliceByteString $ mkBuiltin PLC.SliceByteString
     defineBuiltinTerm 'Builtins.lengthOfByteString $ mkBuiltin PLC.LengthOfByteString
     defineBuiltinTerm 'Builtins.indexByteString $ mkBuiltin PLC.IndexByteString

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -93,12 +93,12 @@ sliceByteString from to bs = BI.sliceByteString (toBuiltin from) (toBuiltin to) 
 {-# INLINABLE takeByteString #-}
 -- | Returns the n length prefix of a 'ByteString'.
 takeByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-takeByteString n = BI.takeByteString (toBuiltin n)
+takeByteString n bs = BI.sliceByteString 0 (toBuiltin n - 1) bs
 
 {-# INLINABLE dropByteString #-}
 -- | Returns the suffix of a 'ByteString' after n elements.
 dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-dropByteString n = BI.dropByteString (toBuiltin n)
+dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs - 1) bs
 
 {-# INLINABLE lengthOfByteString #-}
 -- | Returns the length of a 'ByteString'.

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -157,14 +157,6 @@ appendByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinByteStri
 consByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegral n) b
 
-{-# NOINLINE takeByteString #-}
-takeByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-takeByteString n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) b
-
-{-# NOINLINE dropByteString #-}
-dropByteString :: BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-dropByteString n (BuiltinByteString b) = BuiltinByteString $ BS.drop (fromIntegral n) b
-
 {-# NOINLINE sliceByteString #-}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 sliceByteString from to (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral $ to - from + 1) (BS.drop (fromIntegral from) b)


### PR DESCRIPTION
Removes `TakeByteString` and `DropByteString` and uses `SliceByteString` instead (waits for #3694).

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
