### PR TITLE
Update plutus-tx naturals

### DIFF
--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -62,7 +63,8 @@ import           Ledger                 (Ada, AssetClass, CurrencySymbol, DatumH
                                          ValidatorHash, Value)
 import           Ledger.Bytes           (LedgerBytes)
 import qualified PlutusTx.AssocMap
-import qualified PlutusTx.Prelude       as P
+import qualified PlutusTx.Builtins      as P
+import qualified PlutusTx.Natural       as P
 import qualified PlutusTx.Ratio         as P
 import           Wallet.Emulator.Wallet (Wallet)
 import           Wallet.Types           (ContractInstanceId)
@@ -256,6 +258,9 @@ instance {-# OVERLAPPABLE #-} (ToSchema a, ToArgument a) => ToArgument [a] where
     toArgument xs = Fix $ FormArrayF (toSchema @a) (toArgument <$> xs)
 
 instance ToSchema AssetClass
+
+deriving via Integer instance ToSchema P.Natural
+deriving via Integer instance ToArgument P.Natural
 
 ------------------------------------------------------------
 class GenericToSchema f where

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -54,6 +54,9 @@ library
         PlutusTx.Maybe
         PlutusTx.Monoid
         PlutusTx.Numeric
+        PlutusTx.Natural
+        PlutusTx.Natural.Internal
+        PlutusTx.Natural.TH
         PlutusTx.Ratio
         PlutusTx.Semigroup
         PlutusTx.Sqrt

--- a/plutus-tx/src/PlutusTx/Natural.hs
+++ b/plutus-tx/src/PlutusTx/Natural.hs
@@ -1,0 +1,18 @@
+-- | An on-chain numeric type representing non-negative integers.
+module PlutusTx.Natural (
+  -- * Types,
+  Internal.Natural (..),
+  Internal.Parity (..),
+
+  -- * Quasi-quoter
+  TH.nat,
+
+  -- * Functions
+  Internal.parity,
+  Internal.powNat,
+  (Internal.^+),
+  (Internal.^-)
+) where
+
+import qualified PlutusTx.Natural.Internal as Internal
+import qualified PlutusTx.Natural.TH       as TH

--- a/plutus-tx/src/PlutusTx/Natural/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Natural/Internal.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | An on-chain numeric type representing non-negative numbers only.
+-}
+module PlutusTx.Natural.Internal (
+  -- * Types,
+  Natural (..),
+  Parity (..),
+
+  -- * Functions
+  parity,
+  powNat,
+  (^+),
+  (^-)
+) where
+
+import           Control.Monad              (guard)
+import           Data.Aeson                 (FromJSON (parseJSON), ToJSON)
+import           PlutusTx.Builtins          (matchData, unsafeDataAsI)
+import           PlutusTx.Builtins.Internal hiding (unsafeDataAsI)
+import           PlutusTx.IsData            (FromData (fromBuiltinData), ToData, UnsafeFromData (unsafeFromBuiltinData))
+import           PlutusTx.Lift              (makeLift)
+import           PlutusTx.Numeric.Class
+import           PlutusTx.Prelude
+import qualified PlutusTx.Prelude           as Plutus
+import qualified Prelude
+
+-- | A non-negative number.
+newtype Natural = Natural Integer
+  deriving
+    ( AdditiveSemigroup
+    , AdditiveMonoid
+    , MultiplicativeSemigroup
+    , MultiplicativeMonoid
+    , Eq
+    , Ord
+    , ToData
+    , ToJSON
+    , Prelude.Eq
+    )
+    via Integer
+  deriving stock (Prelude.Show)
+
+-- | 'Natural' monus is \'difference-or-zero\'.
+instance AdditiveHemigroup Natural where
+  {-# INLINEABLE (^-) #-}
+  Natural n ^- Natural m
+    | m > n = zero
+    | otherwise = Natural (n - m)
+
+instance EuclideanClosed Natural where
+  {-# INLINEABLE divMod #-}
+  divMod n@(Natural x) (Natural y)
+    | y == zero = BuiltinPair (zero, n)
+    | y == one = BuiltinPair (n, zero)
+    | otherwise = BuiltinPair
+      ( Natural . divide x $ y
+      , Natural . modulo x $ y
+      )
+
+instance FromJSON Natural where
+  parseJSON v = Prelude.fmap Natural $ do
+    i <- parseJSON v
+    guard (i >= 0)
+    Prelude.pure i
+
+instance FromData Natural where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData dat =
+    matchData
+      dat
+      (\_ -> const Nothing)
+      (const Nothing)
+      (const Nothing)
+      go
+      (const Nothing)
+    where
+      go :: Integer -> Maybe Natural
+      go x
+        | x < zero = Nothing
+        | otherwise = Just . Natural $ x
+
+instance UnsafeFromData Natural where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData dat =
+    let asI = unsafeDataAsI dat
+     in if asI >= 0
+          then Natural asI
+          else Plutus.error . Plutus.trace "Cannot decode a negative value to Natural" $ ()
+
+instance IntegralDomain Integer Natural where
+  {-# INLINEABLE abs #-}
+  abs = natAbs
+  {-# INLINEABLE signum #-}
+  signum x
+    | x == zero = zero
+    | x < zero = negate one
+    | otherwise = one
+  {-# INLINEABLE projectAbs #-}
+  projectAbs = Natural . abs
+  {-# INLINEABLE restrictMay #-}
+  restrictMay x
+    | x < zero = Nothing
+    | otherwise = Just . Natural $ x
+  {-# INLINEABLE addExtend #-}
+  addExtend (Natural i) = i
+
+
+-- This is partial all over the place, but so is Enum for most things.
+instance Plutus.Enum Natural where
+  {-# INLINEABLE succ #-}
+  succ (Natural n) = Natural (n + 1)
+  {-# INLINEABLE pred #-}
+  pred (Natural n)
+    | n <= 0 = Plutus.error . Plutus.trace "No predecessor to Natural 0" $ ()
+    | otherwise = Natural (n - 1)
+  {-# INLINEABLE toEnum #-}
+  toEnum i
+    | i < 0 = Plutus.error . Plutus.trace "Cannot convert a negative number to a Natural" $ ()
+    | otherwise = Natural i
+  {-# INLINEABLE fromEnum #-}
+  fromEnum (Natural n) = n
+
+-- | A demonstration of the parity of a number.
+data Parity = Even | Odd
+  deriving stock (Prelude.Eq, Prelude.Show)
+
+-- | Determine the parity of a number.
+parity :: Natural -> Parity
+parity (Natural n)
+  | even n = Even
+  | otherwise = Odd
+
+
+{- | Raise by a 'Natural' power.
+
+ = Note
+
+ This really /ought/ to be a method of 'MultiplicativeMonoid', but as we can't
+ modify type classes provided by Plutus, this is the next best option.
+
+ = Laws
+
+ 1. @'powNat' x 'zero' = 'one'@
+ 2. @'powNat' x 'one' = x@
+ 3. If @n '>' 'one'@, then @'powNat' x n = x '*' 'powNat' x (n '^-' 'one')@
+-}
+{-# INLINEABLE powNat #-}
+powNat :: MultiplicativeMonoid m => m -> Natural -> m
+powNat x (Natural n) =
+  if n == zero
+    then one
+    else expBySquaring x n
+
+infixr 8 `powNat`
+
+-- | 'powNat' as an infix operator.
+{-# INLINEABLE (^+) #-}
+(^+) :: MultiplicativeMonoid m => m -> Natural -> m
+(^+) = powNat
+
+infixr 8 ^+
+
+makeLift ''Natural

--- a/plutus-tx/src/PlutusTx/Natural/TH.hs
+++ b/plutus-tx/src/PlutusTx/Natural/TH.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PlutusTx.Natural.TH (nat) where
+
+import           Language.Haskell.TH.Quote  (QuasiQuoter (QuasiQuoter))
+import           Language.Haskell.TH.Syntax (Dec, Exp (AppE, ConE, LitE), Lit (IntegerL), Pat (ConP, LitP), Q, Type)
+import           PlutusTx.Natural.Internal  (Natural (Natural))
+import           Prelude
+import           Text.Read                  (readMaybe)
+
+{- | Quasi-quoter for 'Natural' literals.
+
+ Used as follows:
+
+ > [nat| 1234 |]
+
+ > case foo of
+ >    [nat| 0 |] -> ...
+ >    [nat| 1 |] -> ...
+-}
+nat :: QuasiQuoter
+nat = QuasiQuoter natExp natPat errorType errorDeclaration
+
+-- Helpers
+
+natExp :: String -> Q Exp
+natExp s = case readMaybe s of
+  Nothing -> fail $ "Not a valid Natural: " <> s
+  Just (i :: Integer) -> case signum i of
+    (-1) -> fail "Cannot use a negative literal for a Natural."
+    _    -> pure . AppE (ConE 'Natural) . LitE . IntegerL $ i
+
+natPat :: String -> Q Pat
+natPat s = case readMaybe s of
+  Nothing -> fail $ "Not a valid Natural: " <> s
+  Just (i :: Integer) -> case signum i of
+    (-1) -> fail "Cannot use a negative literal for a Natural."
+    _    -> pure . ConP 'Natural $ [LitP . IntegerL $ i]
+
+errorType :: String -> Q Type
+errorType _ = fail "Cannot use 'nat' in a type context."
+
+errorDeclaration :: String -> Q [Dec]
+errorDeclaration _ = fail "Cannot use 'nat' in a declaration context."


### PR DESCRIPTION
This repo is a part of https://github.com/input-output-hk/plutus/pull/3852 that restructures natural interface for `plutus-tx` by adding reexports and some useful functions over naturals (such as `powNat`). Tests for this module will be provided once we're done with arbitrary instances for `plutus-tx` and `plutus-ledger-api` types in a separate repo.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
