### PR TITLE
Revert "bitte: Test not clearing the PAB on restart"

### DIFF
--- a/bitte/pab.nix
+++ b/bitte/pab.nix
@@ -78,11 +78,11 @@ let
   pab-init-cmd = writeShellScriptBin "pab-init-cmd" ''
     set -eEuo pipefail
 
-    if [ ! -f ${dbFile} ]
-    then
-      echo "[pab-init-cmd]: Creating new DB '${dbFile}'" >&2
-      ${pabExe} --config=${pabYaml} migrate;
-    fi
+    echo "[pab-init-cmd]: Dropping PAB database file '${dbFile}'" >&2
+    rm -rf ${dbFile}
+
+    echo "[pab-init-cmd]: Creating new DB '${dbFile}'" >&2
+    ${pabExe} --config=${pabYaml} migrate;
   '';
 in
 writeShellScriptBin "entrypoint" ''


### PR DESCRIPTION
Keeping the state around isn't helpful (currently) because we can't
get pre-reset wallets.

This reverts commit e98ecd57bc7e1cd97fd9eb9bb0a0bfa47b1024c2.
