### PR TITLE
SCP-2779 - Marlowe Run - fix toast when reloading or different tab

### DIFF
--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
@@ -7,28 +7,37 @@ module Capability.PlutusApps.MarloweApp
   , createContract
   , applyInputs
   , redeem
+  , waitForResponse
   , createEndpointMutex
   , onNewActiveEndpoints
+  , onNewObservableState
   ) where
 
 import Prologue
 import AppM (AppM)
 import Bridge (toBack)
+import Capability.Contract (class ManageContract)
 import Capability.Contract (invokeEndpoint) as Contract
-import Capability.PlutusApps.MarloweApp.Lenses (_applyInputs, _create, _marloweAppEndpointMutex, _redeem)
-import Capability.PlutusApps.MarloweApp.Types (EndpointMutex, MarloweAppEndpointMutexEnv)
+import Capability.PlutusApps.MarloweApp.Lenses (_applyInputs, _create, _marloweAppEndpointMutex, _redeem, _requests)
+import Capability.PlutusApps.MarloweApp.Types (EndpointMutex, LastResult(..), MarloweAppEndpointMutexEnv)
+import Contacts.Types (PubKeyHash)
 import Control.Monad.Reader (class MonadAsk, asks)
+import Data.Array (findMap, take, (:))
 import Data.Foldable (elem)
 import Data.Json.JsonNTuple ((/\), type (/\)) as Json
-import Data.Lens (toArrayOf, traversed, view)
+import Data.Lens (Lens', toArrayOf, traversed, view)
 import Data.Lens.Record (prop)
 import Data.Map (Map)
 import Data.Symbol (SProxy(..))
-import Data.Tuple.Nested ((/\))
+import Data.Tuple.Nested ((/\), type (/\))
+import Data.UUID (UUID, genUUID)
 import Effect (Effect)
+import Effect.AVar (AVar)
 import Effect.AVar as EAVar
 import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff, liftAff)
+import Effect.Class (liftEffect)
+import Foreign.Generic (class Encode)
 import Marlowe.PAB (PlutusAppId)
 import Marlowe.Semantics (Contract, MarloweParams, SlotInterval(..), TokenName, TransactionInput(..))
 import Plutus.Contract.Effects (ActiveEndpoint, _ActiveEndpoint)
@@ -38,48 +47,134 @@ import Plutus.V1.Ledger.Value (TokenName) as Back
 import PlutusTx.AssocMap (Map) as Back
 import Types (AjaxResponse)
 import Wallet.Types (_EndpointDescription)
-import Contacts.Types (PubKeyHash)
 
 class MarloweApp m where
   createContract :: PlutusAppId -> Map TokenName PubKeyHash -> Contract -> m (AjaxResponse Unit)
   applyInputs :: PlutusAppId -> MarloweParams -> TransactionInput -> m (AjaxResponse Unit)
   -- TODO auto
-  -- TODO close (I think it currently does nothing, maybe remove?)
+  -- TODO close
   redeem :: PlutusAppId -> MarloweParams -> TokenName -> PubKeyHash -> m (AjaxResponse Unit)
 
 instance marloweAppM :: MarloweApp AppM where
   createContract plutusAppId roles contract = do
+    reqId <- liftEffect genUUID
     let
       backRoles :: Back.Map Back.TokenName Back.PubKeyHash
       backRoles = toBack roles
-    mutex <- asks $ view (_marloweAppEndpointMutex <<< _create)
-    liftAff $ AVar.take mutex
-    Contract.invokeEndpoint plutusAppId "create" (backRoles /\ contract)
+
+      payload = reqId Json./\ backRoles Json./\ contract
+    invokeMutexedEndpoint plutusAppId reqId "create" _create payload
   applyInputs plutusAppId marloweContractId (TransactionInput { interval: SlotInterval slotStart slotEnd, inputs }) = do
+    reqId <- liftEffect genUUID
     let
       backSlotInterval :: Back.Slot Json./\ Back.Slot
       backSlotInterval = (toBack slotStart) Json./\ (toBack slotEnd)
 
-      payload = marloweContractId Json./\ Just backSlotInterval Json./\ inputs
-    mutex <- asks $ view (_marloweAppEndpointMutex <<< _applyInputs)
-    liftAff $ AVar.take mutex
-    Contract.invokeEndpoint plutusAppId "apply-inputs" payload
+      payload = reqId Json./\ marloweContractId Json./\ Just backSlotInterval Json./\ inputs
+    invokeMutexedEndpoint plutusAppId reqId "apply-inputs" _applyInputs payload
   redeem plutusAppId marloweContractId tokenName pubKeyHash = do
