### PR TITLE
Remove underscores from _exBudgetCPU and _exBudgetMemory

### DIFF
--- a/plutus-core/cost-model/data/cekMachineCosts.json
+++ b/plutus-core/cost-model/data/cekMachineCosts.json
@@ -1,11 +1,11 @@
 {
-    "cekStartupCost" : {"_exBudgetCPU":     100, "_exBudgetMemory": 100},
-    "cekVarCost"     : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekConstCost"   : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekLamCost"     : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekDelayCost"   : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekForceCost"   : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekApplyCost"   : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100},
-    "cekBuiltinCost" : {"_exBudgetCPU":   29773, "_exBudgetMemory": 100}
+    "cekStartupCost" : {"exBudgetCPU":     100, "exBudgetMemory": 100},
+    "cekVarCost"     : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekConstCost"   : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekLamCost"     : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekDelayCost"   : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekForceCost"   : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekApplyCost"   : {"exBudgetCPU":   29773, "exBudgetMemory": 100},
+    "cekBuiltinCost" : {"exBudgetCPU":   29773, "exBudgetMemory": 100}
 }
 

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -173,7 +173,7 @@ testPredictOne haskellModelFun modelFun = propertyR $ do
       in
         (\t -> msToPs (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs))[[1]]|]
     predictH :: CostingInteger -> CostingInteger
-    predictH x = coerce $ _exBudgetCPU $ runCostingFunOneArgument modelH (ExMemory x)
+    predictH x = coerce $ exBudgetCPU $ runCostingFunOneArgument modelH (ExMemory x)
     sizeGen = do
       x <- Gen.integral (Range.exponential 0 5000)
       pure x
@@ -198,7 +198,7 @@ testPredictTwo haskellModelFun modelFun = propertyR $ do
       in
         (\t -> msToPs (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
     predictH :: CostingInteger -> CostingInteger -> CostingInteger
-    predictH x y = coerce $ _exBudgetCPU $ runCostingFunTwoArguments modelH (ExMemory x) (ExMemory y)
+    predictH x y = coerce $ exBudgetCPU $ runCostingFunTwoArguments modelH (ExMemory x) (ExMemory y)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)
       x <- Gen.integral (Range.exponential 0 5000)
@@ -225,7 +225,7 @@ testPredictThree haskellModelFun modelFun = propertyR $ do
       in
         (\t -> msToPs (fromSomeSEXP t :: Double)) <$> [r|predict(model_hs, data.frame(x_mem=xD_hs, y_mem=yD_hs))[[1]]|]
     predictH :: CostingInteger -> CostingInteger -> CostingInteger -> CostingInteger
-    predictH x y z = coerce $ _exBudgetCPU $ runCostingFunThreeArguments modelH (ExMemory x) (ExMemory y) (ExMemory z)
+    predictH x y z = coerce $ exBudgetCPU $ runCostingFunThreeArguments modelH (ExMemory x) (ExMemory y) (ExMemory z)
     sizeGen = do
       y <- Gen.integral (Range.exponential 0 5000)
       x <- Gen.integral (Range.exponential 0 5000)

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -117,8 +117,8 @@ printBudgetStateBudget :: CekModel -> ExBudget -> IO ()
 printBudgetStateBudget model b =
     case model of
       Unit -> pure ()
-      _ ->  let ExCPU cpu = _exBudgetCPU b
-                ExMemory mem = _exBudgetMemory b
+      _ ->  let ExCPU cpu = exBudgetCPU b
+                ExMemory mem = exBudgetMemory b
             in do
               putStrLn $ "CPU budget:    " ++ show cpu
               putStrLn $ "Memory budget: " ++ show mem
@@ -164,7 +164,7 @@ printBudgetStateTally term model (Cek.CekExTally costs) = do
         builtinsAndCosts = List.foldl f [] (H.toList costs)
         builtinCosts = mconcat (map snd builtinsAndCosts)
         -- ^ Total builtin evaluation time (according to the models) in picoseconds (units depend on BuiltinCostModel.costMultiplier)
-        getCPU b = let ExCPU b' = _exBudgetCPU b in fromIntegral b'::Double
+        getCPU b = let ExCPU b' = exBudgetCPU b in fromIntegral b'::Double
         totalCost = getSpent Cek.BStartup <> totalComputeCost <> builtinCosts
         totalTime = (getCPU $ getSpent Cek.BStartup) + getCPU totalComputeCost + getCPU builtinCosts
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -172,7 +172,7 @@ class ExBudgetBuiltin fun exBudgetCat where
 instance ExBudgetBuiltin fun () where
     exBudgetBuiltin _ = ()
 
-data ExBudget = ExBudget { _exBudgetCPU :: ExCPU, _exBudgetMemory :: ExMemory }
+data ExBudget = ExBudget { exBudgetCPU :: ExCPU, exBudgetMemory :: ExMemory }
     deriving stock (Eq, Show, Generic, Lift)
     deriving anyclass (PrettyBy config, NFData)
     deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier LowerIntialCharacter] ExBudget

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -33,7 +33,7 @@ randomCekCosts =
                     }
 
 cekVarCostCpuKey :: Text.Text
-cekVarCostCpuKey = "cekVarCost-_exBudgetCPU"  -- This is the result of flatten . toJSON
+cekVarCostCpuKey = "cekVarCost-exBudgetCPU"  -- This is the result of flatten . toJSON
 
 randomCekCostModel :: CekCostModel
 randomCekCostModel = CostModel randomCekCosts defaultBuiltinCostModel


### PR DESCRIPTION
Remove some annoying underscores that we don't seem to need any more. Previously used for some lens-related thing?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
