### PR TITLE
Give PlutusTx.AssocMap IsData instances that use the map type in Data

### DIFF
--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx 02c6f1dfefa23d7142ffb4223370a0c2d350e1385c82f336ec80534226849979:
+                Tx b4fbdb680ef6b4154f550a5a86591218b1e89845952f0285631325bd69b3b319:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential)
+                      addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -36,23 +36,23 @@ Slot 1: W2: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W2: Finished balancing. f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
+Slot 1: W2: Finished balancing. 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
-Slot 1: W2: Submitting tx: f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
-Slot 1: W2: TxSubmit: f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
+Slot 1: W2: Submitting tx: 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
+Slot 1: W2: TxSubmit: 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 25.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx f31c626181ef5f3167d10e9eee05ef9e0ab84f3d079906389e537d1221931891:
+                Tx dc98f8608ebda22ce6fc39c1307d46bd78d44a2f66995f6ea70eb5c3755c596d:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential)
+                      addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -64,17 +64,17 @@ Slot 1: W3: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W3: Finished balancing. 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
-Slot 1: W3: Submitting tx: 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
-Slot 1: W3: TxSubmit: 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
+Slot 1: W3: Finished balancing. f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+Slot 1: W3: Submitting tx: f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+Slot 1: W3: TxSubmit: f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx 4271cdc250f3936351a0e57121f6807b98ef6d4e44d5caff7f4d21f70c9ad60d:
+                Tx d7ce795cf6115d1a498273120557dc76b994a35d63fcfc8abb67bf30382d11ff:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential)
+                      addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -86,23 +86,23 @@ Slot 1: W4: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W4: Finished balancing. 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
-Slot 1: W4: Submitting tx: 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
-Slot 1: W4: TxSubmit: 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
-Slot 1: TxnValidate 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
-Slot 1: TxnValidate 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
-Slot 1: TxnValidate f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
+Slot 1: W4: Finished balancing. 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+Slot 1: W4: Submitting tx: 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+Slot 1: W4: TxSubmit: 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+Slot 1: TxnValidate 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+Slot 1: TxnValidate f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+Slot 1: TxnValidate 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx 4bf75bbbdebc5b19c044bd3588a38c42ceb0cfbcc12513eaeccd9b9d3c2b5b93:
+                 Tx a078b4a4879760003956f42d2c7d7fff31cb11746aedcf13fe467dd6ceb93257:
                    {inputs:
-                      - 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c!1
+                      - 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e!1
                         <>
-                      - 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3!1
+                      - 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888!1
                         <>
-                      - f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556!1
+                      - f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738!1
                         <>
                    collateral inputs:
                    outputs:
@@ -114,20 +114,20 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    data:}
                Requires signatures:
                Utxo index:
-                 ( 09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c!1
-                 , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential) )
-                 ( 6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3!1
+                 ( 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e!1
                  , - Value (Map [(,Map [("",25)])]) addressed to
-                     addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential) )
-                 ( f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556!1
+                     addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
+                 ( 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888!1
                  , - Value (Map [(,Map [("",100)])]) addressed to
-                     addressed to ScriptCredential: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809 (no staking credential) )
+                     addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
+                 ( f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738!1
+                 , - Value (Map [(,Map [("",100)])]) addressed to
+                     addressed to ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
                Validity range:
                  [ POSIXTime 1596059111000 , POSIXTime 1596059120999 ]
-Slot 20: W1: Finished balancing. a50a890e9f6b1e4ca495b72cc681e5d52061ef26d49bdd075f2fa8c182af1140
-Slot 20: W1: Submitting tx: a50a890e9f6b1e4ca495b72cc681e5d52061ef26d49bdd075f2fa8c182af1140
-Slot 20: W1: TxSubmit: a50a890e9f6b1e4ca495b72cc681e5d52061ef26d49bdd075f2fa8c182af1140
+Slot 20: W1: Finished balancing. 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
+Slot 20: W1: Submitting tx: 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
+Slot 20: W1: TxSubmit: 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate a50a890e9f6b1e4ca495b72cc681e5d52061ef26d49bdd075f2fa8c182af1140
+Slot 20: TxnValidate 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -3,89 +3,10 @@
     (nonrec)
     (datatypebind
       (datatype
-        (tyvardecl TxOutRef (type))
-
-        TxOutRef_match
-        (vardecl TxOutRef (fun (con bytestring) (fun (con integer) TxOutRef)))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl ThreadToken (type))
-
-        ThreadToken_match
-        (vardecl ThreadToken (fun TxOutRef (fun (con bytestring) ThreadToken)))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Credential (type))
-
-        Credential_match
-        (vardecl PubKeyCredential (fun (con bytestring) Credential))
-        (vardecl ScriptCredential (fun (con bytestring) Credential))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl StakingCredential (type))
-
-        StakingCredential_match
-        (vardecl StakingHash (fun Credential StakingCredential))
-        (vardecl
-          StakingPtr
-          (fun (con integer) (fun (con integer) (fun (con integer) StakingCredential)))
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl DCert (type))
-
-        DCert_match
-        (vardecl DCertDelegDeRegKey (fun StakingCredential DCert))
-        (vardecl
-          DCertDelegDelegate
-          (fun StakingCredential (fun (con bytestring) DCert))
-        )
-        (vardecl DCertDelegRegKey (fun StakingCredential DCert))
-        (vardecl DCertGenesis DCert)
-        (vardecl DCertMir DCert)
-        (vardecl
-          DCertPoolRegister (fun (con bytestring) (fun (con bytestring) DCert))
-        )
-        (vardecl
-          DCertPoolRetire (fun (con bytestring) (fun (con integer) DCert))
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl ScriptPurpose (type))
-
-        ScriptPurpose_match
-        (vardecl Certifying (fun DCert ScriptPurpose))
-        (vardecl Minting (fun (con bytestring) ScriptPurpose))
-        (vardecl Rewarding (fun StakingCredential ScriptPurpose))
-        (vardecl Spending (fun TxOutRef ScriptPurpose))
-      )
-    )
-    (datatypebind
-      (datatype
         (tyvardecl Maybe (fun (type) (type)))
         (tyvardecl a (type))
         Maybe_match
         (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Address (type))
-
-        Address_match
-        (vardecl
-          Address (fun Credential (fun [Maybe StakingCredential] Address))
-        )
       )
     )
     (datatypebind
@@ -108,6 +29,115 @@
       )
       (let
         (nonrec)
+        (termbind
+          (strict)
+          (vardecl
+            fFromDataMap
+            (all v (type) (all k (type) [Maybe [List [[Tuple2 k] v]]]))
+          )
+          (abs
+            v
+            (type)
+            (abs
+              k (type) [ { Just [List [[Tuple2 k] v]] } { Nil [[Tuple2 k] v] } ]
+            )
+          )
+        )
+        (datatypebind
+          (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+        )
+        (termbind
+          (strict)
+          (vardecl
+            fFromDataMap
+            (all v (type) (all k (type) (fun Unit [Maybe [List [[Tuple2 k] v]]])))
+          )
+          (abs v (type) (abs k (type) (lam ds Unit { { fFromDataMap v } k })))
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl TxOutRef (type))
+
+            TxOutRef_match
+            (vardecl
+              TxOutRef (fun (con bytestring) (fun (con integer) TxOutRef))
+            )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl ThreadToken (type))
+
+            ThreadToken_match
+            (vardecl
+              ThreadToken (fun TxOutRef (fun (con bytestring) ThreadToken))
+            )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Credential (type))
+
+            Credential_match
+            (vardecl PubKeyCredential (fun (con bytestring) Credential))
+            (vardecl ScriptCredential (fun (con bytestring) Credential))
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl StakingCredential (type))
+
+            StakingCredential_match
+            (vardecl StakingHash (fun Credential StakingCredential))
+            (vardecl
+              StakingPtr
+              (fun (con integer) (fun (con integer) (fun (con integer) StakingCredential)))
+            )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl DCert (type))
+
+            DCert_match
+            (vardecl DCertDelegDeRegKey (fun StakingCredential DCert))
+            (vardecl
+              DCertDelegDelegate
+              (fun StakingCredential (fun (con bytestring) DCert))
+            )
+            (vardecl DCertDelegRegKey (fun StakingCredential DCert))
+            (vardecl DCertGenesis DCert)
+            (vardecl DCertMir DCert)
+            (vardecl
+              DCertPoolRegister
+              (fun (con bytestring) (fun (con bytestring) DCert))
+            )
+            (vardecl
+              DCertPoolRetire (fun (con bytestring) (fun (con integer) DCert))
+            )
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl ScriptPurpose (type))
+
+            ScriptPurpose_match
+            (vardecl Certifying (fun DCert ScriptPurpose))
+            (vardecl Minting (fun (con bytestring) ScriptPurpose))
+            (vardecl Rewarding (fun StakingCredential ScriptPurpose))
+            (vardecl Spending (fun TxOutRef ScriptPurpose))
+          )
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Address (type))
+
+            Address_match
+            (vardecl
+              Address (fun Credential (fun [Maybe StakingCredential] Address))
+            )
+          )
+        )
         (datatypebind
           (datatype
             (tyvardecl TxOut (type))
@@ -2016,14 +2046,6 @@
                             )
                           )
                         )
