### PR TITLE
Make `traceToStacks` show some help when there is no input

### DIFF
--- a/plutus-core/executables/traceToStacks/Main.hs
+++ b/plutus-core/executables/traceToStacks/Main.hs
@@ -12,7 +12,7 @@ Workflow for profiling evaluation time:
 or by using the Plutus Tx plugin option 'dump-plc' if you have a self-contained program.
 3. Run the dumped program with 'uplc --trace-mode LogsWithTimestamps -o logs'
 4. Run 'cat logs | traceToStacks | flamegraph.pl > out.svg'
-5. Open out.svg in your viewer of choiece e.g. firefox.
+5. Open out.svg in your viewer of choice e.g. firefox.
 
 You can also profile the abstract memory and budget units.
 To do so, run 'uplc' with '--trace-mode LogsWithBudgets'.
@@ -120,7 +120,7 @@ getStacks = go []
       error "go: tried to exit but couldn't."
     go [] [] = []
     go stacks [] = error $
-      "go: stack " <> show stacks <> " isn't empty but the log is."
+      "getStacks; go: stack " <> show stacks <> " isn't empty but the log is."
 
 column :: Parser Int
 column = option auto
@@ -153,7 +153,7 @@ opts = info ((Opts <$> input <*> column) <**> helper)
 
 main :: IO ()
 main = do
-  Opts inp valIx <- execParser opts
+  Opts inp valIx <- customExecParser (prefs showHelpOnEmpty) opts
   input <- case inp of
       FileInput fp -> BSL.readFile fp
       StdInput     -> BSL.getContents


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Before adding some unit tests for the pure functions, I wanted to follow the profiling workflow and improve the user experience. I noticed that when I run `cabal run traceToStacks`, it hangs. This PR is to fix that with the `showHelpOnEmpty` preference setting (like in our other executables). But currently it's still hanging. I've tried using `showHelpOnError` as well but it still hangs. Advice appreciated.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
