### PR TITLE
SCP-3031

### DIFF
--- a/plutus-metatheory/src/Algorithmic.lagda
+++ b/plutus-metatheory/src/Algorithmic.lagda
@@ -171,59 +171,70 @@ btype b = let Φ ,, Γ ,, C = sig b in subNf (λ()) (sig2type Φ Γ C)
 postulate btype-ren : ∀{Φ Ψ} b (ρ : ⋆.Ren Φ Ψ) → btype b ≡ renNf ρ (btype b)
 postulate btype-sub : ∀{Φ Ψ} b (ρ : SubNf Φ Ψ) → btype b ≡ subNf ρ (btype b)
 
-infixl 7 _·⋆_
+infixl 7 _·⋆_/_
 
 data _⊢_ {Φ} (Γ : Ctx Φ) : Φ ⊢Nf⋆ * → Set where
 
   ` : ∀ {A : Φ ⊢Nf⋆ *}
     → Γ ∋ A
-      ------
+      -----
     → Γ ⊢ A
 
   ƛ : ∀ {A B : Φ ⊢Nf⋆ *}
     → Γ , A ⊢ B
-      -----------
+      ---------
     → Γ ⊢ A ⇒ B
 
   _·_ : ∀ {A B : Φ ⊢Nf⋆ *}
     → Γ ⊢ A ⇒ B
     → Γ ⊢ A
-      -----------
+      ---------
     → Γ ⊢ B
 
   Λ : ∀ {K}
     → {B : Φ ,⋆ K ⊢Nf⋆ *}
     → Γ ,⋆ K ⊢ B
-      ----------
+      -------------------
     → Γ ⊢ Π B
 
-  _·⋆_ : ∀ {K}
+  _·⋆_/_ : ∀ {K C}
     → {B : Φ ,⋆ K ⊢Nf⋆ *}
     → Γ ⊢ Π B
     → (A : Φ ⊢Nf⋆ K)
-      ---------------
-    → Γ ⊢ B [ A ]
+    → C ≡ B [ A ]
+      --------------
+    → Γ ⊢ C
 
   wrap : ∀{K}
    → (A : Φ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *)
    → (B : Φ ⊢Nf⋆ K)
    → Γ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)
+     -------------------------------------------------------------
    → Γ ⊢ μ A B
 
-  unwrap : ∀{K}
+  unwrap : ∀{K C}
     → {A : Φ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
     → {B : Φ ⊢Nf⋆ K}
     → Γ ⊢ μ A B
-    → Γ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)
+    → C ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)
+      -------------------------------------------------------------
+    → Γ ⊢ C
 
   con : ∀{tcn}
     → TermCon {Φ} (con tcn)
-      -------------------
+      ---------------------
     → Γ ⊢ con tcn
 
-  builtin : (b :  Builtin) → Γ ⊢ btype b
+  builtin_/_ : ∀{C}
+    → (b :  Builtin)
+    → C ≡ btype b
+      --------------
+    → Γ ⊢ C
 
-  error : (A : Φ ⊢Nf⋆ *) → Γ ⊢ A
+  error :
+      (A : Φ ⊢Nf⋆ *)
+      --------------
+    → Γ ⊢ A
 \end{code}
 
 Utility functions

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -21,54 +21,54 @@ open import Data.Product renaming (_,_ to _,,_)
 dissect : ∀{A B}(E : EC A B) → A ≡ B ⊎ Σ (∅ ⊢Nf⋆ *) λ C → EC A C × Frame C B
 dissect []        = inj₁ refl
 dissect (E l· M') with dissect E
-... | inj₁ refl         = inj₂ (_ ,, [] ,, -· M')
+... | inj₁ refl           = inj₂ (_ ,, [] ,, -· M')
 ... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, E' l· M' ,, F)
 dissect (VM ·r E) with dissect E
-... | inj₁ refl         = inj₂ (_ ,, [] ,, VM ·-)
+... | inj₁ refl           = inj₂ (_ ,, [] ,, VM ·-)
 ... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, VM ·r E' ,, F)
-dissect (E ·⋆ A) with dissect E
-... | inj₁ refl         = inj₂ (_ ,, [] ,,  -·⋆ A)
-... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, E' ·⋆ A ,, F)
+dissect (E ·⋆ A / refl) with dissect E
+... | inj₁ refl           = inj₂ (_ ,, [] ,,  -·⋆ A)
+... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, E' ·⋆ A / refl ,, F)
 dissect (wrap E) with dissect E
-... | inj₁ refl         = inj₂ (_ ,, [] ,, wrap-)
+... | inj₁ refl           = inj₂ (_ ,, [] ,, wrap-)
 ... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, wrap E' ,, F)
-dissect (unwrap E) with dissect E
-... | inj₁ refl         = inj₂ (_ ,, [] ,, unwrap-)
-... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, unwrap E' ,, F)
+dissect (unwrap E / refl) with dissect E
+... | inj₁ refl           = inj₂ (_ ,, [] ,, unwrap-)
+... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, unwrap E' / refl ,, F)
 
 dissect-inj₁ : ∀{A B}(E : EC A B)(p : A ≡ B) → dissect E ≡ inj₁ p
   → subst (λ A → EC A B) p E ≡ []
-dissect-inj₁ [] refl refl = refl
-dissect-inj₁ (E l· N) p q with dissect E
-dissect-inj₁ (E l· N) refl q | inj₁ ()
-dissect-inj₁ (VM ·r E) p q with dissect E
-dissect-inj₁ (VM ·r E) refl () | inj₁ refl
-dissect-inj₁ (E ·⋆ A) p q with dissect E
-dissect-inj₁ (E ·⋆ A) p () | inj₁ refl
-dissect-inj₁ (wrap E) p q with dissect E
-dissect-inj₁ (wrap E) p () | inj₁ refl
-dissect-inj₁ (unwrap E) p q with dissect E
-dissect-inj₁ (unwrap E) p () | inj₁ refl
+dissect-inj₁ []                refl refl = refl
+dissect-inj₁ (E l· N)          p    q with dissect E
+dissect-inj₁ (E l· N)          refl q | inj₁ ()
+dissect-inj₁ (VM ·r E)         p    q with dissect E
+dissect-inj₁ (VM ·r E)         refl () | inj₁ refl
+dissect-inj₁ (E ·⋆ A / refl)   p    q with dissect E
+dissect-inj₁ (E ·⋆ A / refl)   p    () | inj₁ refl
+dissect-inj₁ (wrap E)          p    q with dissect E
+dissect-inj₁ (wrap E)          p    () | inj₁ refl
+dissect-inj₁ (unwrap E / refl) p    q with dissect E
+dissect-inj₁ (unwrap E / refl) p    () | inj₁ refl
 
 compEC : ∀{A B C} → EC A B → EC B C → EC A C
-compEC []         E' = E'
-compEC (E  l· M') E' = compEC E E' l· M'
-compEC (VM ·r E)  E' = VM ·r compEC E E'
-compEC (E ·⋆ A)   E' = compEC E E' ·⋆ A
-compEC (wrap E)   E' = wrap (compEC E E')
-compEC (unwrap E) E' = unwrap (compEC E E')
+compEC []                E' = E'
+compEC (E  l· M')        E' = compEC E E' l· M'
+compEC (VM ·r E)         E' = VM ·r compEC E E'
+compEC (E ·⋆ A / refl)   E' = compEC E E' ·⋆ A / refl
+compEC (wrap E)          E' = wrap (compEC E E')
+compEC (unwrap E / refl) E' = unwrap (compEC E E') / refl
 
 extEC : ∀{A B C}(E : EC A B)(F : Frame B C) → EC A C
-extEC []         (-· M') = [] l· M'
-extEC []         (VM ·-) = VM ·r []
-extEC []         (-·⋆ A) = [] ·⋆ A
-extEC []         wrap-   = wrap []
-extEC []         unwrap- = unwrap []
-extEC (E l· M')  F       = extEC E F l· M'
-extEC (VM ·r E)  F       = VM ·r extEC E F
-extEC (E ·⋆ A)   F       = extEC E F ·⋆ A
-extEC (wrap E)   F       = wrap (extEC E F)
-extEC (unwrap E) F       = unwrap (extEC E F)
+extEC []                (-· M') = [] l· M'
+extEC []                (VM ·-) = VM ·r []
+extEC []                (-·⋆ A) = [] ·⋆ A / refl
+extEC []                wrap-   = wrap []
+extEC []                unwrap- = unwrap [] / refl
+extEC (E l· M')         F       = extEC E F l· M'
+extEC (VM ·r E)         F       = VM ·r extEC E F
+extEC (E ·⋆ A / refl)   F       = extEC E F ·⋆ A / refl
+extEC (wrap E)          F       = wrap (extEC E F)
+extEC (unwrap E / refl) F       = unwrap (extEC E F) / refl
 
 dissect-inj₂ : ∀{A B C}(E : EC A C)(E' : EC A B)(F : Frame B C)
   → dissect E ≡ inj₂ (_ ,, E' ,, F) → E ≡ extEC E' F
@@ -82,31 +82,32 @@ dissect-inj₂ (VM ·r E) .[] .(VM ·-) refl | inj₁ refl | I[ eq ] =
   cong (VM ·r_) ( dissect-inj₁ E refl eq)
 dissect-inj₂ (VM ·r E) .(VM ·r E') .F refl | inj₂ (_ ,, E' ,, F) | I[ eq ] =
   cong (VM ·r_) (dissect-inj₂ E E' F eq)
-dissect-inj₂ (E ·⋆ A) E' F p with dissect E | inspect dissect E
-dissect-inj₂ (E ·⋆ A) .[] .(-·⋆ A) refl | inj₁ refl | I[ eq ] =
-  cong (_·⋆ A) (dissect-inj₁ E refl eq)
-dissect-inj₂ (E ·⋆ A) .(E'' ·⋆ A) .F' refl | inj₂ (_ ,, E'' ,, F') | I[ eq ] =
-  cong (_·⋆ A) (dissect-inj₂ E E'' F' eq)
+dissect-inj₂ (E ·⋆ A / refl) E' F p with dissect E | inspect dissect E
+dissect-inj₂ (E ·⋆ A / refl) .[] .(-·⋆ A) refl | inj₁ refl | I[ eq ] =
+  cong (_·⋆ A / refl) (dissect-inj₁ E refl eq)
+dissect-inj₂ (E ·⋆ A / refl) .(E'' ·⋆ A / refl) .F' refl
+  | inj₂ (_ ,, E'' ,, F') | I[ eq ]
+  = cong (_·⋆ A / refl) (dissect-inj₂ E E'' F' eq)
 dissect-inj₂ (wrap E) E' F p with dissect E | inspect dissect E
 dissect-inj₂ (wrap E) .[] .wrap- refl | inj₁ refl | I[ eq ] =
   cong wrap (dissect-inj₁ E refl eq)
 dissect-inj₂ (wrap E) .(wrap E'') .F' refl | inj₂ (_ ,, E'' ,, F') | I[ eq ] =
   cong wrap (dissect-inj₂ E E'' F' eq)
-
-dissect-inj₂ (unwrap E) E' F p with dissect E | inspect dissect E
-dissect-inj₂ (unwrap E) .[] .unwrap- refl | inj₁ refl | I[ eq ] =
-  cong unwrap (dissect-inj₁ E refl eq)
-dissect-inj₂ (unwrap E) .(unwrap E'') .F' refl | inj₂ (_ ,, E'' ,, F') | I[ eq ]
-  = cong unwrap (dissect-inj₂ E E'' F' eq)
+dissect-inj₂ (unwrap E / refl) E' F p with dissect E | inspect dissect E
+dissect-inj₂ (unwrap E / refl) .[] .unwrap- refl | inj₁ refl | I[ eq ] =
+  cong (λ E → unwrap E / refl) (dissect-inj₁ E refl eq)
+dissect-inj₂ (unwrap E / refl) .(unwrap E'' / refl) .F' refl
+  | inj₂ (_ ,, E'' ,, F') | I[ eq ]
+  = cong (λ E → unwrap E / refl) (dissect-inj₂ E E'' F' eq)
 
 
 compEC' : ∀{A B C} → EC A B → EC B C → EC A C
-compEC' E []          = E
-compEC' E (E' l· M')  = compEC' (extEC E (-· M')) E'
-compEC' E (VM ·r E')  = compEC' (extEC E (VM ·-)) E'
-compEC' E (E' ·⋆ A)   = compEC' (extEC E (-·⋆ A)) E'
-compEC' E (wrap E')   = compEC' (extEC E wrap-) E'
-compEC' E (unwrap E') = compEC' (extEC E unwrap-) E'
+compEC' E []                 = E
+compEC' E (E' l· M')         = compEC' (extEC E (-· M')) E'
+compEC' E (VM ·r E')         = compEC' (extEC E (VM ·-)) E'
+compEC' E (E' ·⋆ A / refl)   = compEC' (extEC E (-·⋆ A)) E'
+compEC' E (wrap E')          = compEC' (extEC E wrap-) E'
+compEC' E (unwrap E' / refl) = compEC' (extEC E unwrap-) E'
 
 postulate
   compEC-eq : ∀{A B C}(E : EC C B)(E' : EC B A) → compEC E E' ≡ compEC' E E'
@@ -116,39 +117,46 @@ compEC'-[] E = sym (compEC-eq [] E)
 
 compEC'-extEC : ∀{A B C D}(E : EC A B)(E' : EC B C)(F : Frame C D)
   → compEC' E (extEC E' F) ≡ extEC (compEC' E E') F
-compEC'-extEC E [] (-· N) = refl
-compEC'-extEC E [] (VM ·-) = refl
-compEC'-extEC E [] (-·⋆ A) = refl
-compEC'-extEC E [] wrap- = refl
-compEC'-extEC E [] unwrap- = refl
-compEC'-extEC E (E' l· N) F = compEC'-extEC (extEC E (-· N)) E' F
-compEC'-extEC E (VM ·r E') F = compEC'-extEC (extEC E (VM ·-)) E' F
-compEC'-extEC E (E' ·⋆ A) F = compEC'-extEC (extEC E (-·⋆ A)) E' F
-compEC'-extEC E (wrap E') F = compEC'-extEC (extEC E wrap-) E' F
-compEC'-extEC E (unwrap E') F = compEC'-extEC (extEC E unwrap-) E' F
+compEC'-extEC E []                 (-· N)  = refl
+compEC'-extEC E []                 (VM ·-) = refl
+compEC'-extEC E []                 (-·⋆ A) = refl
+compEC'-extEC E []                 wrap-   = refl
+compEC'-extEC E []                 unwrap- = refl
+compEC'-extEC E (E' l· N)          F       =
+  compEC'-extEC (extEC E (-· N)) E' F
+compEC'-extEC E (VM ·r E')         F       =
+  compEC'-extEC (extEC E (VM ·-)) E' F
+compEC'-extEC E (E' ·⋆ A / refl)   F       =
+  compEC'-extEC (extEC E (-·⋆ A)) E' F
+compEC'-extEC E (wrap E')          F       =
+  compEC'-extEC (extEC E wrap-) E' F
+compEC'-extEC E (unwrap E' / refl) F       =
+  compEC'-extEC (extEC E unwrap-) E' F
 
 extEC-[]ᴱ : ∀{A B C}(E : EC A B)(F : Frame B C)(M : ∅ ⊢ C) →
   extEC E F [ M ]ᴱ ≡ E [ F [ M ]ᶠ ]ᴱ
-extEC-[]ᴱ [] (-· N) M = refl
-extEC-[]ᴱ [] (VL ·-) M = refl
-extEC-[]ᴱ [] (-·⋆ A) M = refl
-extEC-[]ᴱ [] wrap- M = refl
-extEC-[]ᴱ [] unwrap- M = refl
-extEC-[]ᴱ (E l· N) F M = cong (_· N) (extEC-[]ᴱ E F M)
-extEC-[]ᴱ (VL ·r E) F M = cong (deval VL ·_) (extEC-[]ᴱ E F M)
-extEC-[]ᴱ (E ·⋆ A) F M = cong (_·⋆ A) (extEC-[]ᴱ E F M)
-extEC-[]ᴱ (wrap E) F M = cong (wrap _ _) (extEC-[]ᴱ E F M)
-extEC-[]ᴱ (unwrap E) F M = cong unwrap (extEC-[]ᴱ E F M)
+extEC-[]ᴱ []                (-· N)  M = refl
+extEC-[]ᴱ []                (VL ·-) M = refl
+extEC-[]ᴱ []                (-·⋆ A) M = refl
+extEC-[]ᴱ []                wrap-   M = refl
+extEC-[]ᴱ []                unwrap- M = refl
+extEC-[]ᴱ (E l· N)          F       M = cong (_· N) (extEC-[]ᴱ E F M)
+extEC-[]ᴱ (VL ·r E)         F       M = cong (deval VL ·_) (extEC-[]ᴱ E F M)
+extEC-[]ᴱ (E ·⋆ A / refl)   F       M = cong (_·⋆ A / refl) (extEC-[]ᴱ E F M)
+extEC-[]ᴱ (wrap E)          F       M = cong (wrap _ _) (extEC-[]ᴱ E F M)
+extEC-[]ᴱ (unwrap E / refl) F       M =
+  cong (λ M → unwrap M refl) (extEC-[]ᴱ E F M)
 
 -- 2nd functor law for []ᴱ
 compEC-[]ᴱ : ∀{A B C}(E : EC A B)(E' : EC B C)(L : ∅ ⊢ C)
   → E [ E' [ L ]ᴱ ]ᴱ ≡ compEC E E' [ L ]ᴱ
-compEC-[]ᴱ []         E' L = refl
-compEC-[]ᴱ (E l· M')  E' L = cong (_· M') (compEC-[]ᴱ E E' L)
-compEC-[]ᴱ (VM ·r E)  E' L = cong (deval VM ·_) (compEC-[]ᴱ E E' L)
-compEC-[]ᴱ (E ·⋆ A)   E' L = cong (_·⋆ A) (compEC-[]ᴱ E E' L)
-compEC-[]ᴱ (wrap E)   E' L = cong (wrap _ _) (compEC-[]ᴱ E E' L)
-compEC-[]ᴱ (unwrap E) E' L = cong unwrap (compEC-[]ᴱ E E' L)
+compEC-[]ᴱ []                E' L = refl
+compEC-[]ᴱ (E l· M')         E' L = cong (_· M') (compEC-[]ᴱ E E' L)
+compEC-[]ᴱ (VM ·r E)         E' L = cong (deval VM ·_) (compEC-[]ᴱ E E' L)
+compEC-[]ᴱ (E ·⋆ A / refl)   E' L = cong (_·⋆ A / refl) (compEC-[]ᴱ E E' L)
+compEC-[]ᴱ (wrap E)          E' L = cong (wrap _ _) (compEC-[]ᴱ E E' L)
+compEC-[]ᴱ (unwrap E / refl) E' L =
+  cong (λ M → unwrap M refl) (compEC-[]ᴱ E E' L)
 ```
 
 # the machine
@@ -165,37 +173,38 @@ data State (T : ∅ ⊢Nf⋆ *) : Set where
 stepV : ∀{A B }{M : ∅ ⊢ A}(V : Value M)
        → (B ≡ A) ⊎ ∃ (λ C → EC B C × Frame C A)
        → State B
