### PR TITLE
Fix another bug in profiling

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -507,6 +507,24 @@ But that's okay, because these are all types we've been creating just now in Quo
 we should have globally unique names
 -}
 
+{- Note [Term/type argument mismatches]
+Given a term t and its type ty we can process them in parallel popping off arguments/function types.
+
+But we can end up with a mismatch:
+- We run out of arguments at the term level e.g. because we see something like `(\x -> \y -> y) 1`,
+which is of function type but isn't a lambda until you reduce.
+- We run out of arguments at the type level e.g. because we see something like `(\a -> (a -> a)) b`,
+which is a function type but isn't a function type until you reduce.
+
+It's usually okay to stop at this point, since the remaining things usually aren't "proper" arguments.
+In the term case, it's a lambda computed by an application, which won't occur form a "proper" argument.
+In the type case, we only generate type lambdas for newtypes, which will blcok "proper" arguments anyway,
+i.e. it comes from something like this:
+
+f :: Identity (a -> a)
+f = Identity (\x -> x)
+-}
+
 -- | Add entry/exit tracing inside a term's leading arguments, both term and type arguments.
 -- @(\a -> /\b -> body)@ into @\a -> /\b -> entryExitTracing body@.
 -- @(\a -> /\b -> body)@ into @\a -> /\b -> entryExitTracing body@.
@@ -531,8 +549,9 @@ entryExitTracingInside lamName displayName = go mempty
             -- See Note [Profiling polymorphic functions]
             let subst' = Map.insert tn2 (PLC.TyVar () tn1) subst
             in TyAbs () tn1 k $ go subst' body ty
-        go _ LamAbs{} _ = error "entryExitTracingInside: type mismatched. Expected a function type."
-        go _ TyAbs{} _ = error "entryExitTracingInside: type mismatched. Expected a quantified type."
+        -- See Note [Term/type argument mismatches]
+        -- Even if there still look like there are arguments on the term or the type level, because we've hit
+        -- a mismatch we go ahead and insert our profiling traces here.
         go subst e ty =
             -- See Note [Profiling polymorphic functions]
             let ty' = PLC.typeSubstTyNames (\tn -> Map.lookup tn subst) ty

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -526,8 +526,7 @@ f = Identity (\x -> x)
 -}
 
 -- | Add entry/exit tracing inside a term's leading arguments, both term and type arguments.
--- @(\a -> \b -> body)@ into @\a -> \b -> entryExitTracing body@.
--- @(/\a -> /\b -> body)@ into @/\a -> /\b -> entryExitTracing body@.
+-- @(/\a -> \b -> body)@ into @/\a -> \b -> entryExitTracing body@.
 entryExitTracingInside ::
     PIR.Name
     -> T.Text

--- a/plutus-tx-plugin/test/Plugin/Profiling/argMismatch1.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/argMismatch1.plc.golden
@@ -1,0 +1,6 @@
+[ entering runIdentity
+, exiting runIdentity
+, entering newtypeFunction
+, exiting newtypeFunction
+, entering fFoldableIdentity
+, exiting fFoldableIdentity ]

--- a/plutus-tx-plugin/test/Plugin/Profiling/argMismatch2.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Profiling/argMismatch2.plc.golden
@@ -1,0 +1,1 @@
+[entering obscuredFunction, exiting obscuredFunction]


### PR DESCRIPTION
It seemed initially plausible that the term and type should match up
exactly when we're processing them, and thus it's okay to blow up if
they don't match.

But this is false: both at the term and the type level. I ran into it at
the type level (type lambdas from newtypes), but it's also false at the
term level.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
