### PR TITLE
SCP-2915: Make fields of TxInfo lazy

### DIFF
--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE TypeApplications   #-}
 {- |
 The interface to Plutus V1 for the ledger.
@@ -30,6 +31,9 @@ module Plutus.V1.Ledger.Api (
     , ScriptContext(..)
     , ScriptPurpose(..)
     -- ** Supporting types used in the context types
+    , Lazy (..)
+    , force
+    , pattern Forced
     -- *** ByteStrings
     , BuiltinByteString
     , toBuiltin
@@ -139,6 +143,7 @@ import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Pretty
 import PlutusTx (FromData (..), ToData (..), UnsafeFromData (..), fromData, toData)
 import PlutusTx.Builtins.Internal (BuiltinData (..), builtinDataToData, dataToBuiltinData)
+import PlutusTx.Lazy
 import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
 import Prettyprinter
 import UntypedPlutusCore qualified as UPLC

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE TypeApplications   #-}
 {- |
 The interface to Plutus V2 for the ledger.
@@ -30,6 +31,9 @@ module Plutus.V2.Ledger.Api (
     , ScriptContext(..)
     , ScriptPurpose(..)
     -- ** Supporting types used in the context types
+    , Lazy (..)
+    , force
+    , pattern Forced
     -- *** ByteStrings
     , BuiltinByteString
     , toBuiltin

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -67,6 +67,7 @@ library
         PlutusTx.Trace
         PlutusTx.These
         PlutusTx.Code
+        PlutusTx.Lazy
         PlutusTx.Lift
         PlutusTx.Lift.Class
         PlutusTx.Builtins

--- a/plutus-tx/src/PlutusTx/Applicative.hs
+++ b/plutus-tx/src/PlutusTx/Applicative.hs
@@ -69,3 +69,9 @@ instance Monoid m => Applicative (Const m) where
     pure _ = Const mempty
     {-# INLINABLE (<*>) #-}
     Const m1 <*> Const m2 = Const (mappend m1 m2)
+
+instance Applicative ((->) b) where
+    {-# INLINABLE pure #-}
+    pure x = const x
+    {-# INLINABLE (<*>) #-}
+    (<*>) f g x = f x $ g x

--- a/plutus-tx/src/PlutusTx/Functor.hs
+++ b/plutus-tx/src/PlutusTx/Functor.hs
@@ -57,3 +57,7 @@ instance Functor Identity where
 instance Functor (Const m) where
     {-# INLINABLE fmap #-}
     fmap _ (Const c) = Const c
+
+instance Functor ((->) b) where
+    {-# INLINABLE fmap #-}
+    fmap f g = f . g

--- a/plutus-tx/src/PlutusTx/Lazy.hs
+++ b/plutus-tx/src/PlutusTx/Lazy.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE ViewPatterns       #-}
+module PlutusTx.Lazy (Lazy(..), force, pattern Forced) where
+
+import PlutusTx.Applicative
+import PlutusTx.Eq
+import PlutusTx.Functor
+import PlutusTx.IsData
+import PlutusTx.Ord
+import Prelude qualified as Haskell
+import Prettyprinter (Pretty (..))
+
+newtype Lazy a = Lazy { unLazy :: () -> a }
+  deriving newtype (Functor, Applicative)
+
+-- These instances are all kind of questionable...
+instance Eq a => Eq (Lazy a) where
+    Forced x == Forced y = x == y
+
+instance Haskell.Eq a => Haskell.Eq (Lazy a) where
+    Forced x == Forced y = x Haskell.== y
+
+instance Ord a => Ord (Lazy a) where
+    compare (Forced x) (Forced y) = compare x y
+
+instance Haskell.Ord a => Haskell.Ord (Lazy a) where
+    compare (Forced x) (Forced y) = Haskell.compare x y
+
+instance Haskell.Show a => Haskell.Show (Lazy a) where
+    show (Forced x) = Haskell.show x
+
+instance Pretty a => Pretty (Lazy a) where
+    pretty (Forced x) = pretty x
+
+{-# COMPLETE Forced #-}
+pattern Forced :: a -> Lazy a
+pattern Forced x <- (force -> x)
+
+force :: Lazy a -> a
+force (Lazy f) = f ()
+
+-- NOTE: this is *not* lazy, because 'FromData' demands we give it the successful/failed status
+-- up front, which is incompatible with doing the work lazily.
+instance FromData a => FromData (Lazy a) where
+    fromBuiltinData d = fmap (\a -> Lazy (\() -> a)) (fromBuiltinData d)
+
+instance UnsafeFromData a => UnsafeFromData (Lazy a) where
+    unsafeFromBuiltinData d = Lazy (\() -> unsafeFromBuiltinData d)
+
+instance ToData a => ToData (Lazy a) where
+    toBuiltinData d = toBuiltinData (force d)
+
+--instance Lift uni a => Lift uni (Lazy a) where
+    --lift (Forced x) =


### PR DESCRIPTION
This is an attempt to make the fields of TxInfo lazy (well, really
"delayed").

After pushing through the required chagnes in `plutus-apps` this shows
quite variable results. Some scripts get significantly faster, some get
significantly slower.

I suspect this is because as written it is easy to force the same
delayed value many times, thus resulting in redoing lots of work. We
would need to carefully refactor the library to pass forced fields rather
than the whole `TxInfo` structure.

Possibly worth trying, but it would be quite a lot of work, so I'm not going
to pursue this for now.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