-stepV V (inj₁ refl)                 = □ V
-stepV V (inj₂ (_ ,, E ,, (-· N)))  = extEC E (V ·-) ▻ N
+stepV V (inj₁ refl) = □ V
+stepV V (inj₂ (_ ,, E ,, (-· N))) = extEC E (V ·-) ▻ N
 stepV V (inj₂ (_ ,, E ,, (V-ƛ M ·-))) = E ▻ (M [ deval V ])
 stepV V (inj₂ (_ ,, E ,, (V-I⇒ b {as' = []} p q ·-))) =
   E ▻ BUILTIN' b (bubble p) (step p q V)
 stepV V (inj₂ (_ ,, E ,, (V-I⇒ b {as' = a ∷ as'} p q ·-))) =
   E ◅ V-I b (bubble p) (step p q V)
-stepV V (inj₂ (_ ,, E ,, wrap-))   = E ◅ V-wrap V
+stepV V (inj₂ (_ ,, E ,, wrap-)) = E ◅ V-wrap V
 stepV (V-Λ M) (inj₂ (_ ,, E ,, -·⋆ A)) = E ▻ (M [ A ]⋆)
 stepV (V-IΠ b {as' = []} p q) (inj₂ (_ ,, E ,, -·⋆ A)) =
-  E ▻ BUILTIN' b (bubble p) (step⋆ p q)
+  E ▻ BUILTIN' b (bubble p) (step⋆ p q refl)
 stepV (V-IΠ b {as' = a ∷ as'} p q) (inj₂ (_ ,, E ,, -·⋆ A)) =
-  E ◅ V-I b (bubble p) (step⋆ p q)
+  E ◅ V-I b (bubble p) (step⋆ p q refl)
 stepV (V-wrap V) (inj₂ (_ ,, E ,, unwrap-)) = E ▻ deval V -- E ◅ V
 
 stepT : ∀{A} → State A → State A
-stepT (E ▻ ƛ M)        = E ◅ V-ƛ M
-stepT (E ▻ (M · M'))   = extEC E (-· M') ▻ M
-stepT (E ▻ Λ M)        = E ◅ V-Λ M
-stepT (E ▻ (M ·⋆ A))   = extEC E (-·⋆ A) ▻ M
-stepT (E ▻ wrap A B M) = extEC E wrap- ▻ M
-stepT (E ▻ unwrap M)   = extEC E unwrap- ▻ M
-stepT (E ▻ con c)      = E ◅ V-con c
-stepT (E ▻ builtin b)  = E ◅ ival b
-stepT (E ▻ error A)    = ◆ A
-stepT (E ◅ V)          = stepV V (dissect E)
-stepT (□ V)            = □ V
-stepT (◆ A)            = ◆ A
+stepT (E ▻ ƛ M)                = E ◅ V-ƛ M
+stepT (E ▻ (M · M'))           = extEC E (-· M') ▻ M
+stepT (E ▻ Λ M)                = E ◅ V-Λ M
+stepT (E ▻ (M ·⋆ A / refl))    = extEC E (-·⋆ A) ▻ M
+stepT (E ▻ wrap A B M)         = extEC E wrap- ▻ M
+stepT (E ▻ unwrap M refl)      = extEC E unwrap- ▻ M
+stepT (E ▻ con c)              = E ◅ V-con c
+stepT (E ▻ (builtin b / refl)) = E ◅ ival b
+stepT (E ▻ error A)            = ◆ A
+stepT (E ◅ V)                  = stepV V (dissect E)
+stepT (□ V)                    = □ V
+stepT (◆ A)                    = ◆ A
 ```
 
 ```
+{-
 data _-→s_ {A : ∅ ⊢Nf⋆ *} : State A → State A → Set where
   base  : {s : State A} → s -→s s
   step* : {s s' s'' : State A}
@@ -1097,3 +1106,4 @@ thm1bV M W M' E refl N V (step* refl q) | inj₁ refl | I[ eq ] rewrite dissect-
 
 thm2b : ∀{A}(M N : ∅ ⊢ A)(V : Value N) → ([] ▻ M) -→s (□ V) → M —↠ N
 thm2b M N V p = thm1b M M [] refl N V p
+-- -}

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -204,7 +204,6 @@ stepT (◆ A)                    = ◆ A
 ```
 
 ```
-{-
 data _-→s_ {A : ∅ ⊢Nf⋆ *} : State A → State A → Set where
   base  : {s : State A} → s -→s s
   step* : {s s' s'' : State A}
@@ -230,15 +229,14 @@ dissect-lemma (E l· M')  F
   rewrite dissect-lemma E F = refl
 dissect-lemma (VM ·r E)  F
   rewrite dissect-lemma E F = refl
-dissect-lemma (E ·⋆ A)   F
+dissect-lemma (E ·⋆ A / refl)   F
   rewrite dissect-lemma E F = refl
 dissect-lemma (wrap E)   F
   rewrite dissect-lemma E F = refl
-dissect-lemma (unwrap E) F
+dissect-lemma (unwrap E / refl) F
   rewrite dissect-lemma E F = refl
 
 open import Builtin
-
 postulate
   lemV : ∀{A B}(M : ∅ ⊢ B)(V : Value M)(E : EC A B) → (E ▻ M) -→s (E ◅ V)
 
@@ -691,6 +689,7 @@ lemV M (V-IΠ mkNilData {as = as ∷ x} (bubble p) x₁) E = {!!}
 lemV M (V-IΠ mkNilPairData {as = as ∷ x} (bubble p) x₁) E = {!!}
 lemV M (V-IΠ mkConsData {as = as ∷ x} (bubble p) x₁) E = {!!}
 -}
+
 lem62 : ∀{A B C}(L : ∅ ⊢ C)(E : EC A B)(E' : EC B C)
       → (E ▻ (E' [ L ]ᴱ)) -→s (compEC' E E' ▻ L)
 lem62 L E []          = base
@@ -699,9 +698,9 @@ lem62 L E (VM ·r E')  = step* refl (step**
   (lemV _ VM (extEC E (-· (E' [ L ]ᴱ))))
   (step* (cong (stepV VM) (dissect-lemma E (-· (E' [ L ]ᴱ))))
          (lem62 L (extEC E (VM ·-)) E')))
-lem62 L E (E' ·⋆ A)   = step* refl (lem62 L (extEC E (-·⋆ A)) E')
+lem62 L E (E' ·⋆ A / refl)   = step* refl (lem62 L (extEC E (-·⋆ A)) E')
 lem62 L E (wrap E')   = step* refl (lem62 L (extEC E wrap-) E')
-lem62 L E (unwrap E') = step* refl (lem62 L (extEC E unwrap-) E')
+lem62 L E (unwrap E' / refl) = step* refl (lem62 L (extEC E unwrap-) E')
 
 open import Data.Empty
 
@@ -713,27 +712,25 @@ unwindVE : ∀{A B C}(M : ∅ ⊢ A)(N : ∅ ⊢ B)(E : EC C B)(E' : EC B A)
       → (compEC' E E' ◅ VM) -→s (E ◅ VN)
 unwindVE A B E E' refl VM VN with dissect E' | inspect dissect E'
 ... | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E' refl eq rewrite uniqueVal A VM VN = base
-... | inj₂ (_ ,, E'' ,, (V-ƛ M ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-ƛ M ·-) eq = ⊥-elim (lemVβ (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (V-ƛ M ·-) A) VN))))
-unwindVE A .(E' [ A ]ᴱ) E E' refl VM VN | inj₂ (_ ,, E'' ,, (V-I⇒ b {as' = []} p x ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-I⇒ b p x ·-) eq = ⊥-elim (valred (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) A) VN))) (β-sbuiltin b (deval (V-I⇒ b p x)) p x A VM))
+... | inj₂ (_ ,, E'' ,, (V-ƛ M ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-ƛ M ·-) eq = ⊥-elim (lemVβ (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (V-ƛ M ·-) A) VN)))
+unwindVE A .(E' [ A ]ᴱ) E E' refl VM VN | inj₂ (_ ,, E'' ,, (V-I⇒ b {as' = []} p x ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-I⇒ b p x ·-) eq = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) A) VN)) (β-sbuiltin b (deval (V-I⇒ b p x)) p x A VM))
 unwindVE A .(E' [ A ]ᴱ) E E' refl VM VN | inj₂ (_ ,, E'' ,, (V-I⇒ b {as' = x₁ ∷ as'} p x ·-)) | I[ eq ] rewrite dissect-inj₂ E' E'' (V-I⇒ b p x ·-) eq =
   step* (trans (cong (λ E → stepV VM (dissect E)) (compEC'-extEC E E'' (V-I⇒ b p x ·-))) (cong (stepV VM) (dissect-lemma (compEC' E E'') (V-I⇒ b p x ·-)))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) A) (V-I b (bubble p) (step p x VM)) VN)
-unwindVE .(Λ M) .(E' [ Λ M ]ᴱ) E E' refl (V-Λ M) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq = ⊥-elim (lemVβ⋆ (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (-·⋆ C) (Λ M)) VN))))
-unwindVE A .(E' [ A ]ᴱ) E E' refl (V-IΠ b {as' = []} p x) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq = ⊥-elim (valred (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (-·⋆ C) A) VN))) (β-sbuiltin⋆ b A p x C))
+unwindVE .(Λ M) .(E' [ Λ M ]ᴱ) E E' refl (V-Λ M) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq = ⊥-elim (lemVβ⋆ (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (-·⋆ C) (Λ M)) VN)))
+unwindVE A .(E' [ A ]ᴱ) E E' refl (V-IΠ b {as' = []} p x) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (-·⋆ C) A) VN)) (β-sbuiltin⋆ b A p x C refl))
 unwindVE A .(E' [ A ]ᴱ) E E' refl (V-IΠ b {as' = a ∷ as'} p x) VN | inj₂ (_ ,, E'' ,, -·⋆ C) | I[ eq ] rewrite dissect-inj₂ E' E'' (-·⋆ C) eq =
-  step* (trans (cong (λ E → stepV _ (dissect E)) (compEC'-extEC E E'' (-·⋆ C))) (cong (stepV (V-IΠ b p x)) (dissect-lemma (compEC' E E'') (-·⋆ C)))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (-·⋆ C) A) (V-I b (bubble p) (step⋆ p x)) VN)
+  step* (trans (cong (λ E → stepV _ (dissect E)) (compEC'-extEC E E'' (-·⋆ C))) (cong (stepV (V-IΠ b p x)) (dissect-lemma (compEC' E E'') (-·⋆ C)))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' (-·⋆ C) A) (V-I b (bubble p) (step⋆ p x refl)) VN)
 ... | inj₂ (_ ,, E'' ,, wrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' wrap- eq = step* (trans (cong (λ E → stepV VM (dissect E)) (compEC'-extEC E E'' wrap-)) (cong (stepV VM) (dissect-lemma (compEC' E E'') wrap-))) (unwindVE _ _ E E'' (extEC-[]ᴱ E'' wrap- A) (V-wrap VM) VN)
-unwindVE .(wrap _ _ _) .(E' [ wrap _ _ _ ]ᴱ) E E' refl (V-wrap VM) VN | inj₂ (_ ,, E'' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' unwrap- eq = ⊥-elim (valred (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' unwrap- (deval (V-wrap VM))) VN))) (β-wrap VM))
-unwindVE .(ƛ M) .(E' [ ƛ M ]ᴱ) E E' refl (V-ƛ M) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = ⊥-elim (lemVβ (lemVE (ƛ M · M') E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (-· M') (ƛ M)) VN))))
-unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {as' = []} p x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = ⊥-elim (valred (lemVE _ E'' (Value2VALUE (subst Value (extEC-[]ᴱ E'' (-· M') A) VN))) (β-sbuiltin b A p x M' (VALUE2Value (lemVE _ (extEC E'' (V ·-)) (Value2VALUE (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V ·-) M'))) VN))))))
-unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {as' = a ∷ as'} p x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = step* (trans (cong (λ E → stepV (V-I⇒ b p x) (dissect E)) (compEC'-extEC E E'' (-· M'))) (cong (stepV (V-I⇒ b p x)) (dissect-lemma (compEC' E E'') (-· M')))) (step** (lemV M' (VALUE2Value (lemVE M' (extEC E'' (V-I⇒ b p x ·-)) (Value2VALUE (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) M'))) VN)))) (extEC (compEC' E E'') (V-I⇒ b p x ·-))) (step* (cong (stepV _) (dissect-lemma (compEC' E E'') (V-I⇒ b p x ·-))) ((unwindVE (A · M') _ E E'' (extEC-[]ᴱ E'' (-· M') A) (V-I b (bubble p)
+unwindVE .(wrap _ _ _) .(E' [ wrap _ _ _ ]ᴱ) E E' refl (V-wrap VM) VN | inj₂ (_ ,, E'' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E' E'' unwrap- eq = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' unwrap- (deval (V-wrap VM))) VN)) (β-wrap VM refl))
+unwindVE .(ƛ M) .(E' [ ƛ M ]ᴱ) E E' refl (V-ƛ M) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = ⊥-elim (lemVβ (lemVE (ƛ M · M') E'' (subst Value (extEC-[]ᴱ E'' (-· M') (ƛ M)) VN)))
+unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {as' = []} p x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = ⊥-elim (valred (lemVE _ E'' (subst Value (extEC-[]ᴱ E'' (-· M') A) VN)) (β-sbuiltin b A p x M' (lemVE _ (extEC E'' (V ·-)) (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V ·-) M'))) VN))))
+unwindVE A .(E' [ A ]ᴱ) E E' refl V@(V-I⇒ b {as' = a ∷ as'} p x) VN | inj₂ (_ ,, E'' ,, (-· M')) | I[ eq ] rewrite dissect-inj₂ E' E'' (-· M') eq = step* (trans (cong (λ E → stepV (V-I⇒ b p x) (dissect E)) (compEC'-extEC E E'' (-· M'))) (cong (stepV (V-I⇒ b p x)) (dissect-lemma (compEC' E E'') (-· M')))) (step** (lemV M' (lemVE M' (extEC E'' (V-I⇒ b p x ·-)) (subst Value (trans (extEC-[]ᴱ E'' (-· M') A) (sym (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) M'))) VN)) (extEC (compEC' E E'') (V-I⇒ b p x ·-))) (step* (cong (stepV _) (dissect-lemma (compEC' E E'') (V-I⇒ b p x ·-))) ((unwindVE (A · M') _ E E'' (extEC-[]ᴱ E'' (-· M') A) (V-I b (bubble p)
   (step p x
-   (VALUE2Value
-    (lemVE M' (extEC E'' (V-I⇒ b p x ·-))
-     (Value2VALUE
+   (lemVE M' (extEC E'' (V-I⇒ b p x ·-))
       (subst Value
        (trans (extEC-[]ᴱ E'' (-· M') A)
         (sym (extEC-[]ᴱ E'' (V-I⇒ b p x ·-) M')))
-       VN)))))) VN))))
+       VN)))) VN))))
 
 unwindE : ∀{A B C}(M : ∅ ⊢ A)(N : ∅ ⊢ B)(E : EC C B)(E' : EC B A)
       → N ≡ E' [ M ]ᴱ
@@ -742,7 +739,7 @@ unwindE : ∀{A B C}(M : ∅ ⊢ A)(N : ∅ ⊢ B)(E : EC C B)(E' : EC B A)
 
 unwindE M N E E' refl VN = step**
   (lemV M _ (compEC' E E'))
-  (unwindVE M N E E' refl (VALUE2Value (lemVE M E' (Value2VALUE VN))) VN)
+  (unwindVE M N E E' refl (lemVE M E' VN) VN)
 
 open import Relation.Nullary
 open import Type.BetaNBE
@@ -797,25 +794,25 @@ refocus : ∀{A B}(E : EC B A)(M : ∅ ⊢ A)(VM : Value M){A'}(E₁ : EC B A')
   → ReFocussing E M VM E₁ L r p
 refocus E M VM E₁ L r p with dissect E | inspect dissect E
 refocus E M VM E₁ L r p | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E refl eq =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VM)) r)
 refocus E M VM E₁ L r p | inj₂ (_ ,, E₂ ,, (-· N)) | I[ eq ] with rlemma51! N
 refocus E M VM E₁ L r p | inj₂ (C ,, E₂ ,, (-· N)) | I[ eq ] | step ¬VN E₃ r' p' U with rlemma51! (E [ M ]ᴱ)
-... | done VEM = ⊥-elim (valredex (lemVE _ E₁ (Value2VALUE (subst Value p VEM))) r)
+... | done VEM = ⊥-elim (valredex (lemVE _ E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₄ r'' p'' U'  rewrite dissect-inj₂ E E₂ (-· N) eq with U' _ p r
 ... | refl ,, _ ,, refl with U' (compEC' (extEC E₂ (VM ·-)) E₃) (trans (extEC-[]ᴱ E₂ (-· N) M) (trans (trans (cong (λ N →  E₂ [ M · N ]ᴱ) p') (sym (extEC-[]ᴱ E₂ (VM ·-) _))) (trans (compEC-[]ᴱ (extEC E₂ (VM ·-)) E₃ _) (cong (λ E → E [ _ ]ᴱ) (compEC-eq (extEC E₂ (VM ·-)) E₃))))) r'
-... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl VM (lemV'· (λ VN → valredex (lemVE L _ (Value2VALUE (subst Value p' VN))) r')) ((VM EC.·r E₃)) (sym (trans (extEC-[]ᴱ E₂ (-· N) M) (trans (trans (cong (λ N →  E₂ [ M · N ]ᴱ) p') (sym (extEC-[]ᴱ E₂ (VM ·-) _))) (trans (compEC-[]ᴱ (extEC E₂ (VM ·-)) E₃ _) (cong (λ E → E [ _ ]ᴱ) (compEC-eq (extEC E₂ (VM ·-)) E₃))))))
+... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl VM (lemV'· (λ VN → valredex (lemVE L _ (subst Value p' VN)) r')) ((VM EC.·r E₃)) (sym (trans (extEC-[]ᴱ E₂ (-· N) M) (trans (trans (cong (λ N →  E₂ [ M · N ]ᴱ) p') (sym (extEC-[]ᴱ E₂ (VM ·-) _))) (trans (compEC-[]ᴱ (extEC E₂ (VM ·-)) E₃ _) (cong (λ E → E [ _ ]ᴱ) (compEC-eq (extEC E₂ (VM ·-)) E₃))))))
 -- same proof twice
 refocus E .(ƛ M) (V-ƛ M) E₁ L r p | inj₂ (_ ,, E₂ ,, (-· N)) | I[ eq ] | done VN with rlemma51! (E [ ƛ M ]ᴱ)
-... | done VEƛM = ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEƛM))) r)
+... | done VEƛM = ⊥-elim (valredex (lemVE L E₁ (subst Value p VEƛM)) r)
 ... | step ¬VEƛM E₃ x₁ x₂ U rewrite dissect-inj₂ E E₂ (-· N) eq with U E₁ p r
 ... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-· N) (ƛ M)) (β (β-ƛ VN))
-... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl (V-ƛ M) (λ V → lemVβ (Value2VALUE V)) [] (sym (extEC-[]ᴱ E₂ (-· N) (ƛ M)))
+... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl (V-ƛ M) (λ V → lemVβ V) [] (sym (extEC-[]ᴱ E₂ (-· N) (ƛ M)))
 refocus E M V@(V-I⇒ b {as' = []} p₁ x) E₁ L r p | inj₂ (_ ,, E₂ ,, (-· N)) | I[ eq ] | done VN with rlemma51! (E [ M ]ᴱ)
 ... | done VEM =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₃ x₂ x₃ U rewrite dissect-inj₂ E E₂ (-· N) eq with U E₁ p r
 ... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-· N) M) (β (β-sbuiltin b M p₁ x N VN))
-... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl V (λ V → valred (Value2VALUE V) (β-sbuiltin b M p₁ x N VN)) [] (sym (extEC-[]ᴱ E₂ (-· N) M))
+... | refl ,, refl ,, refl = locate E₂ (-· N) [] refl V (λ V → valred V (β-sbuiltin b M p₁ x N VN)) [] (sym (extEC-[]ᴱ E₂ (-· N) M))
 refocus E M (V-I⇒ b {as' = x₁ ∷ as'} p₁ x) E₁ L r p | inj₂ (_ ,, E₂ ,, (-· N)) | I[ eq ] | done VN rewrite dissect-inj₂ E E₂ (-· N) eq with refocus E₂ (M · N) (V-I b (bubble p₁) (step p₁ x VN)) E₁ L r (trans (sym (extEC-[]ᴱ E₂ (-· N) M)) p)
 ... | locate E₃ F E₄ x₂ x₃ x₄ E₅ x₅ = locate
   E₃
@@ -831,18 +828,18 @@ refocus E M (V-I⇒ b {as' = x₁ ∷ as'} p₁ x) E₁ L r p | inj₂ (_ ,, E�
 refocus E M VM E₁ L r p | inj₂ (_ ,, E₂ ,, (V@(V-ƛ M₁) ·-))      | I[ eq ]
   with rlemma51! (E [ M ]ᴱ)
 ... | done VEM =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₃ x₁ x₂ U  rewrite dissect-inj₂ E E₂ (V ·-) eq
   with U E₁ p r
 ... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (V ·-) M) (β (β-ƛ VM))
-... | refl ,, refl ,, refl = locate E₂ (V ·-) [] refl VM (λ V → lemVβ (Value2VALUE V)) [] (sym (extEC-[]ᴱ E₂ (V ·-) M))
+... | refl ,, refl ,, refl = locate E₂ (V ·-) [] refl VM (λ V → lemVβ V) [] (sym (extEC-[]ᴱ E₂ (V ·-) M))
 refocus E M VM E₁ L r p | inj₂ (_ ,, E₂ ,, (V@(V-I⇒ b {as' = []} p₁ x) ·-)) | I[ eq ] with rlemma51! (E [ M ]ᴱ)
 ... | done VEM =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₃ x₁ x₂ U rewrite dissect-inj₂ E E₂ (V ·-) eq
   with U E₁ p r
 ... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (V ·-) M) (β (β-sbuiltin b _ p₁ x M VM))
-... | refl ,, refl ,, refl = locate E₂ (V ·-) [] refl VM (λ V → valred (Value2VALUE V) (β-sbuiltin b _ p₁ x M VM)) [] (sym (extEC-[]ᴱ E₂ (V ·-) M))
+... | refl ,, refl ,, refl = locate E₂ (V ·-) [] refl VM (λ V → valred V (β-sbuiltin b _ p₁ x M VM)) [] (sym (extEC-[]ᴱ E₂ (V ·-) M))
 refocus E M VM E₁ L r p | inj₂ (_ ,, E₂ ,, _·- {t = t} (V@(V-I⇒ b {as' = _ ∷ as'} p₁ x))) | I[ eq ] rewrite dissect-inj₂ E E₂ (V ·-) eq with refocus E₂ (t · M) (V-I b (bubble p₁) (step p₁ x VM)) E₁ L r (trans (sym (extEC-[]ᴱ E₂ (V ·-) M)) p)
 ... | locate E₃ F E₄ x₂ x₃ x₄ E₅ x₅ = locate
   E₃
@@ -855,17 +852,17 @@ refocus E M VM E₁ L r p | inj₂ (_ ,, E₂ ,, _·- {t = t} (V@(V-I⇒ b {as' 
   E₅
   (trans x₅ (sym (extEC-[]ᴱ E₂ (V ·-) M)))
 refocus E .(Λ M) (V-Λ M) E₁ L r p | inj₂ (_ ,, E₂ ,, -·⋆ A) | I[ eq ]  with rlemma51! (E [ Λ M ]ᴱ)
-... | done VEƛM = ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEƛM))) r)
+... | done VEƛM = ⊥-elim (valredex (lemVE L E₁ (subst Value p VEƛM)) r)
 ... | step ¬VEƛM E₃ x₁ x₂ U rewrite dissect-inj₂ E E₂ (-·⋆ A) eq with U E₁ p r
-... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-·⋆ A) (Λ M)) (β β-Λ)
-... | refl ,, refl ,, refl = locate E₂ (-·⋆ A) [] refl (V-Λ M) (λ V → lemVβ⋆ (Value2VALUE V)) [] (sym (extEC-[]ᴱ E₂ (-·⋆ A) (Λ M)))
+... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-·⋆ A) (Λ M)) (β (β-Λ refl))
+... | refl ,, refl ,, refl = locate E₂ (-·⋆ A) [] refl (V-Λ M) (λ V → lemVβ⋆ V) [] (sym (extEC-[]ᴱ E₂ (-·⋆ A) (Λ M)))
 refocus E M V@(V-IΠ b {as' = []} p₁ x) E₁ L r p | inj₂ (_ ,, E₂ ,, -·⋆ A) | I[ eq ] with rlemma51! (E [ M ]ᴱ)
 ... | done VEM =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₃ x₂ x₃ U rewrite dissect-inj₂ E E₂ (-·⋆ A) eq with U E₁ p r
-... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-·⋆ A) M) (β (β-sbuiltin⋆ b M p₁ x A))
-... | refl ,, refl ,, refl = locate E₂ (-·⋆ A) [] refl V (λ V → valred (Value2VALUE V) (β-sbuiltin⋆ b M p₁ x A)) [] (sym (extEC-[]ᴱ E₂ (-·⋆ A) M))
-refocus E M (V-IΠ b {as' = _ ∷ as'} p₁ x) E₁ L r p | inj₂ (_ ,, E₂ ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E₂ (-·⋆ A) eq with refocus E₂ (M ·⋆ A) (V-I b (bubble p₁) (step⋆ p₁ x)) E₁ L r (trans (sym (extEC-[]ᴱ E₂ (-·⋆ A) M)) p)
+... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ (-·⋆ A) M) (β (β-sbuiltin⋆ b M p₁ x A refl))
+... | refl ,, refl ,, refl = locate E₂ (-·⋆ A) [] refl V (λ V → valred V (β-sbuiltin⋆ b M p₁ x A refl)) [] (sym (extEC-[]ᴱ E₂ (-·⋆ A) M))
+refocus E M (V-IΠ b {as' = _ ∷ as'} p₁ x) E₁ L r p | inj₂ (_ ,, E₂ ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E₂ (-·⋆ A) eq with refocus E₂ (M ·⋆ A / refl) (V-I b (bubble p₁) (step⋆ p₁ x refl)) E₁ L r (trans (sym (extEC-[]ᴱ E₂ (-·⋆ A) M)) p)
 ... | locate E₃ F E₄ x₂ x₃ x₄ E₅ x₅ = locate
   E₃
   F
@@ -880,12 +877,11 @@ refocus E M VM E₁ L r p | inj₂ (μ A B ,, E₂ ,, wrap-) | I[ eq ] rewrite d
 ... | locate E₃ F E₄ x x₁ x₂ E₅ x₃ = locate E₃ F (extEC E₄ wrap-) ((trans (compEC'-extEC (extEC E₃ F) E₄ wrap-) (cong (λ E → extEC E wrap-) x))) (subst Value (sym (extEC-[]ᴱ E₄ wrap- M)) x₁) (λ V → x₂ (subst Value (cong (F [_]ᶠ) (extEC-[]ᴱ E₄ wrap- M)) V)) E₅ (trans x₃ (sym (extEC-[]ᴱ E₂ wrap- M)))
 refocus E (wrap A B M) (V-wrap VM) E₁ L r p | inj₂ (_ ,, E₂ ,, unwrap-) | I[ eq ] with rlemma51! (E [ wrap A B M ]ᴱ)
 ... | done VEM =
-  ⊥-elim (valredex (lemVE L E₁ (Value2VALUE (subst Value p VEM))) r)
+  ⊥-elim (valredex (lemVE L E₁ (subst Value p VEM)) r)
 ... | step ¬VEM E₃ x₁ x₂ U rewrite dissect-inj₂ E E₂ unwrap- eq
   with U E₁ p r
-... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ unwrap- (wrap A B M)) (β (β-wrap VM))
-... | refl ,, refl ,, refl = locate E₂ unwrap- [] refl (V-wrap VM) (λ V → valred (Value2VALUE V) (β-wrap VM)) [] (sym (extEC-[]ᴱ E₂ unwrap- (wrap A B M)))
-
+... | refl ,, refl ,, refl with U E₂ (extEC-[]ᴱ E₂ unwrap- (wrap A B M)) (β (β-wrap VM refl))
+... | refl ,, refl ,, refl = locate E₂ unwrap- [] refl (V-wrap VM) (λ V → valred V (β-wrap VM refl)) [] (sym (extEC-[]ᴱ E₂ unwrap- (wrap A B M)))
 
 lem-→s⋆ : ∀{A B}(E : EC A B){L N} →  L —→⋆ N -> (E ▻ L) -→s (E ▻ N)
 lem-→s⋆ E (β-ƛ V) = step*
@@ -895,17 +891,17 @@ lem-→s⋆ E (β-ƛ V) = step*
                  (step** (lemV _ V (extEC E (V-ƛ _ ·-)))
                          (step* (cong (stepV V) (dissect-lemma E (V-ƛ _ ·-)))
                                 base))))
-lem-→s⋆ E β-Λ = step*
+lem-→s⋆ E (β-Λ refl) = step*
   refl
   (step** (lemV _ (V-Λ _) (extEC E (-·⋆ _)))
           (step* (cong (stepV (V-Λ _)) (dissect-lemma E (-·⋆ _)))
                  base))
-lem-→s⋆ E (β-wrap V) = step*
+lem-→s⋆ E (β-wrap V refl) = step*
   refl
   (step** (lemV _ (V-wrap V) (extEC E unwrap-))
           (step* (cong (stepV (V-wrap V)) (dissect-lemma E unwrap-))
                  base))
-lem-→s⋆ E (β-sbuiltin b t p bt u vu) with bappTermLem b t p (BApp2BAPP bt)
+lem-→s⋆ E (β-sbuiltin b t p bt u vu) with bappTermLem b t p bt
 ... | _ ,, _ ,, refl = step*
   refl
   (step** (lemV t (V-I⇒ b p bt) (extEC E (-· u)))
@@ -913,7 +909,7 @@ lem-→s⋆ E (β-sbuiltin b t p bt u vu) with bappTermLem b t p (BApp2BAPP bt)
                  (step** (lemV u vu (extEC E (V-I⇒ b p bt ·-)))
                          (step* (cong (stepV vu) (dissect-lemma E (V-I⇒ b p bt ·-)))
                                 base))))
-lem-→s⋆ E (β-sbuiltin⋆ b t p bt A) with bappTypeLem b t p (BApp2BAPP bt)
+lem-→s⋆ E (β-sbuiltin⋆ b t p bt A refl) with bappTypeLem b t p bt
 ... | _ ,, _ ,, refl = step*
   refl
   (step** (lemV t (V-IΠ b p bt) (extEC E (-·⋆ A)))
@@ -942,12 +938,12 @@ lemmaF' : ∀{A A' B B'}(M : ∅ ⊢ A)(F : Frame B A)(E : EC B' B)
       → (extEC E F ◅ V) -→s (compEC' E E' ▻ L')
 lemmaF' M (-· N) E E' L L' V r ¬VFM x₁ with rlemma51! N
 ... | step ¬VN  E₁ x₃ refl U with rlemma51! (extEC E (-· N) [ M ]ᴱ)
-... | done VMN = ⊥-elim (¬VFM (VALUE2Value (lemVE (M · E₁ [ _ ]ᴱ) E (Value2VALUE (subst Value (extEC-[]ᴱ E (-· (E₁ [ _ ]ᴱ)) M) VMN))) ))
+... | done VMN = ⊥-elim (¬VFM (lemVE (M · E₁ [ _ ]ᴱ) E (subst Value (extEC-[]ᴱ E (-· (E₁ [ _ ]ᴱ)) M) VMN)))
 ... | step ¬VEMN E₂ x₆ x₇ U' with U' (compEC' E E') x₁ (β r)
 ... | refl ,, refl ,, refl with U' (compEC' (extEC E (V ·-)) E₁) (trans (extEC-[]ᴱ E (-· N) M) (trans (trans (sym (extEC-[]ᴱ E (V ·-) _)) (compEC-[]ᴱ (extEC E (V ·-)) E₁ _)) (cong (_[ _ ]ᴱ) (compEC-eq (extEC E (V ·-)) E₁)))) x₃
 ... | refl ,, x ,, refl rewrite x = step* (cong (stepV V) (dissect-lemma E (-· (E₁ [ L ]ᴱ)))) (step** (lem62 L (extEC E (V ·-)) E₁) (lem-→s⋆ _ r))
 lemmaF' .(ƛ M) (-· N) E E' L L' (V-ƛ M) r ¬VFM x₁ | done VN with rlemma51! (extEC E (-· N) [ ƛ M ]ᴱ)
-... | done VƛMN = ⊥-elim (lemVβ (lemVE _ E (Value2VALUE (subst Value (extEC-[]ᴱ E (-· N) (ƛ M)) VƛMN))))
+... | done VƛMN = ⊥-elim (lemVβ (lemVE _ E (subst Value (extEC-[]ᴱ E (-· N) (ƛ M)) VƛMN)))
 ... | step ¬VƛMN E₁ x₂ x₃ U with U E (extEC-[]ᴱ E (-· N) (ƛ M)) (β (β-ƛ VN))
 ... | refl ,, refl ,, refl with U (compEC' E E') x₁ (β r)
 lemmaF' .(ƛ M) (-· N) E E' L _ (V-ƛ M) (β-ƛ _) ¬VFM x₁ | done VN | step ¬VƛMN E₁ x₂ x₃ U | refl ,, refl ,, refl | refl ,, x ,, refl = step*
@@ -956,7 +952,7 @@ lemmaF' .(ƛ M) (-· N) E E' L _ (V-ƛ M) (β-ƛ _) ¬VFM x₁ | done VN | step 
           (step* (cong (stepV VN) (dissect-lemma E (V-ƛ M ·-))) (subst (λ E' →  (E ▻ (M [ N ])) -→s (E' ▻ (M [ N ]))) x base)))
 
 lemmaF' M (-· N) E E' L L' V@(V-I⇒ b {as' = []} p x) r ¬VFM x₁ | done VN with rlemma51! (extEC E (-· N) [ M ]ᴱ)
-... | done VMN = ⊥-elim (valred (lemVE _ E (Value2VALUE (subst Value (extEC-[]ᴱ E (-· N) M) VMN))) (β-sbuiltin b M p x N VN))
+... | done VMN = ⊥-elim (valred (lemVE _ E (subst Value (extEC-[]ᴱ E (-· N) M) VMN)) (β-sbuiltin b M p x N VN))
 ... | step ¬VMN E₁ x₃ x₄ U with U E (extEC-[]ᴱ E (-· N) M) (β (β-sbuiltin b M p x N VN))
 ... | refl ,, refl ,, refl with U (compEC' E E') x₁ (β r)
 lemmaF' M (-· N) E E' .(M · N) _ V@(V-I⇒ b {as' = []} p x) (β-sbuiltin b₁ .M p₁ bt .N vu) ¬VFM x₁ | done VN | step ¬VMN E x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl with uniqueVal N VN vu | uniqueVal M V (V-I⇒ b₁ p₁ bt)
@@ -968,7 +964,7 @@ lemmaF' M (-· N) E E' L L' (V-I⇒ b {as' = x₂ ∷ as'} p x) r ¬VFM x₁ | d
   ⊥-elim (¬VFM (V-I b (bubble p) (step p x VN)))
 
 lemmaF' M (VN ·-) E E' L L' V x x₁ x₂ with rlemma51! (extEC E (VN ·-) [ M ]ᴱ)
-... | done VNM = ⊥-elim (x₁ (VALUE2Value (lemVE (deval VN · M) E (Value2VALUE (subst Value (extEC-[]ᴱ E (VN ·-) M) VNM)))))
+... | done VNM = ⊥-elim (x₁ (lemVE (deval VN · M) E (subst Value (extEC-[]ᴱ E (VN ·-) M) VNM)))
 lemmaF' M (V-ƛ M₁ ·-) E E' L L' V x x₁ x₂ | step ¬VƛM₁M E₁ x₃ x₄ U with U (compEC' E E') x₂ (β x)
 ... | refl ,, refl ,, refl with U E (extEC-[]ᴱ E (V-ƛ M₁ ·-) M) (β (β-ƛ V))
 lemmaF' M (V-ƛ M₁ ·-) E E' L L' V (β-ƛ _) x₁ x₂ | step ¬VƛM₁M E₁ x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl = step* (cong (stepV V) (dissect-lemma E (V-ƛ M₁ ·-))) ((subst (λ E' → (E ▻ _) -→s (E' ▻ _)) (sym q) base))
@@ -979,23 +975,23 @@ lemmaF' M (VN@(V-I⇒ b {as' = []} p x₃) ·-) E E' L L' V x x₁ x₂ | step �
   (cong (stepV V) (dissect-lemma E (VN ·-)))
   (subst (λ E' → (E ▻ _) -→s (E' ▻ _)) q base)
 lemmaF' M (-·⋆ A) E E' L L' V x x₁ x₂ with rlemma51! (extEC E (-·⋆ A) [ M ]ᴱ)
-... | done VM·⋆A = ⊥-elim (x₁ (VALUE2Value (lemVE (M ·⋆ A) E (Value2VALUE (subst Value (extEC-[]ᴱ E (-·⋆ A) M) VM·⋆A)))))
+... | done VM·⋆A = ⊥-elim (x₁ (lemVE (M ·⋆ A / refl) E (subst Value (extEC-[]ᴱ E (-·⋆ A) M) VM·⋆A)))
 lemmaF' M (-·⋆ A) E E' L L' V x x₁ x₂ | step ¬VM·⋆A E₁ x₃ x₄ U with U (compEC' E E') x₂ (β x)
-lemmaF' .(Λ M) (-·⋆ A) E E' L L' (V-Λ M) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E (-·⋆ A) (Λ M)) (β β-Λ)
-lemmaF' .(Λ M) (-·⋆ A) E E' L L' (V-Λ M) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-Λ) = step*
+lemmaF' .(Λ M) (-·⋆ A) E E' L L' (V-Λ M) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E (-·⋆ A) (Λ M)) (β (β-Λ refl))
+lemmaF' .(Λ M) (-·⋆ A) E E' L L' (V-Λ M) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-Λ refl) = step*
   (cong (stepV (V-Λ M)) (dissect-lemma E (-·⋆ A)))
   (subst (λ E' → (E ▻ _) -→s (E' ▻ _)) (sym q) base)
-lemmaF' M (-·⋆ A) E E' L L' (V-IΠ b {as' = []} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E (-·⋆ A) M) (β (β-sbuiltin⋆ b M p x₅ A))
-lemmaF' M (-·⋆ A) E E' L L' VM@(V-IΠ b {as' = []} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-sbuiltin⋆ b M p x₅ A) = step*
+lemmaF' M (-·⋆ A) E E' L L' (V-IΠ b {as' = []} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E (-·⋆ A) M) (β (β-sbuiltin⋆ b M p x₅ A refl))
+lemmaF' M (-·⋆ A) E E' L L' VM@(V-IΠ b {as' = []} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-sbuiltin⋆ b M p x₅ A refl) = step*
   (cong (stepV VM) (dissect-lemma E (-·⋆ A)))
   (subst (λ E' → (E ▻ _) -→s (E' ▻ _)) (sym q) base)
