### PR TITLE
Rename plutus-tx interval width to intervalWidth and add slotWidth

### DIFF
--- a/plutus-contract/src/Wallet/API.hs
+++ b/plutus-contract/src/Wallet/API.hs
@@ -40,7 +40,7 @@ module Wallet.API(
     Interval(..),
     Slot,
     SlotRange,
-    width,
+    intervalWidth,
     defaultSlotRange,
     interval,
     singleton,

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Slot.hs
@@ -17,7 +17,7 @@
 module Plutus.V1.Ledger.Slot(
       Slot(..)
     , SlotRange
-    , width
+    , slotWidth
     ) where
 
 import           Codec.Serialise.Class     (Serialise)
@@ -33,7 +33,7 @@ import qualified PlutusTx                  as PlutusTx
 import           PlutusTx.Lift             (makeLift)
 import           PlutusTx.Prelude
 
-import           Plutus.V1.Ledger.Interval
+import           Plutus.V1.Ledger.Interval hiding (slotWidth)
 
 {- HLINT ignore "Redundant if" -}
 
@@ -53,16 +53,16 @@ instance Pretty Slot where
 -- | An 'Interval' of 'Slot's.
 type SlotRange = Interval Slot
 
-{-# INLINABLE width #-}
--- | Number of 'Slot's covered by the interval, if finite. @width (from x) == Nothing@.
-width :: SlotRange -> Maybe Integer
-width (Interval (LowerBound (Finite (Slot s1)) in1) (UpperBound (Finite (Slot s2)) in2)) =
+{-# INLINABLE slotWidth #-}
+-- | Number of 'Slot's covered by the interval, if finite. @slotWidth (from x) == Nothing@.
+slotWidth :: SlotRange -> Maybe Integer
+slotWidth (Interval (LowerBound (Finite (Slot s1)) in1) (UpperBound (Finite (Slot s2)) in2)) =
     let lowestValue = if in1 then s1 else s1 + 1
         highestValue = if in2 then s2 else s2 - 1
     in if lowestValue <= highestValue
-    -- +1 avoids fencepost error: width of [2,4] is 3.
+    -- +1 avoids fencepost error: slotWidth of [2,4] is 3.
     then Just $ (highestValue - lowestValue) + 1
     -- low > high, i.e. empty interval
     else Nothing
 -- Infinity is involved!
-width _ = Nothing
+slotWidth _ = Nothing


### PR DESCRIPTION
This PR is a part of https://github.com/input-output-hk/plutus/pull/3852 that renames `plutus-tx` interval function to `intervalWidth` and adds `slotWidth`.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
