### PR TITLE
Add arbitrary instances for plutus-tx and plutus-ledger-api types 

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -49,6 +49,7 @@ library
         Plutus.V1.Ledger.Interval
         Plutus.V1.Ledger.Orphans
         Plutus.V1.Ledger.Scripts
+        Plutus.V1.Ledger.Arbitrary
         Plutus.V1.Ledger.Slot
         Plutus.V1.Ledger.Tx
         Plutus.V1.Ledger.TxId
@@ -63,6 +64,8 @@ library
         flat -any,
         hashable -any,
         plutus-core -any,
+        generic-arbitrary -any,
+        quickcheck-instances -any,
         memory -any,
         mtl -any,
         plutus-tx -any,
@@ -90,6 +93,7 @@ test-suite plutus-ledger-api-test
         base >=4.9 && <5,
         aeson -any,
         plutus-ledger-api -any,
+        plutus-tx -any,
         hedgehog -any,
         tasty -any,
         tasty-hedgehog -any,

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Arbitrary.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Arbitrary.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TupleSections      #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Plutus.V1.Ledger.Arbitrary where
+
+import           Test.QuickCheck.Arbitrary.Generic (Arbitrary (arbitrary, shrink), genericArbitrary, genericShrink)
+import           Test.QuickCheck.Instances         ()
+
+import           Plutus.V1.Ledger.Api
+import           Plutus.V1.Ledger.Crypto
+import           Plutus.V1.Ledger.Slot
+import           Plutus.V1.Ledger.Value
+import           PlutusTx.Arbitrary                ()
+import           PlutusTx.Prelude                  hiding (fmap, (<$>))
+
+deriving newtype instance Arbitrary BuiltinData
+deriving newtype instance Arbitrary CurrencySymbol
+deriving newtype instance Arbitrary AssetClass
+deriving newtype instance Arbitrary Datum
+deriving newtype instance Arbitrary DatumHash
+deriving newtype instance Arbitrary LedgerBytes
+deriving newtype instance Arbitrary POSIXTime
+deriving newtype instance Arbitrary PubKey
+deriving newtype instance Arbitrary PubKeyHash
+deriving newtype instance Arbitrary Signature
+deriving newtype instance Arbitrary Slot
+deriving newtype instance Arbitrary TokenName
+deriving newtype instance Arbitrary TxId
+deriving newtype instance Arbitrary ValidatorHash
+
+--------------------------------------------------------------------------------
+-- Generics.
+-- Would like to have GenericArbitrary newtype from 0.2.0 for deriving-via on all of these
+
+instance Arbitrary TxOutRef where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+
+instance Arbitrary Value where
+  arbitrary = Prelude.foldMap (uncurry3 singleton) <$> arbitrary @[(CurrencySymbol, TokenName, Integer)]
+  shrink = fmap (Prelude.foldMap (uncurry3 singleton)) . shrink . flattenValue

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -61,6 +61,7 @@ library
         Ledger.TimeSlot
         Ledger.Tokens
         Ledger.Tx
+        Ledger.Arbitrary
         Ledger.Typed.Scripts
         Ledger.Typed.Scripts.MonetaryPolicies
         Ledger.Typed.Scripts.StakeValidators
@@ -79,7 +80,8 @@ library
         Plutus.V1.Ledger.Slot as Ledger.Slot,
         Plutus.V1.Ledger.TxId as Ledger.TxId,
         Plutus.V1.Ledger.Time as Ledger.Time,
-        Plutus.V1.Ledger.Value as Ledger.Value
+        Plutus.V1.Ledger.Value as Ledger.Value,
+        Plutus.V1.Ledger.Arbitrary as Ledger.V1.Arbitrary
         -- The rest of the plutus-ledger-api modules are reexported from within
         -- the Haskell modules and not in the current cabal file.
         -- For example: Plutus.V1.Ledger.Address is reexported by Ledger.Address
@@ -93,6 +95,7 @@ library
         containers -any,
         cryptonite >=0.25,
         data-default -any,
+        generic-arbitrary -any,
         flat -any,
         hashable -any,
         hedgehog -any,

