### PR TITLE
Update to a more recent nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,18 +135,18 @@
     "nixpkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1610942247,
-        "narHash": "sha256-PKo1ATAlC6BmfYSRmX0TVmNoFbrec+A5OKcabGEu2yU=",
+        "lastModified": 1623862044,
+        "narHash": "sha256-mY7nldu9Wl/Yb0qMPihZrWw0bRWXNsk6iyYztw/6F6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d71001b796340b219d1bfa8552c81995017544a",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "7d71001b796340b219d1bfa8552c81995017544a",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       repo = "nixpkgs";
 
       # We pin this revision to avoid mass-rebuilds from the auto-update process.
-      rev = "7d71001b796340b219d1bfa8552c81995017544a";
+      rev = "0747387223edf1aa5beaedf48983471315d95e16";
 
       ref = "nixpkgs-unstable";
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,13 +15,15 @@ let
       (import ./overlays/nixpkgs-overrides.nix)
       # fix r-modules
       (import ./overlays/r.nix)
+      # stdenv.lib is still needed by the pinned version of easy purescipt
+      (final: prev: { stdenv = prev.stdenv // { inherit (final) lib; }; })
     ];
 
   iohkNixMain = import sources.iohk-nix { };
 
   extraOverlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
-    haskellNix.overlays
+    haskellNix.nixpkgsArgs.overlays
     # our own overlays:
     # needed for cardano-api wich uses a patched libsodium
     ++ iohkNixMain.overlays.crypto
@@ -34,7 +36,7 @@ let
     # which breaks flake's pure evaluation.
     localSystem = { inherit system; };
     overlays = extraOverlays ++ overlays;
-    config = haskellNix.config // config;
+    config = haskellNix.nixpkgsArgs.config // config;
   };
 
   plutus = import ./pkgs { inherit pkgs checkMaterialization enableHaskellProfiling sources; };

--- a/nix/overlays/nixpkgs-overrides.nix
+++ b/nix/overlays/nixpkgs-overrides.nix
@@ -1,16 +1,24 @@
 self: super: {
-  morph = super.morph.overrideAttrs (old: {
-    # See https://github.com/DBCDK/morph/pull/141
-    # Note that this patch does refelct the original content
-    # of the PR above since it was broken.
-    patches = [ ../pkgs/morph/sshopts.patch ];
+  # nixpkgs-fmt 1.2.0 breaks indentation of code examples in comments
+  nixpkgs-fmt = self.rustPlatform.buildRustPackage rec {
+    pname = "nixpkgs-fmt";
+    version = "1.1.0";
+
     src = self.fetchFromGitHub {
-      owner = "DBCDK";
-      repo = "morph";
-      rev = "c048d6339f18613a1544bc62ff852cb4c6de1042";
-      sha256 = "0yb8prji2nqjsj1aiiqnbqaajbi5l17rg8k78ry7pl3a8sqa3h1x";
+      owner = "nix-community";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "1fb2mm1y2qb3imc48g2ad3rdbjlj326cggrc4hvdc0fb41vxinpp";
     };
-  });
+
+    cargoSha256 = "1lsw6dwkjdwdqcx7gjsg2ndi4r79m8qyxgx7yz3al0iscwm7i645";
+    meta = with self.lib; {
+      description = "Nix code formatter for nixpkgs";
+      homepage = "https://nix-community.github.io/nixpkgs-fmt";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ zimbatm ];
+    };
+  };
 
   python3 = super.python3.override {
     packageOverrides = python-self: python-super: {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -73,6 +73,16 @@ let
         rev = "v${version}";
         sha256 = "14h3jprm6924g9576v25axn9v6xnip354hvpzlcqsc5qqyj7zzjs";
       };
+      # This is preConfigure is copied from more recent nixpkgs that also uses version 1.7 of standard-library
+      # Old nixpkgs (that used 1.4) had a preConfigure step that worked with 1.7
+      # Less old nixpkgs (that used 1.6) had a preConfigure step that attempts to `rm` files that are now in the
+      # .gitignore list for 1.7
+      preConfigure = ''
+        runhaskell GenerateEverything.hs
+        # We will only build/consider Everything.agda, in particular we don't want Everything*.agda
+        # do be copied to the store.
+        rm EverythingSafe.agda
+      '';
     });
 
     in agdaPackages.agda.withPackages [ stdlib ];

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -193,7 +193,7 @@ let
     latex = pkgs.callPackage ../lib/latex.nix { };
     filterNpm = pkgs.callPackage ../lib/filter-npm.nix { };
     npmlock2nix = pkgs.callPackage sources.npmlock2nix { };
-    buildPursPackage = pkgs.callPackage ../lib/purescript.nix { inherit easyPS;inherit (pkgs) nodejs; };
+    buildPursPackage = pkgs.callPackage ../lib/purescript.nix { inherit easyPS; inherit (pkgs) nodejs; };
     buildNodeModules = pkgs.callPackage ../lib/node_modules.nix ({
       inherit npmlock2nix;
     } // pkgs.lib.optionalAttrs (stdenv.isDarwin) {


### PR DESCRIPTION
This updates nixpkgs to the nixpkgs-unstable pin used by haskell.nix.

This will help to get windows cross compilation working #3430 (there is an issue with mingw or wine in the older version that causes GHC builds to fail).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
