### PR TITLE
[Builtin] Introduce 'AssociateType' in 'KnownTypeIn'

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -93,7 +93,7 @@ nopCostParameters = toMachineParameters $ CostModel defaultCekMachineCosts nopCo
    arguments.  We have checked this and there there was no dependence: let's
    leave open the possibility of doing it again in case anything changes.
 -}
-instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFuns where
+instance KnownBuiltinTypeIn uni Integer => ToBuiltinMeaning uni NopFuns where
     type CostingPart uni NopFuns = NopCostModel
     toBuiltinMeaning
         :: HasConstantIn uni term

--- a/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE TypeOperators             #-}
 
 module PlutusCore.Generators.Internal.Denotation
@@ -100,7 +101,7 @@ insertBuiltin
 insertBuiltin fun =
     case toBuiltinMeaning fun of
         BuiltinMeaning sch meta _ ->
-           case typeSchemeResult sch of
+           case typeSchemeResult @(Term TyName Name DefaultUni DefaultFun ()) sch of
                AsKnownType ->
                    insertDenotation $ Denotation fun (Builtin ()) meta sch
 

--- a/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
@@ -112,7 +112,7 @@ revealUnique (Name name uniq) =
 -- TODO: we can generate more types here.
 -- | Generate a 'Builtin' and supply its typed version to a continuation.
 withTypedBuiltinGen
