### PR TITLE
SCP-2592 - Marlowe Web Commons - Fix problem with semantic payments

### DIFF
--- a/web-common-marlowe/src/Marlowe/Semantics.purs
+++ b/web-common-marlowe/src/Marlowe/Semantics.purs
@@ -1406,7 +1406,7 @@ giveMoney accountId payee token@(Token cur tok) amount accounts =
       Party _ -> accounts
       Account accId -> addMoneyToAccount accId token amount accounts
   in
-    Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
+    Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) newAccounts
 
 -- | Carry a step of the contract with no inputs
 reduceContractStep :: Environment -> State -> Contract -> ReduceStepResult


### PR DESCRIPTION
This PR fixes bug 2592. When we made a Payment from one account to the other, the payment was not being registered, as the following screenshot shows

![Screen Shot 2021-08-25 at 17 04 43](https://user-images.githubusercontent.com/2634059/130857498-81160ab0-daa5-4381-a393-ce12465eebe3.png)

It was a translation problem from Semantic.hs to Semantic.purs in the `giveMoney` function, which was using the old accounts instead of the new one. 

![Screen Shot 2021-08-25 at 17 08 47](https://user-images.githubusercontent.com/2634059/130857944-f6a1cbe7-025d-43b3-a718-e61bfdb4e98c.png)

Now the balances are correctly shown

![Screen Shot 2021-08-25 at 17 05 28](https://user-images.githubusercontent.com/2634059/130858271-0b66d821-d8f2-4c0d-aff0-e43439447133.png)

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
