### PR TITLE
Export AssocMap.Map from the V2 API

### DIFF
--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
@@ -78,6 +78,9 @@ module Plutus.V2.Ledger.Api (
     , upperBound
     , strictLowerBound
     , strictUpperBound
+    -- *** Association maps
+    , Map
+    , fromList
     -- *** Newtypes for script/datum types and hash types
     , Validator (..)
     , mkValidatorScript
@@ -113,6 +116,7 @@ import           Data.Text                 (Text)
 
 import           Plutus.V1.Ledger.Api      hiding (ScriptContext (..), TxInfo (..), plutusScriptEnvelopeType)
 import           Plutus.V2.Ledger.Contexts
+import           PlutusTx.AssocMap         (Map, fromList)
 
 plutusScriptEnvelopeType :: Text
 plutusScriptEnvelopeType = "PlutusV2Script"


### PR DESCRIPTION
We now use it in `TxInfo`, so we should export it so the ledger doesn't
need to import anything else.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
