### PR TITLE
[PlutusTx.Ratio]: Added `INLINABLE` pragmas to `recip`, `fromInteger`, `toGHC`, `fromGHC`

### DIFF
--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -190,20 +190,24 @@ infixl 7 %
 (%) :: Integer -> Integer -> Ratio Integer
 x % y = reduce (x P.* signum y) (abs y)
 
+{-# INLINABLE recip #-}
 -- | Reciprocal fraction
 recip :: Ratio Integer -> Ratio Integer
 recip (x :% y) = reduce n d
     where (n :% d) = ((y P.* signum x) :% abs x)
 
+{-# INLINABLE fromInteger #-}
 -- | Convert an 'Interger' to a 'Rational'
 fromInteger :: Integer -> Ratio Integer
 fromInteger n = n :% 1
 
+{-# INLINABLE fromGHC #-}
 -- | Convert a 'Data.Ratio.Rational' to a
 --   Plutus-compatible 'PlutusTx.Ratio.Rational'
 fromGHC :: Ratio.Rational -> Ratio Integer
 fromGHC (n Ratio.:% d) = n :% d
 
+{-# INLINABLE toGHC #-}
 -- | Convert a 'PlutusTx.Ratio.Rational' to a
 --   'Data.Ratio.Rational'
 toGHC :: Rational -> Ratio.Rational

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -201,13 +201,11 @@ recip (x :% y) = reduce n d
 fromInteger :: Integer -> Ratio Integer
 fromInteger n = n :% 1
 
-{-# INLINABLE fromGHC #-}
 -- | Convert a 'Data.Ratio.Rational' to a
 --   Plutus-compatible 'PlutusTx.Ratio.Rational'
 fromGHC :: Ratio.Rational -> Ratio Integer
 fromGHC (n Ratio.:% d) = n :% d
 
-{-# INLINABLE toGHC #-}
 -- | Convert a 'PlutusTx.Ratio.Rational' to a
 --   'Data.Ratio.Rational'
 toGHC :: Rational -> Ratio.Rational


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested

### Summary ###

Some exported functions do not have a pragma `INLINABLE`:
- `recip`
- `fromInteger`
- `toGHC`
-  `fromGHC`
As a result, they may not be possible to use in on-chain code.

For these `INLINABLE` pragma has been added.
