### PR TITLE
Fix slice bytestring and add builtin tests

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
@@ -103,6 +103,7 @@
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
             ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
@@ -103,6 +103,7 @@
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
             ];

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -180,7 +180,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             mempty -- TODO: budget. To be replace with: (runCostingFunOneArgument . paramConsByteString)
     toBuiltinMeaning SliceByteString =
         makeBuiltinMeaning
-            (\from to xs -> BS.take (to - from + 1) (BS.drop from xs))
+            (\from to xs -> BS.take (to - from) (BS.drop from xs))
             mempty -- TODO: budget. To be replace with: (runCostingFunOneArgument . paramSliceByteString)
     toBuiltinMeaning LengthOfByteString =
         makeBuiltinMeaning

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -180,7 +180,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             mempty -- TODO: budget. To be replace with: (runCostingFunOneArgument . paramConsByteString)
     toBuiltinMeaning SliceByteString =
         makeBuiltinMeaning
-            (\from to xs -> BS.take (to - from) (BS.drop from xs))
+            (\start n xs -> BS.take n (BS.drop start xs))
             mempty -- TODO: budget. To be replace with: (runCostingFunOneArgument . paramSliceByteString)
     toBuiltinMeaning LengthOfByteString =
         makeBuiltinMeaning

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -378,8 +378,8 @@ test_String = testCase "String" $ do
 
     evals @ByteString "h" SliceByteString [cons @Integer 0, cons @Integer 1, cons @ByteString "hello world"]
     evals @ByteString "he" SliceByteString [cons @Integer 0, cons @Integer 2, cons @ByteString "hello world"]
-    evals @ByteString "e" SliceByteString [cons @Integer 1, cons @Integer 2, cons @ByteString "hello world"]
-    evals @ByteString "llo" SliceByteString [cons @Integer 2, cons @Integer 5, cons @ByteString "hello world"]
+    evals @ByteString "el" SliceByteString [cons @Integer 1, cons @Integer 2, cons @ByteString "hello world"]
+    evals @ByteString "world" SliceByteString [cons @Integer 6, cons @Integer 5, cons @ByteString "hello world"]
 
     evals @Integer 11 LengthOfByteString [cons @ByteString "hello world"]
     evals @Integer 0 LengthOfByteString [cons @ByteString ""]

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -376,8 +376,10 @@ test_String = testCase "String" $ do
     -- 65 is ASCII A
     evals @ByteString "Ahello world" ConsByteString [cons @Integer 65, cons @ByteString "hello world"]
 
-    -- TODO: SliceByteString
-    -- evals @ByteString "h" SliceByteString [cons @Integer 0, cons @Integer 1, cons @ByteString "hello world"]
+    evals @ByteString "h" SliceByteString [cons @Integer 0, cons @Integer 1, cons @ByteString "hello world"]
+    evals @ByteString "he" SliceByteString [cons @Integer 0, cons @Integer 2, cons @ByteString "hello world"]
+    evals @ByteString "e" SliceByteString [cons @Integer 1, cons @Integer 2, cons @ByteString "hello world"]
+    evals @ByteString "llo" SliceByteString [cons @Integer 2, cons @Integer 5, cons @ByteString "hello world"]
 
     evals @Integer 11 LengthOfByteString [cons @ByteString "hello world"]
     evals @Integer 0 LengthOfByteString [cons @ByteString ""]

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -106,5 +106,6 @@ test-suite plutus-tx-test
         hedgehog -any,
         tasty -any,
         tasty-hedgehog -any,
