### PR TITLE
SCP-3058: PIR: track dependencies dynamically instead of statically

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -343,6 +343,7 @@ compileMarkedExpr locStr codeTy origE = do
             ccNameInfo = nameInfo,
             ccScopes = initialScopeStack,
             ccBlackholed = mempty,
+            ccCurDef = Nothing,
             ccModBreaks = modBreaks
             }
 

--- a/plutus-tx-plugin/test/IsData/deconstructData.plc.golden
+++ b/plutus-tx-plugin/test/IsData/deconstructData.plc.golden
@@ -2,6 +2,9 @@
   (let
     (nonrec)
     (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
+    (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
@@ -31,9 +34,6 @@
       (strict)
       (vardecl equalsInteger (fun (con integer) (fun (con integer) (con bool))))
       (builtin equalsInteger)
-    )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
     )
     (datatypebind
       (datatype

--- a/plutus-tx-plugin/test/IsData/unit.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unit.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_68 (lam case_False_69 case_True_68)))
+(delay (lam case_True_66 (lam case_False_67 case_True_66)))

--- a/plutus-tx-plugin/test/IsData/unitInterop.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unitInterop.plc.golden
@@ -1,1 +1,1 @@
-(delay (lam case_True_49 (lam case_False_50 case_True_49)))
+(delay (lam case_True_47 (lam case_False_48 case_True_47)))

--- a/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
@@ -2,6 +2,9 @@
   (let
     (nonrec)
     (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
+    (datatypebind
       (datatype
         (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
@@ -62,9 +65,6 @@
         )
       )
       (builtin unConstrData)
-    )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
     )
     (termbind
       (strict)

--- a/plutus-tx-plugin/test/Plugin/Primitives/trace.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/trace.plc.golden
@@ -1,6 +1,9 @@
 (program
   (let
     (nonrec)
+    (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
     (termbind
       (strict)
       (vardecl trace (all a (type) (fun (con string) (fun a a))))
@@ -10,9 +13,6 @@
       (nonstrict)
       (vardecl trace (all a (type) (fun (con string) (fun a a))))
       trace
-    )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
     )
     (lam ds (con string) [ [ { trace Unit } ds ] Unit ])
   )


### PR DESCRIPTION
See `Note [Dependency tracking]` for the rationale.

I think overall this makes things simpler, and probably faster (since
we're not traversing things to get their free variables all the time).

It also fixes a long-standing hack whereby I made everything depend on
`Unit`, precisely because we would occasionally insert references to it
in a dynamic way. That goes away, which explains the test changes
(moving the `Unit` definition to a slightly more precise location).

This removes the need for the hack in
https://github.com/input-output-hk/plutus/issues/4148.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
