### PR TITLE
Marlowe Playground Client - Disable link to actus labs

### DIFF
--- a/marlowe-playground-client/src/MainFrame/View.purs
+++ b/marlowe-playground-client/src/MainFrame/View.purs
@@ -43,7 +43,8 @@ render state =
               , projectTitle
               , div_
                   [ a [ href "./doc/marlowe/tutorials/index.html", target "_blank", classNames [ "font-semibold" ] ] [ text "Tutorial" ]
-                  , a [ onClick $ const $ Just $ ChangeView ActusBlocklyEditor, classNames [ "ml-medium", "font-semibold" ] ] [ text "Actus Labs" ]
+                  -- Link disabled as the Actus labs is not working properly. Future plans might include moving this functionality to Marlowe run
+                  -- , a [ onClick $ const $ Just $ ChangeView ActusBlocklyEditor, classNames [ "ml-medium", "font-semibold" ] ] [ text "Actus Labs" ]
                   ]
               ]
           , topBar


### PR DESCRIPTION
The current implementation is broken and the plan is to integrate that functionality as a dynamic form in Marlowe Run/Marketplace instead of a Blockly interface in the playground. For now disabling, we can remove the code in a future PR (which will eliminate some libraries dependencies as well).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
