### PR TITLE
[Builtins] Reimplement 'KnownBuiltIn' for pairs in a recursive manner

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Typed.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Typed.hs
@@ -534,7 +534,8 @@ class (uni ~ UniOf term, KnownTypeAst uni a) => KnownTypeIn uni term a where
     -- | Convert a Haskell value to the corresponding PLC term.
     -- The inverse of 'readKnown'.
     makeKnown
-        :: ( MonadEmitter m, MonadError (ErrorWithCause err cause) m, AsEvaluationFailure err
+        :: ( MonadEmitter m
+           , MonadError (ErrorWithCause err cause) m, AsUnliftingError err, AsEvaluationFailure err
            )
         => Maybe cause -> a -> m term
     default makeKnown
@@ -608,7 +609,7 @@ instance (MonadError err m, AsEvaluationFailure err) =>
 -- | Same as 'makeKnown', but allows for neither emitting nor storing the cause of a failure.
 -- For example the monad can be simply 'EvaluationResult'.
 makeKnownOrFail :: (KnownType term a, MonadError err m, AsEvaluationFailure err) => a -> m term
-makeKnownOrFail = unNoCauseT . unNoEmitterT . makeKnown Nothing
+makeKnownOrFail = undefined -- unNoCauseT . unNoEmitterT . makeKnown Nothing
 
 instance KnownTypeAst uni a => KnownTypeAst uni (EvaluationResult a) where
     type ToBinds (EvaluationResult a) = ToBinds a


### PR DESCRIPTION
This PR here is for me to cry. It allows us to lift / unlift `(a, b)` where `a` and `b` are arbitrary types implementing `KnownTypeIn` rather than just types of constants. This would make it possible to add a bit more to the inference machinery and get `TypeScheme` inference for `fst :: (a, b) -> a` and `snd :: (a, b) -> b` and then similarly `head :: [a] -> a`, `tail :: [a] -> [a]` etc. Unfortunately, the cost is that every element of a polymorphic built-in type needs to be processed explicitly then. I.e. in order to unlift a tuple we need to match on the tuple and unlift each element individually. And the same for lists. Which makes unlifting of a `[a]` O(n), while currently it's `O(1)`. So this is not going to fly.

We could consider `unsafeCoerce`ing stuff and using `Any`, but we probably don't want to.