-    :: (uni ~ DefaultUni, HasConstantIn uni term, Monad m)
+    :: forall term m c uni. (uni ~ DefaultUni, HasConstantIn uni term, Monad m)
     => (forall a. AsKnownType term a -> GenT m c) -> GenT m c
 withTypedBuiltinGen k = Gen.choice
     [ k @Integer       AsKnownType
@@ -123,14 +123,14 @@ withTypedBuiltinGen k = Gen.choice
 -- | Generate a 'Term' along with the value it computes to,
 -- having a generator of terms of built-in types.
 withCheckedTermGen
-    :: (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
+    :: forall m c uni fun. (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
     => TypedBuiltinGenT (Plain Term uni fun) m
     -> (forall a. AsKnownType (Plain Term uni fun) a ->
             TermOf (Plain Term uni fun) (EvaluationResult (Plain Term uni fun)) ->
                 GenT m c)
     -> GenT m c
 withCheckedTermGen genTb k =
-    withTypedBuiltinGen $ \akt@AsKnownType -> do
+    withTypedBuiltinGen @(Plain Term uni fun) $ \akt@AsKnownType -> do
         termWithMetaValue <- genTb akt
         let termWithResult = unsafeTypeEvalCheck termWithMetaValue
         k akt termWithResult
@@ -210,7 +210,7 @@ genTerm genBase context0 depth0 = Morph.hoist runQuoteT . go context0 depth0 whe
             -- A list of recursive generators.
             recursive = map proceed $ lookupInContext akt
             -- Generate a lambda and immediately apply it to a generated argument of a generated type.
-            lambdaApply = withTypedBuiltinGen $ \argKt@AsKnownType -> do
+            lambdaApply = withTypedBuiltinGen @(Plain Term uni fun) $ \argKt@AsKnownType -> do
                 -- Generate a name for the name representing the argument.
                 name <- lift $ revealUnique <$> freshName "x"
                 -- Get the 'Type' of the argument from a generated 'TypedBuiltin'.
@@ -231,7 +231,8 @@ genTermLoose = genTerm genTypedBuiltinDef typedBuiltins 4
 -- | Generate a 'TypedBuiltin' and a 'TermOf' of the corresponding type,
 -- attach the 'TypedBuiltin' to the value part of the 'TermOf' and pass that to a continuation.
 withAnyTermLoose
-     :: (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
+     :: forall m c uni fun. (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
      => (forall a. KnownType (Plain Term uni fun) a => TermOf (Plain Term uni fun) a -> GenT m c)
      -> GenT m c
-withAnyTermLoose k = withTypedBuiltinGen $ \akt@AsKnownType -> genTermLoose akt >>= k
+withAnyTermLoose k =
+  withTypedBuiltinGen @(Plain Term uni fun) $ \akt@AsKnownType -> genTermLoose akt >>= k

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -137,11 +137,17 @@ instance KnownTypeAst uni a => KnownTypeAst uni (PlcListRep a) where
 
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
 
+class    Ignore a
+instance Ignore a
+
 instance KnownTypeAst DefaultUni Void where
     toTypeAst _ = runQuote $ do
         a <- freshTyName "a"
         pure $ TyForall () a (Type ()) $ TyVar () a
-instance UniOf term ~ DefaultUni => KnownTypeIn DefaultUni term Void where
+instance KnownTypeIn DefaultUni Void where
+    -- Values of type @Void@ (none of them) are not embedded as constants and so we don't need to
+    -- require anything from @term@.
+    type AssociateTerm DefaultUni Void = Ignore
     makeKnown _ = absurd
     readKnown mayCause _ = throwingWithCause _UnliftingError "Can't unlift a 'Void'" mayCause
 

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Debug.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Debug.hs
@@ -46,8 +46,9 @@ enumerateDebug = id
 -- inferDebug False :: Bool
 -- >>> :t inferDebug $ Just 'a'
 -- <interactive>:1:1-21: error:
---     • There's no 'KnownType' instance for Maybe Char
---       Did you add a new built-in type and forget to provide a 'KnownType' instance for it?
+--     • No instance for (KnownPolytype
+--                          (ToBinds (Maybe Char)) TermDebug '[] (Maybe Char) (Maybe Char))
+--         arising from a use of ‘inferDebug’
 --     • In the expression: inferDebug $ Just 'a'
 -- >>> :t inferDebug $ \_ -> ()
 -- inferDebug $ \_ -> ()
@@ -59,7 +60,6 @@ inferDebug
     :: forall a binds args res j.
        ( args ~ GetArgs a, a ~ FoldArgs args res, binds ~ Merge (ListToBinds args) (ToBinds res)
        , KnownPolytype binds TermDebug args res a, EnumerateFromTo 0 j TermDebug a
-       , KnownMonotype TermDebug args res a
        )
     => a -> a
 inferDebug = id

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -187,7 +187,7 @@ class KnownMonotype term args res a | args res -> a, a -> res where
 instance (res ~ res', KnownType term res) => KnownMonotype term '[] res res' where
     knownMonotype = TypeSchemeResult Proxy
 
--- | Every term-level argument becomes as 'TypeSchemeArrow'.
+-- | Every term-level argument becomes a 'TypeSchemeArrow'.
 instance (KnownType term arg, KnownMonotype term args res a) =>
             KnownMonotype term (arg ': args) res (arg -> a) where
     knownMonotype = Proxy `TypeSchemeArrow` knownMonotype
@@ -332,12 +332,6 @@ makeBuiltinMeaning
     :: forall a term cost binds args res j.
        ( args ~ GetArgs a, a ~ FoldArgs args res, binds ~ Merge (ListToBinds args) (ToBinds res)
        , KnownPolytype binds term args res a, EnumerateFromTo 0 j term a
-       -- This constraint is just to get through 'KnownPolytype' stuck on an unknown type straight
-       -- to the custom type error that we have in the @Typed@ module. Though, somehow, the error
-       -- gets triggered even without the constraint when this function in used, but I don't
-       -- understand how that is possible and it does not work when the function from the @Debug@
-       -- module is used. So we're just doing the right thing here and adding the constraint.
-       , KnownMonotype term args res a
        )
     => a -> (cost -> FoldArgsEx args) -> BuiltinMeaning term cost
 makeBuiltinMeaning = BuiltinMeaning (knownPolytype (Proxy @binds) :: TypeScheme term args res)

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -180,14 +180,14 @@ instance KnownBuiltinTypeAst DefaultUni [a]           => KnownTypeAst DefaultUni
 instance KnownBuiltinTypeAst DefaultUni (a, b)        => KnownTypeAst DefaultUni (a, b)
 instance KnownBuiltinTypeAst DefaultUni Data          => KnownTypeAst DefaultUni Data
 
-instance KnownBuiltinTypeIn DefaultUni term Integer       => KnownTypeIn DefaultUni term Integer
-instance KnownBuiltinTypeIn DefaultUni term BS.ByteString => KnownTypeIn DefaultUni term BS.ByteString
-instance KnownBuiltinTypeIn DefaultUni term Text.Text     => KnownTypeIn DefaultUni term Text.Text
-instance KnownBuiltinTypeIn DefaultUni term ()            => KnownTypeIn DefaultUni term ()
-instance KnownBuiltinTypeIn DefaultUni term Bool          => KnownTypeIn DefaultUni term Bool
-instance KnownBuiltinTypeIn DefaultUni term [a]           => KnownTypeIn DefaultUni term [a]
-instance KnownBuiltinTypeIn DefaultUni term (a, b)        => KnownTypeIn DefaultUni term (a, b)
-instance KnownBuiltinTypeIn DefaultUni term Data          => KnownTypeIn DefaultUni term Data
+instance KnownBuiltinTypeAst DefaultUni Integer       => KnownTypeIn DefaultUni Integer
+instance KnownBuiltinTypeAst DefaultUni BS.ByteString => KnownTypeIn DefaultUni BS.ByteString
+instance KnownBuiltinTypeAst DefaultUni Text.Text     => KnownTypeIn DefaultUni Text.Text
+instance KnownBuiltinTypeAst DefaultUni ()            => KnownTypeIn DefaultUni ()
+instance KnownBuiltinTypeAst DefaultUni Bool          => KnownTypeIn DefaultUni Bool
+instance KnownBuiltinTypeAst DefaultUni [a]           => KnownTypeIn DefaultUni [a]
+instance KnownBuiltinTypeAst DefaultUni (a, b)        => KnownTypeIn DefaultUni (a, b)
+instance KnownBuiltinTypeAst DefaultUni Data          => KnownTypeIn DefaultUni Data
 
 -- If this tells you a 'KnownTypeIn' instance is missing, add it right above, following the pattern
 -- (you'll also need to add a 'KnownTypeAst' instance as well).
@@ -195,7 +195,7 @@ instance TestTypesFromTheUniverseAreAllKnown DefaultUni
 
 {- Note [Int as Integer]
 We represent 'Int' as 'Integer' in PLC and check that an 'Integer' fits into 'Int' when
-unlifting constants fo type 'Int' and fail with an evaluation failure (via 'AsEvaluationFailure')
+unlifting constants of type 'Int' and fail with an evaluation failure (via 'AsEvaluationFailure')
 if it doesn't. We couldn't fail via 'AsUnliftingError', because an out-of-bounds error is not an
 internal one -- it's a normal evaluation failure, but unlifting errors have this connotation of
 being "internal".
@@ -205,7 +205,7 @@ instance KnownTypeAst DefaultUni Int where
     toTypeAst _ = toTypeAst $ Proxy @Integer
 
 -- See Note [Int as Integer].
-instance HasConstantIn DefaultUni term => KnownTypeIn DefaultUni term Int where
+instance KnownTypeIn DefaultUni Int where
     makeKnown mayCause = makeKnown mayCause . toInteger
     readKnown mayCause term = do
         i :: Integer <- readKnown mayCause term


### PR DESCRIPTION
This drops the `term` argument from `KnownTypeIn` allowing us to
express more and require less. See the comments.
 
`KnownType term a` is recovered and user code is not affected
apart from `KnownTypeIn DefaultUni` instances being simpler and
some old testing code (that was already behaving weirdly) requiring
a few explicit type applications.
