### PR TITLE
Constrain tests by platform

### DIFF
--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -83,6 +83,48 @@ library
     Language.Marlowe.Analysis.FSSemantics
   other-modules:
 
+test-suite marlowe-test-long-running
+    import: lang
+    hs-source-dirs:
+      test
+      pab
+    type: exitcode-stdio-1.0
+    main-is: SpecLongRunning.hs
+    other-modules:
+        Spec.PAB.Workflow
+        MarloweContract
+    build-depends:
+        aeson -any,
+        base >=4.9 && <5,
+        containers -any,
+        data-default  -any,
+        hint -any,
+        lens -any,
+        bytestring -any,
+        freer-simple -any,
+        tasty -any,
+        tasty-hunit -any,
+        tasty-quickcheck,
+        text -any,
+        serialise,
+        cborg,
+        plutus-chain-index -any,
+        plutus-contract -any,
+        plutus-ledger -any,
+        marlowe,
+        plutus-tx -any,
+        QuickCheck,
+        template-haskell -any,
+        streaming -any,
+        plutus-pab -any,
+        async -any,
+        prettyprinter -any,
+        purescript-bridge -any,
+        servant-client -any,
+        http-client -any,
+        websockets -any,
+        network -any,
+
 test-suite marlowe-test
     import: lang
     hs-source-dirs:
@@ -94,7 +136,6 @@ test-suite marlowe-test
         Spec.Marlowe.Common
         Spec.Marlowe.Marlowe
         Spec.Marlowe.AutoExecute
-        Spec.PAB.Workflow
         MarloweContract
     build-depends:
         aeson -any,

--- a/marlowe/test/Spec.hs
+++ b/marlowe/test/Spec.hs
@@ -3,14 +3,12 @@ module Main(main) where
 
 import qualified Spec.Marlowe.AutoExecute
 import qualified Spec.Marlowe.Marlowe
--- import qualified Spec.PAB.Workflow
 
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 main :: IO ()
 main = defaultMain tests
-
 
 tests :: TestTree
 tests = testGroup "Marlowe"
@@ -26,9 +24,4 @@ tests = testGroup "Marlowe"
     , testGroup "Marlowe JSON"
         [ testProperty "Serialise deserialise loops" Spec.Marlowe.Marlowe.prop_jsonLoops
         ]
-    -- TODO: Will be reinstated very soon; have to comment out so that the
-    -- mac-mini tests don't time out :(
-    -- , testGroup "PAB Workflow"
-    --   [ Spec.PAB.Workflow.tests
-    --   ]
     ]

--- a/marlowe/test/SpecLongRunning.hs
+++ b/marlowe/test/SpecLongRunning.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main(main) where
+
+import qualified Spec.PAB.Workflow
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Marlowe"
+    [ testGroup "PAB Workflow"
+      [ Spec.PAB.Workflow.tests
+      ]
+    ]

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -202,6 +202,12 @@ let
             export ACTUS_TEST_DATA_DIR=${actus-tests}/tests/
           '';
 
+          marlowe.components.tests.marlowe-test-long-running = {
+            # Note: These tests fail on the mac-mini, so we're disablihg them
+            # for _all_ macs here.
+            platforms = lib.platforms.linux;
+          };
+
           # Broken due to warnings, unclear why the setting that fixes this for the build doesn't work here.
           iohk-monitoring.doHaddock = false;
 

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -202,11 +202,21 @@ let
             export ACTUS_TEST_DATA_DIR=${actus-tests}/tests/
           '';
 
+
+          # Note: The following two statements say that these tests should
+          # _only_ run on linux. In actual fact we just don't want them
+          # running on the 'mac-mini' instances, because these tests time out
+          # there. In an ideal world this would be reflected here more
+          # accurately.
+          # TODO: Resolve this situation in a better way.
           marlowe.components.tests.marlowe-test-long-running = {
-            # Note: These tests fail on the mac-mini, so we're disablihg them
-            # for _all_ macs here.
             platforms = lib.platforms.linux;
           };
