### PR TITLE
plutus-playground: fix editor suggestions dropdown render

### DIFF
--- a/plutus-playground-client/static/layout.scss
+++ b/plutus-playground-client/static/layout.scss
@@ -77,7 +77,7 @@ body {
         padding: .25rem 1rem;
     }
 
-    .main {
+    > .main {
         // further general styles in body.scss
         // further specific styles in editor.scss, simulations.scss, and transactions.scss
         flex: 1;


### PR DESCRIPTION
Fixes #3858 

by avoiding applying styles that were only meant to be used outside of
the monaco editor. This is due to the suggestions dropdown was also using
.main as a classname and this change only applies to the direct children 
element that manages the layout as originally intended.



<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
