### PR TITLE
SCP-2594: Handle errors from the Marlowe contract (version 3)

### DIFF
--- a/deployment/morph/machines/marlowe-dash.nix
+++ b/deployment/morph/machines/marlowe-dash.nix
@@ -21,10 +21,10 @@
     nodePort = 8082;
     chainIndexPort = 8083;
     signingProcessPort = 8084;
-    slotZeroTime = 1591566291000; # POSIX time of 2020-06-07T21:44:51Z (Sunday, June 7, 2020 21:44:51)
+    slotZeroTime = 1596059091000; # In milliseconds. See note [Datetime to slot] in Marlowe.Slot
     slotLength = 1000; # In milliseconds
     constantFee = 10; # Constant fee per transaction in lovelace
-    scriptsFeeFactor = 1.0; # Factor by which to multiply the size-dependent scripts fee in lovelace
+    scriptsFeeFactor = 0.0; # Factor by which to multiply the size-dependent scripts fee in lovelace
   };
 
 }

--- a/marlowe-dashboard-client/src/Capability/Contract.purs
+++ b/marlowe-dashboard-client/src/Capability/Contract.purs
@@ -13,10 +13,10 @@ module Capability.Contract
   ) where
 
 import Prelude
+import API.Contract as API
 import API.Lenses (_cicCurrentState, _hooks, _observableState)
 import AppM (AppM)
 import Bridge (toBack, toFront)
-import API.Contract as API
 import Control.Monad.Except (lift, runExceptT)
 import Data.Lens (view)
 import Data.RawJson (RawJson)

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -25,11 +25,13 @@ import Bridge (toBack, toFront)
 import Capability.Contract (activateContract, getContractInstanceClientState, getContractInstanceObservableState, getWalletContractInstances, invokeEndpoint) as Contract
 import Capability.Contract (class ManageContract)
 import Capability.MarloweStorage (class ManageMarloweStorage, addAssets, getContracts, getWalletLibrary, getWalletRoleContracts, insertContract, insertWalletRoleContracts)
+import Capability.PlutusApps.MarloweApp as MarloweApp
 import Capability.Wallet (class ManageWallet)
 import Capability.Wallet (createWallet, getWalletInfo, getWalletTotalFunds) as Wallet
 import Capability.Websocket (class ManageWebsocket)
 import Capability.Websocket (subscribeToContract, subscribeToWallet, unsubscribeFromContract, unsubscribeFromWallet) as Websocket
 import Control.Monad.Except (ExceptT(..), except, lift, mapExceptT, runExcept, runExceptT, withExceptT)
+import Control.Monad.Reader (class MonadAsk)
 import Control.Monad.Reader.Class (ask)
 import Data.Array (filter) as Array
 import Data.Array (find)
@@ -53,6 +55,7 @@ import Effect.Aff (delay)
 import Effect.Class (liftEffect)
 import Effect.Random (random)
 import Env (DataProvider(..))
+import Env (Env)
 import Foreign (MultipleErrors)
 import Foreign.Generic (decodeJSON)
 import Halogen (HalogenM, liftAff)
@@ -94,7 +97,7 @@ class
   unsubscribeFromPlutusApp :: DataProvider -> PlutusAppId -> m Unit
   unsubscribeFromWallet :: DataProvider -> Wallet -> m Unit
 
-instance monadMarloweAppM :: ManageMarlowe AppM where
+instance manageMarloweAppM :: ManageMarlowe AppM where
   -- create a Wallet, together with a WalletCompanion and a MarloweApp, and return the WalletDetails
   createWallet = do
     { dataProvider } <- ask
@@ -232,11 +235,8 @@ instance monadMarloweAppM :: ManageMarlowe AppM where
       MarlowePAB ->
         let
           marloweAppId = view _marloweAppId walletDetails
-
-          bRoles :: Back.Map Back.TokenName Back.PubKeyHash
-          bRoles = toBack roles
         in
-          Contract.invokeEndpoint marloweAppId "create" (bRoles /\ contract)
+          MarloweApp.createContract marloweAppId roles contract
       LocalStorage -> do
         walletLibrary <- getWalletLibrary
         uuid <- liftEffect genUUID
@@ -263,19 +263,14 @@ instance monadMarloweAppM :: ManageMarlowe AppM where
               void $ insertWalletRoleContracts (unwrap pubKeyHash) marloweParams marloweData
         pure $ Right unit
   -- "apply-inputs" to a Marlowe contract on the blockchain
-  applyTransactionInput walletDetails marloweParams transactionInput@(TransactionInput { interval, inputs }) = do
+  applyTransactionInput walletDetails marloweParams transactionInput = do
     { dataProvider } <- ask
     case dataProvider of
       MarlowePAB ->
         let
           marloweAppId = view _marloweAppId walletDetails
