### PR TITLE
Bump haskell.nix for the dependency resolution speed fixes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 -- Bump this if you need newer packages
-index-state: 2021-07-07T00:00:00Z
+index-state: 2021-08-14T00:00:00Z
 
 packages: doc
           fake-pab

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cardano-repo-tool": {
       "flake": false,
       "locked": {
-        "lastModified": 1617222828,
-        "narHash": "sha256-DGIPO80BoXM0t5mY2IlvflyN/XFwzkSjBsCnCJsRszs=",
+        "lastModified": 1624584417,
+        "narHash": "sha256-YSepT97PagR/1jTYV/Yer8a2GjFe9+tTwaTCHxuK50M=",
         "owner": "input-output-hk",
         "repo": "cardano-repo-tool",
-        "rev": "71b1333552989093a89e6b04c5397f0b7bb9d0d0",
+        "rev": "30e826ed8f00e3e154453b122a6f3d779b2f73ec",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1624882916,
-        "narHash": "sha256-Bfumd24xNLAX1UjnqNHN1hZg1qpwubAvIRFDneruO+I=",
+        "lastModified": 1628944002,
+        "narHash": "sha256-eRTG5eWjFN6i0CIPbt5XSeYjvIJ3nsmuS/5ggCVAMXg=",
         "owner": "tweag",
         "repo": "npmlock2nix",
-        "rev": "9d71a0fc7a7450e740dba1bcdaed1eb9faa57bc2",
+        "rev": "bf6515b9614645429e1f1846ce07c31f5879e45f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -67,17 +67,17 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1625706684,
-        "narHash": "sha256-XZZglZoSpgMkibRgkB7A0DPUeYkmx2kVqpT8gUwgBsw=",
+        "lastModified": 1628989898,
+        "narHash": "sha256-8UjuRjQskif/46d9h6g3ERVq5lr+y2/uJDbDAWet8JQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "afafb0104f1f5029155fcbb15bc1ce1bcd98ea6b",
+        "rev": "23545a41ef50c4328e3f95b9a63db59f3ada3518",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "afafb0104f1f5029155fcbb15bc1ce1bcd98ea6b",
+        "rev": "23545a41ef50c4328e3f95b9a63db59f3ada3518",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1622650193,
-        "narHash": "sha256-qSzUpJDv04ajS9FXoCq6NjVF3qOt9IiGIiGh0P8amyw=",
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0398f0649e0a741660ac5e8216760bae5cc78579",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -101,17 +101,17 @@
     "haskell-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1628558200,
-        "narHash": "sha256-kXbfLl3Gn3Veg/Q83HET0trGgRkNfcPAVDYuhJpXzvQ=",
+        "lastModified": 1628990061,
+        "narHash": "sha256-ByTi1UrA/AjIHZvZSbQCqyn3zSZ6VyyfbQnsSsZSgVY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "40c97135df2d83ac0d5531a32028d23eca6d130e",
+        "rev": "64c8bc4937fde531bf0c4756df44d37d9a00aa97",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "40c97135df2d83ac0d5531a32028d23eca6d130e",
+        "rev": "64c8bc4937fde531bf0c4756df44d37d9a00aa97",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     };
     haskell-nix = {
       # We pin this revision to avoid mass-rebuilds from the auto-update process.
-      url = "github:input-output-hk/haskell.nix?rev=40c97135df2d83ac0d5531a32028d23eca6d130e";
+      url = "github:input-output-hk/haskell.nix?rev=64c8bc4937fde531bf0c4756df44d37d9a00aa97";
 
       flake = false;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
     };
     hackage-nix = {
       # We pin this revision to avoid unhelpful daily churn from the auto-update process.
-      url = "github:input-output-hk/hackage.nix?rev=afafb0104f1f5029155fcbb15bc1ce1bcd98ea6b";
+      url = "github:input-output-hk/hackage.nix?rev=23545a41ef50c4328e3f95b9a63db59f3ada3518";
 
       flake = false;
     };

--- a/nix/pkgs/haskell/agda.sha
+++ b/nix/pkgs/haskell/agda.sha
@@ -1,1 +1,1 @@
-1x1wrd93zrqdfx2m4gf9gwrczvfrfnk6kjmb0wk4j8dll0kij1sc
+01hbpv3pmprh5d1mvp5cbx27k1mv5wiq21vw143i68ssdrvljlbk

--- a/nix/pkgs/haskell/cabal-install.sha
+++ b/nix/pkgs/haskell/cabal-install.sha
@@ -1,1 +1,1 @@
-0cn5jx6sjyansv263mvw78k73af995pmgnnihxyf6kwq9vgr019k
+0djgxvhmylkwyk4c9j95njgglr34987jj6vrir7g7gl1g4fi07mq

