### PR TITLE
[Builtins] [Refac] Improve the meaning of 'Trace'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -258,11 +258,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     -- Tracing
     toBuiltinMeaning Trace =
         makeBuiltinMeaning
-            emitPlc
+            (\text a -> a <$ emit @Emitter text)
             (runCostingFunTwoArguments . paramTrace)
-        where
-          emitPlc :: SomeConstantOf uni Text '[] -> Opaque term a -> Emitter (Opaque term a)
-          emitPlc (SomeConstantOfRes _ s) t = emit s >> pure t
     -- Pairs
     toBuiltinMeaning FstPair =
         makeBuiltinMeaning


### PR DESCRIPTION
I noticed the `trace` builtin was definitely very suboptimally. I'm not sure if there's any valid use case for `SomeConstantOf uni Some_type '[]`, but I can't think of any. `SomeConstant uni Some_type`  is a better way to spell that, but that also only makes sense when `Some_type` represents a Plutus type variable. So what should be used in `Trace` instead of `SomeConstantOf uni Text '[]` is simply `Text` and at that point inference works well and no type signatures are required.

Note that this is not just a nicer definition, it's also faster, since the `KnownType` instance of `SomeConstantOf` does quite a lot of bookkeeping.