+        tasty-hunit -any,
         serialise -any,
         cborg -any

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -88,7 +88,7 @@ consByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 consByteString n bs = BI.consByteString (toBuiltin n) bs
 
 {-# INLINABLE sliceByteString #-}
--- | Returns the substring of a 'ByteString' from index 'from' to index 'to'.
+-- | Returns the substring of a 'ByteString' from index 'from' up to but not including index 'to'.
 sliceByteString :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
 sliceByteString from to bs = BI.sliceByteString (toBuiltin from) (toBuiltin to) bs
 

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -7,8 +7,6 @@ module PlutusTx.Builtins (
                                 BuiltinByteString
                                 , appendByteString
                                 , consByteString
-                                , takeByteString
-                                , dropByteString
                                 , sliceByteString
                                 , lengthOfByteString
                                 , indexByteString
@@ -91,16 +89,6 @@ consByteString n bs = BI.consByteString (toBuiltin n) bs
 -- | Returns the substring of a 'ByteString' from index 'start' of length 'n'.
 sliceByteString :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
 sliceByteString start n bs = BI.sliceByteString (toBuiltin start) (toBuiltin n) bs
-
-{-# INLINABLE takeByteString #-}
--- | Returns the n length prefix of a 'ByteString'.
-takeByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-takeByteString n bs = BI.sliceByteString 0 (toBuiltin n) bs
-
-{-# INLINABLE dropByteString #-}
--- | Returns the suffix of a 'ByteString' after n elements.
-dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs - n) bs
 
 {-# INLINABLE lengthOfByteString #-}
 -- | Returns the length of a 'ByteString'.

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -95,12 +95,12 @@ sliceByteString from to bs = BI.sliceByteString (toBuiltin from) (toBuiltin to) 
 {-# INLINABLE takeByteString #-}
 -- | Returns the n length prefix of a 'ByteString'.
 takeByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-takeByteString n bs = BI.sliceByteString 0 (toBuiltin n - 1) bs
+takeByteString n bs = BI.sliceByteString 0 (toBuiltin n) bs
 
 {-# INLINABLE dropByteString #-}
 -- | Returns the suffix of a 'ByteString' after n elements.
 dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs - 1) bs
+dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs) bs
 
 {-# INLINABLE lengthOfByteString #-}
 -- | Returns the length of a 'ByteString'.

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -88,7 +88,7 @@ consByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 consByteString n bs = BI.consByteString (toBuiltin n) bs
 
 {-# INLINABLE sliceByteString #-}
--- | Returns the substring of a 'ByteString'.
+-- | Returns the substring of a 'ByteString' from index 'from' to index 'to'.
 sliceByteString :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
 sliceByteString from to bs = BI.sliceByteString (toBuiltin from) (toBuiltin to) bs
 

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -88,9 +88,9 @@ consByteString :: Integer -> BuiltinByteString -> BuiltinByteString
 consByteString n bs = BI.consByteString (toBuiltin n) bs
 
 {-# INLINABLE sliceByteString #-}
--- | Returns the substring of a 'ByteString' from index 'from' up to but not including index 'to'.
+-- | Returns the substring of a 'ByteString' from index 'start' of length 'n'.
 sliceByteString :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
-sliceByteString from to bs = BI.sliceByteString (toBuiltin from) (toBuiltin to) bs
+sliceByteString start n bs = BI.sliceByteString (toBuiltin start) (toBuiltin n) bs
 
 {-# INLINABLE takeByteString #-}
 -- | Returns the n length prefix of a 'ByteString'.

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -100,7 +100,7 @@ takeByteString n bs = BI.sliceByteString 0 (toBuiltin n) bs
 {-# INLINABLE dropByteString #-}
 -- | Returns the suffix of a 'ByteString' after n elements.
 dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
-dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs) bs
+dropByteString n bs = BI.sliceByteString (toBuiltin n) (BI.lengthOfByteString bs - n) bs
 
 {-# INLINABLE lengthOfByteString #-}
 -- | Returns the length of a 'ByteString'.

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -159,7 +159,7 @@ consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegr
 
 {-# NOINLINE sliceByteString #-}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-sliceByteString from to (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral $ to - from) (BS.drop (fromIntegral from) b)
+sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) (BS.drop (fromIntegral start) b)
 
 {-# NOINLINE lengthOfByteString #-}
 lengthOfByteString :: BuiltinByteString -> BuiltinInteger

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -159,7 +159,7 @@ consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegr
 
 {-# NOINLINE sliceByteString #-}
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
-sliceByteString from to (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral $ to - from + 1) (BS.drop (fromIntegral from) b)
+sliceByteString from to (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral $ to - from) (BS.drop (fromIntegral from) b)
 
 {-# NOINLINE lengthOfByteString #-}
 lengthOfByteString :: BuiltinByteString -> BuiltinInteger

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -93,11 +93,10 @@ import           PlutusCore.Data      (Data (..))
 import           PlutusTx.Applicative as Applicative
 import           PlutusTx.Bool        as Bool
 import           PlutusTx.Builtins    (BuiltinByteString, BuiltinData, BuiltinString, appendByteString, appendString,
-                                       consByteString, decodeUtf8, dropByteString, emptyByteString, emptyString,
-                                       encodeUtf8, equalsByteString, equalsString, error, fromBuiltin,
-                                       greaterThanByteString, indexByteString, lengthOfByteString, lessThanByteString,
-                                       sha2_256, sha3_256, sliceByteString, takeByteString, toBuiltin, trace,
-                                       verifySignature)
+                                       consByteString, decodeUtf8, emptyByteString, emptyString, encodeUtf8,
+                                       equalsByteString, equalsString, error, fromBuiltin, greaterThanByteString,
+                                       indexByteString, lengthOfByteString, lessThanByteString, sha2_256, sha3_256,
+                                       sliceByteString, toBuiltin, trace, verifySignature)
 import qualified PlutusTx.Builtins    as Builtins
 import           PlutusTx.Either      as Either
 import           PlutusTx.Enum        as Enum
@@ -195,3 +194,13 @@ infixr 0 $
 -- | Plutus Tx version of 'Data.Function.($)'.
 ($) :: (a -> b) -> a -> b
 f $ a = f a
+
+{-# INLINABLE takeByteString #-}
+-- | Returns the n length prefix of a 'ByteString'.
+takeByteString :: Integer -> BuiltinByteString -> BuiltinByteString
+takeByteString n bs = Builtins.sliceByteString 0 (toBuiltin n) bs
+
+{-# INLINABLE dropByteString #-}
+-- | Returns the suffix of a 'ByteString' after n elements.
+dropByteString :: Integer -> BuiltinByteString -> BuiltinByteString
+dropByteString n bs = Builtins.sliceByteString (toBuiltin n) (Builtins.lengthOfByteString bs - n) bs

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE LambdaCase       #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 module Main(main) where
 
 import qualified Codec.CBOR.FlatTerm as FlatTerm
@@ -10,10 +11,12 @@ import qualified Hedgehog.Gen        as Gen
 import qualified Hedgehog.Range      as Range
 import           PlutusCore.Data     (Data (..))
 import           PlutusTx.Numeric    (negate)
+import           PlutusTx.Prelude    (dropByteString, takeByteString)
 import           PlutusTx.Ratio      (Rational, denominator, numerator, recip, (%))
 import           PlutusTx.Sqrt       (Sqrt (..), isqrt, rsqrt)
 import           Prelude             hiding (Rational, negate, recip)
 import           Test.Tasty
+import           Test.Tasty.HUnit    (testCase, (@?=))
 import           Test.Tasty.Hedgehog (testProperty)
 
 main :: IO ()
@@ -24,6 +27,7 @@ tests = testGroup "plutus-tx" [
     serdeTests
     , sqrtTests
     , ratioTests
+    , bytestringTests
     ]
 
 sqrtTests :: TestTree
@@ -166,3 +170,25 @@ reciprocalOrdering3 = property $ do
   x <- genNegativeRational
   y <- genPositiveRational
   assert (recip x < recip y)
+
+bytestringTests :: TestTree
+bytestringTests = testGroup "ByteString"
+  [ takeByteStringTests
+  , dropByteStringTests
+  ]
+
+takeByteStringTests :: TestTree
+takeByteStringTests = testGroup "takeByteString"
+  [ testCase "take 0" $ takeByteString 0 "hello" @?= ""
+  , testCase "take 1" $ takeByteString 1 "hello" @?= "h"
+  , testCase "take 3" $ takeByteString 3 "hello" @?= "hel"
+  , testCase "take 10" $ takeByteString 10 "hello" @?= "hello"
+  ]
+
+dropByteStringTests :: TestTree
+dropByteStringTests = testGroup "dropByteString"
+  [ testCase "drop 0" $ dropByteString 0 "hello" @?= "hello"
+  , testCase "drop 1" $ dropByteString 1 "hello" @?= "ello"
+  , testCase "drop 3" $ dropByteString 3 "hello" @?= "lo"
+  , testCase "drop 10" $ dropByteString 10 "hello" @?= ""
+  ]


### PR DESCRIPTION
@bezirg noticed yesterday that our `sliceByteString` differs from slice operations in other languages:

```
python: "hello world"[0:1] == java's "hello world".substring(0,1) == javascript  "hello world".slice(0,1) == "h"
```

While in Plutus we do `"hello world".slice(0,1) == "he"` which is incorrect.

- This PR changes the behaviour to the same as in `slice` from `vector` package.
- Add tests.

---

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
