### PR TITLE
Add unit cost model for builtins (SCP-2815)

### DIFF
--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -54,7 +54,7 @@ cekmodel :: Parser CekModel
 cekmodel = flag Default Unit
            (  short '1'
            <> long "unit-cek-model"
-           <> help "Use unit AST node costs for CEK cost model (tallying mode only)"
+           <> help "Use unit AST node costs and builtin costs for CEK cost model (tallying mode only)"
            )
 
 evalOpts :: Parser EvalOptions


### PR DESCRIPTION
If you run `uplc` with the `-t -1` options it reports the number of times each AST constructor is evaluated, but used to ignore builtins. This extends it to report how often each built-in function is executed as well, using a unit-cost cost model for builtins.  This might make it a bit easier to diagnose inaccuracies in the costing functions for builtins. 
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
