### PR TITLE
Shot in the dark attempt to fix benchmarking.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
     "nixpkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1628785280,
-        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
+        "lastModified": 1635394657,
+        "narHash": "sha256-kjiVquP0Z1f7JmYbKU5CbvO689GNg8066AwgqP1H13k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
+        "rev": "8652402ac5bc4dff28ac2b9cb37de6d621c9a706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumping nixpkgs to 2457ddc9522b0861649ee5e952fa2e505c1743b7 broke it, while I bisect that may as well get hydra going...