### PR TITLE
Reduce the number of `removeDeadBindings` calls

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -42,22 +42,21 @@ instance PLC.HasTypeCheckConfig (PirTCConfig uni fun) uni fun where
     typeCheckConfig = pirConfigTCConfig
 
 data CompilationOpts = CompilationOpts {
-    _coOptimize                         :: Bool
-    , _coPedantic                       :: Bool
-    , _coVerbose                        :: Bool
-    , _coDebug                          :: Bool
-    , _coMaxSimplifierIterations        :: Int
+    _coOptimize                   :: Bool
+    , _coPedantic                 :: Bool
+    , _coVerbose                  :: Bool
+    , _coDebug                    :: Bool
+    , _coMaxSimplifierIterations  :: Int
     -- Simplifier passes
-    , _coDoSimplifierUnwrapCancel       :: Bool
-    , _coDoSimplifierBeta               :: Bool
-    , _coDoSimplifierInline             :: Bool
-    , _coDoSimplifierRemoveDeadBindings :: Bool
+    , _coDoSimplifierUnwrapCancel :: Bool
+    , _coDoSimplifierBeta         :: Bool
+    , _coDoSimplifierInline       :: Bool
     } deriving (Eq, Show)
 
 makeLenses ''CompilationOpts
 
 defaultCompilationOpts :: CompilationOpts
