### PR TITLE
builtin lists and data experiment

### DIFF
--- a/plutus-metatheory/src/Builtin/Constant/Term.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/Term.lagda.md
@@ -5,10 +5,9 @@ open import Utils hiding (TermCon)
 
 ```
 module Builtin.Constant.Term
-  (Ctx⋆ Kind : Set)
-  (* : Kind)
+  (Ctx⋆ : Set)
   (_⊢⋆_ : Ctx⋆ → Kind → Set)
-  (con : ∀{Φ} → TyCon Ctx⋆ (_⊢⋆ *) Φ → Φ ⊢⋆ *)
+  (con : ∀{Φ} → TyCon Ctx⋆ (_⊢⋆_) Φ * → Φ ⊢⋆ *)
   where
 
 open import Builtin

--- a/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
@@ -10,8 +10,9 @@ The postulated operations are in this module because it is not
 parameterised. They could also be placed elsewhere.
 
 ```
+open import Utils
 module Builtin.Constant.Type
-  (Con : Set)(Ty : Con → Set) where
+  (Con : Set)(Ty : Con → Kind → Set) where
 ```
 
 ## Imports
@@ -24,13 +25,11 @@ open import Data.Integer using (ℤ;-_;+≤+;-≤+;-≤-;_<_;_>_;_≤?_;_<?_;_�
 open import Data.Unit using (⊤)
 open import Data.Bool using (Bool)
 open import Data.Product
-open import Relation.Binary
 open import Data.Nat using (ℕ;_*_;z≤n;s≤s;zero;suc)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
 open import Function
 
-open import Utils
 ```
 
 ## Type constants
@@ -38,15 +37,17 @@ open import Utils
 We have six base types referred to as type constants:
 
 ```
-data TyCon (Φ : Con) : Set where
-  integer    : TyCon Φ
-  bytestring : TyCon Φ
-  string     : TyCon Φ
-  unit       : TyCon Φ
-  bool       : TyCon Φ
-  list       : Ty Φ → TyCon Φ
-  pair       : Ty Φ → Ty Φ → TyCon Φ
-  Data       : TyCon Φ
+data TyCon (Φ : Con) : Kind → Set where
+  integer    : TyCon Φ *
+  bytestring : TyCon Φ *
+  string     : TyCon Φ *
+  unit       : TyCon Φ *
+  bool       : TyCon Φ *
+  protolist  : TyCon Φ (* ⇒ *)
+  protopair  : TyCon Φ (* ⇒ (* ⇒ *))
+  Data       : TyCon Φ *
+  apply      : ∀{K J} → TyCon Φ (K ⇒ J) → TyCon Φ K → TyCon Φ J
+
 
 
 --{-# FOREIGN GHC {-# LANGUAGE GADTs, PatternSynonyms #-}                #-}

--- a/plutus-metatheory/src/Declarative.lagda.md
+++ b/plutus-metatheory/src/Declarative.lagda.md
@@ -16,7 +16,7 @@ open import Type.Equality
 open import Builtin
 open import Utils hiding (TermCon)
 open import Builtin.Constant.Type
-open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con
+open import Builtin.Constant.Term Ctx⋆ _⊢⋆_ con
 
 open import Relation.Binary.PropositionalEquality
   hiding ([_]) renaming (subst to substEq)

--- a/plutus-metatheory/src/Declarative/Erasure.lagda.md
+++ b/plutus-metatheory/src/Declarative/Erasure.lagda.md
@@ -22,7 +22,7 @@ open import Type
 open import Declarative
 open import Builtin hiding (length)
 open import Utils
-open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con
+open import Builtin.Constant.Term Ctx⋆ _⊢⋆_ con
   renaming (TermCon to TyTermCon)
 
 open import Data.Nat.Properties

--- a/plutus-metatheory/src/Declarative/Examples/StdLib/ChurchNat.lagda
+++ b/plutus-metatheory/src/Declarative/Examples/StdLib/ChurchNat.lagda
@@ -7,7 +7,7 @@ open import Utils
 open import Type
 open import Declarative
 open import Builtin
-open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con
+open import Builtin.Constant.Term Ctx⋆ _⊢⋆_ con
 
 open import Data.Unit
 \end{code}

--- a/plutus-metatheory/src/Declarative/RenamingSubstitution.lagda.md
+++ b/plutus-metatheory/src/Declarative/RenamingSubstitution.lagda.md
@@ -21,7 +21,7 @@ open import Utils hiding (TermCon)
 open import Type
 import Type.RenamingSubstitution as ⋆
 open import Type.Equality
-open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con
+open import Builtin.Constant.Term Ctx⋆ _⊢⋆_ con
 open import Declarative
 ```
 

