### PR TITLE
Fix flat output in uplc for deBruijn-indexed ASTs

### DIFF
--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -86,8 +86,8 @@ class Executable p where
 instance Executable PlcProg where
   parseProgram = PLC.parseProgram
   checkProgram = PLC.checkProgram
-  serialiseProgramFlat fmt p =
-      case fmt of
+  serialiseProgramFlat nameType p =
+      case nameType of
         Named         -> pure $ BSL.fromStrict $ flat p
         DeBruijn      -> typedDeBruijnNotSupportedError
         NamedDeBruijn -> typedDeBruijnNotSupportedError
@@ -97,8 +97,8 @@ instance Executable PlcProg where
 instance Executable UplcProg where
   parseProgram = UPLC.parseProgram
   checkProgram = UPLC.checkProgram
-  serialiseProgramFlat fmt p =
-      case fmt of
+  serialiseProgramFlat nameType p =
+      case nameType of
         Named         -> pure $ BSL.fromStrict $ flat p
         DeBruijn      -> BSL.fromStrict . flat <$> toDeBruijn p
         NamedDeBruijn -> BSL.fromStrict . flat <$> toNamedDeBruijn p

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -359,11 +359,7 @@ getProgram fmt inp =
                return $ PLC.AlexPn 0 0 0 <$ prog  -- No source locations in Flat, so we have to make them up.
 
 
----------------- Serialise a program using Flat ----------------
-
---serialiseProgramFlat ::
---  (Flat a) => a -> BSL.ByteString
---serialiseProgramFlat p = BSL.fromStrict $ flat p
+---------------- Serialise a program using Flat and write it to a given output ----------------
 
 writeFlat ::
   (Executable a, Functor a) => Output -> AstNameType -> a b -> IO ()

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -355,7 +355,7 @@ writeFlat ::
 writeFlat outp flatMode prog = do
   flatProg <- case flatMode of
             Named         -> pure $ serialiseProgramFlat (() <$ prog) -- Change annotations to (): see Note [Annotation types].
-            DeBruijn      -> typedDeBruijnNotSupportedError -- TODO, this should work but we don't have a program here :/
+            DeBruijn      -> serialiseDbProgramFlat (() <$ prog)
             NamedDeBruijn -> serialiseDbProgramFlat (() <$ prog)
   case outp of
     FileOutput file -> BSL.writeFile file flatProg

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -267,11 +267,11 @@ getInput StdInput         = getContents
 
 -- | Read and parse a source program
 parseInput ::
-  (Executable a, PLC.Rename (a PLC.AlexPosn) ) =>
+  (Executable p, PLC.Rename (p PLC.AlexPosn) ) =>
   -- | The source program
   Input ->
   -- | The output is either a UPLC or PLC program with annotation
-  IO (a PLC.AlexPosn)
+  IO (p PLC.AlexPosn)
 parseInput inp = do
     bsContents <- BSL.fromStrict . encodeUtf8 . T.pack <$> getInput inp
     -- parse the UPLC program
@@ -347,10 +347,10 @@ loadUplcASTfromFlat flatMode inp = do
 
 -- Read either a PLC file or a Flat file, depending on 'fmt'
 getProgram ::
-  (Executable a,
-   Functor a,
-   PLC.Rename (a PLC.AlexPosn)) =>
-  Format -> Input -> IO (a PLC.AlexPosn)
+  (Executable p,
+   Functor p,
+   PLC.Rename (p PLC.AlexPosn)) =>
+  Format -> Input -> IO (p PLC.AlexPosn)
 getProgram fmt inp =
     case fmt of
       Textual  -> parseInput inp
@@ -362,7 +362,7 @@ getProgram fmt inp =
 ---------------- Serialise a program using Flat and write it to a given output ----------------
 
 writeFlat ::
-  (Executable a, Functor a) => Output -> AstNameType -> a b -> IO ()
+  (Executable p, Functor p) => Output -> AstNameType -> p ann -> IO ()
 writeFlat outp flatMode prog = do
   flatProg <- serialiseProgramFlat flatMode (() <$ prog) -- Change annotations to (): see Note [Annotation types].
   case outp of
@@ -380,10 +380,10 @@ getPrintMethod = \case
       ReadableDebug -> PP.prettyPlcReadableDebug
 
 writeProgram ::
-  (Executable a,
-   Functor a,
-   PP.PrettyBy PP.PrettyConfigPlc (a b)) =>
-   Output -> Format -> PrintMode -> a b -> IO ()
+  (Executable p,
+   Functor p,
+   PP.PrettyBy PP.PrettyConfigPlc (p ann)) =>
+   Output -> Format -> PrintMode -> p ann -> IO ()
 writeProgram outp Textual mode prog      = writePrettyToFileOrStd outp mode prog
 writeProgram outp (Flat flatMode) _ prog = writeFlat outp flatMode prog
 

--- a/plutus-core/executables/Parsers.hs
+++ b/plutus-core/executables/Parsers.hs
@@ -71,6 +71,7 @@ outputformat = option (maybeReader formatReader)
   <> value Textual
   <> showDefault
   <> help ("Output format: " ++ formatHelp))
+
 -- -x -> run 100 times and print the mean time
 timing1 :: Parser TimingMode
 timing1 = flag NoTiming (Timing 100)

--- a/plutus-core/executables/Parsers.hs
+++ b/plutus-core/executables/Parsers.hs
@@ -42,7 +42,7 @@ stdOutput = flag' StdOutput
 
 formatHelp :: String
 formatHelp =
-  "textual, flat (de Bruijn indices), or flat-named (names)"
+  "textual, flat-named (names), flat (de Bruijn indices), or flat-namedDeBruijn (names and de Bruijn indices)"
 
 formatReader :: String -> Maybe Format
 formatReader =


### PR DESCRIPTION
I was trying to use `uplc` to convert some files to flat format and got an error like this:
```
$ cabal exec uplc convert -- -i plutus-benchmark/validation/data/auction_1-1.flat -o /dev/null --if flat --of flat
uplc: De-Bruijn-named ASTs are not supported for typed Plutus Core
```

The code that should handle this just raised an error for some reason.  This one-line PR gets it to do what it should (I think).  I'm not sure why it was like that in the first place (maybe my fault?).



<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