-lemmaF' M (-·⋆ A) E E' L L' (V-IΠ b {as' = x₆ ∷ as'} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl = ⊥-elim (x₁ (V-I b (bubble p) (step⋆ p x₅)))
+lemmaF' M (-·⋆ A) E E' L L' (V-IΠ b {as' = x₆ ∷ as'} p x₅) x x₁ x₂ | step ¬VM·⋆A .(compEC' E E') x₃ x₄ U | refl ,, refl ,, refl = ⊥-elim (x₁ (V-I b (bubble p) (step⋆ p x₅ refl)))
 lemmaF' M wrap- E E' L L' V x x₁ x₂ = ⊥-elim (x₁ (V-wrap V))
 lemmaF' (wrap A B M) unwrap- E E' L L' (V-wrap V) x x₁ x₂ with rlemma51! (extEC E unwrap- [ wrap A B M ]ᴱ)
-... | done VEunwrapwrapV = ⊥-elim (x₁ (VALUE2Value (lemVE (unwrap (wrap A B M)) E (Value2VALUE (subst Value (extEC-[]ᴱ E unwrap- (wrap A B M)) VEunwrapwrapV)))))
+... | done VEunwrapwrapV = ⊥-elim (x₁ (lemVE (unwrap (wrap A B M) refl) E (subst Value (extEC-[]ᴱ E unwrap- (wrap A B M)) VEunwrapwrapV)))
 ... | step ¬VEunwrapwrapV E₁ x₄ x₅ U with U (compEC' E E') x₂ (β x)
-lemmaF' (wrap A B M) unwrap- E E' L L' (V-wrap V) x x₁ x₂ | step ¬VEunwrapwrapV E₁ x₄ x₅ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E unwrap- (wrap A B M)) (β (β-wrap V))
-lemmaF' (wrap A B M) unwrap- E E' L L' (V-wrap V) x x₁ x₂ | step ¬VEunwrapwrapV E₁ x₄ x₅ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-wrap V) = step*
+lemmaF' (wrap A B M) unwrap- E E' L L' (V-wrap V) x x₁ x₂ | step ¬VEunwrapwrapV E₁ x₄ x₅ U | refl ,, refl ,, refl with U E (extEC-[]ᴱ E unwrap- (wrap A B M)) (β (β-wrap V refl))
+lemmaF' (wrap A B M) unwrap- E E' L L' (V-wrap V) x x₁ x₂ | step ¬VEunwrapwrapV E₁ x₄ x₅ U | refl ,, refl ,, refl | refl ,, q ,, refl rewrite determinism⋆ x (β-wrap V refl) = step*
   (cong (stepV (V-wrap V)) (dissect-lemma E unwrap-))
   (subst (λ E' → (E ▻ _) -→s (E' ▻ _)) (sym q) base)
 
@@ -1047,15 +1043,15 @@ thm1b (ƛ M) M' E p N V (step* refl q) = thm1bV (ƛ M) (V-ƛ M) M' E p N V q
 thm1b (M · M₁) M' E p N V (step* refl q) =
   thm1b M _ (extEC E (-· M₁)) (trans p (sym (extEC-[]ᴱ E (-· M₁) M))) N V q
 thm1b (Λ M) M' E p N V (step* refl q) = thm1bV (Λ M) (V-Λ M) M' E p N V q
-thm1b (M ·⋆ A) M' E p N V (step* refl q) =
+thm1b (M ·⋆ A / refl) M' E p N V (step* refl q) =
   thm1b M _ (extEC E (-·⋆ A)) (trans p (sym (extEC-[]ᴱ E (-·⋆ A) M))) N V q
 thm1b (wrap A B M) M' E p N V (step* refl q) =
   thm1b M _ (extEC E wrap-) (trans p (sym (extEC-[]ᴱ E wrap- M))) N V q
-thm1b (unwrap M) M' E p N V (step* refl q) =
+thm1b (unwrap M refl) M' E p N V (step* refl q) =
   thm1b M _ (extEC E unwrap-) (trans p (sym (extEC-[]ᴱ E unwrap- M))) N V q
 thm1b (con c) M' E p N V (step* refl q) = thm1bV (con c) (V-con c) M' E p N V q
-thm1b (builtin b) M' E p N V (step* refl q) =
-  thm1bV (builtin b) (ival b) M' E p N V q
+thm1b (builtin b / refl) M' E p N V (step* refl q) =
+  thm1bV (builtin b / refl) (ival b) M' E p N V q
 thm1b (error _) M' E p N V (step* refl q) = ⊥-elim (diamond2box N V q)
 
 thm1bV M W M' E p N V (step* x q) with dissect E | inspect dissect E
@@ -1085,13 +1081,13 @@ thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, (VI@(V-I⇒ b {as' = x
          N
          V
          q
-thm1bV .(Λ M) (V-Λ M) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq = trans—↠ (ruleEC E' β-Λ (trans p (extEC-[]ᴱ E' (-·⋆ A) (Λ M))) refl) (thm1b (M [ A ]⋆) _ E' refl N V q)
+thm1bV .(Λ M) (V-Λ M) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq = trans—↠ (ruleEC E' (β-Λ refl) (trans p (extEC-[]ᴱ E' (-·⋆ A) (Λ M))) refl) (thm1b (M [ A ]⋆) _ E' refl N V q)
 thm1bV M (V-IΠ b {as' = []} p₁ x₁) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq = trans—↠
-  (ruleEC E' (β-sbuiltin⋆ b _ p₁ x₁ A) (trans p (extEC-[]ᴱ E' (-·⋆ A) M)) refl)
-  (thm1b (BUILTIN' b (bubble p₁) (step⋆ p₁ x₁)) _ E' refl N V q)
+  (ruleEC E' (β-sbuiltin⋆ b _ p₁ x₁ A refl) (trans p (extEC-[]ᴱ E' (-·⋆ A) M)) refl)
+  (thm1b (BUILTIN' b (bubble p₁) (step⋆ p₁ x₁ refl)) _ E' refl N V q)
 thm1bV M (V-IΠ b {as' = x₂ ∷ as'} p₁ x₁) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, -·⋆ A) | I[ eq ] rewrite dissect-inj₂ E E' (-·⋆ A) eq =
