### PR TITLE
Update store when a contract instance is done or stopped

### DIFF
--- a/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
+++ b/plutus-pab/src/Plutus/PAB/Core/ContractInstance.hs
@@ -305,6 +305,7 @@ stmInstanceLoop def instanceId = do
         [] -> do
             let ContractResponse{err} = resp
             ask >>= liftIO . STM.atomically . InstanceState.setActivity (Done err)
+            Contract.putStopInstance @t instanceId
         _ -> do
             response <- respondToRequestsSTM @t instanceId currentState
             let rsp' = Right <$> response
@@ -313,6 +314,7 @@ stmInstanceLoop def instanceId = do
             case event of
                 Left () -> do
                     ask >>= liftIO . STM.atomically . InstanceState.setActivity Stopped
+                    Contract.putStopInstance @t instanceId
                 Right event' -> do
                     (newState :: Contract.State t) <- Contract.updateContract @t instanceId (caID def) currentState event'
                     Contract.putState @t def instanceId newState

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -618,7 +618,10 @@ handleContractStore = \case
         instancesTVar <- view instances <$> (Core.askUserEnv @t @(SimulatorState t))
         fmap _contractDef <$> liftIO (STM.readTVarIO instancesTVar)
     Contract.PutStartInstance{} -> pure ()
-    Contract.PutStopInstance{} -> pure ()
+    Contract.PutStopInstance instanceId -> do
+        instancesTVar <- view instances <$> (Core.askUserEnv @t @(SimulatorState t))
+        liftIO $ STM.atomically $ do
+            STM.modifyTVar instancesTVar (set (at instanceId) Nothing)
 
 render :: forall a. Pretty a => a -> Text
 render = Render.renderStrict . layoutPretty defaultLayoutOptions . pretty

--- a/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
+++ b/plutus-pab/src/Plutus/PAB/Webserver/Handler.hs
@@ -34,7 +34,6 @@ import           Data.Foldable                           (traverse_)
 import qualified Data.Map                                as Map
 import           Data.Maybe                              (mapMaybe)
 import           Data.Proxy                              (Proxy (..))
-import qualified Data.Set                                as Set
 import           Data.Text                               (Text)
 import qualified Data.UUID                               as UUID
 import           Ledger                                  (Value, pubKeyHash)
@@ -149,10 +148,8 @@ instancesForWallets wallet = filter ((==) (Wallet wallet) . cicWallet) <$> allIn
 allInstanceStates :: forall t env. Contract.PABContract t => PABAction t env [ContractInstanceClientState (Contract.ContractDef t)]
 allInstanceStates = do
     mp <- Contract.getActiveContracts @t
-    inst <- Core.runningInstances
-    let isRunning i = Set.member i inst
     let get (i, ContractActivationArgs{caWallet, caID}) = fromInternalState caID i caWallet . fromResp . Contract.serialisableState (Proxy @t) <$> Contract.getState @t i
-    filter (isRunning . cicContract) <$> traverse get (Map.toList mp)
+    traverse get (Map.toList mp)
 
 availableContracts :: forall t env. Contract.PABContract t => PABAction t env [ContractSignatureResponse (Contract.ContractDef t)]
 availableContracts = do

--- a/plutus-pab/test/full/Plutus/PAB/CoreSpec.hs
+++ b/plutus-pab/test/full/Plutus/PAB/CoreSpec.hs
@@ -53,7 +53,7 @@ import           Plutus.Contracts.PingPong                (PingPongState (..))
 import           Plutus.PAB.Core                          as Core
 import           Plutus.PAB.Core.ContractInstance         (ContractInstanceMsg)
 import           Plutus.PAB.Core.ContractInstance.STM     (BlockchainEnv (..))
-import           Plutus.PAB.Effects.Contract              (ContractEffect, serialisableState)
+import           Plutus.PAB.Effects.Contract              (ContractEffect, getActiveContracts, serialisableState)
 import           Plutus.PAB.Effects.Contract.Builtin      (Builtin)
 import qualified Plutus.PAB.Effects.Contract.Builtin      as Builtin
 import           Plutus.PAB.Effects.Contract.ContractTest (TestContracts (..))
@@ -147,6 +147,8 @@ stopContractInstanceTest = do
         _ <- Simulator.waitUntilFinished p1
         st <- Simulator.instanceActivity p1
         assertEqual "Instance should be 'Stopped'" st Simulator.Stopped
+        contracts <- getActiveContracts @(Builtin TestContracts)
+        assertEqual "Active contracts should be empty" 0 (Map.size contracts)
 
 slotChangeTest :: IO ()
 slotChangeTest = runScenario $ do


### PR DESCRIPTION
* Set active field in db store when contract is done or stopped
* Ensure GetActiveContracts for Simulator only returns active contracts
* Base instance active status solely from ContractStore

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