--- a/plutus-metatheory/src/Raw.lagda
+++ b/plutus-metatheory/src/Raw.lagda
@@ -22,7 +22,6 @@ The raw un-scope-checked and un-type-checked syntax
 
 \begin{code}
 data RawTy : Set
-open import Builtin.Constant.Type ⊤ (λ _ → RawTy)
 
 data RawTyCon : Set
 
@@ -45,8 +44,9 @@ data RawTyCon where
   string     : RawTyCon
   unit       : RawTyCon
   bool       : RawTyCon
-  list       : RawTy → RawTyCon
-  pair       : RawTy → RawTy → RawTyCon
+  protolist  : RawTyCon
+  protopair  : RawTyCon
+  apply      : RawTyCon → RawTyCon → RawTyCon
   Data       : RawTyCon
 
 {-# COMPILE GHC RawTyCon = data RTyCon (RTyConInt | RTyConBS | RTyConStr | RTyConUnit | RTyConBool | RTyConList | RTyConPair | RTyConData) #-}

--- a/plutus-metatheory/src/Type.lagda.md
+++ b/plutus-metatheory/src/Type.lagda.md
@@ -85,7 +85,7 @@ open import Data.String
 
 data _⊢⋆_ : Ctx⋆ → Kind → Set
 
-open import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢⋆_)
 
 data _⊢⋆_ where
   ` : Φ ∋⋆ J
@@ -115,7 +115,7 @@ data _⊢⋆_ where
       ---------------------
     → Φ ⊢⋆ *
 
-  con : TyCon Φ
+  con : TyCon Φ *
         ------
       → Φ ⊢⋆ *
 ```

--- a/plutus-metatheory/src/Type/BetaNBE.lagda
+++ b/plutus-metatheory/src/Type/BetaNBE.lagda
@@ -10,8 +10,8 @@ open import Type
 open import Type.BetaNormal
 open import Type.RenamingSubstitution
 open import Type.Equality
-import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *) as Syn
-import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆ *) as Nf
+import Builtin.Constant.Type Ctx⋆ (_⊢⋆_) as Syn
+import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆_) as Nf
 
 open import Function
 open import Data.Sum
@@ -126,16 +126,17 @@ reifying.
 
 \begin{code}
 eval : ∀{Φ Ψ K} → Ψ ⊢⋆ K → Env Ψ Φ → Val Φ K
-evalTyCon : ∀{Φ Ψ} → Syn.TyCon Ψ → Env Ψ Φ → Nf.TyCon Φ
+evalTyCon : ∀{K Φ Ψ} → Syn.TyCon Ψ K → Env Ψ Φ → Nf.TyCon Φ K
 