-
-          backSlotInterval :: JsonTuple Back.Slot Back.Slot
-          backSlotInterval = toBack interval
-
-          payload = JsonTriple (marloweParams /\ (Just backSlotInterval) /\ inputs)
         in
-          Contract.invokeEndpoint marloweAppId "apply-inputs" payload
+          MarloweApp.applyInputs marloweAppId marloweParams transactionInput
       LocalStorage -> do
         existingContracts <- getContracts
         -- When we emulate these calls we add a 500ms delay so we give time to the submit button
@@ -295,11 +290,8 @@ instance monadMarloweAppM :: ManageMarlowe AppM where
           marloweAppId = view _marloweAppId walletDetails
 
           pubKeyHash = view (_walletInfo <<< _pubKeyHash) walletDetails
-
-          payload :: JsonTriple MarloweParams Back.TokenName Back.PubKeyHash
-          payload = JsonTriple (marloweParams /\ toBack tokenName /\ toBack pubKeyHash)
         in
-          Contract.invokeEndpoint marloweAppId "redeem" payload
+          MarloweApp.redeem marloweAppId marloweParams tokenName pubKeyHash
       LocalStorage -> pure $ Right unit
   -- get the WalletInfo of a wallet given the PlutusAppId of its WalletCompanion
   lookupWalletInfo companionAppId = do
@@ -418,7 +410,7 @@ instance monadMarloweAppM :: ManageMarlowe AppM where
   unsubscribeFromPlutusApp dataProvider plutusAppId = Websocket.unsubscribeFromContract $ toBack plutusAppId
   unsubscribeFromWallet dataProvider wallet = Websocket.unsubscribeFromWallet $ toBack wallet
 
-instance monadMarloweHalogenM :: (ManageMarlowe m, ManageWebsocket m) => ManageMarlowe (HalogenM state action slots Msg m) where
+instance monadMarloweHalogenM :: (ManageMarlowe m, ManageWebsocket m, MonadAsk Env m) => ManageMarlowe (HalogenM state action slots Msg m) where
   createWallet = lift createWallet
   followContract walletDetails marloweParams = lift $ followContract walletDetails marloweParams
   createPendingFollowerApp = lift <<< createPendingFollowerApp

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
@@ -14,16 +14,14 @@ import Prelude
 import AppM (AppM)
 import Bridge (toBack)
 import Capability.Contract (invokeEndpoint) as Contract
-import Capability.PlutusApps.MarloweApp.Types (MarloweAppState, LastResult(..), MarloweAppEndpoint(..))
-import Capability.Toast (class Toast, addToast)
+import Capability.PlutusApps.MarloweApp.Types (MarloweAppEndpoint(..), MarloweAppState)
+import Capability.Toast (class Toast)
 import Control.Monad.Reader (class MonadAsk, asks)
 import Data.Json.JsonTriple (JsonTriple(..))
 import Data.Json.JsonTuple (JsonTuple)
 import Data.Map (Map)
 import Data.Maybe (Maybe(..))
-import Data.Traversable (for_)
 import Data.Tuple.Nested ((/\))
-import Debug.Trace (traceM)
 import Effect.Aff.AVar (AVar)
 import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff, liftAff)
@@ -33,7 +31,6 @@ import Plutus.V1.Ledger.Crypto (PubKeyHash) as Back
 import Plutus.V1.Ledger.Slot (Slot) as Back
 import Plutus.V1.Ledger.Value (TokenName) as Back
 import PlutusTx.AssocMap (Map) as Back
-import Toast.Types (errorToast, successToast)
 import Types (AjaxResponse)
 import WalletData.Types (PubKeyHash)
 
@@ -50,7 +47,6 @@ instance marloweAppM :: MarloweApp AppM where
       backRoles :: Back.Map Back.TokenName Back.PubKeyHash
       backRoles = toBack roles
     mutex <- asks _.lastMarloweAppEndpointCall
-    traceM "Mutex put Create"
     liftAff $ AVar.put Create mutex
     Contract.invokeEndpoint plutusAppId "create" (backRoles /\ contract)
   applyInputs plutusAppId marloweContractId (TransactionInput { interval, inputs }) = do
@@ -60,7 +56,6 @@ instance marloweAppM :: MarloweApp AppM where
 
       payload = JsonTriple (marloweContractId /\ (Just backSlotInterval) /\ inputs)
     mutex <- asks _.lastMarloweAppEndpointCall
-    traceM "Mutex put ApplyInputs"
     liftAff $ AVar.put ApplyInputs mutex
     Contract.invokeEndpoint plutusAppId "apply-inputs" payload
   redeem plutusAppId marloweContractId tokenName pubKeyHash = do
