### PR TITLE
SCP-3109: Various profiling improvements

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -3,11 +3,12 @@
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE StrictData           #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# LANGUAGE StrictData           #-}
+{-# OPTIONS_GHC -O0           #-}
 
 module PlutusCore.Evaluation.Machine.BuiltinCostModel
     ( BuiltinCostModel

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -447,7 +447,7 @@ maybeProfileRhs var t = do
         varName = PLC._varDeclName var
         isFunctionOrAbstraction = case ty of { PLC.TyFun{} -> True; PLC.TyForall{} -> True; _ -> False }
     -- Trace only if profiling is on *and* the thing being defined is a function
-    pure $ if coProfile profileOpts==All && isFunctionOrAbstraction then traceInside varName thunk t ty else t
+    pure $ if coProfile compileOpts==All && isFunctionOrAbstraction then traceInside varName thunk t ty else t
 
 mkTrace
     :: (PLC.Contains uni T.Text)

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -29,12 +29,13 @@ profiling = testNested "Profiling" [
   , goldenUEvalProfile "fib4" [toUPlc fibTest, toUPlc $ plc (Proxy @"4") (4::Integer)]
   , goldenUEvalProfile "fact4" [toUPlc factTest, toUPlc $ plc (Proxy @"4") (4::Integer)]
   , goldenPir "addInt" addIntTest
-  , goldenUEvalProfile "addInt3" [toUPlc addIntTest, toUPlc  $ plc (Proxy @"3") (3::Integer)]
+  , goldenUEvalProfile "addInt3" [toUPlc addIntTest, toUPlc $ plc (Proxy @"3") (3::Integer)]
   , goldenUEvalProfile "letInFun" [toUPlc letInFunTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer)]
   , goldenUEvalProfile "letInFunMoreArg" [toUPlc letInFunMoreArgTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer), toUPlc $ plc (Proxy @"5") (5::Integer)]
   -- ghc does the function application
   , goldenUEvalProfile "id" [toUPlc idTest]
   , goldenUEvalProfile "swap" [toUPlc swapTest]
+  , goldenUEvalProfile "typeclass" [toUPlc typeclassTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer)]
   ]
 
 fact :: Integer -> Integer
@@ -88,3 +89,22 @@ swap (a,b) = (b,a)
 
 swapTest :: CompiledCode (Integer, Bool)
 swapTest = plc (Proxy @"swap") (swap (True,1))
+
+-- Two method typeclasses definitely get dictionaries, rather than just being passed as single functions
+class TwoMethods a where
+    methodA :: a -> a -> Integer
+    methodB :: a -> a -> Integer
+
+instance TwoMethods Integer where
+    {-# INLINABLE methodA #-}
+    methodA = Builtins.addInteger
+    {-# INLINABLE methodB #-}
+    methodB = Builtins.subtractInteger
+
+-- Make a function that uses the typeclass polymorphically to check that
+useTypeclass :: TwoMethods a => a -> a -> Integer
+useTypeclass a b = Builtins.addInteger (methodA a b) (methodB a b)
+
+-- Check that typeclass methods get traces
+typeclassTest :: CompiledCode (Integer -> Integer -> Integer)
+typeclassTest = plc (Proxy @"typeclass") (\(x::Integer) (y::Integer) -> useTypeclass x y)

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -32,7 +32,7 @@ profiling = testNested "Profiling" [
   , goldenUEvalProfile "addInt3" [toUPlc addIntTest, toUPlc $ plc (Proxy @"3") (3::Integer)]
   , goldenUEvalProfile "letInFun" [toUPlc letInFunTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer)]
   , goldenUEvalProfile "letInFunMoreArg" [toUPlc letInFunMoreArgTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer), toUPlc $ plc (Proxy @"5") (5::Integer)]
-  -- ghc does the function application
+  , goldenPir "idCode" idTest
   , goldenUEvalProfile "id" [toUPlc idTest]
   , goldenUEvalProfile "swap" [toUPlc swapTest]
   , goldenUEvalProfile "typeclass" [toUPlc typeclassTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer)]
@@ -82,7 +82,7 @@ letInFunMoreArgTest =
         Builtins.multiplyInteger z (Builtins.addInteger (f x) (f y)))
 
 idTest :: CompiledCode Integer
-idTest = plc (Proxy @"id") (id (1::Integer))
+idTest = plc (Proxy @"id") (id (id (1::Integer)))
 
 swap :: (a,b) -> (b,a)
 swap (a,b) = (b,a)

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -32,6 +32,7 @@ profiling = testNested "Profiling" [
   , goldenUEvalProfile "addInt3" [toUPlc addIntTest, toUPlc $ plc (Proxy @"3") (3::Integer)]
   , goldenUEvalProfile "letInFun" [toUPlc letInFunTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer)]
   , goldenUEvalProfile "letInFunMoreArg" [toUPlc letInFunMoreArgTest, toUPlc $ plc (Proxy @"1") (1::Integer), toUPlc $ plc (Proxy @"4") (4::Integer), toUPlc $ plc (Proxy @"5") (5::Integer)]
+  , goldenUEvalProfile "letRecInFun" [toUPlc letRecInFunTest, toUPlc $ plc (Proxy @"3") (3::Integer)]
   , goldenPir "idCode" idTest
   , goldenUEvalProfile "id" [toUPlc idTest]
   , goldenUEvalProfile "swap" [toUPlc swapTest]
