### PR TITLE
fundsAtAddressCondition await on utxos updates 

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -344,11 +344,10 @@ fundsAtAddressCondition
 fundsAtAddressCondition condition addr = loopM go () where
     go () = do
         cur <- utxoAt addr
-        sl <- currentSlot
         let presentVal = foldMap (txOutValue . txOutTxOut) cur
         if condition presentVal
             then pure (Right cur)
-            else awaitSlot (sl + 1) >> pure (Left ())
+            else awaitUtxoProduced addr >> pure (Left ())
 
 -- | Watch an address for changes, and return the outputs
 --   at that address when the total value at the address


### PR DESCRIPTION
instead of polling on every slot. 

This is already an improvement as is, but ideally this would block until the condition is met instead of poll on utxos changes alone

This was first encountered on #3526 where an endpoint should only be exposed after an address has been given funds, but given the original polling behavior of fundsAtAddressCondition that had to receive responses of the current slot in order to poll until the next one it ended preventing the other endpoint of funding the address from being exposed

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
