### PR TITLE
make transaction status return an either

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
@@ -225,6 +225,7 @@ data TxStatusFailure =
       -- state ... that we didn't know how to decode in
       -- 'Plutus.ChainIndex.TxIdState.transactionStatus'.
       TxIdStateInvalid BlockNumber TxId TxIdState
+      deriving (Show, Eq)
 
 data TxIdState = TxIdState
   { txnsConfirmed :: Map TxId TxConfirmedState

--- a/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
@@ -20,6 +20,9 @@ module Plutus.ChainIndex.Types(
     , BlockNumber(..)
     , Depth(..)
     , Diagnostics(..)
+    , TxConfirmedState(..)
+    , TxStatusFailure(..)
+    , TxIdState(..)
     ) where
 
 import qualified Codec.Serialise                  as CBOR
@@ -28,6 +31,10 @@ import           Data.Aeson                       (FromJSON, ToJSON)
 import qualified Data.ByteArray                   as BA
 import qualified Data.ByteString.Lazy             as BSL
 import           Data.Default                     (Default (..))
+import           Data.Map                         (Map)
+import qualified Data.Map                         as Map
+import           Data.Monoid                      (Last (..), Sum (..))
+import           Data.Semigroup.Generic           (GenericSemigroupMonoid (..))
 import           Data.Set                         (Set)
 import qualified Data.Set                         as Set
 import           Data.Text.Prettyprint.Doc.Extras (PrettyShow (..))
@@ -212,3 +219,39 @@ data Diagnostics =
         }
         deriving stock (Eq, Ord, Show, Generic)
         deriving anyclass (ToJSON, FromJSON)
+
+data TxStatusFailure =
+      -- | We couldn't return the status because the 'TxIdState' was in a ...
+      -- state ... that we didn't know how to decode in
+      -- 'Plutus.ChainIndex.TxIdState.transactionStatus'.
+      TxIdStateInvalid BlockNumber TxId TxIdState
+
+data TxIdState = TxIdState
+  { txnsConfirmed :: Map TxId TxConfirmedState
+  -- ^ Number of times this transaction has been added as well as other
+  -- necessary metadata.
+  , txnsDeleted   :: Map TxId (Sum Int)
+  -- ^ Number of times this transaction has been deleted.
+  }
+  deriving stock (Eq, Generic, Show)
+
+instance Monoid TxIdState where
+    mappend = (<>)
+    mempty  = TxIdState { txnsConfirmed=mempty, txnsDeleted=mempty }
+
+data TxConfirmedState =
+  TxConfirmedState
+    { timesConfirmed :: Sum Int
+    , blockAdded     :: Last BlockNumber
+    , validity       :: Last TxValidity
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (Semigroup, Monoid) via (GenericSemigroupMonoid TxConfirmedState)
+
+-- A semigroup instance that merges the two maps, instead of taking the
+-- leftmost one.
+instance Semigroup TxIdState where
+  TxIdState{txnsConfirmed=c, txnsDeleted=d} <> TxIdState{txnsConfirmed=c', txnsDeleted=d'}
+    = TxIdState { txnsConfirmed = Map.unionWith (<>) c c'
+                , txnsDeleted   = Map.unionWith (<>) d d'
+                }

--- a/plutus-chain-index/test/Generators.hs
+++ b/plutus-chain-index/test/Generators.hs
@@ -47,9 +47,8 @@ import           Ledger.Tx                   (Address, TxIn (..), TxOut (..), Tx
 import           Ledger.TxId                 (TxId (..))
 import           Ledger.Value                (Value)
 import           Plutus.ChainIndex.Tx        (ChainIndexTx (..), ChainIndexTxOutputs (..))
-import           Plutus.ChainIndex.TxIdState (TxIdState)
 import qualified Plutus.ChainIndex.TxIdState as TxIdState
-import           Plutus.ChainIndex.Types     (BlockId (..), BlockNumber (..), Tip (..))
+import           Plutus.ChainIndex.Types     (BlockId (..), BlockNumber (..), Tip (..), TxIdState)
 import           Plutus.ChainIndex.UtxoState (TxUtxoBalance (..), fromTx)
 import qualified PlutusTx.Prelude            as PlutusTx
 

--- a/plutus-chain-index/test/Spec.hs
+++ b/plutus-chain-index/test/Spec.hs
@@ -101,9 +101,9 @@ rollbackTxIdState = property $ do
       status3 = transactionStatus (BlockNumber 2) (getState f3) (txB ^. citxTxId)
       status4 = transactionStatus (BlockNumber 3) (getState f4) (txB ^. citxTxId)
 
-  status2 === TentativelyConfirmed (Depth 0) TxValid
-  status3 === Unknown
-  status4 === TentativelyConfirmed (Depth 1) TxValid
+  status2 === (Right $ TentativelyConfirmed (Depth 0) TxValid)
+  status3 === (Right $ Unknown)
+  status4 === (Right $ TentativelyConfirmed (Depth 1) TxValid)
 
 transactionDepthIncreases :: Property
 transactionDepthIncreases = property $ do
@@ -121,8 +121,8 @@ transactionDepthIncreases = property $ do
       status2 = transactionStatus (BlockNumber 1) (UtxoState._usTxUtxoData (measure f2)) (txA ^. citxTxId)
       status3 = transactionStatus (BlockNumber (1 + d)) (UtxoState._usTxUtxoData (measure f2)) (txA ^. citxTxId)
 
-  status2 === increaseDepth status1
-  status3 === Committed TxValid
+  status2 === (increaseDepth <$> status1)
+  status3 === (Right $ Committed TxValid)
 
 uniqueTransactionIds :: Property
 uniqueTransactionIds = property $ do


### PR DESCRIPTION
Fixes SCP-2735

Just adds an `Either` around the `transactionStatus` function.

The only questionable decision is [here](https://github.com/input-output-hk/plutus/compare/scp-2735-better-rollback-handling?expand=1#diff-cd4b79c0e47357f6c23774aab7a7428886411ce2d53405ef85f1bccbe8ae112eR431) where I've opted to retry on case of finding an error, instead of bumping the error up. I think this might be the thing you'd want, but it's debatable.

~Note that this doesn't address the other part of SCP-2735; making `updateTransactionState` return an error. I think in order to this properly things need to be shifted to use effects. Just want to clarify that idea first.~ ~Actually, I'm doing something here.)~

For discussion:
- [ ] I "handle" the errors by erroring - Is there something better to do?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