-defaultCompilationOpts = CompilationOpts True False False False 8 True True True True
+defaultCompilationOpts = CompilationOpts True False False False 8 True True True
 
 data CompilationCtx uni fun a = CompilationCtx {
     _ccOpts              :: CompilationOpts

--- a/plutus-core/plutus-ir/test/datatypes/listMatchEval.golden
+++ b/plutus-core/plutus-ir/test/datatypes/listMatchEval.golden
@@ -1,1 +1,1 @@
-(delay (lam x_877 x_877))
+(delay (lam x_138 x_138))

--- a/plutus-core/plutus-ir/test/datatypes/maybe.golden
+++ b/plutus-core/plutus-ir/test/datatypes/maybe.golden
@@ -2,13 +2,12 @@
   1.0.0
   [
     [
-      (lam
-        Just_i0
-        (all
-          a_i0
-          (type)
-          (fun
-            a_i1
+      [
+        (lam
+          Nothing_i0
+          (all
+            a_i0
+            (type)
             [
               (lam
                 a_i0
@@ -22,17 +21,50 @@
               a_i1
             ]
           )
-        )
-        (lam
-          match_Maybe_i0
-          (all
-            a_i0
-            (type)
-            (fun
-              [
-                (lam
-                  a_i0
-                  (type)
+          (lam
+            Just_i0
+            (all
+              a_i0
+              (type)
+              (fun
+                a_i1
+                [
+                  (lam
+                    a_i0
+                    (type)
+                    (all
+                      out_Maybe_i0
+                      (type)
+                      (fun
+                        out_Maybe_i1 (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1)
+                      )
+                    )
+                  )
+                  a_i1
+                ]
+              )
+            )
+            (lam
+              match_Maybe_i0
+              (all
+                a_i0
+                (type)
+                (fun
+                  [
+                    (lam
+                      a_i0
+                      (type)
+                      (all
+                        out_Maybe_i0
+                        (type)
+                        (fun
+                          out_Maybe_i1
+                          (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1)
+                        )
+                      )
+                    )
+                    a_i1
+                  ]
                   (all
                     out_Maybe_i0
                     (type)
@@ -41,21 +73,28 @@
                     )
                   )
                 )
-                a_i1
-              ]
-              (all
-                out_Maybe_i0
-                (type)
-                (fun out_Maybe_i1 (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1))
               )
+              [
+                { Just_i2 (all a_i0 (type) (fun a_i1 a_i1)) }
+                (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
+              ]
             )
           )
-          [
-            { Just_i2 (all a_i0 (type) (fun a_i1 a_i1)) }
-            (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
-          ]
         )
-      )
+        (abs
+          a_i0
+          (type)
+          (abs
+            out_Maybe_i0
+            (type)
+            (lam
+              case_Nothing_i0
+              out_Maybe_i2
+              (lam case_Just_i0 (fun a_i4 out_Maybe_i3) case_Nothing_i2)
+            )
+          )
+        )
+      ]
       (abs
         a_i0
         (type)

--- a/plutus-core/plutus-ir/test/recursion/even3Eval.golden
+++ b/plutus-core/plutus-ir/test/recursion/even3Eval.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_2675 (lam case_False_2676 case_False_2676)))
+(delay (lam case_True_365 (lam case_False_366 case_False_366)))

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -367,7 +367,6 @@ runCompiler moduleName opts expr = do
                  & set (PIR.ccOpts . PIR.coDoSimplifierUnwrapCancel)       (poDoSimplifierUnwrapCancel opts)
                  & set (PIR.ccOpts . PIR.coDoSimplifierBeta)               (poDoSimplifierBeta opts)
                  & set (PIR.ccOpts . PIR.coDoSimplifierInline)             (poDoSimplifierInline opts)
-                 & set (PIR.ccOpts . PIR.coDoSimplifierRemoveDeadBindings) (poDoSimplifierRemoveDeadBindings opts)
 
 
     -- GHC.Core -> Pir translation.

--- a/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingEmulatorTestOutput.txt
@@ -19,12 +19,12 @@ Slot 1: 00000000-0000-4000-8000-000000000002 {Contract instance for wallet 3}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",100)])])"
 Slot 1: W2: Balancing an unbalanced transaction:
               Tx:
-                Tx b4fbdb680ef6b4154f550a5a86591218b1e89845952f0285631325bd69b3b319:
+                Tx 947db1bae7ee290900220af4dfa49ae06e32c31a277c24ccdb15e662530d7b6d:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
+                      ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -36,23 +36,23 @@ Slot 1: W2: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W2: Finished balancing. 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
+Slot 1: W2: Finished balancing. 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract instance started
-Slot 1: W2: Submitting tx: 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
-Slot 1: W2: TxSubmit: 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
+Slot 1: W2: Submitting tx: 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
+Slot 1: W2: TxSubmit: 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Receive endpoint call on 'contribute' for Object (fromList [("contents",Array [Object (fromList [("getEndpointDescription",String "contribute")]),Object (fromList [("unEndpointValue",Object (fromList [("contribValue",Object (fromList [("getValue",Array [Array [Object (fromList [("unCurrencySymbol",String "")]),Array [Array [Object (fromList [("unTokenName",String "")]),Number 25.0]]]])]))]))])]),("tag",String "ExposeEndpointResp")])
 Slot 1: 00000000-0000-4000-8000-000000000003 {Contract instance for wallet 4}:
           Contract log: String "Contributing Value (Map [(,Map [(\"\",25)])])"
 Slot 1: W3: Balancing an unbalanced transaction:
               Tx:
-                Tx dc98f8608ebda22ce6fc39c1307d46bd78d44a2f66995f6ea70eb5c3755c596d:
+                Tx ea7b4c6e02cb0bb07b85d85552f6ae01c3a2012dad9d27553e28d96c6a576396:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",100)])]) addressed to
-                      ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
+                      ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -64,17 +64,17 @@ Slot 1: W3: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W3: Finished balancing. f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
-Slot 1: W3: Submitting tx: f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
-Slot 1: W3: TxSubmit: f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+Slot 1: W3: Finished balancing. d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
+Slot 1: W3: Submitting tx: d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
+Slot 1: W3: TxSubmit: d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
 Slot 1: W4: Balancing an unbalanced transaction:
               Tx:
-                Tx d7ce795cf6115d1a498273120557dc76b994a35d63fcfc8abb67bf30382d11ff:
+                Tx 98dadaa94aff1b40ddf49bb801fddf3d1816274d11914e53f985bb3429265056:
                   {inputs:
                   collateral inputs:
                   outputs:
                     - Value (Map [(,Map [("",25)])]) addressed to
-                      ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential)
+                      ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential)
                   mint: Value (Map [])
                   fee: Value (Map [])
                   mps:
@@ -86,23 +86,23 @@ Slot 1: W4: Balancing an unbalanced transaction:
               Utxo index:
               Validity range:
                 (-∞ , POSIXTime 1596059111000 ]
-Slot 1: W4: Finished balancing. 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
-Slot 1: W4: Submitting tx: 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
-Slot 1: W4: TxSubmit: 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
-Slot 1: TxnValidate 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
-Slot 1: TxnValidate f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
-Slot 1: TxnValidate 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
+Slot 1: W4: Finished balancing. 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
+Slot 1: W4: Submitting tx: 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
+Slot 1: W4: TxSubmit: 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
+Slot 1: TxnValidate 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
+Slot 1: TxnValidate d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
+Slot 1: TxnValidate 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract log: String "Collecting funds"
 Slot 20: W1: Balancing an unbalanced transaction:
                Tx:
-                 Tx a078b4a4879760003956f42d2c7d7fff31cb11746aedcf13fe467dd6ceb93257:
+                 Tx f506e07d3a43c6c7bd8ba125cfbbc770a5da51d3b8bb2f23e1a9336189227ed5:
                    {inputs:
-                      - 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e!1
+                      - 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b!1
                         <>
-                      - 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888!1
+                      - 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248!1
                         <>
-                      - f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738!1
+                      - d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31!1
                         <>
                    collateral inputs:
                    outputs:
@@ -114,20 +114,20 @@ Slot 20: W1: Balancing an unbalanced transaction:
                    data:}
                Requires signatures:
                Utxo index:
-                 ( 6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e!1
+                 ( 46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b!1
+                 , - Value (Map [(,Map [("",100)])]) addressed to
+                     ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential) )
+                 ( 5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248!1
                  , - Value (Map [(,Map [("",25)])]) addressed to
-                     ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
-                 ( 6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888!1
+                     ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential) )
+                 ( d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31!1
                  , - Value (Map [(,Map [("",100)])]) addressed to
-                     ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
-                 ( f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738!1
-                 , - Value (Map [(,Map [("",100)])]) addressed to
-                     ScriptCredential: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9 (no staking credential) )
+                     ScriptCredential: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea (no staking credential) )
                Validity range:
                  [ POSIXTime 1596059111000 , POSIXTime 1596059120999 ]
-Slot 20: W1: Finished balancing. 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
-Slot 20: W1: Submitting tx: 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
-Slot 20: W1: TxSubmit: 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
+Slot 20: W1: Finished balancing. 9b9e9a03b31eb21258c55e7b1097625115751ed6ddc0eca49580d34b3aee4e30
+Slot 20: W1: Submitting tx: 9b9e9a03b31eb21258c55e7b1097625115751ed6ddc0eca49580d34b3aee4e30
+Slot 20: W1: TxSubmit: 9b9e9a03b31eb21258c55e7b1097625115751ed6ddc0eca49580d34b3aee4e30
 Slot 20: 00000000-0000-4000-8000-000000000000 {Contract instance for wallet 1}:
            Contract instance stopped (no errors)
-Slot 20: TxnValidate 1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
+Slot 20: TxnValidate 9b9e9a03b31eb21258c55e7b1097625115751ed6ddc0eca49580d34b3aee4e30

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+TxId:       5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5840bf9cbb7fcca9d1243710a117858a7f6300d4...
+              Signature: 5840f00edbb8f2df6dfe6c35752c61f64ba151be...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: bcc083ade3fdd0a372cb6c43ef00ef02fcb52e95... (Wallet 4)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999965
 
   ---- Output 1 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  25
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  25
 
 ==== Slot #1, Tx #1 ====
-TxId:       f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+TxId:       d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 58400c97ed9d0de34a7a27f5756bf58742a804b4...
+              Signature: 5840e9c901b2a3dc6514b68b51a7073c056fcf20...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 7f8a76c0ebaa4ad20dfdcd51a5de070ab771f4bf... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  100
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  125
 
 ==== Slot #1, Tx #2 ====
-TxId:       6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
+TxId:       46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840752f7fadbbb7ed1163044160f1744b9913b8...
+              Signature: 584083c8c348f5fc1ab9659e68466724db97c5ad...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99999890
 
   ---- Output 1 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  100
 
@@ -318,16 +318,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  225
 
 ==== Slot #2, Tx #0 ====
-TxId:       1575f1a7b735d02d4cb1c388e0d578f532dff4ce275ebc7da6471a1703259782
-Fee:        Ada:      Lovelace:  14650
+TxId:       9b9e9a03b31eb21258c55e7b1097625115751ed6ddc0eca49580d34b3aee4e30
+Fee:        Ada:      Lovelace:  15769
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840332594c7e9b4b9aefcaf4e2af8c69076f952...
+              Signature: 58404e5644d5c1b9f8f17f28d45f6a2e7fc6f1e8...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -339,44 +339,44 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
+  Value:
+    Ada:      Lovelace:  100
+  Source:
+    Tx:     46db2504a554f17697ad593add53d1032ba021c817c168f2f73268edb354cf3b
+    Output #1
+    Script: 590fe90100003323232332233223332223233322...
+
+  ---- Input 2 ----
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  25
   Source:
-    Tx:     6872ac2e61e2b0d6123bac7d93b803e9f60206e459d0d02690fe89a64a07556e
+    Tx:     5832e2962a56dee925adce3e6ad3413b87df7e7ed89ac3988ee54c2bca1b5248
     Output #1
-    Script: 590ede0100003323232332233223332223233322...
-
-  ---- Input 2 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
-  Value:
-    Ada:      Lovelace:  100
-  Source:
-    Tx:     6c3047550550c2e9671a694b57c05ebab1b86a347da79a963b8bcc1154c14888
-    Output #1
-    Script: 590ede0100003323232332233223332223233322...
+    Script: 590fe90100003323232332233223332223233322...
 
   ---- Input 3 ----
-  Destination:  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Destination:  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     f63468ac827c4bcbe30e8aac779cfedb1576945270797c4de7b85ef68e2bd738
+    Tx:     d3329ad493275970eb25749b5629763cb0336679ec583e7974e88564a6fd8d31
     Output #1
-    Script: 590ede0100003323232332233223332223233322...
+    Script: 590fe90100003323232332233223332223233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99985575
+    Ada:      Lovelace:  99984456
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99985575
+    Ada:      Lovelace:  99984456
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -414,6 +414,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 6681212a6a0117b469d34534a513d30ca911feeac0736297d25aeec9
+  Script: 5c0d229e7092fb146213d94fe002234a629e65f7c8262f3d72dfdfea
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
+TxId:       0146d20e5ad848ff54d4608a72b59ef8a071dd0fad36a62a08aa4b928bcd613b
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 5840c13f90d052624c191f6a17a497bb64b5b9fc...
+              Signature: 58401f1d72875781754ff985acb4a1a0add242e0...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999982
 
   ---- Output 1 ----
-  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Destination:  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
 
@@ -170,51 +170,51 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #2, Tx #0 ====
-TxId:       2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
-Fee:        Ada:      Lovelace:  13051
-Mint:       1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+TxId:       cc5f9bfd1a6d5bf0fc25b6bf579ce4edeaa17a1e8fefd9e9bf155d776f052815
+Fee:        Ada:      Lovelace:  13493
+Mint:       b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 584023520aa53693196a6c186434ac0a4f064b06...
+              Signature: 5840e64039ddd51a4fe3d41cb4689e343e887bec...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
     Ada:      Lovelace:  99999982
   Source:
-    Tx:     8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
+    Tx:     0146d20e5ad848ff54d4608a72b59ef8a071dd0fad36a62a08aa4b928bcd613b
     Output #0
 
 
   ---- Input 1 ----
-  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Destination:  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     8046940d48ed164aa9bfdf5b41b71fab7f8cf19035e1c50ba537dda2fa54f283
+    Tx:     0146d20e5ad848ff54d4608a72b59ef8a071dd0fad36a62a08aa4b928bcd613b
     Output #1
-    Script: 591e5b0100003323232332233223332223233322...
+    Script: 591fca0100003323232332233223332223233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986931
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  -
+    Ada:      Lovelace:  99986489
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  -
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Destination:  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
 
@@ -222,8 +222,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986931
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    Ada:      Lovelace:  99986489
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -261,34 +261,34 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #3, Tx #0 ====
-TxId:       69d73020b43d21058fd96271312dd34bdf7ee3b2f4501ab725b81820efcfc28f
+TxId:       bce4fa802a816d43804de4b04a2af39e0db0795d33074af3c8940eb2ca53ba73
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58408e97f39e99df8ba175caa0ae50464f83dfbb...
+              Signature: 5840384993db2f9b384e60b6c1e631d40c8654e9...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986931
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  -
+    Ada:      Lovelace:  99986489
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  -
   Source:
-    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
+    Tx:     cc5f9bfd1a6d5bf0fc25b6bf579ce4edeaa17a1e8fefd9e9bf155d776f052815
     Output #0
 
 
   ---- Input 1 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
     Ada:      -
   Source:
-    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
+    Tx:     cc5f9bfd1a6d5bf0fc25b6bf579ce4edeaa17a1e8fefd9e9bf155d776f052815
     Output #1
 
 
@@ -297,20 +297,20 @@ Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986921
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
+    Ada:      Lovelace:  99986479
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
 
 
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986921
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
+    Ada:      Lovelace:  99986479
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -335,7 +335,7 @@ Balances Carried Forward:
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
     Ada:      Lovelace:  100000000
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -349,16 +349,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
 
 ==== Slot #4, Tx #0 ====
-TxId:       9b9d5413bcc07f89e5aabc270beac0ba940723f7cea3d556e955a64ffb3ba866
-Fee:        Ada:      Lovelace:  13051
-Mint:       1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
+TxId:       670462580e1385d1b4b31325560c78f9b1a8f1c59b3f6830ff1cc34a73ba9d03
+Fee:        Ada:      Lovelace:  13493
+Mint:       b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    0
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584040da2a39f1f018be353c245e2c379fddc523...
+              Signature: 58409a826cb550bb5d87252a1d4a2c33fd929193...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -370,39 +370,39 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
+  Value:
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
+  Source:
+    Tx:     bce4fa802a816d43804de4b04a2af39e0db0795d33074af3c8940eb2ca53ba73
+    Output #1
+
+
+  ---- Input 2 ----
+  Destination:  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  8
   Source:
-    Tx:     2c1361b5424dd45b9782806e223ab748bbd385571e0bf17c089fda393c277f00
+    Tx:     cc5f9bfd1a6d5bf0fc25b6bf579ce4edeaa17a1e8fefd9e9bf155d776f052815
     Output #2
-    Script: 591e5b0100003323232332233223332223233322...
-
-  ---- Input 2 ----
-  Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
-  Value:
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
-  Source:
-    Tx:     69d73020b43d21058fd96271312dd34bdf7ee3b2f4501ab725b81820efcfc28f
-    Output #1
-
+    Script: 591fca0100003323232332233223332223233322...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99986952
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
+    Ada:      Lovelace:  99986510
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    0
 
   ---- Output 1 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
     Ada:      -
 
   ---- Output 2 ----
-  Destination:  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Destination:  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  5
 
@@ -410,8 +410,8 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99986921
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    0
+    Ada:      Lovelace:  99986479
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    0
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -435,8 +435,8 @@ Balances Carried Forward:
 
   PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
   Value:
-    Ada:      Lovelace:  99986952
-    1fc60df3d9b4aaa3cad3a21ae2b09f6883f69299514638060fbe9c2f:  guess:    1
+    Ada:      Lovelace:  99986510
+    b66b5e7bda30b447e5f947f47f8feab1a8a44021e42ba2a9545cb69b:  guess:    1
 
   PubKeyHash: b1fd7c427a17e57c112473449d8b237484c5ebf6... (Wallet 7)
   Value:
@@ -450,6 +450,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: a5ec767da7e3e499e18500fb85c32a77981cc0529f05d1c60f1f49c1
+  Script: 92208de9a6f3403c0138c7c0b2798e43e90ad70dded40d125c1f5257
   Value:
     Ada:      Lovelace:  5

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  100000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       168b08011236050dc54d8150b8049704e15c197064238dbdbcd92339b9b861ed
+TxId:       2d12d579efe2eb9021f81189a97f06660b7753e9b44ba9b744ed6241cb38d143
 Fee:        Ada:      Lovelace:  10
 Mint:       -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840d1bcdbe67d79cf7e9c3512b1903b007266e1...
+              Signature: 584070321f87e3fcd666561d2a74cfd0edadacfd...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 977efb35ab621d39dbeb7274ec7795a34708ff4d... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  99999930
 
   ---- Output 1 ----
-  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
+  Destination:  Script: 968517c162fe60040b486554b7fe891c1da6151301061b313a281705
   Value:
     Ada:      Lovelace:  60
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
+  Script: 968517c162fe60040b486554b7fe891c1da6151301061b313a281705
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #2, Tx #0 ====
-TxId:       674124e6dd62b5bdc4fd7341ef4ba6d7fcd27ae504163cc95697a9e469f04250
-Fee:        Ada:      Lovelace:  6462
+TxId:       626512d9b4cd006be6066411ca30da1b95ebdaec439f8d785a520ba542c35ce1
+Fee:        Ada:      Lovelace:  6771
 Mint:       -
 Signatures  PubKey: d75a980182b10ab7d54bfed3c964073a0ee172f3...
-              Signature: 58409428cfbd69233a151258ed184aaee2f32e70...
+              Signature: 5840119ac4be8b1ad63e23db8bf2e3875662458b...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
@@ -191,23 +191,23 @@ Inputs:
 
 
   ---- Input 1 ----
-  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
+  Destination:  Script: 968517c162fe60040b486554b7fe891c1da6151301061b313a281705
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     168b08011236050dc54d8150b8049704e15c197064238dbdbcd92339b9b861ed
+    Tx:     2d12d579efe2eb9021f81189a97f06660b7753e9b44ba9b744ed6241cb38d143
     Output #1
-    Script: 5913ac0100003323232332233223332223232323...
+    Script: 5914980100003323232332233223332223232323...
 
 
 Outputs:
   ---- Output 0 ----
   Destination:  PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99993548
+    Ada:      Lovelace:  99993239
 
   ---- Output 1 ----
-  Destination:  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
+  Destination:  Script: 968517c162fe60040b486554b7fe891c1da6151301061b313a281705
   Value:
     Ada:      Lovelace:  50
 
@@ -215,7 +215,7 @@ Outputs:
 Balances Carried Forward:
   PubKeyHash: 35dedd2982a03cf39e7dce03c839994ffdec2ec6... (Wallet 1)
   Value:
-    Ada:      Lovelace:  99993548
+    Ada:      Lovelace:  99993239
 
   PubKeyHash: 3c88c96ed5ab14b16a32771bcfcb49928a5557fc... (Wallet 10)
   Value:
@@ -253,6 +253,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100000000
 
-  Script: 95d31138289f67c739339ea005e04a77be6c243492df34284baf4e76
+  Script: 968517c162fe60040b486554b7fe891c1da6151301061b313a281705
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Profiling the pir compiler demonstrated that a lot of time is spent during deadcode optimisations. This PR reduces the multiple number of `removeDeadBindings` calls to only two:
1. before `simplifyTerm` in `compileToReadable`
2. before `simplifyTerm` in `compileReadableToPlc`

### Results

Before this change:

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/588373/131625251-3df42110-107e-4fc4-b42e-f2a2a33d3483.png">


After this change:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/588373/131626083-3b52f352-e4e2-4c5a-86d3-84930a432685.png">

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