-                        (datatypebind
-                          (datatype
-                            (tyvardecl Unit (type))
-
-                            Unit_match
-                            (vardecl Unit Unit)
-                          )
-                        )
                         (termbind
                           (strict)
                           (vardecl
@@ -2745,383 +2767,6 @@
                         (termbind
                           (strict)
                           (vardecl
-                            fFromDataTuple2_cfromBuiltinData
-                            (all a (type) (all b (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun [(lam a (type) (fun (con data) [Maybe a])) b] (fun (con data) [Maybe [[Tuple2 a] b]])))))
-                          )
-                          (abs
-                            a
-                            (type)
-                            (abs
-                              b
-                              (type)
-                              (lam
-                                dFromData
-                                [(lam a (type) (fun (con data) [Maybe a])) a]
-                                (lam
-                                  dFromData
-                                  [(lam a (type) (fun (con data) [Maybe a])) b]
-                                  (lam
-                                    d
-                                    (con data)
-                                    [
-                                      [
-                                        [
-                                          [
-                                            [
-                                              [
-                                                [
-                                                  {
-                                                    (builtin chooseData)
-                                                    (fun Unit [Maybe [[Tuple2 a] b]])
-                                                  }
-                                                  d
-                                                ]
-                                                (lam
-                                                  ds
-                                                  Unit
-                                                  (let
-                                                    (nonrec)
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        tup
-                                                        [[(con pair) (con integer)] [(con list) (con data)]]
-                                                      )
-                                                      [
-                                                        (builtin unConstrData) d
-                                                      ]
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        l
-                                                        [(con list) (con data)]
-                                                      )
-                                                      [
-                                                        {
-                                                          {
-                                                            (builtin sndPair)
-                                                            (con integer)
-                                                          }
-                                                          [(con list) (con data)]
-                                                        }
-                                                        tup
-                                                      ]
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        l
-                                                        [(con list) (con data)]
-                                                      )
-                                                      [
-                                                        {
-                                                          (builtin tailList)
-                                                          (con data)
-                                                        }
-                                                        l
-                                                      ]
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        nilCase
-                                                        [Maybe [[Tuple2 a] b]]
-                                                      )
-                                                      {
-                                                        [
-                                                          [
-                                                            {
-                                                              [
-                                                                {
-                                                                  Maybe_match a
-                                                                }
-                                                                [
-                                                                  dFromData
-                                                                  [
-                                                                    {
-                                                                      (builtin
-                                                                        headList
-                                                                      )
-                                                                      (con data)
-                                                                    }
-                                                                    l
-                                                                  ]
-                                                                ]
-                                                              ]
-                                                              (all dead (type) [Maybe [[Tuple2 a] b]])
-                                                            }
-                                                            (lam
-                                                              ipv
-                                                              a
-                                                              (abs
-                                                                dead
-                                                                (type)
-                                                                {
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        [
-                                                                          {
-                                                                            Maybe_match
-                                                                            b
-                                                                          }
-                                                                          [
-                                                                            dFromData
-                                                                            [
-                                                                              {
-                                                                                (builtin
-                                                                                  headList
-                                                                                )
-                                                                                (con data)
-                                                                              }
-                                                                              l
-                                                                            ]
-                                                                          ]
-                                                                        ]
-                                                                        (all dead (type) [Maybe [[Tuple2 a] b]])
-                                                                      }
-                                                                      (lam
-                                                                        ipv
-                                                                        b
-                                                                        (abs
-                                                                          dead
-                                                                          (type)
-                                                                          [
-                                                                            {
-                                                                              Just
-                                                                              [[Tuple2 a] b]
-                                                                            }
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  {
-                                                                                    Tuple2
-                                                                                    a
-                                                                                  }
-                                                                                  b
-                                                                                }
-                                                                                ipv
-                                                                              ]
-                                                                              ipv
-                                                                            ]
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                    ]
-                                                                    (abs
-                                                                      dead
-                                                                      (type)
-                                                                      {
-                                                                        Nothing
-                                                                        [[Tuple2 a] b]
-                                                                      }
-                                                                    )
-                                                                  ]
-                                                                  (all dead (type) dead)
-                                                                }
-                                                              )
-                                                            )
-                                                          ]
-                                                          (abs
-                                                            dead
-                                                            (type)
-                                                            {
-                                                              Nothing
-                                                              [[Tuple2 a] b]
-                                                            }
-                                                          )
-                                                        ]
-                                                        (all dead (type) dead)
-                                                      }
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        lvl
-                                                        [Maybe [[Tuple2 a] b]]
-                                                      )
-                                                      [
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                {
-                                                                  (builtin
-                                                                    chooseList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                                              }
-                                                              [
-                                                                {
-                                                                  (builtin
-                                                                    tailList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                l
-                                                              ]
-                                                            ]
-                                                            (lam ds Unit nilCase
-                                                            )
-                                                          ]
-                                                          (lam
-                                                            ds
-                                                            Unit
-                                                            {
-                                                              Nothing
-                                                              [[Tuple2 a] b]
-                                                            }
-                                                          )
-                                                        ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        lvl
-                                                        [Maybe [[Tuple2 a] b]]
-                                                      )
-                                                      [
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                {
-                                                                  (builtin
-                                                                    chooseList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                                              }
-                                                              l
-                                                            ]
-                                                            (lam
-                                                              ds
-                                                              Unit
-                                                              {
-                                                                Nothing
-                                                                [[Tuple2 a] b]
-                                                              }
-                                                            )
-                                                          ]
-                                                          (lam ds Unit lvl)
-                                                        ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl
-                                                        x [Maybe [[Tuple2 a] b]]
-                                                      )
-                                                      [
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                {
-                                                                  (builtin
-                                                                    chooseList
-                                                                  )
-                                                                  (con data)
-                                                                }
-                                                                (fun Unit [Maybe [[Tuple2 a] b]])
-                                                              }
-                                                              l
-                                                            ]
-                                                            (lam
-                                                              ds
-                                                              Unit
-                                                              {
-                                                                Nothing
-                                                                [[Tuple2 a] b]
-                                                              }
-                                                            )
-                                                          ]
-                                                          (lam ds Unit lvl)
-                                                        ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                    [
-                                                      [
-                                                        [
-                                                          [
-                                                            {
-                                                              (builtin
-                                                                ifThenElse
-                                                              )
-                                                              (fun (con unit) [Maybe [[Tuple2 a] b]])
-                                                            }
-                                                            [
-                                                              [
-                                                                (builtin
-                                                                  equalsInteger
-                                                                )
-                                                                [
-                                                                  {
-                                                                    {
-                                                                      (builtin
-                                                                        fstPair
-                                                                      )
-                                                                      (con integer)
-                                                                    }
-                                                                    [(con list) (con data)]
-                                                                  }
-                                                                  tup
-                                                                ]
-                                                              ]
-                                                              (con integer 0)
-                                                            ]
-                                                          ]
-                                                          (lam ds (con unit) x)
-                                                        ]
-                                                        (lam
-                                                          ds
-                                                          (con unit)
-                                                          {
-                                                            Nothing
-                                                            [[Tuple2 a] b]
-                                                          }
-                                                        )
-                                                      ]
-                                                      (con unit ())
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                              (lam
-                                                ds
-                                                Unit
-                                                { Nothing [[Tuple2 a] b] }
-                                              )
-                                            ]
-                                            (lam
-                                              ds Unit { Nothing [[Tuple2 a] b] }
-                                            )
-                                          ]
-                                          (lam
-                                            ds Unit { Nothing [[Tuple2 a] b] }
-                                          )
-                                        ]
-                                        (lam ds Unit { Nothing [[Tuple2 a] b] })
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
                             fFromDataBuiltinByteString_cfromBuiltinData
                             (fun (con data) [Maybe (con bytestring)])
                           )
@@ -3165,98 +2810,108 @@
                           )
                         )
                         (termbind
-                          (nonstrict)
+                          (strict)
                           (vardecl
-                            fFromDataValue
-                            (fun (con data) [Maybe [[Tuple2 (con bytestring)] (con integer)]])
+                            fFromDataMap
+                            (all v (type) (all k (type) (fun Unit [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]])))
                           )
