### PR TITLE
remove openapi3 dep from plutus-tx

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
@@ -50,7 +50,6 @@
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-          (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
           ];
         buildable = true;
         modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
@@ -50,7 +50,6 @@
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-          (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
           ];
         buildable = true;
         modules = [

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
@@ -50,7 +50,6 @@
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-          (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
           ];
         buildable = true;
         modules = [

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -120,7 +120,7 @@ library
         cardano-crypto -any,
         cardano-crypto-class -any,
         deepseq -any,
-        openapi3,
+        openapi3 -any,
         freer-extras
 
     ghc-options: -fprint-potential-instances

--- a/plutus-ledger/src/Ledger/Orphans.hs
+++ b/plutus-ledger/src/Ledger/Orphans.hs
@@ -24,6 +24,7 @@ import           Plutus.V1.Ledger.Slot          (Slot (..))
 import           Plutus.V1.Ledger.Tx
 import           Plutus.V1.Ledger.Value
 import           PlutusCore
+import qualified PlutusTx.AssocMap              as AssocMap
 import           Prelude                        as Haskell
 import           Web.HttpApiData                (FromHttpApiData (..), ToHttpApiData (..))
 
@@ -39,8 +40,12 @@ instance ToHttpApiData LedgerBytes where
 instance FromHttpApiData LedgerBytes where
     parseUrlPiece = bimap Text.pack fromBytes . JSON.tryDecode
 
+
 -- | OpenApi instances for swagger support
 
+deriving anyclass instance (OpenApi.ToSchema k, OpenApi.ToSchema v) => OpenApi.ToSchema (AssocMap.Map k v)
+instance OpenApi.ToSchema BuiltinByteString where
+    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Bytes") mempty
 instance OpenApi.ToSchema Crypto.XPub where
     declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "PubKey") mempty
 instance OpenApi.ToSchema Crypto.XPrv where

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -94,8 +94,7 @@ library
         aeson -any,
         hashable -any,
         memory -any,
-        serialise -any,
-        openapi3
+        serialise -any
 
 test-suite plutus-tx-test
     import: lang

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -38,7 +38,6 @@ module PlutusTx.AssocMap (
     ) where
 
 import           Control.DeepSeq            (NFData)
-import           Data.OpenApi.Schema        as OpenApi
 import           Data.Text.Prettyprint.Doc  (Pretty (..))
 import           GHC.Generics               (Generic)
 import qualified PlutusTx.Builtins          as P
@@ -56,7 +55,6 @@ import qualified Prelude                    as Haskell
 newtype Map k v = Map { unMap :: [(k, v)] }
     deriving stock (Generic, Haskell.Eq, Haskell.Show)
     deriving newtype (Eq, Ord, NFData)
-    deriving anyclass (OpenApi.ToSchema)
 
 -- Hand-written instances to use the underlying 'Map' type in 'Data', and to be reasonably efficient.
 instance (ToData k, ToData v) => ToData (Map k v) where

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -21,7 +21,6 @@ import qualified Data.ByteString.Hash      as Hash
 import           Data.Coerce               (coerce)
 import           Data.Hashable             (Hashable)
 import           Data.Maybe                (fromMaybe)
-import qualified Data.OpenApi              as OpenApi
 import           Data.Text                 as Text (Text, empty)
 import           Data.Text.Encoding        as Text (decodeUtf8, encodeUtf8)
 import           Data.Text.Prettyprint.Doc (Pretty (..), viaShow)
@@ -153,9 +152,6 @@ newtype BuiltinByteString = BuiltinByteString ByteString
   deriving stock (Generic)
   deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord, Haskell.Semigroup, Haskell.Monoid)
   deriving newtype (Hashable, Serialise, NFData, BA.ByteArrayAccess, BA.ByteArray)
-
-instance OpenApi.ToSchema BuiltinByteString where
-    declareNamedSchema _ = pure $ OpenApi.NamedSchema (Just "Bytes") mempty
 
 instance Pretty BuiltinByteString where
     pretty = viaShow


### PR DESCRIPTION
Fix for extra dep merged in https://github.com/input-output-hk/plutus/pull/3807#issuecomment-925813317 ; it's now gone and instances are over in `Ledger.Oprhans`.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