+    reqId <- liftEffect genUUID
     let
-      payload :: MarloweParams Json./\ Back.TokenName Json./\ Back.PubKeyHash
-      payload = marloweContractId Json./\ toBack tokenName Json./\ toBack pubKeyHash
-    mutex <- asks $ view (_marloweAppEndpointMutex <<< _redeem)
-    -- TODO: we could later add a forkAff with a timer that unlocks this timer if we
-    --       dont get a response
-    liftAff $ AVar.take mutex
-    Contract.invokeEndpoint plutusAppId "redeem" payload
+      payload :: UUID Json./\ MarloweParams Json./\ Back.TokenName Json./\ Back.PubKeyHash
+      payload = reqId Json./\ marloweContractId Json./\ toBack tokenName Json./\ toBack pubKeyHash
+    invokeMutexedEndpoint plutusAppId reqId "redeem" _redeem payload
 
 createEndpointMutex :: Effect EndpointMutex
 createEndpointMutex = do
   create <- EAVar.empty
   applyInputs <- EAVar.empty
   redeem <- EAVar.empty
-  pure { create, applyInputs, redeem }
+  requests <- EAVar.new mempty
+  pure { create, applyInputs, redeem, requests }
+
+invokeMutexedEndpoint ::
+  forall payload m env.
+  Encode payload =>
+  MonadAff m =>
+  ManageContract m =>
+  MonadAsk (MarloweAppEndpointMutexEnv env) m =>
+  PlutusAppId ->
+  UUID ->
+  String ->
+  Lens' EndpointMutex (AVar Unit) ->
+  payload ->
+  m (AjaxResponse Unit)
+invokeMutexedEndpoint plutusAppId reqId endpointName _endpointMutex payload = do
+  -- There are three mutex involved in this operation:
+  --   * The endpointMutex help us avoid making multiple requests to the same endpoint if its not
+  --     available.
+  --   * The global requestMutex help us manage the request queue concurrently.
+  --   * For each request in the queue, we store one mutex that represents the response.
+  endpointMutex <- asks $ view (_marloweAppEndpointMutex <<< _endpointMutex)
+  requestMutex <- asks $ view (_marloweAppEndpointMutex <<< _requests)
+  -- First we need to see if the endpoint is available to make a request
+  -- TODO: we could later add a forkAff with a timer that unlocks this timer if we
+  --       dont get a response
+  -- TODO: We could change this take for a read and listen for a 500 error with EndpointUnavailabe
+  --       to retry and take it (instead of preemptively taking it).
+  liftAff $ AVar.take endpointMutex
+  result <- Contract.invokeEndpoint plutusAppId endpointName payload
+  -- After making the request, we lock on the global request array so we can add
+  -- a new request id with its corresponding mutex.
+  -- TODO: It would be nice if the invokeEndpoint returns a requestId instead of having to generate
+  --       one from the FE.
+  liftAff do
+    requests <- AVar.take requestMutex
+    newRequestMutex <- AVar.empty
+    let
+      -- We add new requests to the begining of the array and remove them from the end.
+      newRequests = take 15 $ (reqId /\ newRequestMutex) : requests
+    AVar.put newRequests requestMutex
+  pure result
+
+-- When a MarloweApp emits a new observable state, it comes with the information of which
+-- request id originated the change. We use this function to update the request queue and
+-- free any thread that might be waiting for the result of an action.
+-- The return type is a Maybe of the same input, if the value is Nothing, then we couldn't
+-- find a request that triggered this response. This can happen for example when reloading
+-- the webpage, or if we have two browsers with the same wallet.
+onNewObservableState ::
+  forall env m.
+  MonadAff m =>
+  MonadAsk (MarloweAppEndpointMutexEnv env) m =>
+  LastResult ->
+  m (Maybe LastResult)
+onNewObservableState lastResult = case lastResult of
+  OK reqId _ -> onNewObservableState' reqId
+  SomeError reqId _ _ -> onNewObservableState' reqId
+  _ -> pure Nothing
+  where
+  onNewObservableState' reqId = do
+    requestMutex <- asks $ view (_marloweAppEndpointMutex <<< _requests)
+    -- This read is blocking but does not take the mutex.
+    requests <- liftAff $ AVar.read requestMutex
+    case findReqId reqId requests of
+      Nothing -> pure Nothing
+      Just reqMutex -> do
+        liftAff $ AVar.put lastResult reqMutex
+        pure $ Just lastResult
+
+findReqId :: UUID -> Array (UUID /\ AVar LastResult) -> Maybe (AVar LastResult)
+findReqId reqId = findMap (\(reqId' /\ reqMutex) -> if reqId == reqId' then Just reqMutex else Nothing)
+
+-- TODO: This function is not used yet, but is intended to be used to be able to the refactor
+--       mentioned in MainFrame.State :: NewObservableState
+waitForResponse ::
+  forall env m.
+  MonadAff m =>
+  MonadAsk (MarloweAppEndpointMutexEnv env) m =>
+  UUID ->
+  m (Maybe LastResult)
+waitForResponse reqId = do
+  requestMutex <- asks $ view (_marloweAppEndpointMutex <<< _requests)
+  -- This read is blocking but does not take the mutex.
+  requests <- liftAff $ AVar.read requestMutex
+  case findReqId reqId requests of
+    Nothing -> pure Nothing
+    Just reqMutex -> do
+      -- TODO: We could add a timer so we don't wait forever
+      lastResult <- liftAff $ AVar.read reqMutex
+      pure $ Just lastResult
 
 -- Plutus contracts have endpoints that can be available or not. We get notified by the
 -- websocket message NewActiveEndpoints when the status change, and we use this function

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Lenses.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Lenses.purs
@@ -1,10 +1,12 @@
 module Capability.PlutusApps.MarloweApp.Lenses where
 
 import Prologue
-import Capability.PlutusApps.MarloweApp.Types (EndpointMutex, MarloweAppEndpointMutexEnv)
+import Capability.PlutusApps.MarloweApp.Types (EndpointMutex, LastResult, MarloweAppEndpointMutexEnv)
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Data.Symbol (SProxy(..))
+import Data.Tuple.Nested (type (/\))
+import Data.UUID (UUID)
 import Effect.AVar (AVar)
 
 _marloweAppEndpointMutex :: forall a. Lens' (MarloweAppEndpointMutexEnv a) EndpointMutex
@@ -18,3 +20,6 @@ _create = prop (SProxy :: SProxy "create")
 
 _applyInputs :: Lens' EndpointMutex (AVar Unit)
 _applyInputs = prop (SProxy :: SProxy "applyInputs")
+
+_requests :: Lens' EndpointMutex (AVar (Array (UUID /\ AVar LastResult)))
+_requests = prop (SProxy :: SProxy "requests")

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
@@ -11,6 +11,8 @@ module Capability.PlutusApps.MarloweApp.Types
 
 import Prologue
 import Data.Generic.Rep (class Generic)
+import Data.UUID (UUID)
+import Data.Tuple.Nested (type (/\))
 import Effect.AVar (AVar)
 import Foreign.Class (class Encode, class Decode)
 import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
@@ -27,8 +29,8 @@ type EndpointName
 -- Right now we are only allowing one endpoint to be called at a time, but we could later extend this
 -- to use a RequestId to map between the request and the response.
 data LastResult
-  = OK EndpointName
-  | SomeError EndpointName MarloweError
+  = OK UUID EndpointName
+  | SomeError UUID EndpointName MarloweError
   | Unknown
 
 derive instance genericLastResult :: Generic LastResult _
@@ -79,11 +81,17 @@ type MarloweAppState
   = LastResult
 
 -- The plutus contracts can have their endpoints active or inactive. We use
--- this AVar object to allow the API users to wait for an endpoint to be available.
+-- this object with Mutex to avoid calling an inactive endpoint and to keep
+-- track of the different requests.
 type EndpointMutex
   = { create :: AVar Unit
     , applyInputs :: AVar Unit
     , redeem :: AVar Unit
+    -- For each request we fire, we store in a queue the tuple of the
+    -- request id and a mutex to wait for the response. We use an array
+    -- instead of a Map because we only want to keep a limited number of
+    -- requests.
+    , requests :: AVar (Array (UUID /\ AVar LastResult))
     }
 
 type MarloweAppEndpointMutexEnv env

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -67,7 +67,8 @@ library
     sbv >= 8.4,
     scientific -any,
     wl-pprint -any,
-    semigroups -any
+    semigroups -any,
+    uuid -any
   if !(impl(ghcjs) || os(ghcjs))
     build-depends: plutus-tx-plugin -any
   exposed-modules:
@@ -124,6 +125,7 @@ test-suite marlowe-test
         http-client -any,
         websockets -any,
         network -any,
+        uuid -any
 
 -- | The PAB Specialised to the marlowe contract(s)
 executable marlowe-pab
@@ -148,5 +150,6 @@ executable marlowe-pab
     plutus-tx -any,
     purescript-bridge -any,
     marlowe -any,
+    uuid -any
   if !(impl(ghcjs) || os(ghcjs))
     build-depends: plutus-tx-plugin -any

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -34,6 +34,7 @@ import           Data.Monoid                  (First (..))
 import           Data.Semigroup.Generic       (GenericSemigroupMonoid (..))
 import qualified Data.Set                     as Set
 import qualified Data.Text                    as T
+import           Data.UUID                    (UUID)
 import           Data.Void                    (absurd)
 import           GHC.Generics                 (Generic)
 import           Language.Marlowe.Scripts
@@ -63,11 +64,11 @@ import qualified PlutusTx
 import qualified PlutusTx.AssocMap            as AssocMap
 
 type MarloweSchema =
-        Endpoint "create" (AssocMap.Map Val.TokenName PubKeyHash, Marlowe.Contract)
-        .\/ Endpoint "apply-inputs" (MarloweParams, Maybe SlotInterval, [Input])
-        .\/ Endpoint "auto" (MarloweParams, Party, Slot)
-        .\/ Endpoint "redeem" (MarloweParams, TokenName, PubKeyHash)
-        .\/ Endpoint "close" ()
+        Endpoint "create" (UUID, AssocMap.Map Val.TokenName PubKeyHash, Marlowe.Contract)
+        .\/ Endpoint "apply-inputs" (UUID, MarloweParams, Maybe SlotInterval, [Input])
+        .\/ Endpoint "auto" (UUID, MarloweParams, Party, Slot)
+        .\/ Endpoint "redeem" (UUID, MarloweParams, TokenName, PubKeyHash)
+        .\/ Endpoint "close" UUID
 
 
 type MarloweCompanionSchema = EmptySchema
@@ -133,10 +134,9 @@ instance Semigroup ContractProgress where
 instance Monoid ContractProgress where
     mempty = InProgress
 
--- TODO: We should change this for a Tuple of endpoint name and request id.
 type EndpointName = String
 
-data LastResult = OK EndpointName | SomeError EndpointName MarloweError | Unknown
+data LastResult = OK UUID EndpointName | SomeError UUID EndpointName MarloweError | Unknown
   deriving (Show,Eq,Generic)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -237,12 +237,12 @@ marloweFollowContract = awaitPromise $ endpoint @"follow" $ \params -> do
 marlowePlutusContract :: Contract MarloweContractState MarloweSchema MarloweError ()
 marlowePlutusContract = selectList [create, apply, auto, redeem, close]
   where
-    catchError endpointName handler = catching _MarloweError
+    catchError reqId endpointName handler = catching _MarloweError
         (void $ mapError (review _MarloweError) handler)
         (\er -> do
-            tell $ SomeError endpointName er
+            tell $ SomeError reqId endpointName er
             marlowePlutusContract)
-    create = endpoint @"create" $ \(owners, contract) -> catchError "create" $ do
+    create = endpoint @"create" $ \(reqId, owners, contract) -> catchError reqId "create" $ do
         -- Create a transaction with the role tokens and pay them to the contract creator
         -- See Note [The contract is not ready]
         (params, distributeRoleTokens, lkps) <- setupMarloweParams owners contract
@@ -258,13 +258,13 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
         -- Create the Marlowe contract and pay the role tokens to the owners
         utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups tx)
         submitTxConfirmed utx