-                          [
-                            [
-                              {
+                          (abs
+                            v
+                            (type)
+                            (abs
+                              k
+                              (type)
+                              (lam
+                                ds
+                                Unit
                                 {
-                                  fFromDataTuple2_cfromBuiltinData
-                                  (con bytestring)
+                                  Nothing
+                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
                                 }
-                                (con integer)
-                              }
-                              fFromDataBuiltinByteString_cfromBuiltinData
-                            ]
-                            fFromDataInteger_cfromBuiltinData
-                          ]
+                              )
+                            )
+                          )
                         )
                         (termbind
                           (strict)
                           (vardecl
-                            fFromDataNil_cfromBuiltinData
-                            (all a (type) (fun [(lam a (type) (fun (con data) [Maybe a])) a] (fun (con data) [Maybe [List a]])))
+                            fFromDataMap_cfromBuiltinData
+                            (all k (type) (all v (type) (fun [(lam a (type) (fun (con data) [Maybe a])) k] (fun [(lam a (type) (fun (con data) [Maybe a])) v] (fun (con data) [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]])))))
                           )
                           (abs
-                            a
+                            k
                             (type)
-                            (lam
-                              dFromData
-                              [(lam a (type) (fun (con data) [Maybe a])) a]
+                            (abs
+                              v
+                              (type)
                               (lam
-                                d
-                                (con data)
-                                (let
-                                  (rec)
-                                  (termbind
-                                    (strict)
-                                    (vardecl
-                                      go
-                                      (fun [(con list) (con data)] [Maybe [List a]])
-                                    )
-                                    (lam
-                                      l
-                                      [(con list) (con data)]
-                                      (let
-                                        (nonrec)
-                                        (termbind
-                                          (nonstrict)
-                                          (vardecl x [Maybe [List a]])
-                                          [ { Just [List a] } { Nil a } ]
+                                dFromData
+                                [(lam a (type) (fun (con data) [Maybe a])) k]
+                                (lam
+                                  dFromData
+                                  [(lam a (type) (fun (con data) [Maybe a])) v]
+                                  (lam
+                                    d
+                                    (con data)
+                                    (let
+                                      (rec)
+                                      (termbind
+                                        (strict)
+                                        (vardecl
+                                          go
+                                          (fun [(con list) [[(con pair) (con data)] (con data)]] [Maybe [List [[Tuple2 k] v]]])
                                         )
-                                        [
-                                          [
-                                            [
+                                        (lam
+                                          l
+                                          [(con list) [[(con pair) (con data)] (con data)]]
+                                          (let
+                                            (nonrec)
+                                            (termbind
+                                              (nonstrict)
+                                              (vardecl
+                                                tup
+                                                [[(con pair) (con data)] (con data)]
+                                              )
                                               [
                                                 {
-                                                  {
-                                                    (builtin chooseList)
-                                                    (con data)
-                                                  }
-                                                  (fun Unit [Maybe [List a]])
+                                                  (builtin headList)
+                                                  [[(con pair) (con data)] (con data)]
                                                 }
                                                 l
                                               ]
-                                              (lam ds Unit x)
-                                            ]
-                                            (lam
-                                              ds
-                                              Unit
+                                            )
+                                            (termbind
+                                              (nonstrict)
+                                              (vardecl
+                                                lvl
+                                                [Maybe [List [[Tuple2 k] v]]]
+                                              )
                                               {
                                                 [
                                                   [
                                                     {
                                                       [
-                                                        { Maybe_match a }
+                                                        { Maybe_match k }
                                                         [
                                                           dFromData
                                                           [
                                                             {
-                                                              (builtin headList)
+                                                              {
+                                                                (builtin fstPair
+                                                                )
+                                                                (con data)
+                                                              }
                                                               (con data)
                                                             }
-                                                            l
+                                                            tup
                                                           ]
                                                         ]
                                                       ]
-                                                      (all dead (type) [Maybe [List a]])
+                                                      (all dead (type) [Maybe [List [[Tuple2 k] v]]])
                                                     }
                                                     (lam
                                                       a
-                                                      a
+                                                      k
                                                       (abs
                                                         dead
                                                         (type)
@@ -3267,44 +2922,104 @@
                                                                 [
                                                                   {
                                                                     Maybe_match
-                                                                    [List a]
+                                                                    v
                                                                   }
                                                                   [
-                                                                    go
+                                                                    dFromData
                                                                     [
                                                                       {
-                                                                        (builtin
-                                                                          tailList
-                                                                        )
+                                                                        {
+                                                                          (builtin
+                                                                            sndPair
+                                                                          )
+                                                                          (con data)
+                                                                        }
                                                                         (con data)
                                                                       }
-                                                                      l
+                                                                      tup
                                                                     ]
                                                                   ]
                                                                 ]
-                                                                (all dead (type) [Maybe [List a]])
+                                                                (all dead (type) [Maybe [List [[Tuple2 k] v]]])
                                                               }
                                                               (lam
                                                                 ipv
-                                                                [List a]
+                                                                v
                                                                 (abs
                                                                   dead
                                                                   (type)
-                                                                  [
-                                                                    {
-                                                                      Just
-                                                                      [List a]
-                                                                    }
+                                                                  {
                                                                     [
                                                                       [
                                                                         {
-                                                                          Cons a
+                                                                          [
+                                                                            {
+                                                                              Maybe_match
+                                                                              [List [[Tuple2 k] v]]
+                                                                            }
+                                                                            [
+                                                                              go
+                                                                              [
+                                                                                {
+                                                                                  (builtin
+                                                                                    tailList
+                                                                                  )
+                                                                                  [[(con pair) (con data)] (con data)]
+                                                                                }
+                                                                                l
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                          (all dead (type) [Maybe [List [[Tuple2 k] v]]])
                                                                         }
-                                                                        a
+                                                                        (lam
+                                                                          ipv
+                                                                          [List [[Tuple2 k] v]]
+                                                                          (abs
+                                                                            dead
+                                                                            (type)
+                                                                            [
+                                                                              {
+                                                                                Just
+                                                                                [List [[Tuple2 k] v]]
+                                                                              }
+                                                                              [
+                                                                                [
+                                                                                  {
+                                                                                    Cons
+                                                                                    [[Tuple2 k] v]
+                                                                                  }
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        {
+                                                                                          Tuple2
+                                                                                          k
+                                                                                        }
+                                                                                        v
+                                                                                      }
+                                                                                      a
+                                                                                    ]
+                                                                                    ipv
+                                                                                  ]
+                                                                                ]
+                                                                                ipv
+                                                                              ]
+                                                                            ]
+                                                                          )
+                                                                        )
                                                                       ]
-                                                                      ipv
+                                                                      (abs
+                                                                        dead
+                                                                        (type)
+                                                                        {
+                                                                          Nothing
+                                                                          [List [[Tuple2 k] v]]
+                                                                        }
+                                                                      )
                                                                     ]
-                                                                  ]
+                                                                    (all dead (type) dead)
+                                                                  }
                                                                 )
                                                               )
                                                             ]
@@ -3312,7 +3027,8 @@
                                                               dead
                                                               (type)
                                                               {
-                                                                Nothing [List a]
+                                                                Nothing
+                                                                [List [[Tuple2 k] v]]
                                                               }
                                                             )
                                                           ]
@@ -3324,85 +3040,152 @@
                                                   (abs
                                                     dead
                                                     (type)
-                                                    { Nothing [List a] }
+                                                    {
+                                                      Nothing
+                                                      [List [[Tuple2 k] v]]
+                                                    }
                                                   )
                                                 ]
                                                 (all dead (type) dead)
                                               }
                                             )
+                                            [
+                                              [
+                                                [
+                                                  [
+                                                    {
+                                                      {
+                                                        (builtin chooseList)
+                                                        [[(con pair) (con data)] (con data)]
+                                                      }
+                                                      (fun Unit [Maybe [List [[Tuple2 k] v]]])
+                                                    }
+                                                    l
+                                                  ]
+                                                  { { fFromDataMap v } k }
+                                                ]
+                                                (lam ds Unit lvl)
+                                              ]
+                                              Unit
+                                            ]
+                                          )
+                                        )
+                                      )
+                                      (let
+                                        (nonrec)
+                                        (termbind
+                                          (nonstrict)
+                                          (vardecl
+                                            lvl
+                                            [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]]
+                                          )
+                                          {
+                                            [
+                                              [
+                                                {
+                                                  [
+                                                    {
+                                                      Maybe_match
+                                                      [List [[Tuple2 k] v]]
+                                                    }
+                                                    [
+                                                      go
+                                                      [ (builtin unMapData) d ]
+                                                    ]
+                                                  ]
+                                                  (all dead (type) [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]])
+                                                }
+                                                (lam
+                                                  a
+                                                  [List [[Tuple2 k] v]]
+                                                  (abs
+                                                    dead
+                                                    (type)
+                                                    [
+                                                      {
+                                                        Just
+                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
+                                                      }
+                                                      a
+                                                    ]
+                                                  )
+                                                )
+                                              ]
+                                              (abs
+                                                dead
+                                                (type)
+                                                {
+                                                  Nothing
+                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
+                                                }
+                                              )
+                                            ]
+                                            (all dead (type) dead)
+                                          }
+                                        )
+                                        [
+                                          [
+                                            [
+                                              [
+                                                [
+                                                  [
+                                                    [
+                                                      {
+                                                        (builtin chooseData)
+                                                        (fun Unit [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]])
+                                                      }
+                                                      d
+                                                    ]
+                                                    { { fFromDataMap v } k }
+                                                  ]
+                                                  (lam ds Unit lvl)
+                                                ]
+                                                { { fFromDataMap v } k }
+                                              ]
+                                              { { fFromDataMap v } k }
+                                            ]
+                                            { { fFromDataMap v } k }
                                           ]
                                           Unit
                                         ]
                                       )
                                     )
                                   )
-                                  [
-                                    [
-                                      [
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  (builtin chooseData)
-                                                  (fun Unit [Maybe [List a]])
-                                                }
-                                                d
-                                              ]
-                                              (lam ds Unit { Nothing [List a] })
-                                            ]
-                                            (lam ds Unit { Nothing [List a] })
-                                          ]
-                                          (lam
-                                            ds
-                                            Unit
-                                            [ go [ (builtin unListData) d ] ]
-                                          )
-                                        ]
-                                        (lam ds Unit { Nothing [List a] })
-                                      ]
-                                      (lam ds Unit { Nothing [List a] })
-                                    ]
-                                    Unit
-                                  ]
                                 )
                               )
                             )
                           )
                         )
                         (termbind
-                          (strict)
-                          (vardecl
-                            fFromDataValue
-                            (fun (con data) [Maybe [List [[Tuple2 (con bytestring)] (con integer)]]])
-                          )
-                          (lam
-                            eta
-                            (con data)
-                            [
-                              [
-                                {
-                                  fFromDataNil_cfromBuiltinData
-                                  [[Tuple2 (con bytestring)] (con integer)]
-                                }
-                                fFromDataValue
-                              ]
-                              eta
-                            ]
-                          )
-                        )
-                        (termbind
                           (nonstrict)
                           (vardecl
                             fFromDataValue
-                            (fun (con data) [Maybe [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
+                            (fun (con data) [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
                           )
                           [
                             [
                               {
                                 {
-                                  fFromDataTuple2_cfromBuiltinData
-                                  (con bytestring)
+                                  fFromDataMap_cfromBuiltinData (con bytestring)
+                                }
+                                (con integer)
+                              }
+                              fFromDataBuiltinByteString_cfromBuiltinData
+                            ]
+                            fFromDataInteger_cfromBuiltinData
+                          ]
+                        )
+                        (termbind
+                          (nonstrict)
+                          (vardecl
+                            fFromDataValue
+                            (fun (con data) [Maybe [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
+                          )
+                          [
+                            [
+                              {
+                                {
+                                  fFromDataMap_cfromBuiltinData (con bytestring)
                                 }
                                 [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                               }
@@ -3410,27 +3193,6 @@
                             ]
                             fFromDataValue
                           ]
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
-                            fFromDataValue
-                            (fun (con data) [Maybe [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
-                          )
-                          (lam
-                            eta
-                            (con data)
-                            [
-                              [
-                                {
-                                  fFromDataNil_cfromBuiltinData
-                                  [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                }
-                                fFromDataValue
-                              ]
-                              eta
-                            ]
-                          )
                         )
                         (termbind
                           (nonstrict)

--- a/plutus-use-cases/test/Spec/governance.pir
+++ b/plutus-use-cases/test/Spec/governance.pir
@@ -93,6 +93,11 @@
         ]
       )
     )
+    (termbind
+      (nonstrict)
+      (vardecl fToDataMap [(con list) [[(con pair) (con data)] (con data)]])
+      [ (builtin mkNilPairData) (con unit ()) ]
+    )
     (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
@@ -100,59 +105,6 @@
         Tuple2_match
         (vardecl Tuple2 (fun a (fun b [[Tuple2 a] b])))
       )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fToDataTuple2_ctoBuiltinData
-        (all a (type) (all b (type) (fun [(lam a (type) (fun a (con data))) a] (fun [(lam a (type) (fun a (con data))) b] (fun [[Tuple2 a] b] (con data))))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dToData
-            [(lam a (type) (fun a (con data))) a]
-            (lam
-              dToData
-              [(lam a (type) (fun a (con data))) b]
-              (lam
-                ds
-                [[Tuple2 a] b]
-                [
-                  { [ { { Tuple2_match a } b } ds ] (con data) }
-                  (lam
-                    arg
-                    a
-                    (lam
-                      arg
-                      b
-                      [
-                        [ (builtin constrData) (con integer 0) ]
-                        [
-                          [ { (builtin mkCons) (con data) } [ dToData arg ] ]
-                          [
-                            [ { (builtin mkCons) (con data) } [ dToData arg ] ]
-                            [ (builtin mkNilData) (con unit ()) ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                ]
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (nonstrict)
-      (vardecl fToDataMap [(con list) (con data)])
-      [ (builtin mkNilData) (con unit ()) ]
     )
     (let
       (rec)
@@ -185,14 +137,15 @@
                   dToData
                   [(lam a (type) (fun a (con data))) v]
                   (lam
-                    eta
+                    ds
                     [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
                     (let
                       (rec)
                       (termbind
                         (strict)
                         (vardecl
-                          go (fun [List [[Tuple2 k] v]] [(con list) (con data)])
+                          go
+                          (fun [List [[Tuple2 k] v]] [(con list) [[(con pair) (con data)] (con data)]])
                         )
                         (lam
                           ds
@@ -202,12 +155,12 @@
                               [
                                 {
                                   [ { Nil_match [[Tuple2 k] v] } ds ]
-                                  (all dead (type) [(con list) (con data)])
+                                  (all dead (type) [(con list) [[(con pair) (con data)] (con data)]])
                                 }
                                 (abs dead (type) fToDataMap)
                               ]
                               (lam
-                                x
+                                ds
                                 [[Tuple2 k] v]
                                 (lam
                                   xs
@@ -216,25 +169,34 @@
                                     dead
                                     (type)
                                     [
-                                      [
-                                        { (builtin mkCons) (con data) }
-                                        [
+                                      {
+                                        [ { { Tuple2_match k } v } ds ]
+                                        [(con list) [[(con pair) (con data)] (con data)]]
+                                      }
+                                      (lam
+                                        k
+                                        k
+                                        (lam
+                                          v
+                                          v
                                           [
                                             [
                                               {
-                                                {
-                                                  fToDataTuple2_ctoBuiltinData k
-                                                }
-                                                v
+                                                (builtin mkCons)
+                                                [[(con pair) (con data)] (con data)]
                                               }
-                                              dToData
+                                              [
+                                                [
+                                                  (builtin mkPairData)
+                                                  [ dToData k ]
+                                                ]
+                                                [ dToData v ]
+                                              ]
                                             ]
-                                            dToData
+                                            [ go xs ]
                                           ]
-                                          x
-                                        ]
-                                      ]
-                                      [ go xs ]
+                                        )
+                                      )
                                     ]
                                   )
                                 )
@@ -244,7 +206,7 @@
                           }
                         )
                       )
-                      [ (builtin listData) [ go eta ] ]
+                      [ (builtin mapData) [ go ds ] ]
                     )
                   )
                 )

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -6,6 +6,11 @@
       (vardecl fToDataInteger_ctoBuiltinData (fun (con integer) (con data)))
       (lam i (con integer) [ (builtin iData) i ])
     )
+    (termbind
+      (nonstrict)
+      (vardecl fToDataMap [(con list) [[(con pair) (con data)] (con data)]])
+      [ (builtin mkNilPairData) (con unit ()) ]
+    )
     (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
@@ -13,59 +18,6 @@
         Tuple2_match
         (vardecl Tuple2 (fun a (fun b [[Tuple2 a] b])))
       )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fToDataTuple2_ctoBuiltinData
-        (all a (type) (all b (type) (fun [(lam a (type) (fun a (con data))) a] (fun [(lam a (type) (fun a (con data))) b] (fun [[Tuple2 a] b] (con data))))))
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            dToData
-            [(lam a (type) (fun a (con data))) a]
-            (lam
-              dToData
-              [(lam a (type) (fun a (con data))) b]
-              (lam
-                ds
-                [[Tuple2 a] b]
-                [
-                  { [ { { Tuple2_match a } b } ds ] (con data) }
-                  (lam
-                    arg
-                    a
-                    (lam
-                      arg
-                      b
-                      [
-                        [ (builtin constrData) (con integer 0) ]
-                        [
-                          [ { (builtin mkCons) (con data) } [ dToData arg ] ]
-                          [
-                            [ { (builtin mkCons) (con data) } [ dToData arg ] ]
-                            [ (builtin mkNilData) (con unit ()) ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                ]
-              )
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (nonstrict)
-      (vardecl fToDataMap [(con list) (con data)])
-      [ (builtin mkNilData) (con unit ()) ]
     )
     (let
       (rec)
@@ -98,14 +50,15 @@
                   dToData
                   [(lam a (type) (fun a (con data))) v]
                   (lam
-                    eta
+                    ds
                     [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
                     (let
                       (rec)
                       (termbind
                         (strict)
                         (vardecl
-                          go (fun [List [[Tuple2 k] v]] [(con list) (con data)])
+                          go
+                          (fun [List [[Tuple2 k] v]] [(con list) [[(con pair) (con data)] (con data)]])
                         )
                         (lam
                           ds
@@ -115,12 +68,12 @@
                               [
                                 {
                                   [ { Nil_match [[Tuple2 k] v] } ds ]
-                                  (all dead (type) [(con list) (con data)])
+                                  (all dead (type) [(con list) [[(con pair) (con data)] (con data)]])
                                 }
                                 (abs dead (type) fToDataMap)
                               ]
                               (lam
-                                x
+                                ds
                                 [[Tuple2 k] v]
                                 (lam
                                   xs
@@ -129,25 +82,34 @@
                                     dead
                                     (type)
                                     [
-                                      [
-                                        { (builtin mkCons) (con data) }
-                                        [
+                                      {
+                                        [ { { Tuple2_match k } v } ds ]
+                                        [(con list) [[(con pair) (con data)] (con data)]]
+                                      }
+                                      (lam
+                                        k
+                                        k
+                                        (lam
+                                          v
+                                          v
                                           [
                                             [
                                               {
-                                                {
-                                                  fToDataTuple2_ctoBuiltinData k
-                                                }
-                                                v
+                                                (builtin mkCons)
+                                                [[(con pair) (con data)] (con data)]
                                               }
-                                              dToData
+                                              [
+                                                [
+                                                  (builtin mkPairData)
+                                                  [ dToData k ]
+                                                ]
+                                                [ dToData v ]
+                                              ]
                                             ]
-                                            dToData
+                                            [ go xs ]
                                           ]
-                                          x
-                                        ]
-                                      ]
-                                      [ go xs ]
+                                        )
+                                      )
                                     ]
                                   )
                                 )
@@ -157,7 +119,7 @@
                           }
                         )
                       )
-                      [ (builtin listData) [ go eta ] ]
+                      [ (builtin mapData) [ go ds ] ]
                     )
                   )
                 )

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
+TxId:       6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840341cccaff738e6c3393a1b0ca0fa1fc87435...
+              Signature: 5840bf9cbb7fcca9d1243710a117858a7f6300d4...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: bcc083ade3fdd0a372cb6c43ef00ef02fcb52e95... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
+TxId:       f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5840cdace28198074a851a17cde1caba540f9c18...
+              Signature: 58400c97ed9d0de34a7a27f5756bf58742a804b4...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 7f8a76c0ebaa4ad20dfdcd51a5de070ab771f4bf... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
+TxId:       6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584018971cbf2083258f6aba8a4056db9c8a08b8...
+              Signature: 5840752f7fadbbb7ed1163044160f1744b9913b8...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  100
 
@@ -318,16 +318,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       a50a890e9f6b1e4ca495b72cc681e5d52061ef26d49bdd075f2fa8c182af1140
-Fee:        Ada:      Lovelace:  14032
+TxId:       1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
+Fee:        Ada:      Lovelace:  14650
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840ecdb2ad7cb03943a928199d80ddc0b2ab9c3...
+              Signature: 5840332594c7e9b4b9aefcaf4e2af8c69076f952...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -339,44 +339,44 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     09c21de7ece5b224ead247754e2fb80ce2dd69eb180d29286612a7c55ec05d3c
-    Output #1
-    Script: 590e420100003323332223232333222333222333...
-
-  ---- Input 2 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  25
   Source:
-    Tx:     6ee5de7047be901322af0e1ff107ce911237f0b60ea38cd935360cbeca8b1cb3
+    Tx:     6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
     Output #1
-    Script: 590e420100003323332223232333222333222333...
+    Script: 590ede0100003323232332233223332223233322...
 
-  ---- Input 3 ----
-  Destination:  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  ---- Input 2 ----
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     f9d5959ed383550d28c45b30dce80260df7bf4741392f2ec1e3e743aa071c556
+    Tx:     6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
     Output #1
-    Script: 590e420100003323332223232333222333222333...
+    Script: 590ede0100003323232332233223332223233322...
+
+  ---- Input 3 ----
+  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Value:
+    Ada:      Lovelace:  100
+  Source:
+    Tx:     f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+    Output #1
+    Script: 590ede0100003323232332233223332223233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986193
+    Ada:      Lovelace:  99985575
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986193
+    Ada:      Lovelace:  99985575
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -414,6 +414,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 5e40a47ab6e241233bcd9eaede9220743c5e829c105dbc65b3ffa809
+  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       e23e115853c2150f95e3bfdbe48344fa0560b45e7d1e33a4a208622e3ad643d8
+TxId:       8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840f13a334a41c4240ef2ee45d81cf27c5b09c3...
+              Signature: 5840c13f90d052624c191f6a17a497bb64b5b9fc...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999982
 
   ---- Output 1 ----
-  Destination:  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
 
@@ -170,51 +170,51 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       c1709bc6bb54a7874f4aea6987f181f4509b8ecc10613a416a399a7719aa4d2b
-Fee:        Ada:      Lovelace:  12641
-Mint:       9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+TxId:       2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
+Fee:        Ada:      Lovelace:  13051
+Mint:       1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584011f863a3aaaeec8ace91bfbe2ea5e7540ff7...
+              Signature: 584023520aa53693196a6c186434ac0a4f064b06...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     e23e115853c2150f95e3bfdbe48344fa0560b45e7d1e33a4a208622e3ad643d8
+    Tx:     8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     e23e115853c2150f95e3bfdbe48344fa0560b45e7d1e33a4a208622e3ad643d8
+    Tx:     8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
     Output #1
-    Script: 591dc10100003323322333222333222323233223...
+    Script: 591e5b0100003323232332233223332223233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987341
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  -
+    Ada:      Lovelace:  99986931
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
 
@@ -222,8 +222,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987341
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    Ada:      Lovelace:  99986931
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       6bbaec8bb79b429e5e5e34a9d1b35b1e48670ca849e4dec0a86697ef4285aa2e
+TxId:       69d73020b43d21058fd96271312dd34bdf7ee3b2f4501ab725b81820efcfc28f
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840efa917b8fa8dae29062958b27c2471a6a79e...
+              Signature: 58408e97f39e99df8ba175caa0ae50464f83dfbb...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987341
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  -
+    Ada:      Lovelace:  99986931
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  -
   Source:
-    Tx:     c1709bc6bb54a7874f4aea6987f181f4509b8ecc10613a416a399a7719aa4d2b
+    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
     Ada:      -
   Source:
-    Tx:     c1709bc6bb54a7874f4aea6987f181f4509b8ecc10613a416a399a7719aa4d2b
+    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
     Output #1
 
 
@@ -297,20 +297,20 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987331
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    0
+    Ada:      Lovelace:  99986921
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987331
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    0
+    Ada:      Lovelace:  99986921
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -335,7 +335,7 @@ Balances Carried Forward:
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -349,16 +349,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       76312850f26c2f91cf578723a20798979e7e4be3582883ba0a2c6dcdee098802
-Fee:        Ada:      Lovelace:  12641
-Mint:       9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    0
+TxId:       9b9d5413bcc07f89e5aabc270beac0ba940723f7cea3d556e955a64ffb3ba866
+Fee:        Ada:      Lovelace:  13051
+Mint:       1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840c2c116a2a26f6e4ca94384d217fc67f36a3e...
+              Signature: 584040da2a39f1f018be353c245e2c379fddc523...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -370,39 +370,39 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
-  Value:
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
-  Source:
-    Tx:     6bbaec8bb79b429e5e5e34a9d1b35b1e48670ca849e4dec0a86697ef4285aa2e
-    Output #1
-
-
-  ---- Input 2 ----
-  Destination:  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     c1709bc6bb54a7874f4aea6987f181f4509b8ecc10613a416a399a7719aa4d2b
+    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
     Output #2
-    Script: 591dc10100003323322333222333222323233223...
+    Script: 591e5b0100003323232332233223332223233322...
+
+  ---- Input 2 ----
+  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
+  Value:
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+  Source:
+    Tx:     69d73020b43d21058fd96271312dd34bdf7ee3b2f4501ab725b81820efcfc28f
+    Output #1
+
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99987362
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    0
+    Ada:      Lovelace:  99986952
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  5
 
@@ -410,8 +410,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99987331
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    0
+    Ada:      Lovelace:  99986921
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -435,8 +435,8 @@ Balances Carried Forward:
 
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99987362
-    9fd2a8ae3d98f40c569ab9660f7f3e3277399af77d8dfb8b4fbfb782:  guess:    1
+    Ada:      Lovelace:  99986952
+    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -450,6 +450,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: f31d4725f37e6dc02c494c3f565c4a61827a4261068e7e0618f7ab69
+  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
   Value:
     Ada:      Lovelace:  5

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       b7ef83398e1f08472494476d64e3258096329c04ffd686a7a1853b40be2166af
+TxId:       168b08011236050dc54d8150b8049704e15c197064238dbdbcd92339b9b861ed
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840e8951d9b2f1352ea0fae400c4403b273d93f...
+              Signature: 5840d1bcdbe67d79cf7e9c3512b1903b007266e1...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: d89cdcfe5f3223851d2bdf42bba7ad5ecd280444f6459ba955965c1f
+  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
   Value:
     Ada:      Lovelace:  60
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d89cdcfe5f3223851d2bdf42bba7ad5ecd280444f6459ba955965c1f
+  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       5f98a69732e572603284017d03f501c644ae1fc525e56625370c24e018e4ece7
-Fee:        Ada:      Lovelace:  6256
+TxId:       674124e6dd62b5bdc4fd7341ef4ba6d7fcd27ae504163cc95697a9e469f04250
+Fee:        Ada:      Lovelace:  6462
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840dcf9ffd45e7f7a13360901a20d34e22770ed...
+              Signature: 58409428cfbd69233a151258ed184aaee2f32e70...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -191,23 +191,23 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: d89cdcfe5f3223851d2bdf42bba7ad5ecd280444f6459ba955965c1f
+  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     b7ef83398e1f08472494476d64e3258096329c04ffd686a7a1853b40be2166af
+    Tx:     168b08011236050dc54d8150b8049704e15c197064238dbdbcd92339b9b861ed
     Output #1
-    Script: 5913100100003323322323233322233322233333...
+    Script: 5913ac0100003323232332233223332223232323...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99993754
+    Ada:      Lovelace:  99993548
 
   ---- Output 1 ----
-  Destination:  Script: d89cdcfe5f3223851d2bdf42bba7ad5ecd280444f6459ba955965c1f
+  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
   Value:
     Ada:      Lovelace:  50
 
@@ -215,7 +215,7 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99993754
+    Ada:      Lovelace:  99993548
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -253,6 +253,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: d89cdcfe5f3223851d2bdf42bba7ad5ecd280444f6459ba955965c1f
+  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
We have it, we might as well use it. In particular, this will give
`Value` a better encoding.

I am going to try and sneak this into the release.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
