### PR TITLE
Add currencyValueOf

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -59,6 +59,7 @@ library
 
         Plutus.V2.Ledger.Api
         Plutus.V2.Ledger.Contexts
+        Plutus.V2.Ledger.Value
     build-depends:
         base >=4.9 && <5,
         aeson -any,

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Value.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Value.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- Prevent unboxing, which the plugin can't deal with
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-spec-constr #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+
+-- | Functions for working with 'Value'.
+module Plutus.V2.Ledger.Value(
+    -- ** Currency symbols
+      CurrencySymbol(..)
+    , currencySymbol
+    , mpsSymbol
+    , currencyMPSHash
+    -- ** Token names
+    , TokenName(..)
+    , tokenName
+    , toString
+    -- * Asset classes
+    , AssetClass(..)
+    , assetClass
+    , assetClassValue
+    , assetClassValueOf
+    -- ** Value
+    , Value(..)
+    , singleton
+    , valueOf
+    , currencyValueOf
+    , scale
+    , symbols
+      -- * Partial order operations
+    , geq
+    , gt
+    , leq
+    , lt
+      -- * Etc.
+    , isZero
+    , split
+    , unionWith
+    , flattenValue
+    ) where
+
+import Plutus.V1.Ledger.Value
+import PlutusTx.AssocMap qualified as Map
+import PlutusTx.Maybe
+import PlutusTx.Monoid
+
+{-# INLINABLE currencyValueOf #-}
+-- | Get the quantities of just the given 'CurrencySymbol' in the 'Value'.
+currencyValueOf :: Value -> CurrencySymbol -> Value
+currencyValueOf (Value m) c = case Map.lookup c m of
+    Nothing -> mempty
+    Just t  -> Value (Map.singleton c t)


### PR DESCRIPTION
The motivating use case is when implementing minting policies, we often want to concern ourselves with only our own `CurrencySymbol` when observing the minted `Value`. See [this example](https://github.com/input-output-hk/plutus-apps/pull/103/files#r759106724).

- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