+
+          plutus-pab.components.tests.plutus-pab-test-full-long-running = {
+            platforms = lib.platforms.linux;
+          };
+
 
           # Broken due to warnings, unclear why the setting that fixes this for the build doesn't work here.
           iohk-monitoring.doHaddock = false;

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -95,6 +95,44 @@
           };
         };
       tests = {
+        "marlowe-test-long-running" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."hint" or (errorHandler.buildDepError "hint"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."streaming" or (errorHandler.buildDepError "streaming"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            ];
+          buildable = true;
+          modules = [ "Spec/PAB/Workflow" "MarloweContract" ];
+          hsSourceDirs = [ "test" "pab" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         "marlowe-test" = {
           depends = [
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
@@ -133,7 +171,6 @@
             "Spec/Marlowe/Common"
             "Spec/Marlowe/Marlowe"
             "Spec/Marlowe/AutoExecute"
-            "Spec/PAB/Workflow"
             "MarloweContract"
             ];
           hsSourceDirs = [ "test" "pab" ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -518,6 +518,9 @@
           buildable = true;
           modules = [
             "ContractExample"
+            "ContractExample/WaitForTx"
+            "ContractExample/AtomicSwap"
+            "ContractExample/PayToWallet"
             "Plutus/PAB/CliSpec"
             "Plutus/PAB/Effects/Contract/ContractTest"
             "Plutus/PAB/Simulator/Test"

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-pab.nix
@@ -474,6 +474,57 @@
           hsSourceDirs = [ "test/full" "examples" ];
           mainPath = [ "Spec.hs" ];
           };
+        "plutus-pab-test-full-long-running" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+            ];
+          buildable = true;
+          modules = [
+            "ContractExample"
+            "Plutus/PAB/CliSpec"
+            "Plutus/PAB/Effects/Contract/ContractTest"
+            "Plutus/PAB/Simulator/Test"
+            ];
+          hsSourceDirs = [ "test/full" "examples" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         };
       };
     } // rec { src = (pkgs.lib).mkDefault ../plutus-pab; }

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1165,6 +1165,7 @@
           "hspec-discover".components.exes."hspec-discover".planned = lib.mkOverride 900 true;
           "prettyprinter-configurable".components.setup.planned = lib.mkOverride 900 true;
           "MonadRandom".components.library.planned = lib.mkOverride 900 true;
+          "marlowe".components.tests."marlowe-test-long-running".planned = lib.mkOverride 900 true;
           "mmorph".components.library.planned = lib.mkOverride 900 true;
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1055,6 +1055,7 @@
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "iohk-monitoring".components.library.planned = lib.mkOverride 900 true;
           "insert-ordered-containers".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab".components.tests."plutus-pab-test-full-long-running".planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
           "criterion-measurement".components.library.planned = lib.mkOverride 900 true;
           "plutus-contract".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -95,6 +95,44 @@
           };
         };
       tests = {
+        "marlowe-test-long-running" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."hint" or (errorHandler.buildDepError "hint"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."streaming" or (errorHandler.buildDepError "streaming"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            ];
+          buildable = true;
+          modules = [ "Spec/PAB/Workflow" "MarloweContract" ];
+          hsSourceDirs = [ "test" "pab" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         "marlowe-test" = {
           depends = [
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
@@ -133,7 +171,6 @@
             "Spec/Marlowe/Common"
             "Spec/Marlowe/Marlowe"
             "Spec/Marlowe/AutoExecute"
-            "Spec/PAB/Workflow"
             "MarloweContract"
             ];
           hsSourceDirs = [ "test" "pab" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -518,6 +518,9 @@
           buildable = true;
           modules = [
             "ContractExample"
+            "ContractExample/WaitForTx"
+            "ContractExample/AtomicSwap"
+            "ContractExample/PayToWallet"
             "Plutus/PAB/CliSpec"
             "Plutus/PAB/Effects/Contract/ContractTest"
             "Plutus/PAB/Simulator/Test"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-pab.nix
@@ -474,6 +474,57 @@
           hsSourceDirs = [ "test/full" "examples" ];
           mainPath = [ "Spec.hs" ];
           };
+        "plutus-pab-test-full-long-running" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+            ];
+          buildable = true;
+          modules = [
+            "ContractExample"
+            "Plutus/PAB/CliSpec"
+            "Plutus/PAB/Effects/Contract/ContractTest"
+            "Plutus/PAB/Simulator/Test"
+            ];
+          hsSourceDirs = [ "test/full" "examples" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         };
       };
     } // rec { src = (pkgs.lib).mkDefault ../plutus-pab; }

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1171,6 +1171,7 @@
           "hspec-discover".components.exes."hspec-discover".planned = lib.mkOverride 900 true;
           "prettyprinter-configurable".components.setup.planned = lib.mkOverride 900 true;
           "MonadRandom".components.library.planned = lib.mkOverride 900 true;
+          "marlowe".components.tests."marlowe-test-long-running".planned = lib.mkOverride 900 true;
           "mmorph".components.library.planned = lib.mkOverride 900 true;
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1060,6 +1060,7 @@
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "iohk-monitoring".components.library.planned = lib.mkOverride 900 true;
           "insert-ordered-containers".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab".components.tests."plutus-pab-test-full-long-running".planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
           "criterion-measurement".components.library.planned = lib.mkOverride 900 true;
           "plutus-contract".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -95,6 +95,44 @@
           };
         };
       tests = {
+        "marlowe-test-long-running" = {
+          depends = [
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."hint" or (errorHandler.buildDepError "hint"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."streaming" or (errorHandler.buildDepError "streaming"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            ];
+          buildable = true;
+          modules = [ "Spec/PAB/Workflow" "MarloweContract" ];
+          hsSourceDirs = [ "test" "pab" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         "marlowe-test" = {
           depends = [
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
@@ -133,7 +171,6 @@
             "Spec/Marlowe/Common"
             "Spec/Marlowe/Marlowe"
             "Spec/Marlowe/AutoExecute"
-            "Spec/PAB/Workflow"
             "MarloweContract"
             ];
           hsSourceDirs = [ "test" "pab" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
@@ -518,6 +518,9 @@
           buildable = true;
           modules = [
             "ContractExample"
+            "ContractExample/WaitForTx"
+            "ContractExample/AtomicSwap"
+            "ContractExample/PayToWallet"
             "Plutus/PAB/CliSpec"
             "Plutus/PAB/Effects/Contract/ContractTest"
             "Plutus/PAB/Simulator/Test"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-pab.nix
@@ -474,6 +474,57 @@
           hsSourceDirs = [ "test/full" "examples" ];
           mainPath = [ "Spec.hs" ];
           };
+        "plutus-pab-test-full-long-running" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
+            (hsPkgs."plutus-use-cases" or (errorHandler.buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."smallcheck" or (errorHandler.buildDepError "smallcheck"))
+            (hsPkgs."tasty-smallcheck" or (errorHandler.buildDepError "tasty-smallcheck"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+            (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+            ];
+          buildable = true;
+          modules = [
+            "ContractExample"
+            "Plutus/PAB/CliSpec"
+            "Plutus/PAB/Effects/Contract/ContractTest"
+            "Plutus/PAB/Simulator/Test"
+            ];
+          hsSourceDirs = [ "test/full" "examples" ];
+          mainPath = [ "SpecLongRunning.hs" ];
+          };
         };
       };
     } // rec { src = (pkgs.lib).mkDefault ../plutus-pab; }

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -1040,6 +1040,7 @@
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "iohk-monitoring".components.library.planned = lib.mkOverride 900 true;
           "insert-ordered-containers".components.library.planned = lib.mkOverride 900 true;
+          "plutus-pab".components.tests."plutus-pab-test-full-long-running".planned = lib.mkOverride 900 true;
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
           "criterion-measurement".components.library.planned = lib.mkOverride 900 true;
           "plutus-contract".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -477,6 +477,9 @@ test-suite plutus-pab-test-full-long-running
     main-is:          SpecLongRunning.hs
     other-modules:
         ContractExample
+        ContractExample.WaitForTx
+        ContractExample.AtomicSwap
+        ContractExample.PayToWallet
         Plutus.PAB.CliSpec
         Plutus.PAB.Effects.Contract.ContractTest
         Plutus.PAB.Simulator.Test

--- a/plutus-pab/plutus-pab.cabal
+++ b/plutus-pab/plutus-pab.cabal
@@ -467,6 +467,60 @@ test-suite plutus-pab-test-full
         servant-client -any,
         uuid -any,
 
+test-suite plutus-pab-test-full-long-running
+    default-language: Haskell2010
+    hs-source-dirs:
+        test/full
+        examples
+
+    type:             exitcode-stdio-1.0
+    main-is:          SpecLongRunning.hs
+    other-modules:
+        ContractExample
+        Plutus.PAB.CliSpec
+        Plutus.PAB.Effects.Contract.ContractTest
+        Plutus.PAB.Simulator.Test
+
+    build-depends:
+        QuickCheck -any,
+        aeson -any,
+        aeson-pretty -any,
+        base >=4.9 && <5,
+        bytestring -any,
+        containers -any,
+        data-default -any,
+        freer-extras -any,
+        freer-simple -any,
+        http-client -any,
+        http-client-tls -any,
+        lens -any,
+        monad-logger -any,
+        mtl -any,
+        plutus-contract -any,
+        plutus-pab,
+        plutus-use-cases -any,
+        plutus-ledger -any,
+        quickcheck-instances -any,
+        servant-client -any,
+        tasty -any,
+        tasty-hunit -any,
+        smallcheck -any,
+        tasty-smallcheck -any,
+        tasty-quickcheck -any,
+        text -any,
+        transformers -any,
+        prettyprinter -any,
+        row-types -any,
+        plutus-tx -any,
+        playground-common -any,
+        yaml -any,
+        iohk-monitoring -any,
+        servant-server -any,
+        purescript-bridge -any,
+        async -any,
+        servant-client -any,
+        uuid -any,
+
 executable tx-inject
     import:           lang
     main-is:          Main.hs

--- a/plutus-pab/test/full/Spec.hs
+++ b/plutus-pab/test/full/Spec.hs
@@ -2,7 +2,6 @@ module Main
     ( main
     ) where
 
-import qualified Plutus.PAB.CliSpec
 import qualified Plutus.PAB.CoreSpec
 import qualified Plutus.PAB.Effects.Contract.BuiltinSpec
 import           Test.Tasty                              (defaultMain, testGroup)
@@ -12,10 +11,6 @@ main =
     defaultMain $
     testGroup
         "all tests"
-        [
-        Plutus.PAB.CoreSpec.tests
-        -- TODO: To be re-instated once we resolve big delays experienced by
-        -- running lots of PABs at once.
-        -- , Plutus.PAB.CliSpec.tests
+        [ Plutus.PAB.CoreSpec.tests
         , Plutus.PAB.Effects.Contract.BuiltinSpec.tests
         ]

--- a/plutus-pab/test/full/SpecLongRunning.hs
+++ b/plutus-pab/test/full/SpecLongRunning.hs
@@ -1,0 +1,14 @@
+module Main
+    ( main
+    ) where
+
+import qualified Plutus.PAB.CliSpec
+import           Test.Tasty         (defaultMain, testGroup)
+
+main :: IO ()
+main =
+    defaultMain $
+    testGroup
+        "all tests"
+        [ Plutus.PAB.CliSpec.tests
+        ]


### PR DESCRIPTION
This follows the idea of @hamishmack to use the `platform` filter to prevent these long-running tests from running on the mac-mini.

Notably, it avoids the tests running _on macs_ in general. This is a bit of a shame, but I think it's one step better than _not running the tests at all_, which was the previous alternative.

Topics for discussion:

- [ ] Does it have to be a separate test module in order to coax the `.platform` thing to ignore it? (i.e. I had to make new cabal components so I could exclude them with the `platform` value.) It would've been much nicer to do it with a `tasty` and include them via `TASTYPATTERN="@long-running"` or something.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
