### PR TITLE
[#3843] Make arbitrary instance for actions in quickcheck-dynamic depend on their sizing

### DIFF
--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -95,7 +95,7 @@ bob = w2
 
 
 zeroCouponBondTest :: TestTree
-zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250) "Zero Coupon Bond Contract"
+zeroCouponBondTest = checkPredicateOptions defaultCheckOptions "Zero Coupon Bond Contract"
     (assertNoFailedTransactions
     -- T..&&. emulatorLog (const False) ""
     T..&&. assertDone marlowePlutusContract (Trace.walletInstanceTag alice) (const True) "contract should close"
@@ -136,7 +136,7 @@ zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250
 
 
 errorHandlingTest :: TestTree
-errorHandlingTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250) "Error handling"
+errorHandlingTest = checkPredicateOptions defaultCheckOptions "Error handling"
     (assertAccumState marlowePlutusContract (Trace.walletInstanceTag alice)
     (\case (SomeError (TransitionError _)) -> True
            _                               -> False
@@ -167,7 +167,7 @@ errorHandlingTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250)
 
 
 trustFundTest :: TestTree
-trustFundTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 200) "Trust Fund Contract"
+trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
     (assertNoFailedTransactions
     -- T..&&. emulatorLog (const False) ""
     T..&&. assertNotDone marlowePlutusContract (Trace.walletInstanceTag alice) "contract should not have any errors"

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -52,36 +52,36 @@ import           Plutus.Contract.Trace.RequestHandler (maybeToHandler)
 
 tests :: TestTree
 tests =
-    let run :: Slot -> String -> TracePredicate -> EmulatorTrace () -> _
-        run sl = checkPredicateOptions (defaultCheckOptions & maxSlot .~ sl & minLogLevel .~ Debug)
+    let run :: String -> TracePredicate -> EmulatorTrace () -> _
+        run = checkPredicateOptions (defaultCheckOptions & minLogLevel .~ Debug)
 
-        check :: Slot -> String -> Contract () Schema ContractError () -> _ -> _
-        check sl nm contract pred = run sl nm (pred contract) (void $ activateContract w1 contract tag)
+        check :: String -> Contract () Schema ContractError () -> _ -> _
+        check nm contract pred = run nm (pred contract) (void $ activateContract w1 contract tag)
 
         tag :: ContractInstanceTag
         tag = "instance 1"
 
     in
     testGroup "contracts"
-        [ check 1 "awaitSlot" (void $ awaitSlot 10) $ \con ->
+        [ check "awaitSlot" (void $ awaitSlot 10) $ \con ->
             waitingForSlot con tag 10
 
-        , check 1 "selectEither" (void $ awaitPromise $ selectEither (isSlot 10) (isSlot 5)) $ \con ->
+        , check "selectEither" (void $ awaitPromise $ selectEither (isSlot 10) (isSlot 5)) $ \con ->
             waitingForSlot con tag 5
 
-        , check 1 "both" (void $ awaitPromise $ Con.both (isSlot 10) (isSlot 20)) $ \con ->
+        , check "both" (void $ awaitPromise $ Con.both (isSlot 10) (isSlot 20)) $ \con ->
             waitingForSlot con tag 10
 
-        , check 1 "both (2)" (void $ awaitPromise $ Con.both (isSlot 10) (isSlot 20)) $ \con ->
+        , check "both (2)" (void $ awaitPromise $ Con.both (isSlot 10) (isSlot 20)) $ \con ->
             waitingForSlot con tag 20
 
-        , check 1 "watchAddressUntilSlot" (void $ watchAddressUntilSlot someAddress 5) $ \con ->
+        , check "watchAddressUntilSlot" (void $ watchAddressUntilSlot someAddress 5) $ \con ->
             waitingForSlot con tag 5
 
-        , check 1 "endpoint" (void $ awaitPromise $ endpoint @"ep" pure) $ \con ->
+        , check "endpoint" (void $ awaitPromise $ endpoint @"ep" pure) $ \con ->
             endpointAvailable @"ep" con tag
 
-        , check 1 "forever" (forever $ awaitPromise $ endpoint @"ep" pure) $ \con ->
+        , check "forever" (forever $ awaitPromise $ endpoint @"ep" pure) $ \con ->
             endpointAvailable @"ep" con tag
 
         , let
@@ -89,7 +89,7 @@ tests =
             oneThree :: Promise () Schema ContractError Int = endpoint @"1" pure .> endpoint @"3" pure .> endpoint @"4" pure
             con = selectList [void oneTwo, void oneThree]
           in
-            run 1 "alternative"
+            run "alternative"
                 (endpointAvailable @"2" con tag
                     .&&. not (endpointAvailable @"3" con tag))
                 $ do
@@ -97,25 +97,25 @@ tests =
                     callEndpoint @"1" hdl 1
 
         , let theContract :: Contract () Schema ContractError () = void $ awaitPromise $ endpoint @"1" @Int pure .> endpoint @"2" @Int pure
-          in run 1 "call endpoint (1)"
+          in run "call endpoint (1)"
                 (endpointAvailable @"1" theContract tag)
                 (void $ activateContract w1 theContract tag)
 
         , let theContract :: Contract () Schema ContractError () = void $ awaitPromise $ endpoint @"1" @Int pure .> endpoint @"2" @Int pure
-          in run 1 "call endpoint (2)"
+          in run "call endpoint (2)"
                 (endpointAvailable @"2" theContract tag
                     .&&. not (endpointAvailable @"1" theContract tag))
                 (activateContract w1 theContract tag >>= \hdl -> callEndpoint @"1" hdl 1)
 
         , let theContract :: Contract () Schema ContractError () = void $ awaitPromise $ endpoint @"1" @Int pure .> endpoint @"2" @Int pure
-          in run 1 "call endpoint (3)"
+          in run "call endpoint (3)"
                 (not (endpointAvailable @"2" theContract tag)
                     .&&. not (endpointAvailable @"1" theContract tag))
                 (activateContract w1 theContract tag >>= \hdl -> callEndpoint @"1" hdl 1 >> callEndpoint @"2" hdl 2)
 
         , let theContract :: Contract () Schema ContractError [ActiveEndpoint] = awaitPromise $ endpoint @"5" @[ActiveEndpoint] pure
               expected = ActiveEndpoint{ aeDescription = EndpointDescription "5", aeMetadata = Nothing}
-          in run 5 "active endpoints"
+          in run "active endpoints"
                 (assertDone theContract tag ((==) [expected]) "should be done")
                 $ do
                     hdl <- activateContract w1 theContract tag
@@ -124,13 +124,13 @@ tests =
                     void $ callEndpoint @"5" hdl eps
 
         , let theContract :: Contract () Schema ContractError () = void $ submitTx mempty >> watchAddressUntilSlot someAddress 20
-          in run 1 "submit tx"
+          in run "submit tx"
                 (waitingForSlot theContract tag 20)
                 (void $ activateContract w1 theContract tag)
 
         , let smallTx = Constraints.mustPayToPubKey (Crypto.pubKeyHash $ walletPubKey w2) (Ada.lovelaceValueOf 10)
               theContract :: Contract () Schema ContractError () = submitTx smallTx >>= awaitTxConfirmed . Ledger.txId >> submitTx smallTx >>= awaitTxConfirmed . Ledger.txId
-          in run 3 "handle several blockchain events"
+          in run "handle several blockchain events"
                 (walletFundsChange w1 (Ada.lovelaceValueOf (-20))
                     .&&. assertNoFailedTransactions
                     .&&. assertDone theContract tag (const True) "all blockchain events should be processed")
@@ -139,28 +139,28 @@ tests =
         , let l = endpoint @"1" pure .> endpoint @"2" pure
               r = endpoint @"3" pure .> endpoint @"4" pure
               theContract :: Contract () Schema ContractError () = void . awaitPromise $ selectEither l r
-          in run 1 "select either"
+          in run "select either"
                 (assertDone theContract tag (const True) "left branch should finish")
                 (activateContract w1 theContract tag >>= (\hdl -> callEndpoint @"1" hdl 1 >> callEndpoint @"2" hdl 2))
 
         , let theContract :: Contract () Schema ContractError () = void $ loopM (\_ -> fmap Left . awaitPromise $ endpoint @"1" @Int pure) 0
-          in run 1 "loopM"
+          in run "loopM"
                 (endpointAvailable @"1" theContract tag)
                 (void $ activateContract w1 theContract tag >>= \hdl -> callEndpoint @"1" hdl 1)
 
         , let theContract :: Contract () Schema ContractError () = void $ throwing Con._ContractError $ OtherError "error"
-          in run 1 "throw an error"
+          in run "throw an error"
                 (assertContractError theContract tag (\case { OtherError "error" -> True; _ -> False}) "failed to throw error")
                 (void $ activateContract w1 theContract tag)
 
-        , run 2 "pay to wallet"
+        , run "pay to wallet"
             (walletFundsChange w1 (Ada.lovelaceValueOf (-200))
                 .&&. walletFundsChange w2 (Ada.lovelaceValueOf 200)
                 .&&. assertNoFailedTransactions)
             (void $ Trace.payToWallet w1 w2 (Ada.lovelaceValueOf 200))
 
         , let theContract :: Contract () Schema ContractError () = void $ awaitUtxoProduced (walletAddress w2)
-          in run 2 "await utxo produced"
+          in run "await utxo produced"
             (assertDone theContract tag (const True) "should receive a notification")
             (void $ do
                 activateContract w1 theContract tag
@@ -169,7 +169,7 @@ tests =
             )
 
         , let theContract :: Contract () Schema ContractError () = void (utxosAt (walletAddress w1) >>= awaitUtxoSpent . fst . head . Map.toList)
-          in run 2 "await txout spent"
+          in run "await txout spent"
             (assertDone theContract tag (const True) "should receive a notification")
             (void $ do
                 activateContract w1 theContract tag
@@ -178,25 +178,25 @@ tests =
             )
 
         , let theContract :: Contract () Schema ContractError PubKey = ownPubKey
-          in run 1 "own public key"
+          in run "own public key"
                 (assertDone theContract tag (== walletPubKey w2) "should return the wallet's public key")
                 (void $ activateContract w2 (void theContract) tag)
 
         , let payment = Constraints.mustPayToPubKey (Crypto.pubKeyHash $ walletPubKey w2) (Ada.lovelaceValueOf 10)
               theContract :: Contract () Schema ContractError () = submitTx payment >>= awaitTxConfirmed . Ledger.txId
-          in run 2 "await tx confirmed"
+          in run "await tx confirmed"
             (assertDone theContract tag (const True) "should be done")
             (activateContract w1 theContract tag >> void (Trace.waitNSlots 1))
 
-        , run 1 "checkpoints"
+        , run "checkpoints"
             (not (endpointAvailable @"2" checkpointContract tag) .&&. endpointAvailable @"1" checkpointContract tag)
             (void $ activateContract w1 checkpointContract tag >>= \hdl -> callEndpoint @"1" hdl 1 >> callEndpoint @"2" hdl 1)
 
-        , run 1 "error handling & checkpoints"
+        , run "error handling & checkpoints"
             (assertDone errorContract tag (\i -> i == 11) "should finish")
             (void $ activateContract w1 (void errorContract) tag >>= \hdl -> callEndpoint @"1" hdl 1 >> callEndpoint @"2" hdl 10 >> callEndpoint @"3" hdl 11)
 
-        , run 1 "loop checkpoint"
+        , run "loop checkpoint"
             (assertDone loopCheckpointContract tag (\i -> i == 4) "should finish"
             .&&. assertResumableResult loopCheckpointContract tag DoShrink (null . view responses) "should collect garbage"
             .&&. assertResumableResult loopCheckpointContract tag DontShrink ((==) 4 . length . view responses) "should keep everything"
@@ -211,7 +211,7 @@ tests =
                   case _cilMessage . EM._eteEvent <$> lgs of
                             [ Started, ContractLog "waiting for endpoint 1", CurrentRequests [_], ReceiveEndpointCall{}, ContractLog "Received value: 27", HandledRequest _, CurrentRequests [], StoppedNoError ] -> True
                             _ -> False
-          in run 1 "contract logs"
+          in run "contract logs"
                 (assertInstanceLog tag matchLogs)
                 (void $ activateContract w1 theContract tag >>= \hdl -> callEndpoint @"1" hdl 27)
 
@@ -221,7 +221,7 @@ tests =
                   case EM._eteEvent <$> lgs of
                             [ UserLog "Received contract state", UserLog "Final state: Right Nothing"] -> True
                             _                                                                          -> False
-          in run 4 "contract state"
+          in run "contract state"
                 (assertUserLog matchLogs)
                 $ do
                     hdl <- Trace.activateContractWallet w1 theContract

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -204,7 +204,7 @@ unNameTyDeBruijn (NamedTyDeBruijn db) = TyDeBruijn $ unNameDeBruijn db
 
 fakeNameDeBruijn
     :: DeBruijn -> NamedDeBruijn
-fakeNameDeBruijn (DeBruijn ix) = NamedDeBruijn "" ix
+fakeNameDeBruijn (DeBruijn ix) = NamedDeBruijn "i" ix
 
 nameToDeBruijn
     :: (MonadReader Levels m, AsFreeVariableError e, MonadError e m)

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -10,7 +10,6 @@
 module Spec.Crowdfunding(tests) where
 
 import qualified Control.Foldl                         as L
-import           Control.Lens                          ((&), (.~))
 import           Control.Monad                         (void)
 import           Control.Monad.Freer                   (run)
 import           Control.Monad.Freer.Extras.Log        (LogLevel (..))
@@ -52,7 +51,7 @@ tests = testGroup "crowdfunding"
             slotCfg <- Trace.getSlotConfig
             void (Trace.activateContractWallet w1 $ theContract $ TimeSlot.scSlotZeroTime slotCfg)
 
-    , checkPredicateOptions (defaultCheckOptions & maxSlot .~ 20) "make contribution"
+    , checkPredicateOptions defaultCheckOptions "make contribution"
         (walletFundsChange w1 (Ada.lovelaceValueOf (-100)))
         $ let contribution = Ada.lovelaceValueOf 100
           in makeContribution w1 contribution >> void Trace.nextSlot


### PR DESCRIPTION
We have found out that `Arbitrary` instance for `Actions state` generates a list of actions that does not exceed 125 slots of `initialState` as of here
https://github.com/input-output-hk/plutus/blob/d87e2eb1c37b995af2c56c5197a68dc02ced2633/quickcheck-dynamic/src/Test/QuickCheck/StateModel.hs#L113-L115

Meaning that even if we can still configure `initialState.lastSlot` in `propRunActionsWithOptions` to make the precondition be satisfied
https://github.com/input-output-hk/plutus/blob/d87e2eb1c37b995af2c56c5197a68dc02ced2633/plutus-contract/src/Plutus/Contract/Test/ContractModel.hs#L530-L531

We only strip list of actions that was already generated by the `Arbitrary` instance above. This PR removes the requirement of having the limitation of contract slots amount since the generator already produces the reasonable test data and the requirement itself of having `lastSlot` in precondition in first place was unbiased as far as I could find. 

There is an attempt to bring in reflection to parametrise the `Arbitrary` instance to generate a list of actions, but the problem is that in this case we're unable to `quickCheck` over such props directly due to impredicativity issues, meaning that we cannot construct a function such as [this one](https://github.com/mlabs-haskell/plutus/blob/c16b46e552fa781375a939ed8a270cda6f0a013b/plutus-use-cases/test/Spec/GameStateMachine.hs#L204-L210). This could be worked around by restructuring `Spec.hs` test runner and exposing state initialisation for each contract spec there for which the cost of having parametrised `Arbitrary` for actions is too high since the list of actions can only depend on its length and every other precondition is validated after the list was generated first. 

Closes https://github.com/input-output-hk/plutus/issues/3843

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
