### PR TITLE
SCP-2799: Support for recording budgets in plutus-tx-plugin

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
@@ -109,6 +109,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
@@ -128,6 +129,8 @@
             ];
           buildable = if flags.use-ghc-stub then false else true;
           modules = [
+            "Budget/Lib"
+            "Budget/Spec"
             "IsData/Spec"
             "Lift/Spec"
             "Plugin/Spec"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
@@ -109,6 +109,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
@@ -128,6 +129,8 @@
             ];
           buildable = if flags.use-ghc-stub then false else true;
           modules = [
+            "Budget/Lib"
+            "Budget/Spec"
             "IsData/Spec"
             "Lift/Spec"
             "Plugin/Spec"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
@@ -109,6 +109,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
@@ -128,6 +129,8 @@
             ];
           buildable = if flags.use-ghc-stub then false else true;
           modules = [
+            "Budget/Lib"
+            "Budget/Spec"
             "IsData/Spec"
             "Lift/Spec"
             "Plugin/Spec"

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -84,6 +84,8 @@ test-suite plutus-tx-tests
     hs-source-dirs: test
     main-is: Spec.hs
     other-modules:
+        Budget.Lib
+        Budget.Spec
         IsData.Spec
         Lift.Spec
         Plugin.Spec
@@ -106,6 +108,7 @@ test-suite plutus-tx-tests
         base >=4.9 && <5,
         flat -any,
         deepseq -any,
+        filepath -any,
         integer-gmp -any,
         plutus-core -any,
         plutus-tx -any,

--- a/plutus-tx-plugin/test/Budget/Lib.hs
+++ b/plutus-tx-plugin/test/Budget/Lib.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+module Budget.Lib where
+
+import           Common
+
+import qualified PlutusCore                               as PLC
+import qualified PlutusCore.Evaluation.Machine.ExBudget   as PLC
+import           PlutusTx.Code                            (CompiledCode, getPlc)
+import qualified PlutusTx.Evaluation                      as PlutusTx
+import qualified UntypedPlutusCore                        as UPLC
+import qualified UntypedPlutusCore.Evaluation.Machine.Cek as UPLC
+
+import           Control.Monad.Except                     (runExceptT)
+import qualified Control.Monad.Reader                     as Reader
+import qualified Data.Text                                as Text
+import           System.FilePath                          ((</>))
+import           Test.Tasty                               (TestName)
+
+goldenBudget :: TestName -> CompiledCode a -> TestNested
+goldenBudget name compiledCode = do
+  path <- Reader.ask
+  let budgetText = measureBudget compiledCode
+  return $
+    goldenVsText name
+                 (foldr (</>) (name ++ ".budget.golden") path)
+                 (maybe "" (Text.pack . show) budgetText)
+
+measureBudget :: CompiledCode a  -> Maybe PLC.ExBudget
+measureBudget compiledCode =
+  let programE = PLC.runQuote
+               $ runExceptT @PLC.FreeVariableError
+               $ UPLC.unDeBruijnProgram
+               $ getPlc compiledCode
+   in case programE of
+        Left _ -> Nothing
+        Right program ->
+          let (_, UPLC.TallyingSt _ budget, _) = PlutusTx.evaluateCekTrace program
+           in Just budget

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+module Budget.Spec where
+
+import           Budget.Lib       (goldenBudget)
+import           Common
+import           Lib              (goldenPir)
+
+import qualified PlutusTx.Prelude as PlutusTx
+import           PlutusTx.TH      (compile)
+
+tests :: TestNested
+tests = testNested "Budget" [
+    goldenBudget "sum" compiledSum
+  , goldenPir "sum" compiledSum
+
+  , goldenBudget "any" compiledAny
+  , goldenPir "any" compiledAny
+
+  , goldenBudget "find" compiledFind
+  , goldenPir "find" compiledFind
+
+  , goldenBudget "filter" compiledFilter
+  , goldenPir "filter" compiledFilter
+
+  , goldenBudget "elem" compiledElem
+  , goldenPir "elem" compiledElem
+  ]
+
+compiledSum = $$(compile [||
+      let ls = [1,2,3,4,5,6,7,8,9,10] :: [Integer]
+       in PlutusTx.sum ls ||])
+
+compiledAny = $$(compile [||
+      let ls = [1,2,3,4,5,6,7,8,9,10] :: [Integer]
+       in PlutusTx.any ((PlutusTx.>) 10) ls ||])
+
+compiledFind = $$(compile [||
+      let ls = [1,2,3,4,5,6,7,8,9,10] :: [Integer]
+       in PlutusTx.find ((PlutusTx.>) 10) ls ||])
+
+compiledFilter = $$(compile [||
+      let ls = [1,2,3,4,5,6,7,8,9,10] :: [Integer]
+       in PlutusTx.filter PlutusTx.even ls ||])
+
+compiledElem = $$(compile [||
+      let ls = [1,2,3,4,5,6,7,8,9,10] :: [Integer]
+       in PlutusTx.elem 0 ls ||])
+

--- a/plutus-tx-plugin/test/Budget/any.budget.golden
+++ b/plutus-tx-plugin/test/Budget/any.budget.golden
@@ -1,0 +1,1 @@
+ExBudget {exBudgetCPU = ExCPU 50830164, exBudgetMemory = ExMemory 165920}

--- a/plutus-tx-plugin/test/Budget/any.plc.golden
+++ b/plutus-tx-plugin/test/Budget/any.plc.golden
@@ -1,0 +1,481 @@
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl Monoid (fun (type) (type)))
+        (tyvardecl a (type))
+        Monoid_match
+        (vardecl
+          CConsMonoid
+          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
+        )
+      )
+    )
+    (termbind
+      (strict)
+      (vardecl
+        p1Monoid
+        (all a (type) (fun [ Monoid a ] [ (lam a (type) (fun a (fun a a))) a ]))
+      )
+      (abs
+        a
+        (type)
+        (lam
+          v
+          [ Monoid a ]
+          [
+            { [ { Monoid_match a } v ] [ (lam a (type) (fun a (fun a a))) a ] }
+            (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+          ]
+        )
+      )
+    )
+    (let
+      (rec)
+      (datatypebind
+        (datatype
+          (tyvardecl List (fun (type) (type)))
+          (tyvardecl a (type))
+          Nil_match
+          (vardecl Nil [ List a ])
+          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
+        )
+      )
+      (let
+        (nonrec)
+        (termbind
+          (strict)
+          (vardecl mempty (all a (type) (fun [ Monoid a ] a)))
+          (abs
+            a
+            (type)
+            (lam
+              v
+              [ Monoid a ]
+              [
+                { [ { Monoid_match a } v ] a }
+                (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+              ]
+            )
+          )
+        )
+        (let
+          (rec)
+          (termbind
+            (strict)
+            (vardecl
+              fFoldableNil_cfoldMap
+              (all
+                m
+                (type)
+                (all
+                  a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
+                )
+              )
+            )
+            (abs
+              m
+              (type)
+              (abs
+                a
+                (type)
+                (lam
+                  dMonoid
+                  [ Monoid m ]
+                  (let
+                    (nonrec)
+                    (termbind
+                      (nonstrict)
+                      (vardecl
+                        dSemigroup [ (lam a (type) (fun a (fun a a))) m ]
+                      )
+                      [ { p1Monoid m } dMonoid ]
+                    )
+                    (lam
+                      ds
+                      (fun a m)
+                      (lam
+                        ds
+                        [ List a ]
+                        {
+                          [
+                            [
+                              { [ { Nil_match a } ds ] (all dead (type) m) }
+                              (abs dead (type) [ { mempty m } dMonoid ])
+                            ]
+                            (lam
+                              x
+                              a
+                              (lam
+                                xs
+                                [ List a ]
+                                (abs
+                                  dead
+                                  (type)
+                                  [
+                                    [ dSemigroup [ ds x ] ]
+                                    [
+                                      [
+                                        [
+                                          { { fFoldableNil_cfoldMap m } a }
+                                          dMonoid
+                                        ]
+                                        ds
+                                      ]
+                                      xs
+                                    ]
+                                  ]
+                                )
+                              )
+                            )
+                          ]
+                          (all dead (type) dead)
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          (let
+            (nonrec)
+            (termbind
+              (nonstrict)
+              (vardecl
+                fFoldableNil
+                [
+                  (lam
+                    t
+                    (fun (type) (type))
+                    (all
+                      m
+                      (type)
+                      (all
+                        a
+                        (type)
+                        (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                      )
+                    )
+                  )
+                  List
+                ]
+              )
+              fFoldableNil_cfoldMap
+            )
+            (datatypebind
+              (datatype
+                (tyvardecl AdditiveMonoid (fun (type) (type)))
+                (tyvardecl a (type))
+                AdditiveMonoid_match
+                (vardecl
+                  CConsAdditiveMonoid
+                  (fun
+                    [ (lam a (type) (fun a (fun a a))) a ]
+                    (fun a [ AdditiveMonoid a ])
+                  )
+                )
+              )
+            )
+            (datatypebind
+              (datatype
+                (tyvardecl Bool (type))
+
+                Bool_match
+                (vardecl True Bool) (vardecl False Bool)
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl bad_name (fun Bool (fun Bool Bool)))
+              (lam
+                l
+                Bool
+                (lam
+                  r
+                  Bool
+                  {
+                    [
+                      [
+                        { [ Bool_match l ] (all dead (type) Bool) }
+                        (abs dead (type) True)
+                      ]
+                      (abs dead (type) r)
+                    ]
+                    (all dead (type) dead)
+                  }
+                )
+              )
+            )
+            (termbind
+              (nonstrict)
+              (vardecl fAdditiveMonoidBool [ AdditiveMonoid Bool ])
+              [ [ { CConsAdditiveMonoid Bool } bad_name ] False ]
+            )
+            (termbind
+              (strict)
+              (vardecl
+                p1AdditiveMonoid
+                (all
+                  a
+                  (type)
+                  (fun
+                    [ AdditiveMonoid a ] [ (lam a (type) (fun a (fun a a))) a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    {
+                      [ { AdditiveMonoid_match a } v ]
+                      [ (lam a (type) (fun a (fun a a))) a ]
+                    }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl zero (all a (type) (fun [ AdditiveMonoid a ] a)))
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    { [ { AdditiveMonoid_match a } v ] a }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fMonoidSum
+                (all
+                  a
+                  (type)
+                  (fun [ AdditiveMonoid a ] [ Monoid [ (lam a (type) a) a ] ])
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    [
+                      { CConsMonoid [ (lam a (type) a) a ] }
+                      (lam
+                        eta
+                        [ (lam a (type) a) a ]
+                        (lam
+                          eta
+                          [ (lam a (type) a) a ]
+                          [ [ [ { p1AdditiveMonoid a } v ] eta ] eta ]
+                        )
+                      )
+                    ]
+                    [ { zero a } v ]
+                  ]
+                )
+              )
+            )
+            (termbind
+              (nonstrict)
+              (vardecl dMonoid [ Monoid [ (lam a (type) a) Bool ] ])
+              [ { fMonoidSum Bool } fAdditiveMonoidBool ]
+            )
+            (termbind
+              (strict)
+              (vardecl
+                any
+                (all
+                  t
+                  (fun (type) (type))
+                  (all
+                    a
+                    (type)
+                    (fun
+                      [
+                        (lam
+                          t
+                          (fun (type) (type))
+                          (all
+                            m
+                            (type)
+                            (all
+                              a
+                              (type)
+                              (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                            )
+                          )
+                        )
+                        t
+                      ]
+                      (fun (fun a Bool) (fun [ t a ] Bool))
+                    )
+                  )
+                )
+              )
+              (abs
+                t
+                (fun (type) (type))
+                (abs
+                  a
+                  (type)
+                  (lam
+                    dFoldable
+                    [
+                      (lam
+                        t
+                        (fun (type) (type))
+                        (all
+                          m
+                          (type)
+                          (all
+                            a
+                            (type)
+                            (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                          )
+                        )
+                      )
+                      t
+                    ]
+                    (lam
+                      p
+                      (fun a Bool)
+                      [
+                        [
+                          { { dFoldable [ (lam a (type) a) Bool ] } a } dMonoid
+                        ]
+                        p
+                      ]
+                    )
+                  )
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                build
+                (all
+                  a
+                  (type)
+                  (fun
+                    (all b (type) (fun (fun a (fun b b)) (fun b b))) [ List a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  g
+                  (all b (type) (fun (fun a (fun b b)) (fun b b)))
+                  [ [ { g [ List a ] } { Cons a } ] { Nil a } ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                ifThenElse (all a (type) (fun (con bool) (fun a (fun a a))))
+              )
+              (builtin ifThenElse)
+            )
+            (termbind
+              (strict)
+              (vardecl
+                lessThanEqualsInteger
+                (fun (con integer) (fun (con integer) (con bool)))
+              )
+              (builtin lessThanEqualsInteger)
+            )
+            (termbind
+              (strict)
+              (vardecl
+                greaterThanInteger (fun (con integer) (fun (con integer) Bool))
+              )
+              (lam
+                x
+                (con integer)
+                (lam
+                  y
+                  (con integer)
+                  [
+                    [
+                      [ { ifThenElse Bool } [ [ lessThanEqualsInteger x ] y ] ]
+                      False
+                    ]
+                    True
+                  ]
+                )
+              )
+            )
+            [
+              [
+                [ { { any List } (con integer) } fFoldableNil ]
+                [ greaterThanInteger (con integer 10) ]
+              ]
+              [
+                { build (con integer) }
+                (abs
+                  a
+                  (type)
+                  (lam
+                    c
+                    (fun (con integer) (fun a a))
+                    (lam
+                      n
+                      a
+                      [
+                        [ c (con integer 1) ]
+                        [
+                          [ c (con integer 2) ]
+                          [
+                            [ c (con integer 3) ]
+                            [
+                              [ c (con integer 4) ]
+                              [
+                                [ c (con integer 5) ]
+                                [
+                                  [ c (con integer 6) ]
+                                  [
+                                    [ c (con integer 7) ]
+                                    [
+                                      [ c (con integer 8) ]
+                                      [
+                                        [ c (con integer 9) ]
+                                        [ [ c (con integer 10) ] n ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    )
+                  )
+                )
+              ]
+            ]
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Budget/elem.budget.golden
+++ b/plutus-tx-plugin/test/Budget/elem.budget.golden
@@ -1,0 +1,1 @@
+ExBudget {exBudgetCPU = ExCPU 50980608, exBudgetMemory = ExMemory 166720}

--- a/plutus-tx-plugin/test/Budget/elem.plc.golden
+++ b/plutus-tx-plugin/test/Budget/elem.plc.golden
@@ -1,0 +1,481 @@
+(program
+  (let
+    (nonrec)
+    (termbind
+      (strict)
+      (vardecl equalsInteger (fun (con integer) (fun (con integer) (con bool))))
+      (builtin equalsInteger)
+    )
+    (termbind
+      (strict)
+      (vardecl ifThenElse (all a (type) (fun (con bool) (fun a (fun a a)))))
+      (builtin ifThenElse)
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl Bool (type))
+
+        Bool_match
+        (vardecl True Bool) (vardecl False Bool)
+      )
+    )
+    (termbind
+      (strict)
+      (vardecl equalsInteger (fun (con integer) (fun (con integer) Bool)))
+      (lam
+        x
+        (con integer)
+        (lam
+          y
+          (con integer)
+          [ [ [ { ifThenElse Bool } [ [ equalsInteger x ] y ] ] True ] False ]
+        )
+      )
+    )
+    (termbind
+      (nonstrict)
+      (vardecl fEqInteger [ (lam a (type) (fun a (fun a Bool))) (con integer) ])
+      equalsInteger
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl Monoid (fun (type) (type)))
+        (tyvardecl a (type))
+        Monoid_match
+        (vardecl
+          CConsMonoid
+          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
+        )
+      )
+    )
+    (termbind
+      (strict)
+      (vardecl
+        p1Monoid
+        (all a (type) (fun [ Monoid a ] [ (lam a (type) (fun a (fun a a))) a ]))
+      )
+      (abs
+        a
+        (type)
+        (lam
+          v
+          [ Monoid a ]
+          [
+            { [ { Monoid_match a } v ] [ (lam a (type) (fun a (fun a a))) a ] }
+            (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+          ]
+        )
+      )
+    )
+    (let
+      (rec)
+      (datatypebind
+        (datatype
+          (tyvardecl List (fun (type) (type)))
+          (tyvardecl a (type))
+          Nil_match
+          (vardecl Nil [ List a ])
+          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
+        )
+      )
+      (let
+        (nonrec)
+        (termbind
+          (strict)
+          (vardecl mempty (all a (type) (fun [ Monoid a ] a)))
+          (abs
+            a
+            (type)
+            (lam
+              v
+              [ Monoid a ]
+              [
+                { [ { Monoid_match a } v ] a }
+                (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+              ]
+            )
+          )
+        )
+        (let
+          (rec)
+          (termbind
+            (strict)
+            (vardecl
+              fFoldableNil_cfoldMap
+              (all
+                m
+                (type)
+                (all
+                  a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
+                )
+              )
+            )
+            (abs
+              m
+              (type)
+              (abs
+                a
+                (type)
+                (lam
+                  dMonoid
+                  [ Monoid m ]
+                  (let
+                    (nonrec)
+                    (termbind
+                      (nonstrict)
+                      (vardecl
+                        dSemigroup [ (lam a (type) (fun a (fun a a))) m ]
+                      )
+                      [ { p1Monoid m } dMonoid ]
+                    )
+                    (lam
+                      ds
+                      (fun a m)
+                      (lam
+                        ds
+                        [ List a ]
+                        {
+                          [
+                            [
+                              { [ { Nil_match a } ds ] (all dead (type) m) }
+                              (abs dead (type) [ { mempty m } dMonoid ])
+                            ]
+                            (lam
+                              x
+                              a
+                              (lam
+                                xs
+                                [ List a ]
+                                (abs
+                                  dead
+                                  (type)
+                                  [
+                                    [ dSemigroup [ ds x ] ]
+                                    [
+                                      [
+                                        [
+                                          { { fFoldableNil_cfoldMap m } a }
+                                          dMonoid
+                                        ]
+                                        ds
+                                      ]
+                                      xs
+                                    ]
+                                  ]
+                                )
+                              )
+                            )
+                          ]
+                          (all dead (type) dead)
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          (let
+            (nonrec)
+            (termbind
+              (nonstrict)
+              (vardecl
+                fFoldableNil
+                [
+                  (lam
+                    t
+                    (fun (type) (type))
+                    (all
+                      m
+                      (type)
+                      (all
+                        a
+                        (type)
+                        (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                      )
+                    )
+                  )
+                  List
+                ]
+              )
+              fFoldableNil_cfoldMap
+            )
+            (termbind
+              (strict)
+              (vardecl
+                build
+                (all
+                  a
+                  (type)
+                  (fun
+                    (all b (type) (fun (fun a (fun b b)) (fun b b))) [ List a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  g
+                  (all b (type) (fun (fun a (fun b b)) (fun b b)))
+                  [ [ { g [ List a ] } { Cons a } ] { Nil a } ]
+                )
+              )
+            )
+            (datatypebind
+              (datatype
+                (tyvardecl AdditiveMonoid (fun (type) (type)))
+                (tyvardecl a (type))
+                AdditiveMonoid_match
+                (vardecl
+                  CConsAdditiveMonoid
+                  (fun
+                    [ (lam a (type) (fun a (fun a a))) a ]
+                    (fun a [ AdditiveMonoid a ])
+                  )
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl bad_name (fun Bool (fun Bool Bool)))
+              (lam
+                l
+                Bool
+                (lam
+                  r
+                  Bool
+                  {
+                    [
+                      [
+                        { [ Bool_match l ] (all dead (type) Bool) }
+                        (abs dead (type) True)
+                      ]
+                      (abs dead (type) r)
+                    ]
+                    (all dead (type) dead)
+                  }
+                )
+              )
+            )
+            (termbind
+              (nonstrict)
+              (vardecl fAdditiveMonoidBool [ AdditiveMonoid Bool ])
+              [ [ { CConsAdditiveMonoid Bool } bad_name ] False ]
+            )
+            (termbind
+              (strict)
+              (vardecl
+                p1AdditiveMonoid
+                (all
+                  a
+                  (type)
+                  (fun
+                    [ AdditiveMonoid a ] [ (lam a (type) (fun a (fun a a))) a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    {
+                      [ { AdditiveMonoid_match a } v ]
+                      [ (lam a (type) (fun a (fun a a))) a ]
+                    }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl zero (all a (type) (fun [ AdditiveMonoid a ] a)))
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    { [ { AdditiveMonoid_match a } v ] a }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fMonoidSum
+                (all
+                  a
+                  (type)
+                  (fun [ AdditiveMonoid a ] [ Monoid [ (lam a (type) a) a ] ])
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    [
+                      { CConsMonoid [ (lam a (type) a) a ] }
+                      (lam
+                        eta
+                        [ (lam a (type) a) a ]
+                        (lam
+                          eta
+                          [ (lam a (type) a) a ]
+                          [ [ [ { p1AdditiveMonoid a } v ] eta ] eta ]
+                        )
+                      )
+                    ]
+                    [ { zero a } v ]
+                  ]
+                )
+              )
+            )
+            (termbind
+              (nonstrict)
+              (vardecl dMonoid [ Monoid [ (lam a (type) a) Bool ] ])
+              [ { fMonoidSum Bool } fAdditiveMonoidBool ]
+            )
+            (termbind
+              (strict)
+              (vardecl
+                elem
+                (all
+                  t
+                  (fun (type) (type))
+                  (all
+                    a
+                    (type)
+                    (fun
+                      [
+                        (lam
+                          t
+                          (fun (type) (type))
+                          (all
+                            m
+                            (type)
+                            (all
+                              a
+                              (type)
+                              (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                            )
+                          )
+                        )
+                        t
+                      ]
+                      (fun
+                        [ (lam a (type) (fun a (fun a Bool))) a ]
+                        (fun a (fun [ t a ] Bool))
+                      )
+                    )
+                  )
+                )
+              )
+              (abs
+                t
+                (fun (type) (type))
+                (abs
+                  a
+                  (type)
+                  (lam
+                    dFoldable
+                    [
+                      (lam
+                        t
+                        (fun (type) (type))
+                        (all
+                          m
+                          (type)
+                          (all
+                            a
+                            (type)
+                            (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                          )
+                        )
+                      )
+                      t
+                    ]
+                    (lam
+                      dEq
+                      [ (lam a (type) (fun a (fun a Bool))) a ]
+                      (lam
+                        x
+                        a
+                        [
+                          [
+                            { { dFoldable [ (lam a (type) a) Bool ] } a }
+                            dMonoid
+                          ]
+                          [ dEq x ]
+                        ]
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            [
+              [
+                [ [ { { elem List } (con integer) } fFoldableNil ] fEqInteger ]
+                (con integer 0)
+              ]
+              [
+                { build (con integer) }
+                (abs
+                  a
+                  (type)
+                  (lam
+                    c
+                    (fun (con integer) (fun a a))
+                    (lam
+                      n
+                      a
+                      [
+                        [ c (con integer 1) ]
+                        [
+                          [ c (con integer 2) ]
+                          [
+                            [ c (con integer 3) ]
+                            [
+                              [ c (con integer 4) ]
+                              [
+                                [ c (con integer 5) ]
+                                [
+                                  [ c (con integer 6) ]
+                                  [
+                                    [ c (con integer 7) ]
+                                    [
+                                      [ c (con integer 8) ]
+                                      [
+                                        [ c (con integer 9) ]
+                                        [ [ c (con integer 10) ] n ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    )
+                  )
+                )
+              ]
+            ]
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Budget/filter.budget.golden
+++ b/plutus-tx-plugin/test/Budget/filter.budget.golden
@@ -1,0 +1,1 @@
+ExBudget {exBudgetCPU = ExCPU 38206702, exBudgetMemory = ExMemory 109530}

--- a/plutus-tx-plugin/test/Budget/filter.plc.golden
+++ b/plutus-tx-plugin/test/Budget/filter.plc.golden
@@ -1,0 +1,232 @@
+(program
+  (let
+    (rec)
+    (datatypebind
+      (datatype
+        (tyvardecl List (fun (type) (type)))
+        (tyvardecl a (type))
+        Nil_match
+        (vardecl Nil [ List a ])
+        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
+      )
+    )
+    (let
+      (nonrec)
+      (termbind
+        (strict)
+        (vardecl
+          build
+          (all
+            a
+            (type)
+            (fun (all b (type) (fun (fun a (fun b b)) (fun b b))) [ List a ])
+          )
+        )
+        (abs
+          a
+          (type)
+          (lam
+            g
+            (all b (type) (fun (fun a (fun b b)) (fun b b)))
+            [ [ { g [ List a ] } { Cons a } ] { Nil a } ]
+          )
+        )
+      )
+      (termbind
+        (strict)
+        (vardecl
+          equalsInteger (fun (con integer) (fun (con integer) (con bool)))
+        )
+        (builtin equalsInteger)
+      )
+      (datatypebind
+        (datatype
+          (tyvardecl Bool (type))
+
+          Bool_match
+          (vardecl True Bool) (vardecl False Bool)
+        )
+      )
+      (termbind
+        (strict)
+        (vardecl ifThenElse (all a (type) (fun (con bool) (fun a (fun a a)))))
+        (builtin ifThenElse)
+      )
+      (termbind
+        (strict)
+        (vardecl
+          modInteger (fun (con integer) (fun (con integer) (con integer)))
+        )
+        (builtin modInteger)
+      )
+      (termbind
+        (strict)
+        (vardecl even (fun (con integer) Bool))
+        (lam
+          n
+          (con integer)
+          [
+            [
+              [
+                { ifThenElse Bool }
+                [
+                  [ equalsInteger [ [ modInteger n ] (con integer 2) ] ]
+                  (con integer 0)
+                ]
+              ]
+              True
+            ]
+            False
+          ]
+        )
+      )
+      (let
+        (rec)
+        (termbind
+          (strict)
+          (vardecl
+            foldr
+            (all
+              a
+              (type)
+              (all b (type) (fun (fun a (fun b b)) (fun b (fun [ List a ] b))))
+            )
+          )
+          (abs
+            a
+            (type)
+            (abs
+              b
+              (type)
+              (lam
+                f
+                (fun a (fun b b))
+                (lam
+                  acc
+                  b
+                  (lam
+                    l
+                    [ List a ]
+                    {
+                      [
+                        [
+                          { [ { Nil_match a } l ] (all dead (type) b) }
+                          (abs dead (type) acc)
+                        ]
+                        (lam
+                          x
+                          a
+                          (lam
+                            xs
+                            [ List a ]
+                            (abs
+                              dead
+                              (type)
+                              [ [ f x ] [ [ [ { { foldr a } b } f ] acc ] xs ] ]
+                            )
+                          )
+                        )
+                      ]
+                      (all dead (type) dead)
+                    }
+                  )
+                )
+              )
+            )
+          )
+        )
+        (let
+          (nonrec)
+          (termbind
+            (strict)
+            (vardecl
+              filter
+              (all a (type) (fun (fun a Bool) (fun [ List a ] [ List a ])))
+            )
+            (abs
+              a
+              (type)
+              (lam
+                p
+                (fun a Bool)
+                [
+                  [
+                    { { foldr a } [ List a ] }
+                    (lam
+                      e
+                      a
+                      (lam
+                        xs
+                        [ List a ]
+                        {
+                          [
+                            [
+                              {
+                                [ Bool_match [ p e ] ]
+                                (all dead (type) [ List a ])
+                              }
+                              (abs dead (type) [ [ { Cons a } e ] xs ])
+                            ]
+                            (abs dead (type) xs)
+                          ]
+                          (all dead (type) dead)
+                        }
+                      )
+                    )
+                  ]
+                  { Nil a }
+                ]
+              )
+            )
+          )
+          [
+            [ { filter (con integer) } even ]
+            [
+              { build (con integer) }
+              (abs
+                a
+                (type)
+                (lam
+                  c
+                  (fun (con integer) (fun a a))
+                  (lam
+                    n
+                    a
+                    [
+                      [ c (con integer 1) ]
+                      [
+                        [ c (con integer 2) ]
+                        [
+                          [ c (con integer 3) ]
+                          [
+                            [ c (con integer 4) ]
+                            [
+                              [ c (con integer 5) ]
+                              [
+                                [ c (con integer 6) ]
+                                [
+                                  [ c (con integer 7) ]
+                                  [
+                                    [ c (con integer 8) ]
+                                    [
+                                      [ c (con integer 9) ]
+                                      [ [ c (con integer 10) ] n ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  )
+                )
+              )
+            ]
+          ]
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Budget/find.budget.golden
+++ b/plutus-tx-plugin/test/Budget/find.budget.golden
@@ -1,0 +1,1 @@
+ExBudget {exBudgetCPU = ExCPU 49758336, exBudgetMemory = ExMemory 162320}

--- a/plutus-tx-plugin/test/Budget/find.plc.golden
+++ b/plutus-tx-plugin/test/Budget/find.plc.golden
@@ -1,0 +1,479 @@
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl Monoid (fun (type) (type)))
+        (tyvardecl a (type))
+        Monoid_match
+        (vardecl
+          CConsMonoid
+          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
+        )
+      )
+    )
+    (termbind
+      (strict)
+      (vardecl
+        p1Monoid
+        (all a (type) (fun [ Monoid a ] [ (lam a (type) (fun a (fun a a))) a ]))
+      )
+      (abs
+        a
+        (type)
+        (lam
+          v
+          [ Monoid a ]
+          [
+            { [ { Monoid_match a } v ] [ (lam a (type) (fun a (fun a a))) a ] }
+            (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+          ]
+        )
+      )
+    )
+    (let
+      (rec)
+      (datatypebind
+        (datatype
+          (tyvardecl List (fun (type) (type)))
+          (tyvardecl a (type))
+          Nil_match
+          (vardecl Nil [ List a ])
+          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
+        )
+      )
+      (let
+        (nonrec)
+        (termbind
+          (strict)
+          (vardecl mempty (all a (type) (fun [ Monoid a ] a)))
+          (abs
+            a
+            (type)
+            (lam
+              v
+              [ Monoid a ]
+              [
+                { [ { Monoid_match a } v ] a }
+                (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+              ]
+            )
+          )
+        )
+        (let
+          (rec)
+          (termbind
+            (strict)
+            (vardecl
+              fFoldableNil_cfoldMap
+              (all
+                m
+                (type)
+                (all
+                  a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
+                )
+              )
+            )
+            (abs
+              m
+              (type)
+              (abs
+                a
+                (type)
+                (lam
+                  dMonoid
+                  [ Monoid m ]
+                  (let
+                    (nonrec)
+                    (termbind
+                      (nonstrict)
+                      (vardecl
+                        dSemigroup [ (lam a (type) (fun a (fun a a))) m ]
+                      )
+                      [ { p1Monoid m } dMonoid ]
+                    )
+                    (lam
+                      ds
+                      (fun a m)
+                      (lam
+                        ds
+                        [ List a ]
+                        {
+                          [
+                            [
+                              { [ { Nil_match a } ds ] (all dead (type) m) }
+                              (abs dead (type) [ { mempty m } dMonoid ])
+                            ]
+                            (lam
+                              x
+                              a
+                              (lam
+                                xs
+                                [ List a ]
+                                (abs
+                                  dead
+                                  (type)
+                                  [
+                                    [ dSemigroup [ ds x ] ]
+                                    [
+                                      [
+                                        [
+                                          { { fFoldableNil_cfoldMap m } a }
+                                          dMonoid
+                                        ]
+                                        ds
+                                      ]
+                                      xs
+                                    ]
+                                  ]
+                                )
+                              )
+                            )
+                          ]
+                          (all dead (type) dead)
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          (let
+            (nonrec)
+            (termbind
+              (nonstrict)
+              (vardecl
+                fFoldableNil
+                [
+                  (lam
+                    t
+                    (fun (type) (type))
+                    (all
+                      m
+                      (type)
+                      (all
+                        a
+                        (type)
+                        (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                      )
+                    )
+                  )
+                  List
+                ]
+              )
+              fFoldableNil_cfoldMap
+            )
+            (termbind
+              (strict)
+              (vardecl
+                build
+                (all
+                  a
+                  (type)
+                  (fun
+                    (all b (type) (fun (fun a (fun b b)) (fun b b))) [ List a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  g
+                  (all b (type) (fun (fun a (fun b b)) (fun b b)))
+                  [ [ { g [ List a ] } { Cons a } ] { Nil a } ]
+                )
+              )
+            )
+            (datatypebind
+              (datatype
+                (tyvardecl Maybe (fun (type) (type)))
+                (tyvardecl a (type))
+                Maybe_match
+                (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fSemigroupFirst_c
+                (all
+                  a
+                  (type)
+                  (fun
+                    [ (lam a (type) [ Maybe a ]) a ]
+                    (fun
+                      [ (lam a (type) [ Maybe a ]) a ]
+                      [ (lam a (type) [ Maybe a ]) a ]
+                    )
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  ds
+                  [ (lam a (type) [ Maybe a ]) a ]
+                  (lam
+                    b
+                    [ (lam a (type) [ Maybe a ]) a ]
+                    {
+                      [
+                        [
+                          {
+                            [ { Maybe_match a } ds ]
+                            (all dead (type) [ (lam a (type) [ Maybe a ]) a ])
+                          }
+                          (lam ipv a (abs dead (type) ds))
+                        ]
+                        (abs dead (type) b)
+                      ]
+                      (all dead (type) dead)
+                    }
+                  )
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fMonoidFirst
+                (all a (type) [ Monoid [ (lam a (type) [ Maybe a ]) a ] ])
+              )
+              (abs
+                a
+                (type)
+                [
+                  [
+                    { CConsMonoid [ (lam a (type) [ Maybe a ]) a ] }
+                    { fSemigroupFirst_c a }
+                  ]
+                  { Nothing a }
+                ]
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fGeneric1TYPEFirst
+                (all
+                  a
+                  (type)
+                  (fun
+                    [ (lam a (type) [ Maybe a ]) a ]
+                    [ (lam a (type) [ Maybe a ]) a ]
+                  )
+                )
+              )
+              (abs a (type) (lam x [ (lam a (type) [ Maybe a ]) a ] x))
+            )
+            (termbind
+              (nonstrict)
+              (vardecl
+                getFirst
+                (all
+                  a (type) (fun [ (lam a (type) [ Maybe a ]) a ] [ Maybe a ])
+                )
+              )
+              fGeneric1TYPEFirst
+            )
+            (datatypebind
+              (datatype
+                (tyvardecl Bool (type))
+
+                Bool_match
+                (vardecl True Bool) (vardecl False Bool)
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                find
+                (all
+                  t
+                  (fun (type) (type))
+                  (all
+                    a
+                    (type)
+                    (fun
+                      [
+                        (lam
+                          t
+                          (fun (type) (type))
+                          (all
+                            m
+                            (type)
+                            (all
+                              a
+                              (type)
+                              (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                            )
+                          )
+                        )
+                        t
+                      ]
+                      (fun (fun a Bool) (fun [ t a ] [ Maybe a ]))
+                    )
+                  )
+                )
+              )
+              (abs
+                t
+                (fun (type) (type))
+                (abs
+                  a
+                  (type)
+                  (lam
+                    dFoldable
+                    [
+                      (lam
+                        t
+                        (fun (type) (type))
+                        (all
+                          m
+                          (type)
+                          (all
+                            a
+                            (type)
+                            (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                          )
+                        )
+                      )
+                      t
+                    ]
+                    (lam
+                      p
+                      (fun a Bool)
+                      (let
+                        (nonrec)
+                        (termbind
+                          (nonstrict)
+                          (vardecl
+                            g (fun [ t a ] [ (lam a (type) [ Maybe a ]) a ])
+                          )
+                          [
+                            [
+                              {
+                                { dFoldable [ (lam a (type) [ Maybe a ]) a ] } a
+                              }
+                              { fMonoidFirst a }
+                            ]
+                            (lam
+                              x
+                              a
+                              {
+                                [
+                                  [
+                                    {
+                                      [ Bool_match [ p x ] ]
+                                      (all dead (type) [ Maybe a ])
+                                    }
+                                    (abs dead (type) [ { Just a } x ])
+                                  ]
+                                  (abs dead (type) { Nothing a })
+                                ]
+                                (all dead (type) dead)
+                              }
+                            )
+                          ]
+                        )
+                        (lam x [ t a ] [ { getFirst a } [ g x ] ])
+                      )
+                    )
+                  )
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                ifThenElse (all a (type) (fun (con bool) (fun a (fun a a))))
+              )
+              (builtin ifThenElse)
+            )
+            (termbind
+              (strict)
+              (vardecl
+                lessThanEqualsInteger
+                (fun (con integer) (fun (con integer) (con bool)))
+              )
+              (builtin lessThanEqualsInteger)
+            )
+            (termbind
+              (strict)
+              (vardecl
+                greaterThanInteger (fun (con integer) (fun (con integer) Bool))
+              )
+              (lam
+                x
+                (con integer)
+                (lam
+                  y
+                  (con integer)
+                  [
+                    [
+                      [ { ifThenElse Bool } [ [ lessThanEqualsInteger x ] y ] ]
+                      False
+                    ]
+                    True
+                  ]
+                )
+              )
+            )
+            [
+              [
+                [ { { find List } (con integer) } fFoldableNil ]
+                [ greaterThanInteger (con integer 10) ]
+              ]
+              [
+                { build (con integer) }
+                (abs
+                  a
+                  (type)
+                  (lam
+                    c
+                    (fun (con integer) (fun a a))
+                    (lam
+                      n
+                      a
+                      [
+                        [ c (con integer 1) ]
+                        [
+                          [ c (con integer 2) ]
+                          [
+                            [ c (con integer 3) ]
+                            [
+                              [ c (con integer 4) ]
+                              [
+                                [ c (con integer 5) ]
+                                [
+                                  [ c (con integer 6) ]
+                                  [
+                                    [ c (con integer 7) ]
+                                    [
+                                      [ c (con integer 8) ]
+                                      [
+                                        [ c (con integer 9) ]
+                                        [ [ c (con integer 10) ] n ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    )
+                  )
+                )
+              ]
+            ]
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Budget/sum.budget.golden
+++ b/plutus-tx-plugin/test/Budget/sum.budget.golden
@@ -1,0 +1,1 @@
+ExBudget {exBudgetCPU = ExCPU 44785764, exBudgetMemory = ExMemory 143920}

--- a/plutus-tx-plugin/test/Budget/sum.plc.golden
+++ b/plutus-tx-plugin/test/Budget/sum.plc.golden
@@ -1,0 +1,428 @@
+(program
+  (let
+    (nonrec)
+    (termbind
+      (strict)
+      (vardecl fAdditiveMonoidInteger_czero (con integer))
+      (con integer 0)
+    )
+    (termbind
+      (strict)
+      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
+      (builtin addInteger)
+    )
+    (termbind
+      (strict)
+      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
+      (lam x (con integer) (lam y (con integer) [ [ addInteger x ] y ]))
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl AdditiveMonoid (fun (type) (type)))
+        (tyvardecl a (type))
+        AdditiveMonoid_match
+        (vardecl
+          CConsAdditiveMonoid
+          (fun
+            [ (lam a (type) (fun a (fun a a))) a ] (fun a [ AdditiveMonoid a ])
+          )
+        )
+      )
+    )
+    (termbind
+      (nonstrict)
+      (vardecl fAdditiveMonoidInteger [ AdditiveMonoid (con integer) ])
+      [
+        [ { CConsAdditiveMonoid (con integer) } addInteger ]
+        fAdditiveMonoidInteger_czero
+      ]
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl Monoid (fun (type) (type)))
+        (tyvardecl a (type))
+        Monoid_match
+        (vardecl
+          CConsMonoid
+          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
+        )
+      )
+    )
+    (termbind
+      (strict)
+      (vardecl
+        p1Monoid
+        (all a (type) (fun [ Monoid a ] [ (lam a (type) (fun a (fun a a))) a ]))
+      )
+      (abs
+        a
+        (type)
+        (lam
+          v
+          [ Monoid a ]
+          [
+            { [ { Monoid_match a } v ] [ (lam a (type) (fun a (fun a a))) a ] }
+            (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+          ]
+        )
+      )
+    )
+    (let
+      (rec)
+      (datatypebind
+        (datatype
+          (tyvardecl List (fun (type) (type)))
+          (tyvardecl a (type))
+          Nil_match
+          (vardecl Nil [ List a ])
+          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
+        )
+      )
+      (let
+        (nonrec)
+        (termbind
+          (strict)
+          (vardecl mempty (all a (type) (fun [ Monoid a ] a)))
+          (abs
+            a
+            (type)
+            (lam
+              v
+              [ Monoid a ]
+              [
+                { [ { Monoid_match a } v ] a }
+                (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+              ]
+            )
+          )
+        )
+        (let
+          (rec)
+          (termbind
+            (strict)
+            (vardecl
+              fFoldableNil_cfoldMap
+              (all
+                m
+                (type)
+                (all
+                  a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
+                )
+              )
+            )
+            (abs
+              m
+              (type)
+              (abs
+                a
+                (type)
+                (lam
+                  dMonoid
+                  [ Monoid m ]
+                  (let
+                    (nonrec)
+                    (termbind
+                      (nonstrict)
+                      (vardecl
+                        dSemigroup [ (lam a (type) (fun a (fun a a))) m ]
+                      )
+                      [ { p1Monoid m } dMonoid ]
+                    )
+                    (lam
+                      ds
+                      (fun a m)
+                      (lam
+                        ds
+                        [ List a ]
+                        {
+                          [
+                            [
+                              { [ { Nil_match a } ds ] (all dead (type) m) }
+                              (abs dead (type) [ { mempty m } dMonoid ])
+                            ]
+                            (lam
+                              x
+                              a
+                              (lam
+                                xs
+                                [ List a ]
+                                (abs
+                                  dead
+                                  (type)
+                                  [
+                                    [ dSemigroup [ ds x ] ]
+                                    [
+                                      [
+                                        [
+                                          { { fFoldableNil_cfoldMap m } a }
+                                          dMonoid
+                                        ]
+                                        ds
+                                      ]
+                                      xs
+                                    ]
+                                  ]
+                                )
+                              )
+                            )
+                          ]
+                          (all dead (type) dead)
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+          (let
+            (nonrec)
+            (termbind
+              (nonstrict)
+              (vardecl
+                fFoldableNil
+                [
+                  (lam
+                    t
+                    (fun (type) (type))
+                    (all
+                      m
+                      (type)
+                      (all
+                        a
+                        (type)
+                        (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                      )
+                    )
+                  )
+                  List
+                ]
+              )
+              fFoldableNil_cfoldMap
+            )
+            (termbind
+              (strict)
+              (vardecl
+                build
+                (all
+                  a
+                  (type)
+                  (fun
+                    (all b (type) (fun (fun a (fun b b)) (fun b b))) [ List a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  g
+                  (all b (type) (fun (fun a (fun b b)) (fun b b)))
+                  [ [ { g [ List a ] } { Cons a } ] { Nil a } ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                p1AdditiveMonoid
+                (all
+                  a
+                  (type)
+                  (fun
+                    [ AdditiveMonoid a ] [ (lam a (type) (fun a (fun a a))) a ]
+                  )
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    {
+                      [ { AdditiveMonoid_match a } v ]
+                      [ (lam a (type) (fun a (fun a a))) a ]
+                    }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl zero (all a (type) (fun [ AdditiveMonoid a ] a)))
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    { [ { AdditiveMonoid_match a } v ] a }
+                    (lam v [ (lam a (type) (fun a (fun a a))) a ] (lam v a v))
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                fMonoidSum
+                (all
+                  a
+                  (type)
+                  (fun [ AdditiveMonoid a ] [ Monoid [ (lam a (type) a) a ] ])
+                )
+              )
+              (abs
+                a
+                (type)
+                (lam
+                  v
+                  [ AdditiveMonoid a ]
+                  [
+                    [
+                      { CConsMonoid [ (lam a (type) a) a ] }
+                      (lam
+                        eta
+                        [ (lam a (type) a) a ]
+                        (lam
+                          eta
+                          [ (lam a (type) a) a ]
+                          [ [ [ { p1AdditiveMonoid a } v ] eta ] eta ]
+                        )
+                      )
+                    ]
+                    [ { zero a } v ]
+                  ]
+                )
+              )
+            )
+            (termbind
+              (strict)
+              (vardecl
+                sum
+                (all
+                  t
+                  (fun (type) (type))
+                  (all
+                    a
+                    (type)
+                    (fun
+                      [
+                        (lam
+                          t
+                          (fun (type) (type))
+                          (all
+                            m
+                            (type)
+                            (all
+                              a
+                              (type)
+                              (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                            )
+                          )
+                        )
+                        t
+                      ]
+                      (fun [ AdditiveMonoid a ] (fun [ t a ] a))
+                    )
+                  )
+                )
+              )
+              (abs
+                t
+                (fun (type) (type))
+                (abs
+                  a
+                  (type)
+                  (lam
+                    dFoldable
+                    [
+                      (lam
+                        t
+                        (fun (type) (type))
+                        (all
+                          m
+                          (type)
+                          (all
+                            a
+                            (type)
+                            (fun [ Monoid m ] (fun (fun a m) (fun [ t a ] m)))
+                          )
+                        )
+                      )
+                      t
+                    ]
+                    (lam
+                      dAdditiveMonoid
+                      [ AdditiveMonoid a ]
+                      [
+                        [
+                          { { dFoldable [ (lam a (type) a) a ] } a }
+                          [ { fMonoidSum a } dAdditiveMonoid ]
+                        ]
+                        (lam v a v)
+                      ]
+                    )
+                  )
+                )
+              )
+            )
+            [
+              [
+                [ { { sum List } (con integer) } fFoldableNil ]
+                fAdditiveMonoidInteger
+              ]
+              [
+                { build (con integer) }
+                (abs
+                  a
+                  (type)
+                  (lam
+                    c
+                    (fun (con integer) (fun a a))
+                    (lam
+                      n
+                      a
+                      [
+                        [ c (con integer 1) ]
+                        [
+                          [ c (con integer 2) ]
+                          [
+                            [ c (con integer 3) ]
+                            [
+                              [ c (con integer 4) ]
+                              [
+                                [ c (con integer 5) ]
+                                [
+                                  [ c (con integer 6) ]
+                                  [
+                                    [ c (con integer 7) ]
+                                    [
+                                      [ c (con integer 8) ]
+                                      [
+                                        [ c (con integer 9) ]
+                                        [ [ c (con integer 10) ] n ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    )
+                  )
+                )
+              ]
+            ]
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Spec.hs
+++ b/plutus-tx-plugin/test/Spec.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Budget.Spec as Budget
 import qualified IsData.Spec as IsData
 import qualified Lift.Spec   as Lift
 import qualified Plugin.Spec as Plugin
@@ -20,4 +21,5 @@ tests = testGroup "tests" <$> sequence [
   , Lift.tests
   , TH.tests
   , Lib.tests
+  , Budget.tests
   ]


### PR DESCRIPTION
Added a few tests in plutus-tx-plugin which record the budget of a few functions in plutus-tx.

That means that if we were to change the implementation of functions in PlutusTx, then the golden files would change as well and we could verify if the change is positive or not.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
