### PR TITLE
Add missing helpers to plutus-tx, plutus-ledger and plutus-ledger-api

### DIFF
--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -62,7 +63,8 @@ import           Ledger                 (Ada, AssetClass, CurrencySymbol, DatumH
                                          ValidatorHash, Value)
 import           Ledger.Bytes           (LedgerBytes)
 import qualified PlutusTx.AssocMap
-import qualified PlutusTx.Prelude       as P
+import qualified PlutusTx.Builtins      as P
+import qualified PlutusTx.Natural       as P
 import qualified PlutusTx.Ratio         as P
 import           Wallet.Emulator.Wallet (Wallet)
 import           Wallet.Types           (ContractInstanceId)
@@ -256,6 +258,9 @@ instance {-# OVERLAPPABLE #-} (ToSchema a, ToArgument a) => ToArgument [a] where
     toArgument xs = Fix $ FormArrayF (toSchema @a) (toArgument <$> xs)
 
 instance ToSchema AssetClass
+
+deriving via Integer instance ToSchema P.Natural
+deriving via Integer instance ToArgument P.Natural
 
 ------------------------------------------------------------
 class GenericToSchema f where

--- a/plutus-contract/src/Wallet/API.hs
+++ b/plutus-contract/src/Wallet/API.hs
@@ -40,7 +40,7 @@ module Wallet.API(
     Interval(..),
     Slot,
     SlotRange,
-    width,
+    intervalWidth,
     defaultSlotRange,
     interval,
     singleton,

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -49,6 +49,7 @@ library
         Plutus.V1.Ledger.Interval
         Plutus.V1.Ledger.Orphans
         Plutus.V1.Ledger.Scripts
+        Plutus.V1.Ledger.Arbitrary
         Plutus.V1.Ledger.Slot
         Plutus.V1.Ledger.Tx
         Plutus.V1.Ledger.TxId
@@ -63,6 +64,8 @@ library
         flat -any,
         hashable -any,
         plutus-core -any,
+        generic-arbitrary -any,
+        quickcheck-instances -any,
         memory -any,
         mtl -any,
         plutus-tx -any,
@@ -90,6 +93,7 @@ test-suite plutus-ledger-api-test
         base >=4.9 && <5,
         aeson -any,
         plutus-ledger-api -any,
+        plutus-tx -any,
         hedgehog -any,
         tasty -any,
         tasty-hedgehog -any,

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Arbitrary.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Arbitrary.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TupleSections      #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Plutus.V1.Ledger.Arbitrary where
+
+import           Test.QuickCheck.Arbitrary.Generic (Arbitrary (arbitrary, shrink), genericArbitrary, genericShrink)
+import           Test.QuickCheck.Instances         ()
+
+import           Plutus.V1.Ledger.Api
+import           Plutus.V1.Ledger.Crypto
+import           Plutus.V1.Ledger.Slot
+import           Plutus.V1.Ledger.Value
+import           PlutusTx.Arbitrary                ()
+import           PlutusTx.Prelude                  hiding (fmap, (<$>))
+
+deriving newtype instance Arbitrary BuiltinData
+deriving newtype instance Arbitrary CurrencySymbol
+deriving newtype instance Arbitrary AssetClass
+deriving newtype instance Arbitrary Datum
+deriving newtype instance Arbitrary DatumHash
+deriving newtype instance Arbitrary LedgerBytes
+deriving newtype instance Arbitrary POSIXTime
+deriving newtype instance Arbitrary PubKey
+deriving newtype instance Arbitrary PubKeyHash
+deriving newtype instance Arbitrary Signature
+deriving newtype instance Arbitrary Slot
+deriving newtype instance Arbitrary TokenName
+deriving newtype instance Arbitrary TxId
+deriving newtype instance Arbitrary ValidatorHash
+
+--------------------------------------------------------------------------------
+-- Generics.
+-- Would like to have GenericArbitrary newtype from 0.2.0 for deriving-via on all of these
+
+instance Arbitrary TxOutRef where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+
+instance Arbitrary Value where
+  arbitrary = Prelude.foldMap (uncurry3 singleton) <$> arbitrary @[(CurrencySymbol, TokenName, Integer)]
+  shrink = fmap (Prelude.foldMap (uncurry3 singleton)) . shrink . flattenValue

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -33,7 +33,7 @@ import qualified PlutusTx                  as PlutusTx
 import           PlutusTx.Lift             (makeLift)
 import           PlutusTx.Prelude
 
-import           Plutus.V1.Ledger.Interval hiding (slotWidth)
+import           Plutus.V1.Ledger.Interval
 
 {- HLINT ignore "Redundant if" -}
 

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -17,7 +17,7 @@
 module Plutus.V1.Ledger.Slot(
       Slot(..)
     , SlotRange
-    , width
+    , slotWidth
     ) where
 
 import           Codec.Serialise.Class     (Serialise)
@@ -33,7 +33,7 @@ import qualified PlutusTx                  as PlutusTx
 import           PlutusTx.Lift             (makeLift)
 import           PlutusTx.Prelude
 
-import           Plutus.V1.Ledger.Interval
+import           Plutus.V1.Ledger.Interval hiding (slotWidth)
 
 {- HLINT ignore "Redundant if" -}
 
@@ -53,16 +53,16 @@ instance Pretty Slot where
 -- | An 'Interval' of 'Slot's.
 type SlotRange = Interval Slot
 
-{-# INLINABLE width #-}
--- | Number of 'Slot's covered by the interval, if finite. @width (from x) == Nothing@.
-width :: SlotRange -> Maybe Integer
-width (Interval (LowerBound (Finite (Slot s1)) in1) (UpperBound (Finite (Slot s2)) in2)) =
+{-# INLINABLE slotWidth #-}
+-- | Number of 'Slot's covered by the interval, if finite. @slotWidth (from x) == Nothing@.
+slotWidth :: SlotRange -> Maybe Integer
+slotWidth (Interval (LowerBound (Finite (Slot s1)) in1) (UpperBound (Finite (Slot s2)) in2)) =
     let lowestValue = if in1 then s1 else s1 + 1
         highestValue = if in2 then s2 else s2 - 1
     in if lowestValue <= highestValue
-    -- +1 avoids fencepost error: width of [2,4] is 3.
+    -- +1 avoids fencepost error: slotWidth of [2,4] is 3.
     then Just $ (highestValue - lowestValue) + 1
     -- low > high, i.e. empty interval
     else Nothing
 -- Infinity is involved!
-width _ = Nothing
+slotWidth _ = Nothing

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -61,6 +61,7 @@ library
         Ledger.TimeSlot
         Ledger.Tokens
         Ledger.Tx
+        Ledger.Arbitrary
         Ledger.Typed.Scripts
         Ledger.Typed.Scripts.MonetaryPolicies
         Ledger.Typed.Scripts.StakeValidators
@@ -79,7 +80,8 @@ library
         Plutus.V1.Ledger.Slot as Ledger.Slot,
         Plutus.V1.Ledger.TxId as Ledger.TxId,
         Plutus.V1.Ledger.Time as Ledger.Time,
-        Plutus.V1.Ledger.Value as Ledger.Value
+        Plutus.V1.Ledger.Value as Ledger.Value,
+        Plutus.V1.Ledger.Arbitrary as Ledger.V1.Arbitrary
         -- The rest of the plutus-ledger-api modules are reexported from within
         -- the Haskell modules and not in the current cabal file.
         -- For example: Plutus.V1.Ledger.Address is reexported by Ledger.Address
@@ -93,6 +95,7 @@ library
         containers -any,
         cryptonite >=0.25,
         data-default -any,
+        generic-arbitrary -any,
         flat -any,
         hashable -any,
         hedgehog -any,

--- a/plutus-ledger/src/Ledger/AddressMap.hs
+++ b/plutus-ledger/src/Ledger/AddressMap.hs
@@ -18,6 +18,7 @@ module Ledger.AddressMap(
     values,
     traverseWithKey,
     singleton,
+    utxoMapValue,
     fromTxOutputs,
     knownAddresses,
     updateAddresses,
@@ -41,6 +42,7 @@ import           Data.Maybe               (mapMaybe)
 import qualified Data.Set                 as Set
 import           GHC.Generics             (Generic)
 
+import qualified Data.Foldable            as Foldable
 import           Ledger.Blockchain
 import           Ledger.Tx                (txId)
 import           Plutus.V1.Ledger.Address (Address (..))
@@ -134,6 +136,10 @@ fromTxOutputs (Valid tx) =
     mkUtxo (i, t) = (txOutAddress t, Map.singleton (TxOutRef h i) (TxOutTx tx t))
     h = txId tx
 fromTxOutputs (Invalid _) = mempty
+
+-- | Get all 'Value' in 'UTXOMap'
+utxoMapValue :: UtxoMap -> Value
+utxoMapValue = Foldable.foldMap (txOutValue . txOutTxOut)
 
 -- | Create a map of unspent transaction outputs to their addresses (the
 -- "inverse" of an 'AddressMap', without the values)

--- a/plutus-ledger/src/Ledger/Arbitrary.hs
+++ b/plutus-ledger/src/Ledger/Arbitrary.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ledger.Arbitrary where
+
+import           Ledger.Oracle
+import           Plutus.V1.Ledger.Arbitrary        ()
+
+import           Test.QuickCheck.Arbitrary.Generic (Arbitrary (arbitrary, shrink), genericArbitrary, genericShrink)
+
+instance Arbitrary (SignedMessage a) where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+instance Arbitrary a => Arbitrary (Observation a) where
+  arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -14,24 +14,33 @@ the Cardano Node CLI expects serialised binary values to be wrapped with a
 module Ledger.Scripts (
     module Export
     , datumHash
+    , datumInputsAt
+    , datumOutputsAt
+    , toDatumHash
+    , toRedeemer
+    , fromRedeemer
     , redeemerHash
     , validatorHash
     , mintingPolicyHash
     , stakeValidatorHash
     ) where
 
-import           Cardano.Api              (AsType, HasTextEnvelope (textEnvelopeType), HasTypeProxy (proxyToAsType),
-                                           SerialiseAsCBOR, TextEnvelopeType (TextEnvelopeType))
-import           Cardano.Binary           (FromCBOR (fromCBOR), ToCBOR (toCBOR))
-import qualified Cardano.Crypto.Hash      as Crypto
-import           Codec.Serialise          (Serialise, decode, encode, serialise)
-import qualified Data.ByteArray           as BA
-import qualified Data.ByteString.Lazy     as BSL
-import qualified Data.Text                as Text
-import           Plutus.V1.Ledger.Api     (plutusDatumEnvelopeType, plutusRedeemerEnvelopeType,
-                                           plutusScriptEnvelopeType)
-import           Plutus.V1.Ledger.Scripts as Export
-import           PlutusTx.Builtins        as Builtins
+import           Cardano.Api               (AsType, HasTextEnvelope (textEnvelopeType), HasTypeProxy (proxyToAsType),
+                                            SerialiseAsCBOR, TextEnvelopeType (TextEnvelopeType))
+import           Cardano.Binary            (FromCBOR (fromCBOR), ToCBOR (toCBOR))
+import qualified Cardano.Crypto.Hash       as Crypto
+import           Codec.Serialise           (Serialise, decode, encode, serialise)
+import qualified Data.ByteArray            as BA
+import qualified Data.ByteString.Lazy      as BSL
+import qualified Data.Text                 as Text
+import           Plutus.V1.Ledger.Api      (FromData, TxInfo, Value, plutusDatumEnvelopeType,
+                                            plutusRedeemerEnvelopeType, plutusScriptEnvelopeType)
+import qualified Plutus.V1.Ledger.Api      as Ledger
+import qualified Plutus.V1.Ledger.Api      as PlutusTx
+import           Plutus.V1.Ledger.Contexts (findDatum, scriptInputsAt, scriptOutputsAt)
+import           Plutus.V1.Ledger.Scripts  as Export
+import           PlutusTx.Builtins         as Builtins
+import qualified PlutusTx.Foldable         as Foldable
 
 instance HasTextEnvelope Script where
     textEnvelopeType _ = TextEnvelopeType $ Text.unpack plutusScriptEnvelopeType
@@ -79,7 +88,59 @@ instance HasTypeProxy Redeemer where
     proxyToAsType _ = AsRedeemer
 
 datumHash :: Datum -> DatumHash
-datumHash = DatumHash . Builtins.sha2_256 . BA.convert
+datumHash = Ledger.DatumHash . Builtins.sha2_256 . BA.convert
+
+-- | Get 'DatumHash' using 'ToData' instance.
+-- **Note**: not intended to be used on-chain.
+toDatumHash
+  :: forall datum.
+     Ledger.ToData datum
+  => datum
+  -> Ledger.DatumHash
+toDatumHash = datumHash . toDatum @datum
+
+
+{-# INLINEABLE datumOutputsAt #-}
+
+-- | Version of scriptOutputsAt which also extracts the associated Datums
+datumOutputsAt
+  :: forall datum.
+     FromData datum
+  => ValidatorHash
+  -> TxInfo
+  -> [(datum, Value)]
+datumOutputsAt script txInfo = do
+  (datumHash, value) <- scriptOutputsAt script txInfo
+  datum <-
+    Foldable.toList $
+      findDatum datumHash txInfo >>= (fromDatum @datum)
+  [(datum, value)] -- PlutusTx doesn't export Applicative List, for some reason
+
+{-# INLINEABLE datumInputsAt #-}
+
+-- | Version scriptInputsAt which also extracts the associated Datums
+datumInputsAt
+  :: forall datum.
+     PlutusTx.FromData datum
+  => ValidatorHash
+  -> TxInfo
+  -> [(datum, Ledger.Value)]
+datumInputsAt script txInfo = do
+  (datumHash, value) <- scriptInputsAt script txInfo
+  datum <-
+    Foldable.toList $
+      findDatum datumHash txInfo >>= fromDatum @datum
+  [(datum, value)]
+
+-- | Construct 'Redeemer' using 'ToData' instance.
+{-# INLINEABLE toRedeemer #-}
+toRedeemer :: Ledger.ToData redeemer => redeemer -> Ledger.Redeemer
+toRedeemer = Ledger.Redeemer . Ledger.toBuiltinData
+
+-- | Parse 'Redeemer' using 'FromData' instance.
+{-# INLINEABLE fromRedeemer #-}
+fromRedeemer :: Ledger.FromData redeemer => Ledger.Redeemer -> Maybe redeemer
+fromRedeemer (Ledger.Redeemer d) = Ledger.fromBuiltinData d
 
 redeemerHash :: Redeemer -> RedeemerHash
 redeemerHash = RedeemerHash . Builtins.sha2_256 . BA.convert

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -121,9 +121,11 @@ test-suite plutus-tx-test
         bytestring -any,
         plutus-core -any,
         plutus-tx -any,
+        QuickCheck -any,
         hedgehog -any,
         tasty -any,
         tasty-hedgehog -any,
         tasty-hunit -any,
+        tasty-quickcheck -any,
         serialise -any,
         cborg -any

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -40,6 +40,7 @@ library
         PlutusTx.Prelude
         PlutusTx.Evaluation
         PlutusTx.Applicative
+        PlutusTx.Arbitrary
         PlutusTx.Bool
         PlutusTx.IsData
         PlutusTx.IsData.Class
@@ -54,6 +55,13 @@ library
         PlutusTx.Maybe
         PlutusTx.Monoid
         PlutusTx.Numeric
+        PlutusTx.Numeric.Class
+        PlutusTx.Natural
+        PlutusTx.Natural.Internal
+        PlutusTx.Natural.TH
+        PlutusTx.NatRatio
+        PlutusTx.NatRatio.Internal
+        PlutusTx.NatRatio.TH
         PlutusTx.Ratio
         PlutusTx.Semigroup
         PlutusTx.Sqrt
@@ -81,6 +89,9 @@ library
         template-haskell >=2.13.0.0,
         th-abstraction -any,
         prettyprinter -any,
+        QuickCheck -any,
+        quickcheck-instances -any,
+        generic-arbitrary -any,
         text -any,
         mtl -any,
         containers -any,
@@ -100,6 +111,10 @@ test-suite plutus-tx-test
     type: exitcode-stdio-1.0
     main-is: Spec.hs
     hs-source-dirs: test
+    other-modules:
+        Suites.Set 
+        Suites.Natural
+        Suites.UniqueMap
     build-tool-depends: doctest:doctest
     build-depends:
         base >=4.9 && <5,

--- a/plutus-tx/src/PlutusTx/Applicative.hs
+++ b/plutus-tx/src/PlutusTx/Applicative.hs
@@ -4,6 +4,7 @@ module PlutusTx.Applicative where
 
 import           Control.Applicative   (Const (..))
 import           Data.Functor.Identity (Identity (..))
+import           PlutusTx.Bool         (not)
 import           PlutusTx.Functor
 import           PlutusTx.Monoid       (Monoid (..), mappend)
 import           Prelude               (Bool, Either (..), Maybe (..))
@@ -38,8 +39,13 @@ a1 *> a2 = (id <$ a1) <*> a2
 
 {-# INLINABLE unless #-}
 -- | Plutus Tx version of 'Control.Monad.unless'.
-unless :: (Applicative f) => Bool -> f () -> f ()
+unless :: Applicative f => Bool -> f () -> f ()
 unless p s = if p then pure () else s
+
+{-# INLINEABLE when #-}
+-- | Plutus Tx version of 'Control.Monad.when'.
+when :: Applicative f => Bool -> f () -> f ()
+when p a = unless (not p) a
 
 instance Applicative Maybe where
     {-# INLINABLE pure #-}

--- a/plutus-tx/src/PlutusTx/Arbitrary.hs
+++ b/plutus-tx/src/PlutusTx/Arbitrary.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module PlutusTx.Arbitrary where
+
+import qualified Data.List                   as List
+
+import           Test.QuickCheck             (Arbitrary (..), Gen, Positive (Positive, getPositive), genericShrink,
+                                              getOrdered, oneof, resize, sized, suchThat)
+import           Test.QuickCheck.Instances   ()
+
+import           PlutusTx                    (Data (B, Constr, I, List, Map))
+import           PlutusTx.AssocMap           (Map)
+import qualified PlutusTx.AssocMap           as AssocMap (fromList, toList)
+import           PlutusTx.Bimap              (Bimap)
+import qualified PlutusTx.Bimap              as Bimap
+import           PlutusTx.Builtins
+import           PlutusTx.Builtins.Internal
+import           PlutusTx.NatRatio.Internal  (NatRatio (NatRatio))
+import           PlutusTx.Natural.Internal   (Natural (Natural))
+import           PlutusTx.NonEmpty           (NonEmpty ((:|)))
+import qualified PlutusTx.Ord                as Ord
+import qualified PlutusTx.Prelude            as PlutusPrelude
+import           PlutusTx.Ratio              (denominator, numerator, (%))
+import qualified PlutusTx.Ratio              as Ratio (Rational, fromGHC, toGHC)
+import           PlutusTx.Set                (Set)
+import qualified PlutusTx.Set                as Set
+import           PlutusTx.UniqueMap.Internal (UniqueMap (UniqueMap))
+
+--------------------------------------------------------------------------------
+-- Special cases
+
+instance Arbitrary BuiltinByteString where
+  arbitrary = BuiltinByteString <$> resize 64 arbitrary
+  shrink (BuiltinByteString x) = BuiltinByteString <$> shrink x
+
+instance Arbitrary Data where
+  -- ToJSON / FromJSON instances of BuiltinData implemented with serialise / deserialise functions from Codec.Serialise.
+  -- In case the length of ByteStrings is more than 64 bytes, deserialization error occurs.
+  --
+  -- Example:
+  -- B "\RS\194w\255$u\144-\191\205u\191\183\&4\232\190\225\249\"}S+\217\ENQf\196\SUB\SI\191\169\149^\DC41n%\252\&1\245wr&\161|OX3\170h7\153\210\225\177\228\233\207\231#\DC1[\191\242\148\210\US\167"
+  -- Failed! Exception: 'DeserialiseFailure 69 "ByteString exceeds 64 bytes"'
+  --
+  -- It goes from the implementation of PlutusCore.Data.decodeBoundedBytes:
+  --
+  -- @
+  -- decodeBoundedBytes :: Decoder s Data
+  -- decodeBoundedBytes =  do
+  -- b <- CBOR.decodeBytes
+  -- if BS.length b <= 64
+  --  then pure $ B b
+  --  else fail $ "ByteString exceeds 64 bytes"
+  -- @
+  arbitrary = sized $ oneof . dataGenList
+    where
+      positive :: Gen Integer
+      positive = getPositive <$> arbitrary @(Positive Integer)
+
+      dataGenList :: Int -> [Gen Data]
+      dataGenList n
+        | n < 2 = [I <$> arbitrary, B <$> arbitrary]
+        | otherwise =
+          [ I <$> arbitrary
+          , B <$> resize 64 arbitrary
+          , Map <$> resize (n `div` 2) arbitrary
+          , List <$> resize (n `div` 2) arbitrary
+          , Constr <$> positive <*> resize (n `div` 2) arbitrary
+          ]
+  shrink = genericShrink
+
+instance (Arbitrary a, Arbitrary b, Ord.Ord a, Ord.Ord b, Ord a, Ord b) => Arbitrary (Bimap a b) where
+  arbitrary = Bimap.fromList . getOrdered <$> arbitrary
+  shrink = fmap Bimap.fromList . shrink . Bimap.toList
+
+instance (Arbitrary k, Arbitrary v) => Arbitrary (Map k v) where
+  arbitrary = AssocMap.fromList <$> arbitrary
+  shrink = fmap AssocMap.fromList . shrink . AssocMap.toList
+
+instance (Arbitrary a) => Arbitrary (NonEmpty a) where
+  arbitrary = (:|) <$> arbitrary <*> arbitrary
+  shrink (a :| as) = do
+    a' <- shrink a
+    as' <- shrink as
+    pure (a' :| as')
+
+instance Arbitrary Ratio.Rational where
+  arbitrary = Ratio.fromGHC <$> arbitrary
+  shrink = fmap Ratio.fromGHC . shrink . Ratio.toGHC
+
+instance (Arbitrary a, Ord a, Ord.Ord a) => Arbitrary (Set a) where
+  arbitrary = Set.fromList . getOrdered <$> arbitrary
+  shrink = fmap Set.fromList . shrink . Set.toList
+
+instance
+  (Arbitrary k, Arbitrary v, Ord k) =>
+  Arbitrary (UniqueMap k v)
+  where
+  arbitrary = do
+    ks <- List.nub . getOrdered <$> arbitrary
+    UniqueMap <$> traverse (\key -> (key,) <$> arbitrary) ks
+  shrink (UniqueMap um) = do
+    um' <- shrink um
+    pure . UniqueMap . List.sortOn Prelude.fst $ um'
+
+instance Arbitrary Natural where
+  arbitrary = do
+    NonNegative n <- arbitrary
+    pure . Natural $ n
+  shrink (Natural n) = do
+    NonNegative n' <- shrink . NonNegative $ n
+    pure . Natural $ n'
+
+instance Arbitrary NatRatio where
+  arbitrary = do
+    NonNegative num <- arbitrary
+    Positive den <- arbitrary
+    pure . NatRatio $ num % den
+  shrink (NatRatio r) = do
+    NonNegative num' <- shrink . NonNegative . numerator $ r
+    Positive den' <- shrink . Positive . denominator $ r
+    pure . NatRatio $ num' % den'
+
+-- | A newtype which ensures we generate a value that is not 'zero'.
+newtype NonZero a = NonZero a
+  deriving stock (Show)
+  deriving
+    ( Eq
+    , PlutusPrelude.AdditiveSemigroup
+    , PlutusPrelude.AdditiveMonoid
+    )
+    via a
+
+instance
+  (Eq a, PlutusPrelude.AdditiveMonoid a, Arbitrary a) =>
+  Arbitrary (NonZero a)
+  where
+  arbitrary = do
+    x <- arbitrary `suchThat` (PlutusPrelude.zero /=)
+    pure . NonZero $ x
+  shrink (NonZero x) = do
+    x' <- filter (PlutusPrelude.zero /=) . shrink $ x
+    pure . NonZero $ x'
+
+-- | A newtype which ensures we generate a value that's not less than 'zero'.
+newtype NonNegative a = NonNegative a
+  deriving stock (Show)
+  deriving (Eq) via a
+
+instance
+  (Arbitrary a, PlutusPrelude.AdditiveMonoid a, PlutusPrelude.Ord a) =>
+  Arbitrary (NonNegative a)
+  where
+  arbitrary = do
+    x <- arbitrary `suchThat` (PlutusPrelude.zero PlutusPrelude.<=)
+    pure . NonNegative $ x
+  shrink (NonNegative x) = do
+    x' <- filter (PlutusPrelude.zero PlutusPrelude.<=) . shrink $ x
+    pure . NonNegative $ x'

--- a/plutus-tx/src/PlutusTx/Bool.hs
+++ b/plutus-tx/src/PlutusTx/Bool.hs
@@ -1,5 +1,12 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Bool (Bool(..), (&&), (||), not) where
+
+module PlutusTx.Bool
+  ( Bool(..)
+  , (&&)
+  , (||)
+  , (==>)
+  , not
+  ) where
 
 import           Prelude hiding (not, (&&), (||))
 

--- a/plutus-tx/src/PlutusTx/Functor.hs
+++ b/plutus-tx/src/PlutusTx/Functor.hs
@@ -1,5 +1,12 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module PlutusTx.Functor (Functor(..), (<$>), (<$), const, id) where
+module PlutusTx.Functor
+    ( Functor(..)
+    , (<$>)
+    , (<$)
+    , ($>)
+    , const
+    , id
+    ) where
 
 import           Control.Applicative   (Const (..))
 import           Data.Functor.Identity (Identity (..))
@@ -26,6 +33,12 @@ infixl 4 <$
 -- | Plutus Tx version of '(Data.Functor.<$)'.
 (<$) :: Functor f => a -> f b -> f a
 (<$) a fb = fmap (const a) fb
+
+infixl 4 $>
+{-# INLINEABLE ($>) #-}
+-- | Flipped version of '<$'.
+($>) :: Functor f => f a -> b -> f b
+f $> x = x <$ f
 
 instance Functor [] where
     {-# INLINABLE fmap #-}

--- a/plutus-tx/src/PlutusTx/NatRatio.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio.hs
@@ -1,0 +1,22 @@
+-- | An on-chain numeric type representing a ratio of non-negative numbers.
+module PlutusTx.NatRatio
+  ( -- * Type
+    Internal.NatRatio
+
+  , -- * Functions
+
+    -- ** Construction
+    Internal.fromNatural
+  , Internal.natRatio
+  , TH.nr
+
+  , -- ** Access
+    Internal.numerator
+  , Internal.denominator
+  , Internal.truncate
+  , Internal.round
+  , Internal.properFraction
+  ) where
+
+import qualified PlutusTx.NatRatio.Internal as Internal
+import qualified PlutusTx.NatRatio.TH       as TH

--- a/plutus-tx/src/PlutusTx/NatRatio/Internal.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio/Internal.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | An on-chain numeric type representing a ratio of non-negative numbers.
+ = Warning
+ This is an internal module; as such, it exposes the 'NatRatio'
+ implementation, which can be used to violate constraints if used without
+ care. This module primarily exists to support @testlib@, or for some internal
+ APIs; if at all possible, use 'PlutusTx.NatRatio' instead.
+-}
+module PlutusTx.NatRatio.Internal (
+  NatRatio (..),
+  natRatio,
+  fromNatural,
+  numerator,
+  denominator,
+  truncate,
+  PlutusTx.NatRatio.Internal.round,
+  properFraction,
+) where
+
+import           Control.Monad             (guard)
+import           Data.Aeson                (FromJSON (parseJSON), ToJSON)
+import           PlutusTx.IsData.Class     (FromData (fromBuiltinData), ToData, UnsafeFromData (unsafeFromBuiltinData))
+import           PlutusTx.Lift             (makeLift)
+import           PlutusTx.Natural.Internal (Natural (Natural))
+import           PlutusTx.Numeric.Class
+import           PlutusTx.Prelude
+import qualified PlutusTx.Ratio            as Ratio
+import qualified Prelude
+
+{- | A ratio of 'Natural's. Similar to 'Rational', but with the numerator and
+ denominator guaranteed non-negative.
+-}
+newtype NatRatio = NatRatio Rational
+  deriving stock (Prelude.Show)
+  deriving
+    ( Prelude.Eq
+    , Eq
+    , Ord
+    , AdditiveSemigroup
+    , AdditiveMonoid
+    , MultiplicativeSemigroup
+    , MultiplicativeMonoid
+    , ToData
+    , ToJSON
+    )
+    via Rational
+
+instance FromJSON NatRatio where
+  parseJSON v = do
+    r <- parseJSON v
+    guard (r >= zero)
+    Prelude.pure . NatRatio $ r
+
+instance FromData NatRatio where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData dat = case fromBuiltinData dat of
+    Nothing -> Nothing
+    Just r ->
+      if natAbs r == r
+        then Just (NatRatio r)
+        else Nothing
+
+instance UnsafeFromData NatRatio where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData dat =
+    let r = unsafeFromBuiltinData dat
+     in if natAbs r == r
+          then NatRatio r
+          else error . trace "Negative fractions cannot be NatRatio" $ ()
+
+-- | 'NatRatio' monus is \'difference-or-zero\'.
+instance AdditiveHemigroup NatRatio where
+  {-# INLINEABLE (^-) #-}
+  NatRatio r1 ^- NatRatio r2
+    | r1 < r2 = zero
+    | otherwise = NatRatio $ r1 - r2
+
+instance MultiplicativeGroup NatRatio where
+  {-# INLINEABLE (/) #-}
+  NatRatio r / NatRatio r' = NatRatio (r / r')
+  {-# INLINEABLE reciprocal #-}
+  reciprocal (NatRatio r) = NatRatio . Ratio.recip $ r
+
+
+-- | Safely construct a 'NatRatio'. Checks for a zero denominator.
+{-# INLINEABLE natRatio #-}
+natRatio :: Natural -> Natural -> Maybe NatRatio
+natRatio (Natural n) (Natural m) =
+  if m == 0
+    then Nothing
+    else Just . NatRatio $ n Ratio.% m
+
+-- | Convert a 'Natural' into a 'NatRatio' with the same value.
+{-# INLINEABLE fromNatural #-}
+fromNatural :: Natural -> NatRatio
+fromNatural (Natural n) = NatRatio . fromInteger $ n
+
+-- | Retrieve the numerator of a 'NatRatio'.
+{-# INLINEABLE numerator #-}
+numerator :: NatRatio -> Natural
+numerator (NatRatio r) = Natural . Ratio.numerator $ r
+
+{- | Retrieve the denominator of a 'NatRatio'. This is guaranteed non-zero,
+ though the result type doesn't specify this.
+-}
+{-# INLINEABLE denominator #-}
+denominator :: NatRatio -> Natural
+denominator (NatRatio r) = Natural . Ratio.denominator $ r
+
+-- | Round the 'NatRatio' down.
+{-# INLINEABLE truncate #-}
+truncate :: NatRatio -> Natural
+truncate (NatRatio r) = Natural . Ratio.truncate $ r
+
+-- | Round the 'NatRatio' arithmetically.
+{-# INLINEABLE round #-}
+round :: NatRatio -> Natural
+round (NatRatio r) = Natural . Ratio.round $ r
+
+{- | Separate a 'NatRatio' into a whole and a fractional part, such that the
+ fractional part is guaranteed to be less than @1@.
+-}
+{-# INLINEABLE properFraction #-}
+properFraction :: NatRatio -> (Natural, NatRatio)
+properFraction (NatRatio r) =
+  let (n, r') = Ratio.properFraction r
+   in (Natural n, NatRatio r')
+
+instance IntegralDomain Rational NatRatio where
+  {-# INLINEABLE abs #-}
+  abs = natAbs
+  {-# INLINEABLE signum #-}
+  signum x
+    | x == zero = zero
+    | x < zero = negate one
+    | otherwise = one
+  {-# INLINEABLE projectAbs #-}
+  projectAbs = NatRatio . natAbs
+  {-# INLINEABLE restrictMay #-}
+  restrictMay x
+    | x < zero = Nothing
+    | otherwise = Just . NatRatio $ x
+  {-# INLINEABLE addExtend #-}
+  addExtend (NatRatio r) = r
+
+makeLift ''NatRatio

--- a/plutus-tx/src/PlutusTx/NatRatio/TH.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio/TH.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PlutusTx.NatRatio.TH (nr) where
+
+import           Language.Haskell.TH.Quote  (QuasiQuoter (QuasiQuoter))
+import           Language.Haskell.TH.Syntax (Dec, Exp (AppE, ConE, LitE, UInfixE, VarE), Lit (IntegerL), Pat, Q, Type)
+import           PlutusTx.NatRatio.Internal (NatRatio (NatRatio))
+import           PlutusTx.Ratio             ((%))
+import           Prelude
+import           Text.Read                  (readMaybe)
+
+{- | Quasi-quoter for 'NatRatio' literals.
+
+ Used as follows:
+
+ > [nr| (10, 100) |]
+-}
+nr :: QuasiQuoter
+nr = QuasiQuoter nrExp errorPat errorType errorDeclaration
+
+-- Helpers
+
+nrExp :: String -> Q Exp
+nrExp s = case readMaybe s of
+  Nothing -> fail $ "Input should be of the form (n, m), but got: " <> s
+  Just (n :: Integer, m :: Integer) -> case signum m of
+    (-1) -> fail "Cannot use a negative literal for a NatRatio denominator."
+    0 -> fail "A NatRatio cannot have denominator 0."
+    _ -> case signum n of
+      (-1) -> fail "Cannot use a negative literal for a NatRatio numerator."
+      _ ->
+        pure
+          . AppE (ConE 'NatRatio)
+          . UInfixE (LitE . IntegerL $ n) (VarE '(%))
+          . LitE
+          . IntegerL
+          $ m
+
+errorPat :: String -> Q Pat
+errorPat _ = fail "Cannot use 'nr' in a pattern context."
+
+errorType :: String -> Q Type
+errorType _ = fail "Cannot use 'nr' in a type context."
+
+errorDeclaration :: String -> Q [Dec]
+errorDeclaration _ = fail "Cannot use 'nr' in a declaration context."

--- a/plutus-tx/src/PlutusTx/Natural.hs
+++ b/plutus-tx/src/PlutusTx/Natural.hs
@@ -1,0 +1,18 @@
+-- | An on-chain numeric type representing non-negative integers.
+module PlutusTx.Natural (
+  -- * Types,
+  Internal.Natural (..),
+  Internal.Parity (..),
+
+  -- * Quasi-quoter
+  TH.nat,
+
+  -- * Functions
+  Internal.parity,
+  Internal.powNat,
+  (Internal.^+),
+  (Internal.^-)
+) where
+
+import qualified PlutusTx.Natural.Internal as Internal
+import qualified PlutusTx.Natural.TH       as TH

--- a/plutus-tx/src/PlutusTx/Natural/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Natural/Internal.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | An on-chain numeric type representing non-negative numbers only.
+-}
+module PlutusTx.Natural.Internal (
+  -- * Types,
+  Natural (..),
+  Parity (..),
+
+  -- * Functions
+  parity,
+  powNat,
+  (^+),
+  (^-)
+) where
+
+import           Control.Monad              (guard)
+import           Data.Aeson                 (FromJSON (parseJSON), ToJSON)
+import           PlutusTx.Builtins          (matchData, unsafeDataAsI)
+import           PlutusTx.Builtins.Internal hiding (unsafeDataAsI)
+import           PlutusTx.IsData            (FromData (fromBuiltinData), ToData, UnsafeFromData (unsafeFromBuiltinData))
+import           PlutusTx.Lift              (makeLift)
+import           PlutusTx.Numeric.Class
+import           PlutusTx.Prelude
+import qualified PlutusTx.Prelude           as Plutus
+import qualified Prelude
+
+-- | A non-negative number.
+newtype Natural = Natural Integer
+  deriving
+    ( AdditiveSemigroup
+    , AdditiveMonoid
+    , MultiplicativeSemigroup
+    , MultiplicativeMonoid
+    , Eq
+    , Ord
+    , ToData
+    , ToJSON
+    , Prelude.Eq
+    )
+    via Integer
+  deriving stock (Prelude.Show)
+
+-- | 'Natural' monus is \'difference-or-zero\'.
+instance AdditiveHemigroup Natural where
+  {-# INLINEABLE (^-) #-}
+  Natural n ^- Natural m
+    | m > n = zero
+    | otherwise = Natural (n - m)
+
+instance EuclideanClosed Natural where
+  {-# INLINEABLE divMod #-}
+  divMod n@(Natural x) (Natural y)
+    | y == zero = BuiltinPair (zero, n)
+    | y == one = BuiltinPair (n, zero)
+    | otherwise = BuiltinPair
+      ( Natural . divide x $ y
+      , Natural . modulo x $ y
+      )
+
+instance FromJSON Natural where
+  parseJSON v = Prelude.fmap Natural $ do
+    i <- parseJSON v
+    guard (i >= 0)
+    Prelude.pure i
+
+instance FromData Natural where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData dat =
+    matchData
+      dat
+      (\_ -> const Nothing)
+      (const Nothing)
+      (const Nothing)
+      go
+      (const Nothing)
+    where
+      go :: Integer -> Maybe Natural
+      go x
+        | x < zero = Nothing
+        | otherwise = Just . Natural $ x
+
+instance UnsafeFromData Natural where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData dat =
+    let asI = unsafeDataAsI dat
+     in if asI >= 0
+          then Natural asI
+          else Plutus.error . Plutus.trace "Cannot decode a negative value to Natural" $ ()
+
+instance IntegralDomain Integer Natural where
+  {-# INLINEABLE abs #-}
+  abs = natAbs
+  {-# INLINEABLE signum #-}
+  signum x
+    | x == zero = zero
+    | x < zero = negate one
+    | otherwise = one
+  {-# INLINEABLE projectAbs #-}
+  projectAbs = Natural . abs
+  {-# INLINEABLE restrictMay #-}
+  restrictMay x
+    | x < zero = Nothing
+    | otherwise = Just . Natural $ x
+  {-# INLINEABLE addExtend #-}
+  addExtend (Natural i) = i
+
+
+-- This is partial all over the place, but so is Enum for most things.
+instance Plutus.Enum Natural where
+  {-# INLINEABLE succ #-}
+  succ (Natural n) = Natural (n + 1)
+  {-# INLINEABLE pred #-}
+  pred (Natural n)
+    | n <= 0 = Plutus.error . Plutus.trace "No predecessor to Natural 0" $ ()
+    | otherwise = Natural (n - 1)
+  {-# INLINEABLE toEnum #-}
+  toEnum i
+    | i < 0 = Plutus.error . Plutus.trace "Cannot convert a negative number to a Natural" $ ()
+    | otherwise = Natural i
+  {-# INLINEABLE fromEnum #-}
+  fromEnum (Natural n) = n
+
+-- | A demonstration of the parity of a number.
+data Parity = Even | Odd
+  deriving stock (Prelude.Eq, Prelude.Show)
+
+-- | Determine the parity of a number.
+parity :: Natural -> Parity
+parity (Natural n)
+  | even n = Even
+  | otherwise = Odd
+
+
+{- | Raise by a 'Natural' power.
+
+ = Note
+
+ This really /ought/ to be a method of 'MultiplicativeMonoid', but as we can't
+ modify type classes provided by Plutus, this is the next best option.
+
+ = Laws
+
+ 1. @'powNat' x 'zero' = 'one'@
+ 2. @'powNat' x 'one' = x@
+ 3. If @n '>' 'one'@, then @'powNat' x n = x '*' 'powNat' x (n '^-' 'one')@
+-}
+{-# INLINEABLE powNat #-}
+powNat :: MultiplicativeMonoid m => m -> Natural -> m
+powNat x (Natural n) =
+  if n == zero
+    then one
+    else expBySquaring x n
+
+infixr 8 `powNat`
+
+-- | 'powNat' as an infix operator.
+{-# INLINEABLE (^+) #-}
+(^+) :: MultiplicativeMonoid m => m -> Natural -> m
+(^+) = powNat
+
+infixr 8 ^+
+
+makeLift ''Natural

--- a/plutus-tx/src/PlutusTx/Natural/TH.hs
+++ b/plutus-tx/src/PlutusTx/Natural/TH.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PlutusTx.Natural.TH (nat) where
+
+import           Language.Haskell.TH.Quote  (QuasiQuoter (QuasiQuoter))
+import           Language.Haskell.TH.Syntax (Dec, Exp (AppE, ConE, LitE), Lit (IntegerL), Pat (ConP, LitP), Q, Type)
+import           PlutusTx.Natural.Internal  (Natural (Natural))
+import           Prelude
+import           Text.Read                  (readMaybe)
+
+{- | Quasi-quoter for 'Natural' literals.
+
+ Used as follows:
+
+ > [nat| 1234 |]
+
+ > case foo of
+ >    [nat| 0 |] -> ...
+ >    [nat| 1 |] -> ...
+-}
+nat :: QuasiQuoter
+nat = QuasiQuoter natExp natPat errorType errorDeclaration
+
+-- Helpers
+
+natExp :: String -> Q Exp
+natExp s = case readMaybe s of
+  Nothing -> fail $ "Not a valid Natural: " <> s
+  Just (i :: Integer) -> case signum i of
+    (-1) -> fail "Cannot use a negative literal for a Natural."
+    _    -> pure . AppE (ConE 'Natural) . LitE . IntegerL $ i
+
+natPat :: String -> Q Pat
+natPat s = case readMaybe s of
+  Nothing -> fail $ "Not a valid Natural: " <> s
+  Just (i :: Integer) -> case signum i of
+    (-1) -> fail "Cannot use a negative literal for a Natural."
+    _    -> pure . ConP 'Natural $ [LitP . IntegerL $ i]
+
+errorType :: String -> Q Type
+errorType _ = fail "Cannot use 'nat' in a type context."
+
+errorDeclaration :: String -> Q [Dec]
+errorDeclaration _ = fail "Cannot use 'nat' in a declaration context."

--- a/plutus-tx/src/PlutusTx/Numeric.hs
+++ b/plutus-tx/src/PlutusTx/Numeric.hs
@@ -2,32 +2,27 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module PlutusTx.Numeric (AdditiveSemigroup (..), AdditiveMonoid (..), AdditiveGroup (..), negate, Additive (..), MultiplicativeSemigroup (..), MultiplicativeMonoid (..), Multiplicative (..), Semiring, Ring, Module (..)) where
+module PlutusTx.Numeric
+  ( AdditiveSemigroup (..)
+  , AdditiveMonoid (..)
+  , AdditiveGroup (..)
+  , negate
+  , Additive (..)
+  , MultiplicativeSemigroup (..)
+  , MultiplicativeMonoid (..)
+  , Multiplicative (..)
+  , Semiring
+  , Ring
+  , Module (..)
+  , AdditiveHemigroup (..)
+  , monus
+  ) where
 
-import           Data.Semigroup     (Product (..), Sum (..))
-import           PlutusTx.Builtins
+import           Data.Semigroup         (Product (..), Sum (..))
 import           PlutusTx.Monoid
+import           PlutusTx.Numeric.Class
 import           PlutusTx.Semigroup
-import           Prelude            hiding (Functor (..), Monoid (..), Num (..), Semigroup (..))
-
-infixl 7 *
-infixl 6 +, -
-
--- | A 'Semigroup' that it is sensible to describe using addition.
-class AdditiveSemigroup a where
-    (+) :: a -> a -> a
-
--- | A 'Monoid' that it is sensible to describe using addition and zero.
-class AdditiveSemigroup a => AdditiveMonoid a where
-    zero :: a
-
--- | A 'Group' that it is sensible to describe using addition, zero, and subtraction.
-class AdditiveMonoid a => AdditiveGroup a where
-    (-) :: a -> a -> a
-
-{-# INLINABLE negate #-}
-negate :: AdditiveGroup a => a -> a
-negate x = zero - x
+import           Prelude                hiding (Functor (..), Monoid (..), Num (..), Semigroup (..), divMod)
 
 -- | A newtype wrapper to derive 'Additive' classes via.
 newtype Additive a = Additive a
@@ -44,16 +39,6 @@ instance Group a => AdditiveGroup (Additive a) where
     {-# INLINABLE (-) #-}
     Additive x - Additive y = Additive (x `gsub` y)
 
--- | A 'Semigroup' that it is sensible to describe using multiplication.
-class MultiplicativeSemigroup a where
-    (*) :: a -> a -> a
-
--- | A 'Semigroup' that it is sensible to describe using multiplication and one.
-class MultiplicativeSemigroup a => MultiplicativeMonoid a where
-    one :: a
-
--- TODO: multiplicative group? I haven't added any since for e.g. integers division
--- is not a proper inverse, so it's of limited use.
 
 -- | A newtype wrapper to derive 'Multiplicative' classes via.
 newtype Multiplicative a = Multiplicative a
@@ -66,50 +51,6 @@ instance Monoid a => MultiplicativeMonoid (Multiplicative a) where
     {-# INLINABLE one #-}
     one = Multiplicative mempty
 
--- | A semiring.
-type Semiring a = (AdditiveMonoid a, MultiplicativeMonoid a)
--- | A ring.
-type Ring a = (AdditiveGroup a, MultiplicativeMonoid a)
-
-instance AdditiveSemigroup Integer where
-    {-# INLINABLE (+) #-}
-    (+) = addInteger
-
-instance AdditiveMonoid Integer where
-    {-# INLINABLE zero #-}
-    zero = 0
-
-instance AdditiveGroup Integer where
-    {-# INLINABLE (-) #-}
-    (-) = subtractInteger
-
-instance MultiplicativeSemigroup Integer where
-    {-# INLINABLE (*) #-}
-    (*) = multiplyInteger
-
-instance MultiplicativeMonoid Integer where
-    {-# INLINABLE one #-}
-    one = 1
-
-instance AdditiveSemigroup Bool where
-    {-# INLINABLE (+) #-}
-    (+) = (||)
-
-instance AdditiveMonoid Bool where
-    {-# INLINABLE zero #-}
-    zero = False
-
-instance MultiplicativeSemigroup Bool where
-    {-# INLINABLE (*) #-}
-    (*) = (&&)
-
-instance MultiplicativeMonoid Bool where
-    {-# INLINABLE one #-}
-    one = True
-
--- | A module, with a type of scalars which can be used to scale the values.
-class (Ring s, AdditiveGroup v) => Module s v | v -> s where
-    scale :: s -> v -> v
 
 instance AdditiveSemigroup a => Semigroup (Sum a) where
     {-# INLINABLE (<>) #-}

--- a/plutus-tx/src/PlutusTx/Numeric/Class.hs
+++ b/plutus-tx/src/PlutusTx/Numeric/Class.hs
@@ -1,0 +1,327 @@
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeSynonymInstances   #-}
+
+module PlutusTx.Numeric.Class where
+
+import           PlutusTx.Builtins.Internal
+import qualified PlutusTx.Eq                as Plutus
+import qualified PlutusTx.Ord               as Plutus
+import           Prelude                    hiding (abs, divMod, fst, negate, snd, (*), (-), (/))
+
+infixl 7 *
+infixl 6 +, -
+
+-- | A 'Semigroup' that it is sensible to describe using addition.
+class AdditiveSemigroup a where
+    (+) :: a -> a -> a
+
+-- | A 'Monoid' that it is sensible to describe using addition and zero.
+class AdditiveSemigroup a => AdditiveMonoid a where
+    zero :: a
+
+-- | A 'Group' that it is sensible to describe using addition, zero, and subtraction.
+class AdditiveMonoid a => AdditiveGroup a where
+    (-) :: a -> a -> a
+
+{-# INLINABLE negate #-}
+negate :: AdditiveGroup a => a -> a
+negate x = zero - x
+
+{-# INLINABLE natAbs #-}
+natAbs :: (Plutus.Ord n, AdditiveGroup n) => n -> n
+natAbs x = if x Plutus.< zero then negate x else x
+
+-- | A 'Semigroup' that it is sensible to describe using multiplication.
+class MultiplicativeSemigroup a where
+    (*) :: a -> a -> a
+
+-- | A 'Semigroup' that it is sensible to describe using multiplication and one.
+class MultiplicativeSemigroup a => MultiplicativeMonoid a where
+    one :: a
+
+-- | A semiring.
+type Semiring a = (AdditiveMonoid a, MultiplicativeMonoid a)
+-- | A ring.
+type Ring a = (AdditiveGroup a, MultiplicativeMonoid a)
+
+{- | An 'AdditiveMonoid' with a notion of monus. Provides one operation @'^-'@,
+ also called \'monus\'.
+
+ = Laws
+
+ In addition to the standard laws of being an 'AdditiveMonoid', the following
+ must also hold:
+
+ 1. @a '+' (b '^-' a) = b + (a '^-' b)@
+ 2. @(a '^-' b) '^-' c = a '^-' (b '+' c)@
+ 3. @a '^-' a = 'zero'@
+ 4. @'zero' '^-' a = 'zero'@
+
+ Formally-speaking, this describes a a hemigroup whose canonical order is
+ total. This implies that '+' is cancellative; specifically, if @x '+' y
+ = x '+' z@, then @y = z@. Additionally, for any @x@ and @y@, there must
+ exist a /unique/ @z@ such that @x <= y + z@ under the canonical order.
+
+ /See also:/
+
+ * Gondran, Michel and Minoux, Michel; /Graphs, Dioids and Semirings: New
+   Models and Algorithms/; Springer, 2008.
+ * [Monus](https://en.wikipedia.org/wiki/Monus)
+-}
+class AdditiveMonoid a => AdditiveHemigroup a where
+  (^-) :: a -> a -> a
+
+infixl 6 ^-
+
+{- | The combination of an 'AdditiveHemigroup' and a 'MultiplicativeMonoid' is a
+ dioid; specifically, a symmetrizable dioid whose canonical order under '+' is
+ total. The literature refers to this combination as a \'hemiring\', but
+ formally-speaking, a hemiring doesn't necessarily possess a total canonical
+ order, or indeed a monus operation.
+
+ For symmetry with 'Ring', as well as for useful properties, we strengthen the
+ notion of hemirings to \'hemiring with monus and total additive canonical
+ order\', as this is the \'smallest\' useful algebra that gives us something
+ we want.
+
+ /See also:/ Gondran, Michel and Minoux, Michel; /Graphs, Dioids and
+ Semirings: New Models and Algorithms/; Springer, 2008.
+-}
+type Hemiring a = (AdditiveHemigroup a, MultiplicativeMonoid a)
+
+{- | The combination of an 'AdditiveHemigroup' and a 'MultiplicativeMonoid' is a
+ dioid (specifically a symmetrizable dioid). We don't bother adding the
+ \'symmetrizable\' to the name, as the only property of interest to us in
+ \'weaker\' dioids is natural ordering, which for the types we care about, we
+ already have.
+ /See also:/ Gondran, Michel and Minoux, Michel; /Graphs, Dioids and
+ Semirings: New Models and Algorithms/; Springer, 2008.
+-}
+type Dioid a = (AdditiveHemigroup a, MultiplicativeMonoid a)
+
+
+{- | A semiring with a notion of (kind of) Euclidean division. This differs from
+ the mathematical notion of this, as we do not exclude zero.
+
+ Intuitively, we provide an operation corresponding to \'division with
+ remainder\' which has invertibility properties in combination with /both/ '+'
+ and '*'. This combination is lawful, total and closed, and is general enough
+ to only require a semiring constraint; in particular, this means that both
+ the ring and dioid \'universes\' can participate equally (though the presence
+ of additive inverses complicates the laws somewhat).
+
+ We avoid the paradoxes induced by defining zero division by \'coupling\'
+ division and remainder, which avoids this problem, as we do not claim that
+ either \'half\' of the operation is invertible by itself.
+
+ = Laws
+
+ In addition to the unstated laws of being a 'Semiring', the following must
+ hold:
+
+ 1. If @'divMod' x y = (d, r)@ then @(d '*' y) '+' r = x@
+ 2. @'divMod' x 'zero' = ('zero', x)@
+ 3. If @'divMod' x y = (d, r)@ and @y '/=' 'zero'@, then @'zero' '<=' |r| '<'
+    |y|@. This property is simplified to @'zero' '<=' r '<' y@ if there is no
+    notion of additive inverses for the instance.
+
+ = Note
+
+ The 'Ord' constraint on the instance may or may not be a natural (or indeed,
+ canonical) order.
+-}
+class (Plutus.Ord a, Semiring a) => EuclideanClosed a where
+  -- | \'Division with remainder\', producing both results.
+  divMod :: a -> a -> BuiltinPair a a
+
+instance AdditiveSemigroup Integer where
+    {-# INLINABLE (+) #-}
+    (+) = addInteger
+
+instance AdditiveMonoid Integer where
+    {-# INLINABLE zero #-}
+    zero = 0
+
+instance AdditiveGroup Integer where
+    {-# INLINABLE (-) #-}
+    (-) = subtractInteger
+
+instance MultiplicativeSemigroup Integer where
+    {-# INLINABLE (*) #-}
+    (*) = multiplyInteger
+
+instance MultiplicativeMonoid Integer where
+    {-# INLINABLE one #-}
+    one = 1
+
+instance AdditiveSemigroup Bool where
+    {-# INLINABLE (+) #-}
+    (+) = (||)
+
+instance AdditiveMonoid Bool where
+    {-# INLINABLE zero #-}
+    zero = False
+
+instance MultiplicativeSemigroup Bool where
+    {-# INLINABLE (*) #-}
+    (*) = (&&)
+
+instance MultiplicativeMonoid Bool where
+    {-# INLINABLE one #-}
+    one = True
+
+-- | 'Bool' monus \'clips\' to 'False'.
+instance AdditiveHemigroup Bool where
+  {-# INLINEABLE (^-) #-}
+  False ^- _    = False
+  True ^- False = True
+  True ^- True  = False
+
+instance EuclideanClosed Integer where
+  {-# INLINEABLE divMod #-}
+  divMod x y =
+    if y == zero
+      then BuiltinPair (zero, x)
+      else BuiltinPair (quotientInteger x y, remainderInteger x y)
+
+type Field a = (AdditiveGroup a, MultiplicativeGroup a)
+
+type Hemifield a = (AdditiveHemigroup a, MultiplicativeGroup a)
+
+{- | A ring with a notion of \'sign\' or \'direction\' separate from magnitude.
+ This allows us to define notions of [absolute
+ value](https://en.wikipedia.org/wiki/Absolute_value_(algebra)) and [signum
+ function](https://en.wikipedia.org/wiki/Sign_function).
+
+ We extend the notion of integral domain with the idea of an \'additive
+ restriction\', which is a type representing \'strictly positive\' values. For
+ example, the \'additive restriction\' of 'Integer' is 'Natural', and the
+ \'additive restricton\' of 'Rational' is 'NatRatio'. This gives us the
+ ability to move between these two types while preserving magnitude.
+
+ = Laws
+
+ For 'abs', the following laws apply:
+
+ 1. @'abs' x '>=' 'zero'@
+ 2. @'abs' 'zero' = 'zero'@
+ 3. @'abs' (x '*' y) = 'abs' x '*' 'abs' y@
+ 4. @'abs' (x '+' y) '<=' 'abs' x '+' 'abs' y@
+
+ Additionally, if you define 'signum', the following law applies:
+
+ 5. @'abs' x '*' 'signum' x = x@
+
+ For the methods relating to the additive restriction, the following laws
+ apply:
+
+ 1. @'projectAbs' '.' 'addExtend' = 'id'@
+ 2. If @'abs' x = x@, then @'addExtend' '.' 'projectAbs' '$' x = x@
+
+ Additionally, if you define 'restrictMay', the following law applies:
+
+ 3. @restrictMay x = Just y@ if and only if @abs x = x@.
+-}
+class (Plutus.Eq a, Ring a) => IntegralDomain a r | a -> r, r -> a where
+  abs :: a -> a
+  projectAbs :: a -> r
+  addExtend :: r -> a
+  restrictMay :: a -> Maybe r
+  restrictMay x
+    | abs x Plutus.== x = Just . projectAbs $ x
+    | otherwise = Nothing
+  signum :: a -> a
+  signum x
+    | x Plutus.== zero = zero
+    | x Plutus.== abs x = one
+    | otherwise = negate one
+
+-- | A module, with a type of scalars which can be used to scale the values.
+class (Ring s, AdditiveGroup v) => Module s v | v -> s where
+    scale :: s -> v -> v
+
+{- | A multiplicative monoid with a notion of multiplicative inverse (for
+ non-zero values).
+
+ We have to exclude division by zero, as it leads to paradoxical situations.
+ This does mean that '/' and 'reciprocal' aren't total, but there's not much
+ we can do about that.
+
+ = Laws
+
+ These assume @y /= 0@.
+
+ 1. If @x '/' y = z@ then @y '*' z = x@.
+ 2. @x '/' y = x '*' 'reciprocal' y@
+ 3. @'powInteger' x 'zero' = 'one'@
+ 4. @'powInteger' x 'one' = x@
+ 5. If @i '<' 0@, then @'powInteger' x i = 'reciprocal' '.' 'powInteger' x .
+    'abs' '$' i@
+ 6. If @i '>' 1@, then @'powInteger' x i = 'x '*' 'powInteger' x (i '-' 'one)@
+-}
+class MultiplicativeMonoid a => MultiplicativeGroup a where
+  {-# MINIMAL (/) | reciprocal #-}
+  (/) :: a -> a -> a
+  x / y = x * reciprocal y
+  reciprocal :: a -> a
+  reciprocal x = one / x
+  powInteger :: a -> Integer -> a
+  powInteger x i
+    | i == zero = one
+    | i == one = x
+    | i < zero = reciprocal . powInteger x . natAbs $ i
+    | otherwise = expBySquaring x i
+
+infixr 8 `powInteger`
+
+-- Helpers
+
+{-# INLINEABLE expBySquaring #-}
+-- We secretly know that 'i' is always positive.
+expBySquaring
+  :: forall a.
+     MultiplicativeMonoid a
+  => a
+  -> Integer
+  -> a
+expBySquaring acc i
+  | i == one = acc
+  | even i = expBySquaring (square acc) . halve $ i
+  | otherwise = (acc *) . expBySquaring (square acc) . halve $ i
+  where
+    square :: a -> a
+    square y = y * y
+    halve :: Integer -> Integer
+    halve = (`divideInteger` 2)
+
+
+
+-- | Non-operator version of '^-'.
+{-# INLINE monus #-}
+monus :: AdditiveHemigroup a => a -> a -> a
+monus = (^-)
+
+infixl 6 `monus`
+
+-- | Gets only the division part of a 'divMod'.
+{-# INLINE div #-}
+div :: EuclideanClosed a => a -> a -> a
+div x = fst . divMod x
+
+infixl 7 `div`
+
+-- | Gets only the remainder part of a 'divMod'.
+{-# INLINE rem #-}
+rem :: EuclideanClosed a => a -> a -> a
+rem x = snd . divMod x
+
+infixl 7 `rem`
+
+-- | Operator version of 'powInteger'.
+(^) :: MultiplicativeGroup a => a -> Integer -> a
+(^) = powInteger
+
+infixr 8 ^

--- a/plutus-tx/src/PlutusTx/Set.hs
+++ b/plutus-tx/src/PlutusTx/Set.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE MonoLocalBinds        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -fno-omit-interface-pragmas
+  -fno-strictness
+  -fno-specialize #-}
+
+module PlutusTx.Set
+  ( Set
+  , empty
+  , singleton
+  , insert
+  , toList
+  , fromList
+  , null
+  , member
+  , size
+  , all
+  , delete
+  , filter
+  , map
+  , union
+  ) where
+
+import           GHC.Generics          (Generic)
+import qualified Prelude
+
+import           Data.Aeson            (FromJSON (parseJSON), ToJSON)
+
+import qualified PlutusTx              (makeLift)
+import           PlutusTx.Builtins     (matchData, mkList, unsafeDataAsList)
+import           PlutusTx.IsData.Class (FromData (fromBuiltinData), ToData (toBuiltinData),
+                                        UnsafeFromData (unsafeFromBuiltinData))
+import           PlutusTx.Prelude      hiding (all, filter, foldMap, map, null, toList)
+import qualified PlutusTx.Prelude
+
+-- | A collection of unique values.
+newtype Set a = Set {unSet :: [a]}
+  deriving stock (Prelude.Eq, Prelude.Show, Generic)
+  deriving (Eq, Ord, ToJSON) via [a]
+
+instance Ord a => Semigroup (Set a) where
+  {-# INLINEABLE (<>) #-}
+  (<>) = union
+
+instance Ord a => Monoid (Set a) where
+  {-# INLINEABLE mempty #-}
+  mempty = empty
+
+instance Foldable Set where
+  {-# INLINEABLE foldMap #-}
+  foldMap :: Monoid m => (a -> m) -> Set a -> m
+  foldMap f = mconcat . fmap f . toList
+
+instance (Ord a, FromJSON a) => FromJSON (Set a) where
+  {-# INLINEABLE parseJSON #-}
+  parseJSON = Prelude.fmap fromList . parseJSON
+
+instance (ToData a) => ToData (Set a) where
+  {-# INLINEABLE toBuiltinData #-}
+  toBuiltinData (Set xs) = mkList . fmap toBuiltinData $ xs
+
+instance (FromData a, Ord a) => FromData (Set a) where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData dat =
+    matchData
+      dat
+      (\_ -> const Nothing)
+      (const Nothing)
+      (foldrM go empty)
+      (const Nothing)
+      (const Nothing)
+    where
+      go :: BuiltinData -> Set a -> Maybe (Set a)
+      go x acc = insert <$> fromBuiltinData x <*> pure acc
+
+instance (UnsafeFromData a, Ord a) => UnsafeFromData (Set a) where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData =
+    foldr (insert . unsafeFromBuiltinData) empty . unsafeDataAsList
+
+{-# INLINEABLE empty #-}
+empty :: Set a
+empty = Set []
+
+{-# INLINEABLE singleton #-}
+singleton :: a -> Set a
+singleton x = Set [x]
+
+{-# INLINEABLE insert #-}
+insert :: forall a. Ord a => a -> Set a -> Set a
+insert n = Set . go . unSet
+  where
+    go :: [a] -> [a]
+    go [] = [n]
+    go lst@(x : xs) = case compare n x of
+      LT -> n : lst
+      EQ -> lst
+      GT -> x : go xs
+
+{-# INLINEABLE toList #-}
+toList :: Set a -> [a]
+toList = unSet
+
+{-# INLINEABLE fromList #-}
+fromList :: Ord a => [a] -> Set a
+fromList = foldr insert (Set [])
+
+{-# INLINEABLE null #-}
+null :: Set a -> Bool
+null = PlutusTx.Prelude.null . unSet
+
+{-# INLINEABLE member #-}
+member :: forall a. Ord a => a -> Set a -> Bool
+member n = go . unSet
+  where
+    go :: [a] -> Bool
+    go [] = False
+    go (x : xs) = case compare n x of
+      LT -> False
+      EQ -> True
+      GT -> go xs
+
+{-# INLINEABLE size #-}
+size :: Set a -> Integer
+size = length . toList
+
+{-# INLINEABLE all #-}
+all :: (a -> Bool) -> Set a -> Bool
+all predicate = PlutusTx.Prelude.all predicate . toList
+
+{-# INLINEABLE delete #-}
+delete :: forall a. Ord a => a -> Set a -> Set a
+delete n = Set . go . unSet
+  where
+    go :: [a] -> [a]
+    go [] = []
+    go lst@(x : xs) = case compare n x of
+      LT -> lst
+      EQ -> xs
+      GT -> x : go xs
+
+{-# INLINEABLE filter #-}
+filter :: (a -> Bool) -> Set a -> Set a
+filter f = Set . PlutusTx.Prelude.filter f . unSet
+
+{- | The resulting set can be less than the initial size
+if f maps two or more different keys to the same new key.
+-}
+{-# INLINEABLE map #-}
+map :: Ord b => (a -> b) -> Set a -> Set b
+map f = fromList . PlutusTx.Prelude.map f . unSet
+
+{-# INLINEABLE union #-}
+union :: Ord a => Set a -> Set a -> Set a
+union x y = foldr insert x (toList y)
+
+PlutusTx.makeLift ''Set

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -22,6 +22,10 @@ import           Test.Tasty
 import           Test.Tasty.HUnit    (testCase, (@?=))
 import           Test.Tasty.Hedgehog (testProperty)
 
+import qualified Suites.Natural      as Natural
+import qualified Suites.Set          as Set
+import qualified Suites.UniqueMap    as UniqueMap
+
 main :: IO ()
 main = defaultMain tests
 
@@ -32,6 +36,9 @@ tests = testGroup "plutus-tx" [
     , ratioTests
     , bytestringTests
     , listTests
+    , testGroup "Natural" Natural.tests
+    , testGroup "Set" Set.tests
+    , testGroup "UniqueMap" UniqueMap.tests
     ]
 
 sqrtTests :: TestTree

--- a/plutus-tx/test/Suites/Natural.hs
+++ b/plutus-tx/test/Suites/Natural.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE LambdaCase  #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Suites.Natural (tests) where
+
+import           PlutusTx.Arbitrary         ()
+import           PlutusTx.Builtins.Internal
+import           PlutusTx.Natural
+import           PlutusTx.Numeric.Class
+import qualified PlutusTx.Prelude           as Plutus
+import           Prelude                    hiding (divMod, product, rem)
+import           Test.QuickCheck            (Property, forAllShrink, (.&&.), (.||.), (=/=), (===))
+import           Test.QuickCheck.Arbitrary  (arbitrary, shrink)
+import           Test.Tasty                 (TestTree, localOption, testGroup)
+import           Test.Tasty.QuickCheck      (QuickCheckTests, testProperty)
+
+tests :: [TestTree]
+tests =
+  [ localOption go . testGroup "EuclideanClosed" $
+      [ testProperty "if divMod x y = (d, r), then (d * y) + r = x" ecProp1
+      , testProperty "divMod x 0 = (0, x)" ecProp2
+      , testProperty "if divMod x y = (d, r) and y /= 0, then 0 <= |r| < |y|" ecProp3
+      ]
+  , localOption go . testGroup "Monus" $
+      [ testProperty "a + (b ^- a) = b + (a ^- b)" monusProp1
+      , testProperty "(a ^- b) ^- c = a ^- (b + c)" monusProp2
+      , testProperty "a ^- a = 0" monusProp3
+      , testProperty "0 ^- a = 0" monusProp4
+      ]
+  , localOption go . testProperty "Parity" $ parityProp
+  , localOption go . testGroup "Exponentiation" $
+      [ testProperty "x ^+ 0 = mempty" expProp1
+      , testProperty "x ^+ 1 = x" expProp2
+      , testProperty "x ^+ n = fold . repeat n $ x" expProp3
+      ]
+  ]
+  where
+    go :: QuickCheckTests
+    go = 1000000
+
+expProp1 :: Property
+expProp1 = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = x ^+ Plutus.zero === Plutus.one
+
+expProp2 :: Property
+expProp2 = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = x ^+ Plutus.one === x
+
+expProp3 :: Property
+expProp3 = forAllShrink arbitrary shrink go
+  where
+    go :: (Natural, Natural) -> Property
+    go (x, n) = x ^+ n === (product . clone n $ x)
+    clone :: Natural -> Natural -> [Natural]
+    clone n x =
+      if n == Plutus.zero
+        then []
+        else x : clone (n ^- Plutus.one) x
+    product :: [Natural] -> Natural
+    product = \case
+      []       -> Plutus.one
+      (n : ns) -> n Plutus.* product ns
+
+ecProp1 :: Property
+ecProp1 = forAllShrink arbitrary shrink go
+  where
+    go :: (Natural, Natural) -> Property
+    go (x, y) =
+      let BuiltinPair (d, r) = divMod x y
+       in (d Plutus.* y) Plutus.+ r === x
+
+ecProp2 :: Property
+ecProp2 = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = divMod x Plutus.zero === BuiltinPair (Plutus.zero, x)
+
+ecProp3 :: Property
+ecProp3 = forAllShrink arbitrary shrink go
+  where
+    go :: (Natural, Natural) -> Property
+    go (x, y) =
+      let BuiltinPair (_, r) = divMod x y
+       in (y === Plutus.zero)
+            .||. ( (Plutus.compare Plutus.zero r =/= GT)
+                    .&&. (Plutus.compare r y === LT)
+                 )
+
+monusProp1 :: Property
+monusProp1 = forAllShrink arbitrary shrink go
+  where
+    go :: (Natural, Natural) -> Property
+    go (x, y) = (x Plutus.+ (y ^- x)) === (y Plutus.+ (x ^- y))
+
+monusProp2 :: Property
+monusProp2 = forAllShrink arbitrary shrink go
+  where
+    go :: (Natural, Natural, Natural) -> Property
+    go (x, y, z) = ((x ^- y) ^- z) === (x ^- (y Plutus.+ z))
+
+monusProp3 :: Property
+monusProp3 = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = x ^- x === Plutus.zero
+
+monusProp4 :: Property
+monusProp4 = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = Plutus.zero ^- x === Plutus.zero
+
+parityProp :: Property
+parityProp = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go x = case x `rem` [nat| 2 |] of
+      [nat| 0 |] -> parity x === Even
+      _          -> parity x === Odd

--- a/plutus-tx/test/Suites/Set.hs
+++ b/plutus-tx/test/Suites/Set.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-missing-signatures #-}
+
+module Suites.Set (tests) where
+
+import           Data.List             (nub, sort)
+import           Prelude
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import qualified PlutusTx.Ord          as PlutusTx
+import           PlutusTx.Set          (Set)
+import qualified PlutusTx.Set          as Set
+import           Test.QuickCheck       (allProperties)
+
+instance (PlutusTx.Ord a, Arbitrary a) => Arbitrary (Set a) where
+  arbitrary =
+    Set.fromList <$> arbitrary @[a]
+
+prop_InsertionEmpty x = Set.insert x Set.empty == Set.singleton x
+
+prop_IdempotentInsert x xs = Set.insert x (Set.insert x xs) == Set.insert x xs
+
+prop_ToListFromListSortedNub xs = Set.toList (Set.fromList xs) == sort (nub xs)
+
+prop_LengthPreservedNubbed xs = Set.size (Set.fromList xs) == toInteger (length (nub xs))
+
+prop_UnionSortedNubbedConcat xs ys =
+  Set.toList (Set.fromList xs `Set.union` Set.fromList ys)
+    == sort (nub (xs <> ys))
+
+prop_InsertDeleteDelete x xs = Set.delete x (Set.insert x xs) == Set.delete x xs
+
+prop_NotNull x xs = not $ Set.null (Set.insert x xs)
+
+prop_ElemsAlwaysUnique xs = Set.toList xs == nub (Set.toList xs)
+
+-- Don't ask me.
+pure []
+
+tests :: [TestTree]
+tests = [testProperties "Set properties" $allProperties]

--- a/plutus-tx/test/Suites/UniqueMap.hs
+++ b/plutus-tx/test/Suites/UniqueMap.hs
@@ -1,0 +1,61 @@
+
+{-# LANGUAGE TypeApplications #-}
+
+module Suites.UniqueMap (tests) where
+
+import           PlutusTx.Arbitrary    ()
+import qualified PlutusTx.Prelude      as P
+import           PlutusTx.UniqueMap    (UniqueMap)
+import qualified PlutusTx.UniqueMap    as UniqueMap
+import           Prelude
+import           Test.QuickCheck       (Property, arbitrary, forAllShrink, shrink, (===))
+import           Test.Tasty            (TestTree, localOption)
+import           Test.Tasty.QuickCheck (QuickCheckTests, testProperty)
+
+tests :: [TestTree]
+tests =
+  [ localOption go . testProperty "Put-get" $ putGetProp
+  , localOption go . testProperty "Put-put" $ putPutProp
+  , localOption go . testProperty "Get from empty" $ getEmptyProp
+  , localOption (go `quot` 8) . testProperty "Semigroup laws" $ semigroupLawsProp
+  ]
+  where
+    go :: QuickCheckTests
+    go = 100000
+
+-- If we insert a key-value pair into a map, we should be able to retrieve the
+-- value.
+putGetProp :: Property
+putGetProp = forAllShrink arbitrary shrink go
+  where
+    go ::
+      (P.Integer, P.Integer, UniqueMap P.Integer P.Integer) ->
+      Property
+    go (key, val, um) =
+      UniqueMap.lookup key (UniqueMap.insert key val um)
+        === Just val
+
+-- If we insert a pair, then insert again under the same key, the second insert
+-- wins.
+putPutProp :: Property
+putPutProp = forAllShrink arbitrary shrink go
+  where
+    go ::
+      (P.Integer, P.Integer, P.Integer, UniqueMap P.Integer P.Integer) ->
+      Property
+    go (key, val1, val2, um) =
+      UniqueMap.insert key val2 (UniqueMap.insert key val1 um)
+        === UniqueMap.insert key val2 um
+
+-- We cannot retrieve anything from an empty map.
+getEmptyProp :: Property
+getEmptyProp = forAllShrink arbitrary shrink go
+  where
+    go :: P.Integer -> Property
+    go key = UniqueMap.lookup key UniqueMap.empty === Nothing @P.Integer
+
+-- Map semigroup operator is associative.
+semigroupLawsProp :: Property
+semigroupLawsProp = forAllShrink arbitrary shrink $
+  \(um1 :: UniqueMap P.Integer [P.Integer], um2, um3) ->
+    (um1 P.<> um2) P.<> um3 === um1 P.<> (um2 P.<> um3)

--- a/web-common-marlowe/src/Marlowe/Semantics.purs
+++ b/web-common-marlowe/src/Marlowe/Semantics.purs
@@ -1406,7 +1406,7 @@ giveMoney accountId payee token@(Token cur tok) amount accounts =
       Party _ -> accounts
       Account accId -> addMoneyToAccount accId token amount accounts
   in
-    Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) accounts
+    Tuple (ReduceWithPayment (Payment accountId payee (asset cur tok amount))) newAccounts
 
 -- | Carry a step of the contract with no inputs
 reduceContractStep :: Environment -> State -> Contract -> ReduceStepResult


### PR DESCRIPTION
This PR is a clipping from our other plutus project that we have found missing some capabilities in the core libraries. Specifically this PR:
  - Adds a lot of missing functionality in `plutus-tx` such as function helpers and operators.
  - Adds a class hierarchy of numeric functions in `plutus-tx`.
  - Adds `UniqueMap` type as a key-value dictionary which ensures key uniqueness to work with on-chain.
  - Adds `NatRatio` type for working with positive rationals on-chain.
  - Adds `Set` type for working with sets on-chain.
  - Provides tests for defined `Set`, `Natural`, `UniqueMap` types.
  - Provides `Arbitrary` instances for a bunch of plutus types. 
  - Adds a bunch of helpers to work with datums in `plutus-ledger-api` and `plutus-ledger`. 
  - Adds `slotWidth` and renames interval width function to `intervalWidth`. 
  - Adds `withTimeout` helper that throws an error if awaiting a promise fails on a specific timeout. 
  
Special thanks @kozross for writing most of this code as well as our liqwid mlabs team as a whole.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
