### PR TITLE
ChainIndex CLI: continue to sync from tip

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/Handlers.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Handlers.hs
@@ -10,7 +10,8 @@
 {-# LANGUAGE UndecidableInstances  #-}
 {-| Handlers for the 'ChainIndexQueryEffect' and the 'ChainIndexControlEffect' -}
 module Plutus.ChainIndex.Handlers
-    ( handleQuery
+    ( fromByteString
+    , handleQuery
     , handleControl
     , ChainIndexState
     ) where


### PR DESCRIPTION
This adds persistent syncing to the Chain Index CLI, to continue to sync from the last tip. Previously it re-syncs from genesis on every start.

A few more ideas we'd like to add to this repo:
- Better error handling. For example, a wrong socket path isn't handled at the moment, the program doesn't even exit, just doesn't sync!
- Package the ChainIndex CLI with a Cardano Node with Docker/Nix.
- Add an extension/customization interface for dApp developers to structure their own caches/UTXO pools for faster queries and UTXO discovery.
- Write setup, customization, and API documentation.

Do tell us if you'd want us to work on anything!

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
