### PR TITLE
Correct type-o

### DIFF
--- a/plutus-core/docs/Builtins.md
+++ b/plutus-core/docs/Builtins.md
@@ -313,7 +313,7 @@ eval $ AppBuiltinFunction EqInteger
     ]
 ```
 
-expands to `hsToPlc (1 == 2)`, which reduces to `hsToPlc True` and this is where we need to lift a Haskell `Bool` into a Plutus Core `bool`. Previousy we would just wrap the result with `ConstantInteger`, but now we need to write an actual conversion function on the Haskell side:
+expands to `hsToPlc (1 == 2)`, which reduces to `hsToPlc False` and this is where we need to lift a Haskell `Bool` into a Plutus Core `bool`. Previousy we would just wrap the result with `ConstantInteger`, but now we need to write an actual conversion function on the Haskell side:
 
 ```haskell
 liftBool :: Bool -> Term


### PR DESCRIPTION
As is the docs seem to say that (1 == 2) should be True.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
