### PR TITLE
plutus-playground: Redirect to index after github auth

### DIFF
--- a/plutus-playground-client/default.nix
+++ b/plutus-playground-client/default.nix
@@ -47,7 +47,7 @@ let
 
     export FRONTEND_URL=https://localhost:8009
     export WEBGHC_URL=http://localhost:8080
-    export GITHUB_CALLBACK_PATH=https://localhost:8009/api/oauth/github/callback
+    export GITHUB_CALLBACK_PATH=/
 
     ${build-playground-exe}/bin/plutus-playground-server webserver "$@"
   '';


### PR DESCRIPTION
instead of redirecting again back to the callback endpoint in development.

related to #2792 

The variable name may be misleading, but it only comes into play for
redirecting once the github auth workflow is finalized and an access
token has been made available. I didn't update the name just yet as
this might run into variables that are behind aws

The actual callback endpoint is set by
https://github.com/input-output-hk/plutus/blob/e84acdf6ec4998b2a82a2d404bfca14fa42adc37/playground-common/src/Auth.hs#L127
which is always set to "/api/oauth/github/callback" as expected by the
plutus github oauth applications.

@shlevy in order to fix #2792 that seems like would require also updating deployment secrets for `GITHUB_CALLBACK_PATH` for staging and others that I don't have access to where they live.  Marking you as reviewer since I've seen you working on deployment bits lately :)

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
