### PR TITLE
linguist fixup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@ nix/pkgs/haskell/materialized*/**/*.nix linguist-generated=true
 # linguist gets confused by PIR files, and thinks they make up a lot of our source!
 *.pir linguist-detectable=false
 stubs/plutus-ghc-stub/** linguist-vendored=true
+# Large HTML files inside 'notes' are dominating our repoistory language
+# estimate.
+notes/**/*.html linguist-documentation
+doc/* linguist-documentation


### PR DESCRIPTION
Curious to see if this fixes the linguist language estimate:

![2021-09-23_15-54](https://user-images.githubusercontent.com/129525/134531023-8d120d54-6e0e-4e7c-8890-697f8521ce38.png)

If you click on HTML, it only shows 8 files, and though they are large, they don't seem to be larger than Haskell in total line count ... 😕 , so I added the docs folder as well?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