-        tell $ OK "create"
+        tell $ OK reqId "create"
         marlowePlutusContract
-    apply = endpoint @"apply-inputs" $ \(params, slotInterval, inputs) -> catchError "apply-inputs" $ do
+    apply = endpoint @"apply-inputs" $ \(reqId, params, slotInterval, inputs) -> catchError reqId "apply-inputs" $ do
         _ <- applyInputs params slotInterval inputs
-        tell $ OK "apply-inputs"
+        tell $ OK reqId "apply-inputs"
         marlowePlutusContract
-    redeem = promiseMap (mapError (review _MarloweError)) $ endpoint @"redeem" $ \(MarloweParams{rolesCurrency}, role, pkh) -> catchError "redeem" $ do
+    redeem = promiseMap (mapError (review _MarloweError)) $ endpoint @"redeem" $ \(reqId, MarloweParams{rolesCurrency}, role, pkh) -> catchError reqId "redeem" $ do
         let address = scriptHashAddress (mkRolePayoutValidatorHash rolesCurrency)
         utxos <- utxoAt address
         let spendPayoutConstraints tx ref TxOutTx{txOutTxOut} = let
@@ -281,7 +281,7 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
         let spendPayouts = Map.foldlWithKey spendPayoutConstraints mempty utxos
         if spendPayouts == mempty
         then do
