### PR TITLE
WIP: Fix minting policy in tutorial and for state machine thread tokens

### DIFF
--- a/doc/plutus/tutorials/BasicPolicies.hs
+++ b/doc/plutus/tutorials/BasicPolicies.hs
@@ -30,7 +30,29 @@ oneAtATimePolicy _ ctx =
         minted = txInfoMint txinfo
     -- Here we're looking at some specific token name, which we
     -- will assume we've got from elsewhere for now.
-    in valueOf minted ownSymbol tname == 1
+    in case Map.lookup ownSymbol (getValue minted) of
+        Nothing -> n == 0
+        Just tokens -> all
+            (\(tname', n') -> if tname' == tname
+                then n' == n
+                else n' == 0  -- TODO in canonical form there should be no 0 elements in a @Value@, but we don't seem to maintain a canonical form (e.g. see `instance Semigroup Value`)
+            )
+            (Map.toList tokens)
+
+        -- TODO
+        --
+        -- This could probably be simplified to:
+        --
+        --    valueOfCurrency ownSymbol minted == singleton ownSymbol tname 1
+        --
+        -- with this helper function:
+        --
+        --    valueOfCurrency :: CurrencySymbol -> Value -> Value
+        --    valueOfCurrency currencySymbol
+        --      = Map.fromList
+        --      . filter (\(k,_) -> k == currencySymbol)
+        --      . Map.toList
+        --      . getValue
 
 -- We can use 'compile' to turn a minting policy into a compiled Plutus Core program,
 -- just as for validator scripts. We also provide a 'wrapMintingPolicy' function

--- a/doc/plutus/tutorials/basic-minting-policies.rst
+++ b/doc/plutus/tutorials/basic-minting-policies.rst
@@ -31,7 +31,7 @@ This will always be a value of type ``Ledger.Validation.PolicyCtx`` encoded as `
 The minting context is very similar to the :term:`validation context`, and allows access to all the same features of the transaction.
 Minting policies tend to be particularly interested in the ``mint`` field, since the point of a minting policy is to control which tokens are minted.
 
-It is also important for a minting policy to look at the tokens in the ``mint`` field that are part of its own asset group.
+It is also important for a minting policy to look at the tokens in the ``mint`` field that use its own currency symbol i.e. policy hash.
 This requires the policy to refer to its own hash -- fortunately this is provided for us in the minting context.
 
 Here is an example that puts this together to make a simple policy that allows anyone to mint the token so long as they do it one token at a time.

--- a/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
+++ b/plutus-contract/src/Plutus/Contract/StateMachine/ThreadToken.hs
@@ -75,10 +75,30 @@ curPolicy outRef = mkMintingPolicyScript $
 threadTokenValue :: CurrencySymbol -> ValidatorHash -> Value
 threadTokenValue currency (ValidatorHash vHash) = Value.singleton currency (TokenName vHash) 1
 
+-- | Check exactly `n` thread tokens and no other tokens with the given
+-- @CurrencySymbol@ are in the given @Value@.
 {-# INLINABLE checkThreadTokenInner #-}
-checkThreadTokenInner :: CurrencySymbol -> ValidatorHash -> Value -> Integer -> Bool
-checkThreadTokenInner currency (ValidatorHash vHash) vl i =
-    Value.valueOf vl currency (TokenName vHash) == i
+checkThreadTokenInner ::
+    -- | The currency symbol of the thread token.
+    CurrencySymbol ->
+    -- | The hash of the (state machine) validator script using this thread
+    -- token. This is used as the @TokenName@ of the thread token.
+    ValidatorHash ->
+    -- | The value to check.
+    Value ->
+    -- | The expected number of thread tokens in the given value, `n`.
+    Integer ->
+    -- | True if and only if exactly `n` thread tokens (and no other tokens)
+    -- with the given @CurrencySymbol@ are in the given @Value@.
+    Bool
+checkThreadTokenInner currency (ValidatorHash vHash) value n = case Map.lookup ownSymbol (getValue vl) of
+    Nothing -> n == 0
+    Just tokens -> all
+        (\(tokenName, n') -> if tokenName == vHash
+            then n' == n
+            else n' == 0  -- TODO in canonical form there should be no 0 elements in a @Value@, but we don't seem to maintain a canonical form (e.g. see `instance Semigroup Value`)
+        )
+        (Map.toList tokens)
 
 {-# INLINABLE checkThreadToken #-}
 checkThreadToken :: Maybe ThreadToken -> ValidatorHash -> Value -> Integer -> Bool


### PR DESCRIPTION
Rather than open an issue I've started a PR with my proposed solution (untested). This grew out of a question I posed on slack as follows.

=== Question Start ===
the tutorial on minting has an example of a "one at a time" minting policy from some statically known token name `tname`:

```haskell
oneAtATimePolicy :: () -> ScriptContext -> Bool
oneAtATimePolicy _ ctx =
    -- 'ownCurrencySymbol' lets us get our own hash (= currency symbol)
    -- from the context
    let ownSymbol = ownCurrencySymbol ctx
        txinfo = scriptContextTxInfo ctx
        minted = txInfoMint txinfo
    -- Here we're looking at some specific token name, which we
    -- will assume we've got from elsewhere for now.
    in valueOf minted ownSymbol tname == 1
```

This seems odd to me! Doesn't this allow me to mint/burn any number of other tokens as long as they use a token name other than tname and as long as I mint a single token tname ? Surely we really want something like this:

```haskell
oneAtATimePolicy :: () -> ScriptContext -> Bool
oneAtATimePolicy _ ctx =
    ...
    in (getValue minted) Map.! ownSymbol == Map.singleton tname 1
```

Am I understanding correctly?
=== Question End ===

@brunjlar @michaelpj and Jean-Frederic Etienne agreed that this was a bug.