### PR TITLE
[Builtins] [Evaluation] Introduce 'TypeSchemeRuntime'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -131,6 +131,7 @@ module PlutusCore
     -- * Budgeting defaults
     , defaultBuiltinCostModel
     , defaultBuiltinsRuntime
+    , defaultBuiltinsRuntime'
     , defaultCekCostModel
     , defaultCekMachineCosts
     , defaultCekParameters

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -1,11 +1,13 @@
 -- GHC doesn't like the definition of 'makeBuiltinMeaning'.
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
+{-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE FunctionalDependencies    #-}
+{-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE StandaloneKindSignatures  #-}
@@ -65,6 +67,40 @@ data BuiltinMeaning term cost =
 -- reasons (there isn't much point in caching a value of a type with a constraint as it becomes a
 -- function at runtime anyway, due to constraints being compiled as dictionaries).
 
+data TypeSchemeRuntime m cause term args res where
+    TypeSchemeRuntimeResult
+        :: !(Maybe cause -> res -> m term)
+        -> TypeSchemeRuntime m cause term '[] res
+    TypeSchemeRuntimeArrow
+        :: !(Maybe cause -> term -> m arg)
+        -> !(TypeSchemeRuntime m cause term args res)
+        -> TypeSchemeRuntime m cause term (arg ': args) res
+    TypeSchemeRuntimeAll
+        :: !(TypeSchemeRuntime m cause term args res)
+        -> TypeSchemeRuntime m cause term args res
+
+toTypeSchemeRuntime
+    :: forall m term args res err cause.
+       ( MonadEmitter m, MonadError (ErrorWithCause err cause) m
+       , AsUnliftingError err, AsEvaluationFailure err
+       )
+    => TypeScheme term args res
+    -> TypeSchemeRuntime m cause term args res
+toTypeSchemeRuntime = go where
+    go
+        :: TypeScheme term args' res
+        -> TypeSchemeRuntime m cause term args' res
+    go (TypeSchemeResult _) =
+        let mk :: Maybe cause -> res -> m term
+            !mk = makeKnown
+        in TypeSchemeRuntimeResult mk
+    go (TypeSchemeArrow (_ :: Proxy arg) schB) =
+        let rk :: Maybe cause -> term -> m arg
+            !rk = readKnown
+        in TypeSchemeRuntimeArrow rk $ go schB
+    go (TypeSchemeAll _ schK) =
+        TypeSchemeRuntimeAll . go $ schK Proxy
+
 -- We tried instantiating 'BuiltinMeaning' on the fly and that was sloer than precaching
 -- 'BuiltinRuntime's.
 -- | A 'BuiltinRuntime' represents a possibly partial builtin application.
@@ -99,6 +135,29 @@ newtype BuiltinsRuntime fun term = BuiltinsRuntime
 toBuiltinRuntime :: cost -> BuiltinMeaning term cost -> BuiltinRuntime term
 toBuiltinRuntime cost (BuiltinMeaning sch f exF) = BuiltinRuntime sch f (exF cost)
 
+data BuiltinRuntime' m cause term =
+    forall args res. BuiltinRuntime'
+        (TypeSchemeRuntime m cause term args res)
+        (FoldArgs args res)  -- Must be lazy, because we don't want to compute the denotation when
+                             -- it's fully saturated before figuring out what it's going to cost.
+        (FoldArgsEx args)    -- We make this lazy, so that evaluators that don't care about costing
+                             -- can put @undefined@ here. TODO: we should test if making this strict
+                             -- introduces any measurable speedup.
+
+-- | A 'BuiltinRuntime' for each builtin from a set of builtins.
+newtype BuiltinsRuntime' fun m cause term = BuiltinsRuntime'
+    { unBuiltinRuntime' :: Array fun (BuiltinRuntime' m cause term)
+    }
+
+-- | Instantiate a 'BuiltinMeaning' given denotations of built-in functions and a cost model.
+toBuiltinRuntime'
+    :: ( MonadEmitter m, MonadError (ErrorWithCause err cause) m
+       , AsUnliftingError err, AsEvaluationFailure err
+       )
+    => cost -> BuiltinMeaning term cost -> BuiltinRuntime' m cause term
+toBuiltinRuntime' cost (BuiltinMeaning sch f exF) =
+    BuiltinRuntime' (toTypeSchemeRuntime sch) f (exF cost)
+
 -- | A type class for \"each function from a set of built-in functions has a 'BuiltinMeaning'\".
 class (Bounded fun, Enum fun, Ix fun) => ToBuiltinMeaning uni fun where
     -- | The @cost@ part of 'BuiltinMeaning'.
@@ -120,12 +179,32 @@ toBuiltinsRuntime
 toBuiltinsRuntime cost =
     BuiltinsRuntime . tabulateArray $ toBuiltinRuntime cost . toBuiltinMeaning
 
+-- | Calculate runtime info for all built-in functions given denotations of builtins
+-- and a cost model.
+toBuiltinsRuntime'
+    :: ( cost ~ CostingPart uni fun, HasConstantIn uni term, ToBuiltinMeaning uni fun
+       , MonadEmitter m, MonadError (ErrorWithCause err cause) m
+       , AsUnliftingError err, AsEvaluationFailure err
+       )
+    => cost -> BuiltinsRuntime' fun m cause term
+toBuiltinsRuntime' cost =
+    BuiltinsRuntime' . tabulateArray $ toBuiltinRuntime' cost . toBuiltinMeaning
+
 -- | Look up the runtime info of a built-in function during evaluation.
 lookupBuiltin
     :: (MonadError (ErrorWithCause err term) m, AsMachineError err fun, Ix fun)
     => fun -> BuiltinsRuntime fun val -> m (BuiltinRuntime val)
 -- @Data.Array@ doesn't seem to have a safe version of @(!)@, hence we use a prism.
 lookupBuiltin fun (BuiltinsRuntime env) = case env ^? ix fun of
+    Nothing  -> throwingWithCause _MachineError (UnknownBuiltin fun) Nothing
+    Just bri -> pure bri
+
+-- | Look up the runtime info of a built-in function during evaluation.
+lookupBuiltin'
+    :: (MonadError (ErrorWithCause err cause) m, AsMachineError err fun, Ix fun)
+    => fun -> BuiltinsRuntime' fun m cause term -> m (BuiltinRuntime' m cause term)
+-- @Data.Array@ doesn't seem to have a safe version of @(!)@, hence we use a prism.
+lookupBuiltin' fun (BuiltinsRuntime' env) = case env ^? ix fun of
     Nothing  -> throwingWithCause _MachineError (UnknownBuiltin fun) Nothing
     Just bri -> pure bri
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -4,6 +4,7 @@
 
 module PlutusCore.Evaluation.Machine.ExBudgetingDefaults
     ( defaultBuiltinsRuntime
+    , defaultBuiltinsRuntime'
     , defaultCekCostModel
     , defaultCekMachineCosts
     , defaultCekParameters
@@ -24,7 +25,9 @@ import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.ExBudget ()
 import PlutusCore.Evaluation.Machine.ExMemory ()
 import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.Name
 
+import UntypedPlutusCore.Core
 import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
 import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
@@ -74,14 +77,23 @@ defaultCekCostModel = CostModel defaultCekMachineCosts defaultBuiltinCostModel
 defaultCostModelParams :: Maybe CostModelParams
 defaultCostModelParams = extractCostModelParams defaultCekCostModel
 
-defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
+defaultCekParameters
+    :: (uni ~ DefaultUni, fun ~ DefaultFun)
+    => MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s)
 defaultCekParameters = toMachineParameters defaultCekCostModel
 
-unitCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
+unitCekParameters
+    :: (uni ~ DefaultUni, fun ~ DefaultFun)
+    => MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s)
 unitCekParameters = toMachineParameters (CostModel unitCekMachineCosts unitCostBuiltinCostModel)
 
 defaultBuiltinsRuntime :: HasConstantIn DefaultUni term => BuiltinsRuntime DefaultFun term
 defaultBuiltinsRuntime = toBuiltinsRuntime defaultBuiltinCostModel
+
+defaultBuiltinsRuntime'
+    :: (uni ~ DefaultUni, fun ~ DefaultFun)
+    => BuiltinsRuntime' DefaultFun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s)
+defaultBuiltinsRuntime' = toBuiltinsRuntime' defaultBuiltinCostModel
 
 
 -- A cost model with unit costs, so we can count how often each builtin is called

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -8,9 +8,10 @@ where
 import PlutusCore.Constant
 
 import PlutusCore.Core.Type hiding (Type)
-import PlutusCore.Evaluation.Machine.ExBudget ()
+import PlutusCore.Evaluation.Machine.Exception
+import PlutusCore.Evaluation.Result
 
-import GHC.Types (Type)
+import Control.Monad.Except
 
 {-| We need to account for the costs of evaluator steps and also built-in function
    evaluation.  The models for these have different structures and are used in
@@ -31,21 +32,23 @@ data CostModel machinecosts builtincosts =
   cost model for builtins and their denotations.  This bundles one of those
   together with the cost model for evaluator steps.  The 'term' type will be
   CekValue when we're using this with the CEK machine. -}
-data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
+data MachineParameters machinecosts fun m cause term =
     MachineParameters {
       machineCosts    :: machinecosts
-    , builtinsRuntime :: BuiltinsRuntime fun (term uni fun)
+    , builtinsRuntime :: BuiltinsRuntime' fun m cause term
     }
 
 {-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}
 toMachineParameters ::
-    ( UniOf (val uni fun) ~ uni
+    ( UniOf term ~ uni
       -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
     , CostingPart uni fun ~ builtincosts
-    , HasConstant (val uni fun)
+    , HasConstant term
     , ToBuiltinMeaning uni fun
+    , MonadEmitter m, MonadError (ErrorWithCause err cause) m
+    , AsUnliftingError err, AsEvaluationFailure err
     )
     => CostModel machinecosts builtincosts
-    -> MachineParameters machinecosts val uni fun
+    -> MachineParameters machinecosts fun m cause term
 toMachineParameters (CostModel mchnCosts builtinCosts) =
-    MachineParameters mchnCosts (toBuiltinsRuntime builtinCosts)
+    MachineParameters mchnCosts (toBuiltinsRuntime' builtinCosts)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -1,6 +1,7 @@
 -- | The API to the CEK machine.
 
 {-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators    #-}
 
@@ -82,8 +83,8 @@ allow one to specify an 'ExBudgetMode'. I.e. such functions are only for fully e
 
 -- | Evaluate a term using the CEK machine with logging disabled and keep track of costing.
 runCekNoEmit
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ()
     -> (Either (CekEvaluationException uni fun) (Term Name uni fun ()), cost)
@@ -98,7 +99,7 @@ unsafeRunCekNoEmit
        , Closed uni, uni `EverywhereAll` '[ExMemoryUsage, PrettyConst]
        , Ix fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ()
     -> (EvaluationResult (Term Name uni fun ()), cost)
@@ -108,9 +109,9 @@ unsafeRunCekNoEmit params mode =
 
 -- | Evaluate a term using the CEK machine with logging enabled.
 evaluateCek
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
+    :: (uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun
+    -> (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> Term Name uni fun ()
     -> (Either (CekEvaluationException uni fun) (Term Name uni fun ()), [Text])
 evaluateCek emitMode params term =
@@ -119,8 +120,8 @@ evaluateCek emitMode params term =
 
 -- | Evaluate a term using the CEK machine with logging disabled.
 evaluateCekNoEmit
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> Term Name uni fun ()
     -> Either (CekEvaluationException uni fun) (Term Name uni fun ())
 evaluateCekNoEmit params = fst . runCekNoEmit params restrictingEnormous
@@ -132,7 +133,7 @@ unsafeEvaluateCek
        , Ix fun, Pretty fun, Typeable fun
        )
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun
+    -> (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> Term Name uni fun ()
     -> (EvaluationResult (Term Name uni fun ()), [Text])
 unsafeEvaluateCek emitTime params =
@@ -145,7 +146,7 @@ unsafeEvaluateCekNoEmit
        , Closed uni, uni `EverywhereAll` '[ExMemoryUsage, PrettyConst]
        , Ix fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> Term Name uni fun ()
     -> EvaluationResult (Term Name uni fun ())
 unsafeEvaluateCekNoEmit params = unsafeExtractEvaluationResult . evaluateCekNoEmit params
@@ -156,7 +157,7 @@ readKnownCek
        , KnownType (Term Name uni fun ()) a
        , Ix fun, PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> Term Name uni fun ()
     -> Either (CekEvaluationException uni fun) a
 readKnownCek params = evaluateCekNoEmit params >=> readKnownSelf

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -3,7 +3,6 @@
 -- string names. I.e. 'Unique's are used instead of string names. This is for efficiency reasons.
 -- The CEK machines handles name capture by design.
 
-
 {-# LANGUAGE BangPatterns             #-}
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE DataKinds                #-}
@@ -24,6 +23,7 @@
 {-# LANGUAGE UndecidableInstances     #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     -- See Note [Compilation peculiarities].
@@ -73,7 +73,6 @@ import Control.Monad.ST.Unsafe
 import Data.Array
 import Data.Hashable (Hashable)
 import Data.Kind qualified as GHC
-import Data.Proxy
 import Data.Semigroup (stimes)
 import Data.Text (Text)
 import Data.Word64Array.Word8
@@ -178,15 +177,15 @@ but functions are not printable and hence we provide a dummy instance.
 -}
 
 -- See Note [Show instance for BuiltinRuntime].
-instance Show (BuiltinRuntime (CekValue uni fun)) where
+instance Show (BuiltinRuntime' (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s)) where
     show _ = "<builtin_runtime>"
 
 -- 'Values' for the modified CEK machine.
-data CekValue uni fun =
+data CekValue uni fun s =
     -- This bang gave us a 1-2% speed-up at the time of writing.
     VCon !(Some (ValueOf uni))
-  | VDelay (Term Name uni fun ()) !(CekValEnv uni fun)
-  | VLamAbs Name (Term Name uni fun ()) !(CekValEnv uni fun)
+  | VDelay (Term Name uni fun ()) !(CekValEnv uni fun s)
+  | VLamAbs Name (Term Name uni fun ()) !(CekValEnv uni fun s)
   | VBuiltin            -- A partial builtin application, accumulating arguments for eventual full application.
       !fun                   -- So that we know, for what builtin we're calculating the cost.
                              -- TODO: any chance we could sneak this into 'BuiltinRuntime'
@@ -199,12 +198,12 @@ data CekValue uni fun =
                              -- discharged values and discharging is expensive, so we don't want to
                              -- do it unless we really have to. Making this field strict resulted
                              -- in a 3-4.5% slowdown at the time of writing.
-      (CekValEnv uni fun)    -- For discharging.
-      !(BuiltinRuntime (CekValue uni fun))  -- The partial application and its costing function.
+      (CekValEnv uni fun s)    -- For discharging.
+      !(BuiltinRuntime' (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))  -- The partial application and its costing function.
                                             -- Check the docs of 'BuiltinRuntime' for details.
     deriving (Show)
 
-type CekValEnv uni fun = UniqueMap TermUnique (CekValue uni fun)
+type CekValEnv uni fun s = UniqueMap TermUnique (CekValue uni fun s)
 
 -- | The CEK machine is parameterized over a @spendBudget@ function. This makes the budgeting machinery extensible
 -- and allows us to separate budgeting logic from evaluation logic and avoid branching on the union
@@ -322,7 +321,7 @@ they don't actually take the context as an argument even at the source level.
 -}
 
 -- | Implicit parameter for the builtin runtime.
-type GivenCekRuntime uni fun = (?cekRuntime :: (BuiltinsRuntime fun (CekValue uni fun)))
+type GivenCekRuntime uni fun s = (?cekRuntime :: BuiltinsRuntime' fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
 -- | Implicit parameter for the log emitter reference.
 type GivenCekEmitter uni fun s = (?cekEmitter :: CekEmitter uni fun s)
 -- | Implicit parameter for budget spender.
@@ -331,7 +330,7 @@ type GivenCekSlippage = (?cekSlippage :: Slippage)
 type GivenCekCosts = (?cekCosts :: CekMachineCosts)
 
 -- | Constraint requiring all of the machine's implicit parameters.
-type GivenCekReqs uni fun s = (GivenCekRuntime uni fun, GivenCekEmitter uni fun s, GivenCekSpender uni fun s, GivenCekSlippage, GivenCekCosts)
+type GivenCekReqs uni fun s = (GivenCekRuntime uni fun s, GivenCekEmitter uni fun s, GivenCekSpender uni fun s, GivenCekSlippage, GivenCekCosts)
 
 data CekUserError
     = CekOutOfExError ExRestrictingBudget -- ^ The final overspent (i.e. negative) budget.
@@ -389,7 +388,7 @@ throwingDischarged
     :: (PrettyUni uni fun)
     => AReview (EvaluationError CekUserError (MachineError fun)) t
     -> t
-    -> CekValue uni fun
+    -> CekValue uni fun s
     -> CekM uni fun s x
 throwingDischarged l t = throwingWithCause l t . Just . dischargeCekValue
 
@@ -415,8 +414,10 @@ instance PrettyUni uni fun => MonadError (CekEvaluationException uni fun) (CekM 
 -- > function. But the "invocation" of instance declarations is done behind the scenes by the
 -- > compiler, so it's hard to figure out exactly where it is done. The easiest thing is to outlaw
 -- > the offending types.
--- instance GivenCekEmitter s => MonadEmitter (CekM uni fun s) where
---     emit = emitCek
+
+-- TODO: screw it.
+instance MonadEmitter (CekM uni fun s) where
+    emit _ = pure ()
 
 instance AsEvaluationFailure CekUserError where
     _EvaluationFailure = _EvaluationFailureVia CekEvaluationFailure
@@ -432,7 +433,7 @@ spendBudgetCek = let (CekBudgetSpender spend) = ?cekBudgetSpender in spend
 -- see Note [Scoping].
 -- | Instantiate all the free variables of a term by looking them up in an environment.
 -- Mutually recursive with dischargeCekVal.
-dischargeCekValEnv :: CekValEnv uni fun -> Term Name uni fun () -> Term Name uni fun ()
+dischargeCekValEnv :: CekValEnv uni fun s -> Term Name uni fun () -> Term Name uni fun ()
 dischargeCekValEnv !valEnv =
     -- We recursively discharge the environments of Cek values, but we will gradually end up doing
     -- this to terms which have no free variables remaining, at which point we won't call this
@@ -443,7 +444,7 @@ dischargeCekValEnv !valEnv =
 
 -- | Convert a 'CekValue' into a 'Term' by replacing all bound variables with the terms
 -- they're bound to (which themselves have to be obtain by recursively discharging values).
-dischargeCekValue :: CekValue uni fun -> Term Name uni fun ()
+dischargeCekValue :: CekValue uni fun s -> Term Name uni fun ()
 dischargeCekValue = \case
     VCon     val           -> Constant () val
     VDelay   body env      -> dischargeCekValEnv env $ Delay () body
@@ -456,15 +457,15 @@ dischargeCekValue = \case
     VBuiltin _ term env _  -> dischargeCekValEnv env term
 
 instance (Closed uni, GShow uni, uni `Everywhere` PrettyConst, Pretty fun) =>
-            PrettyBy PrettyConfigPlc (CekValue uni fun) where
+            PrettyBy PrettyConfigPlc (CekValue uni fun s) where
     prettyBy cfg = prettyBy cfg . dischargeCekValue
 
-type instance UniOf (CekValue uni fun) = uni
+type instance UniOf (CekValue uni fun s) = uni
 
-instance FromConstant (CekValue uni fun) where
+instance FromConstant (CekValue uni fun s) where
     fromConstant = VCon
 
-instance AsConstant (CekValue uni fun) where
+instance AsConstant (CekValue uni fun s) where
     asConstant _        (VCon val) = pure val
     asConstant mayCause _          = throwNotAConstant mayCause
 
@@ -474,14 +475,14 @@ The context in which the machine operates.
 Morally, this is a stack of frames, but we use the "intrusive list" representation so that
 we can match on context and the top frame in a single, strict pattern match.
 -}
-data Context uni fun
-    = FrameApplyFun !(CekValue uni fun) !(Context uni fun)                         -- ^ @[V _]@
-    | FrameApplyArg !(CekValEnv uni fun) (Term Name uni fun ()) !(Context uni fun) -- ^ @[_ N]@
-    | FrameForce !(Context uni fun)                                               -- ^ @(force _)@
+data Context uni fun s
+    = FrameApplyFun !(CekValue uni fun s) !(Context uni fun s)                         -- ^ @[V _]@
+    | FrameApplyArg !(CekValEnv uni fun s) (Term Name uni fun ()) !(Context uni fun s) -- ^ @[_ N]@
+    | FrameForce !(Context uni fun s)                                               -- ^ @(force _)@
     | NoFrame
     deriving (Show)
 
-toExMemory :: (Closed uni, uni `Everywhere` ExMemoryUsage) => CekValue uni fun -> ExMemory
+toExMemory :: (Closed uni, uni `Everywhere` ExMemoryUsage) => CekValue uni fun s -> ExMemory
 toExMemory = \case
     VCon c      -> memoryUsage c
     VDelay {}   -> 1
@@ -497,12 +498,13 @@ tryError a = (Right <$> a) `catchError` (pure . Left)
 runCekM
     :: forall a cost uni fun.
     (PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> (forall s. GivenCekReqs uni fun s => CekM uni fun s a)
     -> (Either (CekEvaluationException uni fun) a, cost, [Text])
-runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) (EmitterMode getEmitterMode) a = runST $ do
+runCekM machineParameters (ExBudgetMode getExBudgetInfo) (EmitterMode getEmitterMode) a = runST $ do
+    let MachineParameters costs runtime = machineParameters
     ExBudgetInfo{_exBudgetModeSpender, _exBudgetModeGetFinal, _exBudgetModeGetCumulative} <- getExBudgetInfo
     CekEmitterInfo{_cekEmitterInfoEmit, _cekEmitterInfoGetFinal} <- getEmitterMode _exBudgetModeGetCumulative
     let ?cekRuntime = runtime
@@ -518,11 +520,11 @@ runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) (Emitte
 
 -- | Extend an environment with a variable name, the value the variable stands for
 -- and the environment the value is defined in.
-extendEnv :: Name -> CekValue uni fun -> CekValEnv uni fun -> CekValEnv uni fun
+extendEnv :: Name -> CekValue uni fun s -> CekValEnv uni fun s -> CekValEnv uni fun s
 extendEnv = insertByName
 
 -- | Look up a variable name in the environment.
-lookupVarName :: forall uni fun s . (PrettyUni uni fun) => Name -> CekValEnv uni fun -> CekM uni fun s (CekValue uni fun)
+lookupVarName :: forall uni fun s . (PrettyUni uni fun) => Name -> CekValEnv uni fun s -> CekM uni fun s (CekValue uni fun s)
 lookupVarName varName varEnv =
     case lookupName varName varEnv of
         Nothing  -> throwingWithCause _MachineError OpenTermEvaluatedMachineError $ Just var where
@@ -536,13 +538,13 @@ evalBuiltinApp
     :: (GivenCekReqs uni fun s, PrettyUni uni fun)
     => fun
     -> Term Name uni fun ()
-    -> CekValEnv uni fun
-    -> BuiltinRuntime (CekValue uni fun)
-    -> CekM uni fun s (CekValue uni fun)
-evalBuiltinApp fun term env runtime@(BuiltinRuntime sch x cost) = case sch of
-    TypeSchemeResult _ -> do
+    -> CekValEnv uni fun s
+    -> BuiltinRuntime' (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s)
+    -> CekM uni fun s (CekValue uni fun s)
+evalBuiltinApp fun term env runtime@(BuiltinRuntime' sch x cost) = case sch of
+    TypeSchemeRuntimeResult mk -> do
         spendBudgetCek (BBuiltinApp fun) cost
-        flip unWithEmitterT ?cekEmitter $ makeKnown (Just term) x
+        mk (Just term) x
     _ -> pure $ VBuiltin fun term env runtime
 {-# INLINE evalBuiltinApp #-}
 
@@ -551,8 +553,8 @@ evalBuiltinApp fun term env runtime@(BuiltinRuntime sch x cost) = case sch of
 enterComputeCek
     :: forall uni fun s
     . (Ix fun, PrettyUni uni fun, GivenCekReqs uni fun s, uni `Everywhere` ExMemoryUsage)
-    => Context uni fun
-    -> CekValEnv uni fun
+    => Context uni fun s
+    -> CekValEnv uni fun s
     -> Term Name uni fun ()
     -> CekM uni fun s (Term Name uni fun ())
 enterComputeCek = computeCek (toWordArray 0) where
@@ -564,8 +566,8 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- 4. looks up a variable in the environment and calls 'returnCek' ('Var')
     computeCek
         :: WordArray
-        -> Context uni fun
-        -> CekValEnv uni fun
+        -> Context uni fun s
+        -> CekValEnv uni fun s
         -> Term Name uni fun ()
         -> CekM uni fun s (Term Name uni fun ())
     -- s ; ρ ▻ {L A}  ↦ s , {_ A} ; ρ ▻ L
@@ -595,7 +597,7 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] [] ρ
     computeCek !unbudgetedSteps !ctx !env term@(Builtin _ bn) = do
         !unbudgetedSteps' <- stepAndMaybeSpend BBuiltin unbudgetedSteps
-        meaning <- lookupBuiltin bn ?cekRuntime
+        meaning <- lookupBuiltin' bn ?cekRuntime
         returnCek unbudgetedSteps' ctx (VBuiltin bn term env meaning)
     -- s ; ρ ▻ error A  ↦  <> A
     computeCek !_ !_ !_ (Error _) =
@@ -612,8 +614,8 @@ enterComputeCek = computeCek (toWordArray 0) where
     -}
     returnCek
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun
+        -> Context uni fun s
+        -> CekValue uni fun s
         -> CekM uni fun s (Term Name uni fun ())
     --- Instantiate all the free variable of the resulting term in case there are any.
     -- . ◅ V           ↦  [] V
@@ -638,17 +640,17 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- if v is anything else, fail.
     forceEvaluate
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun
+        -> Context uni fun s
+        -> CekValue uni fun s
         -> CekM uni fun s (Term Name uni fun ())
     forceEvaluate !unbudgetedSteps !ctx (VDelay body env) = computeCek unbudgetedSteps ctx env body
-    forceEvaluate !unbudgetedSteps !ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) = do
+    forceEvaluate !unbudgetedSteps !ctx (VBuiltin fun term env (BuiltinRuntime' sch f exF)) = do
         let term' = Force () term
         case sch of
             -- It's only possible to force a builtin application if the builtin expects a type
             -- argument next.
-            TypeSchemeAll  _ schK -> do
-                let runtime' = BuiltinRuntime (schK Proxy) f exF
+            TypeSchemeRuntimeAll schB -> do
+                let runtime' = BuiltinRuntime' schB f exF
                 -- We allow a type argument to appear last in the type of a built-in function,
                 -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
                 -- application.
@@ -668,26 +670,26 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- If v is anything else, fail.
     applyEvaluate
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun   -- lhs of application
-        -> CekValue uni fun   -- rhs of application
+        -> Context uni fun s
+        -> CekValue uni fun s   -- lhs of application
+        -> CekValue uni fun s   -- rhs of application
         -> CekM uni fun s (Term Name uni fun ())
     applyEvaluate !unbudgetedSteps !ctx (VLamAbs name body env) arg =
         computeCek unbudgetedSteps ctx (extendEnv name arg env) body
     -- Annotating @f@ and @exF@ with bangs gave us some speed-up, but only until we added a bang to
     -- 'VCon'. After that the bangs here were making things a tiny bit slower and so we removed them.
-    applyEvaluate !unbudgetedSteps !ctx (VBuiltin fun term env (BuiltinRuntime sch f exF)) arg = do
+    applyEvaluate !unbudgetedSteps !ctx (VBuiltin fun term env (BuiltinRuntime' sch f exF)) arg = do
         let argTerm = dischargeCekValue arg
             term' = Apply () term argTerm
         case sch of
             -- It's only possible to apply a builtin application if the builtin expects a term
             -- argument next.
-            TypeSchemeArrow _ schB -> do
-                x <- readKnown (Just argTerm) arg
+            TypeSchemeRuntimeArrow rk schB -> do
+                x <- rk (Just argTerm) arg
                 -- TODO: should we bother computing that 'ExMemory' eagerly? We may not need it.
                 -- We pattern match on @arg@ twice: in 'readKnown' and in 'toExMemory'.
                 -- Maybe we could fuse the two?
-                let runtime' = BuiltinRuntime schB (f x) . exF $ toExMemory arg
+                let runtime' = BuiltinRuntime' schB (f x) . exF $ toExMemory arg
                 res <- evalBuiltinApp fun term' env runtime'
                 returnCek unbudgetedSteps ctx res
             _ ->
@@ -722,8 +724,8 @@ enterComputeCek = computeCek (toWordArray 0) where
 -- See Note [Compilation peculiarities].
 -- | Evaluate a term using the CEK machine and keep track of costing, logging is optional.
 runCek
-    :: ( uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    :: (uni `Everywhere` ExMemoryUsage, Ix fun, PrettyUni uni fun)
+    => (forall s. MachineParameters CekMachineCosts fun (CekM uni fun s) (Term Name uni fun ()) (CekValue uni fun s))
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ()

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -1,5 +1,6 @@
 -- | Tests for all kinds of built-in functions.
 
+{-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications      #-}
@@ -31,7 +32,9 @@ import PlutusCore.StdLib.Data.Unit
 
 import Evaluation.Builtins.Common
 
+import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
+import UntypedPlutusCore.Evaluation.Machine.Cek.Internal
 
 import Control.Exception
 import Data.ByteString (ByteString)
@@ -46,7 +49,8 @@ import Test.Tasty.HUnit
 import Test.Tasty.Hedgehog
 
 defaultCekParametersExt
-    :: MachineParameters CekMachineCosts CekValue DefaultUni (Either DefaultFun ExtensionFun)
+    :: (uni ~ DefaultUni, fun ~ Either DefaultFun ExtensionFun)
+    => MachineParameters CekMachineCosts fun (CekM uni fun s) (UPLC.Term Name uni fun ()) (CekValue uni fun s)
 defaultCekParametersExt =
     toMachineParameters $ CostModel defaultCekMachineCosts (defaultBuiltinCostModel, ())
 


### PR DESCRIPTION
This adds `TypeSchemeRuntime`, which is the same thing as `TypeScheme` except properly instantiated and without evaluation-irrelevant stuff. Should be faster.

I'm not able to build the benchmarks by the way, neither `stack` nor `cabal` works. Both give me this:

```
plutus-tx-plugin> /home/effectfully/code/iohk/plutus/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs:776:41: error:
plutus-tx-plugin>     Not in scope: type constructor or class ‘GHC.GenTickish’
plutus-tx-plugin>     Perhaps you meant one of these:
plutus-tx-plugin>       ‘GHC.Tickish’ (imported from GhcPlugins),
plutus-tx-plugin>       ‘GHC.Tickish’ (imported from CoreSyn)
plutus-tx-plugin>     Neither ‘Class’, ‘CoreSyn’, ‘CostCentre’, ‘GhcPlugins’,
plutus-tx-plugin>             ‘MkId’ nor ‘PrelNames’ exports ‘GenTickish’.
plutus-tx-plugin>     |
plutus-tx-plugin> 776 | getSourceSpan :: Maybe GHC.ModBreaks -> GHC.GenTickish pass -> Maybe GHC.RealSrcSpan
plutus-tx-plugin>     | 
```