### PR TITLE
SCP-2911 - Notes in docs about seeing testing output

### DIFF
--- a/plutus-playground-server/README.md
+++ b/plutus-playground-server/README.md
@@ -23,3 +23,9 @@ Tests should be run with nix:
 ```sh
 nix build -L -f default.nix plutus.haskell.packages.plutus-playground-server.checks
 ```
+
+You can then see the test output by looking in `result/test-stdout`:
+
+```sh
+cat result/test-stdout
+```

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -85,6 +85,8 @@ mkSimulatorWallet simulatorWalletWallet simulatorWalletBalance =
 
 --  Unfortunately it's currently not possible to get these tests to work outside of a nix build.
 --  Running `cabal test` will yield a lot of import errors because of missing modules.
+--
+--  See the README.md for details on how to run the tests with nix.
 runningInNixBuildTest :: TestTree
 runningInNixBuildTest =
     testGroup


### PR DESCRIPTION
The tests were just fixed by https://github.com/input-output-hk/plutus/pull/4121; but this adds a clarifying note to explain how to see the test output after running via nix, because it wasn't immediately obvious to me.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested