### PR TITLE
SCP-2771: Plutus V2 interface

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
@@ -78,6 +78,8 @@
           "Plutus/V1/Ledger/TxId"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V2/Ledger/Api"
+          "Plutus/V2/Ledger/Contexts"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
@@ -78,6 +78,8 @@
           "Plutus/V1/Ledger/TxId"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V2/Ledger/Api"
+          "Plutus/V2/Ledger/Contexts"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
@@ -78,6 +78,8 @@
           "Plutus/V1/Ledger/TxId"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V2/Ledger/Api"
+          "Plutus/V2/Ledger/Contexts"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -37,6 +37,7 @@ library
         Data.Aeson.Extras
         Data.Either.Extras
         Data.Text.Prettyprint.Doc.Extras
+
         Plutus.V1.Ledger.Address
         Plutus.V1.Ledger.Ada
         Plutus.V1.Ledger.Api
@@ -54,6 +55,9 @@ library
         Plutus.V1.Ledger.TxId
         Plutus.V1.Ledger.Time
         Plutus.V1.Ledger.Value
+
+        Plutus.V2.Ledger.Api
+        Plutus.V2.Ledger.Contexts
     build-depends:
         base >=4.9 && <5,
         aeson -any,

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -275,7 +275,7 @@ instance BA.ByteArrayAccess Datum where
 -- | 'Redeemer' is a wrapper around 'Data' values that are used as redeemers in transaction inputs.
 newtype Redeemer = Redeemer { getRedeemer :: BuiltinData }
   deriving stock (Generic, Haskell.Show)
-  deriving newtype (Haskell.Eq, Haskell.Ord, Eq)
+  deriving newtype (Haskell.Eq, Haskell.Ord, Eq, ToData, FromData, UnsafeFromData)
   deriving (ToJSON, FromJSON, Serialise, NFData, Pretty) via PLC.Data
 
 instance BA.ByteArrayAccess Redeemer where
@@ -439,3 +439,5 @@ makeLift ''DatumHash
 makeLift ''RedeemerHash
 
 makeLift ''Datum
+
+makeLift ''Redeemer

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
+{- |
+The interface to Plutus V2 for the ledger.
+-}
+module Plutus.V2.Ledger.Api (
+    -- * Scripts
+    SerializedScript
+    , Script
+    , fromCompiledCode
+    -- * Validating scripts
+    , validateScript
+    -- * Running scripts
+    , evaluateScriptRestricting
+    , evaluateScriptCounting
+    -- ** Verbose mode and log output
+    , VerboseMode (..)
+    , LogOutput
+    -- * Serialising scripts
+    , plutusScriptEnvelopeType
+    , plutusDatumEnvelopeType
+    , plutusRedeemerEnvelopeType
+    -- * Costing-related types
+    , ExBudget (..)
+    , ExCPU (..)
+    , ExMemory (..)
+    , SatInt
+    -- ** Cost model
+    , validateCostModelParams
+    , defaultCostModelParams
+    , CostModelParams
+    -- * Context types
+    , ScriptContext(..)
+    , ScriptPurpose(..)
+    -- ** Supporting types used in the context types
+    -- *** ByteStrings
+    , BuiltinByteString
+    , toBuiltin
+    , fromBuiltin
+    -- *** Bytes
+    , LedgerBytes (..)
+    , fromBytes
+    -- *** Certificates
+    , DCert(..)
+    -- *** Credentials
+    , StakingCredential(..)
+    , Credential(..)
+    -- *** Value
+    , Value (..)
+    , CurrencySymbol (..)
+    , TokenName (..)
+    , singleton
+    , unionWith
+    , adaSymbol
+    , adaToken
+    -- *** Time
+    , POSIXTime (..)
+    , POSIXTimeRange
+    -- *** Types for representing transactions
+    , Address (..)
+    , PubKeyHash (..)
+    , TxId (..)
+    , TxInfo (..)
+    , TxOut(..)
+    , TxOutRef(..)
+    , TxInInfo(..)
+    -- *** Intervals
+    , Interval (..)
+    , Extended (..)
+    , Closure
+    , UpperBound (..)
+    , LowerBound (..)
+    , always
+    , from
+    , to
+    , lowerBound
+    , upperBound
+    , strictLowerBound
+    , strictUpperBound
+    -- *** Newtypes for script/datum types and hash types
+    , Validator (..)
+    , mkValidatorScript
+    , unValidatorScript
+    , ValidatorHash (..)
+    , MintingPolicy (..)
+    , mkMintingPolicyScript
+    , unMintingPolicyScript
+    , MintingPolicyHash (..)
+    , StakeValidator (..)
+    , mkStakeValidatorScript
+    , unStakeValidatorScript
+    , StakeValidatorHash (..)
+    , Redeemer (..)
+    , RedeemerHash (..)
+    , Datum (..)
+    , DatumHash (..)
+    -- * Data
+    , Data (..)
+    , BuiltinData (..)
+    , ToData (..)
+    , FromData (..)
+    , UnsafeFromData (..)
+    , toData
+    , fromData
+    , dataToBuiltinData
+    , builtinDataToData
+    -- * Errors
+    , EvaluationError (..)
+) where
+
+import           Data.Text                 (Text)
+
+import           Plutus.V1.Ledger.Api      hiding (ScriptContext (..), TxInfo (..), plutusScriptEnvelopeType)
+import           Plutus.V2.Ledger.Contexts
+
+plutusScriptEnvelopeType :: Text
+plutusScriptEnvelopeType = "PlutusV2Script"

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
@@ -54,6 +54,7 @@ module Plutus.V2.Ledger.Contexts
 
 import           Data.Text.Prettyprint.Doc   (Pretty (..), nest, vsep, (<+>))
 import           GHC.Generics                (Generic)