--- a/nix/pkgs/haskell/cardano-repo-tool.sha
+++ b/nix/pkgs/haskell/cardano-repo-tool.sha
@@ -1,1 +1,1 @@
-0dpjc1sf2vyrmwi9cflr8wvc1zxs8ra8743pvy270rgh3vjjdvqr
+15ngmljjmwhdrskawxqy6z3cmq2lz23hlxdaf000jdxx802x0s9l

--- a/nix/pkgs/haskell/hlint.sha
+++ b/nix/pkgs/haskell/hlint.sha
@@ -1,1 +1,1 @@
-1h71dwyyxxs99ajlv09p7bfi6m0qdhpnj6wfapa5h18ynl62mim3
+104cga4crflhwqlzf4g60j4kx57krg8wh8ah8alj6fpgxyxcdb0s

--- a/nix/pkgs/haskell/hls-darwin.sha
+++ b/nix/pkgs/haskell/hls-darwin.sha
@@ -1,1 +1,1 @@
-16pcgb9rgs52plb7dgg6md6b2v4c4rl97bwqvpr1qziyf871lrdc
+1k8qgrx8pcdmflhsvnavs34mzg6bqnpwq5ywaqc2dgsinivqavja

--- a/nix/pkgs/haskell/hls-linux.sha
+++ b/nix/pkgs/haskell/hls-linux.sha
@@ -1,1 +1,1 @@
-0i219m12k6r3xrv4894644a6wnkf0mln2n06lyqlhhfr3x5aiaha
+0gbx0blynw08v4849zfp3vv6g1k3fmxb29viia6sddqj3xfrlxcb

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -18,7 +18,7 @@
         "serialise".revision = (((hackage."serialise")."0.2.3.0").revisions).default;
         "serialise".flags.newtime15 = true;
         "dependent-sum".revision = (((hackage."dependent-sum")."0.7.1.0").revisions).default;
