### PR TITLE
Fix bug in transactionStatus, and TxIdState tracking when rolling-back

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/TxIdState.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/TxIdState.hs
@@ -123,14 +123,14 @@ rollback targetPoint idx@(viewTip -> currentTip)
         case tip (measure before) of
             TipAtGenesis -> Left $ OldPointNotFound targetPoint
             oldTip | targetPoint `pointsToTip` oldTip ->
-                      let x = _usTxUtxoData (measure deleted)
+                      let oldTxIdState = _usTxUtxoData (measure deleted)
                           newTxIdState = TxIdState
-                                            { txnsConfirmed = txnsConfirmed x
+                                            { txnsConfirmed = mempty
                                             -- All the transactions that were confirmed in the deleted
                                             -- section are now deleted.
-                                            , txnsDeleted = const 1 <$> txnsConfirmed x
+                                            , txnsDeleted = const 1 <$> txnsConfirmed oldTxIdState
                                             }
-                          newUtxoState = UtxoState newTxIdState oldTip
+                          newUtxoState = UtxoState (oldTxIdState <> newTxIdState) oldTip
                        in Right RollbackResult{newTip=oldTip, rolledBackIndex=before |> newUtxoState }
                    | otherwise -> Left  TipMismatch{foundTip=oldTip, targetPoint}
     where

--- a/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
@@ -220,11 +220,12 @@ data Diagnostics =
         deriving stock (Eq, Ord, Show, Generic)
         deriving anyclass (ToJSON, FromJSON)
 
-data TxStatusFailure =
+data TxStatusFailure
       -- | We couldn't return the status because the 'TxIdState' was in a ...
       -- state ... that we didn't know how to decode in
       -- 'Plutus.ChainIndex.TxIdState.transactionStatus'.
-      TxIdStateInvalid BlockNumber TxId TxIdState
+      = TxIdStateInvalid BlockNumber TxId TxIdState
+      | InvalidRollbackAttempt BlockNumber TxId TxIdState
       deriving (Show, Eq)
 
 data TxIdState = TxIdState

--- a/plutus-chain-index/test/Generators.hs
+++ b/plutus-chain-index/test/Generators.hs
@@ -25,7 +25,8 @@ module Generators(
     execTxIdGenState,
     txgsBlocks,
     txgsNumTransactions,
-    genTxIdStateTipAndTxId
+    genTxIdStateTipAndTxId,
+    txIdFromInt
     ) where
 
 import           Codec.Serialise             (serialise)


### PR DESCRIPTION
Fixes SCP-2736

~I'm going to try and add a few more tests~, but @j-mueller it's of interest to note that I already caught one.

The issue was twofold:

- In the rollback, we were losing the old `txnsConfirmed`, so now it grabs the old state and adds it to the new one,
- In `transactionStatus` I just had the logic wrong for something being confirmed! `>=` vs `>` !

TODO:

- [ ] Take a glance over the generators and try and make them a bit more interesting?
- [ ] Try and think up at least one more interesting test? Or, alternatively, make sure all code-paths in `transactionStatus` as hit.
  - [x] ~TxIdStateInvalid~ (Not much point, it'd just be building one by hand?)
  - [x] Unknown

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
