### PR TITLE
More precise lower bound on semigroups

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -297,7 +297,7 @@ library
         primitive -any,
         recursion-schemes -any,
         semigroupoids -any,
-        semigroups -any,
+        semigroups >=0.19.1,
         serialise -any,
         size-based -any,
         some < 1.0.3,


### PR DESCRIPTION
`GenericSemigroupMonoid` (used in `UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode` and perhaps other modules) was added in `semigroups-0.19.1`, and without this bound `cabal` might construct build plans that use a lower version of `semigroups`, leading to build failures — I'm actually observing this in a project:
```
untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs:70:39: error:
    Not in scope: type constructor or class ‘GenericSemigroupMonoid’
   |
70 |     deriving (Semigroup, Monoid) via (GenericSemigroupMonoid (CekExTally fun))
   |                                       ^^^^^^^^^^^^^^^^^^^^^^

untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs:82:39: error:
    Not in scope: type constructor or class ‘GenericSemigroupMonoid’
   |
82 |     deriving (Semigroup, Monoid) via (GenericSemigroupMonoid (TallyingSt fun))
   |
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
