### PR TITLE
Revert "[Builtin] Introduce 'AssociateType' in 'KnownTypeIn'"

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -93,7 +93,7 @@ nopCostParameters = toMachineParameters $ CostModel defaultCekMachineCosts nopCo
    arguments.  We have checked this and there there was no dependence: let's
    leave open the possibility of doing it again in case anything changes.
 -}
-instance KnownBuiltinTypeIn uni Integer => ToBuiltinMeaning uni NopFuns where
+instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFuns where
     type CostingPart uni NopFuns = NopCostModel
     toBuiltinMeaning
         :: HasConstantIn uni term

--- a/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Denotation.hs
@@ -3,7 +3,6 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE TypeOperators             #-}
 
 module PlutusCore.Generators.Internal.Denotation
@@ -101,7 +100,7 @@ insertBuiltin
 insertBuiltin fun =
     case toBuiltinMeaning fun of
         BuiltinMeaning sch meta _ ->
-           case typeSchemeResult @(Term TyName Name DefaultUni DefaultFun ()) sch of
+           case typeSchemeResult sch of
                AsKnownType ->
                    insertDenotation $ Denotation fun (Builtin ()) meta sch
 

--- a/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
+++ b/plutus-core/generators/PlutusCore/Generators/Internal/Entity.hs
@@ -112,7 +112,7 @@ revealUnique (Name name uniq) =
 -- TODO: we can generate more types here.
 -- | Generate a 'Builtin' and supply its typed version to a continuation.
 withTypedBuiltinGen
