### PR TITLE
Fix pretty printing `fakeNameDeBruijn`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -204,7 +204,7 @@ unNameTyDeBruijn (NamedTyDeBruijn db) = TyDeBruijn $ unNameDeBruijn db
 
 fakeNameDeBruijn
     :: DeBruijn -> NamedDeBruijn
-fakeNameDeBruijn (DeBruijn ix) = NamedDeBruijn "" ix
+fakeNameDeBruijn (DeBruijn ix) = NamedDeBruijn "i" ix
 
 nameToDeBruijn
     :: (MonadReader Levels m, AsFreeVariableError e, MonadError e m)


### PR DESCRIPTION
According to the Plutus Core specifications, names can only start with letters.
```
Name n ::= [a-zA-Z][a-zA-Z0-9_’]*
```

But currently `fakeNameDeBruijn` gives an empty `ndbnString`, which leads to "invalid" pretty-printed programs in this scenario:
- Call `mkTermToEvaluate` on a `Script`.
- The program is named with `fakeNameDeBruijn`.
- The `NamedDeBruijn`s are translated to `Name` through `unDeBruijnProgram`.
- `prettyPlcClassicDebug`ing the program/term leads to names like `_0`, `_1` because of the `PrettyBy` instance of `Name`:
```
instance HasPrettyConfigName config => PrettyBy config Name where
    prettyBy config (Name txt (Unique uniq))
        | showsUnique = pretty txt <> "_" <> pretty uniq
...
```

This leads to the `uplc` CLI itself failing to parse the program:
```
$ cat alwaystrue.uplc | uplc print
uplc: Lexical error: lexical error at line 3, column 12
```

This PR fixes it:
```
cat alwaystrue.uplc | uplc print
(program
  1.0.0
  [
    [
      (lam i_0_0 (lam i_1_1 (lam i_2_2 (lam i_3_3 (lam i_4_4 i_0_0)))))
      (delay (lam i_5_5 i_5_5))
    ]
    (lam i_6_6 i_6_6)
  ]
)
```

I've read that pretty-printing isn't the priority at the moment, but changes like these do help transpiler writers who desire tight (pretty-printed) Plutus Core programs to process.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
