### PR TITLE
[Builtins] Try using the 'SomeValueOf' data family everywhere

### DIFF
--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -54,7 +54,7 @@ interListData = runQuote $ do
         . TyFun () (mkIterTyFun () [TyVar () a, TyVar () b, interlistBA] $ TyVar () r)
         $ TyVar () r
 
-interNil :: Term TyName Name uni fun ()
+interNil :: HasSomeValueOf uni => Term TyName Name uni fun ()
 interNil = runQuote $ do
     let RecursiveType interlist wrapInterList = interListData
     a <- freshTyName "a"
@@ -72,7 +72,7 @@ interNil = runQuote $ do
         . LamAbs () f (mkIterTyFun () [TyVar () a, TyVar () b, interlistBA] $ TyVar () r)
         $ Var () z
 
-interCons :: Term TyName Name uni fun ()
+interCons :: HasSomeValueOf uni => Term TyName Name uni fun ()
 interCons = runQuote $ do
     let RecursiveType interlist wrapInterList = interListData
     a  <- freshTyName "a"
@@ -100,7 +100,7 @@ interCons = runQuote $ do
           , Var () xs
           ]
 
-foldrInterList :: uni `Includes` () => Term TyName Name uni fun ()
+foldrInterList :: (HasSomeValueOf uni, uni `Includes` ()) => Term TyName Name uni fun ()
 foldrInterList = runQuote $ do
     let interlist = _recursiveType interListData
     a0  <- freshTyName "a0"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
@@ -62,7 +62,7 @@ shad = runQuote $ do
 -- But that problem is already solved before type checking starts as we rename the program and that
 -- makes all binders uniques, so no variable capture is possible due to the outer and inner bindings
 -- being distinct.
-mkShad :: uni `Includes` Integer => Term TyName Name uni fun ()
+mkShad :: (HasSomeValueOf uni, uni `Includes` Integer) => Term TyName Name uni fun ()
 mkShad = runQuote $ do
     a     <- freshTyName "a"
     f     <- freshTyName "f"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
@@ -168,7 +168,7 @@ forestData = runQuote $ do
 --
 -- > /\(a :: *) -> \(x : a) (fr : forest a) ->
 -- >     wrapTree [a] /\(r :: *) -> \(f : a -> forest a -> r) -> f x fr
-treeNode :: HasUniApply uni => Term TyName Name uni fun ()
+treeNode :: (HasUniApply uni, HasSomeValueOf uni) => Term TyName Name uni fun ()
 treeNode = runQuote $ normalizeTypesIn =<< do
     let RecursiveType _      wrapTree = treeData
         RecursiveType forest _        = forestData
@@ -196,7 +196,7 @@ treeNode = runQuote $ normalizeTypesIn =<< do
 --
 -- > /\(a :: *) ->
 -- >     wrapForest [a] /\(r :: *) -> \(z : r) (f : tree a -> forest a -> r) -> z
-forestNil :: HasUniApply uni => Term TyName Name uni fun ()
+forestNil :: (HasUniApply uni, HasSomeValueOf uni) => Term TyName Name uni fun ()
 forestNil = runQuote $ normalizeTypesIn =<< do
     let RecursiveType tree   _          = treeData
         RecursiveType forest wrapForest = forestData
@@ -220,7 +220,7 @@ forestNil = runQuote $ normalizeTypesIn =<< do
 --
 -- > /\(a :: *) -> \(tr : tree a) (fr : forest a)
 -- >     wrapForest [a] /\(r :: *) -> \(z : r) (f : tree a -> forest a -> r) -> f tr fr
-forestCons :: HasUniApply uni => Term TyName Name uni fun ()
+forestCons :: (HasUniApply uni, HasSomeValueOf uni) => Term TyName Name uni fun ()
 forestCons = runQuote $ normalizeTypesIn =<< do
     let RecursiveType tree   _          = treeData
         RecursiveType forest wrapForest = forestData

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
@@ -39,13 +39,13 @@ instance (HasUniques (Type tyname uni ann), GEq uni) => Eq (Type tyname uni ann)
 
 instance
         ( HasUniques (Term tyname name uni fun ann)
-        , GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun
+        , GEq uni, Closed uni, Eq (SomeValueOf uni), Eq fun
         ) => Eq (Term tyname name uni fun ann) where
     term1 == term2 = runEqRename $ eqTermM term1 term2
 
 instance
         ( HasUniques (Program tyname name uni fun ann)
-        , GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun
+        , GEq uni, Closed uni, Eq (SomeValueOf uni), Eq fun
         ) => Eq (Program tyname name uni fun ann) where
     prog1 == prog2 = runEqRename $ eqProgramM prog1 prog2
 
