### PR TITLE
[Builtins] [Refactoring] Move 'ToBinds' into 'KnownTypeAst'

### DIFF
--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -130,8 +130,9 @@ defBuiltinsRuntimeExt = toBuiltinsRuntime (defaultBuiltinCostModel, ())
 
 data PlcListRep (a :: GHC.Type)
 instance KnownTypeAst uni a => KnownTypeAst uni (PlcListRep a) where
+    type ToBinds (PlcListRep a) = ToBinds a
+
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
-type instance ToBinds (PlcListRep a) = ToBinds a
 
 instance KnownTypeAst uni Void where
     toTypeAst _ = runQuote $ do
@@ -140,7 +141,6 @@ instance KnownTypeAst uni Void where
 instance KnownType term Void where
     makeKnown _ = absurd
     readKnown mayCause _ = throwingWithCause _UnliftingError "Can't unlift a 'Void'" mayCause
-type instance ToBinds Void = '[]
 
 data BuiltinErrorCall = BuiltinErrorCall
     deriving (Show, Eq, Exception)


### PR DESCRIPTION
This moves a type family into an existing type class, because there's a very sensible default implementation for that type family. The outcome is that the user now needs to do fewer things when adding a new built-in type (regardless of whether it's polymorphic or monomorphic).