@@ -70,10 +65,12 @@ instance marloweAppM :: MarloweApp AppM where
     mutex <- asks _.lastMarloweAppEndpointCall
     -- TODO: we could later add a forkAff with a timer that unlocks this timer if we
     --       dont get a response
-    traceM "Mutex put Redeem"
     liftAff $ AVar.put Redeem mutex
     Contract.invokeEndpoint plutusAppId "redeem" payload
 
+-- FIXME: change the mutex from onNewState to onNewActiveEndpoints that allow us to
+-- know when an endpoint is available or not. And instead of hooking into NewObservableState
+-- hook into NewActiveEndpoints
 onNewState ::
   forall env m.
   MonadAff m =>
@@ -86,17 +83,4 @@ onNewState lastResult = do
   -- We try to take instead of taking as the later will block the thread until there
   -- is a response, but if we are at this point, we should already have a value put in
   -- the mutex. We use for_ to ignore the case in which we have a response but not a request.
-  traceM "Mutex tryTake"
-  traceM lastResult
-  mLastMarloweAppEndpointCall <- liftAff $ AVar.tryTake mutex
-  traceM mLastMarloweAppEndpointCall
-  for_ mLastMarloweAppEndpointCall \lastMarloweAppEndpointCall -> case lastResult of
-    OK -> case lastMarloweAppEndpointCall of
-      Create -> addToast $ successToast "Contract initialised."
-      ApplyInputs -> addToast $ successToast "Contract update applied."
-      _ -> pure unit
-    SomeError marloweError -> case lastMarloweAppEndpointCall of
-      Create -> addToast $ errorToast "Failed to initialise contract." Nothing
-      ApplyInputs -> addToast $ errorToast "Failed to update contract." Nothing
-      _ -> pure unit
-    Unknown -> pure unit
+  void $ liftAff $ AVar.tryTake mutex

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
@@ -1,0 +1,102 @@
+-- This capability exposes the API for the Plutus Aplication called `MarloweApp`, which
+-- has it's endpoints defined as the MarloweSchema in Language.Marlowe.Client module.
+-- There is one `MarloweApp` per wallet, and it serves as a control app for all
+-- the Marlowe contracts that the wallet has a role token.
+module Capability.PlutusApps.MarloweApp
+  ( class MarloweApp
+  , createContract
+  , applyInputs
+  , redeem
+  , onNewState
+  ) where
+
+import Prelude
+import AppM (AppM)
+import Bridge (toBack)
+import Capability.Contract (invokeEndpoint) as Contract
+import Capability.PlutusApps.MarloweApp.Types (MarloweAppState, LastResult(..), MarloweAppEndpoint(..))
+import Capability.Toast (class Toast, addToast)
+import Control.Monad.Reader (class MonadAsk, asks)
+import Data.Json.JsonTriple (JsonTriple(..))
+import Data.Json.JsonTuple (JsonTuple)
+import Data.Map (Map)
+import Data.Maybe (Maybe(..))
+import Data.Traversable (for_)
+import Data.Tuple.Nested ((/\))
+import Debug.Trace (traceM)
+import Effect.Aff.AVar (AVar)
+import Effect.Aff.AVar as AVar
+import Effect.Aff.Class (class MonadAff, liftAff)
+import Marlowe.PAB (PlutusAppId)
+import Marlowe.Semantics (Contract, MarloweParams, TokenName, TransactionInput(..))
+import Plutus.V1.Ledger.Crypto (PubKeyHash) as Back
+import Plutus.V1.Ledger.Slot (Slot) as Back
+import Plutus.V1.Ledger.Value (TokenName) as Back
+import PlutusTx.AssocMap (Map) as Back
+import Toast.Types (errorToast, successToast)
+import Types (AjaxResponse)
+import WalletData.Types (PubKeyHash)
+
+class MarloweApp m where
+  createContract :: PlutusAppId -> Map TokenName PubKeyHash -> Contract -> m (AjaxResponse Unit)
+  applyInputs :: PlutusAppId -> MarloweParams -> TransactionInput -> m (AjaxResponse Unit)
+  -- TODO auto
+  -- TODO close (I think it currently does nothing, maybe remove?)
+  redeem :: PlutusAppId -> MarloweParams -> TokenName -> PubKeyHash -> m (AjaxResponse Unit)
+
+instance marloweAppM :: MarloweApp AppM where
+  createContract plutusAppId roles contract = do
+    let
+      backRoles :: Back.Map Back.TokenName Back.PubKeyHash
+      backRoles = toBack roles
+    mutex <- asks _.lastMarloweAppEndpointCall
+    traceM "Mutex put Create"
+    liftAff $ AVar.put Create mutex
+    Contract.invokeEndpoint plutusAppId "create" (backRoles /\ contract)
+  applyInputs plutusAppId marloweContractId (TransactionInput { interval, inputs }) = do
+    let
+      backSlotInterval :: JsonTuple Back.Slot Back.Slot
+      backSlotInterval = toBack interval
+
+      payload = JsonTriple (marloweContractId /\ (Just backSlotInterval) /\ inputs)
+    mutex <- asks _.lastMarloweAppEndpointCall
+    traceM "Mutex put ApplyInputs"
+    liftAff $ AVar.put ApplyInputs mutex
+    Contract.invokeEndpoint plutusAppId "apply-inputs" payload
+  redeem plutusAppId marloweContractId tokenName pubKeyHash = do
+    let
+      payload :: JsonTriple MarloweParams Back.TokenName Back.PubKeyHash
+      payload = JsonTriple (marloweContractId /\ toBack tokenName /\ toBack pubKeyHash)
+    mutex <- asks _.lastMarloweAppEndpointCall
+    -- TODO: we could later add a forkAff with a timer that unlocks this timer if we
+    --       dont get a response
+    traceM "Mutex put Redeem"
+    liftAff $ AVar.put Redeem mutex
+    Contract.invokeEndpoint plutusAppId "redeem" payload
+
+onNewState ::
+  forall env m.
+  MonadAff m =>
+  Toast m =>
+  MonadAsk { lastMarloweAppEndpointCall :: AVar MarloweAppEndpoint | env } m =>
+  MarloweAppState ->
+  m Unit
+onNewState lastResult = do
+  mutex :: AVar MarloweAppEndpoint <- asks _.lastMarloweAppEndpointCall
+  -- We try to take instead of taking as the later will block the thread until there
+  -- is a response, but if we are at this point, we should already have a value put in
+  -- the mutex. We use for_ to ignore the case in which we have a response but not a request.
+  traceM "Mutex tryTake"
+  traceM lastResult
+  mLastMarloweAppEndpointCall <- liftAff $ AVar.tryTake mutex
+  traceM mLastMarloweAppEndpointCall
+  for_ mLastMarloweAppEndpointCall \lastMarloweAppEndpointCall -> case lastResult of
+    OK -> case lastMarloweAppEndpointCall of
+      Create -> addToast $ successToast "Contract initialised."
+      ApplyInputs -> addToast $ successToast "Contract update applied."
+      _ -> pure unit
+    SomeError marloweError -> case lastMarloweAppEndpointCall of
+      Create -> addToast $ errorToast "Failed to initialise contract." Nothing
+      ApplyInputs -> addToast $ errorToast "Failed to update contract." Nothing
+      _ -> pure unit
+    Unknown -> pure unit

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Lenses.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Lenses.purs
@@ -1,0 +1,20 @@
+module Capability.PlutusApps.MarloweApp.Lenses where
+
+import Prelude
+import Capability.PlutusApps.MarloweApp.Types (EndpointMutex, MarloweAppEndpointMutexEnv)
+import Data.Lens (Lens')
+import Data.Lens.Record (prop)
+import Data.Symbol (SProxy(..))
+import Effect.AVar (AVar)
+
+_marloweAppEndpointMutex :: forall a. Lens' (MarloweAppEndpointMutexEnv a) EndpointMutex
+_marloweAppEndpointMutex = prop (SProxy :: SProxy "marloweAppEndpointMutex")
+
+_redeem :: Lens' EndpointMutex (AVar Unit)
+_redeem = prop (SProxy :: SProxy "redeem")
+
+_create :: Lens' EndpointMutex (AVar Unit)
+_create = prop (SProxy :: SProxy "create")
+
+_applyInputs :: Lens' EndpointMutex (AVar Unit)
+_applyInputs = prop (SProxy :: SProxy "applyInputs")

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
@@ -6,11 +6,14 @@ module Capability.PlutusApps.MarloweApp.Types
   , EndpointName
   , MarloweError
   , MarloweAppState
+  , EndpointMutex
+  , MarloweAppEndpointMutexEnv
   ) where
 
 import Prelude
 import Data.Generic.Rep (class Generic)
 import Data.Tuple (Tuple)