@@ -90,7 +90,7 @@ eqTypeM TyBuiltin{} _ = empty
 -- See Note [No catch-all].
 -- | Check equality of two 'Term's.
 eqTermM
-    :: (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun)
+    :: (GEq uni, Closed uni, Eq (SomeValueOf uni), Eq fun)
     => EqRenameOf ScopedRenaming (Term tyname name uni fun ann)
 eqTermM (LamAbs _ name1 ty1 body1) (LamAbs _ name2 ty2 body2) = do
     eqTypeM ty1 ty2
@@ -131,7 +131,7 @@ eqTermM Builtin{}  _ = empty
 
 -- | Check equality of two 'Program's.
 eqProgramM
-    :: (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun)
+    :: (GEq uni, Closed uni, Eq (SomeValueOf uni), Eq fun)
     => EqRenameOf ScopedRenaming (Program tyname name uni fun ann)
 eqProgramM (Program _ ver1 term1) (Program _ ver2 term2) = do
     guard $ ver1 == ver2

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Classic.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Classic.hs
@@ -60,7 +60,7 @@ instance (PrettyClassicBy configName tyname, GShow uni, Pretty ann) =>
 instance
         ( PrettyClassicBy configName tyname
         , PrettyClassicBy configName name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, PrettySomeValueOf uni, HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => PrettyBy (PrettyConfigClassic configName) (Term tyname name uni fun ann) where
     prettyBy config = \case
@@ -76,7 +76,7 @@ instance
             brackets' (sep (consAnnIf config ann
                 [prettyBy config t1, prettyBy config t2]))
         Constant ann c ->
-            sexp "con" (consAnnIf config ann [prettyTypeOf c, pretty c])
+            sexp "con" (consAnnIf config ann [pretty $ uniOf c, pretty c])
         Builtin ann bi ->
             sexp "builtin" (consAnnIf config ann [pretty bi])
         TyInst ann t ty ->
@@ -89,9 +89,9 @@ instance
                 [prettyBy config ty1, prettyBy config ty2, prettyBy config t])
         Unwrap ann t ->
             sexp "unwrap" (consAnnIf config ann [prettyBy config t])
