### PR TITLE
Improve ChainIndex config handling

### DIFF
--- a/plutus-chain-index/app/CommandLine.hs
+++ b/plutus-chain-index/app/CommandLine.hs
@@ -36,10 +36,12 @@ applyOverrides CLIConfigOverrides{ccSocketPath, ccPort, ccNetworkId} =
 
 -- | Configuration
 data Command =
-    DumpDefaultConfig -- ^ Write default logging configuration
-      { outputFile :: !FilePath
-      }
-  | StartChainIndex -- ^ Start the chain index and connect it to a cardano node
+    DumpDefaultConfig { dumpConfigPath :: !FilePath }
+    -- ^ Write default chain index configuration
+  | DumpDefaultLoggingConfig { dumpLoggingConfigPath :: !FilePath }
+    -- ^ Write default logging configuration
+  | StartChainIndex
+    -- ^ Start the chain index and connect it to a cardano node
     deriving (Show)
 
 data AppConfig = AppConfig
@@ -86,7 +88,7 @@ configParser =
         <> metavar "CONFIG"
         <> value Nothing
         <> short 'c'
-        <> help "Path to the configuration file." )
+        <> help "Path to the chain index configuration file." )
 
 debuggingOutputParser :: Parser (Maybe Severity)
 debuggingOutputParser =
@@ -108,22 +110,28 @@ commandParser =
   subparser $
   mconcat
     [ dumpDefaultConfigParser
+    , dumpDefaultLoggingConfigParser
     , startChainIndexParser
     ]
 
 dumpDefaultConfigParser :: Mod CommandFields Command
 dumpDefaultConfigParser =
-  command "default-loggging-config" $
-  flip info (fullDesc <> progDesc "Write the default logging configuration YAML to a file") $ do
-    outputFile' <-
+  command "default-config" $
+  flip info (fullDesc <> progDesc "Write the default chain index JSON configuration to a file") $
+    DumpDefaultConfig <$>
       argument str
-               ( metavar "OUTPUT_FILE"
-              <> help "Output file to write logging config TAML to." )
-    pure $ DumpDefaultConfig { outputFile = outputFile' }
+        (metavar "OUTPUT_FILE" <> help "Output JSON file to write chain index config to.")
+
+dumpDefaultLoggingConfigParser :: Mod CommandFields Command
+dumpDefaultLoggingConfigParser =
+  command "default-logging-config" $
+  flip info (fullDesc <> progDesc "Write the default logging YAML configuration to a file") $
+    DumpDefaultLoggingConfig <$>
+      argument str
+        (metavar "OUTPUT_FILE" <> help "Output YAML file to write logging config to.")
 
 startChainIndexParser :: Mod CommandFields Command
 startChainIndexParser =
   command "start-index" $
   flip info (fullDesc <> progDesc "Start the chain index and connect it to a cardano node") $ do
     pure StartChainIndex
-

--- a/plutus-chain-index/app/Config.hs
+++ b/plutus-chain-index/app/Config.hs
@@ -9,6 +9,7 @@
 
 module Config(
   ChainIndexConfig(..),
+  DecodeConfigException(..),
   defaultConfig,
   -- * Lenses
   socketPath,
@@ -18,6 +19,7 @@ module Config(
   ) where
 
 import           Cardano.Api               (NetworkId (..))
+import           Control.Exception         (Exception)
 import           Control.Lens              (makeLensesFor)
 import           Data.Aeson                (FromJSON, ToJSON)
 import           Data.Text.Prettyprint.Doc (Pretty (..), viaShow, vsep, (<+>))
@@ -68,3 +70,6 @@ makeLensesFor [
   ("cicNetworkId", "networkId"),
   ("cicSlotConfig", "slotConfig")
   ] 'ChainIndexConfig
+
+newtype DecodeConfigException = DecodeConfigException String
+  deriving (Show, Exception)


### PR DESCRIPTION
- Further distinguish chain index & logging configs. 
- Support print default configs to file.

Previously there is an unhandled `DumpDefaultConfig` CLI command, with a few misdescriptions between the two config types.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