+import Effect.AVar (AVar)
 import Foreign.Class (class Encode, class Decode)
 import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
 import Marlowe.Semantics (Input, MarloweData, Slot, TransactionError)
@@ -77,6 +80,18 @@ type MarloweSlotRange
 type MarloweAppState
   = LastResult
 
+-- The plutus contracts can have their endpoints active or inactive. We use
+-- this AVar object to allow the API users to wait for an endpoint to be available.
+type EndpointMutex
+  = { create :: AVar Unit
+    , applyInputs :: AVar Unit
+    , redeem :: AVar Unit
+    }
+
+type MarloweAppEndpointMutexEnv env
+  = { marloweAppEndpointMutex :: EndpointMutex | env }
+
+-- FIXME: Delete
 -- These are the endpoints of the main marlowe (control) contract.
 data MarloweAppEndpoint
   = Create

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
@@ -1,0 +1,79 @@
+-- The types are defined separated from the MarloweApp to avoid this circular dependency
+-- Capability.PlutusApps.MarloweApp -> AppM -> Env -> Capability.PlutusApps.MarloweApp
+module Capability.PlutusApps.MarloweApp.Types
+  ( MarloweAppEndpoint(..)
+  , LastResult(..)
+  , MarloweError
+  , MarloweAppState
+  ) where
+
+import Prelude
+import Data.Generic.Rep (class Generic)
+import Data.Tuple (Tuple)
+import Foreign.Class (class Encode, class Decode)
+import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
+import Marlowe.Semantics (Input, MarloweData, Slot, TransactionError)
+import Plutus.Contract.StateMachine (InvalidTransition, SMContractError)
+import Wallet.Types (ContractError)
+
+-- The Plutus contract state keeps track of the result of the last action. This is needed because
+-- the PAB needs to return inmediatly and the result might take a while to compute.
+-- Right now we are only allowing one endpoint to be called at a time, but we could later extend this
+-- to use a RequestId to map between the request and the response.
+data LastResult
+  = OK
+  | SomeError MarloweError
+  | Unknown
+
+data MarloweError
+  = StateMachineError SMContractError
+  -- ^ can arise when applying inputs if:
+  --     (a) there's a duplicate marlowe contract (which could theoretially happen if someone is deliberately trying to break things)
+  --     (b) the contract doesn't exist or has already closed
+  --     (c) you don't have enough money
+  | TransitionError (InvalidTransition MarloweData MarloweInput)
+  -- ^ can arise when applying inputs if:
+  --     (a) you don't have the right role token (the frontend should rule this out anyway)
+  --     (b) someone else made the move first
+  --     (c) you don't have enough money
+  | MarloweEvaluationError TransactionError
+  -- ^ can arise when applying inputs (should just match the frontend semantics)
+  | OtherContractError ContractError
+  -- ^ can arise when creating a contract if you don't provide pubKeys for all the roles (the frontend should rule this out anyway)
+  -- note `ContractError` is more general, but we only use this here for its `OtherError` constructor, and in this one specific case
+  | RolesCurrencyError ContractError
+
+-- ^ can arise when creating a contract if you don't have enough money
+derive instance eqMarloweError :: Eq MarloweError
+
+derive instance genericMarloweError :: Generic MarloweError _
+
+instance encodeMarloweError :: Encode MarloweError where
+  encode a = genericEncode defaultOptions a
+
+instance decodeMarloweError :: Decode MarloweError where
+  decode a = genericDecode defaultOptions a
+
+type MarloweInput
+  = Tuple MarloweSlotRange (Array Input)
+
+type MarloweSlotRange
+  = Tuple Slot Slot
+
+-- We use an alias because we could later on add more info to the state
+type MarloweAppState
+  = LastResult
+
+derive instance genericLastResult :: Generic LastResult _
+
+instance encodeLastResult :: Encode LastResult where
+  encode a = genericEncode defaultOptions a
+
+instance decodeLastResult :: Decode LastResult where
+  decode a = genericDecode defaultOptions a
+
+-- These are the endpoints of the main marlowe (control) contract.
+data MarloweAppEndpoint
+  = Create
+  | ApplyInputs
+  | Redeem

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
@@ -1,8 +1,7 @@
 -- The types are defined separated from the MarloweApp to avoid this circular dependency
 -- Capability.PlutusApps.MarloweApp -> AppM -> Env -> Capability.PlutusApps.MarloweApp
 module Capability.PlutusApps.MarloweApp.Types
