### PR TITLE
Add clearer guidelines for external contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,11 @@ A clear and concise description of what you expected to happen.
 
 ## Screenshots and attachments
 
-- If applicable, add screenshots, config files and/or logs to help explain the problem.
+If applicable, add screenshots, config files and/or logs to help explain the problem.
+
+## Describe the approach you would take to fix this 
+
+If you would like to work on this yourself (optional!), then let us know what approach you would take so we can advise you.
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,6 +26,10 @@ A clear and detailed description of what you are suggesting.
 
 A clear and concise description of any alternative solutions or features you've considered.
 
+## Describe the approach you would take to implement this 
+
+If you would like to work on this yourself (optional!), then let us know what approach you would take so we can advise you.
+
 ## Additional context / screenshots
 
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 <!--
+IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.
+
 Here are some checklists you may like to use. Use your judgement.
 
 This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
@@ -11,6 +13,7 @@ Pre-submit checklist:
     - [ ] Relevant tickets are mentioned in commit messages
     - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
 - PR
+    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
     - [ ] Self-reviewed the diff
     - [ ] Useful pull request description
     - [ ] Reviewer requested

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -362,6 +362,28 @@ Read these blog posts for more good tips:
 - https://mtlynch.io/human-code-reviews-1/
 - https://mtlynch.io/human-code-reviews-2/
 
+== External contributors
+
+The Plutus team welcomes contributions from external contributors.
+However, it can be difficult for the Plutus team to quickly review contributions from people where we don't have an existing relationship.
+For that reason, we ask you to follow these additional guidelines (the rest of the document also applies!), which will make it easier for us to review your work, and therefore make the contributing process smoother for you.
+
+=== All changes must have an issue
+
+Make sure that any change you make has a corresponding GitHub issue.
+The issue should describe the problem and describe your proposed solutiion. 
+Before you start working on implementing it, you must get a comment from the Plutus team that the solution seems sensible.
+This functions as a light "design review" before you get too stuck into doing a PR.
+
+Reviewing the issue makes things easier for the Plutus team (it's easier to read an issue than a PR); and less frustrating for the contributor (it's nicer to get design feeback *before* you have done lots of work on the implementation).
+We can also offer advice on implementation, or let you know that we're already planning to fix the issue (or that there is a good reason not to!).
+
+=== Keep changes well-scoped
+
+Try to keep your PR focussed on one change.
+This is a pratice we try to follow generally, but especially for external contributions where reviews tend to be more laborious, it's good to keep things focussed.
+If your PR contains a dozen drive-by refactorings, it's unlikely to be merged as such!
+
 == Supporting systems
 
 === Continuous integration


### PR DESCRIPTION
This is an attempt to structure our interactions with external contributors a bit more clearly, mainly by asking that all changes come with an issue, and that the implementation approach has had signoff from someone one the Plutus team. The goal here isn't to put up more barriers, but rather to help external contributors make it easy for the Plutus team to review and assess their work, hopefully making things less time-consuming and frustrating all round.

Most of our good external contributors already do this (or nearly this), so hopefully it's not too controversial.

Also cc @silky @jhbertra @asutherlandus