### PR TITLE
SCP-2766: Add workflow comments

### DIFF
--- a/marlowe-dashboard-client/src/Contacts/State.purs
+++ b/marlowe-dashboard-client/src/Contacts/State.purs
@@ -159,7 +159,7 @@ handleAction (SetRemoteWalletInfo remoteWalletInfo) = do
   walletLibrary <- use _walletLibrary
   handleAction $ WalletIdInputAction $ InputField.SetValidator $ walletIdError remoteWalletInfo walletLibrary
 
-handleAction (UseWallet walletNickname companionAppId) = do
+handleAction (ConnectWallet walletNickname companionAppId) = do
   ajaxWalletDetails <- lookupWalletDetails companionAppId
   case ajaxWalletDetails of
     Right walletDetails -> do

--- a/marlowe-dashboard-client/src/Contacts/Types.purs
+++ b/marlowe-dashboard-client/src/Contacts/Types.purs
@@ -148,7 +148,7 @@ data Action
   | WalletNicknameInputAction (InputField.Action WalletNicknameError)
   | WalletIdInputAction (InputField.Action WalletIdError)
   | SetRemoteWalletInfo (WebData WalletInfo)
-  | UseWallet WalletNickname PlutusAppId
+  | ConnectWallet WalletNickname PlutusAppId
   | ClipboardAction Clipboard.Action
 
 instance actionIsEvent :: IsEvent Action where
@@ -159,5 +159,5 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (WalletNicknameInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (WalletIdInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (SetRemoteWalletInfo _) = Nothing
-  toEvent (UseWallet _ _) = Just $ defaultEvent "UseWallet"
+  toEvent (ConnectWallet _ _) = Just $ defaultEvent "ConnectWallet"
   toEvent (ClipboardAction _) = Just $ defaultEvent "ClipboardAction"

--- a/marlowe-dashboard-client/src/Contacts/View.purs
+++ b/marlowe-dashboard-client/src/Contacts/View.purs
@@ -146,7 +146,7 @@ walletDetailsCard currentWallet walletDetails =
               [ classNames $ Css.primaryButton <> [ "flex-1", "text-center" ]
               , onClick_ $ ConnectWallet walletNickname companionAppId
               ]
-              [ text "Use this wallet" ]
+              [ text "Connect wallet" ]
         ]
     ]
 

--- a/marlowe-dashboard-client/src/Contacts/View.purs
+++ b/marlowe-dashboard-client/src/Contacts/View.purs
@@ -144,7 +144,7 @@ walletDetailsCard currentWallet walletDetails =
           else
             button
               [ classNames $ Css.primaryButton <> [ "flex-1", "text-center" ]
-              , onClick_ $ UseWallet walletNickname companionAppId
+              , onClick_ $ ConnectWallet walletNickname companionAppId
               ]
               [ text "Use this wallet" ]
         ]

--- a/marlowe-dashboard-client/src/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Contract/State.purs
@@ -239,6 +239,7 @@ handleAction { followerAppId } (SetNickname nickname) =
     put $ Started started { nickname = nickname }
     insertIntoContractNicknames followerAppId nickname
 
+{- [Workflow 5][0] Move a contract forward -}
 handleAction input@{ currentSlot, walletDetails } (ConfirmAction namedAction) =
   withStarted \started@{ executionState, marloweParams } -> do
     let

--- a/marlowe-dashboard-client/src/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Dashboard/Types.purs
@@ -63,7 +63,7 @@ type Input
     }
 
 data Action
-  = PutdownWallet
+  = DisconnectWallet
   | ContactsAction Contacts.Action
   | ToggleMenu
   | OpenCard Card
@@ -82,7 +82,7 @@ data Action
 
 -- | Here we decide which top-level queries to track as GA events, and how to classify them.
 instance actionIsEvent :: IsEvent Action where
-  toEvent PutdownWallet = Just $ defaultEvent "PutdownWallet"
+  toEvent DisconnectWallet = Just $ defaultEvent "DisconnectWallet"
   toEvent (ContactsAction contactsAction) = toEvent contactsAction
   toEvent ToggleMenu = Just $ defaultEvent "ToggleMenu"
   toEvent (OpenCard _) = Nothing