-  ( MarloweAppEndpoint(..)
-  , LastResult(..)
+  ( LastResult(..)
   , EndpointName
   , MarloweError
   , MarloweAppState
@@ -90,10 +89,3 @@ type EndpointMutex
 
 type MarloweAppEndpointMutexEnv env
   = { marloweAppEndpointMutex :: EndpointMutex | env }
-
--- FIXME: Delete
--- These are the endpoints of the main marlowe (control) contract.
-data MarloweAppEndpoint
-  = Create
-  | ApplyInputs
-  | Redeem

--- a/marlowe-dashboard-client/src/Dashboard/State.purs
+++ b/marlowe-dashboard-client/src/Dashboard/State.purs
@@ -222,7 +222,7 @@ handleAction input (UpdateFollowerApps companionAppState) = do
               Nothing -> followContract walletDetails marloweParams
             case ajaxFollowerApp of
               Left decodedAjaxError -> addToast $ decodedAjaxErrorToast "Failed to load new contract." decodedAjaxError
-              Right (followerAppId /\ contractHistory) -> subscribeToPlutusApp dataProvider followerAppId
+              Right (followerAppId /\ contractHistory) -> subscribeToPlutusApp followerAppId
           LocalStorage -> do
             ajaxFollowerApp <- followContract walletDetails marloweParams
             case ajaxFollowerApp of

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -9,7 +9,7 @@ import Contract.State (isContractClosed)
 import Contract.Types (State) as Contract
 import Contract.View (actionConfirmationCard, contractPreviewCard, contractScreen)
 import Css as Css
-import Dashboard.Lenses (_card, _cardOpen, _contractFilter, _contract, _menuOpen, _selectedContract, _selectedContractFollowerAppId, _templateState, _walletCompanionStatus, _walletDetails, _walletDataState)
+import Dashboard.Lenses (_card, _cardOpen, _contractFilter, _contract, _menuOpen, _selectedContract, _selectedContractFollowerAppId, _templateState, _walletDetails, _walletDataState)
 import Dashboard.Types (Action(..), Card(..), ContractFilter(..), Input, State, WalletCompanionStatus(..))
 import Data.Lens (preview, view, (^.))
 import Data.Map (Map, filter, isEmpty, toUnfoldable)

--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -8,7 +8,7 @@ import Effect.AVar (AVar)
 import Halogen (SubscriptionId)
 import Plutus.PAB.Webserver (SPParams_)
 import Servant.PureScript.Settings (SPSettings_)
-import Capability.PlutusApps.MarloweApp.Types (MarloweAppEndpoint)
+import Capability.PlutusApps.MarloweApp.Types as MarloweApp
 
 -- Application enviroment configuration
 type Env
@@ -22,8 +22,10 @@ type Env
     --    creation functions didn't require that, so it seemed wrong to lift several functions into Effect.
     --    In contrast, the Env is created in Main, where we already have access to Effect
     , contractStepCarouselSubscription :: AVar SubscriptionId
-    -- FIXME: Add comment
-    , lastMarloweAppEndpointCall :: AVar MarloweAppEndpoint
+    -- FIXME: remove
+    , lastMarloweAppEndpointCall :: AVar MarloweApp.MarloweAppEndpoint
+    -- See note on Capability.PlutusApps.MarloweApp.Types
+    , marloweAppEndpointMutex :: MarloweApp.EndpointMutex
     , dataProvider :: DataProvider
     }
 

--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -8,6 +8,7 @@ import Effect.AVar (AVar)
 import Halogen (SubscriptionId)
 import Plutus.PAB.Webserver (SPParams_)
 import Servant.PureScript.Settings (SPSettings_)
+import Capability.PlutusApps.MarloweApp.Types (MarloweAppEndpoint)
 
 -- Application enviroment configuration
 type Env
@@ -21,6 +22,8 @@ type Env
     --    creation functions didn't require that, so it seemed wrong to lift several functions into Effect.
     --    In contrast, the Env is created in Main, where we already have access to Effect
     , contractStepCarouselSubscription :: AVar SubscriptionId
+    -- FIXME: Add comment
+    , lastMarloweAppEndpointCall :: AVar MarloweAppEndpoint
     , dataProvider :: DataProvider
     }
 