-            tell $ OK "redeem"
+            tell $ OK reqId "redeem"
         else do
             let
               constraints = spendPayouts
@@ -294,17 +294,17 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
                   <> Constraints.ownPubKeyHash pkh
             tx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx @Void lookups constraints)
             _ <- submitUnbalancedTx tx
-            tell $ OK "redeem"
+            tell $ OK reqId "redeem"
 
         marlowePlutusContract
-    auto = endpoint @"auto" $ \(params, party, untilSlot) -> catchError "auto" $ do
+    auto = endpoint @"auto" $ \(reqId, params, party, untilSlot) -> catchError reqId "auto" $ do
         let theClient = mkMarloweClient params
         let continueWith :: MarloweData -> Contract MarloweContractState MarloweSchema MarloweError ()
             continueWith md@MarloweData{marloweContract} =
                 if canAutoExecuteContractForParty party marloweContract
-                then autoExecuteContract theClient party md
+                then autoExecuteContract reqId theClient party md
                 else do
-                    tell $ OK "auto"
+                    tell $ OK reqId "auto"
                     marlowePlutusContract
 
         maybeState <- SM.getOnChainState theClient
@@ -314,11 +314,11 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
                 case wr of
                     ContractEnded{} -> do
                         logInfo @String $ "Contract Ended for party " <> show party
