### PR TITLE
[Typo] Fix a typo in a comment in 'prettyprinter-configurable'

### DIFF
--- a/prettyprinter-configurable/src/Text/Fixity/Internal.hs
+++ b/prettyprinter-configurable/src/Text/Fixity/Internal.hs
@@ -108,7 +108,7 @@ Parsing Mixfix Operators paper)
 
 4. Our system
 
-We allow unary operators to have associativity. It makes sense to render @-(-x)@ as @--x@ and it
+We allow unary operators to have associativity. It makes sense to render @-(-x)@ as @-(-x)@ and it
 makes sense to render @~(~x)@ as @~~x@ (where @~@is boolean NOT). It really should be configurable
 and associativity is one way to configure how unary operators get pretty-printed. See docs of
 'FixityOver' for details.


### PR DESCRIPTION
A stupid typo. I checked, the code does the right thing and there's a [correct](https://github.com/input-output-hk/plutus/blob/78ebc12905a86df1f43b3f19a339d6d7dbc448b8/prettyprinter-configurable/src/Text/Fixity/Internal.hs#L217-L219) comment as well.