### PR TITLE
SCP-2671: Support for storing CardanoAPI transactions in chain index

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-ledger"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -63,6 +63,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
           (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-ledger"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -63,6 +63,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
           (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger.nix
@@ -10,7 +10,7 @@
   {
     flags = { defer-plugin-errors = false; };
     package = {
-      specVersion = "2.2";
+      specVersion = "3.0";
       identifier = { name = "plutus-ledger"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "";
@@ -63,6 +63,7 @@
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
           (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))

--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -177,9 +177,15 @@ exBudgetBridge = do
     typeModule ^== "PlutusCore.Evaluation.Machine.ExBudget"
     pure psJson
 
+someCardanoApiTxBridge :: BridgePart
+someCardanoApiTxBridge = do
+    typeName ^== "SomeCardanoApiTx"
+    typeModule ^== "Ledger.Tx"
+    pure psJson
+
 miscBridge :: BridgePart
 miscBridge =
-    bultinByteStringBridge <|> byteStringBridge <|> integerBridge <|> scientificBridge <|> digestBridge <|> naturalBridge <|> satIntBridge <|> exBudgetBridge
+    bultinByteStringBridge <|> byteStringBridge <|> integerBridge <|> scientificBridge <|> digestBridge <|> naturalBridge <|> satIntBridge <|> exBudgetBridge <|> someCardanoApiTxBridge
 
 ------------------------------------------------------------
 

--- a/plutus-chain-index/src/Plutus/ChainIndex/Server.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Server.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MonoLocalBinds   #-}
 {-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators    #-}

--- a/plutus-chain-index/test/Generators.hs
+++ b/plutus-chain-index/test/Generators.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE MonoLocalBinds       #-}
 {-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE NumericUnderscores   #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-| Hedgehog generators for types used in plutus-chain-index
@@ -35,6 +35,7 @@ import qualified Hedgehog.Gen                as Gen
 import qualified Hedgehog.Range              as Range
 import qualified Ledger.Ada                  as Ada
 import           Ledger.Address              (pubKeyAddress)
+import qualified Ledger.Generators           as Gen
 import qualified Ledger.Interval             as Interval
 import           Ledger.Slot                 (Slot (..))
 import           Ledger.Tx                   (Address, TxIn (..), TxOut (..), TxOutRef (..))
@@ -145,6 +146,7 @@ genTx = do
                 pure (firstInput : otherInputs)
 
     deleteInputs (Set.fromList allInputs)
+
     ChainIndexTx
         <$> nextTxId
         <*> pure (Set.fromList $ fmap (flip TxIn Nothing) allInputs)
@@ -157,6 +159,10 @@ genTx = do
         <*> pure mempty
         <*> pure mempty
         <*> pure mempty
+
+        -- TODO: We need a way to convert the generated 'ChainIndexTx' to a
+        -- 'SomeCardanoTx', or vis-versa. And then put it here.
+        <*> pure Nothing
 
 -- | Generate a 'TxUtxoBalance' based on the state of utxo changes produced so
 --   far. Ensures that tx outputs are created before they are spent, and that

--- a/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Plutus/Contract/Trace/RequestHandler.hs
@@ -218,7 +218,7 @@ handleChainIndexQueries ::
     )
     => RequestHandler effs ChainIndexQuery ChainIndexResponse
 handleChainIndexQueries = RequestHandler $ \chainIndexQuery ->
-    surroundDebug @Text "handleUtxoQueries" $ do
+    surroundDebug @Text "handleChainIndexQueries" $ do
       case chainIndexQuery of
         DatumFromHash h            -> DatumHashResponse <$> ChainIndexEff.datumFromHash h
         ValidatorFromHash h        -> ValidatorHashResponse <$> ChainIndexEff.validatorFromHash h

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name: plutus-ledger
 version: 0.1.0.0
 license: Apache-2.0
@@ -115,6 +115,7 @@ library
         newtype-generics -any,
         http-api-data -any,
         cardano-api -any,
+        cardano-api:gen -any,
         cardano-binary -any,
         cardano-crypto -any,
         cardano-crypto-class -any,

--- a/plutus-ledger/src/Ledger/Tx.hs
+++ b/plutus-ledger/src/Ledger/Tx.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
@@ -19,6 +21,7 @@ module Ledger.Tx
     , ciTxOutValidator
     , _PublicKeyChainIndexTxOut
     , _ScriptChainIndexTxOut
+    , SomeCardanoApiTx(..)
     -- * Transactions
     , addSignature
     , pubKeyTxOut
@@ -31,11 +34,15 @@ module Ledger.Tx
     , txId
     ) where
 
+import qualified Cardano.Api               as C
 import           Cardano.Crypto.Hash       (SHA256, digest)
 import qualified Codec.CBOR.Write          as Write
 import           Codec.Serialise.Class     (Serialise, encode)
-import           Control.Lens
-import           Data.Aeson                (FromJSON, ToJSON)
+import           Control.Applicative       ((<|>))
+import           Control.Lens              hiding ((.=))
+import           Data.Aeson                (FromJSON (parseJSON), ToJSON (toJSON), object, (.:), (.=))
+import qualified Data.Aeson                as Aeson
+import           Data.Aeson.Types          (Parser, parseFail, prependFailure, typeMismatch)
 import           Data.Map                  (Map)
 import qualified Data.Map                  as Map
 import           Data.Proxy
@@ -97,6 +104,142 @@ instance Pretty ChainIndexTxOut where
                 hang 2 $ vsep ["-" <+> pretty _ciTxOutValue <+> "addressed to", pretty _ciTxOutAddress]
     pretty ScriptChainIndexTxOut {_ciTxOutAddress, _ciTxOutValue} =
                 hang 2 $ vsep ["-" <+> pretty _ciTxOutValue <+> "addressed to", pretty _ciTxOutAddress]
+
+-- TODO Move to cardano-api
+deriving instance Eq (C.EraInMode era mode)
+
+-- TODO Move to cardano-api
+instance FromJSON (C.EraInMode C.ByronEra C.CardanoMode) where
+  parseJSON "ByronEraInCardanoMode" = pure C.ByronEraInCardanoMode
+  parseJSON invalid =
+      prependFailure "parsing 'EraInMode ByronEra CardanoMode' failed, "
+                     (typeMismatch "ByronEraInCardanoMode" invalid)
+
+-- TODO Move to cardano-api
+instance FromJSON (C.EraInMode C.ShelleyEra C.CardanoMode) where
+  parseJSON "ShelleyEraInCardanoMode" = pure C.ShelleyEraInCardanoMode
+  parseJSON invalid =
+      prependFailure "parsing 'EraInMode ShelleyEra CardanoMode' failed, "
+                     (typeMismatch "ShelleyEraInCardanoMode" invalid)
+
+-- TODO Move to cardano-api
+instance FromJSON (C.EraInMode C.AllegraEra C.CardanoMode) where
+  parseJSON "AllegraEraInCardanoMode" = pure C.AllegraEraInCardanoMode
+  parseJSON invalid =
+      prependFailure "parsing 'EraInMode AllegraEra CardanoMode' failed, "
+                     (typeMismatch "AllegraEraInCardanoMode" invalid)
+
+-- TODO Move to cardano-api
+instance FromJSON (C.EraInMode C.MaryEra C.CardanoMode) where
+  parseJSON "MaryEraInCardanoMode" = pure C.MaryEraInCardanoMode
+  parseJSON invalid =
+      prependFailure "parsing 'EraInMode MaryEra CardanoMode' failed, "
+                     (typeMismatch "MaryEraInCardanoMode" invalid)
+
+-- TODO Move to cardano-api
+instance FromJSON (C.EraInMode C.AlonzoEra C.CardanoMode) where
+  parseJSON "AlonzoEraInCardanoMode" = pure C.AlonzoEraInCardanoMode
+  parseJSON invalid =
+      prependFailure "parsing 'EraInMode AlonzoEra CardanoMode' failed, "
+                     (typeMismatch "AlonzoEraInCardanoMode" invalid)
+
+-- TODO Move to cardano-api
+instance ToJSON (C.EraInMode era mode) where
+  toJSON C.ByronEraInByronMode     = "ByronEraInByronMode"
+  toJSON C.ShelleyEraInShelleyMode = "ShelleyEraInShelleyMode"
+  toJSON C.ByronEraInCardanoMode   = "ByronEraInCardanoMode"
+  toJSON C.ShelleyEraInCardanoMode = "ShelleyEraInCardanoMode"
+  toJSON C.AllegraEraInCardanoMode = "AllegraEraInCardanoMode"
+  toJSON C.MaryEraInCardanoMode    = "MaryEraInCardanoMode"
+  toJSON C.AlonzoEraInCardanoMode  = "AlonzoEraInCardanoMode"
+
+data SomeCardanoApiTx where
+  SomeTx :: C.IsCardanoEra era => C.Tx era -> C.EraInMode era C.CardanoMode -> SomeCardanoApiTx
+
+instance Eq SomeCardanoApiTx where
+  (SomeTx tx1 C.ByronEraInCardanoMode) == (SomeTx tx2 C.ByronEraInCardanoMode)     = tx1 == tx2
+  (SomeTx tx1 C.ShelleyEraInCardanoMode) == (SomeTx tx2 C.ShelleyEraInCardanoMode) = tx1 == tx2
+  (SomeTx tx1 C.AllegraEraInCardanoMode) == (SomeTx tx2 C.AllegraEraInCardanoMode) = tx1 == tx2
+  (SomeTx tx1 C.MaryEraInCardanoMode) == (SomeTx tx2 C.MaryEraInCardanoMode)       = tx1 == tx2
+  (SomeTx tx1 C.AlonzoEraInCardanoMode) == (SomeTx tx2 C.AlonzoEraInCardanoMode)   = tx1 == tx2
+  _ == _                                                                           = False
+
+deriving instance Show SomeCardanoApiTx
+
+instance ToJSON SomeCardanoApiTx where
+  toJSON (SomeTx tx eraInMode) =
+    object [ "tx" .= C.serialiseToTextEnvelope Nothing tx
+           , "eraInMode" .= eraInMode
+           ]
+
+-- | Converting 'SomeCardanoApiTx' to JSON.
+--
+-- If the "tx" field is from an unknown era, the JSON parser will print an
+-- error at runtime while parsing.
+instance FromJSON SomeCardanoApiTx where
+  parseJSON v = parseByronInCardanoModeTx v
+            <|> parseShelleyEraInCardanoModeTx v
+            <|> parseAllegraEraInCardanoModeTx v
+            <|> parseMaryEraInCardanoModeTx v
+            <|> parseAlonzoEraInCardanoModeTx v
+            <|> parseEraInCardanoModeFail v
+
+parseByronInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseByronInCardanoModeTx =
+  parseSomeCardanoTx "Failed to parse ByronEra 'tx' field from SomeCardanoApiTx"
+                     C.AsByronTx
+
+parseShelleyEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseShelleyEraInCardanoModeTx =
+  parseSomeCardanoTx "Failed to parse ShelleyEra 'tx' field from SomeCardanoApiTx"
+                     C.AsShelleyTx
+
+parseMaryEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseMaryEraInCardanoModeTx =
+  parseSomeCardanoTx "Failed to parse MaryEra 'tx' field from SomeCardanoApiTx"
+                     maryEraTxAsType
+
+parseAllegraEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseAllegraEraInCardanoModeTx =
+  parseSomeCardanoTx "Failed to parse AllegraEra 'tx' field from SomeCardanoApiTx"
+                     allegraEraTxAsType
+
+parseAlonzoEraInCardanoModeTx :: Aeson.Value -> Parser SomeCardanoApiTx
+parseAlonzoEraInCardanoModeTx =
+  parseSomeCardanoTx "Failed to parse AlonzoEra 'tx' field from SomeCardanoApiTx"
+                     alonzoEraTxAsType
+
+parseEraInCardanoModeFail :: Aeson.Value -> Parser SomeCardanoApiTx
+parseEraInCardanoModeFail _ = fail "Unable to parse 'eraInMode'"
+
+parseSomeCardanoTx
+  :: ( FromJSON (C.EraInMode era C.CardanoMode)
+     , C.IsCardanoEra era
+     )
+  => String
+  -> C.AsType (C.Tx era)
+  -> Aeson.Value
+  -> Parser SomeCardanoApiTx
+parseSomeCardanoTx errorMsg txAsType (Aeson.Object v) =
+  SomeTx
+    <$> (v .: "tx" >>= \envelope -> either (const $ parseFail errorMsg)
+                                           pure
+                                           $ C.deserialiseFromTextEnvelope txAsType envelope)
+    <*> v .: "eraInMode"
+parseSomeCardanoTx _ _ invalid =
+    prependFailure "parsing SomeCardanoApiTx failed, "
+      (typeMismatch "Object" invalid)
+
+-- TODO Add the following 3 functions in 'Cardano.Api.Tx'.
+
+maryEraTxAsType :: C.AsType (C.Tx C.MaryEra)
+maryEraTxAsType = C.proxyToAsType $ Proxy @(C.Tx C.MaryEra)
+
+allegraEraTxAsType :: C.AsType (C.Tx C.AllegraEra)
+allegraEraTxAsType = C.proxyToAsType $ Proxy @(C.Tx C.AllegraEra)
+
+alonzoEraTxAsType :: C.AsType (C.Tx C.AlonzoEra)
+alonzoEraTxAsType = C.proxyToAsType $ Proxy @(C.Tx C.AlonzoEra)
 
 instance Pretty Tx where
     pretty t@Tx{txInputs, txCollateral, txOutputs, txMint, txFee, txValidRange, txSignatures, txMintScripts, txData} =

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -113,6 +113,9 @@ tests = testGroup "all tests" [
           slotToTimeRangeBoundsInverseProp,
         testProperty "slot to time range has lower bound <= upper bound"
           slotToTimeRangeHasLowerAndUpperBoundsProp
+        ],
+    testGroup "SomeCardanoApiTx" [
+        testProperty "Value ToJSON/FromJSON" (jsonRoundTrip Gen.genSomeCardanoApiTx)
         ]
     ]
 

--- a/plutus-pab/src/Plutus/PAB/Simulator.hs
+++ b/plutus-pab/src/Plutus/PAB/Simulator.hs
@@ -109,8 +109,7 @@ import           Ledger.TimeSlot                                (SlotConfig)
 import           Ledger.Value                                   (Value, flattenValue)
 import           Plutus.ChainIndex                              (ChainIndexControlEffect, ChainIndexEmulatorState,
                                                                  ChainIndexError, ChainIndexLog,
-                                                                 ChainIndexQueryEffect (DatumFromHash, GetTip, MintingPolicyFromHash, RedeemerFromHash, StakeValidatorFromHash, TxFromTxId, TxOutFromRef, UtxoSetAtAddress, UtxoSetMembership, ValidatorFromHash),
-                                                                 getTip)
+                                                                 ChainIndexQueryEffect (..), getTip)
 import qualified Plutus.ChainIndex                              as ChainIndex
 import           Plutus.Contract.Effects                        (TxStatus)
 import           Plutus.PAB.Core                                (EffectHandlers (..))


### PR DESCRIPTION
Support for storing CardanoAPI transactions in chain index.

Biggest work of this PR was the `FromJSON/ToJSON` instances for the new datatype `SomeCardanoApiTx`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