+import           PlutusTx.AssocMap
 import           PlutusTx.Prelude
 
 import           Plutus.V1.Ledger.Credential (StakingCredential)
@@ -74,10 +75,10 @@ data TxInfo = TxInfo
     , txInfoFee         :: Value -- ^ The fee paid by this transaction.
     , txInfoMint        :: Value -- ^ The 'Value' minted by this transaction.
     , txInfoDCert       :: [DCert] -- ^ Digests of certificates included in this transaction
-    , txInfoWdrl        :: [(StakingCredential, Integer)] -- ^ Withdrawals
+    , txInfoWdrl        :: Map StakingCredential Integer -- ^ Withdrawals
     , txInfoValidRange  :: POSIXTimeRange -- ^ The valid range for the transaction.
     , txInfoSignatories :: [PubKeyHash] -- ^ Signatures provided with the transaction, attested that they all signed the tx
-    , txInfoData        :: [(DatumHash, Datum)]
+    , txInfoData        :: Map DatumHash Datum
     , txInfoId          :: TxId
     -- ^ Hash of the pending transaction (excluding witnesses)
     } deriving stock (Generic, Haskell.Show, Haskell.Eq)

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns         #-}
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+{-# OPTIONS_GHC -fno-strictness #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Plutus.V2.Ledger.Contexts
+    (
+    -- * Pending transactions and related types
+      TxInfo(..)
+    , ScriptContext(..)
+    , ScriptPurpose(..)
+    , TxOut(..)
+    , TxOutRef(..)
+    , TxInInfo(..)
+    , findOwnInput
+    , findDatum
+    , findDatumHash
+    , findTxInByTxOutRef
+    , findContinuingOutputs
+    , getContinuingOutputs
+    -- ** Hashes (see note [Hashes in validator scripts])
+    -- * Validator functions
+    -- ** Signatures
+    , txSignedBy
+    -- ** Transactions
+    , pubKeyOutput
+    , scriptOutputsAt
+    , pubKeyOutputsAt
+    , valueLockedBy
+    , valuePaidTo
+    , adaLockedBy
+    , signsTransaction
+    , spendsOutput
+    , valueSpent
+    , valueProduced
+    , ownCurrencySymbol
+    , ownHashes
+    , ownHash
+    , fromSymbol
+    ) where
+
+import           Data.Text.Prettyprint.Doc   (Pretty (..), nest, vsep, (<+>))
+import           GHC.Generics                (Generic)
+import           PlutusTx.Prelude
+
+import           Plutus.V1.Ledger.Credential (StakingCredential)
+import           Plutus.V1.Ledger.Crypto     (PubKeyHash (..))
+import           Plutus.V1.Ledger.DCert      (DCert (..))
+import           Plutus.V1.Ledger.Scripts
+import           Plutus.V1.Ledger.Time       (POSIXTimeRange)
+import           Plutus.V1.Ledger.TxId
+import           Plutus.V1.Ledger.Value      (Value)
+import qualified Prelude                     as Haskell
+
+import           Plutus.V1.Ledger.Contexts   hiding (ScriptContext (..), TxInfo (..))
+
+-- | A pending transaction. This is the view as seen by validator scripts, so some details are stripped out.
+data TxInfo = TxInfo
+    { txInfoInputs      :: [TxInInfo] -- ^ Transaction inputs
+    , txInfoOutputs     :: [TxOut] -- ^ Transaction outputs
+    , txInfoFee         :: Value -- ^ The fee paid by this transaction.
+    , txInfoMint        :: Value -- ^ The 'Value' minted by this transaction.
+    , txInfoDCert       :: [DCert] -- ^ Digests of certificates included in this transaction
+    , txInfoWdrl        :: [(StakingCredential, Integer)] -- ^ Withdrawals
+    , txInfoValidRange  :: POSIXTimeRange -- ^ The valid range for the transaction.
+    , txInfoSignatories :: [PubKeyHash] -- ^ Signatures provided with the transaction, attested that they all signed the tx
+    , txInfoData        :: [(DatumHash, Datum)]
+    , txInfoId          :: TxId
+    -- ^ Hash of the pending transaction (excluding witnesses)
+    } deriving stock (Generic, Haskell.Show, Haskell.Eq)
+
+instance Eq TxInfo where
+    {-# INLINABLE (==) #-}
+    TxInfo i o f m c w r s d tid == TxInfo i' o' f' m' c' w' r' s' d' tid' =
+        i == i' && o == o' && f == f' && m == m' && c == c' && w == w' && r == r' && s == s' && d == d' && tid == tid'
+
+instance Pretty TxInfo where
+    pretty TxInfo{txInfoInputs, txInfoOutputs, txInfoFee, txInfoMint, txInfoDCert, txInfoWdrl, txInfoValidRange, txInfoSignatories, txInfoData, txInfoId} =
+        vsep
+            [ "TxId:" <+> pretty txInfoId
+            , "Inputs:" <+> pretty txInfoInputs
+            , "Outputs:" <+> pretty txInfoOutputs
+            , "Fee:" <+> pretty txInfoFee
+            , "Value minted:" <+> pretty txInfoMint
+            , "DCerts:" <+> pretty txInfoDCert
+            , "Wdrl:" <+> pretty txInfoWdrl
+            , "Valid range:" <+> pretty txInfoValidRange
+            , "Signatories:" <+> pretty txInfoSignatories
+            , "Datums:" <+> pretty txInfoData
+            ]
+
+data ScriptContext = ScriptContext{scriptContextTxInfo :: TxInfo, scriptContextPurpose :: ScriptPurpose }
+    deriving stock (Generic, Haskell.Eq, Haskell.Show)
+
+instance Eq ScriptContext where
+    {-# INLINABLE (==) #-}
+    ScriptContext info purpose == ScriptContext info' purpose' = info == info' && purpose == purpose'
+
+instance Pretty ScriptContext where
+    pretty ScriptContext{scriptContextTxInfo, scriptContextPurpose} =
+        vsep
+            [ "Purpose:" <+> pretty scriptContextPurpose
+            , nest 2 $ vsep ["TxInfo:", pretty scriptContextTxInfo]
+            ]

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
@@ -78,6 +78,7 @@ data TxInfo = TxInfo
     , txInfoWdrl        :: Map StakingCredential Integer -- ^ Withdrawals
     , txInfoValidRange  :: POSIXTimeRange -- ^ The valid range for the transaction.
     , txInfoSignatories :: [PubKeyHash] -- ^ Signatures provided with the transaction, attested that they all signed the tx
+    , txInfoRedeemers   :: Map ScriptPurpose Redeemer
     , txInfoData        :: Map DatumHash Datum
     , txInfoId          :: TxId
     -- ^ Hash of the pending transaction (excluding witnesses)
@@ -85,11 +86,11 @@ data TxInfo = TxInfo
 
 instance Eq TxInfo where
     {-# INLINABLE (==) #-}
-    TxInfo i o f m c w r s d tid == TxInfo i' o' f' m' c' w' r' s' d' tid' =
-        i == i' && o == o' && f == f' && m == m' && c == c' && w == w' && r == r' && s == s' && d == d' && tid == tid'
+    TxInfo i o f m c w r s rs d tid == TxInfo i' o' f' m' c' w' r' s' rs' d' tid' =
+        i == i' && o == o' && f == f' && m == m' && c == c' && w == w' && r == r' && s == s' && rs == rs' && d == d' && tid == tid'
 
 instance Pretty TxInfo where
-    pretty TxInfo{txInfoInputs, txInfoOutputs, txInfoFee, txInfoMint, txInfoDCert, txInfoWdrl, txInfoValidRange, txInfoSignatories, txInfoData, txInfoId} =
+    pretty TxInfo{txInfoInputs, txInfoOutputs, txInfoFee, txInfoMint, txInfoDCert, txInfoWdrl, txInfoValidRange, txInfoSignatories, txInfoRedeemers, txInfoData, txInfoId} =
         vsep
             [ "TxId:" <+> pretty txInfoId
             , "Inputs:" <+> pretty txInfoInputs
@@ -100,6 +101,7 @@ instance Pretty TxInfo where
             , "Wdrl:" <+> pretty txInfoWdrl
             , "Valid range:" <+> pretty txInfoValidRange
             , "Signatories:" <+> pretty txInfoSignatories
+            , "Redeemers:" <+> pretty txInfoRedeemers
             , "Datums:" <+> pretty txInfoData
             ]
 

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Contexts.hs
@@ -54,19 +54,25 @@ module Plutus.V2.Ledger.Contexts
 
 import           Data.Text.Prettyprint.Doc   (Pretty (..), nest, vsep, (<+>))
 import           GHC.Generics                (Generic)
-import           PlutusTx.AssocMap
-import           PlutusTx.Prelude
+import           PlutusTx
+import           PlutusTx.AssocMap           hiding (filter, mapMaybe)
+import           PlutusTx.Prelude            hiding (toList)
 
-import           Plutus.V1.Ledger.Credential (StakingCredential)
-import           Plutus.V1.Ledger.Crypto     (PubKeyHash (..))
+import           Plutus.V1.Ledger.Ada        (Ada)
+import qualified Plutus.V1.Ledger.Ada        as Ada
+import           Plutus.V1.Ledger.Address    (Address (..))
+import           Plutus.V1.Ledger.Bytes      (LedgerBytes (..))
+import           Plutus.V1.Ledger.Credential (Credential (..), StakingCredential)
+import           Plutus.V1.Ledger.Crypto     (PubKey (..), PubKeyHash (..), Signature (..))
 import           Plutus.V1.Ledger.DCert      (DCert (..))
 import           Plutus.V1.Ledger.Scripts
 import           Plutus.V1.Ledger.Time       (POSIXTimeRange)
 import           Plutus.V1.Ledger.TxId
-import           Plutus.V1.Ledger.Value      (Value)
+import           Plutus.V1.Ledger.Value      (CurrencySymbol, Value)
 import qualified Prelude                     as Haskell
 
-import           Plutus.V1.Ledger.Contexts   hiding (ScriptContext (..), TxInfo (..))
+import           Plutus.V1.Ledger.Contexts   (ScriptPurpose (..), TxInInfo (..), TxOut (..), TxOutRef (..), fromSymbol,
+                                              pubKeyOutput)
 
 -- | A pending transaction. This is the view as seen by validator scripts, so some details are stripped out.
 data TxInfo = TxInfo
@@ -118,3 +124,137 @@ instance Pretty ScriptContext where
             [ "Purpose:" <+> pretty scriptContextPurpose
             , nest 2 $ vsep ["TxInfo:", pretty scriptContextTxInfo]
             ]
+
+{-# INLINABLE findOwnInput #-}
+-- | Find the input currently being validated.
+findOwnInput :: ScriptContext -> Maybe TxInInfo
+findOwnInput ScriptContext{scriptContextTxInfo=TxInfo{txInfoInputs}, scriptContextPurpose=Spending txOutRef} =
+    find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == txOutRef) txInfoInputs
+findOwnInput _ = Nothing
+
+{-# INLINABLE findDatum #-}
+-- | Find the data corresponding to a data hash, if there is one
+findDatum :: DatumHash -> TxInfo -> Maybe Datum
+findDatum dsh TxInfo{txInfoData} = lookup dsh txInfoData
+
+{-# INLINABLE findDatumHash #-}
+-- | Find the hash of a datum, if it is part of the pending transaction's
+--   hashes
+findDatumHash :: Datum -> TxInfo -> Maybe DatumHash
+findDatumHash ds TxInfo{txInfoData} = fst <$> find f (toList txInfoData)
+    where
+        f (_, ds') = ds' == ds
+
+{-# INLINABLE findTxInByTxOutRef #-}
+findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
+findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
+    find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
+
+{-# INLINABLE findContinuingOutputs #-}
+-- | Finds all the outputs that pay to the same script address that we are currently spending from, if any.
+findContinuingOutputs :: ScriptContext -> [Integer]
+findContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = findIndices (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
+    where
+        f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
+findContinuingOutputs _ = traceError "Le" -- "Can't find any continuing outputs"
+
+{-# INLINABLE getContinuingOutputs #-}
+getContinuingOutputs :: ScriptContext -> [TxOut]
+getContinuingOutputs ctx | Just TxInInfo{txInInfoResolved=TxOut{txOutAddress}} <- findOwnInput ctx = filter (f txOutAddress) (txInfoOutputs $ scriptContextTxInfo ctx)
+    where
+        f addr TxOut{txOutAddress=otherAddress} = addr == otherAddress
+getContinuingOutputs _ = traceError "Lf" -- "Can't get any continuing outputs"
+
+{-# INLINABLE txSignedBy #-}
+-- | Check if a transaction was signed by the given public key.
+txSignedBy :: TxInfo -> PubKeyHash -> Bool
+txSignedBy TxInfo{txInfoSignatories} k = case find ((==) k) txInfoSignatories of
+    Just _  -> True
+    Nothing -> False
+
+{-# INLINABLE ownHashes #-}
+-- | Get the validator and datum hashes of the output that is curently being validated
+ownHashes :: ScriptContext -> (ValidatorHash, DatumHash)
+ownHashes (findOwnInput -> Just TxInInfo{txInInfoResolved=TxOut{txOutAddress=Address (ScriptCredential s) _, txOutDatumHash=Just dh}}) = (s,dh)
+ownHashes _ = traceError "Lg" -- "Can't get validator and datum hashes"
+
+{-# INLINABLE ownHash #-}
+-- | Get the hash of the validator script that is currently being validated.
+ownHash :: ScriptContext -> ValidatorHash
+ownHash p = fst (ownHashes p)
+
+{-# INLINABLE scriptOutputsAt #-}
+-- | Get the list of 'TxOut' outputs of the pending transaction at
+--   a given script address.
+scriptOutputsAt :: ValidatorHash -> TxInfo -> [(DatumHash, Value)]
+scriptOutputsAt h p =
+    let flt TxOut{txOutDatumHash=Just ds, txOutAddress=Address (ScriptCredential s) _, txOutValue} | s == h = Just (ds, txOutValue)
+        flt _ = Nothing
+    in mapMaybe flt (txInfoOutputs p)
+
+{-# INLINABLE valueLockedBy #-}
+-- | Get the total value locked by the given validator in this transaction.
+valueLockedBy :: TxInfo -> ValidatorHash -> Value
+valueLockedBy ptx h =
+    let outputs = map snd (scriptOutputsAt h ptx)
+    in mconcat outputs
+
+{-# INLINABLE pubKeyOutputsAt #-}
+-- | Get the values paid to a public key address by a pending transaction.
+pubKeyOutputsAt :: PubKeyHash -> TxInfo -> [Value]
+pubKeyOutputsAt pk p =
+    let flt TxOut{txOutAddress = Address (PubKeyCredential pk') _, txOutValue} | pk == pk' = Just txOutValue
+        flt _                             = Nothing
+    in mapMaybe flt (txInfoOutputs p)
+
+{-# INLINABLE valuePaidTo #-}
+-- | Get the total value paid to a public key address by a pending transaction.
+valuePaidTo :: TxInfo -> PubKeyHash -> Value
+valuePaidTo ptx pkh = mconcat (pubKeyOutputsAt pkh ptx)
+
+{-# INLINABLE adaLockedBy #-}
+-- | Get the total amount of 'Ada' locked by the given validator in this transaction.
+adaLockedBy :: TxInfo -> ValidatorHash -> Ada
+adaLockedBy ptx h = Ada.fromValue (valueLockedBy ptx h)
+
+{-# INLINABLE signsTransaction #-}
+-- | Check if the provided signature is the result of signing the pending
+--   transaction (without witnesses) with the given public key.
+signsTransaction :: Signature -> PubKey -> TxInfo -> Bool
+signsTransaction (Signature sig) (PubKey (LedgerBytes pk)) TxInfo{txInfoId=TxId h} =
+    verifySignature pk h sig
+
+{-# INLINABLE valueSpent #-}
+-- | Get the total value of inputs spent by this transaction.
+valueSpent :: TxInfo -> Value
+valueSpent = foldMap (txOutValue . txInInfoResolved) . txInfoInputs
+
+{-# INLINABLE valueProduced #-}
+-- | Get the total value of outputs produced by this transaction.
+valueProduced :: TxInfo -> Value
+valueProduced = foldMap txOutValue . txInfoOutputs
+
+{-# INLINABLE ownCurrencySymbol #-}
+-- | The 'CurrencySymbol' of the current validator script.
+ownCurrencySymbol :: ScriptContext -> CurrencySymbol
+ownCurrencySymbol ScriptContext{scriptContextPurpose=Minting cs} = cs
+ownCurrencySymbol _                                              = traceError "Lh" -- "Can't get currency symbol of the current validator script"
+
+{-# INLINABLE spendsOutput #-}
+-- | Check if the pending transaction spends a specific transaction output
+--   (identified by the hash of a transaction and an index into that
+--   transactions' outputs)
+spendsOutput :: TxInfo -> TxId -> Integer -> Bool
+spendsOutput p h i =
+    let spendsOutRef inp =
+            let outRef = txInInfoOutRef inp
+            in h == txOutRefId outRef
+                && i == txOutRefIdx outRef
+
+    in any spendsOutRef (txInfoInputs p)
+
+makeLift ''TxInfo
+makeIsDataIndexed ''TxInfo [('TxInfo,0)]
+
+makeLift ''ScriptContext
+makeIsDataIndexed ''ScriptContext [('ScriptContext,0)]

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -40,6 +40,7 @@ module PlutusTx.AssocMap (
     ) where
 
 import           Control.DeepSeq            (NFData)
+import           Data.Text.Prettyprint.Doc  (Pretty (..))
 import           GHC.Generics               (Generic)
 import qualified PlutusTx.Builtins          as P
 import qualified PlutusTx.Builtins.Internal as BI
@@ -112,6 +113,9 @@ instance (Eq k, Semigroup v) => Semigroup (Map k v) where
 
 instance (Eq k, Semigroup v) => Monoid (Map k v) where
     mempty = empty
+
+instance (Pretty k, Pretty v) => Pretty (Map k v) where
+    pretty (Map mp) = pretty mp
 
 {-# INLINABLE fromList #-}
 fromList :: [(k, v)] -> Map k v


### PR DESCRIPTION
This is a first attempt at a V2 ledger interface.

- It re-exports almost everything from V1.
- It has new definitions of `TxInfo` and `ScriptContext` (which depends on `TxInfo`), as well as the functions that operate on `TxInfo`, and the envelope type.
- Changes to `TxInfo`:
    - Use `Map` for the maps
    - Add redeemer map

I have not changed anything to use it: in the future we'll want to do that, but probably the `plutus-ledger` stuff should happen after we split the repo.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