--- a/marlowe-dashboard-client/src/Dashboard/View.purs
+++ b/marlowe-dashboard-client/src/Dashboard/View.purs
@@ -462,7 +462,7 @@ currentWalletCard walletDetails =
               [ text "Cancel" ]
           , button
               [ classNames $ Css.primaryButton <> [ "flex-1" ]
-              , onClick_ PutdownWallet
+              , onClick_ DisconnectWallet
               ]
               [ text "Drop wallet" ]
           ]

--- a/marlowe-dashboard-client/src/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Welcome/State.purs
@@ -81,6 +81,17 @@ handleAction CloseCard = do
   handleAction $ WalletNicknameOrIdInputAction $ InputField.Reset
   handleAction $ WalletNicknameInputAction $ InputField.Reset
 
+{- [Workflow 1][0] Generating a new wallet
+Here we attempt to create a new demo wallet (with everything that entails), and - if successful -
+open up the UseNewWalletCard for connecting the wallet just created.
+Note the `createWallet` function doesn't just create a wallet. It also creates two PAB apps for
+that wallet: a `WalletCompanion` and a `MarloweApp`.
+- The `WalletCompanion` will watch for any new role tokens paid to this wallet, and then update its
+  internal state to include the `MarloweParams` and initial `MarloweData` for the corresponding
+  contract.
+- The `MarloweApp` is a control app, used to create Marlowe contracts, apply inputs, and redeem
+  payments to this wallet.
+-}
 handleAction GenerateWallet = do
   walletLibrary <- use _walletLibrary
   assign _remoteWalletDetails Loading
@@ -94,6 +105,26 @@ handleAction GenerateWallet = do
       assign _walletId $ walletDetails ^. _companionAppId
       handleAction $ OpenCard UseNewWalletCard
 
+{- [Workflow 2][0] Connect a wallet
+The app lets you connect a wallet using an "omnibox" input, into which you can either enter a
+wallet nickname that you have saved in your browser's LocalStorage, or the appId of the wallet's
+`WalletCompanion` app. If you enter a valid appId, we lookup the details of a corresponding wallet
+in the PAB; if you enter a nickname, we have a cache of the details in LocalStorage. Either way,
+we then open up the UseWalletCard (or UseNewWalletCard), essentially a confirmation box for
+connecting this wallet.
+TODO: We currently use the appId of the wallet's `WalletCompanion` app as the "public" identifier
+for wallets: this is what is shown to the user, what they are told to copy and give to others, and
+what they need to enter into the "omnibox". This is because we need to know several things about
+each wallet (see the `WalletDetails` type), and in the initial stages of this app's development,
+it was possible to find out all of these things from just the appId of the `WalletCompanion`, and
+not possible to find out all of them from anything else.
+However, I realised recently that - with some PAB developments that have happened since, it should
+now be possible to determine the full `WalletDetails` given only the ID of the wallet itself. This
+might be preferable. The general strategy would be this: (1) use `Capability.Wallet.getWalletInfo`
+to get the wallet's pubKey and pubKeyHash; (2) use `Capability.Contract.getWalletContractInstances`
+to get all the contracts (i.e. PAB apps) running in that wallet; (3) search those apps for the
+wallet's `WalletCompanion` and `MarloweApp` (by checking their `cicDefinition`).
+-}
 handleAction (WalletNicknameOrIdInputAction inputFieldAction) = do
   toWalletNicknameOrIdInput $ InputField.handleAction inputFieldAction
   case inputFieldAction of
@@ -129,6 +160,13 @@ handleAction (WalletNicknameOrIdInputAction inputFieldAction) = do
       for_ (lookup walletNicknameOrId walletLibrary) (handleAction <<< OpenUseWalletCardWithDetails)
     _ -> pure unit
 
+{- [Workflow 2][1] Connect a wallet
+If we are connecting a wallet that was selected by the user inputting a wallet nickname, then we
+will have a cache of it's `WalletDetails` in LocalStorage. But those details may well be out of
+date. This intermediate step makes sure we have the current details before proceeding.
+This is also factored out into a separate handler so that it can be called directly when the user
+selects a wallet nickname from the dropdown menu (as well as indirectly via the previous handler).
+-}
 handleAction (OpenUseWalletCardWithDetails walletDetails) = do
   assign _remoteWalletDetails Loading
   ajaxWalletDetails <- lookupWalletDetails $ view _companionAppId walletDetails