@@ -80,6 +81,13 @@ letInFunMoreArgTest =
     (\(x::Integer) (y::Integer) (z::Integer)
       -> let f n = Builtins.addInteger n 1 in
         Builtins.multiplyInteger z (Builtins.addInteger (f x) (f y)))
+
+-- Try a recursive function so it definitely won't be inlined
+letRecInFunTest :: CompiledCode (Integer -> Integer)
+letRecInFunTest =
+  plc
+    (Proxy @"letRecInFun")
+    (\(x::Integer) -> let f n = if Builtins.equalsInteger n 0 then 0 else Builtins.addInteger 1 (f (Builtins.subtractInteger n 1)) in f x)
 
 idTest :: CompiledCode Integer
 idTest = plc (Proxy @"id") (id (id (1::Integer)))

--- a/plutus-tx-plugin/test/Plugin/Profiling/id.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/id.plc.golden
@@ -1,1 +1,1 @@
-[entering id, exiting id]
+[entering id, exiting id, entering id, exiting id]

--- a/plutus-tx-plugin/test/Plugin/Profiling/idCode.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/idCode.plc.golden
@@ -1,0 +1,32 @@
+(program
+  (let
+    (nonrec)
+    (termbind
+      (strict)
+      (vardecl id (all a (type) (fun a a)))
+      (abs
+        a
+        (type)
+        (lam
+          x
+          a
+          [
+            [
+              [
+                { (builtin trace) (fun (con unit) a) }
+                (con string "entering id")
+              ]
+              (lam
+                thunk
+                (con unit)
+                [ [ { (builtin trace) a } (con string "exiting id") ] x ]
+              )
+            ]
+            (con unit ())
+          ]
+        )
+      )
+    )
+    [ { id (con integer) } [ { id (con integer) } (con integer 1) ] ]
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Profiling/letInFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/letInFun.plc.golden
@@ -1,6 +1,10 @@
-[ entering addInteger
-, exiting addInteger
+[ entering f
 , entering addInteger
 , exiting addInteger
+, exiting f
+, entering f
+, entering addInteger
+, exiting addInteger
+, exiting f
 , entering addInteger
 , exiting addInteger ]

--- a/plutus-tx-plugin/test/Plugin/Profiling/letInFunMoreArg.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/letInFunMoreArg.plc.golden
@@ -1,7 +1,11 @@
-[ entering addInteger
-, exiting addInteger
+[ entering f
 , entering addInteger
 , exiting addInteger
+, exiting f
+, entering f
+, entering addInteger
+, exiting addInteger
+, exiting f
 , entering addInteger
 , exiting addInteger
 , entering multiplyInteger

--- a/plutus-tx-plugin/test/Plugin/Profiling/letRecInFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/letRecInFun.plc.golden
@@ -1,20 +1,28 @@
-[ entering equalsInteger
-, exiting equalsInteger
-, entering subtractInteger
-, exiting subtractInteger
+[ entering f
 , entering equalsInteger
 , exiting equalsInteger
 , entering subtractInteger
 , exiting subtractInteger
+, entering f
 , entering equalsInteger
 , exiting equalsInteger
 , entering subtractInteger
 , exiting subtractInteger
+, entering f
 , entering equalsInteger
 , exiting equalsInteger
+, entering subtractInteger
+, exiting subtractInteger
+, entering f
+, entering equalsInteger
+, exiting equalsInteger
+, exiting f
 , entering addInteger
 , exiting addInteger
+, exiting f
 , entering addInteger
 , exiting addInteger
+, exiting f
 , entering addInteger
-, exiting addInteger ]
+, exiting addInteger
+, exiting f ]

--- a/plutus-tx-plugin/test/Plugin/Profiling/letRecInFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/letRecInFun.plc.golden
@@ -1,0 +1,20 @@
+[ entering equalsInteger
+, exiting equalsInteger
+, entering subtractInteger
+, exiting subtractInteger
+, entering equalsInteger
+, exiting equalsInteger
+, entering subtractInteger
+, exiting subtractInteger
+, entering equalsInteger
+, exiting equalsInteger
+, entering subtractInteger
+, exiting subtractInteger
+, entering equalsInteger
+, exiting equalsInteger
+, entering addInteger
+, exiting addInteger
+, entering addInteger
+, exiting addInteger
+, entering addInteger
+, exiting addInteger ]

--- a/plutus-tx-plugin/test/Plugin/Profiling/typeclass.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/typeclass.plc.golden
@@ -1,0 +1,12 @@
+[ entering useTypeclass
+, entering methodA
+, exiting methodA
+, entering addInteger
+, exiting addInteger
+, entering methodB
+, exiting methodB
+, entering subtractInteger
+, exiting subtractInteger
+, entering addInteger
+, exiting addInteger
+, exiting useTypeclass ]


### PR DESCRIPTION
1. Add a test confirming we profile typeclass methods
2. Add a test confirming we don't profile local functions
3. Fix the tracing of polymorphic functions, which wasn't working at all :scream: 
4. Add tracing of local functions

I think 3 is the killer here, that's going to have cut out lots of functions from normal Haskell code! Unfortunately the test was working by accident: we basically did this:
```
id = traceStuff (/\ a . \a -> a)
``` 
rather than
```
id = /\ a . \a -> traceStuff a
```
because we didn't go under the type abstractions. But the test called `id` once, so didn't notice this! I tweaked the test to call `id` twice, and lo we got the wrong answer (because the trace was happening when it was *defined* not when it was *called*).

 Fixing that turned out to be a little involved for annoying reasons, see the Note.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
