### PR TITLE
Changes to support the partial tx format

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-use-cases.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-use-cases.nix
@@ -127,6 +127,7 @@
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-use-cases.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-use-cases.nix
@@ -127,6 +127,7 @@
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [

--- a/plutus-contract/src/Plutus/Contract.hs
+++ b/plutus-contract/src/Plutus/Contract.hs
@@ -68,6 +68,7 @@ module Plutus.Contract(
     , Request.submitUnbalancedTx
     , Request.submitBalancedTx
     , Request.balanceTx
+    , Request.mkTxConstraints
     -- ** Creating transactions
     , module Tx
     -- ** Tx confirmation

--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -62,6 +62,7 @@ module Plutus.Contract.Request(
     , submitTxConstraintsSpending
     , submitTxConstraintsWith
     , submitTxConfirmed
+    , mkTxConstraints
     -- * Etc.
     , ContractRow
     , pabReq
@@ -500,6 +501,19 @@ submitTxConstraintsSpending inst utxo =
   let lookups = Constraints.typedValidatorLookups inst <> Constraints.unspentOutputs utxo
   in submitTxConstraintsWith lookups
 
+-- | Build a transaction that satisfies the constraints
+mkTxConstraints :: forall a w s e.
+  ( PlutusTx.ToData (RedeemerType a)
+  , PlutusTx.FromData (DatumType a)
+  , PlutusTx.ToData (DatumType a)
+  , AsContractError e
+  )
+  => ScriptLookups a
+  -> TxConstraints (RedeemerType a) (DatumType a)
+  -> Contract w s e UnbalancedTx
+mkTxConstraints sl constraints =
+  either (throwError . review _ConstraintResolutionError) pure (Constraints.mkTx sl constraints)
+
 -- | Build a transaction that satisfies the constraints, then submit it to the
 --   network. Using the given constraints.
 submitTxConstraintsWith
@@ -512,9 +526,7 @@ submitTxConstraintsWith
   => ScriptLookups a
   -> TxConstraints (RedeemerType a) (DatumType a)
   -> Contract w s e Tx
-submitTxConstraintsWith sl constraints = do
-  tx <- either (throwError . review _ConstraintResolutionError) pure (Constraints.mkTx sl constraints)
-  submitUnbalancedTx tx
+submitTxConstraintsWith sl constraints = mkTxConstraints sl constraints >>= submitUnbalancedTx
 
 -- | A version of 'submitTx' that waits until the transaction has been
 --   confirmed on the ledger before returning.

--- a/plutus-ledger/src/Ledger/Constraints.hs
+++ b/plutus-ledger/src/Ledger/Constraints.hs
@@ -34,6 +34,7 @@ module Ledger.Constraints(
     , otherData
     , ownPubKeyHash
     , mkTx
+    , pubKey
     -- ** Combining multiple typed scripts into one transaction
     , SomeLookupsAndConstraints(..)
     , mkSomeTx
@@ -41,7 +42,7 @@ module Ledger.Constraints(
 
 import           Ledger.Constraints.OffChain      (MkTxError (..), ScriptLookups (..), SomeLookupsAndConstraints (..),
                                                    UnbalancedTx, mintingPolicy, mkSomeTx, mkTx, otherData, otherScript,
-                                                   ownPubKeyHash, typedValidatorLookups, unspentOutputs)
+                                                   ownPubKeyHash, pubKey, typedValidatorLookups, unspentOutputs)
 import           Ledger.Constraints.OnChain       (checkScriptContext)
 import           Ledger.Constraints.TxConstraints
 

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -219,7 +219,8 @@ executable plutus-use-cases-scripts
         aeson-pretty -any,
         cardano-api -any,
         cardano-binary -any,
-        cborg -any
+        cborg -any,
+        memory -any
 
     if !(impl(ghcjs) || os(ghcjs))
         build-depends: plutus-tx-plugin -any

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -1,35 +1,42 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-module Main(main) where
+module Main(main, ExportTx(..)) where
 
 import qualified Cardano.Api                    as C
 import qualified Cardano.Api.Shelley            as C
 import qualified Control.Foldl                  as L
 import           Control.Monad.Freer            (run)
-import           Data.Aeson                     (ToJSON (..), object, (.=))
+import           Data.Aeson                     (FromJSON (..), ToJSON (..), Value (Object), object, (.:), (.=))
 import qualified Data.Aeson                     as Aeson
 import           Data.Aeson.Encode.Pretty       (encodePretty)
 import           Data.Bitraversable             (bitraverse)
+import           Data.ByteArray.Encoding        (Base (Base16), convertToBase)
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Default                   (Default (..))
 import           Data.Foldable                  (traverse_)
 import           Data.Int                       (Int64)
 import           Data.Map                       (Map)
 import qualified Data.Map                       as Map
+import           Data.Maybe                     (mapMaybe)
 import           Data.Monoid                    (Sum (..))
-import           Data.Set                       (Set)
-import qualified Data.Set                       as Set
+import           Data.Proxy                     (Proxy (..))
+import           Data.Text                      (Text)
+import qualified Data.Text.Encoding             as Text
 import           Data.Text.Prettyprint.Doc      (Pretty (..))
 import           Data.Typeable                  (Typeable)
 import           Flat                           (flat)
 import           GHC.Generics                   (Generic)
 import qualified Ledger                         as Plutus
+import           Ledger.Bytes                   (LedgerBytes (..))
 import           Ledger.Constraints.OffChain    (UnbalancedTx (..))
+import           Ledger.Crypto                  (PubKey (..))
 import           Ledger.Index                   (ScriptType (..), ScriptValidationEvent (..))
 import           Options.Applicative
 import qualified Plutus.Contract.CardanoAPI     as CardanoAPI
@@ -213,12 +220,22 @@ uncurry3 f (a, b, c) = f a b c
 theFold :: Folds.EmulatorEventFold ([ScriptValidationEvent], [UnbalancedTx])
 theFold = (,) <$> Folds.scriptEvents <*> Folds.walletTxBalanceEvents
 
+{- Note [Keys in ExportTx]
+
+The wallet backend (receiver of 'ExportTx' values) expectes the public keys in the
+'signatories' field to be 'Cardano.Crypto.Wallet.XPub' keys - extended public keys
+of 64 bytes. In the emulator we only deal with ED25519 keys of 32 bytes. Until that
+is changed (https://jira.iohk.io/browse/SCP-2644) we simply append each of our keys
+to itself in order to get a key of the correct length.
+
+-}
+
 -- | Partial transaction that can be balanced by the wallet backend.
 data ExportTx =
         ExportTx
             { partialTx   :: C.Tx C.AlonzoEra -- ^ The transaction itself
             , lookups     :: [ExportTxInput] -- ^ The tx outputs for all inputs spent by the partial tx
-            , signatories :: [C.Hash C.PaymentKey] -- ^ Key(s) that we expect to be used for balancing & signing. (Advisory)
+            , signatories :: [Text] -- ^ Key(s) that we expect to be used for balancing & signing. (Advisory) See note [Keys in ExportT]
             }
     deriving stock (Generic, Typeable)
 
@@ -231,8 +248,16 @@ instance ToJSON ExportTx where
         object
             [ "transaction" .= toJSON (C.serialiseToTextEnvelope Nothing partialTx)
             , "inputs"      .= toJSON lookups
-            , "signatories" .= toJSON (C.serialiseToRawBytesHexText <$> signatories)
+            , "signatories" .= toJSON signatories
             ]
+
+instance FromJSON ExportTx where
+    parseJSON (Object v) =
+        ExportTx
+            <$> ((v .: "transaction") >>= either (fail . show) pure . C.deserialiseFromTextEnvelope (C.proxyToAsType Proxy))
+            <*> pure mempty -- FIXME: How to deserialise Utxo / [(TxIn, TxOut)] ) see https://github.com/input-output-hk/cardano-node/issues/3051
+            <*> v .: "signatories"
+    parseJSON _ = fail "Expexted Object"
 
 export :: C.ProtocolParameters -> C.NetworkId -> UnbalancedTx -> Either CardanoAPI.ToCardanoError ExportTx
 export params networkId UnbalancedTx{unBalancedTxTx, unBalancedTxUtxoIndex, unBalancedTxRequiredSignatories} =
@@ -247,8 +272,10 @@ mkTx params networkId = fmap (C.makeSignedTransaction []) . CardanoAPI.toCardano
 mkLookups :: C.NetworkId -> Map Plutus.TxOutRef Plutus.TxOut -> Either CardanoAPI.ToCardanoError [ExportTxInput]
 mkLookups networkId = fmap (fmap $ uncurry ExportTxInput) . traverse (bitraverse CardanoAPI.toCardanoTxIn (CardanoAPI.toCardanoTxOut networkId)) . Map.toList
 
-mkSignatories :: Set Plutus.PubKeyHash -> Either CardanoAPI.ToCardanoError [C.Hash C.PaymentKey]
-mkSignatories = traverse CardanoAPI.toCardanoPaymentKeyHash . Set.toList
+mkSignatories :: Map Plutus.PubKeyHash (Maybe Plutus.PubKey) -> Either CardanoAPI.ToCardanoError [Text]
+mkSignatories =
+    -- see note [Keys in ExportTx]
+    Right . fmap (\(PubKey (LedgerBytes k)) -> Text.decodeUtf8 $ convertToBase Base16 (k <> k)) . mapMaybe snd . Map.toList
 
 data ValidatorMode = FullyAppliedValidators | UnappliedValidators
     deriving (Eq, Ord, Show)
@@ -263,3 +290,5 @@ getScript UnappliedValidators ScriptValidationEvent{sveType} =
 filenameSuffix :: ValidatorMode -> String
 filenameSuffix FullyAppliedValidators = ""
 filenameSuffix UnappliedValidators    = "-unapplied"
+
+-- ApiAccountPublicKey

--- a/plutus-use-cases/scripts/Main.hs
+++ b/plutus-use-cases/scripts/Main.hs
@@ -290,5 +290,3 @@ getScript UnappliedValidators ScriptValidationEvent{sveType} =
 filenameSuffix :: ValidatorMode -> String
 filenameSuffix FullyAppliedValidators = ""
 filenameSuffix UnappliedValidators    = "-unapplied"
-
--- ApiAccountPublicKey

--- a/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Plutus/Contracts/MultiSig.hs
@@ -39,7 +39,7 @@ import           Prelude                  as Haskell (Semigroup (..), Show, fold
 
 type MultiSigSchema =
         Endpoint "lock" (MultiSig, Value)
-        .\/ Endpoint "unlock" (MultiSig, [PubKeyHash])
+        .\/ Endpoint "unlock" (MultiSig, [PubKey])
 
 data MultiSig =
         MultiSig
@@ -88,5 +88,8 @@ unlock = endpoint @"unlock" $ \(ms, pks) -> do
     let inst = typedValidator ms
     utx <- utxoAt (Scripts.validatorAddress inst)
     let tx = Tx.collectFromScript utx ()
-                <> foldMap Constraints.mustBeSignedBy pks
-    void $ submitTxConstraintsSpending inst utx tx
+                <> foldMap (Constraints.mustBeSignedBy . pubKeyHash) pks
+        lookups = Constraints.typedValidatorLookups inst
+                <> Constraints.unspentOutputs utx
+                <> foldMap Constraints.pubKey pks
+    void $ submitTxConstraintsWith lookups tx

--- a/plutus-use-cases/test/Spec/MultiSig.hs
+++ b/plutus-use-cases/test/Spec/MultiSig.hs
@@ -41,7 +41,7 @@ failingTrace = do
     Trace.callEndpoint @"lock" hdl (multiSig, Ada.lovelaceValueOf 10)
     _ <- Trace.waitNSlots 1
     Trace.setSigningProcess w1 (signWallets [w1, w2])
-    Trace.callEndpoint @"unlock" hdl (multiSig, fmap (Ledger.pubKeyHash . walletPubKey) [w1, w2])
+    Trace.callEndpoint @"unlock" hdl (multiSig, fmap walletPubKey [w1, w2])
     void $ Trace.waitNSlots 1
 
 -- | Lock some funds, then unlock them with a transaction that has the
@@ -52,7 +52,7 @@ succeedingTrace = do
     Trace.callEndpoint @"lock" hdl (multiSig, Ada.lovelaceValueOf 10)
     _ <- Trace.waitNSlots 1
     Trace.setSigningProcess w1 (signWallets [w1, w2, w3])
-    Trace.callEndpoint @"unlock" hdl (multiSig, fmap (Ledger.pubKeyHash . walletPubKey) [w1, w2, w3])
+    Trace.callEndpoint @"unlock" hdl (multiSig, fmap walletPubKey [w1, w2, w3])
     void $ Trace.waitNSlots 1
 
 w1, w2, w3 :: Wallet

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -29,6 +29,7 @@ theContract = do
                   , slTxOutputs = Map.singleton txOutRef txOutTx
                   , slOtherScripts = Map.singleton (Scripts.validatorAddress pkInst) (Scripts.validatorScript pkInst)
                   , slOtherData = Map.empty
+                  , slPubKeyHashes = Map.empty
                   , slTypedValidator = Nothing
                   , slOwnPubkey = Nothing
                   }


### PR DESCRIPTION
The `signatories` field of the partial tx should contain a list of (64 byte) [`XPub`](https://github.com/input-output-hk/cardano-crypto/blob/develop/src/Cardano/Crypto/Wallet.hs#L79) keys. This is quite different from the emulator, where only deal with _hashes_ of 32 byte keys.

Fixing this involves two steps.
1) Change the `ExportTx` type, and `UnbalancedTx` which it is based on, to include public keys instead of public key hashes. This required some changes to the constraint mechanism. I first tried changing the constraints themselves to use public keys instead of public key hashes, but the subsequent changes to the validators meant that we would have to hash public keys in on-chain code, which we really want to avoid (because there is a high risk that we will do it wrong). So instead I added a field to the `TxLookups` type, which fits well with the other lookups we already have in there.
2) Use `XPub` instead of our regular 32 byte keys in the mock wallet. This is a bigger change, best addressed in a separate PR - see https://jira.iohk.io/browse/SCP-2644

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