--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -22,8 +22,6 @@ type Env
     --    creation functions didn't require that, so it seemed wrong to lift several functions into Effect.
     --    In contrast, the Env is created in Main, where we already have access to Effect
     , contractStepCarouselSubscription :: AVar SubscriptionId
-    -- FIXME: remove
-    , lastMarloweAppEndpointCall :: AVar MarloweApp.MarloweAppEndpoint
     -- See note on Capability.PlutusApps.MarloweApp.Types
     , marloweAppEndpointMutex :: MarloweApp.EndpointMutex
     , dataProvider :: DataProvider

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -66,7 +66,7 @@ main = do
       $ forkAff
       $ WS.runWebSocketManager
           (WS.URI "/ws")
-          (\msg -> void $ driver.query $ ReceiveWebSocketMessage msg unit)
+          (\msg -> void $ forkAff $ driver.query $ ReceiveWebSocketMessage msg unit)
           wsManager
     driver.subscribe
       $ consumer

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -2,6 +2,7 @@ module Main where
 
 import Prelude
 import AppM (runAppM)
+import Capability.PlutusApps.MarloweApp as MarloweApp
 import Control.Coroutine (Consumer, Process, connect, consumer, runProcess)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -39,11 +40,13 @@ mkEnvironment = do
     encodeJson = SPSettingsEncodeJson_ jsonOptions
   contractStepCarouselSubscription <- AVar.empty
   lastMarloweAppEndpointCall <- AVar.empty
