### PR TITLE
Fix duplicate block error

### DIFF
--- a/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
+++ b/plutus-chain-index/src/Plutus/ChainIndex/Types.hs
@@ -127,7 +127,7 @@ instance Monoid Tip where
 instance Ord Tip where
     TipAtGenesis <= _            = True
     _            <= TipAtGenesis = False
-    (Tip ls _ _) <= (Tip rs _ _) = ls <= rs
+    (Tip _ _ lb) <= (Tip _ _ rb) = lb <= rb
 
 instance Pretty Tip where
     pretty TipAtGenesis = "TipAtGenesis"


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

The finger tree implementation for the utxo uses the block number for ordering while the tip uses the slot number. Since the slot number is dependent on the computer clock there were times when the slots were offset by `1` and the comparison that checks for duplicate blocks failed.

I changed the `Tip` ordering to be done on the block number and the issue was fixed (also the one reported on github is fixed).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
