### PR TITLE
Re-enable playground server tests. Make them sequential this time.

### DIFF
--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -220,9 +220,6 @@ let
             platforms = lib.platforms.linux;
           };
 
-          # FIXME: This is failing mysteriouly on Hydra, perhaps with a sercret OOM :(
-          plutus-playyground-server.components.tests.plutus-playground-server-test.doCheck = false;
-
           # Broken due to warnings, unclear why the setting that fixes this for the build doesn't work here.
           iohk-monitoring.doHaddock = false;
 

--- a/plutus-playground-server/plutus-playground-server.cabal
+++ b/plutus-playground-server/plutus-playground-server.cabal
@@ -224,7 +224,10 @@ test-suite plutus-playground-server-test
         Playground.InterpreterSpec
         Playground.UsecasesSpec
     default-language: Haskell2010
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat
+    -- We don't want "-threaded" and friends here as there are many tests with heavy GHC compilation.
+    -- This is a hack as one can fine-tune test cases better (like sequential tests) with in-code tasty dependencies.
+    -- See #4085.
+    ghc-options: -Wall -Wcompat
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wno-missing-import-lists -Wredundant-constraints
                  -fprint-potential-instances


### PR DESCRIPTION
This quick hack handles the problem raised in #4085 (multiple heavy `runghc` instances run at the same time as the default behavior of `tasty`). A more appropriate solution is to define sequential tests through in-code `tasty` dependencies.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