+  marloweAppEndpointMutex <- MarloweApp.createEndpointMutex
   pure
     { ajaxSettings: SPSettings_ (settings { decodeJson = decodeJson, encodeJson = encodeJson })
     , contractStepCarouselSubscription
     , dataProvider: MarlowePAB
     , lastMarloweAppEndpointCall
+    , marloweAppEndpointMutex
     }
 
 main :: Effect Unit

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -39,13 +39,11 @@ mkEnvironment = do
 
     encodeJson = SPSettingsEncodeJson_ jsonOptions
   contractStepCarouselSubscription <- AVar.empty
-  lastMarloweAppEndpointCall <- AVar.empty
   marloweAppEndpointMutex <- MarloweApp.createEndpointMutex
   pure
     { ajaxSettings: SPSettings_ (settings { decodeJson = decodeJson, encodeJson = encodeJson })
     , contractStepCarouselSubscription
     , dataProvider: MarlowePAB
-    , lastMarloweAppEndpointCall
     , marloweAppEndpointMutex
     }
 

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -38,10 +38,12 @@ mkEnvironment = do
 
     encodeJson = SPSettingsEncodeJson_ jsonOptions
   contractStepCarouselSubscription <- AVar.empty
+  lastMarloweAppEndpointCall <- AVar.empty
   pure
     { ajaxSettings: SPSettings_ (settings { decodeJson = decodeJson, encodeJson = encodeJson })
     , contractStepCarouselSubscription
     , dataProvider: MarlowePAB
+    , lastMarloweAppEndpointCall
     }
 
 main :: Effect Unit

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -2,7 +2,7 @@ module MainFrame.State (mkMainFrame, handleAction) where
 
 import Prelude
 import Bridge (toFront)
-import Capability.Marlowe (class ManageMarlowe, getFollowerApps, getRoleContracts, subscribeToPlutusApp, subscribeToWallet, unsubscribeFromPlutusApp, unsubscribeFromWallet)
+import Capability.Marlowe (class ManageMarlowe, getFollowerApps, subscribeToPlutusApp, subscribeToWallet, unsubscribeFromPlutusApp, unsubscribeFromWallet)
 import Capability.MarloweStorage (class ManageMarloweStorage, getContractNicknames, getWalletLibrary)
 import Capability.PlutusApps.MarloweApp as MarloweApp
 import Capability.PlutusApps.MarloweApp.Types (LastResult(..))
@@ -44,7 +44,7 @@ import WalletData.Lenses (_assets, _companionAppId, _marloweAppId, _previousComp
 import WebSocket.Support as WS
 import Welcome.Lenses (_walletLibrary)
 import Welcome.State (handleAction, dummyState, mkInitialState) as Welcome
-import Welcome.Types (Action(..), State) as Welcome
+import Welcome.Types (Action, State) as Welcome
 
 mkMainFrame ::
   forall m.

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -154,14 +154,12 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
                 -- if this is the wallet's MarloweApp...
                 if (plutusAppId == marloweAppId) then case runExcept $ decodeJSON $ unwrap rawJson of
                   Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError
-                  Right lastResult -> do
-                    MarloweApp.onNewState lastResult
-                    case lastResult of
-                      OK "create" -> addToast $ successToast "Contract initialised."
-                      OK "apply-inputs" -> addToast $ successToast "Contract update applied."
-                      SomeError "create" marloweError -> addToast $ errorToast "Failed to initialise contract." Nothing
-                      SomeError "apply-inputs" marloweError -> addToast $ errorToast "Failed to update contract." Nothing
-                      _ -> pure unit
+                  Right lastResult -> case lastResult of
+                    OK "create" -> addToast $ successToast "Contract initialised."
+                    OK "apply-inputs" -> addToast $ successToast "Contract update applied."
+                    SomeError "create" marloweError -> addToast $ errorToast "Failed to initialise contract." Nothing
+                    SomeError "apply-inputs" marloweError -> addToast $ errorToast "Failed to update contract." Nothing
+                    _ -> pure unit
                 -- otherwise this should be one of the wallet's WalletFollowerApps
                 else case runExcept $ decodeJSON $ unwrap rawJson of
                   Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError

--- a/marlowe-dashboard-client/src/Marlowe/Client.purs
+++ b/marlowe-dashboard-client/src/Marlowe/Client.purs
@@ -15,60 +15,8 @@ import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple)
 import Foreign.Class (class Encode, class Decode)
