### PR TITLE
Explicitly include pkg-config in devcontainer

### DIFF
--- a/nix/devcontainer/plutus-devcontainer.nix
+++ b/nix/devcontainer/plutus-devcontainer.nix
@@ -23,6 +23,7 @@ pkgs.callPackage (import ./devcontainer.nix) {
     plutus.haskell-language-server
     plutus.cabal-install
     pkgs.binutils
+    pkgs.pkg-config
   ];
   extraCommands = ''
     # Put the environment stuff somewhere convenient


### PR DESCRIPTION
In order to fix `haskell-language-server` when used from `devcontainer` when it's trying to build `cardano-crypto-class`

I ran into this while working on a fix for #3454 

--

original issue after the lastest container bump https://github.com/input-output-hk/plutus-starter/pull/26
![image (1)](https://user-images.githubusercontent.com/817138/130848334-42d94e92-36eb-4d30-8817-ba972164fcc0.png)

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
