### PR TITLE
SCP-2753: Extract datums, redeemers and scripts when converting carda…

### DIFF
--- a/playground-common/src/PSGenerator/Common.hs
+++ b/playground-common/src/PSGenerator/Common.hs
@@ -215,6 +215,12 @@ languageBridge :: BridgePart
 languageBridge = dataBridge <|> assocMapBridge
 
 ------------------------------------------------------------
+scriptHashBridge :: BridgePart
+scriptHashBridge = do
+    typeName ^== "ScriptHash"
+    typeModule ^== "Plutus.V1.Ledger.Scripts"
+    pure psString
+
 scriptBridge :: BridgePart
 scriptBridge = do
     typeName ^== "Script"
@@ -272,6 +278,7 @@ walletIdBridge = do
 ledgerBridge :: BridgePart
 ledgerBridge =
         scriptBridge
+    <|> scriptHashBridge
     <|> redeemerHashBridge
     <|> redeemerBridge
     <|> datumBridge

--- a/plutus-chain-index/app/CommandLine.hs
+++ b/plutus-chain-index/app/CommandLine.hs
@@ -10,8 +10,8 @@ module CommandLine(
 
 import           Control.Lens             (over)
 import           Options.Applicative      (CommandFields, Mod, Parser, ParserInfo, argument, auto, command, flag,
-                                           fullDesc, header, help, helper, info, long, metavar, option, progDesc, short,
-                                           str, subparser, value, (<**>))
+                                           fullDesc, header, help, helper, hsubparser, info, long, metavar, option,
+                                           progDesc, short, str, value, (<**>))
 
 import           Cardano.Api              (NetworkId (..), NetworkMagic (..))
 import           Cardano.BM.Data.Severity
@@ -111,7 +111,7 @@ cmdWithHelpParser =
 
 commandParser :: Parser Command
 commandParser =