-import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
-import Marlowe.Semantics (Input, MarloweData, MarloweParams, Slot, TransactionError, TransactionInput, aesonCompatibleOptions)
-import Plutus.Contract.StateMachine (InvalidTransition, SMContractError)
-import Wallet.Types (ContractError)
-
--- This is the state of the main marlowe (control) contract. Its purpose is to provide feedback if
--- anything goes wrong when we try to create a contract or apply inputs.
-data LastResult
-  = OK
-  | SomeError MarloweError
-  | Unknown
-
-derive instance genericLastResult :: Generic LastResult _
-
-instance encodeLastResult :: Encode LastResult where
-  encode a = genericEncode defaultOptions a
-
-instance decodeLastResult :: Decode LastResult where
-  decode a = genericDecode defaultOptions a
-
-data MarloweError
-  = StateMachineError SMContractError
-  -- ^ can arise when applying inputs if:
-  --     (a) there's a duplicate marlowe contract (which could theoretially happen if someone is deliberately trying to break things)
-  --     (b) the contract doesn't exist or has already closed
-  --     (c) you don't have enough money
-  | TransitionError (InvalidTransition MarloweData MarloweInput)
-  -- ^ can arise when applying inputs if:
-  --     (a) you don't have the right role token (the frontend should rule this out anyway)
-  --     (b) someone else made the move first
-  --     (c) you don't have enough money
-  | MarloweEvaluationError TransactionError
-  -- ^ can arise when applying inputs (should just match the frontend semantics)
-  | OtherContractError ContractError
-  -- ^ can arise when creating a contract if you don't provide pubKeys for all the roles (the frontend should rule this out anyway)
-  -- note `ContractError` is more general, but we only use this here for its `OtherError` constructor, and in this one specific case
-  | RolesCurrencyError ContractError
-
--- ^ can arise when creating a contract if you don't have enough money
-derive instance eqMarloweError :: Eq MarloweError
-
-derive instance genericMarloweError :: Generic MarloweError _
-
-instance encodeMarloweError :: Encode MarloweError where
-  encode a = genericEncode defaultOptions a
-
-instance decodeMarloweError :: Decode MarloweError where
-  decode a = genericDecode defaultOptions a
-
-type MarloweInput
-  = Tuple MarloweSlotRange (Array Input)
-
-type MarloweSlotRange
-  = Tuple Slot Slot
+import Foreign.Generic (genericDecode, genericEncode)
+import Marlowe.Semantics (MarloweData, MarloweParams, TransactionInput, aesonCompatibleOptions)
 
 -- This is the state of the follower contract. Its purpose is to provide us with an up-to-date
 -- transaction history for a Marlowe contract running on the blockchain.

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -103,8 +103,8 @@ zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250
     T..&&. assertDone marlowePlutusContract (Trace.walletInstanceTag bob) (const True) "contract should close"
     T..&&. walletFundsChange alice (lovelaceValueOf (150))
     T..&&. walletFundsChange bob (lovelaceValueOf (-150))
-    T..&&. assertAccumState marlowePlutusContract (Trace.walletInstanceTag alice) ((==) OK) "should be OK"
-    T..&&. assertAccumState marlowePlutusContract (Trace.walletInstanceTag bob) ((==) OK) "should be OK"
+    T..&&. assertAccumState marlowePlutusContract (Trace.walletInstanceTag alice) ((==) (OK "close")) "should be OK"
+    T..&&. assertAccumState marlowePlutusContract (Trace.walletInstanceTag bob) ((==) (OK "close")) "should be OK"
     ) $ do
     -- Init a contract
     let alicePk = PK $ (pubKeyHash $ walletPubKey alice)
@@ -139,8 +139,8 @@ zeroCouponBondTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250
 errorHandlingTest :: TestTree
 errorHandlingTest = checkPredicateOptions (defaultCheckOptions & maxSlot .~ 250) "Error handling"
     (assertAccumState marlowePlutusContract (Trace.walletInstanceTag alice)
-    (\case SomeError (TransitionError _) -> True
-           _                             -> False
+    (\case SomeError "apply-inputs" (TransitionError _) -> True
+           _                                            -> False
     ) "should be fail with SomeError"
     ) $ do
     -- Init a contract


### PR DESCRIPTION
This PR is the third modification to improve the errors received from the BE. ([first modification](https://github.com/input-output-hk/plutus/pull/3835), [second modification](https://github.com/input-output-hk/plutus/pull/3883)) 

It adds the endpoint name to the MarloweApp contract so we can tie a response to an action (we should later expand for a requestId approach) and it adds a mutex logic to avoid calling unavailable endpoints.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