--- a/plutus-ledger/src/Ledger/Arbitrary.hs
+++ b/plutus-ledger/src/Ledger/Arbitrary.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ledger.Arbitrary where
+
+import           Ledger.Oracle
+import           Plutus.V1.Ledger.Arbitrary        ()
+
+import           Test.QuickCheck.Arbitrary.Generic (Arbitrary (arbitrary, shrink), genericArbitrary, genericShrink)
+
+instance Arbitrary (SignedMessage a) where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
+instance Arbitrary a => Arbitrary (Observation a) where
+  arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -40,6 +40,7 @@ library
         PlutusTx.Prelude
         PlutusTx.Evaluation
         PlutusTx.Applicative
+        PlutusTx.Arbitrary
         PlutusTx.Bool
         PlutusTx.IsData
         PlutusTx.IsData.Class

--- a/plutus-tx/src/PlutusTx/Arbitrary.hs
+++ b/plutus-tx/src/PlutusTx/Arbitrary.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module PlutusTx.Arbitrary where
+
+import qualified Data.List                   as List
+
+import           Test.QuickCheck             (Arbitrary (..), Gen, Positive (Positive, getPositive), genericShrink,
+                                              getOrdered, oneof, resize, sized, suchThat)
+import           Test.QuickCheck.Instances   ()
+
+import           PlutusTx                    (Data (B, Constr, I, List, Map))
+import           PlutusTx.AssocMap           (Map)
+import qualified PlutusTx.AssocMap           as AssocMap (fromList, toList)
+import           PlutusTx.Bimap              (Bimap)
+import qualified PlutusTx.Bimap              as Bimap
+import           PlutusTx.Builtins
+import           PlutusTx.Builtins.Internal
+import           PlutusTx.NatRatio.Internal  (NatRatio (NatRatio))
+import           PlutusTx.Natural.Internal   (Natural (Natural))
+import           PlutusTx.NonEmpty           (NonEmpty ((:|)))
+import qualified PlutusTx.Ord                as Ord
+import qualified PlutusTx.Prelude            as PlutusPrelude
+import           PlutusTx.Ratio              (denominator, numerator, (%))
+import qualified PlutusTx.Ratio              as Ratio (Rational, fromGHC, toGHC)
+import           PlutusTx.Set                (Set)
+import qualified PlutusTx.Set                as Set
+import           PlutusTx.UniqueMap.Internal (UniqueMap (UniqueMap))
+
+--------------------------------------------------------------------------------
+-- Special cases
+
+instance Arbitrary BuiltinByteString where
+  arbitrary = BuiltinByteString <$> resize 64 arbitrary
+  shrink (BuiltinByteString x) = BuiltinByteString <$> shrink x
+
+instance Arbitrary Data where
+  -- ToJSON / FromJSON instances of BuiltinData implemented with serialise / deserialise functions from Codec.Serialise.
+  -- In case the length of ByteStrings is more than 64 bytes, deserialization error occurs.
+  --
+  -- Example:
+  -- B "\RS\194w\255$u\144-\191\205u\191\183\&4\232\190\225\249\"}S+\217\ENQf\196\SUB\SI\191\169\149^\DC41n%\252\&1\245wr&\161|OX3\170h7\153\210\225\177\228\233\207\231#\DC1[\191\242\148\210\US\167"
+  -- Failed! Exception: 'DeserialiseFailure 69 "ByteString exceeds 64 bytes"'
+  --
+  -- It goes from the implementation of PlutusCore.Data.decodeBoundedBytes:
+  --
+  -- @
+  -- decodeBoundedBytes :: Decoder s Data
+  -- decodeBoundedBytes =  do
+  -- b <- CBOR.decodeBytes
+  -- if BS.length b <= 64
+  --  then pure $ B b
+  --  else fail $ "ByteString exceeds 64 bytes"
+  -- @
+  arbitrary = sized $ oneof . dataGenList
+    where
+      positive :: Gen Integer
+      positive = getPositive <$> arbitrary @(Positive Integer)
+
+      dataGenList :: Int -> [Gen Data]
+      dataGenList n
+        | n < 2 = [I <$> arbitrary, B <$> arbitrary]
+        | otherwise =
+          [ I <$> arbitrary
+          , B <$> resize 64 arbitrary
+          , Map <$> resize (n `div` 2) arbitrary
+          , List <$> resize (n `div` 2) arbitrary
+          , Constr <$> positive <*> resize (n `div` 2) arbitrary
+          ]
+  shrink = genericShrink
+
+instance (Arbitrary a, Arbitrary b, Ord.Ord a, Ord.Ord b, Ord a, Ord b) => Arbitrary (Bimap a b) where
+  arbitrary = Bimap.fromList . getOrdered <$> arbitrary
+  shrink = fmap Bimap.fromList . shrink . Bimap.toList
+
+instance (Arbitrary k, Arbitrary v) => Arbitrary (Map k v) where
+  arbitrary = AssocMap.fromList <$> arbitrary
+  shrink = fmap AssocMap.fromList . shrink . AssocMap.toList
+
+instance (Arbitrary a) => Arbitrary (NonEmpty a) where
+  arbitrary = (:|) <$> arbitrary <*> arbitrary
+  shrink (a :| as) = do
+    a' <- shrink a
+    as' <- shrink as
+    pure (a' :| as')
+
+instance Arbitrary Ratio.Rational where
+  arbitrary = Ratio.fromGHC <$> arbitrary
+  shrink = fmap Ratio.fromGHC . shrink . Ratio.toGHC
+
+instance (Arbitrary a, Ord a, Ord.Ord a) => Arbitrary (Set a) where
+  arbitrary = Set.fromList . getOrdered <$> arbitrary
+  shrink = fmap Set.fromList . shrink . Set.toList
+
+instance
+  (Arbitrary k, Arbitrary v, Ord k) =>
+  Arbitrary (UniqueMap k v)
+  where
+  arbitrary = do
+    ks <- List.nub . getOrdered <$> arbitrary
+    UniqueMap <$> traverse (\key -> (key,) <$> arbitrary) ks
+  shrink (UniqueMap um) = do
+    um' <- shrink um
+    pure . UniqueMap . List.sortOn Prelude.fst $ um'
+
+instance Arbitrary Natural where
+  arbitrary = do
+    NonNegative n <- arbitrary
+    pure . Natural $ n
+  shrink (Natural n) = do
+    NonNegative n' <- shrink . NonNegative $ n
+    pure . Natural $ n'
+
+instance Arbitrary NatRatio where
+  arbitrary = do
+    NonNegative num <- arbitrary
+    Positive den <- arbitrary
+    pure . NatRatio $ num % den
+  shrink (NatRatio r) = do
+    NonNegative num' <- shrink . NonNegative . numerator $ r
+    Positive den' <- shrink . Positive . denominator $ r
+    pure . NatRatio $ num' % den'
+
+-- | A newtype which ensures we generate a value that is not 'zero'.
+newtype NonZero a = NonZero a
+  deriving stock (Show)
+  deriving
+    ( Eq
+    , PlutusPrelude.AdditiveSemigroup
+    , PlutusPrelude.AdditiveMonoid
+    )
+    via a
+
+instance
+  (Eq a, PlutusPrelude.AdditiveMonoid a, Arbitrary a) =>
+  Arbitrary (NonZero a)
+  where
+  arbitrary = do
+    x <- arbitrary `suchThat` (PlutusPrelude.zero /=)
+    pure . NonZero $ x
+  shrink (NonZero x) = do
+    x' <- filter (PlutusPrelude.zero /=) . shrink $ x
+    pure . NonZero $ x'
+
+-- | A newtype which ensures we generate a value that's not less than 'zero'.
+newtype NonNegative a = NonNegative a
+  deriving stock (Show)
+  deriving (Eq) via a
+
+instance
+  (Arbitrary a, PlutusPrelude.AdditiveMonoid a, PlutusPrelude.Ord a) =>
+  Arbitrary (NonNegative a)
+  where
+  arbitrary = do
+    x <- arbitrary `suchThat` (PlutusPrelude.zero PlutusPrelude.<=)
+    pure . NonNegative $ x
+  shrink (NonNegative x) = do
+    x' <- filter (PlutusPrelude.zero PlutusPrelude.<=) . shrink $ x
+    pure . NonNegative $ x'


### PR DESCRIPTION
This PR is a part of https://github.com/input-output-hk/plutus/pull/3852 that adds `Arbitrary` instances to a bunch of `plutus-tx` and `plutus-ledger-api` types. Note, that this PR depends on https://github.com/input-output-hk/plutus/pull/3923 https://github.com/input-output-hk/plutus/pull/3920 https://github.com/input-output-hk/plutus/pull/3921 and https://github.com/input-output-hk/plutus/pull/3922 and hence cannot be merged unless these aren't. 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
