### PR TITLE
Improve the performance of `PlutusIR.Transform.Inline.inline`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Name.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name.hs
@@ -26,6 +26,7 @@ module PlutusCore.Name
     , lookupNameIndex
     , mapNameString
     , mapTyNameString
+    , isEmpty
     ) where
 
 import           PlutusPrelude
@@ -162,3 +163,7 @@ lookupNameIndex
     :: (HasUnique name unique1, Coercible unique2 Unique)
     => name -> UniqueMap unique2 a -> Maybe a
 lookupNameIndex = lookupUnique . coerce . view unique
+
+{-# INLINE isEmpty #-}
+isEmpty :: UniqueMap unique a -> Bool
+isEmpty (UniqueMap m) = IM.null m


### PR DESCRIPTION
The compilation of the auction contract was about ~6s before improvements.

1. By using a concrete monad instead of a polymorphic one the time reduced to ~4s.
2. By skipping an empty substitution the time reduced to ~1.5s

Before:

![image](https://user-images.githubusercontent.com/588373/131695427-07c4dfd8-5c21-4ef5-8d7d-5868363a0e71.png)

After two improvements:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/588373/131695506-ea92a7b6-9476-4be0-a57a-32fbdc05e335.png">


---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