-  thm1bV (M ·⋆ A)
-         (V-I b (bubble p₁) (step⋆ p₁ x₁))
+  thm1bV (M ·⋆ A / refl)
+         (V-I b (bubble p₁) (step⋆ p₁ x₁ refl))
          M'
          E'
          (trans p (extEC-[]ᴱ E' (-·⋆ A) M))
@@ -1100,10 +1096,9 @@ thm1bV M (V-IΠ b {as' = x₂ ∷ as'} p₁ x₁) M' E p N V (step* refl q) | in
          q
 
 thm1bV M W M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, wrap-) | I[ eq ] rewrite dissect-inj₂ E E' wrap- eq = thm1bV (wrap _ _ M) (V-wrap W) _ E' (trans p (extEC-[]ᴱ E' wrap- M)) N V q
-thm1bV .(wrap _ _ _) (V-wrap W) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E E' unwrap- eq = trans—↠ (ruleEC E' (β-wrap W) (trans p (extEC-[]ᴱ E' unwrap- _)) refl) (thm1b _ _ E' refl N V q)
+thm1bV .(wrap _ _ _) (V-wrap W) M' E p N V (step* refl q) | inj₂ (_ ,, E' ,, unwrap-) | I[ eq ] rewrite dissect-inj₂ E E' unwrap- eq = trans—↠ (ruleEC E' (β-wrap W refl) (trans p (extEC-[]ᴱ E' unwrap- _)) refl) (thm1b _ _ E' refl N V q)
 thm1bV M W M' E refl N V (step* refl q) | inj₁ refl | I[ eq ] rewrite dissect-inj₁ E refl eq with box2box M N W V q
 ... | refl ,, refl = refl—↠
 
 thm2b : ∀{A}(M N : ∅ ⊢ A)(V : Value N) → ([] ▻ M) -→s (□ V) → M —↠ N
 thm2b M N V p = thm1b M M [] refl N V p
--- -}

--- a/plutus-metatheory/src/Algorithmic/CK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CK.lagda.md
@@ -47,9 +47,9 @@ data State (T : ∅ ⊢Nf⋆ *) : Set where
 closeFrame : ∀{T H} → Frame T H → ∅ ⊢ H → ∅ ⊢ T
 closeFrame (-· u)          t = t · u
 closeFrame (_·- {t = t} v) u = t · u
-closeFrame (-·⋆ A)         t = _·⋆_ t A
+closeFrame (-·⋆ A)         t = t ·⋆ A / refl
 closeFrame wrap-           t = wrap _ _ t
-closeFrame unwrap-         t = unwrap t
+closeFrame unwrap-         t = unwrap t refl
 -- Plugging a term into a stack yields a term again
 
 closeStack : ∀{T H} → Stack T H → ∅ ⊢ H → ∅ ⊢ T
@@ -71,9 +71,9 @@ step : ∀{A} → State A → State A
 step (s ▻ ƛ L)                    = s ◅ V-ƛ L
 step (s ▻ (L · M))                = (s , -· M) ▻ L
 step (s ▻ Λ L)                    = s ◅ V-Λ L
-step (s ▻ (L ·⋆ A))               = (s , -·⋆ A) ▻ L
+step (s ▻ (L ·⋆ A / refl))        = (s , -·⋆ A) ▻ L
 step (s ▻ wrap A B L)             = (s , wrap-) ▻ L
-step (s ▻ unwrap L)               = (s , unwrap-) ▻ L
+step (s ▻ unwrap L refl)          = (s , unwrap-) ▻ L
 step (s ▻ con cn)                 = s ◅ V-con cn
 step (s ▻ error A)                = ◆ A
 step (ε ◅ V)                      = □ V
@@ -82,15 +82,15 @@ step ((s , (V-ƛ t ·-)) ◅ V)       = s ▻ (t [ discharge V ])
 step ((s , (-·⋆ A)) ◅ V-Λ t)      = s ▻ (t [ A ]⋆)
 step ((s , wrap-) ◅ V)            = s ◅ (V-wrap V)
 step ((s , unwrap-) ◅ V-wrap V)   = s ▻ deval V
-step (s ▻ builtin b) = s ◅ ival b
+step (s ▻ (builtin b / refl))     = s ◅ ival b
 step ((s , (V-I⇒ b {as' = []} p bt ·-)) ◅ vu) =
   s ▻ BUILTIN' b (bubble p) (app p bt vu)
 step ((s , (V-I⇒ b {as' = _ ∷ as'} p bt ·-)) ◅ vu) =
   s ◅ V-I b (bubble p) (app p bt vu)
 step ((s , -·⋆ A) ◅ V-IΠ b {as' = []} p bt) =
-  s ▻ BUILTIN' b (bubble p) (app⋆ p bt)
-step ((s , -·⋆ A) ◅ V-IΠ b {as' = x ∷ as'} p bt) =
-  s ◅ V-I b (bubble p) (app⋆ p bt)
+  s ▻ BUILTIN' b (bubble p) (app⋆ p bt refl)
+step ((s , -·⋆ A) ◅ V-IΠ b {as' = _ ∷ as'} p bt) =
+  s ◅ V-I b (bubble p) (app⋆ p bt refl)
 step (□ V)                        = □ V
 step (◆ A)                        = ◆ A
 
@@ -106,7 +106,11 @@ stepper (suc n) st | (s ◅ V) = stepper n (s ◅ V)
 stepper (suc n) st | (□ V)   = return (□ V)
 stepper (suc n) st | ◆ A     = return (◆ A)
 
+
+
 import Algorithmic.CC as CC
+
+{-
 open import Relation.Binary.PropositionalEquality
 open import Data.Sum
 
@@ -251,3 +255,4 @@ lem◆ (step* refl p) = lem◆ p
 
 lem◆' : ∀ {A A'}{M : ∅ ⊢ A}(V : Value M) → ◆ A' -→s □ V → ⊥
 lem◆' V (step* refl p) = lem◆' V p
+-- -}

--- a/plutus-metatheory/src/Algorithmic/CK.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CK.lagda.md
@@ -110,7 +110,6 @@ stepper (suc n) st | ◆ A     = return (◆ A)
 
 import Algorithmic.CC as CC
 
-{-
 open import Relation.Binary.PropositionalEquality
 open import Data.Sum
 
@@ -164,15 +163,15 @@ thm64 (E CC.▻ ƛ M) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
 thm64 (E CC.▻ (M · N)) E' (CC.step* refl p) =
   step* (cong (λ E → E ▻ M) (lemmaH E (-· N))) (thm64 _ E' p)
 thm64 (E CC.▻ Λ M) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
-thm64 (E CC.▻ (M ·⋆ A)) E' (CC.step* refl p) =
+thm64 (E CC.▻ (M ·⋆ A / refl)) E' (CC.step* refl p) =
   step* (cong (λ E → E ▻ M) (lemmaH E (-·⋆ A))) (thm64 _ E' p)
 thm64 (E CC.▻ wrap A B M) E' (CC.step* refl p) =
   step* (cong (λ E → E ▻ M) (lemmaH E wrap-)) (thm64 _ E' p)
-thm64 (E CC.▻ unwrap M) E' (CC.step* refl p) =
+thm64 (E CC.▻ unwrap M refl) E' (CC.step* refl p) =
   step* (cong (λ E → E ▻ M) (lemmaH E unwrap-)) (thm64 _ E' p)
 thm64 (E CC.▻ con M) E' (CC.step* refl p) =
   step* refl (thm64 _ E' p)
-thm64 (E CC.▻ builtin b) E' (CC.step* refl p) =
+thm64 (E CC.▻ (builtin b / refl)) E' (CC.step* refl p) =
   step* refl (thm64 _ E' p)
 thm64 (E CC.▻ error _) E' (CC.step* refl p) = step* refl (thm64 _ E' p)
 thm64 (E CC.◅ V) E' (CC.step* refl p) with CC.dissect E | inspect CC.dissect E
@@ -197,11 +196,11 @@ thm64b s .s base = CC.base
 thm64b (s ▻ ƛ M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (s ▻ (M · M₁)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (s ▻ Λ M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
-thm64b (s ▻ (M ·⋆ A)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ (M ·⋆ A / refl)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (s ▻ wrap A B M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
-thm64b (s ▻ unwrap M) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ unwrap M refl) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (s ▻ con c) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
-thm64b (s ▻ builtin b) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
+thm64b (s ▻ (builtin b / refl)) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (s ▻ error _) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (ε ◅ V) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b ((s , (-· M)) ◅ V) s' (step* refl p) = CC.step*
@@ -239,7 +238,7 @@ thm64b (□ x₁) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 thm64b (◆ A) s' (step* refl p) = CC.step* refl (thm64b _ s' p)
 
 test : State (con unit)
-test = ε ▻ (ƛ (con unit) · (builtin iData · con (integer (+ 0))))
+test = ε ▻ (ƛ (con unit) · (builtin iData / refl · con (integer (+ 0))))
 
 postulate
   lemV : ∀{A B}(M : ∅ ⊢ B)(V : Value M)(E : Stack A B) → (E ▻ M) -→s (E ◅ V)
@@ -255,4 +254,5 @@ lem◆ (step* refl p) = lem◆ p
 
 lem◆' : ∀ {A A'}{M : ∅ ⊢ A}(V : Value M) → ◆ A' -→s □ V → ⊥
 lem◆' V (step* refl p) = lem◆' V p
--- -}
+
+

--- a/plutus-metatheory/src/Algorithmic/Completeness.lagda
+++ b/plutus-metatheory/src/Algorithmic/Completeness.lagda
@@ -126,7 +126,7 @@ nfType (Syn.Λ {B = B} t) =
 nfType (Syn._·⋆_ {B = B} t A) = Norm.conv⊢
   refl
   (lem[] A B)
-  (Norm._·⋆_ (Norm.conv⊢ refl (lemΠ B) (nfType t)) (nf A))
+  (Norm._·⋆_/_ (Norm.conv⊢ refl (lemΠ B) (nfType t)) (nf A) refl)
 nfType (Syn.wrap A B t) = Norm.wrap
   (nf A)
   (nf B)
@@ -134,10 +134,10 @@ nfType (Syn.wrap A B t) = Norm.wrap
 nfType (Syn.unwrap {A = A}{B = B} t) = Norm.conv⊢
   refl
   (sym (stability-μ A B))
-  (Norm.unwrap (nfType t))
+  (Norm.unwrap (nfType t) refl)
 nfType (Syn.conv p t) = Norm.conv⊢ refl (completeness p) (nfType t)
 nfType (Syn.con t) = Norm.con (nfTypeTC t)
-nfType (Syn.builtin b) = Norm.conv⊢ refl (btype-lem b) (Norm.builtin b)
+nfType (Syn.builtin b) = Norm.conv⊢ refl (btype-lem b) (Norm.builtin b / refl)
 nfType (Syn.error A) = Norm.error (nf A)
 
 completenessT : ∀{Φ Γ}{A : Φ ⊢⋆ *} → Γ Syn.⊢ A

--- a/plutus-metatheory/src/Algorithmic/Erasure.lagda
+++ b/plutus-metatheory/src/Algorithmic/Erasure.lagda
@@ -63,11 +63,11 @@ erase (` α)                = ` (eraseVar α)
 erase (ƛ t)                = ƛ (erase t) 
 erase (t · u)              = erase t · erase u
 erase (Λ t)                = delay (erase t)
-erase (_·⋆_ t A)           = force (erase t)
+erase (t ·⋆ A / refl)      = force (erase t)
 erase (wrap A B t)         = erase t
-erase (unwrap t)           = erase t
+erase (unwrap t refl)      = erase t
 erase {Γ = Γ} (con t)      = con (eraseTC {Γ = Γ} t)
-erase (builtin b)          = builtin b
+erase (builtin b / refl)     = builtin b
 erase (error A)            = error
 \end{code}
 
@@ -253,7 +253,7 @@ same {Γ = Γ} (D._·⋆_ {B = B} t A) = trans
          (lem-force (lenLemma Γ) (erase (nfType t))))
   (cong (subst _⊢ (lenLemma Γ))
         (trans (cong force (lem-erase' (lemΠ B) (nfType t)))
-        (lem-erase' (lem[] A B) (conv⊢ refl (lemΠ B) (nfType t) ·⋆ nf A))))
+        (lem-erase' (lem[] A B) (conv⊢ refl (lemΠ B) (nfType t) ·⋆ nf A / refl))))
 same {Γ = Γ} (D.wrap A B t) = trans
   (same t)
   (cong (subst _⊢ (lenLemma Γ)) (lem-erase' (stability-μ A B) (nfType t)))
@@ -261,7 +261,7 @@ same {Γ = Γ} (D.unwrap {A = A}{B = B} t) = trans
   (same t)
   (cong
     (subst _⊢ (lenLemma Γ))
-    (lem-erase' (sym (stability-μ A B)) (unwrap (nfType t)))) 
+    (lem-erase' (sym (stability-μ A B)) (unwrap (nfType t) refl))) 
 same {Γ = Γ} (D.conv p t) = trans
   (same t)
   (cong (subst _⊢ (lenLemma Γ)) (lem-erase' (completeness p) (nfType t)))
@@ -271,7 +271,7 @@ same {Γ = Γ} (D.con tcn) = trans
 
 same {Γ = Γ} (D.builtin b) = trans
   (lembuiltin b (lenLemma Γ)) (cong (subst _⊢ (lenLemma Γ))
-  (lem-erase refl (btype-lem b) (builtin b)))
+  (lem-erase refl (btype-lem b) (builtin b / refl)))
 same {Γ = Γ} (D.error A) = lemerror (lenLemma Γ)
 
 open import Algorithmic.Soundness
@@ -318,14 +318,14 @@ same' {Γ = Γ} (t · u) = trans
 same' {Γ = Γ} (Λ t) =  trans
   (cong delay (same' t))
   (lem-delay (same'Len Γ) (D.erase (emb t)))
-same' {Γ = Γ} (t ·⋆ A)   = trans
+same' {Γ = Γ} (t ·⋆ A / refl)   = trans
   (cong force (same' t))
   (lem-force (same'Len Γ) (D.erase (emb t)))
 same' {Γ = Γ} (wrap A B t)   = same' t
-same' {Γ = Γ} (unwrap t) = same' t
+same' {Γ = Γ} (unwrap t refl) = same' t
 same' {Γ = Γ} (con x) = trans
   (cong con (same'TC {Γ = Γ} x))
   (lemcon' (same'Len Γ) (D.eraseTC {Γ = embCtx Γ}(embTC x)))
-same' {Γ = Γ} (builtin b) = lembuiltin b (same'Len Γ)
+same' {Γ = Γ} (builtin b / refl) = lembuiltin b (same'Len Γ)
 same' {Γ = Γ} (error A) = lemerror (same'Len Γ)
 \end{code}

--- a/plutus-metatheory/src/Algorithmic/Properties.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Properties.lagda.md
@@ -61,13 +61,14 @@ lem-·⋆unwrap : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B
   → M _⊢_.·⋆ A ≅ _⊢_.unwrap M'
   → ⊥
 lem-·⋆unwrap ()
-
+-}
 lem-unwrap : ∀{K K'}{A}{A'}{B : ∅ ⊢Nf⋆ K}{B' : ∅ ⊢Nf⋆ K'}
-  → ∀{M : ∅ ⊢ μ A B}{M' : ∅ ⊢ μ A' B'}
-  → _⊢_.unwrap M ≅ _⊢_.unwrap M'
-  → A ≅ A' × B ≅ B' × M ≅ M'
-lem-unwrap refl = refl ,, refl ,, refl
-
+  → ∀{M : ∅ ⊢ μ A B}{M' : ∅ ⊢ μ A' B'}{C}
+  → {p : C ≡ _}{q : C ≡ _}
+  → _⊢_.unwrap M p ≡ _⊢_.unwrap M' q
+  → K ≡ K' × A ≅ A' × B ≅ B' × M ≅ M'
+lem-unwrap refl = refl ,, refl ,, refl ,, refl
+{-
 inj⊢ : ∀{A A' : ∅ ⊢Nf⋆ *}{L : ∅ ⊢ A}{L' : ∅ ⊢ A'} → L ≅ L' → A ≡ A'
 inj⊢ refl = refl
 

--- a/plutus-metatheory/src/Algorithmic/Properties.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Properties.lagda.md
@@ -20,19 +20,27 @@ open import Data.Empty
 ## Pragmas
 
 ```
-{-# INJECTIVE _⊢Nf⋆_ #-}
-{-# INJECTIVE _⊢_ #-}
 ```
 
 ## Some syntactic lemmas
 
 ```
+{-
 lem-·⋆' : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B' : ∅ ,⋆ K' ⊢Nf⋆ *}
   → ∀{M : ∅ ⊢ Π B}{M' : ∅ ⊢ Π B'}
-  → M' _⊢_.·⋆ A' ≅ M _⊢_.·⋆ A
+  → ∀{C C'}(p : C ≡ B [ A ]Nf)(p' : C' ≡ B' [ A' ]Nf)
+  → M' _⊢_.·⋆ A' / p' ≅ M _⊢_.·⋆ A / p
   → M' ≅ M × A ≅ A' × B ≅ B'
-lem-·⋆' refl = refl ,, refl ,, refl
+lem-·⋆' p p' X = {!X!}
+-}
+lem-·⋆'' : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B' : ∅ ,⋆ K' ⊢Nf⋆ *}
+  → ∀{M : ∅ ⊢ Π B}{M' : ∅ ⊢ Π B'}
+  → ∀{C}(p : C ≡ B [ A ]Nf)(p' : C ≡ B' [ A' ]Nf)
+  → M' _⊢_.·⋆ A' / p' ≡ M _⊢_.·⋆ A / p
+  → M' ≅ M × A ≅ A' × B ≅ B'
+lem-·⋆'' p .p refl = refl ,, refl ,, refl
 
+{-
 lem-·⋆ : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B B'}
   → (o : K ≡ K')
   → (p : subst (∅ ⊢Nf⋆_) o A ≡ A')
@@ -69,3 +77,4 @@ lemΛ·⋆ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}
   → Λ L ≅ (L' _⊢_.·⋆ A)
   → ⊥
 lemΛ·⋆ ()
+-- -}

--- a/plutus-metatheory/src/Algorithmic/Properties.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/Properties.lagda.md
@@ -33,12 +33,12 @@ lem-·⋆' : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K 
   → M' ≅ M × A ≅ A' × B ≅ B'
 lem-·⋆' p p' X = {!X!}
 -}
-lem-·⋆'' : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B' : ∅ ,⋆ K' ⊢Nf⋆ *}
+lem-·⋆ : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B : ∅ ,⋆ K ⊢Nf⋆ *}{B' : ∅ ,⋆ K' ⊢Nf⋆ *}
   → ∀{M : ∅ ⊢ Π B}{M' : ∅ ⊢ Π B'}
   → ∀{C}(p : C ≡ B [ A ]Nf)(p' : C ≡ B' [ A' ]Nf)
   → M' _⊢_.·⋆ A' / p' ≡ M _⊢_.·⋆ A / p
-  → M' ≅ M × A ≅ A' × B ≅ B'
-lem-·⋆'' p .p refl = refl ,, refl ,, refl
+  → ∃ λ (p : K ≡ K') → M' ≅ M × A ≅ A' × B ≅ B'
+lem-·⋆ p .p refl = refl ,, refl ,, refl ,, refl
 
 {-
 lem-·⋆ : ∀{K K'}{A : ∅ ⊢Nf⋆ K}{A' : ∅ ⊢Nf⋆ K'}{B B'}

--- a/plutus-metatheory/src/Algorithmic/Reduction.lagda
+++ b/plutus-metatheory/src/Algorithmic/Reduction.lagda
@@ -286,7 +286,7 @@ data _—→_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set whe
   ξ-·⋆ : ∀ {K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{L L' : ∅ ⊢ Π B}{A}
     → L —→ L'
       -----------------
-    → L ·⋆ A —→ L' ·⋆ A
+    → L ·⋆ A / refl —→ L' ·⋆ A / refl
 
   β-ƛ : {A B : ∅ ⊢Nf⋆ *}{N : ∅ , A ⊢ B} {V : ∅ ⊢ A}
     → Value V
@@ -295,21 +295,21 @@ data _—→_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set whe
 
   β-Λ : ∀ {K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{N : ∅ ,⋆ K ⊢ B}{A}
       -------------------
-    → (Λ N) ·⋆ A —→ N [ A ]⋆
+    → (Λ N) ·⋆ A / refl —→ N [ A ]⋆
 
   β-wrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
     → {B : ∅ ⊢Nf⋆ K}
     → {M : ∅ ⊢ _}
     → Value M
-    → unwrap (wrap A B M) —→ M
+    → unwrap (wrap A B M) refl —→ M
 
   ξ-unwrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
     → {B : ∅ ⊢Nf⋆ K}
     → {M M' : ∅ ⊢ μ A B}
     → M —→ M'
-    → unwrap M —→ unwrap M'
+    → unwrap M refl —→ unwrap M' refl
     
   ξ-wrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
@@ -324,11 +324,11 @@ data _—→_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set whe
   E-·₁ : {A B : ∅ ⊢Nf⋆ *}{M : ∅ ⊢ A}
     → error (A ⇒ B) · M —→ error B
   E-·⋆ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{A : ∅ ⊢Nf⋆ K}
-    → error (Π B) ·⋆ A —→ error (B [ A ]Nf)
+    → error (Π B) ·⋆ A / refl —→ error (B [ A ]Nf)
   E-unwrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
     → {B : ∅ ⊢Nf⋆ K}
-    → unwrap (error (μ A B))
+    → unwrap (error (μ A B)) refl
         —→ error (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B))
   E-wrap : ∀{K}
     → {A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}
@@ -363,7 +363,7 @@ data _—→_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set whe
     → (t : ∅ ⊢ subNf σ (Π C'))
     → (tel : ITel b Γ' σ)
       -----------------------------
-    → t ·⋆ A —→ conv⊢ refl (subNf-cons-[]Nf C') (proj₁ (IBUILTIN' b p q (subNf-cons σ A) (tel ,, A) C' r))
+    → t ·⋆ A / refl —→ conv⊢ refl (subNf-cons-[]Nf C') (proj₁ (IBUILTIN' b p q (subNf-cons σ A) (tel ,, A) C' r))
 \end{code}
 
 \begin{code}
@@ -427,71 +427,71 @@ progress-· (error E-error) q = step E-·₁
 convValue : ∀{A A'}{t : ∅ ⊢ A}(p : A ≡ A') → Value (conv⊢ refl p t) → Value t
 convValue refl v = v
 
-ival : ∀ b → Value (builtin b)
-ival addInteger = V-I⇒ addInteger refl refl refl (λ()) (skip base) tt (builtin addInteger)
-ival subtractInteger = V-I⇒ subtractInteger refl refl refl (λ()) (skip base) tt (builtin subtractInteger)
-ival multiplyInteger = V-I⇒ multiplyInteger refl refl refl (λ()) (skip base) tt (builtin multiplyInteger)
-ival divideInteger = V-I⇒ divideInteger refl refl refl (λ()) (skip base) tt (builtin divideInteger)
-ival quotientInteger = V-I⇒ quotientInteger refl refl refl (λ()) (skip base) tt (builtin quotientInteger)
-ival remainderInteger = V-I⇒ remainderInteger refl refl refl (λ()) (skip base) tt (builtin remainderInteger)
-ival modInteger = V-I⇒ modInteger refl refl refl (λ()) (skip base) tt (builtin modInteger)
-ival lessThanInteger = V-I⇒ lessThanInteger refl refl refl (λ()) (skip base) tt (builtin lessThanInteger)
-ival lessThanEqualsInteger = V-I⇒ lessThanEqualsInteger refl refl refl (λ()) (≤Cto≤C' (skip base)) tt (builtin lessThanEqualsInteger)
-ival equalsInteger = V-I⇒ equalsInteger refl refl refl (λ()) (skip base) tt (builtin equalsInteger)
-ival lessThanByteString = V-I⇒ lessThanByteString refl refl refl (λ()) (skip base) tt (builtin lessThanByteString)
-ival lessThanEqualsByteString = V-I⇒ lessThanEqualsByteString refl refl refl (λ()) (≤Cto≤C' (skip base)) tt (builtin lessThanEqualsByteString)
-ival sha2-256 = V-I⇒ sha2-256 refl refl refl (λ()) base tt (builtin sha2-256)
-ival sha3-256 = V-I⇒ sha3-256 refl refl refl (λ()) base tt (builtin sha3-256)
-ival verifySignature = V-I⇒ verifySignature refl refl refl (λ()) (skip (skip base)) tt (builtin verifySignature)
-ival equalsByteString = V-I⇒ equalsByteString refl refl refl (λ()) (skip base) tt (builtin equalsByteString)
-ival appendByteString = V-I⇒ appendByteString refl refl refl (λ()) (skip base) tt (builtin appendByteString)
-ival appendString = V-I⇒ appendString refl refl refl (λ()) (skip base) tt (builtin appendString)
-ival ifThenElse = V-IΠ ifThenElse refl refl refl (λ()) (skip (skip (skip base))) tt (builtin ifThenElse)
-ival trace = V-IΠ trace refl refl refl (λ()) (skip (skip base)) tt (builtin trace)
-ival equalsString = V-I⇒ equalsString refl refl refl (λ()) (skip base) tt (builtin equalsString)
-ival encodeUtf8 = V-I⇒ encodeUtf8 refl refl refl (λ()) base tt (builtin encodeUtf8)
-ival decodeUtf8 = V-I⇒ decodeUtf8 refl refl refl (λ()) base tt (builtin decodeUtf8)
-ival fstPair = V-IΠ fstPair refl refl refl (λ()) (skip⋆ (skip base)) tt (builtin fstPair)
-ival sndPair = V-IΠ sndPair refl refl refl (λ()) (skip⋆ (skip base)) tt (builtin sndPair)
-ival nullList = V-IΠ nullList refl refl refl (λ()) (skip base) tt (builtin nullList)
-ival headList = V-IΠ headList refl refl refl (λ()) (skip base) tt (builtin headList)
-ival tailList = V-IΠ tailList refl refl refl (λ()) (skip base) tt (builtin tailList)
-ival chooseList = V-IΠ chooseList refl refl refl (λ()) (skip⋆ (skip (skip (skip base)))) tt (builtin chooseList)
-ival constrData = V-I⇒ constrData refl refl refl (λ()) (skip base) tt (builtin constrData)
-ival mapData = V-I⇒ mapData refl refl refl (λ()) base tt (builtin mapData)
-ival listData = V-I⇒ listData refl refl refl (λ()) base tt (builtin listData)
-ival iData = V-I⇒ iData refl refl refl (λ()) base tt (builtin iData)
-ival bData = V-I⇒ bData refl refl refl (λ()) base tt (builtin bData)
-ival unConstrData = V-I⇒ unConstrData refl refl refl (λ()) base tt (builtin unConstrData)
-ival unMapData = V-I⇒ unMapData refl refl refl (λ()) base tt (builtin unMapData) 
-ival unListData = V-I⇒ unListData refl refl refl (λ()) base tt (builtin unListData)
-ival unIData = V-I⇒ unIData refl refl refl (λ()) base tt (builtin unIData)
-ival unBData = V-I⇒ unBData refl refl refl (λ()) base tt (builtin unBData)
-ival equalsData = V-I⇒ equalsData refl refl refl (λ()) (skip base) tt (builtin equalsData)
-ival chooseData = V-IΠ chooseData refl refl refl (λ()) (skip (skip (skip (skip (skip (skip base)))))) tt (builtin chooseData)
-ival chooseUnit = V-IΠ chooseUnit refl refl refl (λ()) (skip (skip base)) tt (builtin chooseUnit)
-ival mkPairData = V-I⇒ mkPairData refl refl refl (λ()) (skip base) tt (builtin mkPairData)
-ival mkNilData = V-I⇒ mkNilData refl refl refl (λ()) base tt (builtin mkNilData)
-ival mkNilPairData = V-I⇒ mkNilPairData refl refl refl (λ()) base tt (builtin mkNilPairData)
-ival mkCons = V-I⇒ mkCons refl refl refl (λ()) (skip base) tt (builtin mkCons)
-ival consByteString = V-I⇒ consByteString refl refl refl (λ()) (skip base) tt (builtin consByteString)
-ival sliceByteString = V-I⇒ sliceByteString refl refl refl (λ()) (skip (skip base)) tt (builtin sliceByteString)
-ival lengthOfByteString = V-I⇒ lengthOfByteString refl refl refl (λ()) base tt (builtin lengthOfByteString)
-ival indexByteString = V-I⇒ indexByteString refl refl refl (λ()) (skip base) tt (builtin indexByteString)
-ival blake2b-256 = V-I⇒ blake2b-256 refl refl refl (λ()) base tt (builtin blake2b-256)
+ival : ∀ b → Value (builtin b / refl)
+ival addInteger = V-I⇒ addInteger refl refl refl (λ()) (skip base) tt (builtin addInteger / refl)
+ival subtractInteger = V-I⇒ subtractInteger refl refl refl (λ()) (skip base) tt (builtin subtractInteger / refl)
+ival multiplyInteger = V-I⇒ multiplyInteger refl refl refl (λ()) (skip base) tt (builtin multiplyInteger / refl)
+ival divideInteger = V-I⇒ divideInteger refl refl refl (λ()) (skip base) tt (builtin divideInteger / refl)
+ival quotientInteger = V-I⇒ quotientInteger refl refl refl (λ()) (skip base) tt (builtin quotientInteger / refl)
+ival remainderInteger = V-I⇒ remainderInteger refl refl refl (λ()) (skip base) tt (builtin remainderInteger / refl)
+ival modInteger = V-I⇒ modInteger refl refl refl (λ()) (skip base) tt (builtin modInteger / refl)
+ival lessThanInteger = V-I⇒ lessThanInteger refl refl refl (λ()) (skip base) tt (builtin lessThanInteger / refl)
+ival lessThanEqualsInteger = V-I⇒ lessThanEqualsInteger refl refl refl (λ()) (≤Cto≤C' (skip base)) tt (builtin lessThanEqualsInteger / refl)
+ival equalsInteger = V-I⇒ equalsInteger refl refl refl (λ()) (skip base) tt (builtin equalsInteger / refl)
+ival lessThanByteString = V-I⇒ lessThanByteString refl refl refl (λ()) (skip base) tt (builtin lessThanByteString / refl)
+ival lessThanEqualsByteString = V-I⇒ lessThanEqualsByteString refl refl refl (λ()) (≤Cto≤C' (skip base)) tt (builtin lessThanEqualsByteString / refl)
+ival sha2-256 = V-I⇒ sha2-256 refl refl refl (λ()) base tt (builtin sha2-256 / refl)
+ival sha3-256 = V-I⇒ sha3-256 refl refl refl (λ()) base tt (builtin sha3-256 / refl)
+ival verifySignature = V-I⇒ verifySignature refl refl refl (λ()) (skip (skip base)) tt (builtin verifySignature / refl)
+ival equalsByteString = V-I⇒ equalsByteString refl refl refl (λ()) (skip base) tt (builtin equalsByteString / refl)
+ival appendByteString = V-I⇒ appendByteString refl refl refl (λ()) (skip base) tt (builtin appendByteString / refl)
+ival appendString = V-I⇒ appendString refl refl refl (λ()) (skip base) tt (builtin appendString / refl)
+ival ifThenElse = V-IΠ ifThenElse refl refl refl (λ()) (skip (skip (skip base))) tt (builtin ifThenElse / refl)
+ival trace = V-IΠ trace refl refl refl (λ()) (skip (skip base)) tt (builtin trace / refl)
+ival equalsString = V-I⇒ equalsString refl refl refl (λ()) (skip base) tt (builtin equalsString / refl)
+ival encodeUtf8 = V-I⇒ encodeUtf8 refl refl refl (λ()) base tt (builtin encodeUtf8 / refl)
+ival decodeUtf8 = V-I⇒ decodeUtf8 refl refl refl (λ()) base tt (builtin decodeUtf8 / refl)
+ival fstPair = V-IΠ fstPair refl refl refl (λ()) (skip⋆ (skip base)) tt (builtin fstPair / refl)
+ival sndPair = V-IΠ sndPair refl refl refl (λ()) (skip⋆ (skip base)) tt (builtin sndPair / refl)
+ival nullList = V-IΠ nullList refl refl refl (λ()) (skip base) tt (builtin nullList / refl)
+ival headList = V-IΠ headList refl refl refl (λ()) (skip base) tt (builtin headList / refl)
+ival tailList = V-IΠ tailList refl refl refl (λ()) (skip base) tt (builtin tailList / refl)
+ival chooseList = V-IΠ chooseList refl refl refl (λ()) (skip⋆ (skip (skip (skip base)))) tt (builtin chooseList / refl)
+ival constrData = V-I⇒ constrData refl refl refl (λ()) (skip base) tt (builtin constrData / refl)
+ival mapData = V-I⇒ mapData refl refl refl (λ()) base tt (builtin mapData / refl)
+ival listData = V-I⇒ listData refl refl refl (λ()) base tt (builtin listData / refl)
+ival iData = V-I⇒ iData refl refl refl (λ()) base tt (builtin iData / refl)
+ival bData = V-I⇒ bData refl refl refl (λ()) base tt (builtin bData / refl)
+ival unConstrData = V-I⇒ unConstrData refl refl refl (λ()) base tt (builtin unConstrData / refl)
+ival unMapData = V-I⇒ unMapData refl refl refl (λ()) base tt (builtin unMapData / refl) 
+ival unListData = V-I⇒ unListData refl refl refl (λ()) base tt (builtin unListData / refl)
+ival unIData = V-I⇒ unIData refl refl refl (λ()) base tt (builtin unIData / refl)
+ival unBData = V-I⇒ unBData refl refl refl (λ()) base tt (builtin unBData / refl)
+ival equalsData = V-I⇒ equalsData refl refl refl (λ()) (skip base) tt (builtin equalsData / refl)
+ival chooseData = V-IΠ chooseData refl refl refl (λ()) (skip (skip (skip (skip (skip (skip base)))))) tt (builtin chooseData / refl)
+ival chooseUnit = V-IΠ chooseUnit refl refl refl (λ()) (skip (skip base)) tt (builtin chooseUnit / refl)
+ival mkPairData = V-I⇒ mkPairData refl refl refl (λ()) (skip base) tt (builtin mkPairData / refl)
+ival mkNilData = V-I⇒ mkNilData refl refl refl (λ()) base tt (builtin mkNilData / refl)
+ival mkNilPairData = V-I⇒ mkNilPairData refl refl refl (λ()) base tt (builtin mkNilPairData / refl)
+ival mkCons = V-I⇒ mkCons refl refl refl (λ()) (skip base) tt (builtin mkCons / refl)
+ival consByteString = V-I⇒ consByteString refl refl refl (λ()) (skip base) tt (builtin consByteString / refl)
+ival sliceByteString = V-I⇒ sliceByteString refl refl refl (λ()) (skip (skip base)) tt (builtin sliceByteString / refl)
+ival lengthOfByteString = V-I⇒ lengthOfByteString refl refl refl (λ()) base tt (builtin lengthOfByteString / refl)
+ival indexByteString = V-I⇒ indexByteString refl refl refl (λ()) (skip base) tt (builtin indexByteString / refl)
+ival blake2b-256 = V-I⇒ blake2b-256 refl refl refl (λ()) base tt (builtin blake2b-256 / refl)
 
 progress-·⋆ : ∀{K B}{t : ∅ ⊢ Π B} → Progress t → (A : ∅ ⊢Nf⋆ K)
-  → Progress (t ·⋆ A)
+  → Progress (t ·⋆ A / refl)
 progress-·⋆ (step p)        A = step (ξ-·⋆ p)
 progress-·⋆ (done (V-Λ t))  A = step β-Λ
 progress-·⋆ (error E-error) A = step E-·⋆
-progress-·⋆ (done (V-IΠ b {C = C} p' q r σ (skip⋆ p) vs t)) A = done (convValue (Πlem p A C σ) (V-IΠ b {C = C} p' q r (subNf-cons σ A) p (vs ,, A) (conv⊢ refl (Πlem p A C σ) (t ·⋆ A))) )
-progress-·⋆ (done (V-IΠ b {C = C} p' q r σ (skip p) vs t))  A = done (convValue (⇒lem p σ C) (V-I⇒ b p' q r (subNf-cons σ A) p (vs ,, A) (conv⊢ refl (⇒lem p σ C) (t ·⋆ A) )))
+progress-·⋆ (done (V-IΠ b {C = C} p' q r σ (skip⋆ p) vs t)) A = done (convValue (Πlem p A C σ) (V-IΠ b {C = C} p' q r (subNf-cons σ A) p (vs ,, A) (conv⊢ refl (Πlem p A C σ) (t ·⋆ A / refl))) )
+progress-·⋆ (done (V-IΠ b {C = C} p' q r σ (skip p) vs t))  A = done (convValue (⇒lem p σ C) (V-I⇒ b p' q r (subNf-cons σ A) p (vs ,, A) (conv⊢ refl (⇒lem p σ C) (t ·⋆ A / refl))))
 progress-·⋆ (done (V-IΠ b p q r σ base vs t)) A = step (β-sbuiltin⋆ b σ p q _ r t vs)
 -- ^ it's the last one, call BUILTIN
 
 progress-unwrap : ∀{K}{A}{B : ∅ ⊢Nf⋆ K}{t : ∅ ⊢ μ A B}
-  → Progress t → Progress (unwrap t)
+  → Progress t → Progress (unwrap t refl)
 progress-unwrap (step q) = step (ξ-unwrap q)
 progress-unwrap (done (V-wrap v)) = step (β-wrap v)
 progress-unwrap {A = A} (error E-error) =
@@ -509,11 +509,11 @@ progress-wrap (error E-error) = step E-wrap
 progress (ƛ M)                = done (V-ƛ M)
 progress (M · N)              = progress-· (progress M) (progress N)
 progress (Λ M)                = done (V-Λ M)
-progress (M ·⋆ A)             = progress-·⋆ (progress M) A
+progress (M ·⋆ A / refl)             = progress-·⋆ (progress M) A
 progress (wrap A B M) = progress-wrap (progress M)
-progress (unwrap M)          = progress-unwrap (progress M)
+progress (unwrap M refl)          = progress-unwrap (progress M)
 progress (con c)              = done (V-con c)
-progress (builtin b) = done (ival b)
+progress (builtin b / refl) = done (ival b)
 progress (error A)            = error E-error
 
 open import Data.Nat

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1526,16 +1526,10 @@ Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B'
   (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (μ A B) B') {L' : ∅ ⊢ B'} →
     M ≡ (E' [ L' ]ᴱ) →
     Redex L' →
-    ∃
-    (λ p₁ → substEq (EC (μ A B)) p₁ E ≡ E' × substEq (_⊢_ ∅) p₁ L ≡ L'))
+    ∃ (λ q → substEq (EC (μ A B)) q E ≡ E' × substEq (_⊢_ ∅) q L ≡ L'))
   →
-  ∃
-  (λ (p₁ : C ≡ B') →
-     substEq
-     (EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)))
-     p₁ (EC.unwrap E / refl)
-     ≅ E'
-     × substEq (_⊢_ ∅) p₁ L ≅ L')
+  ∃ (λ (q : C ≡ B') →
+    substEq (EC X) q (EC.unwrap E / p) ≡ E' × substEq (_⊢_ ∅) q L ≡ L')
 Uunwrap1 ¬VM eq [] refl (β (β-wrap x .eq)) U = ⊥-elim (¬VM (V-wrap x))
 Uunwrap1 ¬VM refl (unwrap E / refl) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
@@ -1544,18 +1538,12 @@ Uunwrap1 ¬VM refl (unwrap E / refl) refl q U with U E refl q
 Uunwrap2 : ∀{A}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{B' : ∅ ⊢Nf⋆ *}{X}
   → Value M
   → (p : X ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) →
-  (E'
-   : EC X B')
+  (E' : EC X B')
   {L' : ∅ ⊢ B'} →
   _⊢_.unwrap (wrap A B M) p ≡ (E' [ L' ]ᴱ) →
   Redex L' →
-  ∃
-  (λ (p : _ ≡ B') →
-     substEq
-     (EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)))
-     p []
-     ≅ E'
-     × unwrap (wrap A B M) (sym p) ≅ L')
+  ∃ (λ (q : X ≡ B')
+    → substEq (EC X) q [] ≡ E' × substEq (∅ ⊢_) q (unwrap (wrap A B M) p) ≡ L')
 Uunwrap2 VM eq (unwrap E / x) p q with lem-unwrap p
 ... | refl ,, refl ,, refl ,, X4 =
   ⊥-elim (valredex (lemVE
@@ -1644,30 +1632,22 @@ rlemma51! (wrap A B M) with rlemma51! M
   (cong (wrap A B) q)
   λ E p' q' → Uwrap E p' q' U
 ... | done VM = done (V-wrap VM)
-rlemma51! (unwrap M x) = {!!}
-rlemma51! (con c) = done (V-con c)
-rlemma51! (builtin b / x) = {!!}
-rlemma51! (error _) = {!!}
-
-{-
-rlemma51! (unwrap M) with rlemma51! M
+rlemma51! (unwrap M x) with rlemma51! M
 ... | step ¬VM E p q U = step
-  (λ V → lemVunwrap (Value2VALUE V))
-  (unwrap E)
+  (λ V → lemVunwrap V)
+  (unwrap E / x)
   p
-  (cong unwrap q)
-  λ E p q → let X ,, Y ,, Y' = Uunwrap1 ¬VM refl E (≡-to-≅ p) q U in
-    X ,, ≅-to-≡ Y ,, ≅-to-≡ Y'
+  (cong (λ M → unwrap M x) q)
+  λ E p' q' → Uunwrap1 ¬VM x E p' q' U
 ... | done (V-wrap VM) = step
-  (λ V → valred (Value2VALUE V) (β-wrap VM))
+  (λ V → valred V (β-wrap VM x))
   []
-  (β (β-wrap VM))
+  (β (β-wrap VM x))
   refl
-  λ E p q → let X ,, Y ,, Y' = Uunwrap2 VM refl E (≡-to-≅ p) q in
-    X ,, ≅-to-≡ Y ,, ≅-to-≡ Y'
-rlemma51! (con c)      = done (V-con c)
-rlemma51! (builtin b)  = done (ival b)
-rlemma51! (error _)    = step
+  λ E p' q' → Uunwrap2 VM x E p' q'
+rlemma51! (con c) = done (V-con c)
+rlemma51! (builtin b / refl) = done (ival b)
+rlemma51! (error _) = step
   (valerr E-error)
   []
   err
@@ -1677,22 +1657,22 @@ rlemma51! (error _)    = step
 unique-EC : ∀{A B}(E E' : EC A B)(L : ∅ ⊢ B) → Redex L
   → E [ L ]ᴱ ≡ E' [ L ]ᴱ → E ≡ E'
 unique-EC  E E' L p q with rlemma51! (E [ L ]ᴱ)
-... | done VEL = ⊥-elim (valredex (lemVE L E (Value2VALUE VEL)) p)
+... | done VEL = ⊥-elim (valredex (lemVE L E VEL) p)
 ... | step ¬VEL E'' r r' U with U E' q p
 ... | refl ,, refl ,, refl with U E refl p
 ... | refl ,, refl ,, refl = refl
 
 notVAL : ∀{A}{L N : ∅ ⊢ A} → Value L → L —→ N → ⊥
-notVAL V (ruleEC E p refl r) = valred (lemVE _ E (Value2VALUE V)) p
+notVAL V (ruleEC E p refl r) = valred (lemVE _ E V) p
 notVAL V (ruleErr E refl)    =
-  valerr E-error (VALUE2Value (lemVE _ E (Value2VALUE V)))
+  valerr E-error (lemVE _ E V)
 
 determinism : ∀{A}{L N N' : ∅ ⊢ A} → L —→ N → L —→ N' → N ≡ N'
 determinism {L = L} p q with rlemma51! L
 determinism {L = .(E [ _ ]ᴱ)} (ruleEC E p refl p') q | done VL =
-  ⊥-elim (valred (lemVE _ E (Value2VALUE VL)) p)
+  ⊥-elim (valred (lemVE _ E VL) p)
 determinism {L = L} (ruleErr E refl)      q | done VL =
-  ⊥-elim (valerr E-error (VALUE2Value (lemVE _ E (Value2VALUE VL))))
+  ⊥-elim (valerr E-error (lemVE _ E VL))
 determinism {L = L} (ruleEC E' p p' p'') q | step ¬VL E r r' U
   with U E' p' (β p)
 determinism {L = L} (ruleEC E p p' p'') (ruleEC E' q q' q'') | step ¬VL E (β r) r' U | refl ,, refl ,, refl with U E' q' (β q)

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1265,18 +1265,20 @@ lemV·⋆ : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}
   → ¬ (VALUE M) → ¬ (VALUE (M ·⋆ A))
 lemV·⋆ ¬VM (V-I⇒ b .(bubble p) q (step⋆ p x)) = ¬VM (V-IΠ b p refl x)
 lemV·⋆ ¬VM (V-IΠ b .(bubble p) q (step⋆ p x)) = ¬VM (V-IΠ b p refl x)
-
+-}
 lemBAppβ : ∀{A B}{b}{az as}{p : az <>> as ∈ arity b}{M : ∅ , A ⊢ B}{M'}
   → ¬ (BApp b p (ƛ M · M'))
 lemBAppβ (step p () x)
 
+{-
 lemBAppβ⋆ : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{b}{az as}{p : az <>> as ∈ arity b}{M : ∅ ,⋆ K ⊢ B} → ¬ (BApp b p (Λ M ·⋆ A))
 lemBAppβ⋆ (step⋆ p ())
+-}
+lemVβ : ∀{A B}{M : ∅ , A ⊢ B}{M'} → ¬ (Value (ƛ M · M'))
+lemVβ (V-I⇒ b p q) = lemBAppβ q
+lemVβ (V-IΠ b p q) = lemBAppβ q
 
-lemVβ : ∀{A B}{M : ∅ , A ⊢ B}{M'} → ¬ (VALUE (ƛ M · M'))
-lemVβ (V-I⇒ b p q x) = lemBAppβ x
-lemVβ (V-IΠ b p q x) = lemBAppβ x
-
+{-
 lemVβ⋆ : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ,⋆ K ⊢ B} → ¬ (VALUE (Λ M ·⋆ A))
 lemVβ⋆ (V-I⇒ b p q x) = lemBAppβ⋆ x
 lemVβ⋆ (V-IΠ b p q x) = lemBAppβ⋆ x
@@ -1318,18 +1320,22 @@ lemVE M (unwrap E) (V-I⇒ b p q ())
 lemVE M (unwrap E) (V-IΠ b p q ())
 -}
 -}
-{-
+
 lemBE : ∀{A B} M (E : EC A B){as a az b}{p : az <>> (a ∷ as) ∈ arity b}
-  → BApp b p (E [ M ]ᴱ) → VALUE M
-lemBE M [] {a = Term} q with bappTermLem _ M _ (BApp2BAPP q)
-... | _ ,, _ ,, refl = V-I⇒ _ _ refl q
-lemBE M [] {a = Type} q with bappTypeLem _ M _ (BApp2BAPP q)
-... | _ ,, _ ,, refl = V-IΠ _ _ refl q
+  → BApp b p (E [ M ]ᴱ) → Value M
+lemBE M [] {a = Term} q with bappTermLem _ M _ q
+... | _ ,, _ ,, refl = V-I⇒ _ _ q
+lemBE M [] {a = Type} q with bappTypeLem _ M _ q
+... | _ ,, _ ,, refl = V-IΠ _ _ q
 lemBE M (E l· x) (step p q x₁) = lemBE _ E q
-lemBE M (x ·r E) (step p q x₁) = lemVE _ E (Value2VALUE x₁)
-lemBE M (E ·⋆ A) (step⋆ p q) = lemBE _ E q
+lemBE M (x ·r E) (step p q x₁) = lemVE _ E x₁
+lemBE M (E ·⋆ A / r) (step⋆ p q refl) = lemBE _ E q
 lemBE M (wrap E) ()
-lemBE M (unwrap E) ()
+lemBE M (unwrap E / r) ()
+
+
+-- these adhoc lemmas about subst are needed as do the uniqueness bits of
+-- lemma51! with pattern matching lambdas and can't use with
 
 subst-l· : ∀{A B C C'}(E : EC (A ⇒ B) C)(M' : ∅ ⊢ A)(p : C ≡ C')
   → substEq (EC B) p (E l· M') ≡ substEq (EC (A ⇒ B)) p E l· M'
@@ -1339,14 +1345,12 @@ subst-·r : ∀{A B C C'}(E : EC A C)(M : ∅ ⊢ A ⇒ B)(VM : Value M)(p : C �
   → substEq (EC B) p (VM ·r E) ≡ VM ·r substEq (EC A) p E
 subst-·r E M VM refl = refl
 
-
 proj· : ∀{A A' B}{t : ∅ ⊢ A ⇒ B}{t' : ∅ ⊢ A' ⇒ B}{u : ∅ ⊢ A}{u' : ∅ ⊢ A'}
   → t _⊢_.· u ≡ t' · u'
   → ∃ λ (p : A ≡ A')
       → substEq (λ A → ∅ ⊢ A ⇒ B) p t ≡ t'
       × substEq (∅ ⊢_) p u ≡ u'
 proj· refl = refl ,, refl ,, refl
--}
 
 valred : ∀{A}{L N : ∅ ⊢ A} → Value L → L —→⋆ N → ⊥
 valred (V-I⇒ b .(bubble p) (step p () x₁)) (β-ƛ VN)
@@ -1381,13 +1385,13 @@ valerr E-error (V-IΠ b p ())
 
 errred : ∀{A}{L N : ∅ ⊢ A} → Error L → L —→⋆ N → ⊥
 errred E-error ()
-{-
+
 -- should replace this with something more general if something similar shows
 -- up again
-substƛVAL : ∀{A A' B}{M : ∅ , A ⊢ B} (p : A ≡ A')
-  → VALUE (substEq (λ A → ∅ ⊢ (A ⇒ B)) p (ƛ M))
-substƛVAL refl = V-ƛ _
--}
+substƛVal : ∀{A A' B}{M : ∅ , A ⊢ B} (p : A ≡ A')
+  → Value (substEq (λ A → ∅ ⊢ (A ⇒ B)) p (ƛ M))
+substƛVal refl = V-ƛ _
+
 BUILTIN-eq : ∀{A b b' az az'}(M : ∅ ⊢ A)(p : az <>> _ ∈ arity b)(p' : az' <>> _ ∈ arity b')(bv : BApp b p M)(bv' : BApp b' p' M)
   → BUILTIN' b p bv ≡ BUILTIN' b' p' bv'
 BUILTIN-eq M p p' bv bv'
@@ -1582,54 +1586,64 @@ Uunwrap2 VM eq (unwrap E / x) p q with lem-unwrap p
                      (V-wrap VM))) q)
 Uunwrap2 VM refl [] refl q = refl ,, refl ,, refl
 
-{-
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
-rlemma51! (ƛ M)        = done (V-ƛ M)
-rlemma51! (M · M') with rlemma51! M
+rlemma51! (ƛ M) = done (V-ƛ M)
+rlemma51! (M · N) with rlemma51! M
 ... | step ¬VM E p q U = step
   (lemV· ¬VM)
-  (E l· M')
+  (E l· N)
   p
-  (cong (_· M') q)
-  λ { [] {.(ƛ _ · M')} refl (β (β-ƛ VM')) → ⊥-elim (¬VM (V-ƛ _))
-    ; [] {.(M · M')} refl (β (β-sbuiltin b .M p bt .M' VM')) →
-      ⊥-elim (¬VM (V-I⇒ b p bt))
-   ; (E' l· B) {L'} refl p' → let X ,, Y ,, Y' = U E' refl p' in
-      X ,, trans (subst-l· E M' (proj₁ (U E' refl p'))) (cong (_l· M') Y) ,, Y'
-    ; (VM ·r E') {L'} refl p' → ⊥-elim (¬VM VM)
-    ; (E' ·⋆ A) {L'} () p'
-    ; (wrap E') {L'} () p'
-    ; (unwrap E') {L'} () p'
+  (cong (_· N) q)
+  λ { [] refl (β (β-ƛ VN)) → ⊥-elim (¬VM (V-ƛ _))
+    ; [] refl (β (β-sbuiltin b .M p bt .N vu)) → ⊥-elim (¬VM (V-I⇒ b p bt))
+    ; (E' l· N') refl r → let X ,, Y ,, Y' = U E' refl r in
+      X ,,  trans ( subst-l· E N X)  (cong (_l· N) Y)  ,, Y'
+    ; (VM ·r E') refl r → ⊥-elim (¬VM VM)
     }
-... | done VM with rlemma51! M'
-... | step ¬VM' E p q U = step
-  (lemV'· ¬VM')
+... | done VM with rlemma51! N
+... | step ¬VN E p q U = step
+  (lemV'· ¬VN)
   (VM ·r E)
   p
   (cong (M ·_) q)
-  λ { [] refl (β (β-ƛ VM')) → ⊥-elim (¬VM' VM')
-    ; [] refl (β (β-sbuiltin b .M p bt .M' VM')) → ⊥-elim (¬VM' VM')
-    ; (E' l· M'') refl p' → ⊥-elim (valredex (lemVE _ _ (Value2VALUE VM)) p')
-    ; (VM'' ·r E') refl p' → let X ,, X'' ,, X''' = U E' refl p' in X ,, trans (subst-·r E M VM X) (trans (cong (VM ·r_) X'') (cong (_·r E') (uniqueVal M VM VM''))) ,, X'''
-    }
-rlemma51! (.(ƛ M) · M') | done (V-ƛ M)       | done VM' = step
-  (λ V → lemVβ (Value2VALUE V))
+  λ { [] refl (β (β-ƛ VN)) → ⊥-elim (¬VN VN)
+    ; [] refl (β (β-sbuiltin b .M p bt .N VN)) → ⊥-elim (¬VN VN)
+    ; (E' l· N') refl q → ⊥-elim (valredex (lemVE _ _ VM) q)
+    ; (VM' ·r E') refl q → let X ,, X'' ,, X''' = U E' refl q in
+      X
+      ,,
+      trans (subst-·r E M VM X)
+            (trans (cong (VM ·r_) X'') (cong (_·r E') (uniqueVal M VM VM')))
+      ,,
+      X'''}
+rlemma51! (.(ƛ M) · N) | done (V-ƛ M) | done VN = step
+  lemVβ
   []
-  (β (β-ƛ VM'))
+  (β (β-ƛ VN))
   refl
-  λ { [] refl (β (β-ƛ VM'')) → refl ,, refl ,, refl
-    ; (E l· N) q p → let X ,, Y ,, Y' = proj· q in
-      ⊥-elim (valredex (lemVE _ E (substEq VALUE Y (substƛVAL X))) p)
-    ; (V ·r E) refl p →
-      ⊥-elim (valredex (lemVE _ E (Value2VALUE VM')) p)}
-rlemma51! (M · M') | done (V-I⇒ b {as' = []}      p q) | done VM' = step
-  (λ V → valred (Value2VALUE V) (β-sbuiltin b M p q M' VM'))
+  λ { [] refl (β (β-ƛ x)) → refl ,, refl ,, refl
+    ; (E' l· N') p q → let X ,, Y ,, Y' = proj· p in
+      ⊥-elim (valredex (lemVE _ E' (substEq Value Y (substƛVal X))) q)
+    ; (VM' ·r E') refl q → ⊥-elim (valredex (lemVE _ E' VN) q)}
+rlemma51! (M · N) | done (V-I⇒ b {as' = []}       p x) | done VN = step
+  (λ V → valred V (β-sbuiltin b M p x N VN))
   []
-  (β (β-sbuiltin b M p q M' VM'))
+  (β (β-sbuiltin b M p x N VN))
   refl
-  λ { [] refl (β (β-sbuiltin b .M p bt .M' vu)) → refl ,, refl ,, refl
-    ; (E l· x) refl p' → ⊥-elim (valredex (lemBE _ E q) p')
-    ; (x ·r E) refl p' → ⊥-elim (valredex (lemVE _ E (Value2VALUE VM')) p')}
+  λ { [] refl (β (β-sbuiltin b .M p bt .N vu)) → refl ,, refl ,, refl
+    ; (E' l· N') refl q → ⊥-elim (valredex (lemBE _ E' x) q)
+    ; (VM' ·r E') refl q → ⊥-elim (valredex (lemVE _ E' VN) q)}
+rlemma51! (M · N) | done (V-I⇒ b {as' = a' ∷ as'} p x) | done VN =
+  done (V-I b (bubble p) (step p x VN))
+rlemma51! (Λ M) = done (V-Λ M)
+rlemma51! (M ·⋆ A / x) = {!!}
+rlemma51! (wrap A B M) = {!!}
+rlemma51! (unwrap M x) = {!!}
+rlemma51! (con c) = done (V-con c)
+rlemma51! (builtin b / x) = {!!}
+rlemma51! (error _) = {!!}
+
+{-
 rlemma51! (M · M') | done (V-I⇒ b {as' = a ∷ as'} p q) | done VM' =
   done (V-I b (bubble p) (step p q VM'))
 rlemma51! (Λ M)        = done (V-Λ M)

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1280,25 +1280,45 @@ lemVβ (V-IΠ b p q x) = lemBAppβ x
 lemVβ⋆ : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ,⋆ K ⊢ B} → ¬ (VALUE (Λ M ·⋆ A))
 lemVβ⋆ (V-I⇒ b p q x) = lemBAppβ⋆ x
 lemVβ⋆ (V-IΠ b p q x) = lemBAppβ⋆ x
+-}
 
-lemVE : ∀{A B} M (E : EC A B) → VALUE (E [ M ]ᴱ) → VALUE M
+postulate lemVE : ∀{A B} M (E : EC A B) → Value (E [ M ]ᴱ) → Value M
+
+{-
+This currently triggers and agda bug:
+Panic: Pattern match failure in do expression at
+src/full/Agda/TypeChecking/Rules/LHS/Unify.hs:1313:7-14
+when checking that the pattern V-I⇒ b p q has type
+Value ((x ·r E) [ M ]ᴱ)
+
+lemVE M []             V = V
+lemVE M (x ·r E) (V-I⇒ b p q) = ?
+lemVE M (x ·r E) (V-IΠ b p q) = ?
+lemVE M (E l· x) (V-I⇒ b .(bubble p) (step p x₁ x₂)) = lemVE _ E (V-I⇒ b p x₁)
+lemVE M (E l· x) (V-IΠ b .(bubble p) (step p x₁ x₂)) = lemVE _ E (V-I⇒ b p x₁)
+lemVE M (E ·⋆ A / x)   V = {!!}
+lemVE M (wrap E)       V = {!!}
+lemVE M (unwrap E / x) V = {!!}
+{-
 lemVE M [] V = V
-lemVE M (E l· M') (V-I⇒ b .(bubble p) refl (step p x x₁)) =
-  lemVE _ E (V-I⇒ b p refl x)
-lemVE M (E l· M') (V-IΠ b .(bubble p) refl (step p x x₁)) =
-  lemVE _ E (V-I⇒ b p refl x)
-lemVE M (VM' ·r E) (V-I⇒ b .(bubble p) refl (step p x x₁)) =
-  lemVE _ E (Value2VALUE x₁)
-lemVE M (VM' ·r E) (V-IΠ b .(bubble p) refl (step p x x₁)) =
-  lemVE _ E (Value2VALUE x₁)
-lemVE M (E ·⋆ A) (V-I⇒ b .(bubble p) q (step⋆ p x)) =
+lemVE M (E l· M') (V-I⇒ b .(bubble p) (step p x x₁)) =
+  lemVE _ E (V-I⇒ b p x)
+lemVE M (E l· M') (V-IΠ b .(bubble p) (step p x x₁)) =
+  lemVE _ E (V-I⇒ b p x)
+lemVE M (VM' ·r E) (V-I⇒ b .(bubble p) (step p x x₁)) =
+  lemVE _ E x₁
+lemVE M (VM' ·r E) (V-IΠ b .(bubble p) (step p x x₁)) =
+  lemVE _ E x₁
+lemVE M (E ·⋆ A / refl) (V-I⇒ b .(bubble p) q (step⋆ p x)) =
   lemVE _ E (V-IΠ b p refl x)
-lemVE M (E ·⋆ A) (V-IΠ b .(bubble p) q (step⋆ p x)) =
+lemVE M (E ·⋆ A / refl) (V-IΠ b .(bubble p) q (step⋆ p x)) =
   lemVE _ E (V-IΠ b p refl x)
 lemVE M (wrap E) (V-wrap V) = lemVE _ E V
 lemVE M (unwrap E) (V-I⇒ b p q ())
 lemVE M (unwrap E) (V-IΠ b p q ())
-
+-}
+-}
+{-
 lemBE : ∀{A B} M (E : EC A B){as a az b}{p : az <>> (a ∷ as) ∈ arity b}
   → BApp b p (E [ M ]ᴱ) → VALUE M
 lemBE M [] {a = Term} q with bappTermLem _ M _ (BApp2BAPP q)
@@ -1423,7 +1443,8 @@ U·⋆1 : ∀{A : ∅ ⊢Nf⋆ K}{B}{L : ∅ ,⋆ K ⊢ B}{X}
  ∃ (λ (q : X ≡ B') → [] ≡ substEq (λ X → EC X B') q E' × Λ L ·⋆ A / trans (sym q) p ≡ L')
 U·⋆1 eq [] refl q = refl ,, refl ,, refl
 U·⋆1 eq (E' ·⋆ A / r) p q with lem-·⋆ r eq p
-U·⋆1 {L = L} eq (E' ·⋆ A / r) {L'} p q | refl ,, Y ,, refl ,, refl with lemΛE'' E' Y
+U·⋆1 {L = L} eq (E' ·⋆ A / r) {L'} p q | refl ,, Y ,, refl ,, refl
+  with lemΛE'' E' Y
 U·⋆1 {_} {A} {L = L} eq (_·⋆_/_ {_} E' A r) {.(Λ L)} p (β ()) | refl ,, Y ,, refl ,, refl | refl ,, X ,, refl
 
 -- M is not a value, it has made a step
@@ -1454,25 +1475,25 @@ U·⋆2 ¬VM eq [] refl (β (β-sbuiltin⋆ b _ p bt _ .eq)) U =
 U·⋆2 ¬VM eq (E ·⋆ A / .eq) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
 
-{-
--- BUILTIN
+
 U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X}
-      → X ≡ B [ A ]Nf →
+      → (p : X ≡ B [ A ]Nf) →
       (E' : EC X B')
       {L' : ∅ ⊢ B'} →
       Value M →
-      M _⊢_.·⋆ A ≅ (E' [ L' ]ᴱ) →
+      M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ) →
       Redex L' →
       Σ
       (B [ A ]Nf ≡ B')
       (λ p₁ →
-         Σ
+         
          (substEq (EC (B [ A ]Nf)) p₁ []
-          ≅ E')
-         (λ x₁ → substEq (_⊢_ ∅) p₁ (M _⊢_.·⋆ A) ≅ L'))
-U·⋆3 eq [] _ refl q = refl ,, refl ,, refl
-U·⋆3 eq (E ·⋆ A) VM refl q = ⊥-elim (valredex (lemVE _ E (Value2VALUE VM)) q)
+          ≅ E') -- could make a closer homogeneous equation using p and p₁
+         × (M _⊢_.·⋆ A / sym p₁) ≡ L')
+U·⋆3 eq (E ·⋆ A / .eq) V refl q = ⊥-elim (valredex (lemVE _ E V) q)
+U·⋆3 refl [] V refl q = refl ,, refl ,, refl
 
+{-
 -- body of wrap made a step, it's not a value
 Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
  → X ≡ μ A B

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1493,12 +1493,11 @@ U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X
 U·⋆3 eq (E ·⋆ A / .eq) V refl q = ⊥-elim (valredex (lemVE _ E V) q)
 U·⋆3 refl [] V refl q = refl ,, refl ,, refl
 
-{-
 -- body of wrap made a step, it's not a value
 Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
- → X ≡ μ A B
+ → (p : X ≡ μ A B)
  → (E' : EC X B') {L' : ∅ ⊢ B'} →
- _⊢_.wrap A B M ≅ E' [ L' ]ᴱ →
+ _⊢_.wrap A B M ≡ substEq (∅ ⊢_) p (E' [ L' ]ᴱ) →
  Redex L' →
  (U : {B' : ∅ ⊢Nf⋆ *}
       (E' : EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) B')
@@ -1525,9 +1524,13 @@ Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (w
  ∃
  (λ (p₁ : C ≡ B') →
     substEq (EC (μ A B)) p₁ (wrap E) ≅ E' × substEq (_⊢_ ∅) p₁ L ≅ L')
-Uwrap eq [] refl (β ()) U
-Uwrap eq (wrap E') refl q U with U E' refl q
+Uwrap refl (E l· x) () q U
+Uwrap refl (x ·r E) () q U
+Uwrap refl (E ·⋆ A / x) () q U
+Uwrap refl (wrap E) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
+Uwrap refl (unwrap E / x) () q U
+Uwrap refl [] refl (β ()) U
 
 -- the body of the unwrap, M, is not a value and made a step
 Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
@@ -1553,7 +1556,7 @@ Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B'
 Uunwrap1 ¬VM eq [] refl (β (β-wrap VM)) U = ⊥-elim (¬VM (V-wrap VM))
 Uunwrap1 ¬VM eq (unwrap E') refl q U with U E' refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
-
+{-
 -- beta step
 Uunwrap2 : ∀{A}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{B' : ∅ ⊢Nf⋆ *}{X}
   → Value M

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1436,7 +1436,8 @@ data RProgress {A : ∅ ⊢Nf⋆ *} (M : ∅ ⊢ A) : Set where
     → RProgress M
 
 -- these lemmas are needed for the uniqueness cases of lemma51!
--- it might be cleaner to define each uniqueness case directly as a lemma
+-- it might be cleaner to define every uniqueness case directly as a lemma
+
 -- a beta⋆ reduction happened
 U·⋆1 : ∀{A : ∅ ⊢Nf⋆ K}{B}{L : ∅ ,⋆ K ⊢ B}{X}
  {B' : ∅ ⊢Nf⋆ *}
@@ -1456,15 +1457,14 @@ U·⋆2 : ∀{K}{C}{A : ∅ ⊢Nf⋆ K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{M : ∅ ⊢ �
  {B' : ∅ ⊢Nf⋆ *}
  → ¬ (Value M)
  → (p : X ≡ B [ A ]Nf) →
- (E'
-  : EC X B')
+ (E' : EC X B')
  {L' : ∅ ⊢ B'} →
  M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ) →
  Redex L' →
  (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (Π B) B') {L' : ∅ ⊢ B'} →
       M ≡ (E' [ L' ]ᴱ) →
       Redex L' →
-      ∃ (λ (p₁ : C ≡ B') → substEq (EC (Π B)) p₁ E ≡ E' × substEq (_⊢_ ∅) p₁ L ≡ L'))
+      ∃ (λ (q : C ≡ B') → substEq (EC _) q E ≡ E' × substEq (_⊢_ ∅) q L ≡ L'))
  →
  ∃
  (λ (p₁ : C ≡ B') →
@@ -1487,54 +1487,33 @@ U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X
       Value M →
       M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ) →
       Redex L' →
-      Σ
-      (X ≡ B')
-      (λ p₁ →
-         
-         (substEq (EC X) p₁ []
-          ≡ E')
-         × substEq (∅ ⊢_) p₁ (M _⊢_.·⋆ A / p) ≡ L')
+      ∃ λ (q : X ≡ B') → substEq (EC X) q [] ≡ E'
+         × substEq (∅ ⊢_) q (M _⊢_.·⋆ A / p) ≡ L'
 U·⋆3 eq (E ·⋆ A / .eq) V refl q = ⊥-elim (valredex (lemVE _ E V) q)
 U·⋆3 refl [] V refl q = refl ,, refl ,, refl
 
 -- body of wrap made a step, it's not a value
-Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
- → (p : X ≡ μ A B)
- → (E' : EC X B') {L' : ∅ ⊢ B'} →
- _⊢_.wrap A B M ≡ substEq (∅ ⊢_) p (E' [ L' ]ᴱ) →
+Uwrap : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}
+ → (E' : EC (μ A B) B') {L' : ∅ ⊢ B'} →
+ _⊢_.wrap A B M ≡ E' [ L' ]ᴱ →
  Redex L' →
  (U : {B' : ∅ ⊢Nf⋆ *}
-      (E' : EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) B')
+      (E' : EC _ B')
       {L' : ∅ ⊢ B'} →
       M ≡ (E' [ L' ]ᴱ) →
       Redex L' →
-      ∃
-      (λ p₁ →
-         substEq
-         (EC
-          ((eval (embNf A) (λ x → reflect (` x)) ·V
-            inj₂
-            (λ ρ v →
-               μ
-               (reify
-                (eval (embNf (renNf S A))
-                 ((λ x → renVal ρ (reflect (` x))) ,,⋆ v)))
-               (reify v)))
-           ·V eval (embNf B) (λ x → reflect (` x))))
-         p₁ E
-         ≡ E'
-         × substEq (_⊢_ ∅) p₁ L ≡ L'))
+      ∃ (λ p → substEq (EC _) p E ≡ E' × substEq (_⊢_ ∅) p L ≡ L'))
  →
  ∃
  (λ (p₁ : C ≡ B') →
-    substEq (EC (μ A B)) p₁ (wrap E) ≅ E' × substEq (_⊢_ ∅) p₁ L ≅ L')
-Uwrap refl (E l· x) () q U
-Uwrap refl (x ·r E) () q U
-Uwrap refl (E ·⋆ A / x) () q U
-Uwrap refl (wrap E) refl q U with U E refl q
+    substEq (EC (μ A B)) p₁ (wrap E) ≡ E' × substEq (_⊢_ ∅) p₁ L ≡ L')
+Uwrap (E l· x) () q U
+Uwrap (x ·r E) () q U
+Uwrap (E ·⋆ A / x) () q U
+Uwrap (wrap E) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
-Uwrap refl (unwrap E / x) () q U
-Uwrap refl [] refl (β ()) U
+Uwrap (unwrap E / x) () q U
+Uwrap [] refl (β ()) U
 
 -- the body of the unwrap, M, is not a value and made a step
 Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
@@ -1657,24 +1636,20 @@ rlemma51! (M ·⋆ A / x) | done (V-IΠ b {as' = x₁ ∷ as'} p q) =
   p
   (cong (_·⋆ A / x) q)
   λ E p q → U·⋆2 ¬VM x E p q U
-rlemma51! (wrap A B M) = {!!}
+rlemma51! (wrap A B M) with rlemma51! M
+... | step ¬VM E p q U = step
+  (λ {(V-wrap VM) → ¬VM VM})
+  (wrap E)
+  p
+  (cong (wrap A B) q)
+  λ E p' q' → Uwrap E p' q' U
+... | done VM = done (V-wrap VM)
 rlemma51! (unwrap M x) = {!!}
 rlemma51! (con c) = done (V-con c)
 rlemma51! (builtin b / x) = {!!}
 rlemma51! (error _) = {!!}
 
 {-
-rlemma51! (M ·⋆ A) | done (V-IΠ b {as' = a ∷ as'} p x) =
-  done (V-I b (bubble p) (step⋆ p x))
-rlemma51! (wrap A B M) with rlemma51! M
-... | done VM = done (V-wrap VM)
-... | step ¬VM E p q U = step
-  (λ {(V-wrap VM) → ¬VM VM})
-  (wrap E)
-  p
-  (cong (wrap A B) q)
-  λ E p q → let X ,, Y ,, Y' = Uwrap refl E (≡-to-≅ p) q U in
-    X ,, ≅-to-≡ Y ,, ≅-to-≡ Y'
 rlemma51! (unwrap M) with rlemma51! M
 ... | step ¬VM E p q U = step
   (λ V → lemVunwrap (Value2VALUE V))

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -339,8 +339,6 @@ data EC : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
   _·r_ : {A B C : ∅ ⊢Nf⋆ *}{t : ∅ ⊢ A ⇒ B} → Value t → EC A C → EC B C
   _·⋆_/_ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{C}{X}
     → EC (Π B) C → (A : ∅ ⊢Nf⋆ K) → X ≡ B [ A ]Nf → EC X C
---  _·⋆_ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{C}
---    → EC (Π B) C → (A : ∅ ⊢Nf⋆ K) → EC (B [ A ]Nf) C
   wrap : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}{C}
     → EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) C
     → EC (μ A B) C
@@ -348,21 +346,6 @@ data EC : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
     → EC (μ A B) C
     → X ≡ (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) 
     → EC X C
-
-{-
-data EC' : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
-  []   : {A : ∅ ⊢Nf⋆ *} → EC' A A
-  _l·_ : {A B C : ∅ ⊢Nf⋆ *} → EC' (A ⇒ B) C → ∅ ⊢ A → EC' B C
-  _·r_ : {A B C : ∅ ⊢Nf⋆ *}{t : ∅ ⊢ A ⇒ B} → Value t → EC' A C → EC' B C
-  _·⋆_~_ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{C}{X}
-    → EC' (Π B) C → (A : ∅ ⊢Nf⋆ K) → X ≡ B [ A ]Nf → EC' X C
-  wrap : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}{C}
-    → EC' (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) C
-    → EC' (μ A B) C
-  unwrap : ∀{K}{A : ∅ ⊢Nf⋆ (K ⇒ *) ⇒ K ⇒ *}{B : ∅ ⊢Nf⋆ K}{C}
-    → EC' (μ A B) C
-    → EC' (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) C
--}
 ```
 
 ```
@@ -1285,7 +1268,7 @@ lemVβ⋆ (V-IΠ b p q) = lemBAppβ⋆ q
 postulate lemVE : ∀{A B} M (E : EC A B) → Value (E [ M ]ᴱ) → Value M
 
 {-
-This currently triggers and agda bug:
+This currently triggers an agda bug:
 Panic: Pattern match failure in do expression at
 src/full/Agda/TypeChecking/Rules/LHS/Unify.hs:1313:7-14
 when checking that the pattern V-I⇒ b p q has type
@@ -1369,6 +1352,7 @@ valred (V-I⇒ b₁ .(bubble p₁) (step⋆ p₁ x q)) (β-sbuiltin⋆ b t p bt 
 valred (V-IΠ b₁ .(bubble p₁) (step⋆ p₁ x q)) (β-sbuiltin⋆ b t p bt A r)
   with uniqueBApp' t p₁ p x bt
 ... | refl ,, refl ,, () ,, refl
+
 {-
 bapperr : ∀{A}{L : ∅ ⊢ A}{b az as}{p : az <>> as ∈ arity b}
   → Error L → BApp b p L → ⊥

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1426,16 +1426,15 @@ U·⋆1 eq (E' ·⋆ A / r) p q with lem-·⋆ r eq p
 U·⋆1 {L = L} eq (E' ·⋆ A / r) {L'} p q | refl ,, Y ,, refl ,, refl with lemΛE'' E' Y
 U·⋆1 {_} {A} {L = L} eq (_·⋆_/_ {_} E' A r) {.(Λ L)} p (β ()) | refl ,, Y ,, refl ,, refl | refl ,, X ,, refl
 
-{-
 -- M is not a value, it has made a step
 U·⋆2 : ∀{K}{C}{A : ∅ ⊢Nf⋆ K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{M : ∅ ⊢ Π B}{E : EC (Π B) C}{L : ∅ ⊢ C}{X}
  {B' : ∅ ⊢Nf⋆ *}
  → ¬ (Value M)
- → X ≡ B [ A ]Nf →
+ → (p : X ≡ B [ A ]Nf) →
  (E'
   : EC X B')
  {L' : ∅ ⊢ B'} →
- M _⊢_.·⋆ A ≅ (E' [ L' ]ᴱ) →
+ M _⊢_.·⋆ A / p ≡ (E' [ L' ]ᴱ) →
  Redex L' →
  (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (Π B) B') {L' : ∅ ⊢ B'} →
       M ≡ (E' [ L' ]ᴱ) →
@@ -1445,15 +1444,17 @@ U·⋆2 : ∀{K}{C}{A : ∅ ⊢Nf⋆ K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{M : ∅ ⊢ �
  ∃
  (λ (p₁ : C ≡ B') →
    substEq
-   (EC (B [ A ]Nf))
-   p₁ (E EC.·⋆ A)
-   ≅ E'
-   × substEq (_⊢_ ∅) p₁ L ≅ L')
-U·⋆2 ¬VM eq [] refl (β β-Λ) U = ⊥-elim (¬VM (V-Λ _))
-U·⋆2 ¬VM eq [] refl (β (β-sbuiltin⋆ b _ p bt _)) U = ⊥-elim (¬VM (V-IΠ b p bt))
-U·⋆2 ¬VM eq (E ·⋆ A) refl q U with U E refl q
+   (EC X)
+   p₁ (E EC.·⋆ A / p)
+   ≡ E'
+   × substEq (_⊢_ ∅) p₁ L ≡ L')
+U·⋆2 ¬VM eq [] refl (β (β-Λ .eq)) U = ⊥-elim (¬VM (V-Λ _))
+U·⋆2 ¬VM eq [] refl (β (β-sbuiltin⋆ b _ p bt _ .eq)) U =
+  ⊥-elim (¬VM (V-IΠ b p bt))
+U·⋆2 ¬VM eq (E ·⋆ A / .eq) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
 
+{-
 -- BUILTIN
 U·⋆3 : ∀{K}{A : ∅ ⊢Nf⋆ K}{B}{M : ∅ ⊢ Π B}{B' : ∅ ⊢Nf⋆ *}{X}
       → X ≡ B [ A ]Nf →

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -1535,10 +1535,10 @@ Uwrap refl [] refl (β ()) U
 -- the body of the unwrap, M, is not a value and made a step
 Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B' : ∅ ⊢Nf⋆ *}{X}
   → ¬ (Value M)
-  → X ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B) →
+  → (p : X ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) →
   (E' : EC X B')
   {L' : ∅ ⊢ B'} →
-  _⊢_.unwrap M ≅ (E' [ L' ]ᴱ) →
+  _⊢_.unwrap M p ≡ (E' [ L' ]ᴱ) →
   Redex L' →
   (U : {B' : ∅ ⊢Nf⋆ *} (E' : EC (μ A B) B') {L' : ∅ ⊢ B'} →
     M ≡ (E' [ L' ]ᴱ) →
@@ -1550,21 +1550,21 @@ Uunwrap1 : ∀{A C}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ μ A B}{L : ∅ ⊢ C}{E}{B'
   (λ (p₁ : C ≡ B') →
      substEq
      (EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)))
-     p₁ (EC.unwrap {A = A}{B} E)
+     p₁ (EC.unwrap E / refl)
      ≅ E'
      × substEq (_⊢_ ∅) p₁ L ≅ L')
-Uunwrap1 ¬VM eq [] refl (β (β-wrap VM)) U = ⊥-elim (¬VM (V-wrap VM))
-Uunwrap1 ¬VM eq (unwrap E') refl q U with U E' refl q
+Uunwrap1 ¬VM eq [] refl (β (β-wrap x .eq)) U = ⊥-elim (¬VM (V-wrap x))
+Uunwrap1 ¬VM refl (unwrap E / refl) refl q U with U E refl q
 ... | refl ,, refl ,, refl = refl ,, refl ,, refl
-{-
+
 -- beta step
 Uunwrap2 : ∀{A}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)}{B' : ∅ ⊢Nf⋆ *}{X}
   → Value M
-  → X ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B) →
+  → (p : X ≡ nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)) →
   (E'
    : EC X B')
   {L' : ∅ ⊢ B'} →
-  _⊢_.unwrap (wrap A B M) ≅ (E' [ L' ]ᴱ) →
+  _⊢_.unwrap (wrap A B M) p ≡ (E' [ L' ]ᴱ) →
   Redex L' →
   ∃
   (λ (p : _ ≡ B') →
@@ -1572,16 +1572,17 @@ Uunwrap2 : ∀{A}{B : ∅ ⊢Nf⋆ K}{M : ∅ ⊢ nf (embNf A · ƛ (μ (embNf (
      (EC (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B)))
      p []
      ≅ E'
-     × substEq (_⊢_ ∅) p (unwrap (wrap A B M)) ≅ L')
-Uunwrap2 VM eq [] refl q = refl ,, refl ,, refl
-Uunwrap2 VM eq (unwrap E') p q with lem-unwrap p
-... | refl ,, refl ,, X =
- ⊥-elim (valredex (lemVE
+     × unwrap (wrap A B M) (sym p) ≅ L')
+Uunwrap2 VM eq (unwrap E / x) p q with lem-unwrap p
+... | refl ,, refl ,, refl ,, X4 =
+  ⊥-elim (valredex (lemVE
                      _
-                     E'
-                     (substEq VALUE (≅-to-≡ X)
-                     (V-wrap (Value2VALUE VM)))) q)
+                     E
+                     (substEq Value (≅-to-≡ X4)
+                     (V-wrap VM))) q)
+Uunwrap2 VM refl [] refl q = refl ,, refl ,, refl
 
+{-
 rlemma51! : {A : ∅ ⊢Nf⋆ *} → (M : ∅ ⊢ A) → RProgress M
 rlemma51! (ƛ M)        = done (V-ƛ M)
 rlemma51! (M · M') with rlemma51! M

--- a/plutus-metatheory/src/Algorithmic/RenamingSubstitution.lagda
+++ b/plutus-metatheory/src/Algorithmic/RenamingSubstitution.lagda
@@ -79,20 +79,20 @@ ren ρ⋆ ρ (` x)    = ` (ρ x)
 ren ρ⋆ ρ (ƛ N)    = ƛ (ren ρ⋆ (ext ρ⋆ ρ) N)
 ren ρ⋆ ρ (L · M)  = ren ρ⋆ ρ L · ren ρ⋆ ρ M 
 ren ρ⋆ ρ (Λ N)    = Λ (ren (⋆.ext ρ⋆) (ext⋆ ρ⋆ ρ) N)
-ren ρ⋆ ρ (_·⋆_ {B = B} t A) = conv⊢
+ren ρ⋆ ρ (_·⋆_/_ {B = B} t A refl) = conv⊢
   refl
   (sym (ren[]Nf ρ⋆ B A))
-  (ren ρ⋆ ρ t ·⋆ renNf ρ⋆ A)
+  (ren ρ⋆ ρ t ·⋆ renNf ρ⋆ A / refl)
 ren ρ⋆ ρ (wrap A B M) = wrap
   (renNf ρ⋆ A)
   (renNf ρ⋆ B)
   (conv⊢ refl (ren-nf-μ ρ⋆ A B) (ren ρ⋆ ρ M))
-ren ρ⋆ ρ (unwrap {A = A}{B} M) = conv⊢
+ren ρ⋆ ρ (unwrap {A = A}{B} M refl) = conv⊢
   refl
   (sym (ren-nf-μ ρ⋆ A B))
-  (unwrap (ren ρ⋆ ρ M)) 
+  (unwrap (ren ρ⋆ ρ M) refl) 
 ren ρ⋆ ρ (con c) = con (renTermCon ρ⋆ c)
-ren ρ⋆ ρ (builtin b) = conv⊢ refl (btype-ren b ρ⋆) (builtin b)
+ren ρ⋆ ρ (builtin b / refl) = conv⊢ refl (btype-ren b ρ⋆) (builtin b / refl)
 ren ρ⋆ ρ (error A) = error (renNf ρ⋆ A)
 \end{code}
 
@@ -168,20 +168,20 @@ sub σ⋆ σ (ƛ N)                     = ƛ (sub σ⋆ (exts σ⋆ σ) N)
 sub σ⋆ σ (L · M)                   = sub σ⋆ σ L · sub σ⋆ σ M
 sub σ⋆ σ (Λ {B = B} N) =
   Λ (conv⊢ refl (sub-nf-Π σ⋆ B) (sub (extsNf σ⋆) (exts⋆ σ⋆ σ) N))
-sub σ⋆ σ (_·⋆_ {B = B} L M) = conv⊢
+sub σ⋆ σ (_·⋆_/_ {B = B} L M refl) = conv⊢
   refl
   (sym (sub[]Nf' σ⋆ M B))
-  (sub σ⋆ σ L ·⋆ subNf σ⋆ M)
+  (sub σ⋆ σ L ·⋆ subNf σ⋆ M / refl)
 sub σ⋆ σ (wrap A B M) = wrap
   (subNf σ⋆ A)
   (subNf σ⋆ B)
   (conv⊢ refl (sub-nf-μ σ⋆ A B) (sub σ⋆ σ M))
-sub σ⋆ σ (unwrap {A = A}{B} M) = conv⊢
+sub σ⋆ σ (unwrap {A = A}{B} M refl) = conv⊢
   refl
   (sym (sub-nf-μ σ⋆ A B))
-  (unwrap (sub σ⋆ σ M))
+  (unwrap (sub σ⋆ σ M) refl)
 sub σ⋆ σ (con c) = con (subTermCon σ⋆ c)
-sub σ⋆ σ (builtin b) = conv⊢ refl (btype-sub b σ⋆) (builtin b)
+sub σ⋆ σ (builtin b / refl) = conv⊢ refl (btype-sub b σ⋆) (builtin b / refl)
 sub σ⋆ σ (error A) = error (subNf σ⋆ A)
 \end{code}
 

--- a/plutus-metatheory/src/Algorithmic/Soundness.lagda
+++ b/plutus-metatheory/src/Algorithmic/Soundness.lagda
@@ -146,16 +146,16 @@ emb (Alg.` α) = Dec.` (embVar α)
 emb (Alg.ƛ {A = A}{B} t) = Dec.ƛ (emb t)
 emb (Alg._·_ {A = A}{B} t u) = emb t Dec.· emb u
 emb (Alg.Λ {B = B} t) = Dec.Λ (emb t)
-emb (Alg._·⋆_ {B = B} t A) =
+emb (Alg._·⋆_/_ {B = B} t A refl) =
     Dec.conv (emb[] A B) (emb t Dec.·⋆ embNf A)
 emb (Alg.wrap A B t) = Dec.wrap
   (embNf A)
   (embNf B)
   (Dec.conv (sym≡β (soundness-μ refl A B)) (emb t))
-emb (Alg.unwrap {A = A}{B} t) =
+emb (Alg.unwrap {A = A}{B} t refl) =
   Dec.conv (soundness-μ refl A B) (Dec.unwrap (emb t))
 emb (Alg.con  {tcn = tcn} t ) = Dec.con (embTC t)
-emb (Alg.builtin b) = Dec.conv (btype-lem≡β b) (Dec.builtin b)
+emb (Alg.builtin b / refl) = Dec.conv (btype-lem≡β b) (Dec.builtin b)
 emb (Alg.error A) = Dec.error (embNf A)
 
 soundnessT : ∀{Φ Γ}{A : Φ ⊢Nf⋆ *} → Γ Alg.⊢ A → embCtx Γ Dec.⊢ embNf A

--- a/plutus-metatheory/src/Check.lagda.md
+++ b/plutus-metatheory/src/Check.lagda.md
@@ -372,7 +372,7 @@ inferType Γ (Λ K L) = do
 inferType Γ (L ·⋆ A) = do
   K ,, B ,, L ← isPi (inferType Γ L)
   A ← checkKind _ A K
-  return (B [ A ]Nf ,, L ·⋆ A)
+  return (B [ A ]Nf ,, L ·⋆ A / refl)
 inferType Γ (ƛ A L) = do
   A ← isStar (inferKind _ A)
   B ,, L ← inferType (Γ , A) L 
@@ -387,7 +387,7 @@ inferType {Φ} Γ (con c) = do
 inferType Γ (error A) = do
   A ← isStar (inferKind _ A)
   return (A ,, error A)
-inferType Γ (builtin b) = inj₂ (btype b ,, builtin b)
+inferType Γ (builtin b) = inj₂ (btype b ,, builtin b / refl)
 inferType Γ (wrap A B L) = do
   K ,, A ← isPat (inferKind _ A)
   B ← checkKind _ B K
@@ -395,5 +395,5 @@ inferType Γ (wrap A B L) = do
   return (μ A B ,, wrap A B L)
 inferType Γ (unwrap L) = do
   K ,, A ,, B ,, L ← isMu (inferType Γ L)
-  return (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B) ,, unwrap L)
+  return (nf (embNf A · ƛ (μ (embNf (weakenNf A)) (` Z)) · embNf B) ,, unwrap L refl)
 ```

--- a/plutus-metatheory/src/Scoped/Extrication.lagda
+++ b/plutus-metatheory/src/Scoped/Extrication.lagda
@@ -99,11 +99,11 @@ extricate (` x) = ` (extricateVar x)
 extricate {Φ}{Γ} (ƛ {A = A} t) = ƛ (extricateNf⋆ A) (extricate t)
 extricate (t · u) = extricate t · extricate u
 extricate (Λ {K = K} t) = Λ K (extricate t)
-extricate {Φ}{Γ} (_·⋆_ t A) = extricate t ScopedTm.·⋆ extricateNf⋆ A
+extricate {Φ}{Γ} (t ·⋆ A / refl) = extricate t ScopedTm.·⋆ extricateNf⋆ A
 extricate {Φ}{Γ} (wrap pat arg t) = wrap (extricateNf⋆ pat) (extricateNf⋆ arg)
   (extricate t)
-extricate (unwrap t) = unwrap (extricate t)
+extricate (unwrap t refl) = unwrap (extricate t)
 extricate (con c) = con (extricateC c)
-extricate (builtin b) = builtin b
+extricate (builtin b / refl) = builtin b
 extricate {Φ}{Γ} (error A) = error (extricateNf⋆ A)
 \end{code}

--- a/plutus-metatheory/src/index.lagda.md
+++ b/plutus-metatheory/src/index.lagda.md
@@ -133,6 +133,7 @@ import Algorithmic.Soundness
 import Algorithmic.Erasure
 import Algorithmic.Erasure.RenamingSubstitution
 import Algorithmic.Erasure.Reduction
+import Algorithmic.CC
 import Algorithmic.CK
 import Algorithmic.CEKV
 


### PR DESCRIPTION
This PR modifies the syntax of algorithmic terms to make them easier to reason about.

The idea is to abstract over return types that contain functions: unwrap, type application and builtin.

Not doing this caused big problems later in values, builtin applications and evaluation contexts.

The intended pay off is to reduce the number of postulated lemmas, duplicated definitions, and extensions required.

We were able to get away without doing this for the structural reduction formalisation and the definition of the machines. but it starts to bite after that. With the previous definition you could pattern match on syntactic term of an arbitrary type but could not pattern match on one of a specific type (such as `A => B`) but you could pattern match on a value of a specific type (such as `A => B`). This functionality was sufficient to prove progress and preservation for the structural presentation of reduction used in fun-and-profit, and implement typechecking and the abstract machines. But, it is not sufficient to do for evaluation context style reduction or the more complicated reasoning needed to show behavioural equivalence.
