### PR TITLE
Deployment: Pin to terraform 0.12. 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -100,7 +100,6 @@ rec {
     inherit pkgs docs;
     inherit (plutus.lib) gitignore-nix;
     inherit (plutus) fixStylishHaskell fixPurty fixPngOptimization;
-    inherit (pkgs) terraform;
     inherit plutus-playground marlowe-playground marlowe-dashboard web-ghc plutus-pab;
     src = ./.;
   };

--- a/deployment/shell.nix
+++ b/deployment/shell.nix
@@ -3,7 +3,8 @@
 }:
 let
   inherit (pkgs) writeShellScriptBin lib mkShell stdenv writeText;
-  inherit (pkgs) awscli terraform morph jq;
+  inherit (pkgs) awscli morph jq;
+  terraform = pkgs.terraform_0_12;
   inherit (pkgs.gitAndTools) hub;
 
   # All environments and the region they are in

--- a/flake.lock
+++ b/flake.lock
@@ -101,17 +101,17 @@
     "haskell-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1627432683,
-        "narHash": "sha256-cOslGeMHH3c46a3IUSr4YqR9UJYoLS/45dOhDASFu18=",
+        "lastModified": 1628558200,
+        "narHash": "sha256-kXbfLl3Gn3Veg/Q83HET0trGgRkNfcPAVDYuhJpXzvQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "531c9f4cac0e335db245849df3b5036973826d36",
+        "rev": "40c97135df2d83ac0d5531a32028d23eca6d130e",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "531c9f4cac0e335db245849df3b5036973826d36",
+        "rev": "40c97135df2d83ac0d5531a32028d23eca6d130e",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -135,18 +135,18 @@
     "nixpkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1623862044,
-        "narHash": "sha256-mY7nldu9Wl/Yb0qMPihZrWw0bRWXNsk6iyYztw/6F6Y=",
+        "lastModified": 1628572867,
+        "narHash": "sha256-CBGONA03V6JUvutdsYsEcC5PwsMNM+Yay6y+bUKg1bE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
+        "rev": "2457ddc9522b0861649ee5e952fa2e505c1743b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
+        "rev": "2457ddc9522b0861649ee5e952fa2e505c1743b7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       repo = "nixpkgs";
 
       # We pin this revision to avoid mass-rebuilds from the auto-update process.
-      rev = "0747387223edf1aa5beaedf48983471315d95e16";
+      rev = "2457ddc9522b0861649ee5e952fa2e505c1743b7";
 
       ref = "nixpkgs-unstable";
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     };
     haskell-nix = {
       # We pin this revision to avoid mass-rebuilds from the auto-update process.
-      url = "github:input-output-hk/haskell.nix?rev=531c9f4cac0e335db245849df3b5036973826d36";
+      url = "github:input-output-hk/haskell.nix?rev=40c97135df2d83ac0d5531a32028d23eca6d130e";
 
       flake = false;
     };

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -4,7 +4,6 @@
 , fixPurty
 , fixPngOptimization
 , src
-, terraform
 , plutus-playground
 , marlowe-playground
 , marlowe-dashboard


### PR DESCRIPTION
The latest terraform breaks our workflow, and this terraform
deployment will be going away soon so not worth fixing the workflow.

nixpkgs update needed to bring in NixOS/nixpkgs#127239

Also update haskell.nix since we're rebuilding anyway.