### PR TITLE
Add a numeric type for non-negative rationals to plutus-tx

### DIFF
--- a/plutus-tx/src/PlutusTx/NatRatio.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio.hs
@@ -1,0 +1,22 @@
+-- | An on-chain numeric type representing a ratio of non-negative numbers.
+module PlutusTx.NatRatio
+  ( -- * Type
+    Internal.NatRatio
+
+  , -- * Functions
+
+    -- ** Construction
+    Internal.fromNatural
+  , Internal.natRatio
+  , TH.nr
+
+  , -- ** Access
+    Internal.numerator
+  , Internal.denominator
+  , Internal.truncate
+  , Internal.round
+  , Internal.properFraction
+  ) where
+
+import qualified PlutusTx.NatRatio.Internal as Internal
+import qualified PlutusTx.NatRatio.TH       as TH

--- a/plutus-tx/src/PlutusTx/NatRatio/Internal.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio/Internal.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | An on-chain numeric type representing a ratio of non-negative numbers.
+ = Warning
+ This is an internal module; as such, it exposes the 'NatRatio'
+ implementation, which can be used to violate constraints if used without
+ care. This module primarily exists for testing purposes, or for some internal
+ APIs; if at all possible, use 'PlutusTx.NatRatio' instead.
+-}
+module PlutusTx.NatRatio.Internal (
+  NatRatio (..),
+  natRatio,
+  fromNatural,
+  numerator,
+  denominator,
+  truncate,
+  PlutusTx.NatRatio.Internal.round,
+  properFraction,
+) where
+
+import           Control.Monad             (guard)
+import           Data.Aeson                (FromJSON (parseJSON), ToJSON)
+import           PlutusTx.IsData.Class     (FromData (fromBuiltinData), ToData, UnsafeFromData (unsafeFromBuiltinData))
+import           PlutusTx.Lift             (makeLift)
+import           PlutusTx.Natural.Internal (Natural (Natural))
+import           PlutusTx.Numeric.Class
+import           PlutusTx.Prelude
+import qualified PlutusTx.Ratio            as Ratio
+import qualified Prelude
+
+{- | A ratio of 'Natural's. Similar to 'Rational', but with the numerator and
+ denominator guaranteed non-negative.
+-}
+newtype NatRatio = NatRatio Rational
+  deriving stock (Prelude.Show)
+  deriving
+    ( Prelude.Eq
+    , Eq
+    , Ord
+    , AdditiveSemigroup
+    , AdditiveMonoid
+    , MultiplicativeSemigroup
+    , MultiplicativeMonoid
+    , ToData
+    , ToJSON
+    )
+    via Rational
+
+instance FromJSON NatRatio where
+  parseJSON v = do
+    r <- parseJSON v
+    guard (r >= zero)
+    Prelude.pure . NatRatio $ r
+
+instance FromData NatRatio where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData dat = case fromBuiltinData dat of
+    Nothing -> Nothing
+    Just r ->
+      if natAbs r == r
+        then Just (NatRatio r)
+        else Nothing
+
+instance UnsafeFromData NatRatio where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData dat =
+    let r = unsafeFromBuiltinData dat
+     in if natAbs r == r
+          then NatRatio r
+          else error . trace "Negative fractions cannot be NatRatio" $ ()
+
+-- | 'NatRatio' monus is \'difference-or-zero\'.
+instance AdditiveHemigroup NatRatio where
+  {-# INLINEABLE (^-) #-}
+  NatRatio r1 ^- NatRatio r2
+    | r1 < r2 = zero
+    | otherwise = NatRatio $ r1 - r2
+
+instance MultiplicativeGroup NatRatio where
+  {-# INLINEABLE (/) #-}
+  NatRatio r / NatRatio r' = NatRatio (r / r')
+  {-# INLINEABLE reciprocal #-}
+  reciprocal (NatRatio r) = NatRatio . Ratio.recip $ r
+
+
+-- | Safely construct a 'NatRatio'. Checks for a zero denominator.
+{-# INLINEABLE natRatio #-}
+natRatio :: Natural -> Natural -> Maybe NatRatio
+natRatio (Natural n) (Natural m) =
+  if m == 0
+    then Nothing
+    else Just . NatRatio $ n Ratio.% m
+
+-- | Convert a 'Natural' into a 'NatRatio' with the same value.
+{-# INLINEABLE fromNatural #-}
+fromNatural :: Natural -> NatRatio
+fromNatural (Natural n) = NatRatio . fromInteger $ n
+
+-- | Retrieve the numerator of a 'NatRatio'.
+{-# INLINEABLE numerator #-}
+numerator :: NatRatio -> Natural
+numerator (NatRatio r) = Natural . Ratio.numerator $ r
+
+{- | Retrieve the denominator of a 'NatRatio'. This is guaranteed non-zero,
+ though the result type doesn't specify this.
+-}
+{-# INLINEABLE denominator #-}
+denominator :: NatRatio -> Natural
+denominator (NatRatio r) = Natural . Ratio.denominator $ r
+
+-- | Round the 'NatRatio' down.
+{-# INLINEABLE truncate #-}
+truncate :: NatRatio -> Natural
+truncate (NatRatio r) = Natural . Ratio.truncate $ r
+
+-- | Round the 'NatRatio' arithmetically.
+{-# INLINEABLE round #-}
+round :: NatRatio -> Natural
+round (NatRatio r) = Natural . Ratio.round $ r
+
+{- | Separate a 'NatRatio' into a whole and a fractional part, such that the
+ fractional part is guaranteed to be less than @1@.
+-}
+{-# INLINEABLE properFraction #-}
+properFraction :: NatRatio -> (Natural, NatRatio)
+properFraction (NatRatio r) =
+  let (n, r') = Ratio.properFraction r
+   in (Natural n, NatRatio r')
+
+instance IntegralDomain Rational NatRatio where
+  {-# INLINEABLE abs #-}
+  abs = natAbs
+  {-# INLINEABLE signum #-}
+  signum x
+    | x == zero = zero
+    | x < zero = negate one
+    | otherwise = one
+  {-# INLINEABLE projectAbs #-}
+  projectAbs = NatRatio . natAbs
+  {-# INLINEABLE restrictMay #-}
+  restrictMay x
+    | x < zero = Nothing
+    | otherwise = Just . NatRatio $ x
+  {-# INLINEABLE addExtend #-}
+  addExtend (NatRatio r) = r
+
+makeLift ''NatRatio

--- a/plutus-tx/src/PlutusTx/NatRatio/TH.hs
+++ b/plutus-tx/src/PlutusTx/NatRatio/TH.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PlutusTx.NatRatio.TH (nr) where
+
+import           Language.Haskell.TH.Quote  (QuasiQuoter (QuasiQuoter))
+import           Language.Haskell.TH.Syntax (Dec, Exp (AppE, ConE, LitE, UInfixE, VarE), Lit (IntegerL), Pat, Q, Type)
+import           PlutusTx.NatRatio.Internal (NatRatio (NatRatio))
+import           PlutusTx.Ratio             ((%))
+import           Prelude
+import           Text.Read                  (readMaybe)
+
+{- | Quasi-quoter for 'NatRatio' literals.
+
+ Used as follows:
+
+ > [nr| (10, 100) |]
+-}
+nr :: QuasiQuoter
+nr = QuasiQuoter nrExp errorPat errorType errorDeclaration
+
+-- Helpers
+
+nrExp :: String -> Q Exp
+nrExp s = case readMaybe s of
+  Nothing -> fail $ "Input should be of the form (n, m), but got: " <> s
+  Just (n :: Integer, m :: Integer) -> case signum m of
+    (-1) -> fail "Cannot use a negative literal for a NatRatio denominator."
+    0 -> fail "A NatRatio cannot have denominator 0."
+    _ -> case signum n of
+      (-1) -> fail "Cannot use a negative literal for a NatRatio numerator."
+      _ ->
+        pure
+          . AppE (ConE 'NatRatio)
+          . UInfixE (LitE . IntegerL $ n) (VarE '(%))
+          . LitE
+          . IntegerL
+          $ m
+
+errorPat :: String -> Q Pat
+errorPat _ = fail "Cannot use 'nr' in a pattern context."
+
+errorType :: String -> Q Type
+errorType _ = fail "Cannot use 'nr' in a type context."
+
+errorDeclaration :: String -> Q [Dec]
+errorDeclaration _ = fail "Cannot use 'nr' in a declaration context."


### PR DESCRIPTION
This PR is a part of https://github.com/input-output-hk/plutus/pull/3852 that introduces a type for non-negative rationals to `plutus-tx`. All test for this type will be added once a PR with arbitrary instances for `plutus-tx` types will be merged.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