@@ -143,7 +181,12 @@ handleAction (OpenUseWalletCardWithDetails walletDetails) = do
 
 handleAction (WalletNicknameInputAction inputFieldAction) = toWalletNicknameInput $ InputField.handleAction inputFieldAction
 
-handleAction (UseWallet walletNickname) = do
+{- [Workflow 2][2] Connect a wallet
+This action is triggered by clicking the confirmation button on the UseWalletCard or
+UseNewWalletCard. It saves the wallet nickname to LocalStorage, and then calls the
+`MainFrame.EnterDashboardState` action.
+-}
+handleAction (ConnectWallet walletNickname) = do
   assign _enteringDashboardState true
   remoteWalletDetails <- use _remoteWalletDetails
   case remoteWalletDetails of

--- a/marlowe-dashboard-client/src/Welcome/Types.purs
+++ b/marlowe-dashboard-client/src/Welcome/Types.purs
@@ -61,7 +61,7 @@ data Action
   | WalletNicknameOrIdInputAction (InputField.Action WalletNicknameOrIdError)
   | OpenUseWalletCardWithDetails WalletDetails
   | WalletNicknameInputAction (InputField.Action WalletNicknameError)
-  | UseWallet WalletNickname
+  | ConnectWallet WalletNickname
   | ClearLocalStorage
   | ClipboardAction Clipboard.Action
 
@@ -73,6 +73,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent (WalletNicknameOrIdInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (OpenUseWalletCardWithDetails _) = Nothing
   toEvent (WalletNicknameInputAction inputFieldAction) = toEvent inputFieldAction
-  toEvent (UseWallet _) = Just $ defaultEvent "UseWallet"
+  toEvent (ConnectWallet _) = Just $ defaultEvent "ConnectWallet"
   toEvent ClearLocalStorage = Just $ defaultEvent "ClearLocalStorage"
   toEvent (ClipboardAction _) = Just $ defaultEvent "ClipboardAction"

--- a/marlowe-dashboard-client/src/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Welcome/View.purs
@@ -252,7 +252,7 @@ useNewWalletCard state =
                 , disabled $ isJust (validate walletNicknameInput) || enteringDashboardState || not isSuccess remoteWalletDetails
                 , onClick_ $ ConnectWallet walletNickname
                 ]
-                [ text if enteringDashboardState then "Loading..." else "Use" ]
+                [ text if enteringDashboardState then "Connecting..." else "Connect Wallet" ]
             ]
         ]
     ]
@@ -304,7 +304,7 @@ useWalletCard state =
                 , onClick_ $ ConnectWallet walletNickname
                 , disabled $ enteringDashboardState || not isSuccess remoteWalletDetails
                 ]
-                [ text if enteringDashboardState then "Loading..." else "Use" ]
+                [ text if enteringDashboardState then "Connecting..." else "Connect Wallet" ]
             ]
         ]
     ]

--- a/marlowe-dashboard-client/src/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Welcome/View.purs
@@ -250,7 +250,7 @@ useNewWalletCard state =
             , button
                 [ classNames $ Css.primaryButton <> [ "flex-1" ]
                 , disabled $ isJust (validate walletNicknameInput) || enteringDashboardState || not isSuccess remoteWalletDetails
-                , onClick_ $ UseWallet walletNickname
+                , onClick_ $ ConnectWallet walletNickname
                 ]
                 [ text if enteringDashboardState then "Loading..." else "Use" ]
             ]
@@ -301,7 +301,7 @@ useWalletCard state =
                 [ text "Cancel" ]
             , button
                 [ classNames $ Css.primaryButton <> [ "flex-1" ]
-                , onClick_ $ UseWallet walletNickname
+                , onClick_ $ ConnectWallet walletNickname
                 , disabled $ enteringDashboardState || not isSuccess remoteWalletDetails
                 ]
                 [ text if enteringDashboardState then "Loading..." else "Use" ]


### PR DESCRIPTION
This PR adds workflow comments throughout the code. They should be self-explanatory - start from the long comment at `MainFrame.State:47`.

While I was at it, I changed some of the "use wallet" terminology to "connect wallet".