-      where
-        prettyTypeOf :: GShow t => Some (ValueOf t) -> Doc dann
-        prettyTypeOf (Some (ValueOf uni _ )) = pretty $ SomeTypeIn uni
+      -- where
+      --   prettyTypeOf :: GShow t => Some (ValueOf t) -> Doc dann
+      --   prettyTypeOf (Some (ValueOf uni _ )) = pretty $ SomeTypeIn uni
 
 instance (PrettyClassicBy configName (Term tyname name uni fun ann), Pretty ann) =>
         PrettyBy (PrettyConfigClassic configName) (Program tyname name uni fun ann) where

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Default.hs
@@ -27,7 +27,7 @@ instance (PrettyClassic tyname, GShow uni, Pretty ann) => Pretty (Type tyname un
 instance
         ( PrettyClassic tyname
         , PrettyClassic name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, PrettySomeValueOf uni, HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => Pretty (Term tyname name uni fun ann) where
     pretty = prettyClassicDef
@@ -35,7 +35,7 @@ instance
 instance
         ( PrettyClassic tyname
         , PrettyClassic name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, PrettySomeValueOf uni, HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => Pretty (Program tyname name uni fun ann) where
     pretty = prettyClassicDef

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
@@ -62,7 +62,7 @@ instance (PrettyReadableBy configName tyname, GShow uni) =>
 instance
         ( PrettyReadableBy configName tyname
         , PrettyReadableBy configName name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, PrettySomeValueOf uni, Pretty fun
         ) => PrettyBy (PrettyConfigReadable configName) (Term tyname name uni fun a) where
     prettyBy = inContextM $ \case
         Constant _ con         -> unitDocM $ pretty con

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes               #-}
+
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE DeriveAnyClass           #-}
 {-# LANGUAGE DerivingVia              #-}
@@ -49,7 +51,7 @@ import PlutusCore.Name
 
 import Control.Lens
 import Data.Hashable
-import Data.Kind qualified as GHC
+import qualified Data.Kind as GHC
 import Instances.TH.Lift ()
 import Language.Haskell.TH.Lift
 import Universe
@@ -82,7 +84,7 @@ data Term tyname name uni fun ann
     | TyAbs ann tyname (Kind ann) (Term tyname name uni fun ann)
     | LamAbs ann name (Type tyname uni ann) (Term tyname name uni fun ann)
     | Apply ann (Term tyname name uni fun ann) (Term tyname name uni fun ann)
-    | Constant ann (Some (ValueOf uni)) -- ^ a constant term
+    | Constant ann (SomeValueOf uni) -- ^ a constant term
     | Builtin ann fun
     | TyInst ann (Term tyname name uni fun ann) (Type tyname uni ann)
     | Unwrap ann (Term tyname name uni fun ann)

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -35,16 +35,17 @@ import PlutusCore.DeBruijn.Internal
 import PlutusCore.Lexer.Type
 import PlutusCore.Name
 import PlutusCore.Pretty
+import PlutusCore.Pretty.PrettyConst
 
 import Control.Lens hiding (use)
 import Control.Monad.Error.Lens
 import Control.Monad.Except
-import Data.Text qualified as T
+import qualified Data.Text as T
 import ErrorCode
 import Prettyprinter (hardline, indent, squotes, (<+>))
 import Prettyprinter.Internal (Doc (Text))
 import Text.Megaparsec.Pos (SourcePos, sourcePosPretty)
-import Universe (Closed (Everywhere), GEq, GShow)
+import Universe (Closed, GEq, GShow, SomeValueOf)
 
 {- Note [Annotations and equality]
 Equality of two errors DOES DEPEND on their annotations.
@@ -89,7 +90,7 @@ data NormCheckError tyname name uni fun ann
     deriving (Show, Functor, Generic, NFData)
 deriving instance
     ( HasUniques (Term tyname name uni fun ann)
-    , GEq uni, Closed uni, uni `Everywhere` Eq
+    , GEq uni, Closed uni, Eq (SomeValueOf uni)
     , Eq fun, Eq ann
     ) => Eq (NormCheckError tyname name uni fun ann)
 makeClassyPrisms ''NormCheckError
@@ -165,7 +166,7 @@ instance ( Pretty ann
         ". Term" <+> squotes (prettyBy config t) <+>
         "is not a" <+> pretty expct <> "."
 
-instance (GShow uni, Closed uni, uni `Everywhere` PrettyConst,  Pretty ann, Pretty fun, Pretty term) =>
+instance (GShow uni, Closed uni, PrettySomeValueOf uni,  Pretty ann, Pretty fun, Pretty term) =>
             PrettyBy PrettyConfigPlc (TypeError term uni fun ann) where
     prettyBy config e@(KindMismatch ann ty k k')          =
         pretty (errorCode e) <> ":" <+>
@@ -191,7 +192,7 @@ instance (GShow uni, Closed uni, uni `Everywhere` PrettyConst,  Pretty ann, Pret
     prettyBy _ (UnknownBuiltinFunctionE ann fun) =
         "An unknown built-in function at" <+> pretty ann <> ":" <+> pretty fun
 
-instance (GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun, Pretty ann) =>
+instance (GShow uni, Closed uni, PrettySomeValueOf uni, Pretty fun, Pretty ann) =>
             PrettyBy PrettyConfigPlc (Error uni fun ann) where
     prettyBy _      (ParseErrorE e)           = pretty e
     prettyBy _      (UniqueCoherencyErrorE e) = pretty e

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -54,12 +54,12 @@ import PlutusCore.Core
 import Universe
 
 -- | A final encoding for Term, to allow PLC terms to be used transparently as PIR terms.
-class TermLike term tyname name uni fun | term -> tyname name uni fun where
+class HasSomeValueOf uni => TermLike term tyname name uni fun | term -> tyname name uni fun where
     var      :: ann -> name -> term ann
     tyAbs    :: ann -> tyname -> Kind ann -> term ann -> term ann
     lamAbs   :: ann -> name -> Type tyname uni ann -> term ann -> term ann
     apply    :: ann -> term ann -> term ann -> term ann
-    constant :: ann -> Some (ValueOf uni) -> term ann
+    constant :: ann -> SomeValueOf uni -> term ann
     builtin  :: ann -> fun -> term ann
     tyInst   :: ann -> term ann -> Type tyname uni ann -> term ann
     unwrap   :: ann -> term ann -> term ann
@@ -89,15 +89,15 @@ mkTyBuiltin ann = mkTyBuiltinOf ann $ knownUni @_ @uni @a
 mkConstantOf
     :: forall a uni fun term tyname name ann. TermLike term tyname name uni fun
     => ann -> uni (Esc a) -> a -> term ann
-mkConstantOf ann uni = constant ann . someValueOf uni
+mkConstantOf ann uni = constant ann . toSomeValueOf uni
 
 -- | Embed a Haskell value (provided its type is in the universe) into a PLC term.
 mkConstant
     :: forall a uni fun term tyname name ann. (TermLike term tyname name uni fun, uni `Includes` a)
     => ann -> a -> term ann
-mkConstant ann = constant ann . someValue
+mkConstant ann = constant ann . toSomeValueOf knownUni
 
-instance TermLike (Term tyname name uni fun) tyname name uni fun where
+instance HasSomeValueOf uni => TermLike (Term tyname name uni fun) tyname name uni fun where
     var      = Var
     tyAbs    = TyAbs
     lamAbs   = LamAbs

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
@@ -16,12 +16,12 @@ module PlutusCore.Pretty.PrettyConst where
 import PlutusCore.Data
 
 import Codec.Serialise (serialise)
-import Data.ByteString qualified as BS
-import Data.ByteString.Lazy qualified as BSL
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce
 import Data.Foldable (fold)
 import Data.Proxy
-import Data.Text qualified as T
+import qualified Data.Text as T
 import Data.Word (Word8)
 import Numeric (showHex)
 import Prettyprinter
@@ -117,6 +117,12 @@ asBytes x = Text 2 $ T.pack $ addLeadingZero $ showHex x mempty
 
 instance PrettyBy ConstConfig Data where
     prettyBy c d = prettyBy c $ BSL.toStrict $ serialise d
+
+class HasSomeValueOf uni => PrettySomeValueOf uni where
+    prettySomeValueOf :: SomeValueOf uni -> Doc ann
+
+instance PrettySomeValueOf uni => Pretty (SomeValueOf uni) where
+    pretty = prettySomeValueOf
 
 instance GShow uni => Pretty (SomeTypeIn uni) where
     pretty (SomeTypeIn uni) = pretty $ gshow uni

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -15,13 +15,13 @@ import PlutusCore.Rename.Monad
 
 import Universe
 
-instance (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, HasUnique name TermUnique) =>
+instance (GEq uni, Closed uni, EqSomeValueOf uni, Eq fun, HasUnique name TermUnique) =>
             Eq (Term name uni fun ann) where
     term1 == term2 = runEqRename $ eqTermM term1 term2
 
 -- | Check equality of two 'Term's.
 eqTermM
-    :: (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, HasUnique name TermUnique)
+    :: (GEq uni, Closed uni, EqSomeValueOf uni, Eq fun, HasUnique name TermUnique)
     => Term name uni fun ann -> Term name uni fun ann -> EqRename (Renaming TermUnique)
 eqTermM (Constant _ con1) (Constant _ con2) =
     eqM con1 con2

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Classic.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Classic.hs
@@ -24,7 +24,7 @@ import Universe
 
 instance
         ( PrettyClassicBy configName name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, Pretty (SomeValueOf uni), HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => PrettyBy (PrettyConfigClassic configName) (Term name uni fun ann) where
     prettyBy config = \case
@@ -37,7 +37,7 @@ instance
             brackets' (sep (consAnnIf config ann
                 [prettyBy config t1, prettyBy config t2]))
         Constant ann c ->
-            sexp "con" (consAnnIf config ann [prettyTypeOf c, pretty c])
+            sexp "con" (consAnnIf config ann [pretty $ uniOf c, pretty c])
         Builtin ann bi ->
             sexp "builtin" (consAnnIf config ann
                 [pretty bi])
@@ -49,9 +49,9 @@ instance
         Force ann term ->
             sexp "force" (consAnnIf config ann
                 [prettyBy config term])
-      where
-        prettyTypeOf :: GShow t => Some (ValueOf t) -> Doc dann
-        prettyTypeOf (Some (ValueOf uni _ )) = pretty $ SomeTypeIn uni
+      -- where
+      --   prettyTypeOf :: GShow t => Some (ValueOf t) -> Doc dann
+      --   prettyTypeOf (Some (ValueOf uni _ )) = pretty $ SomeTypeIn uni
 
 instance (PrettyClassicBy configName (Term name uni fun ann), Pretty ann) =>
         PrettyBy (PrettyConfigClassic configName) (Program name uni fun ann) where

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Default.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Default.hs
@@ -21,14 +21,14 @@ import Universe
 
 instance
         ( PrettyClassic name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, Pretty (SomeValueOf uni), HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => Pretty (Term name uni fun ann) where
     pretty = prettyClassicDef
 
 instance
         ( PrettyClassic name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, Pretty (SomeValueOf uni), HasSomeValueOf uni, Pretty fun
         , Pretty ann
         ) => Pretty (Program name uni fun ann) where
     pretty = prettyClassicDef

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Pretty/Readable.hs
@@ -23,7 +23,7 @@ import Universe
 
 instance
         ( PrettyReadableBy configName name
-        , GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun
+        , GShow uni, Closed uni, Pretty (SomeValueOf uni), Pretty fun
         ) => PrettyBy (PrettyConfigReadable configName) (Term name uni fun a) where
     prettyBy = inContextM $ \case
         Constant _ val -> unitDocM $ pretty val


### PR DESCRIPTION
I tried Kmett's suggestion to define a `data family` instead of using `Some (ValueOf uni)`. It seems to work, but it's pretty annoying to deal with, but then I realized we don't need it everywhere, just in `CekValue`s, so I'm gonna try only introducing it there.