### PR TITLE
SCP-2716: Add missing values to export tx

### DIFF
--- a/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-contract/src/Plutus/Contract/CardanoAPI.hs
@@ -405,6 +405,7 @@ data ToCardanoError
     | NoDefaultCostModelParams
     | StakingPointersNotSupported
     | MissingTxInType
+    | UnableToResolveInput Api.TxOutRef
     | Tag String ToCardanoError
 
 instance Pretty ToCardanoError where
@@ -416,4 +417,5 @@ instance Pretty ToCardanoError where
     pretty NoDefaultCostModelParams    = "Extracting default cost model failed"
     pretty StakingPointersNotSupported = "Staking pointers are not supported"
     pretty MissingTxInType             = "Missing TxInType"
+    pretty (UnableToResolveInput i)    = "Unable to resolve input" <> colon <+> pretty i
     pretty (Tag t err)                 = pretty t <> colon <+> pretty err


### PR DESCRIPTION
`ExportTx` has a new field `missingValueBalance` indicating the crypto value that needs to be supplied by additional inputs or paid to additional outputs. This information is already contained in the `transaction` field, but it can be helpful to see it directly in the JSON.

Example:

```haskell
{
    "transaction": {
        "cborHex": "84a60081(...)",
        "description": "",
        "type": "Tx AlonzoEra"
    },
    "signatories": [],
    "inputs": [
        {
            "txIn": "8d73f4d4df61b16e5db0debea1c6f7d975b0c68f7c8647aedde730a114f71b9e#2",
            "txOut": {
                "address": "addr1wxfy83f7qgt734ph2m992a063tucwp74psdtefmr5kjzwfc4dlfvg",
                "data": "89c864ada93e78e54c0146da830077d209999197a36f8b172323b705832ad5cf",
                "value": {
                    "lovelace": 101
                }
            }
        }
    ],
    "missing-value": {
        "outputs": {
            "73e56188788f45b176f3f2735be07a12cc466b864da0449a313e7792": {
                "stablecoin": 50
            }
        },
        "inputs": {
            "lovelace": 50
        }
    }
}
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
