### PR TITLE
SCP-2770 - Add an 'exit on error' flag

### DIFF
--- a/bitte/pab.nix
+++ b/bitte/pab.nix
@@ -69,6 +69,10 @@ let
         getWallet = "1";
       };
     };
+
+    metaLoggingConfig = {
+      exitOnError = false;
+    };
   });
 
   # Note: The db is dropped as a workaround for a problem with

--- a/nix/modules/pab.nix
+++ b/nix/modules/pab.nix
@@ -64,6 +64,9 @@ let
       };
     };
 
+    metaLoggingConfig = {
+      exitOnError = false;
+    };
   };
 
   pabYaml = pkgs.writeText "pab.yaml" (builtins.toJSON pabConfig);

--- a/plutus-pab-client/config.nix
+++ b/plutus-pab-client/config.nix
@@ -58,4 +58,6 @@
   metadataServerConfig:
     mdBaseUrl: http://localhost:${ metadata-server-port }
 
+  metaLoggingConfig:
+    exitOnError: False
 ''

--- a/plutus-pab/plutus-pab.yaml.sample
+++ b/plutus-pab/plutus-pab.yaml.sample
@@ -49,6 +49,9 @@ signingProcessConfig:
 metadataServerConfig:
   mdBaseUrl: http://localhost:9085
 
+metaLoggingConfig:
+  exitOnError: False
+
 # Optional EKG Server Config
 # ----
 # monitoringConfig:

--- a/plutus-pab/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-pab/src/Cardano/ChainIndex/Server.hs
@@ -30,13 +30,14 @@ import           Cardano.Protocol.Socket.Mock.Client (runChainSync)
 import           Ledger.Slot                         (Slot (..))
 import           Plutus.ChainIndex                   (ChainIndexEmulatorState)
 import           Plutus.ChainIndex.Server            (serveChainIndexQueryServer)
+import           Plutus.PAB.Types                    (MetaLoggingConfig)
 
 -- $chainIndex
 -- The PAB chain index that keeps track of transaction data (UTXO set enriched
 -- with datums)
 
-main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> SlotConfig -> IO ()
-main trace ChainIndexConfig{ciBaseUrl} socketPath slotConfig = runLogEffects trace $ do
+main :: ChainIndexTrace -> ChainIndexConfig -> FilePath -> SlotConfig -> MetaLoggingConfig -> IO ()
+main trace ChainIndexConfig{ciBaseUrl} socketPath slotConfig metaLoggingConfig = runLogEffects trace $ do
     tVarState <- liftIO $ STM.atomically $ STM.newTVar mempty
 
     logInfo StartingNodeClientThread
@@ -48,4 +49,4 @@ main trace ChainIndexConfig{ciBaseUrl} socketPath slotConfig = runLogEffects tra
         servicePort = baseUrlPort (coerce ciBaseUrl)
         updateChainState :: TVar ChainIndexEmulatorState -> Block -> Slot -> IO ()
         updateChainState tv block slot = do
-          processChainIndexEffects trace tv $ syncState block slot
+          processChainIndexEffects trace metaLoggingConfig tv $ syncState block slot

--- a/plutus-pab/src/Plutus/PAB/Run/Cli.hs
+++ b/plutus-pab/src/Plutus/PAB/Run/Cli.hs
@@ -206,12 +206,13 @@ runConfigCommand contractHandler c@ConfigCommandArgs{ccaAvailability} (ForkComma
       pure asyncId
 
 -- Run the chain-index service
-runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig=Config { nodeServerConfig, chainIndexConfig }} ChainIndex =
+runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig=Config { nodeServerConfig, chainIndexConfig, metaLoggingConfig}} ChainIndex =
     ChainIndex.main
         (toChainIndexLog ccaTrace)
         chainIndexConfig
         (mscSocketPath nodeServerConfig)
         (mscSlotConfig nodeServerConfig)
+        metaLoggingConfig
 
 -- Get the state of a contract
 runConfigCommand _ ConfigCommandArgs{ccaTrace, ccaPABConfig=Config{dbConfig}} (ContractState contractInstanceId) = do

--- a/plutus-pab/src/Plutus/PAB/Types.hs
+++ b/plutus-pab/src/Plutus/PAB/Types.hs
@@ -104,6 +104,25 @@ defaultDbConfig
 instance Default DbConfig where
   def = defaultDbConfig
 
+data MetaLoggingConfig =
+    MetaLoggingConfig
+      { exitOnError :: Bool
+      -- ^ If we ever log an error, instead of doing that, just error out
+      -- immediately.
+      }
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Default logging (meta) config
+defaultMetaLoggingConfig :: MetaLoggingConfig
+defaultMetaLoggingConfig
+  = MetaLoggingConfig
+      { exitOnError = False
+      }
+
+instance Default MetaLoggingConfig where
+  def = defaultMetaLoggingConfig
+
 data Config =
     Config
         { dbConfig                :: DbConfig
@@ -112,6 +131,7 @@ data Config =
         , pabWebserverConfig      :: WebserverConfig
         , chainIndexConfig        :: ChainIndex.ChainIndexConfig
         , requestProcessingConfig :: RequestProcessingConfig
+        , metaLoggingConfig       :: MetaLoggingConfig
         }
     deriving (Show, Eq, Generic, FromJSON)
 
@@ -124,6 +144,7 @@ defaultConfig =
     , pabWebserverConfig = def
     , chainIndexConfig = def
     , requestProcessingConfig = def
+    , metaLoggingConfig = def
     }
 
 instance Default Config where

--- a/plutus-pab/test/full/Plutus/PAB/CliSpec.hs
+++ b/plutus-pab/test/full/Plutus/PAB/CliSpec.hs
@@ -58,7 +58,7 @@ import           Plutus.PAB.Run.Cli                  (ConfigCommandArgs (..), ru
 import           Plutus.PAB.Run.Command              (ConfigCommand (..), allServices)
 import           Plutus.PAB.Run.CommandParser        (AppOpts (..))
 import           Plutus.PAB.Run.PSGenerator          (HasPSTypes (..))
-import           Plutus.PAB.Types                    (Config (..))
+import           Plutus.PAB.Types                    (Config (..), MetaLoggingConfig (..))
 import qualified Plutus.PAB.Types                    as PAB.Types
 import           Plutus.PAB.Webserver.API            (API)
 import           Plutus.PAB.Webserver.Client         (InstanceClient (..), PabClient (..), pabClient)
@@ -106,6 +106,9 @@ defaultPabConfig
       -- (not unreasonably...)
       { pabWebserverConfig = def { PAB.Types.endpointTimeout = Just 60 }
       , nodeServerConfig = def { Node.Types.mscSocketPath = "/tmp/node-server.sock" }
+      -- In tests, we _always_ want to exit if we logged an error. This
+      -- ensures that the tests fail.
+      , metaLoggingConfig = def { exitOnError = True }
       }
 
 -- | Bump all the default ports, and any other needed things so that we

--- a/plutus-pab/tx-inject/config.yaml
+++ b/plutus-pab/tx-inject/config.yaml
@@ -113,3 +113,5 @@ signingProcessConfig:
 metadataServerConfig:
   mdBaseUrl: http://localhost:9085
 
+metaLoggingConfig:
+  exitOnError: False


### PR DESCRIPTION
Fixes SCP-2770

Just adds a simple flag that causes the PAB to exit immediately if it ever tries to log an error (via `logError`).

There might be nicer way to integrate this; so open to ideas.

Notably, with any luck, as-is this PR will _fail_ because the tests should use this flag, and that may pick up an error that is being logged.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
