### PR TITLE
Short circuit ops for booleans (over QQ)

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."haskell-src-meta" or (errorHandler.buildDepError "haskell-src-meta"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
@@ -64,6 +65,7 @@
           "PlutusTx/Applicative"
           "PlutusTx/Base"
           "PlutusTx/Bool"
+          "PlutusTx/Bool/TH"
           "PlutusTx/IsData"
           "PlutusTx/IsData/Class"
           "PlutusTx/ErrorCodes"

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -121,6 +121,7 @@
         "QuickCheck".flags.old-random = false;
         "QuickCheck".flags.templatehaskell = true;
         "uuid-types".revision = (((hackage."uuid-types")."1.0.5").revisions).default;
+        "haskell-src-meta".revision = (((hackage."haskell-src-meta")."0.8.7").revisions).default;
         "scientific".revision = (((hackage."scientific")."0.3.7.0").revisions).default;
         "scientific".flags.integer-simple = false;
         "scientific".flags.bytestring-builder = false;
@@ -256,6 +257,7 @@
         "tagged".flags.transformers = true;
         "barbies".revision = (((hackage."barbies")."2.0.3.0").revisions).default;
         "quiet".revision = (((hackage."quiet")."0.2").revisions).default;
+        "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
         "quickcheck-instances".revision = (((hackage."quickcheck-instances")."0.3.25.2").revisions).default;
         "quickcheck-instances".flags.bytestring-builder = false;
         "criterion-measurement".revision = (((hackage."criterion-measurement")."0.1.3.0").revisions).default;
@@ -550,6 +552,7 @@
           "quickcheck-instances".components.library.planned = lib.mkOverride 900 true;
           "barbies".components.library.planned = lib.mkOverride 900 true;
           "quiet".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-exts".components.library.planned = lib.mkOverride 900 true;
           "tagged".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "ghc".components.library.planned = lib.mkOverride 900 true;
@@ -663,6 +666,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "hspec-discover".components.library.planned = lib.mkOverride 900 true;
           "orphans-deriving-via".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."haskell-src-meta" or (errorHandler.buildDepError "haskell-src-meta"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
@@ -64,6 +65,7 @@
           "PlutusTx/Applicative"
           "PlutusTx/Base"
           "PlutusTx/Bool"
+          "PlutusTx/Bool/TH"
           "PlutusTx/IsData"
           "PlutusTx/IsData/Class"
           "PlutusTx/ErrorCodes"

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -121,6 +121,7 @@
         "QuickCheck".flags.old-random = false;
         "QuickCheck".flags.templatehaskell = true;
         "uuid-types".revision = (((hackage."uuid-types")."1.0.5").revisions).default;
+        "haskell-src-meta".revision = (((hackage."haskell-src-meta")."0.8.7").revisions).default;
         "scientific".revision = (((hackage."scientific")."0.3.7.0").revisions).default;
         "scientific".flags.integer-simple = false;
         "scientific".flags.bytestring-builder = false;
@@ -256,6 +257,7 @@
         "tagged".flags.transformers = true;
         "barbies".revision = (((hackage."barbies")."2.0.3.0").revisions).default;
         "quiet".revision = (((hackage."quiet")."0.2").revisions).default;
+        "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
         "quickcheck-instances".revision = (((hackage."quickcheck-instances")."0.3.25.2").revisions).default;
         "quickcheck-instances".flags.bytestring-builder = false;
         "criterion-measurement".revision = (((hackage."criterion-measurement")."0.1.3.0").revisions).default;
@@ -550,6 +552,7 @@
           "quickcheck-instances".components.library.planned = lib.mkOverride 900 true;
           "barbies".components.library.planned = lib.mkOverride 900 true;
           "quiet".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-exts".components.library.planned = lib.mkOverride 900 true;
           "tagged".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "ghc".components.library.planned = lib.mkOverride 900 true;
@@ -663,6 +666,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "hspec-discover".components.library.planned = lib.mkOverride 900 true;
           "orphans-deriving-via".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."haskell-src-meta" or (errorHandler.buildDepError "haskell-src-meta"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
@@ -64,6 +65,7 @@
           "PlutusTx/Applicative"
           "PlutusTx/Base"
           "PlutusTx/Bool"
+          "PlutusTx/Bool/TH"
           "PlutusTx/IsData"
           "PlutusTx/IsData/Class"
           "PlutusTx/ErrorCodes"

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -120,6 +120,7 @@
         "QuickCheck".flags.old-random = false;
         "QuickCheck".flags.templatehaskell = true;
         "uuid-types".revision = (((hackage."uuid-types")."1.0.5").revisions).default;
+        "haskell-src-meta".revision = (((hackage."haskell-src-meta")."0.8.7").revisions).default;
         "scientific".revision = (((hackage."scientific")."0.3.7.0").revisions).default;
         "scientific".flags.integer-simple = false;
         "scientific".flags.bytestring-builder = false;
@@ -249,6 +250,7 @@
         "barbies".revision = (((hackage."barbies")."2.0.3.0").revisions).default;
         "quiet".revision = (((hackage."quiet")."0.2").revisions).default;
         "regex-posix-clib".revision = (((hackage."regex-posix-clib")."2.7").revisions).default;
+        "haskell-src-exts".revision = (((hackage."haskell-src-exts")."1.23.1").revisions).default;
         "quickcheck-instances".revision = (((hackage."quickcheck-instances")."0.3.25.2").revisions).default;
         "quickcheck-instances".flags.bytestring-builder = false;
         "criterion-measurement".revision = (((hackage."criterion-measurement")."0.1.3.0").revisions).default;
@@ -540,6 +542,7 @@
           "barbies".components.library.planned = lib.mkOverride 900 true;
           "quiet".components.library.planned = lib.mkOverride 900 true;
           "regex-posix-clib".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-exts".components.library.planned = lib.mkOverride 900 true;
           "tagged".components.library.planned = lib.mkOverride 900 true;
           "some".components.library.planned = lib.mkOverride 900 true;
           "newtype".components.library.planned = lib.mkOverride 900 true;
@@ -647,6 +650,7 @@
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "hspec-discover".components.library.planned = lib.mkOverride 900 true;
           "orphans-deriving-via".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -43,6 +43,7 @@ library
         PlutusTx.Applicative
         PlutusTx.Base
         PlutusTx.Bool
+        PlutusTx.Bool.TH
         PlutusTx.IsData
         PlutusTx.IsData.Class
         PlutusTx.ErrorCodes
@@ -82,6 +83,7 @@ library
         base >=4.9 && <5,
         bytestring -any,
         deepseq -any,
+        haskell-src-meta -any,
         template-haskell >=2.13.0.0,
         th-abstraction -any,
         prettyprinter -any,

--- a/plutus-tx/src/PlutusTx/Bool/TH.hs
+++ b/plutus-tx/src/PlutusTx/Bool/TH.hs
@@ -1,0 +1,66 @@
+-- | TH operators for booleans that implement short-circuit as quasi-quoter expressions.
+module PlutusTx.Bool.TH(
+  and_if,
+  or_if
+) where
+
+import Prelude
+
+import Language.Haskell.Meta.Parse qualified as P
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+-- | QQ for list of @and@-expressions written with if-then-else.
+-- It implements short circuit.
+--
+-- > [and_if| expr1, expr2, expr3, ... |]
+--
+-- where @exprN@ is valid haskell expression. It is expanded to:
+--
+-- > if expr1
+-- >   then if expr2
+-- >     then if expr3
+-- >       then True
+-- >       else False
+-- >     else False
+-- >   else False
+and_if :: QuasiQuoter
+and_if = listExpr "and_if" $ foldr (\e res -> CondE e res false) true
+
+-- | QQ for list of @or@-expressions written with if-then-else.
+-- It implements short circuit.
+--
+-- > [or_if| expr1, expr2, expr3, ... |]
+--
+-- where @exprN@ is valid haskell expression. It is expanded to:
+--
+-- > if expr1
+-- >   then True
+-- >   else if expr2
+-- >     then True
+-- >     else if expr3
+-- >       then True
+-- >       else False
+or_if :: QuasiQuoter
+or_if = listExpr "or_if" $ foldr (\e res -> CondE e true res) false
+
+listExpr :: String -> ([Exp] -> Exp) -> QuasiQuoter
+listExpr name f = qqExprExp $ \s -> do
+  case P.parseExp $ mconcat ["[", s, "]"] of
+    Right (ListE args) -> pure $ f args
+    _                  -> fail $ mconcat [ "Not a list of comma separated ", name
+                                        , "-expressions, failed to parse. "
+                                        , "Use [|", name, "| expr1, expr2, expr3 |]"]
+
+qqExprExp :: (String -> Q Exp) -> QuasiQuoter
+qqExprExp f = QuasiQuoter
+  { quoteExp = f
+  , quotePat = undefined
+  , quoteDec = undefined
+  , quoteType = undefined
+  }
+
+true, false :: Exp
+true = ConE $ mkName "True"
+false = ConE $ mkName "False"
+

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -38,6 +38,7 @@ module PlutusTx.Prelude (
     check,
     -- * Booleans
     module Bool,
+    module BoolTH,
     -- * Integer numbers
     Integer,
     divide,
@@ -84,6 +85,7 @@ import PlutusCore.Data (Data (..))
 import PlutusTx.Applicative as Applicative
 import PlutusTx.Base as Base
 import PlutusTx.Bool as Bool
+import PlutusTx.Bool.TH as BoolTH
 import PlutusTx.Builtins (BuiltinByteString, BuiltinData, BuiltinString, Integer, appendByteString, appendString,
                           consByteString, decodeUtf8, emptyByteString, emptyString, encodeUtf8, equalsByteString,
                           equalsString, error, fromBuiltin, greaterThanByteString, indexByteString, lengthOfByteString,

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE TypeApplications  #-}
 module Main(main) where
 
@@ -14,6 +15,7 @@ import Hedgehog (MonadGen, Property, PropertyT, annotateShow, assert, forAll, pr
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import PlutusCore.Data (Data (..))
+import PlutusTx.Bool.TH (and_if, or_if)
 import PlutusTx.List (nub, nubBy)
 import PlutusTx.Numeric (negate)
 import PlutusTx.Prelude (dropByteString, takeByteString)
@@ -34,6 +36,7 @@ tests = testGroup "plutus-tx" [
     , ratioTests
     , bytestringTests
     , listTests
+    , thBoolTests
     ]
 
 sqrtTests :: TestTree
@@ -258,4 +261,26 @@ nubTests = testGroup "nub"
   , testCase "[2, 1, 1] == [2, 1]" $ nub [2 :: Integer, 1, 1] @?= [2, 1]
   , testCase "[1, 1, 1] == [1]" $ nub [1 :: Integer, 1, 1] @?= [1]
   , testCase "[1, 2, 3, 4, 5] == [1, 2, 3, 4, 5]" $ nub [1 :: Integer, 2, 3, 4, 5] @?= [1, 2, 3, 4, 5]
+  ]
+
+thBoolTests :: TestTree
+thBoolTests = testGroup "TH bool"
+  [ andIfTests
+  , orIfTests
+  ]
+
+andIfTests :: TestTree
+andIfTests = testGroup "and_if"
+  [ testCase "[and_if| |] == True" $ [and_if| |] @?= True
+  , testCase "[and_if| True, True |] == True" $ [and_if| True, True |] @?= True
+  , testCase "[and_if| True, False |] == False" $ [and_if| True, False |] @?= False
+  , testCase "lazy: [and_if| False, error \"\"|] == False" $ [and_if| False, error "" |] @?= False
+  ]
+
+orIfTests :: TestTree
+orIfTests = testGroup "or_if"
+  [ testCase "[or_if| |] == False" $ [or_if|  |] @?= False
+  , testCase "[or_if| True, False |] == True" $ [or_if| True, False |] @?= True
+  , testCase "[or_if| False, False |] == True" $ [or_if| False, False |] @?= False
+  , testCase "lazy: [or_if| True, error \"\"|] == True" $ [or_if| True, error "" |] @?= True
   ]


### PR DESCRIPTION
Fixes #4114

The problem is that plutus booleans don't use short circuit on evaluation.
There is ugly fix to rewrite all expressions with `if-then-else`. 
But code becomes rather clumsy. We can fix that with meta TH.

Proposed fix defines two qq-functions `and_if` and `or_if`:

```haskell
[and_if| expr1, expr2, expr3]
```

for arbitrary number of arguments is expanded to 

```haskell
if expr1
  then if expr2
    then if expr3
      then True
      else False
    else False
  else False 
```

and 

```haskell
[or_if| expr1, expr2, expr3]
```

is expanded to

```haskell
if expr1
  then True
  else if expr2
    then True
    else if expr3
      then True
      else False
```