-        "generic-random".revision = (((hackage."generic-random")."1.4.0.0").revisions).default;
+        "generic-random".revision = (((hackage."generic-random")."1.5.0.0").revisions).default;
         "generic-random".flags.enable-inspect = false;
         "ghc-boot".revision = (((hackage."ghc-boot")."8.10.4.20210212").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.1").revisions).default;
@@ -180,7 +180,7 @@
         "auto-update".revision = (((hackage."auto-update")."0.1.6").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
         "http-conduit".flags.aeson = true;
-        "monad-control".revision = (((hackage."monad-control")."1.0.2.3").revisions).default;
+        "monad-control".revision = (((hackage."monad-control")."1.0.3.1").revisions).default;
         "random".revision = (((hackage."random")."1.2.0").revisions).default;
         "code-page".revision = (((hackage."code-page")."0.2.1").revisions).default;
         "validation".revision = (((hackage."validation")."1.1.1").revisions).default;
@@ -191,7 +191,7 @@
         "optparse-applicative".revision = (((hackage."optparse-applicative")."0.16.1.0").revisions).default;
         "optparse-applicative".flags.process = true;
         "time-manager".revision = (((hackage."time-manager")."0.0.0").revisions).default;
-        "hspec-discover".revision = (((hackage."hspec-discover")."2.8.2").revisions).default;
+        "hspec-discover".revision = (((hackage."hspec-discover")."2.8.3").revisions).default;
         "cborg".revision = (((hackage."cborg")."0.2.5.0").revisions).default;
         "cborg".flags.optimize-gmp = true;
         "parallel".revision = (((hackage."parallel")."3.2.2.0").revisions).default;
@@ -228,14 +228,14 @@
         "alex".revision = (((hackage."alex")."3.2.6").revisions).default;
         "alex".flags.small_base = true;
         "tasty-hunit".revision = (((hackage."tasty-hunit")."0.10.0.3").revisions).default;
-        "megaparsec".revision = (((hackage."megaparsec")."9.0.1").revisions).default;
+        "megaparsec".revision = (((hackage."megaparsec")."9.1.0").revisions).default;
         "megaparsec".flags.dev = false;
         "th-orphans".revision = (((hackage."th-orphans")."0.13.11").revisions).default;
         "pretty-show".revision = (((hackage."pretty-show")."1.10").revisions).default;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
         "distributive".flags.semigroups = true;
-        "transformers-base".revision = (((hackage."transformers-base")."0.4.5.2").revisions).default;
+        "transformers-base".revision = (((hackage."transformers-base")."0.4.6").revisions).default;
         "transformers-base".flags.orphaninstances = true;
         "base16-bytestring".revision = (((hackage."base16-bytestring")."1.0.1.0").revisions).default;
         "wai-extra".revision = (((hackage."wai-extra")."3.1.6").revisions).default;
@@ -269,8 +269,8 @@
         "postgresql-libpq".revision = (((hackage."postgresql-libpq")."0.9.4.3").revisions).default;
         "postgresql-libpq".flags.use-pkg-config = false;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
-        "foldl".revision = (((hackage."foldl")."1.4.11").revisions).default;
-        "regex-posix".revision = (((hackage."regex-posix")."0.96.0.0").revisions).default;
+        "foldl".revision = (((hackage."foldl")."1.4.12").revisions).default;
+        "regex-posix".revision = (((hackage."regex-posix")."0.96.0.1").revisions).default;
         "regex-posix".flags._regex-posix-clib = false;
         "moo".revision = (((hackage."moo")."1.2").revisions).default;
         "cmdargs".revision = (((hackage."cmdargs")."0.10.21").revisions).default;
@@ -317,13 +317,13 @@
         "unix".revision = (((hackage."unix")."2.7.2.2").revisions).default;
         "dependent-sum-template".revision = (((hackage."dependent-sum-template")."0.1.0.3").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.1").revisions).default;
-        "data-fix".revision = (((hackage."data-fix")."0.3.1").revisions).default;
-        "typed-process".revision = (((hackage."typed-process")."0.2.6.0").revisions).default;
+        "data-fix".revision = (((hackage."data-fix")."0.3.2").revisions).default;
+        "typed-process".revision = (((hackage."typed-process")."0.2.6.1").revisions).default;
         "mersenne-random-pure64".revision = (((hackage."mersenne-random-pure64")."0.2.2.0").revisions).default;
         "mersenne-random-pure64".flags.small_base = false;
         "dense-linear-algebra".revision = (((hackage."dense-linear-algebra")."0.1.0.0").revisions).default;
         "logict".revision = (((hackage."logict")."0.7.0.3").revisions).default;
-        "contravariant".revision = (((hackage."contravariant")."1.5.3").revisions).default;
+        "contravariant".revision = (((hackage."contravariant")."1.5.5").revisions).default;
         "contravariant".flags.tagged = true;
         "contravariant".flags.semigroups = true;
         "contravariant".flags.statevar = true;
@@ -341,7 +341,7 @@
         "base58-bytestring".revision = (((hackage."base58-bytestring")."0.1.0").revisions).default;
         "srcloc".revision = (((hackage."srcloc")."0.6").revisions).default;
         "aeson-casing".revision = (((hackage."aeson-casing")."0.2.0.0").revisions).default;
-        "unliftio".revision = (((hackage."unliftio")."0.2.18").revisions).default;
+        "unliftio".revision = (((hackage."unliftio")."0.2.19").revisions).default;
         "wcwidth".revision = (((hackage."wcwidth")."0.0.2").revisions).default;
         "wcwidth".flags.split-base = true;
         "wcwidth".flags.cli = false;
@@ -429,7 +429,7 @@
         "tagged".revision = (((hackage."tagged")."0.8.6.1").revisions).default;
         "tagged".flags.deepseq = true;
         "tagged".flags.transformers = true;
-        "barbies".revision = (((hackage."barbies")."2.0.2.0").revisions).default;
+        "barbies".revision = (((hackage."barbies")."2.0.3.0").revisions).default;
         "tdigest".revision = (((hackage."tdigest")."0.2.1.1").revisions).default;
         "quiet".revision = (((hackage."quiet")."0.2").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
@@ -444,7 +444,7 @@
         "base-orphans".revision = (((hackage."base-orphans")."0.8.4").revisions).default;
         "fin".revision = (((hackage."fin")."0.1.1").revisions).default;
         "prettyprinter-ansi-terminal".revision = (((hackage."prettyprinter-ansi-terminal")."1.1.2").revisions).default;
-        "primitive".revision = (((hackage."primitive")."0.7.1.0").revisions).default;
+        "primitive".revision = (((hackage."primitive")."0.7.2.0").revisions).default;
         "servant-server".revision = (((hackage."servant-server")."0.18.3").revisions).default;
         "pqueue".revision = (((hackage."pqueue")."1.4.1.3").revisions).default;
         "smallcheck".revision = (((hackage."smallcheck")."1.2.1").revisions).default;
@@ -471,7 +471,7 @@
         "microlens".revision = (((hackage."microlens")."0.4.12.0").revisions).default;
         "nonempty-vector".revision = (((hackage."nonempty-vector")."0.2.1.0").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
-        "resourcet".revision = (((hackage."resourcet")."1.2.4.2").revisions).default;
+        "resourcet".revision = (((hackage."resourcet")."1.2.4.3").revisions).default;
         "ordered-containers".revision = (((hackage."ordered-containers")."0.2.2").revisions).default;
         "aeson".revision = (((hackage."aeson")."1.5.6.0").revisions).default;
         "aeson".flags.developer = false;
@@ -484,7 +484,7 @@
         "data-default".revision = (((hackage."data-default")."0.7.1.1").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
         "finite-typelits".revision = (((hackage."finite-typelits")."0.1.4.2").revisions).default;
-        "typerep-map".revision = (((hackage."typerep-map")."0.3.3.0").revisions).default;
+        "typerep-map".revision = (((hackage."typerep-map")."0.4.0.0").revisions).default;
         "semigroups".revision = (((hackage."semigroups")."0.19.1").revisions).default;
         "semigroups".flags.bytestring = true;
         "semigroups".flags.deepseq = true;
@@ -506,7 +506,7 @@
         "libyaml".flags.no-unicode = false;
         "servant-subscriber".revision = (((hackage."servant-subscriber")."0.7.0.0").revisions).default;
         "servant-subscriber".flags.websockets_0_11 = true;
-        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.1.0.0").revisions).default;
+        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.2.0.0").revisions).default;
         "splitmix".revision = (((hackage."splitmix")."0.1.0.3").revisions).default;
         "splitmix".flags.optimised-mixer = false;
         "x509-store".revision = (((hackage."x509-store")."1.6.7").revisions).default;
@@ -522,7 +522,7 @@
         "system-filepath".revision = (((hackage."system-filepath")."0.4.14").revisions).default;
         "recursion-schemes".revision = (((hackage."recursion-schemes")."5.1.3").revisions).default;
         "recursion-schemes".flags.template-haskell = true;
-        "hspec-core".revision = (((hackage."hspec-core")."2.8.2").revisions).default;
+        "hspec-core".revision = (((hackage."hspec-core")."2.8.3").revisions).default;
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "filepath".revision = (((hackage."filepath")."1.4.2.1").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
@@ -545,7 +545,7 @@
         "tasty".flags.clock = true;
         "statistics-linreg".revision = (((hackage."statistics-linreg")."0.3").revisions).default;
         "deepseq".revision = (((hackage."deepseq")."1.4.4.0").revisions).default;
-        "kan-extensions".revision = (((hackage."kan-extensions")."5.2.2").revisions).default;
+        "kan-extensions".revision = (((hackage."kan-extensions")."5.2.3").revisions).default;
         "vector-th-unbox".revision = (((hackage."vector-th-unbox")."0.2.1.9").revisions).default;
         "indexed-profunctors".revision = (((hackage."indexed-profunctors")."0.1.1").revisions).default;
         "strict".revision = (((hackage."strict")."0.4.0.1").revisions).default;
@@ -555,7 +555,7 @@
         "http-api-data".flags.use-text-show = false;
         "attoparsec".revision = (((hackage."attoparsec")."0.13.2.5").revisions).default;
         "attoparsec".flags.developer = false;
-        "generic-lens".revision = (((hackage."generic-lens")."2.1.0.0").revisions).default;
+        "generic-lens".revision = (((hackage."generic-lens")."2.2.0.0").revisions).default;
         "unix-bytestring".revision = (((hackage."unix-bytestring")."0.3.7.3").revisions).default;
         "monad-logger".revision = (((hackage."monad-logger")."0.3.36").revisions).default;
         "monad-logger".flags.template_haskell = true;
@@ -567,7 +567,7 @@
         "blaze-textual".flags.native = true;
         "blaze-textual".flags.integer-simple = false;
         "blaze-textual".flags.developer = false;
-        "digest".revision = (((hackage."digest")."0.0.1.2").revisions).default;
+        "digest".revision = (((hackage."digest")."0.0.1.3").revisions).default;
         "digest".flags.bytestring-in-base = false;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "file-embed".revision = (((hackage."file-embed")."0.0.14.0").revisions).default;
@@ -576,11 +576,11 @@
         "colour".revision = (((hackage."colour")."2.3.6").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.4").revisions).default;
         "syb".revision = (((hackage."syb")."0.7.2.1").revisions).default;
-        "safe-exceptions".revision = (((hackage."safe-exceptions")."0.1.7.1").revisions).default;
+        "safe-exceptions".revision = (((hackage."safe-exceptions")."0.1.7.2").revisions).default;
         "blaze-html".revision = (((hackage."blaze-html")."0.9.1.2").revisions).default;
         "invariant".revision = (((hackage."invariant")."0.5.3").revisions).default;
         "dependent-map".revision = (((hackage."dependent-map")."0.4.0.0").revisions).default;
-        "generic-arbitrary".revision = (((hackage."generic-arbitrary")."0.1.0").revisions).default;
+        "generic-arbitrary".revision = (((hackage."generic-arbitrary")."0.2.0").revisions).default;
         "system-fileio".revision = (((hackage."system-fileio")."0.3.16.4").revisions).default;
         "hashable".revision = (((hackage."hashable")."1.3.2.0").revisions).default;
         "hashable".flags.integer-gmp = true;
@@ -594,7 +594,7 @@
         "comonad".flags.containers = true;
         "natural-transformation".revision = (((hackage."natural-transformation")."0.4").revisions).default;
         "immortal".revision = (((hackage."immortal")."0.3").revisions).default;
-        "lifted-async".revision = (((hackage."lifted-async")."0.10.2").revisions).default;
+        "lifted-async".revision = (((hackage."lifted-async")."0.10.2.1").revisions).default;
         "ghc-heap".revision = (((hackage."ghc-heap")."8.10.4.20210212").revisions).default;
         "dictionary-sharing".revision = (((hackage."dictionary-sharing")."0.1.0.0").revisions).default;
         "ghci".revision = (((hackage."ghci")."8.10.4.20210212").revisions).default;
@@ -602,7 +602,7 @@
         "statistics".revision = (((hackage."statistics")."0.15.2.0").revisions).default;
         "sqlite-simple".revision = (((hackage."sqlite-simple")."0.4.18.0").revisions).default;
         "asn1-parse".revision = (((hackage."asn1-parse")."0.9.5").revisions).default;
-        "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.0.1").revisions).default;
+        "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.1.0").revisions).default;
         "gray-code".revision = (((hackage."gray-code")."0.3.1").revisions).default;
         "regex-base".revision = (((hackage."regex-base")."0.94.0.1").revisions).default;
         "bin".revision = (((hackage."bin")."0.1").revisions).default;
@@ -617,7 +617,7 @@
         "deriving-compat".flags.base-4-9 = true;
         "deriving-compat".flags.template-haskell-2-11 = true;
         "Cabal".revision = (((hackage."Cabal")."3.2.1.0").revisions).default;
-        "hspec".revision = (((hackage."hspec")."2.8.2").revisions).default;
+        "hspec".revision = (((hackage."hspec")."2.8.3").revisions).default;
         "cryptonite".revision = (((hackage."cryptonite")."0.27").revisions).default;
         "cryptonite".flags.old_toolchain_inliner = false;
         "cryptonite".flags.support_pclmuldq = false;
@@ -662,8 +662,8 @@
         "split".revision = (((hackage."split")."0.2.3.4").revisions).default;
         "x509-validation".revision = (((hackage."x509-validation")."1.6.11").revisions).default;
         "dec".revision = (((hackage."dec")."0.0.4").revisions).default;
-        "transformers-except".revision = (((hackage."transformers-except")."0.1.1").revisions).default;
-        "StateVar".revision = (((hackage."StateVar")."1.2.1").revisions).default;
+        "transformers-except".revision = (((hackage."transformers-except")."0.1.2").revisions).default;
+        "StateVar".revision = (((hackage."StateVar")."1.2.2").revisions).default;
         "monoidal-containers".revision = (((hackage."monoidal-containers")."0.6.0.1").revisions).default;
         "monoidal-containers".flags.split-these = true;
         "composition-prelude".revision = (((hackage."composition-prelude")."3.0.0.2").revisions).default;

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -18,7 +18,7 @@
         "serialise".revision = (((hackage."serialise")."0.2.3.0").revisions).default;
         "serialise".flags.newtime15 = true;
         "dependent-sum".revision = (((hackage."dependent-sum")."0.7.1.0").revisions).default;
-        "generic-random".revision = (((hackage."generic-random")."1.4.0.0").revisions).default;
+        "generic-random".revision = (((hackage."generic-random")."1.5.0.0").revisions).default;
         "generic-random".flags.enable-inspect = false;
         "ghc-boot".revision = (((hackage."ghc-boot")."8.10.4.20210212").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.1").revisions).default;
@@ -181,7 +181,7 @@
         "auto-update".revision = (((hackage."auto-update")."0.1.6").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
         "http-conduit".flags.aeson = true;
-        "monad-control".revision = (((hackage."monad-control")."1.0.2.3").revisions).default;
+        "monad-control".revision = (((hackage."monad-control")."1.0.3.1").revisions).default;
         "random".revision = (((hackage."random")."1.2.0").revisions).default;
         "code-page".revision = (((hackage."code-page")."0.2.1").revisions).default;
         "validation".revision = (((hackage."validation")."1.1.1").revisions).default;
@@ -193,7 +193,7 @@
         "optparse-applicative".revision = (((hackage."optparse-applicative")."0.16.1.0").revisions).default;
         "optparse-applicative".flags.process = true;
         "time-manager".revision = (((hackage."time-manager")."0.0.0").revisions).default;
-        "hspec-discover".revision = (((hackage."hspec-discover")."2.8.2").revisions).default;
+        "hspec-discover".revision = (((hackage."hspec-discover")."2.8.3").revisions).default;
         "cborg".revision = (((hackage."cborg")."0.2.5.0").revisions).default;
         "cborg".flags.optimize-gmp = true;
         "parallel".revision = (((hackage."parallel")."3.2.2.0").revisions).default;
@@ -230,14 +230,14 @@
         "alex".revision = (((hackage."alex")."3.2.6").revisions).default;
         "alex".flags.small_base = true;
         "tasty-hunit".revision = (((hackage."tasty-hunit")."0.10.0.3").revisions).default;
-        "megaparsec".revision = (((hackage."megaparsec")."9.0.1").revisions).default;
+        "megaparsec".revision = (((hackage."megaparsec")."9.1.0").revisions).default;
         "megaparsec".flags.dev = false;
         "th-orphans".revision = (((hackage."th-orphans")."0.13.11").revisions).default;
         "pretty-show".revision = (((hackage."pretty-show")."1.10").revisions).default;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
         "distributive".flags.semigroups = true;
-        "transformers-base".revision = (((hackage."transformers-base")."0.4.5.2").revisions).default;
+        "transformers-base".revision = (((hackage."transformers-base")."0.4.6").revisions).default;
         "transformers-base".flags.orphaninstances = true;
         "base16-bytestring".revision = (((hackage."base16-bytestring")."1.0.1.0").revisions).default;
         "wai-extra".revision = (((hackage."wai-extra")."3.1.6").revisions).default;
@@ -271,8 +271,8 @@
         "postgresql-libpq".revision = (((hackage."postgresql-libpq")."0.9.4.3").revisions).default;
         "postgresql-libpq".flags.use-pkg-config = false;
         "network-uri".revision = (((hackage."network-uri")."2.6.4.1").revisions).default;
-        "foldl".revision = (((hackage."foldl")."1.4.11").revisions).default;
-        "regex-posix".revision = (((hackage."regex-posix")."0.96.0.0").revisions).default;
+        "foldl".revision = (((hackage."foldl")."1.4.12").revisions).default;
+        "regex-posix".revision = (((hackage."regex-posix")."0.96.0.1").revisions).default;
         "regex-posix".flags._regex-posix-clib = false;
         "moo".revision = (((hackage."moo")."1.2").revisions).default;
         "cmdargs".revision = (((hackage."cmdargs")."0.10.21").revisions).default;
@@ -319,13 +319,13 @@
         "unix".revision = (((hackage."unix")."2.7.2.2").revisions).default;
         "dependent-sum-template".revision = (((hackage."dependent-sum-template")."0.1.0.3").revisions).default;
         "sop-core".revision = (((hackage."sop-core")."0.5.0.1").revisions).default;
-        "data-fix".revision = (((hackage."data-fix")."0.3.1").revisions).default;
-        "typed-process".revision = (((hackage."typed-process")."0.2.6.0").revisions).default;
+        "data-fix".revision = (((hackage."data-fix")."0.3.2").revisions).default;
+        "typed-process".revision = (((hackage."typed-process")."0.2.6.1").revisions).default;
         "mersenne-random-pure64".revision = (((hackage."mersenne-random-pure64")."0.2.2.0").revisions).default;
         "mersenne-random-pure64".flags.small_base = false;
         "dense-linear-algebra".revision = (((hackage."dense-linear-algebra")."0.1.0.0").revisions).default;
         "logict".revision = (((hackage."logict")."0.7.0.3").revisions).default;
-        "contravariant".revision = (((hackage."contravariant")."1.5.3").revisions).default;
+        "contravariant".revision = (((hackage."contravariant")."1.5.5").revisions).default;
         "contravariant".flags.tagged = true;
         "contravariant".flags.semigroups = true;
         "contravariant".flags.statevar = true;
@@ -343,7 +343,7 @@
         "base58-bytestring".revision = (((hackage."base58-bytestring")."0.1.0").revisions).default;
         "srcloc".revision = (((hackage."srcloc")."0.6").revisions).default;
         "aeson-casing".revision = (((hackage."aeson-casing")."0.2.0.0").revisions).default;
-        "unliftio".revision = (((hackage."unliftio")."0.2.18").revisions).default;
+        "unliftio".revision = (((hackage."unliftio")."0.2.19").revisions).default;
         "wcwidth".revision = (((hackage."wcwidth")."0.0.2").revisions).default;
         "wcwidth".flags.split-base = true;
         "wcwidth".flags.cli = false;
@@ -431,7 +431,7 @@
         "tagged".revision = (((hackage."tagged")."0.8.6.1").revisions).default;
         "tagged".flags.deepseq = true;
         "tagged".flags.transformers = true;
-        "barbies".revision = (((hackage."barbies")."2.0.2.0").revisions).default;
+        "barbies".revision = (((hackage."barbies")."2.0.3.0").revisions).default;
         "tdigest".revision = (((hackage."tdigest")."0.2.1.1").revisions).default;
         "quiet".revision = (((hackage."quiet")."0.2").revisions).default;
         "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
@@ -446,7 +446,7 @@
         "base-orphans".revision = (((hackage."base-orphans")."0.8.4").revisions).default;
         "fin".revision = (((hackage."fin")."0.1.1").revisions).default;
         "prettyprinter-ansi-terminal".revision = (((hackage."prettyprinter-ansi-terminal")."1.1.2").revisions).default;
-        "primitive".revision = (((hackage."primitive")."0.7.1.0").revisions).default;
+        "primitive".revision = (((hackage."primitive")."0.7.2.0").revisions).default;
         "servant-server".revision = (((hackage."servant-server")."0.18.3").revisions).default;
         "pqueue".revision = (((hackage."pqueue")."1.4.1.3").revisions).default;
         "smallcheck".revision = (((hackage."smallcheck")."1.2.1").revisions).default;
@@ -473,7 +473,7 @@
         "microlens".revision = (((hackage."microlens")."0.4.12.0").revisions).default;
         "nonempty-vector".revision = (((hackage."nonempty-vector")."0.2.1.0").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
-        "resourcet".revision = (((hackage."resourcet")."1.2.4.2").revisions).default;
+        "resourcet".revision = (((hackage."resourcet")."1.2.4.3").revisions).default;
         "ordered-containers".revision = (((hackage."ordered-containers")."0.2.2").revisions).default;
         "aeson".revision = (((hackage."aeson")."1.5.6.0").revisions).default;
         "aeson".flags.developer = false;
@@ -486,7 +486,7 @@
         "data-default".revision = (((hackage."data-default")."0.7.1.1").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
         "finite-typelits".revision = (((hackage."finite-typelits")."0.1.4.2").revisions).default;
-        "typerep-map".revision = (((hackage."typerep-map")."0.3.3.0").revisions).default;
+        "typerep-map".revision = (((hackage."typerep-map")."0.4.0.0").revisions).default;
         "semigroups".revision = (((hackage."semigroups")."0.19.1").revisions).default;
         "semigroups".flags.bytestring = true;
         "semigroups".flags.deepseq = true;
@@ -508,7 +508,7 @@
         "libyaml".flags.no-unicode = false;
         "servant-subscriber".revision = (((hackage."servant-subscriber")."0.7.0.0").revisions).default;
         "servant-subscriber".flags.websockets_0_11 = true;
-        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.1.0.0").revisions).default;
+        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.2.0.0").revisions).default;
         "splitmix".revision = (((hackage."splitmix")."0.1.0.3").revisions).default;
         "splitmix".flags.optimised-mixer = false;
         "x509-store".revision = (((hackage."x509-store")."1.6.7").revisions).default;
@@ -524,7 +524,7 @@
         "system-filepath".revision = (((hackage."system-filepath")."0.4.14").revisions).default;
         "recursion-schemes".revision = (((hackage."recursion-schemes")."5.1.3").revisions).default;
         "recursion-schemes".flags.template-haskell = true;
-        "hspec-core".revision = (((hackage."hspec-core")."2.8.2").revisions).default;
+        "hspec-core".revision = (((hackage."hspec-core")."2.8.3").revisions).default;
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "filepath".revision = (((hackage."filepath")."1.4.2.1").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
@@ -547,7 +547,7 @@
         "tasty".flags.clock = true;
         "statistics-linreg".revision = (((hackage."statistics-linreg")."0.3").revisions).default;
         "deepseq".revision = (((hackage."deepseq")."1.4.4.0").revisions).default;
-        "kan-extensions".revision = (((hackage."kan-extensions")."5.2.2").revisions).default;
+        "kan-extensions".revision = (((hackage."kan-extensions")."5.2.3").revisions).default;
         "vector-th-unbox".revision = (((hackage."vector-th-unbox")."0.2.1.9").revisions).default;
         "indexed-profunctors".revision = (((hackage."indexed-profunctors")."0.1.1").revisions).default;
         "strict".revision = (((hackage."strict")."0.4.0.1").revisions).default;
@@ -557,7 +557,7 @@
         "http-api-data".flags.use-text-show = false;
         "attoparsec".revision = (((hackage."attoparsec")."0.13.2.5").revisions).default;
         "attoparsec".flags.developer = false;
-        "generic-lens".revision = (((hackage."generic-lens")."2.1.0.0").revisions).default;
+        "generic-lens".revision = (((hackage."generic-lens")."2.2.0.0").revisions).default;
         "unix-bytestring".revision = (((hackage."unix-bytestring")."0.3.7.3").revisions).default;
         "monad-logger".revision = (((hackage."monad-logger")."0.3.36").revisions).default;
         "monad-logger".flags.template_haskell = true;
@@ -569,7 +569,7 @@
         "blaze-textual".flags.native = true;
         "blaze-textual".flags.integer-simple = false;
         "blaze-textual".flags.developer = false;
-        "digest".revision = (((hackage."digest")."0.0.1.2").revisions).default;
+        "digest".revision = (((hackage."digest")."0.0.1.3").revisions).default;
         "digest".flags.bytestring-in-base = false;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "file-embed".revision = (((hackage."file-embed")."0.0.14.0").revisions).default;
@@ -578,11 +578,11 @@
         "colour".revision = (((hackage."colour")."2.3.6").revisions).default;
         "terminfo".revision = (((hackage."terminfo")."0.4.1.4").revisions).default;
         "syb".revision = (((hackage."syb")."0.7.2.1").revisions).default;
-        "safe-exceptions".revision = (((hackage."safe-exceptions")."0.1.7.1").revisions).default;
+        "safe-exceptions".revision = (((hackage."safe-exceptions")."0.1.7.2").revisions).default;
         "blaze-html".revision = (((hackage."blaze-html")."0.9.1.2").revisions).default;
         "invariant".revision = (((hackage."invariant")."0.5.3").revisions).default;
         "dependent-map".revision = (((hackage."dependent-map")."0.4.0.0").revisions).default;
-        "generic-arbitrary".revision = (((hackage."generic-arbitrary")."0.1.0").revisions).default;
+        "generic-arbitrary".revision = (((hackage."generic-arbitrary")."0.2.0").revisions).default;
         "system-fileio".revision = (((hackage."system-fileio")."0.3.16.4").revisions).default;
         "hashable".revision = (((hackage."hashable")."1.3.2.0").revisions).default;
         "hashable".flags.integer-gmp = true;
@@ -598,7 +598,7 @@
         "immortal".revision = (((hackage."immortal")."0.3").revisions).default;
         "hsyslog".revision = (((hackage."hsyslog")."5.0.2").revisions).default;
         "hsyslog".flags.install-examples = false;
-        "lifted-async".revision = (((hackage."lifted-async")."0.10.2").revisions).default;
+        "lifted-async".revision = (((hackage."lifted-async")."0.10.2.1").revisions).default;
         "ghc-heap".revision = (((hackage."ghc-heap")."8.10.4.20210212").revisions).default;
         "dictionary-sharing".revision = (((hackage."dictionary-sharing")."0.1.0.0").revisions).default;
         "ghci".revision = (((hackage."ghci")."8.10.4.20210212").revisions).default;
@@ -606,7 +606,7 @@
         "statistics".revision = (((hackage."statistics")."0.15.2.0").revisions).default;
         "sqlite-simple".revision = (((hackage."sqlite-simple")."0.4.18.0").revisions).default;
         "asn1-parse".revision = (((hackage."asn1-parse")."0.9.5").revisions).default;
-        "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.0.1").revisions).default;
+        "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.1.0").revisions).default;
         "gray-code".revision = (((hackage."gray-code")."0.3.1").revisions).default;
         "regex-base".revision = (((hackage."regex-base")."0.94.0.1").revisions).default;
         "bin".revision = (((hackage."bin")."0.1").revisions).default;
@@ -621,7 +621,7 @@
         "deriving-compat".flags.base-4-9 = true;
         "deriving-compat".flags.template-haskell-2-11 = true;
         "Cabal".revision = (((hackage."Cabal")."3.2.1.0").revisions).default;
-        "hspec".revision = (((hackage."hspec")."2.8.2").revisions).default;
+        "hspec".revision = (((hackage."hspec")."2.8.3").revisions).default;
         "cryptonite".revision = (((hackage."cryptonite")."0.27").revisions).default;
         "cryptonite".flags.old_toolchain_inliner = false;
         "cryptonite".flags.support_pclmuldq = false;
@@ -667,8 +667,8 @@
         "split".revision = (((hackage."split")."0.2.3.4").revisions).default;
         "x509-validation".revision = (((hackage."x509-validation")."1.6.11").revisions).default;
         "dec".revision = (((hackage."dec")."0.0.4").revisions).default;
-        "transformers-except".revision = (((hackage."transformers-except")."0.1.1").revisions).default;
-        "StateVar".revision = (((hackage."StateVar")."1.2.1").revisions).default;
+        "transformers-except".revision = (((hackage."transformers-except")."0.1.2").revisions).default;
+        "StateVar".revision = (((hackage."StateVar")."1.2.2").revisions).default;
         "monoidal-containers".revision = (((hackage."monoidal-containers")."0.6.0.1").revisions).default;
         "monoidal-containers".flags.split-these = true;
         "composition-prelude".revision = (((hackage."composition-prelude")."3.0.0.2").revisions).default;

--- a/nix/pkgs/haskell/stylish-haskell.sha
+++ b/nix/pkgs/haskell/stylish-haskell.sha
@@ -1,1 +1,1 @@
-1cygdsx896czk2nridzgaimraq5ayhr5ndkphfqx6bidq3iha5mp
+1xv6griwawzxgzymp1mz4s3f0wxcd1ipg7k2hj8dgdwgkpwdr1hm


### PR DESCRIPTION
After:
```
result/bin/cabal build all --dry-run  12.06s user 1.20s system 72% cpu 18.296 total
```

I also updated some other minor things and the hackage index, if I'm going to get hydra to do some work.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