-                        tell $ OK "auto"
+                        tell $ OK reqId "auto"
                         marlowePlutusContract
                     Timeout{} -> do
                         logInfo @String $ "Contract Timeout for party " <> show party
-                        tell $ OK "auto"
+                        tell $ OK reqId "auto"
                         marlowePlutusContract
                     Transition _ _ marloweData -> continueWith marloweData
                     InitialState _ marloweData -> continueWith marloweData
@@ -327,14 +327,15 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
                 continueWith marloweData
     -- The MarloweApp contract is closed implicitly by not returning
     -- itself (marlowePlutusContract) as a continuation
-    close = endpoint @"close" $ \_ -> tell $ OK "close"
+    close = endpoint @"close" $ \reqId -> tell $ OK reqId "close"
 
 
-    autoExecuteContract :: StateMachineClient MarloweData MarloweInput
+    autoExecuteContract :: UUID
+                      -> StateMachineClient MarloweData MarloweInput
                       -> Party
                       -> MarloweData
                       -> Contract MarloweContractState MarloweSchema MarloweError ()
-    autoExecuteContract theClient party marloweData = do
+    autoExecuteContract reqId theClient party marloweData = do
         slot <- currentSlot
         let slotRange = (slot, slot + defaultTxValidationRange)
         let action = getAction slotRange party marloweData
@@ -362,7 +363,7 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
                 case wr of
                     ContractEnded{} -> do
                         logInfo @String $ "Contract Ended"
-                        tell $ OK "auto"
+                        tell $ OK reqId "auto"
                         marlowePlutusContract
                     Timeout{} -> do
                         logInfo @String $ "Contract Timeout"
@@ -372,16 +373,16 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
 
             CloseContract -> do
                 logInfo @String $ "CloseContract"
-                tell $ OK "auto"
+                tell $ OK reqId "auto"
                 marlowePlutusContract
 
             NotSure -> do
                 logInfo @String $ "NotSure"
-                tell $ OK "auto"
+                tell $ OK reqId "auto"
                 marlowePlutusContract
 
           where
-            continueWith = autoExecuteContract theClient party
+            continueWith = autoExecuteContract reqId theClient party
 
 
 setupMarloweParams

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -53,6 +53,7 @@
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
         buildable = true;
         modules = [
@@ -83,6 +84,7 @@
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [ "MarloweContract" ];
@@ -124,6 +126,7 @@
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
             (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -53,6 +53,7 @@
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
         buildable = true;
         modules = [
@@ -83,6 +84,7 @@
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [ "MarloweContract" ];
@@ -124,6 +126,7 @@
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
             (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -53,6 +53,7 @@
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
           ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
         buildable = true;
         modules = [
@@ -83,6 +84,7 @@
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."purescript-bridge" or (errorHandler.buildDepError "purescript-bridge"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
           buildable = true;
           modules = [ "MarloweContract" ];
@@ -124,6 +126,7 @@
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."websockets" or (errorHandler.buildDepError "websockets"))
             (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
             ];
           buildable = true;
           modules = [


### PR DESCRIPTION
This PR fixes a problem in which we show a Toast message for an action we might have performed before refreshing or in a different tab. To solve this (and also other problems that can arise by the fact that the response comes in a WS message) we use UUID to identify requests and keep track of which request has a response.
 
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