-  subparser $
+  hsubparser $
   mconcat
     [ dumpDefaultConfigParser
     , dumpDefaultLoggingConfigParser

--- a/plutus-chain-index/plutus-chain-index.cabal
+++ b/plutus-chain-index/plutus-chain-index.cabal
@@ -75,6 +75,7 @@ library
         beam-sqlite -any,
         beam-migrate -any,
         cardano-api -any,
+        cardano-ledger-alonzo -any,
         cardano-ledger-byron -any,
         containers -any,
         contra-tracer -any,

--- a/plutus-chain-index/src/Plutus/ChainIndex/Emulator/DiskState.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Emulator/DiskState.hs
@@ -10,9 +10,7 @@ used in the emulator.
 module Plutus.ChainIndex.Emulator.DiskState(
     DiskState
     , dataMap
-    , validatorMap
-    , mintingPolicyMap
-    , stakeValidatorMap
+    , scriptMap
     , redeemerMap
     , txMap
     , addressMap
@@ -30,13 +28,12 @@ import           Data.Semigroup.Generic  (GenericSemigroupMonoid (..))
 import           Data.Set                (Set)
 import qualified Data.Set                as Set
 import           GHC.Generics            (Generic)
-import           Ledger                  (Address (..), TxOut (..), TxOutRef)
+import           Ledger                  (Address (..), Script, ScriptHash, TxOut (..), TxOutRef)
 import           Ledger.Credential       (Credential)
-import           Ledger.Scripts          (Datum, DatumHash, MintingPolicy, MintingPolicyHash, Redeemer, RedeemerHash,
-                                          StakeValidator, StakeValidatorHash, Validator, ValidatorHash)
+import           Ledger.Scripts          (Datum, DatumHash, Redeemer, RedeemerHash)
 import           Ledger.TxId             (TxId)
-import           Plutus.ChainIndex.Tx    (ChainIndexTx (..), citxData, citxMintingPolicies, citxRedeemers,
-                                          citxStakeValidators, citxTxId, citxValidators, txOutsWithRef)
+import           Plutus.ChainIndex.Tx    (ChainIndexTx (..), citxData, citxRedeemers, citxScripts, citxTxId,
+                                          txOutsWithRef)
 import           Plutus.ChainIndex.Types (Diagnostics (..))
 
 -- | Set of transaction output references for each address.
@@ -73,13 +70,11 @@ txCredentialMap  =
 --   other structures for the disk-backed storage)
 data DiskState =
     DiskState
-        { _DataMap           :: Map DatumHash Datum
-        , _ValidatorMap      :: Map ValidatorHash Validator
-        , _MintingPolicyMap  :: Map MintingPolicyHash MintingPolicy
-        , _StakeValidatorMap :: Map StakeValidatorHash StakeValidator
-        , _RedeemerMap       :: Map RedeemerHash Redeemer
-        , _TxMap             :: Map TxId ChainIndexTx
-        , _AddressMap        :: CredentialMap
+        { _DataMap     :: Map DatumHash Datum
+        , _ScriptMap   :: Map ScriptHash Script
+        , _RedeemerMap :: Map RedeemerHash Redeemer
+        , _TxMap       :: Map TxId ChainIndexTx
+        , _AddressMap  :: CredentialMap
         }
         deriving stock (Eq, Show, Generic)
         deriving (Semigroup, Monoid) via (GenericSemigroupMonoid DiskState)
@@ -91,19 +86,17 @@ fromTx :: ChainIndexTx -> DiskState
 fromTx tx =
     DiskState
         { _DataMap = view citxData tx
-        , _ValidatorMap = view citxValidators tx
-        , _MintingPolicyMap = view citxMintingPolicies tx
-        , _StakeValidatorMap = view citxStakeValidators tx
+        , _ScriptMap = view citxScripts tx
         , _TxMap = Map.singleton (view citxTxId tx) tx
         , _RedeemerMap = view citxRedeemers tx
         , _AddressMap = txCredentialMap tx
         }
 
 diagnostics :: DiskState -> Diagnostics
-diagnostics DiskState{_DataMap, _ValidatorMap, _MintingPolicyMap, _TxMap, _StakeValidatorMap, _RedeemerMap, _AddressMap} =
+diagnostics DiskState{_DataMap, _ScriptMap, _TxMap, _RedeemerMap, _AddressMap} =
     Diagnostics
         { numTransactions = toInteger $ Map.size _TxMap
-        , numScripts = toInteger $ Map.size _ValidatorMap + Map.size _MintingPolicyMap + Map.size _StakeValidatorMap + Map.size _RedeemerMap
+        , numScripts = toInteger $ Map.size _ScriptMap
         , numAddresses = toInteger $ Map.size $ _unCredentialMap _AddressMap
         , someTransactions = take 10 $ fmap fst $ Map.toList _TxMap
         }

--- a/plutus-chain-index/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Handlers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ExplicitNamespaces    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
@@ -6,7 +5,6 @@
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
@@ -240,9 +238,7 @@ fromTx :: ChainIndexTx -> Db InsertRows
 fromTx tx = mempty
     { datumRows = fromMap citxData DatumRow
     , scriptRows = mconcat
-        [ fromMap citxValidators ScriptRow
-        , fromMap citxMintingPolicies ScriptRow
-        , fromMap citxStakeValidators ScriptRow
+        [ fromMap citxScripts ScriptRow
         , fromMap citxRedeemers ScriptRow
         ]
     , txRows = fromPairs (const [(_citxTxId tx, tx)]) TxRow

--- a/plutus-chain-index/src/Plutus/ChainIndex/Tx.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Tx.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -24,9 +25,7 @@ module Plutus.ChainIndex.Tx(
     , citxValidRange
     , citxData
     , citxRedeemers
-    , citxMintingPolicies
-    , citxStakeValidators
-    , citxValidators
+    , citxScripts
     , citxCardanoTx
     , _InvalidTx
     , _ValidTx
@@ -42,10 +41,11 @@ import qualified Data.Set                  as Set
 import           Data.Text.Prettyprint.Doc
 import           Data.Tuple                (swap)
 import           GHC.Generics              (Generic)
-import           Ledger                    (Address, Datum, DatumHash, MintingPolicy, MintingPolicyHash, OnChainTx (..),
-                                            Redeemer (..), RedeemerHash, SlotRange, SomeCardanoApiTx, StakeValidator,
-                                            StakeValidatorHash, Tx (..), TxId, TxIn (txInType), TxInType (..),
-                                            TxOut (txOutAddress), TxOutRef (..), Validator, ValidatorHash, datumHash,
+import           Ledger                    (Address, Datum, DatumHash, MintingPolicy (getMintingPolicy),
+                                            MintingPolicyHash (MintingPolicyHash), OnChainTx (..), Redeemer (..),
+                                            RedeemerHash, Script, ScriptHash (..), SlotRange, SomeCardanoApiTx, Tx (..),
+                                            TxId, TxIn (txInType), TxInType (..), TxOut (txOutAddress), TxOutRef (..),
+                                            Validator (getValidator), ValidatorHash (ValidatorHash), datumHash,
                                             mintingPolicyHash, redeemerHash, txId, validatorHash)
 
 -- | List of outputs of a transaction. There are no outputs if the transaction
@@ -58,44 +58,45 @@ data ChainIndexTxOutputs =
 makePrisms ''ChainIndexTxOutputs
 
 data ChainIndexTx = ChainIndexTx {
-    _citxTxId            :: TxId,
+    _citxTxId       :: TxId,
     -- ^ The id of this transaction.
-    _citxInputs          :: Set TxIn,
+    _citxInputs     :: Set TxIn,
     -- ^ The inputs to this transaction.
-    _citxOutputs         :: ChainIndexTxOutputs,
+    _citxOutputs    :: ChainIndexTxOutputs,
     -- ^ The outputs of this transaction, ordered so they can be referenced by index.
-    _citxValidRange      :: !SlotRange,
+    _citxValidRange :: !SlotRange,
     -- ^ The 'SlotRange' during which this transaction may be validated.
-    _citxData            :: Map DatumHash Datum,
+    _citxData       :: Map DatumHash Datum,
     -- ^ Datum objects recorded on this transaction.
-    _citxRedeemers       :: Map RedeemerHash Redeemer,
+    _citxRedeemers  :: Map RedeemerHash Redeemer,
     -- ^ Redeemers of the minting scripts.
-    _citxMintingPolicies :: Map MintingPolicyHash MintingPolicy,
-    -- ^ The scripts used to check minting conditions.
-    _citxStakeValidators :: Map StakeValidatorHash StakeValidator,
-    _citxValidators      :: Map ValidatorHash Validator,
-    _citxCardanoTx       :: Maybe SomeCardanoApiTx -- Might be Nothing if we are in the emulator
+    _citxScripts    :: Map ScriptHash Script,
+    -- ^ The scripts (validator, stake validator or minting) part of cardano tx.
+    _citxCardanoTx  :: Maybe SomeCardanoApiTx
+    -- ^ The full Cardano API tx which was used to populate the rest of the
+    -- 'ChainIndexTx' fields. Useful because 'ChainIndexTx' doesn't have all the
+    -- details of the tx, so we keep it as a safety net. Might be Nothing if we
+    -- are in the emulator.
     } deriving (Show, Eq, Generic, ToJSON, FromJSON, Serialise)
 
 makeLenses ''ChainIndexTx
 
-
 instance Pretty ChainIndexTx where
-    pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = ValidTx outputs, _citxValidRange, _citxMintingPolicies, _citxData, _citxRedeemers} =
+    pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = ValidTx outputs, _citxValidRange, _citxData, _citxRedeemers, _citxScripts} =
         let lines' =
                 [ hang 2 (vsep ("inputs:" : fmap pretty (Set.toList _citxInputs)))
                 , hang 2 (vsep ("outputs:" : fmap pretty outputs))
-                , hang 2 (vsep ("minting policies:": fmap (pretty . fst) (Map.toList _citxMintingPolicies)))
+                , hang 2 (vsep ("scripts hashes:": fmap (pretty . fst) (Map.toList _citxScripts)))
                 , "validity range:" <+> viaShow _citxValidRange
                 , hang 2 (vsep ("data:": fmap (pretty . snd) (Map.toList _citxData) ))
                 , hang 2 (vsep ("redeemers:": fmap (pretty . snd) (Map.toList _citxRedeemers) ))
                 ]
         in nest 2 $ vsep ["Valid tx" <+> pretty _citxTxId <> colon, braces (vsep lines')]
-    pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = InvalidTx, _citxValidRange, _citxMintingPolicies, _citxData, _citxRedeemers} =
+    pretty ChainIndexTx{_citxTxId, _citxInputs, _citxOutputs = InvalidTx, _citxValidRange, _citxData, _citxRedeemers, _citxScripts} =
         let lines' =
                 [ hang 2 (vsep ("inputs:" : fmap pretty (Set.toList _citxInputs)))
                 , hang 2 (vsep ["no outputs:"])
-                , hang 2 (vsep ("minting policies:": fmap (pretty . fst) (Map.toList _citxMintingPolicies)))
+                , hang 2 (vsep ("scripts hashes:": fmap (pretty . fst) (Map.toList _citxScripts)))
                 , "validity range:" <+> viaShow _citxValidRange
                 , hang 2 (vsep ("data:": fmap (pretty . snd) (Map.toList _citxData) ))
                 , hang 2 (vsep ("redeemers:": fmap (pretty . snd) (Map.toList _citxRedeemers) ))
@@ -137,9 +138,7 @@ fromOnChainTx = \case
             , _citxValidRange = txValidRange
             , _citxData = txData <> otherDataHashes
             , _citxRedeemers = redeemers
-            , _citxMintingPolicies = mintingPolicies txMintScripts
-            , _citxStakeValidators = mempty
-            , _citxValidators = validatorHashes
+            , _citxScripts = mintingPolicies txMintScripts <> validatorHashes
             , _citxCardanoTx = Nothing
             }
     Invalid tx@Tx{txCollateral, txValidRange, txData, txInputs, txMintScripts} ->
@@ -151,23 +150,23 @@ fromOnChainTx = \case
             , _citxValidRange = txValidRange
             , _citxData = txData <> otherDataHashes
             , _citxRedeemers = redeemers
-            , _citxMintingPolicies = mintingPolicies txMintScripts
-            , _citxStakeValidators = mempty
-            , _citxValidators = validatorHashes
+            , _citxScripts = mintingPolicies txMintScripts <> validatorHashes
             , _citxCardanoTx = Nothing
             }
 
-mintingPolicies :: Set MintingPolicy -> Map MintingPolicyHash MintingPolicy
-mintingPolicies =
-    let withHash mps = (mintingPolicyHash mps, mps) in
-    Map.fromList . fmap withHash . Set.toList
+mintingPolicies :: Set MintingPolicy -> Map ScriptHash Script
+mintingPolicies = Map.fromList . fmap withHash . Set.toList
+  where
+    withHash mp = let (MintingPolicyHash mph) = mintingPolicyHash mp
+                   in (ScriptHash mph, getMintingPolicy mp)
 
-validators :: Set TxIn -> (Map ValidatorHash Validator, Map DatumHash Datum, Map RedeemerHash Redeemer)
-validators =
-    let withHash (ConsumeScriptAddress val red dat) =
-            ( Map.singleton (validatorHash val) val
-            , Map.singleton (datumHash dat) dat
-            , Map.singleton (redeemerHash red) red
-            )
-        withHash _ = mempty
-    in foldMap (maybe mempty withHash . txInType) . Set.toList
+validators :: Set TxIn -> (Map ScriptHash Script, Map DatumHash Datum, Map RedeemerHash Redeemer)
+validators = foldMap (maybe mempty withHash . txInType) . Set.toList
+  where
+    withHash (ConsumeScriptAddress val red dat) =
+      let (ValidatorHash vh) = validatorHash val
+       in ( Map.singleton (ScriptHash vh) (getValidator val)
+          , Map.singleton (datumHash dat) dat
+          , Map.singleton (redeemerHash red) red
+          )
+    withHash _ = mempty

--- a/plutus-chain-index/src/Plutus/ChainIndex/TxIdState.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/TxIdState.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MonoLocalBinds        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 module Plutus.ChainIndex.TxIdState(
@@ -73,7 +69,7 @@ transactionStatus currentBlock txIdState txId
             else if isCommitted block'
                     -- Illegal - We can't roll this transaction back.
                     then Left $ InvalidRollbackAttempt currentBlock txId txIdState
-                    else Right $ Unknown
+                    else Right Unknown
 
        _ -> Left $ TxIdStateInvalid currentBlock txId txIdState
     where

--- a/plutus-chain-index/src/Plutus/ChainIndex/UtxoState.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/UtxoState.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-chain-index/src/Plutus/Contract/CardanoAPI.hs
+++ b/plutus-chain-index/src/Plutus/Contract/CardanoAPI.hs
@@ -41,52 +41,149 @@ module Plutus.Contract.CardanoAPI(
   , FromCardanoError(..)
 ) where
 
-import qualified Cardano.Api                    as C
-import qualified Cardano.Api.Byron              as C
-import qualified Cardano.Api.Shelley            as C
-import           Cardano.BM.Data.Tracer         (ToObject (..))
-import           Cardano.Chain.Common           (addrToBase58)
-import qualified Codec.Serialise                as Codec
-import           Data.Aeson                     (FromJSON, ToJSON)
-import           Data.Bifunctor                 (first)
-import           Data.ByteString                as BS
-import qualified Data.ByteString.Lazy           as BSL
-import           Data.ByteString.Short          as BSS
-import qualified Data.Map                       as Map
-import qualified Data.Set                       as Set
-import           Data.Text.Prettyprint.Doc      (Pretty (..), colon, (<+>))
-import           GHC.Generics                   (Generic)
-import qualified Ledger                         as P
-import qualified Ledger.Ada                     as Ada
-import           Plutus.ChainIndex.Tx           (ChainIndexTx (..))
-import qualified Plutus.ChainIndex.Tx           as ChainIndex.Tx
-import           Plutus.Contract.CardanoAPITemp (makeTransactionBody')
-import qualified Plutus.V1.Ledger.Api           as Api
-import qualified Plutus.V1.Ledger.Credential    as Credential
-import qualified Plutus.V1.Ledger.Value         as Value
-import qualified PlutusCore.Data                as Data
-import qualified PlutusTx.Prelude               as PlutusTx
+import qualified Cardano.Api                     as C
+import qualified Cardano.Api.Byron               as C
+import qualified Cardano.Api.Shelley             as C
+import           Cardano.BM.Data.Tracer          (ToObject (..))
+import           Cardano.Chain.Common            (addrToBase58)
+import qualified Cardano.Ledger.Alonzo.Scripts   as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxWitness as C
+import qualified Cardano.Ledger.Core             as Ledger
+import           Codec.Serialise                 (deserialiseOrFail)
+import qualified Codec.Serialise                 as Codec
+import           Data.Aeson                      (FromJSON, ToJSON)
+import           Data.Bifunctor                  (first)
+import           Data.ByteString                 as BS
+import qualified Data.ByteString.Lazy            as BSL
+import           Data.ByteString.Short           as BSS
+import qualified Data.ByteString.Short           as SBS
+import           Data.Map                        (Map)
+import qualified Data.Map                        as Map
+import           Data.Maybe                      (mapMaybe)
+import qualified Data.Set                        as Set
+import           Data.Text.Prettyprint.Doc       (Pretty (..), colon, (<+>))
+import           GHC.Generics                    (Generic)
+import           Ledger                          (SomeCardanoApiTx (SomeTx))
+import qualified Ledger                          as P
+import qualified Ledger.Ada                      as Ada
+import           Plutus.ChainIndex.Tx            (ChainIndexTx (..))
+import qualified Plutus.ChainIndex.Tx            as ChainIndex.Tx
+import           Plutus.Contract.CardanoAPITemp  (makeTransactionBody')
+import qualified Plutus.V1.Ledger.Api            as Api
+import qualified Plutus.V1.Ledger.Credential     as Credential
+import qualified Plutus.V1.Ledger.Value          as Value
+import qualified PlutusCore.Data                 as Data
+import qualified PlutusTx.Prelude                as PlutusTx
 
 fromCardanoBlock :: C.BlockInMode C.CardanoMode -> Either FromCardanoError [ChainIndexTx]
-fromCardanoBlock (C.BlockInMode (C.Block (C.BlockHeader _ _ _) txs) era) =
-  traverse (fromCardanoTx era) txs
+fromCardanoBlock (C.BlockInMode (C.Block C.BlockHeader {} txs) eraInMode) =
+  case eraInMode of
+    -- Unfortunately, we need to pattern match again all eras because
+    -- 'fromCardanoTx' has the constraints 'C.IsCardanoEra era', but not
+    -- 'C.BlockInMode'.
+    C.ByronEraInCardanoMode   -> traverse (fromCardanoTx eraInMode) txs
+    C.ShelleyEraInCardanoMode -> traverse (fromCardanoTx eraInMode) txs
+    C.AllegraEraInCardanoMode -> traverse (fromCardanoTx eraInMode) txs
+    C.MaryEraInCardanoMode    -> traverse (fromCardanoTx eraInMode) txs
+    C.AlonzoEraInCardanoMode  -> traverse (fromCardanoTx eraInMode) txs
 
-fromCardanoTx ::C.EraInMode era C.CardanoMode -> C.Tx era -> Either FromCardanoError ChainIndexTx
-fromCardanoTx _era (C.Tx b@(C.TxBody C.TxBodyContent{..}) _keyWitnesses) = do
+-- | Convert a Cardano API tx of any given era to a Plutus chain index tx.
+fromCardanoTx
+  :: C.IsCardanoEra era
+  => C.EraInMode era C.CardanoMode
+  -> C.Tx era
+  -> Either FromCardanoError ChainIndexTx
+fromCardanoTx eraInMode tx@(C.Tx txBody@(C.TxBody C.TxBodyContent{..}) _) = do
     txOutputs <- traverse fromCardanoTxOut txOuts
-    pure
-        ChainIndexTx
-            { _citxTxId = fromCardanoTxId (C.getTxId b)
+    let scriptMap = plutusScriptsFromTxBody txBody
+        isTxScriptValid = fromTxScriptValidity txScriptValidity
+        (datums, redeemers) = scriptDataFromCardanoTxBody txBody
+        inputs =
+          if isTxScriptValid
+            then fst <$> txIns
+            else case txInsCollateral of
+                   C.TxInsCollateralNone     -> []
+                   C.TxInsCollateral _ txins -> txins
+
+    pure ChainIndexTx
+            { _citxTxId = fromCardanoTxId (C.getTxId txBody)
             , _citxValidRange = fromCardanoValidityRange txValidityRange
-            , _citxInputs = Set.fromList $ fmap ((`P.TxIn` Nothing) . fromCardanoTxIn . fst) txIns
-            , _citxOutputs = ChainIndex.Tx.ValidTx txOutputs -- FIXME: Check if tx is invalid
-            , _citxData = mempty -- only available with a Build Tx
-            , _citxRedeemers = mempty -- only available with a Build Tx
-            , _citxMintingPolicies = mempty -- only available with a Build Tx
-            , _citxStakeValidators = mempty -- only available with a Build Tx
-            , _citxValidators = mempty -- only available with a Build Tx
-            , _citxCardanoTx = Nothing -- FIXME: Should be SomeTx t era, but we are missing a 'C.IsCardanoEra era' constraint. This constraint is required in 'Ledger.Tx' for the JSON instance.
+            -- If the transaction is invalid, we use collateral inputs
+            , _citxInputs = Set.fromList $ fmap ((`P.TxIn` Nothing) . fromCardanoTxIn) inputs
+            -- No outputs if the one of scripts failed
+            , _citxOutputs = if isTxScriptValid then ChainIndex.Tx.ValidTx txOutputs
+                                                else ChainIndex.Tx.InvalidTx
+            , _citxData = datums
+            , _citxRedeemers = redeemers
+            , _citxScripts = scriptMap
+            , _citxCardanoTx = Just $ SomeTx tx eraInMode
             }
+
+-- | Given a 'C.TxScriptValidity era', if the @era@ supports scripts, return a
+-- @True@ or @False@ depending on script validity. If the @era@ does not support
+-- scripts, always return @True@.
+fromTxScriptValidity :: C.TxScriptValidity era -> Bool
+fromTxScriptValidity C.TxScriptValidityNone                                                      = True
+fromTxScriptValidity (C.TxScriptValidity C.TxScriptValiditySupportedInAlonzoEra C.ScriptValid)   = True
+fromTxScriptValidity (C.TxScriptValidity C.TxScriptValiditySupportedInAlonzoEra C.ScriptInvalid) = False
+
+-- | Given a 'C.TxBody from a 'C.Tx era', return the datums and redeemers along
+-- with their hashes.
+scriptDataFromCardanoTxBody
+  :: C.TxBody era
+  -> (Map P.DatumHash P.Datum, Map P.RedeemerHash P.Redeemer)
+scriptDataFromCardanoTxBody C.ByronTxBody {} = (mempty, mempty)
+scriptDataFromCardanoTxBody (C.ShelleyTxBody _ _ _ C.TxBodyNoScriptData _ _) =
+  (mempty, mempty)
+scriptDataFromCardanoTxBody
+  (C.ShelleyTxBody _ _ _ (C.TxBodyScriptData _ (C.TxDats' dats) (C.Redeemers' reds)) _ _) =
+
+  let datums = Map.fromList
+             $ fmap ( (\d -> (P.datumHash d, d))
+                    . P.Datum
+                    . fromCardanoScriptData
+                    . C.fromAlonzoData
+                    )
+             $ Map.elems dats
+      redeemers = Map.fromList
+                $ fmap ( (\r -> (P.redeemerHash r, r))
+                       . P.Redeemer
+                       . fromCardanoScriptData
+                       . C.fromAlonzoData
+                       . fst
+                       )
+                $ Map.elems reds
+   in (datums, redeemers)
+
+-- | Extract plutus scripts from a Cardano API tx body.
+--
+-- Note that Plutus scripts are only supported in Alonzo era and onwards.
+plutusScriptsFromTxBody :: C.TxBody era -> Map P.ScriptHash P.Script
+plutusScriptsFromTxBody C.ByronTxBody {} = mempty
+plutusScriptsFromTxBody (C.ShelleyTxBody shelleyBasedEra _ scripts _ _ _) =
+  Map.fromList $ mapMaybe (fromLedgerScript shelleyBasedEra) scripts
+
+-- | Convert a script from a Cardano api in shelley based era to a Plutus script along with it's hash.
+--
+-- Note that Plutus scripts are only supported in Alonzo era and onwards.
+fromLedgerScript
+  :: C.ShelleyBasedEra era
+  -> Ledger.Script (C.ShelleyLedgerEra era)
+  -> Maybe (P.ScriptHash, P.Script)
+fromLedgerScript C.ShelleyBasedEraShelley _     = Nothing
+fromLedgerScript C.ShelleyBasedEraAllegra _     = Nothing
+fromLedgerScript C.ShelleyBasedEraMary _        = Nothing
+fromLedgerScript C.ShelleyBasedEraAlonzo script = fromAlonzoLedgerScript script
+
+-- | Convert a script the Alonzo era to a Plutus script along with it's hash.
+fromAlonzoLedgerScript :: Alonzo.Script a -> Maybe (P.ScriptHash, P.Script)
+fromAlonzoLedgerScript Alonzo.TimelockScript {} = Nothing
+fromAlonzoLedgerScript (Alonzo.PlutusScript bs) =
+  let script = fmap (\s -> (P.scriptHash s, s))
+             $ deserialiseOrFail
+             $ BSL.fromStrict
+             $ SBS.fromShort bs
+   in either (const Nothing) Just script
 
 toCardanoTxBody ::
     Maybe C.ProtocolParameters -- ^ Protocol parameters to use. Building Plutus transactions will fail if this is 'Nothing'

--- a/plutus-chain-index/test/Generators.hs
+++ b/plutus-chain-index/test/Generators.hs
@@ -190,8 +190,6 @@ genTx = do
         <*> pure mempty
         <*> pure mempty
         <*> pure mempty
-        <*> pure mempty
-        <*> pure mempty
 
         -- TODO: We need a way to convert the generated 'ChainIndexTx' to a
         -- 'SomeCardanoTx', or vis-versa. And then put it here.
@@ -209,8 +207,6 @@ genTxIdStateTx = do
         <*> pure mempty
         <*> pure (ValidTx [])
         <*> pure Interval.always
-        <*> pure mempty
-        <*> pure mempty
         <*> pure mempty
         <*> pure mempty
         <*> pure mempty

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -50,6 +50,7 @@ module Plutus.V1.Ledger.Scripts(
     -- * Hashes
     DatumHash(..),
     RedeemerHash(..),
+    ScriptHash(..),
     ValidatorHash(..),
     MintingPolicyHash (..),
     StakeValidatorHash (..),
@@ -222,8 +223,8 @@ instance FromJSON Script where
         (SerialiseViaFlat p) <- JSON.decodeSerialise v
         Haskell.return $ Script p
 
-deriving via (JSON.JSONViaSerialise PLC.Data) instance ToJSON (PLC.Data)
-deriving via (JSON.JSONViaSerialise PLC.Data) instance FromJSON (PLC.Data)
+deriving via (JSON.JSONViaSerialise PLC.Data) instance ToJSON PLC.Data
+deriving via (JSON.JSONViaSerialise PLC.Data) instance FromJSON PLC.Data
 
 mkValidatorScript :: CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> ()) -> Validator
 mkValidatorScript = Validator . fromCompiledCode
@@ -315,6 +316,14 @@ instance BA.ByteArrayAccess StakeValidator where
         BA.length . BSL.toStrict . serialise
     withByteArray =
         BA.withByteArray . BSL.toStrict . serialise
+
+-- | Script runtime representation of a @Digest SHA256@.
+newtype ScriptHash =
+    ScriptHash { getScriptHash :: Builtins.BuiltinByteString }
+    deriving (IsString, Haskell.Show, Serialise, Pretty) via LedgerBytes
+    deriving stock (Generic)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, ToData, FromData, UnsafeFromData)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, NFData)
 
 -- | Script runtime representation of a @Digest SHA256@.
 newtype ValidatorHash =

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -89,13 +88,13 @@ redeemerHash :: Redeemer -> RedeemerHash
 redeemerHash = RedeemerHash . dataHash . getRedeemer
 
 validatorHash :: Validator -> ValidatorHash
-validatorHash = ValidatorHash . scriptHash . getValidator
+validatorHash = ValidatorHash . getScriptHash . scriptHash . getValidator
 
 mintingPolicyHash :: MintingPolicy -> MintingPolicyHash
-mintingPolicyHash = MintingPolicyHash . scriptHash . getMintingPolicy
+mintingPolicyHash = MintingPolicyHash . getScriptHash . scriptHash . getMintingPolicy
 
 stakeValidatorHash :: StakeValidator -> StakeValidatorHash
-stakeValidatorHash = StakeValidatorHash . scriptHash . getStakeValidator
+stakeValidatorHash = StakeValidatorHash . getScriptHash . scriptHash . getStakeValidator
 
 -- | Hash a 'Builtins.BuiltinData'
 dataHash :: Builtins.BuiltinData -> Builtins.BuiltinByteString
@@ -107,9 +106,10 @@ dataHash =
     . builtinDataToData
 
 -- | Hash a 'Script'
-scriptHash :: Script -> Builtins.BuiltinByteString
+scriptHash :: Script -> ScriptHash
 scriptHash =
-    toBuiltin
+    ScriptHash
+    . toBuiltin
     . Script.serialiseToRawBytes
     . Script.hashScript
     . toCardanoApiScript


### PR DESCRIPTION
SCP-2753: Extract datums, redeemers and scripts when converting cardano api tx to plutus tx. Most changes are in `fromCardanoTx` which convert a cardano tx to a chain index tx. 

Notable change: The chain index disk state does not anymore separate kinds of scripts (validators, stake validators, minting policy) in it's representation. All kinds of scripts are stored in the same list. The reason is because the `cardano-api` can give us the Plutus scripts for a transaction, but doesn't know it's kind.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
