### PR TITLE
Add `withTimeout` to `plutus-contract`

### DIFF
--- a/plutus-contract/src/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Plutus/Contract/Request.hs
@@ -21,6 +21,7 @@ module Plutus.Contract.Request(
     , currentSlot
     , waitNSlots
     , awaitTime
+    , withTimeout
     , isTime
     , currentTime
     , waitNMilliSeconds
@@ -180,6 +181,23 @@ awaitTime ::
     => POSIXTime
     -> Contract w s e POSIXTime
 awaitTime s = pabReq (AwaitTimeReq s) E._AwaitTimeResp
+
+-- | Await a promise, or throw an error after timeout
+withTimeout
+  :: forall w endpoints err a.
+     AsContractError err
+  => -- | Timeout duration to wait for. Note: this will round to Slot time
+     POSIXTime
+  -> -- | Error thrown on timeout
+     err
+  -> Promise w endpoints err a
+  -> Contract w endpoints err a
+withTimeout len err promise = do
+  time <- currentTime
+  result <-
+    awaitPromise $
+      promise `selectEither` isTime (time + len)
+  either pure (const $ throwError err) result
 
 -- | Wait until the slot where the given time falls into and return latest time
 -- we know has passed.


### PR DESCRIPTION
It's a part of https://github.com/input-output-hk/plutus/pull/3852 that adds `withTimeout` function to `plutus-contract`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