-evalTyCon Syn.integer    η = Nf.integer
-evalTyCon Syn.bytestring η = Nf.bytestring
-evalTyCon Syn.string     η = Nf.string
-evalTyCon Syn.unit       η = Nf.unit
-evalTyCon Syn.bool       η = Nf.bool
-evalTyCon (Syn.list A)   η = Nf.list (eval A η)
-evalTyCon (Syn.pair A B) η = Nf.pair (eval A η) (eval B η)
-evalTyCon Syn.Data       η = Nf.Data
+evalTyCon Syn.integer     η = Nf.integer
+evalTyCon Syn.bytestring  η = Nf.bytestring
+evalTyCon Syn.string      η = Nf.string
+evalTyCon Syn.unit        η = Nf.unit
+evalTyCon Syn.bool        η = Nf.bool
+evalTyCon Syn.protolist   η = Nf.protolist
+evalTyCon Syn.protopair   η = Nf.protopair
+evalTyCon Syn.Data        η = Nf.Data
+evalTyCon (Syn.apply A B) η = Nf.apply (evalTyCon A η) (evalTyCon B η)
 
 eval (` α)   η = η α
 eval (Π B)   η = Π (reify (eval B (exte η)))

--- a/plutus-metatheory/src/Type/BetaNBE/Completeness.lagda
+++ b/plutus-metatheory/src/Type/BetaNBE/Completeness.lagda
@@ -10,8 +10,8 @@ open import Type.RenamingSubstitution
 open import Type.BetaNormal
 open import Type.BetaNBE
 open import Type.BetaNormal.Equality
-import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *) as Syn
-import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆ *) as Nf
+import Builtin.Constant.Type Ctx⋆ (_⊢⋆_) as Syn
+import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆_) as Nf
 
 open import Relation.Binary.PropositionalEquality hiding (subst)
 open import Data.Sum
@@ -277,9 +277,9 @@ idext : ∀{K}{η η' : Env Φ Ψ}
     ---------------------------
   → CR K (eval t η) (eval t η')
 
-idextTyCon : ∀{Φ Ψ}{η η' : Env Φ Ψ}
+idextTyCon : ∀{K Φ Ψ}{η η' : Env Φ Ψ}
   → EnvCR η η'
-  → (c : Syn.TyCon Φ)
+  → (c : Syn.TyCon Φ K)
     ------------------------------
   → evalTyCon c η ≡ evalTyCon c η'
 idextTyCon p Syn.integer    = refl
@@ -287,8 +287,9 @@ idextTyCon p Syn.bytestring = refl
 idextTyCon p Syn.string     = refl
 idextTyCon p Syn.unit       = refl
 idextTyCon p Syn.bool       = refl
-idextTyCon p (Syn.list A)   = cong Nf.list (idext p A)
-idextTyCon p (Syn.pair A B) = cong₂ Nf.pair (idext p A) (idext p B)
+idextTyCon p Syn.protolist  = refl
+idextTyCon p Syn.protopair  = refl
+idextTyCon p (Syn.apply A B) = refl -- cong₂ Nf.apply (idext p A) (idext p B)
 idextTyCon p Syn.Data       = refl
 
 renVal-eval : ∀{Φ Ψ Θ K}
@@ -300,7 +301,7 @@ renVal-eval : ∀{Φ Ψ Θ K}
   → CR K (renVal ρ (eval t η)) (eval t (renVal ρ ∘ η'))
 
 renValTyCon-eval : 
-    (c : Syn.TyCon Ψ)
+    ∀{K}(c : Syn.TyCon Ψ K)
   → {η η' : Env Ψ Φ}
   → (p : EnvCR η η')
   → (ρ : Ren Φ Θ )
@@ -311,9 +312,9 @@ renValTyCon-eval Syn.bytestring p ρ = refl
 renValTyCon-eval Syn.string     p ρ = refl
 renValTyCon-eval Syn.unit       p ρ = refl
 renValTyCon-eval Syn.bool       p ρ = refl
-renValTyCon-eval (Syn.list A)   p ρ = cong Nf.list (renVal-eval A p ρ)
-renValTyCon-eval (Syn.pair A B) p ρ =
-  cong₂ Nf.pair (renVal-eval A p ρ) (renVal-eval B p ρ) 
+renValTyCon-eval Syn.protolist      p ρ = refl -- cong Nf.list (renVal-eval A p ρ)
+renValTyCon-eval Syn.protopair      p ρ = refl
+renValTyCon-eval (Syn.apply A B)    p ρ = cong₂ Nf.apply (renValTyCon-eval A p ρ) (renValTyCon-eval B p ρ) 
 renValTyCon-eval Syn.Data       p ρ = refl
 
 idext p (` x) = p x
