### PR TITLE
Add buildable flag

### DIFF
--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -18,6 +18,10 @@ source-repository head
     type: git
     location: https://github.com/input-output-hk/plutus
 
+Flag buildable
+  Description:   Whether this package is buildable
+  Default:       True
+
 common lang
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables
@@ -125,6 +129,9 @@ library
     if flag(defer-plugin-errors)
         ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
+    if !flag(buildable)
+        buildable:          False
+
 test-suite plutus-ledger-test
     type: exitcode-stdio-1.0
     main-is: Spec.hs
@@ -146,3 +153,6 @@ test-suite plutus-ledger-test
         aeson -any,
         plutus-core -any,
         plutus-tx-plugin -any
+
+    if !flag(buildable)
+        buildable:          False

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -18,6 +18,10 @@ source-repository head
     type: git
     location: https://github.com/input-output-hk/plutus
 
+Flag buildable
+  Description:   Whether this package is buildable
+  Default:       True
+
 common lang
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables
@@ -66,6 +70,9 @@ library
         transformers -any,
         plutus-tx -any
 
+  if !flag(buildable)
+    buildable:          False
+
 test-suite plutus-tx-tests
     type: exitcode-stdio-1.0
     hs-source-dirs: test
@@ -111,3 +118,6 @@ test-suite plutus-tx-tests
     -- NOTE: -g makes the plugin give better errors
     -- NOTE: we disable the simplifier as it simplifies away some tests
     ghc-options: -g -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0
+
+  if !flag(buildable)
+    buildable:          False


### PR DESCRIPTION
Add buildable flag to packages that involve plugins.

This will be used in downstream projects to mark these packages as non-buildable when cross-compiling for Windows because plugins to not make sense in that build environment.