-    :: forall term m c uni. (uni ~ DefaultUni, HasConstantIn uni term, Monad m)
+    :: (uni ~ DefaultUni, HasConstantIn uni term, Monad m)
     => (forall a. AsKnownType term a -> GenT m c) -> GenT m c
 withTypedBuiltinGen k = Gen.choice
     [ k @Integer       AsKnownType
@@ -123,14 +123,14 @@ withTypedBuiltinGen k = Gen.choice
 -- | Generate a 'Term' along with the value it computes to,
 -- having a generator of terms of built-in types.
 withCheckedTermGen
-    :: forall m c uni fun. (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
+    :: (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
     => TypedBuiltinGenT (Plain Term uni fun) m
     -> (forall a. AsKnownType (Plain Term uni fun) a ->
             TermOf (Plain Term uni fun) (EvaluationResult (Plain Term uni fun)) ->
                 GenT m c)
     -> GenT m c
 withCheckedTermGen genTb k =
-    withTypedBuiltinGen @(Plain Term uni fun) $ \akt@AsKnownType -> do
+    withTypedBuiltinGen $ \akt@AsKnownType -> do
         termWithMetaValue <- genTb akt
         let termWithResult = unsafeTypeEvalCheck termWithMetaValue
         k akt termWithResult
@@ -210,7 +210,7 @@ genTerm genBase context0 depth0 = Morph.hoist runQuoteT . go context0 depth0 whe
             -- A list of recursive generators.
             recursive = map proceed $ lookupInContext akt
             -- Generate a lambda and immediately apply it to a generated argument of a generated type.
-            lambdaApply = withTypedBuiltinGen @(Plain Term uni fun) $ \argKt@AsKnownType -> do
+            lambdaApply = withTypedBuiltinGen $ \argKt@AsKnownType -> do
                 -- Generate a name for the name representing the argument.
                 name <- lift $ revealUnique <$> freshName "x"
                 -- Get the 'Type' of the argument from a generated 'TypedBuiltin'.
@@ -231,8 +231,7 @@ genTermLoose = genTerm genTypedBuiltinDef typedBuiltins 4
 -- | Generate a 'TypedBuiltin' and a 'TermOf' of the corresponding type,
 -- attach the 'TypedBuiltin' to the value part of the 'TermOf' and pass that to a continuation.
 withAnyTermLoose
-     :: forall m c uni fun. (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
+     :: (uni ~ DefaultUni, fun ~ DefaultFun, Monad m)
      => (forall a. KnownType (Plain Term uni fun) a => TermOf (Plain Term uni fun) a -> GenT m c)
      -> GenT m c
-withAnyTermLoose k =
-  withTypedBuiltinGen @(Plain Term uni fun) $ \akt@AsKnownType -> genTermLoose akt >>= k
+withAnyTermLoose k = withTypedBuiltinGen $ \akt@AsKnownType -> genTermLoose akt >>= k

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -137,17 +137,11 @@ instance KnownTypeAst uni a => KnownTypeAst uni (PlcListRep a) where
 
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
 
-class    Ignore a
-instance Ignore a
-
 instance KnownTypeAst DefaultUni Void where
     toTypeAst _ = runQuote $ do
         a <- freshTyName "a"
         pure $ TyForall () a (Type ()) $ TyVar () a
-instance KnownTypeIn DefaultUni Void where
-    -- Values of type @Void@ (none of them) are not embedded as constants and so we don't need to
-    -- require anything from @term@.
-    type AssociateTerm DefaultUni Void = Ignore
+instance UniOf term ~ DefaultUni => KnownTypeIn DefaultUni term Void where
     makeKnown _ = absurd
     readKnown mayCause _ = throwingWithCause _UnliftingError "Can't unlift a 'Void'" mayCause
 

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Debug.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Debug.hs
@@ -46,9 +46,8 @@ enumerateDebug = id
 -- inferDebug False :: Bool
 -- >>> :t inferDebug $ Just 'a'
 -- <interactive>:1:1-21: error:
---     • No instance for (KnownPolytype
---                          (ToBinds (Maybe Char)) TermDebug '[] (Maybe Char) (Maybe Char))
---         arising from a use of ‘inferDebug’
+--     • There's no 'KnownType' instance for Maybe Char
+--       Did you add a new built-in type and forget to provide a 'KnownType' instance for it?
 --     • In the expression: inferDebug $ Just 'a'
 -- >>> :t inferDebug $ \_ -> ()
 -- inferDebug $ \_ -> ()
@@ -60,6 +59,7 @@ inferDebug
     :: forall a binds args res j.
        ( args ~ GetArgs a, a ~ FoldArgs args res, binds ~ Merge (ListToBinds args) (ToBinds res)
        , KnownPolytype binds TermDebug args res a, EnumerateFromTo 0 j TermDebug a
+       , KnownMonotype TermDebug args res a
        )
     => a -> a
 inferDebug = id

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Typed.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Typed.hs
@@ -40,9 +40,9 @@ module PlutusCore.Constant.Typed
     , KnownTypeAst (..)
     , Merge
     , ListToBinds
-    , AssociateBuiltinType
-    , KnownTypeIn (..)
     , KnownBuiltinTypeIn
+    , KnownBuiltinType
+    , KnownTypeIn (..)
     , KnownType
     , TestTypesFromTheUniverseAreAllKnown
     , readKnownSelf
@@ -451,10 +451,8 @@ instance FromConstant (Term tyname name uni fun ()) where
 type HasConstant term = (AsConstant term, FromConstant term)
 
 -- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from
--- and connects @term@ and its @uni@. A class synonym so that it can be used when defining
--- 'AssociateTerm' for built-in types.
-class    (UniOf term ~ uni, HasConstant term) => HasConstantIn uni term
-instance (UniOf term ~ uni, HasConstant term) => HasConstantIn uni term
+-- and connects @term@ and its @uni@.
+type HasConstantIn uni term = (UniOf term ~ uni, HasConstant term)
 
 -- | A constraint for \"@a@ is a 'KnownTypeAst' by means of being included in @uni@\".
 -- We add such a trivial type synonym to make instances of 'KnownTypeAst' for built-in types look
@@ -471,7 +469,9 @@ instance (UniOf term ~ uni, HasConstant term) => HasConstantIn uni term
 --
 -- We could omit the constraint in both the cases due to `Integer` being monomorphic, but for
 -- polymorphic built-in types we do need it and so we keep things uniform by introducing this
--- type synonym.
+-- type synonym. Which also allows us to replicate the same pattern as with 'KnownTypeIn':
+--
+-- > instance KnownBuiltinTypeIn DefaultUni term Integer => KnownTypeIn DefaultUni term Integer
 type KnownBuiltinTypeAst = Contains
 
 class KnownTypeAst uni (a :: k) where
@@ -510,10 +510,16 @@ type family ListToBinds (x :: [a]) :: [GADT.Some TyNameRep]
 type instance ListToBinds '[]       = '[]
 type instance ListToBinds (x ': xs) = Merge (ToBinds x) (ListToBinds xs)
 
--- | Constraints required for a type @a@ to be liftable to or unliftable from @term@ by means
--- of being included in its universe.
-type AssociateBuiltinType uni a term =
-    (HasConstantIn uni term, GShow uni, GEq uni, uni `Contains` a)
+-- We need to be able to partially apply that in the definition of 'ImplementedKnownBuiltinTypeIn',
+-- hence defining it as a class synonym.
+-- | A constraint for \"@a@ is a 'KnownType' by means of being included in @uni@\".
+class    (HasConstantIn uni term, GShow uni, GEq uni, uni `Contains` a) =>
+            KnownBuiltinTypeIn uni term a
+instance (HasConstantIn uni term, GShow uni, GEq uni, uni `Contains` a) =>
+            KnownBuiltinTypeIn uni term a
+
+-- | A constraint for \"@a@ is a 'KnownType' by means of being included in @UniOf term@\".
+type KnownBuiltinType term a = KnownBuiltinTypeIn (UniOf term) term a
 
 -- We use @default@ for providing instances for built-in types instead of @DerivingVia@, because
 -- the latter breaks on @m a@ (and for brevity).
@@ -524,39 +530,16 @@ type AssociateBuiltinType uni a term =
 -- as a term). Note that an evaluator might require the cause to be computed lazily for best
 -- performance on the happy path and @Maybe@ ensures that even if we somehow force the argument,
 -- the cause stored in it is not forced due to @Maybe@ being a lazy data type.
-class KnownTypeAst uni a => KnownTypeIn uni a where
-    -- | Associate a universe @uni@ and a type @a@ with @term@, to which values of type @a@ will be
-    -- lifted (and unlifted). For built-in types we only need to require @term@ to have a
-    -- @Constant@-like constructor (all other requirements do not mention @term@, see
-    -- 'AssociateBuiltinType').
-    --
-    -- We need to establish a connection between @a@ and @term@ in order to support polymorphism.
-    -- @a@ can be @Opaque term' rep@ and for lifting or unlifting that we need @term'@ to be equal
-    -- to @term@.
-    --
-    -- Instead of constraining @term@ via a type family we could simply pull it out as an argument
-    -- to 'KnownTypeIn'. This is what we originally had, however it was inconvenient and had the
-    -- wrong semantics: it does not make sense to decide whether a type is known based on @term@
-    -- (e.g. it'd be pretty nonsensical to allowing embedding 'Integer' into a Plutus Core term and
-    -- disallow that for Plutus IR). And the instances for built-in types had to mention that
-    -- irrelevant @term@, for which we also had to provide a separate constraint, while with
-    -- 'AssociateTerm' it's possible to get away with 'KnownBuiltinTypeAst' for both 'KnownTypeAst'
-    -- and 'KnownTypeIn'. Plus, not having @term@ as an argument to 'KnownTypeIn' allows us to
-    -- introduce a 'KnownBuiltinTypeIn' constraint in case we want to specify which built-in types a
-    -- universe supplied to a function is expected to have without hardcoding a particular universe.
-    type AssociateTerm uni a :: GHC.Type -> Constraint
-    type AssociateTerm uni a = HasConstantIn uni
-
+class (uni ~ UniOf term, KnownTypeAst uni a) => KnownTypeIn uni term a where
     -- | Convert a Haskell value to the corresponding PLC term.
     -- The inverse of 'readKnown'.
     makeKnown
         :: ( MonadEmitter m, MonadError (ErrorWithCause err cause) m, AsEvaluationFailure err
-           , uni ~ UniOf term, AssociateTerm uni a term
            )
         => Maybe cause -> a -> m term
     default makeKnown
         :: ( MonadError (ErrorWithCause err cause) m
-           , AssociateBuiltinType uni a term
+           , KnownBuiltinType term a
            )
         => Maybe cause -> a -> m term
     -- Forcing the value to avoid space leaks. Note that the value is only forced to WHNF,
@@ -568,12 +551,11 @@ class KnownTypeAst uni a => KnownTypeIn uni a where
     -- The inverse of 'makeKnown'.
     readKnown
         :: ( MonadError (ErrorWithCause err cause) m, AsUnliftingError err, AsEvaluationFailure err
-           , uni ~ UniOf term, AssociateTerm uni a term
            )
         => Maybe cause -> term -> m a
     default readKnown
         :: ( MonadError (ErrorWithCause err cause) m, AsUnliftingError err
-           , AssociateBuiltinType uni a term
+           , KnownBuiltinType term a
            )
         => Maybe cause -> term -> m a
     readKnown mayCause term = asConstant mayCause term >>= \case
@@ -589,13 +571,8 @@ class KnownTypeAst uni a => KnownTypeIn uni a where
                             ]
                     throwingWithCause _UnliftingError err mayCause
 
--- | A constraint for \"@a@ is a 'KnownTypeIn' by means of only requiring a @term@ to have a
--- @Constant@-like constructor for values of type @a@ to be liftable to / unliftable from @term@.
-class    (KnownTypeIn uni a, AssociateTerm uni a ~ HasConstantIn uni) => KnownBuiltinTypeIn uni a
-instance (KnownTypeIn uni a, AssociateTerm uni a ~ HasConstantIn uni) => KnownBuiltinTypeIn uni a
-
 -- | Haskell types known to exist on the PLC side. See 'KnownTypeIn'.
-type KnownType term a = (KnownTypeIn (UniOf term) a, AssociateTerm (UniOf term) a term)
+type KnownType term = KnownTypeIn (UniOf term) term
 
 -- | Same as 'readKnown', but the cause of a potential failure is the provided term itself.
 readKnownSelf
@@ -606,9 +583,11 @@ readKnownSelf
 readKnownSelf term = readKnown (Just term) term
 
 -- | For providing a 'KnownTypeIn' instance for a built-in type it's enough for that type to satisfy
--- 'KnownBuiltinTypeAst', hence the definition.
-class    (KnownBuiltinTypeAst uni a => KnownTypeIn uni a) => ImplementedKnownBuiltinTypeIn uni a
-instance (KnownBuiltinTypeAst uni a => KnownTypeIn uni a) => ImplementedKnownBuiltinTypeIn uni a
+-- 'KnownBuiltinTypeIn', hence the definition.
+class    (forall term. KnownBuiltinTypeIn uni term a => KnownTypeIn uni term a) =>
+    ImplementedKnownBuiltinTypeIn uni a
+instance (forall term. KnownBuiltinTypeIn uni term a => KnownTypeIn uni term a) =>
+    ImplementedKnownBuiltinTypeIn uni a
 
 -- | An instance of this class not having any constraints ensures that every type
 -- (according to 'Everywhere') from the universe has a 'KnownTypeIn' instance.
@@ -636,10 +615,8 @@ instance KnownTypeAst uni a => KnownTypeAst uni (EvaluationResult a) where
 
     toTypeAst _ = toTypeAst $ Proxy @a
 
-instance (KnownTypeAst uni a, KnownTypeIn uni a) =>
-            KnownTypeIn uni (EvaluationResult a) where
-    type AssociateTerm uni (EvaluationResult a) = AssociateTerm uni a
-
+instance (KnownTypeAst uni a, KnownTypeIn uni term a) =>
+            KnownTypeIn uni term (EvaluationResult a) where
     makeKnown mayCause EvaluationFailure     = throwingWithCause _EvaluationFailure () mayCause
     makeKnown mayCause (EvaluationSuccess x) = makeKnown mayCause x
 
@@ -657,8 +634,7 @@ instance KnownTypeAst uni a => KnownTypeAst uni (Emitter a) where
 
     toTypeAst _ = toTypeAst $ Proxy @a
 
-instance KnownTypeIn uni a => KnownTypeIn uni (Emitter a) where
-    type AssociateTerm uni (Emitter a) = AssociateTerm uni a
+instance KnownTypeIn uni term a => KnownTypeIn uni term (Emitter a) where
     makeKnown mayCause = unEmitter >=> makeKnown mayCause
     -- TODO: we really should tear 'KnownType' apart into two separate type classes.
     readKnown mayCause _ = throwingWithCause _UnliftingError "Can't unlift an 'Emitter'" mayCause
@@ -677,7 +653,8 @@ instance (uni ~ uni', KnownTypeAst uni rep) => KnownTypeAst uni (SomeConstant un
 
     toTypeAst _ = toTypeAst $ Proxy @rep
 
-instance (uni ~ uni', KnownTypeAst uni rep) => KnownTypeIn uni (SomeConstant uni' rep) where
+instance (HasConstantIn uni term, KnownTypeAst uni rep) =>
+            KnownTypeIn uni term (SomeConstant uni rep) where
     makeKnown _ = pure . fromConstant . unSomeConstant
     readKnown mayCause = fmap SomeConstant . asConstant mayCause
 
@@ -723,7 +700,7 @@ runSomeConstantOf :: SomeConstantOf uni f reps -> Some (ValueOf uni)
 runSomeConstantOf (SomeConstantOfRes uniA x) = Some $ ValueOf uniA x
 runSomeConstantOf (SomeConstantOfArg _ svn)  = runSomeConstantOf svn
 
-instance (uni ~ uni', uni `Contains` f, All (KnownTypeAst uni) reps) =>
+instance (uni `Contains` f, uni ~ uni', All (KnownTypeAst uni) reps) =>
             KnownTypeAst uni (SomeConstantOf uni' f reps) where
     type ToBinds (SomeConstantOf uni' f reps) = ListToBinds reps
 
@@ -741,9 +718,8 @@ type ReadSomeConstantOf
 data ReadSomeConstantOf m uni f reps =
     forall k (a :: k). ReadSomeConstantOf (SomeConstantOf uni a reps) (uni (Esc a))
 
-instance ( uni ~ uni', GShow uni, GEq uni, uni `Contains` f
-         , All (KnownTypeAst uni) reps, HasUniApply uni
-         ) => KnownTypeIn uni (SomeConstantOf uni' f reps) where
+instance (KnownBuiltinTypeIn uni term f, All (KnownTypeAst uni) reps, HasUniApply uni) =>
+            KnownTypeIn uni term (SomeConstantOf uni f reps) where
     makeKnown _ = pure . fromConstant . runSomeConstantOf
 
     readKnown (mayCause :: Maybe cause) term = asConstant mayCause term >>= \case
@@ -810,8 +786,8 @@ instance KnownTypeAst uni rep => KnownTypeAst uni (Opaque term rep) where
 
     toTypeAst _ = toTypeAst $ Proxy @rep
 
-instance KnownTypeAst uni rep => KnownTypeIn uni (Opaque term rep) where
-    type AssociateTerm uni (Opaque term rep) = (~) term
+instance (term ~ term', uni ~ UniOf term, KnownTypeAst uni rep) =>
+            KnownTypeIn uni term (Opaque term' rep) where
     makeKnown _ = pure . unOpaque
     readKnown _ = pure . Opaque
 

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -181,14 +181,14 @@ instance KnownBuiltinTypeAst DefaultUni [a]           => KnownTypeAst DefaultUni
 instance KnownBuiltinTypeAst DefaultUni (a, b)        => KnownTypeAst DefaultUni (a, b)
 instance KnownBuiltinTypeAst DefaultUni Data          => KnownTypeAst DefaultUni Data
 
-instance KnownBuiltinTypeAst DefaultUni Integer       => KnownTypeIn DefaultUni Integer
-instance KnownBuiltinTypeAst DefaultUni BS.ByteString => KnownTypeIn DefaultUni BS.ByteString
-instance KnownBuiltinTypeAst DefaultUni Text.Text     => KnownTypeIn DefaultUni Text.Text
-instance KnownBuiltinTypeAst DefaultUni ()            => KnownTypeIn DefaultUni ()
-instance KnownBuiltinTypeAst DefaultUni Bool          => KnownTypeIn DefaultUni Bool
-instance KnownBuiltinTypeAst DefaultUni [a]           => KnownTypeIn DefaultUni [a]
-instance KnownBuiltinTypeAst DefaultUni (a, b)        => KnownTypeIn DefaultUni (a, b)
-instance KnownBuiltinTypeAst DefaultUni Data          => KnownTypeIn DefaultUni Data
+instance KnownBuiltinTypeIn DefaultUni term Integer       => KnownTypeIn DefaultUni term Integer
+instance KnownBuiltinTypeIn DefaultUni term BS.ByteString => KnownTypeIn DefaultUni term BS.ByteString
+instance KnownBuiltinTypeIn DefaultUni term Text.Text     => KnownTypeIn DefaultUni term Text.Text
+instance KnownBuiltinTypeIn DefaultUni term ()            => KnownTypeIn DefaultUni term ()
+instance KnownBuiltinTypeIn DefaultUni term Bool          => KnownTypeIn DefaultUni term Bool
+instance KnownBuiltinTypeIn DefaultUni term [a]           => KnownTypeIn DefaultUni term [a]
+instance KnownBuiltinTypeIn DefaultUni term (a, b)        => KnownTypeIn DefaultUni term (a, b)
+instance KnownBuiltinTypeIn DefaultUni term Data          => KnownTypeIn DefaultUni term Data
 
 -- If this tells you a 'KnownTypeIn' instance is missing, add it right above, following the pattern
 -- (you'll also need to add a 'KnownTypeAst' instance as well).
@@ -196,7 +196,7 @@ instance TestTypesFromTheUniverseAreAllKnown DefaultUni
 
 {- Note [Int as Integer]
 We represent 'Int' as 'Integer' in PLC and check that an 'Integer' fits into 'Int' when
-unlifting constants of type 'Int' and fail with an evaluation failure (via 'AsEvaluationFailure')
+unlifting constants fo type 'Int' and fail with an evaluation failure (via 'AsEvaluationFailure')
 if it doesn't. We couldn't fail via 'AsUnliftingError', because an out-of-bounds error is not an
 internal one -- it's a normal evaluation failure, but unlifting errors have this connotation of
 being "internal".
@@ -206,7 +206,7 @@ instance KnownTypeAst DefaultUni Int where
     toTypeAst _ = toTypeAst $ Proxy @Integer
 
 -- See Note [Int as Integer].
-instance KnownTypeIn DefaultUni Int where
+instance HasConstantIn DefaultUni term => KnownTypeIn DefaultUni term Int where
     makeKnown mayCause = makeKnown mayCause . toInteger
     readKnown mayCause term = do
         i :: Integer <- readKnown mayCause term


### PR DESCRIPTION
Reverts input-output-hk/plutus#4172 due to performance [problems](https://github.com/input-output-hk/plutus/pull/4172#issuecomment-961809116) with it. I have an idea on how to fix them, so the war is not over.