@@ -389,7 +390,7 @@ ren-eval :
   CR K (eval (ren ρ t) η) (eval t (η' ∘ ρ))
 
 renTyCon-eval :
-  (c : Syn.TyCon Θ)
+  ∀{K}(c : Syn.TyCon Θ K)
   {η η' : Env Ψ Φ}
   (p : EnvCR η η')
   (ρ : Ren Θ Ψ) →
@@ -400,9 +401,9 @@ renTyCon-eval Syn.bytestring p ρ = refl
 renTyCon-eval Syn.string     p ρ = refl
 renTyCon-eval Syn.unit       p ρ = refl
 renTyCon-eval Syn.bool       p ρ = refl
-renTyCon-eval (Syn.list A)   p ρ = cong Nf.list (ren-eval A p ρ)
-renTyCon-eval (Syn.pair A B) p ρ =
-  cong₂ Nf.pair (ren-eval A p ρ) (ren-eval B p ρ) 
+renTyCon-eval Syn.protolist p ρ = refl
+renTyCon-eval Syn.protopair p ρ =  refl
+renTyCon-eval (Syn.apply A B) p ρ = cong₂ Nf.apply (renTyCon-eval A p ρ) (renTyCon-eval B p ρ) 
 renTyCon-eval Syn.Data       p ρ = refl
 
 ren-eval (` x) p ρ = p (ρ x)
@@ -450,7 +451,7 @@ sub-eval :
   CR K (eval (sub σ t) η) (eval t (λ x → eval (σ x) η'))
 
 subTyCon-eval :
-  (c : Syn.TyCon Θ)
+  (c : Syn.TyCon Θ K)
   {η η' : Env Ψ Φ}
   (p : EnvCR η η')
   (σ : Sub Θ Ψ) →
@@ -461,9 +462,9 @@ subTyCon-eval Syn.bytestring p ρ = refl
 subTyCon-eval Syn.string     p ρ = refl
 subTyCon-eval Syn.unit       p ρ = refl
 subTyCon-eval Syn.bool       p ρ = refl
-subTyCon-eval (Syn.list A)   p ρ = cong Nf.list (sub-eval A p ρ)
-subTyCon-eval (Syn.pair A B) p ρ =
-  cong₂ Nf.pair (sub-eval A p ρ) (sub-eval B p ρ) 
+subTyCon-eval Syn.protolist       p ρ = refl
+subTyCon-eval Syn.protopair p ρ = refl
+subTyCon-eval (Syn.apply A B) p ρ = cong₂ Nf.apply (subTyCon-eval A p ρ) (subTyCon-eval B p ρ) 
 subTyCon-eval Syn.Data       p ρ = refl
 
 sub-eval (` x)      p σ = idext p (σ x)
@@ -518,13 +519,12 @@ fund : {η η' : Env Φ Ψ}
 
 fundTyCon : {η η' : Env Φ Ψ}
           → EnvCR η η'
-          → {c c' : Syn.TyCon Φ}
+          → {c c' : Syn.TyCon Φ K}
           → c ≡βTyCon c'
             -------------------------------
           → evalTyCon c η ≡ evalTyCon c' η'
 fundTyCon p (refl≡β c) = idextTyCon p c
-fundTyCon p (list≡β A) = cong Nf.list (fund p A)
-fundTyCon p (pair≡β A B) = cong₂ Nf.pair (fund p A) (fund p B) 
+fundTyCon p (apply≡β A B) = cong₂ Nf.apply (fundTyCon p A) (fundTyCon p B) 
 
 fund p (refl≡β A)          = idext p A
 fund p (sym≡β q)           = symCR (fund (symCR ∘ p) q)

--- a/plutus-metatheory/src/Type/BetaNBE/Soundness.lagda
+++ b/plutus-metatheory/src/Type/BetaNBE/Soundness.lagda
@@ -9,7 +9,7 @@ open import Type.Equality
 open import Type.RenamingSubstitution
 open import Type.BetaNormal
 open import Type.BetaNBE
-import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *) as Syn
+import Builtin.Constant.Type Ctx⋆ (_⊢⋆_) as Syn
 
 open import Relation.Binary.PropositionalEquality
   renaming (subst to substEq)
@@ -182,7 +182,7 @@ evalSR : ∀{Φ Ψ K}(A : Φ ⊢⋆ K){σ : Sub Φ Ψ}{η : Env Φ Ψ}
   → SREnv σ η
   → SR K (sub σ A) (eval A η)
 
-evalSRTyCon : ∀{Φ Ψ}(c : Syn.TyCon Φ){σ : Sub Φ Ψ}{η : Env Φ Ψ}
+evalSRTyCon : ∀{K Φ Ψ}(c : Syn.TyCon Φ K){σ : Sub Φ Ψ}{η : Env Φ Ψ}
   → SREnv σ η
   → subTyCon σ c ≡βTyCon embNfTyCon (evalTyCon c η)
 evalSRTyCon Syn.integer p = refl≡β _
@@ -190,8 +190,10 @@ evalSRTyCon Syn.bytestring p = refl≡β _
 evalSRTyCon Syn.string p = refl≡β _
 evalSRTyCon Syn.unit p = refl≡β _
 evalSRTyCon Syn.bool p = refl≡β _
-evalSRTyCon (Syn.list A) p = list≡β (evalSR A p)
-evalSRTyCon (Syn.pair A B) p = pair≡β (evalSR A p) (evalSR B p)
+evalSRTyCon Syn.protolist p = refl≡β _
+evalSRTyCon Syn.protopair p = refl≡β _
+evalSRTyCon (Syn.apply A B) p = apply≡β (evalSRTyCon A p) (evalSRTyCon B p)
+
 evalSRTyCon Syn.Data p = refl≡β _
 
 

--- a/plutus-metatheory/src/Type/BetaNBE/Stability.lagda
+++ b/plutus-metatheory/src/Type/BetaNBE/Stability.lagda
@@ -9,7 +9,7 @@ open import Type.BetaNormal
 open import Type.BetaNormal.Equality
 open import Type.BetaNBE
 open import Type.BetaNBE.Completeness
-open import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆_)
 
 open import Relation.Binary.PropositionalEquality
 open import Function
@@ -23,14 +23,15 @@ perturb the expression.
 
 \begin{code}
 stability : ∀{K}(n : Φ ⊢Nf⋆ K) → nf (embNf n) ≡ n
-stabilityTyCon : (c : TyCon Φ) → evalTyCon (embNfTyCon c) (idEnv _) ≡ c
+stabilityTyCon : ∀{K}(c : TyCon Φ K) → evalTyCon (embNfTyCon c) (idEnv _) ≡ c
 stabilityTyCon integer    = refl
 stabilityTyCon bytestring = refl
 stabilityTyCon string     = refl
 stabilityTyCon unit       = refl
 stabilityTyCon bool       = refl
-stabilityTyCon (list A)   = cong list (stability A)
-stabilityTyCon (pair A B) = cong₂ pair (stability A) (stability B)
+stabilityTyCon protolist = refl
+stabilityTyCon protopair = refl
+stabilityTyCon (apply A B) = cong₂ apply (stabilityTyCon A) (stabilityTyCon B)
 stabilityTyCon Data       = refl
 
 stabilityNe : (n : Φ ⊢Ne⋆ K) → CR K (eval (embNe n) (idEnv _)) (reflect n)

--- a/plutus-metatheory/src/Type/BetaNormal/Equality.lagda.md
+++ b/plutus-metatheory/src/Type/BetaNormal/Equality.lagda.md
@@ -8,7 +8,7 @@ open import Type
 open import Type.Equality
 open import Type.BetaNormal
 open import Type.RenamingSubstitution
-open import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢Nf⋆_)
 
 open import Function
 open import Relation.Binary.PropositionalEquality
@@ -23,7 +23,7 @@ renNf-cong : {f g : Ren Φ Ψ}
 
 renNfTyCon-cong : {f g : Ren Φ Ψ}
                 → (∀ {J}(α : Φ ∋⋆ J) → f α ≡ g α)
-                → (c : TyCon Φ)
+                → ∀{K}(c : TyCon Φ K)
                   -------------------------------
                 → renNfTyCon f c ≡ renNfTyCon g c
 renNfTyCon-cong p integer    = refl
@@ -31,8 +31,9 @@ renNfTyCon-cong p bytestring = refl
 renNfTyCon-cong p string     = refl
 renNfTyCon-cong p unit       = refl
 renNfTyCon-cong p bool       = refl
-renNfTyCon-cong p (list A)   = cong list (renNf-cong p A) 
-renNfTyCon-cong p (pair A B) = cong₂ pair (renNf-cong p A) (renNf-cong p B)
+renNfTyCon-cong p protolist  = refl 
+renNfTyCon-cong p protopair  = refl
+renNfTyCon-cong p (apply A B) = cong₂ apply (renNfTyCon-cong p A) (renNfTyCon-cong p B)
 renNfTyCon-cong p Data       = refl
 
 
@@ -58,7 +59,7 @@ renNf-id : (n : Φ ⊢Nf⋆ J)
            --------------
          → renNf id n ≡ n
 
-renNfTyCon-id : (c : TyCon Φ)
+renNfTyCon-id : ∀{K}(c : TyCon Φ K)
            --------------
          → renNfTyCon id c ≡ c
 renNfTyCon-id integer    = refl
@@ -66,8 +67,9 @@ renNfTyCon-id bytestring = refl
 renNfTyCon-id string     = refl
 renNfTyCon-id unit       = refl
 renNfTyCon-id bool       = refl
-renNfTyCon-id (list A)   = cong list (renNf-id A) 
-renNfTyCon-id (pair A B) = cong₂ pair (renNf-id A) (renNf-id B)
+renNfTyCon-id protolist  = refl
+renNfTyCon-id protopair  = refl
+renNfTyCon-id (apply A B) = cong₂ apply (renNfTyCon-id A) (renNfTyCon-id B)
 renNfTyCon-id Data       = refl
 
 renNe-id : (n : Φ ⊢Ne⋆ J)
@@ -94,7 +96,7 @@ renNf-comp : {g : Ren Φ Ψ}
 
 renNfTyCon-comp : {g : Ren Φ Ψ}
                 → {f : Ren Ψ Θ}
-                → (c : TyCon Φ)
+                → ∀{K}(c : TyCon Φ K)
                   -------------------------------------
                 → renNfTyCon (f ∘ g) c ≡ renNfTyCon f (renNfTyCon g c)
 renNfTyCon-comp integer    = refl
@@ -102,8 +104,9 @@ renNfTyCon-comp bytestring = refl
 renNfTyCon-comp string     = refl
 renNfTyCon-comp unit       = refl
 renNfTyCon-comp bool       = refl
-renNfTyCon-comp (list A)   = cong list (renNf-comp A) 
-renNfTyCon-comp (pair A B) = cong₂ pair (renNf-comp A) (renNf-comp B)
+renNfTyCon-comp protolist  = refl
+renNfTyCon-comp protopair  = refl --
+renNfTyCon-comp {g = g}{f}(apply A B) = cong₂ apply (renNfTyCon-comp {g = g}{f} A) (renNfTyCon-comp {g = g}{f} B)
 renNfTyCon-comp Data       = refl
 
 renNe-comp : {g : Ren Φ Ψ}
@@ -116,9 +119,8 @@ renNf-comp (Π B)   = cong Π (trans (renNf-cong ext-comp B) (renNf-comp B))
 renNf-comp (A ⇒ B) = cong₂ _⇒_ (renNf-comp A) (renNf-comp B)
 renNf-comp (ƛ A)   = cong ƛ (trans (renNf-cong ext-comp A) (renNf-comp A))
 renNf-comp (ne A)  = cong ne (renNe-comp A)
-renNf-comp (con c) = cong con (renNfTyCon-comp c)
+renNf-comp {g = g}{f}(con c) = cong con (renNfTyCon-comp {g = g}{f} c)
 renNf-comp (μ A B) = cong₂ μ (renNf-comp A) (renNf-comp B)
-
 renNe-comp (` x)   = refl
 renNe-comp (A · B) = cong₂ _·_ (renNe-comp A) (renNf-comp B)
 ```

--- a/plutus-metatheory/src/Type/Equality.lagda.md
+++ b/plutus-metatheory/src/Type/Equality.lagda.md
@@ -19,7 +19,7 @@ infix  1 _≡β_
 open import Utils
 open import Type
 open import Type.RenamingSubstitution
-open import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢⋆_)
 
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; cong; cong₂; trans; sym)
@@ -38,19 +38,17 @@ application.
 
 ```
 data _≡β_ : Φ ⊢⋆ J → Φ ⊢⋆ J → Set
-data _≡βTyCon_ : TyCon Φ → TyCon Φ → Set where
-  refl≡β : (c : TyCon Φ)
+data _≡βTyCon_ : ∀{K} → TyCon Φ K → TyCon Φ K → Set where
+  refl≡β : (c : TyCon Φ K)
            ------------
          → c ≡βTyCon c
 
-  list≡β : A ≡β A'
+  apply≡β : ∀{Φ K J}{A A' : TyCon Φ (K ⇒ J)}
+         → A ≡βTyCon A'
+         → {B B' : TyCon Φ K}
+         → B ≡βTyCon B'
            ----------------------
-         → list A ≡βTyCon list A'
-
-  pair≡β : A ≡β A'
-         → B ≡β B'
-           ----------------------
-         → pair A B ≡βTyCon pair A' B'
+         → apply A B ≡βTyCon apply A' B'
 
 data _≡β_ where
 
@@ -96,7 +94,7 @@ data _≡β_ where
         ----------------
       → μ A B ≡β μ A' B'
 
-  con≡β : ∀{c c' : TyCon Φ}
+  con≡β : ∀{c c' : TyCon Φ *}
         → c ≡βTyCon c'
           -----------
         → con c ≡β con c'
@@ -124,13 +122,12 @@ ren≡β : (ρ : Ren Φ Ψ)
       → ren ρ A ≡β ren ρ B
 
 ren≡βTyCon : (ρ : Ren Φ Ψ)
-      → ∀{c c'}
+      → ∀{c c' : TyCon Φ K}
       → c ≡βTyCon c'
         ------------------
       → renTyCon ρ c ≡βTyCon renTyCon ρ c'
 ren≡βTyCon ρ (refl≡β _)   = refl≡β _
-ren≡βTyCon ρ (list≡β p)   = list≡β (ren≡β ρ p)
-ren≡βTyCon ρ (pair≡β p q) = pair≡β (ren≡β ρ p) (ren≡β ρ q)
+ren≡βTyCon ρ (apply≡β p q) = apply≡β (ren≡βTyCon ρ p) (ren≡βTyCon ρ q)
 
 ren≡β ρ (refl≡β A)    = refl≡β (ren ρ A)
 ren≡β ρ (sym≡β p)     = sym≡β (ren≡β ρ p)
@@ -157,13 +154,12 @@ sub≡β : (σ : Sub Φ Ψ)
       → sub σ A ≡β sub σ B
 
 sub≡βTyCon : (σ : Sub Φ Ψ)
-      → ∀{c c'}
+      → ∀{c c' : TyCon Φ K}
       → c ≡βTyCon c'
         ------------------
       → subTyCon σ c ≡βTyCon subTyCon σ c'
 sub≡βTyCon σ (refl≡β _)   = refl≡β _
-sub≡βTyCon σ (list≡β p)   = list≡β (sub≡β σ p)
-sub≡βTyCon σ (pair≡β p q) = pair≡β (sub≡β σ p) (sub≡β σ q)
+sub≡βTyCon σ (apply≡β p q) = apply≡β (sub≡βTyCon σ p) (sub≡βTyCon σ q)
 
 sub≡β σ (refl≡β A)    = refl≡β (sub σ A)
 sub≡β σ (sym≡β p)     = sym≡β (sub≡β σ p)
@@ -178,6 +174,6 @@ sub≡β σ (β≡β B A)     = trans≡β
   (≡2β (trans (trans (sym (sub-comp B))
                      (sub-cong (sub-sub-cons σ A) B))
               (sub-comp B)))
-sub≡β ρ (con≡β p) = con≡β (sub≡βTyCon ρ p)       
+sub≡β ρ (con≡β p) = con≡β (sub≡βTyCon ρ p)
 ```
 

--- a/plutus-metatheory/src/Type/ReductionC.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionC.lagda.md
@@ -23,7 +23,7 @@ version does full normalisation.
 open import Utils hiding (lem0)
 open import Type
 open import Type.RenamingSubstitution
-open import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢⋆_)
 open import Relation.Nullary
 open import Data.Product hiding (∃!)
 open import Data.Empty
@@ -54,7 +54,7 @@ data Value⋆ : ∅ ⊢⋆ J → Set where
         -----------------
       → Value⋆ (ƛ N)
 
-  V-con : (tcn : TyCon ∅)
+  V-con : (tcn : TyCon ∅ *)
           ----------------
         → Value⋆ (con tcn)
 

--- a/plutus-metatheory/src/Type/ReductionS.lagda.md
+++ b/plutus-metatheory/src/Type/ReductionS.lagda.md
@@ -22,7 +22,7 @@ version does full normalisation.
 open import Utils
 open import Type
 open import Type.RenamingSubstitution
-open import Builtin.Constant.Type Ctx⋆ (_⊢⋆ *)
+open import Builtin.Constant.Type Ctx⋆ (_⊢⋆_)
 open import Relation.Nullary
 open import Data.Product
 open import Data.Empty
@@ -53,7 +53,7 @@ data Value⋆ : ∅ ⊢⋆ J → Set where
         -----------------
       → Value⋆ (ƛ N)
 
-  V-con : (tcn : TyCon ∅)
+  V-con : (tcn : TyCon ∅ *)
           ----------------
         → Value⋆ (con tcn)
 

--- a/plutus-metatheory/src/Utils.lagda
+++ b/plutus-metatheory/src/Utils.lagda
@@ -191,6 +191,9 @@ postulate ByteString : Set
 {-# COMPILE GHC ByteString = type BS.ByteString #-}
 
 data DATA : Set where
+  constrDATA : I.ℤ → List DATA → DATA
+  mapDATA : List (DATA × DATA) → DATA
+  listDATA : List DATA → DATA
   iDATA : I.ℤ → DATA
   bDATA : ByteString → DATA
 


### PR DESCRIPTION
Currently plutus-metatheory has open type constants that can depend on variables and support for `list a` and `pair a b` where `a` and `b` are variables. `plutus-core` has higher order type constants `list` and `pair` and a special type constant type application operator. This PR is an experiment in extending the open type constants to also be higher order.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
