### PR TITLE
Fix a shadowing bug in generating recursive types.

### DIFF
--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
@@ -744,10 +744,12 @@ makeRecursiveType1
 makeRecursiveType1 ann dataName argVar patBody1 = do
     let varName = _tyVarDeclName argVar
         varKind = _tyVarDeclKind argVar
+    varName' <- freshenTyName varName
+    let
         recKind = KindArrow ann varKind $ Type ann
         pat1 = TyLam ann dataName recKind $ TyLam ann varName varKind patBody1
         -- recType = \(v :: k) -> ifix (\(dataName :: k -> *) (v :: k) -> patBody1) v
-        recType = TyLam ann varName varKind . TyIFix ann pat1 $ TyVar ann varName
+        recType = TyLam ann varName' varKind . TyIFix ann pat1 $ TyVar ann varName'
         wrap args = case args of
             [arg] -> iWrap ann pat1 arg
             _     -> throw . IndicesLengthsMismatchException 1 (length args) $ dataName

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -190,12 +190,6 @@ compileReadableToPlc =
     >=> through check
     -- We introduce some non-recursive let bindings while eliminating recursive let-bindings, so we
     -- can eliminate any of them which are unused here.
-    >=> (<$ logVerbose "  !!! rename")
-    >=> PLC.rename
-    >=> through check
-    -- NOTE: There was a bug in renamer handling non-rec terms, so we need to
-    -- rename again.
-    -- https://jira.iohk.io/browse/SCP-2156
     >=> (<$ logVerbose "  !!! removeDeadBindings")
     >=> DeadCode.removeDeadBindings
     >=> (<$ logVerbose "  !!! simplifyTerm")

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -141,7 +141,8 @@ typeCheckTerm t = do
 check :: Compiling m e uni fun b => Term TyName Name uni fun (Provenance b) -> m ()
 check arg = do
     shouldCheck <- view (ccOpts . coPedantic)
-    if shouldCheck then typeCheckTerm arg else pure ()
+    -- the typechecker requires global uniqueness, so rename here
+    if shouldCheck then typeCheckTerm =<< PLC.rename arg else pure ()
 
 -- | The 1st half of the PIR compiler pipeline up to floating/merging the lets.
 -- We stop momentarily here to give a chance to the tx-plugin

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -185,19 +185,21 @@ compileReadableToPlc =
     >=> through check
     >=> (<$ logVerbose "  !!! compileLets RecTerms")
     >=> Let.compileLets Let.RecTerms
-    -- TODO: add 'check' steps from here on. Can't do this since we seem to generate a wrong type
-    -- somewhere in the recursive binding compilation step
     >=> through check
     -- We introduce some non-recursive let bindings while eliminating recursive let-bindings, so we
     -- can eliminate any of them which are unused here.
     >=> (<$ logVerbose "  !!! removeDeadBindings")
     >=> DeadCode.removeDeadBindings
+    >=> through check
     >=> (<$ logVerbose "  !!! simplifyTerm")
     >=> simplifyTerm
+    >=> through check
     >=> (<$ logVerbose "  !!! compileLets Types")
     >=> Let.compileLets Let.Types
+    >=> through check
     >=> (<$ logVerbose "  !!! compileLets NonRecTerms")
     >=> Let.compileLets Let.NonRecTerms
+    >=> through check
     >=> (<$ logVerbose "  !!! lowerTerm")
     >=> lowerTerm
 

--- a/plutus-core/plutus-ir/test/datatypes/listMatchEval.golden
+++ b/plutus-core/plutus-ir/test/datatypes/listMatchEval.golden
@@ -1,1 +1,1 @@
-(delay (lam x_138 x_138))
+(delay (lam x_85 x_85))

--- a/plutus-core/plutus-ir/test/recursion/even3Eval.golden
+++ b/plutus-core/plutus-ir/test/recursion/even3Eval.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_365 (lam case_False_366 case_False_366)))
+(delay (lam case_True_228 (lam case_False_229 case_False_229)))

--- a/plutus-core/plutus-ir/test/types/listMatch.golden
+++ b/plutus-core/plutus-ir/test/types/listMatch.golden
@@ -1,1 +1,1 @@
-(fun (con integer) (all a_48 (type) (fun a_48 a_48)))
+(fun (con integer) (all a_49 (type) (fun a_49 a_49)))

--- a/plutus-core/plutus-ir/test/types/mutuallyRecursiveTypes.golden
+++ b/plutus-core/plutus-ir/test/types/mutuallyRecursiveTypes.golden
@@ -1,1 +1,1 @@
-[ Forest_11 (all a_42 (type) (fun a_42 a_42)) ]
+[ Forest_11 (all a_44 (type) (fun a_44 a_44)) ]


### PR DESCRIPTION
This was coming up on the inlining branch, but it's independent (see https://github.com/input-output-hk/plutus/pull/3630#issuecomment-912915629).

The issue was that we were reusing a variable in two separate binders, which led to us using the wrong one in the body.

The error looks like this. The issue is that we were using the `a` from the outer type abstraction instead of the `a` from the inner type lambda, which makes it all go wrong.
```
Expected type
  '(fun
    (ifix
      (lam
        self
        (fun (type) (type))
        (lam a (type) (fun [ self (fun a b) ] (fun a b)))
      )
      (fun a b)
    )
    (fun a b)
  )',
found type
  '(fun
    (ifix
      (lam self (fun (type) (type)) (lam a (type) (fun [ self a ] a))) (fun a b)
    )
    (fun a b)
  )'
```

When debugging this I had lots of other issues. Printing out the code, I found that most of the terms relating to recursive types were not properly renamed. Previously we had assumed that we would rename such things before inserting them, but I think this is not quite okay, since some of them can contain variable references from outside. So I moved lots of them to properly operate in `Quote`, which let me find the actual issue.

(@jakzale for interest: the single-occurrence inlining branch works after this fix)

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
