### PR TITLE
Kwxm/print builtin types

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -376,6 +376,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -335,6 +335,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -376,6 +376,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -335,6 +335,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -376,6 +376,7 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -335,6 +335,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Common where
 
@@ -10,12 +13,14 @@ import PlutusPrelude (through)
 
 import PlutusCore qualified as PLC
 import PlutusCore.Check.Uniques as PLC (checkProgram)
+import PlutusCore.Constant qualified as PLC
 import PlutusCore.Error (AsParseError, AsUniqueError, UniqueError)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..), ExRestrictingBudget (..))
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Generators qualified as Gen
 import PlutusCore.Generators.Interesting qualified as Gen
 import PlutusCore.Generators.Test qualified as Gen
+import PlutusCore.Normalize (normalizeType)
 import PlutusCore.Pretty qualified as PP
 import PlutusCore.Rename (rename)
 import PlutusCore.StdLib.Data.Bool qualified as StdLib
@@ -30,17 +35,21 @@ import UntypedPlutusCore.Parser qualified as UPLC (parseProgram)
 
 import Control.DeepSeq (NFData, rnf)
 import Control.Monad.Except
+import Data.Aeson qualified as Aeson
 import Data.Bifunctor (second)
 import Data.ByteString.Lazy qualified as BSL
 import Data.Foldable (traverse_)
 import Data.HashMap.Monoidal qualified as H
-import Data.List (nub)
+import Data.List (intercalate, nub)
 import Data.List qualified as List
+import Data.Maybe (fromJust)
+import Data.Proxy (Proxy (..))
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.IO qualified as T
 import Data.Traversable (for)
 import Flat (Flat, flat, unflat)
+import GHC.TypeLits (symbolVal)
 import Prettyprinter (Doc, pretty, (<+>))
 
 import System.CPUTime (getCPUTime)
@@ -559,3 +568,66 @@ runPrintExample getFn (ExampleOptions (ExampleSingle name)) = do
     T.putStrLn $ case lookup name examples of
         Nothing -> "Unknown name: " <> name
         Just ex -> PP.render $ prettyExample ex
+
+
+---------------- Print the cost model parameters ----------------
+
+runDumpModel :: IO ()
+runDumpModel = do
+    let params = fromJust PLC.defaultCostModelParams
+    BSL.putStr $ Aeson.encode params
+
+
+---------------- Print the type signatures of the default builtins ----------------
+
+-- Some types to represent signatures of built-in functions
+type PlcTerm = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ()
+type PlcType = PLC.Type PLC.TyName PLC.DefaultUni ()
+data QVarOrType = QVar String | Type PlcType  -- Quantified type variable or actual type
+
+data Signature = Signature [QVarOrType] PlcType  -- Argument types, return type
+instance Show Signature where
+    show (Signature args res) =
+        "[ " ++ (intercalate ", " $ map showQT args) ++ " ] -> " ++ showTy (normTy res)
+            where showQT =
+                      \case
+                       QVar tv -> "forall " ++ tv
+                       Type ty -> showTy (normTy ty)
+                  normTy :: PlcType -> PlcType
+                  normTy ty = PLC.runQuote $ PLC.unNormalized <$> normalizeType ty
+                  showTy ty =
+                      case ty of
+                        PLC.TyBuiltin _ t -> show $ PP.pretty t
+                        PLC.TyApp {}      -> showMultiTyApp $ unwrapTyApp ty
+                        _                 -> show $ PP.pretty ty
+                  unwrapTyApp ty =
+                      case ty of
+                        PLC.TyApp _ t1 t2 -> (unwrapTyApp t1) ++ [t2]
+                        -- Assumes iterated built-in type applications all associate to the left;
+                        -- if not, we'll just get some odd formatting.
+                        _                 -> [ty]
+                  showMultiTyApp =
+                      \case
+                        []     -> "<empty type application>"   -- Should never happen
+                        op:tys -> showTy op ++ " (" ++ intercalate ", " (map showTy tys) ++ ")"
+
+typeSchemeToSignature :: PLC.TypeScheme PlcTerm args res -> Signature
+typeSchemeToSignature = toSig []
+    where toSig :: [QVarOrType] -> PLC.TypeScheme PlcTerm args res -> Signature
+          toSig acc =
+              \case
+               PLC.TypeSchemeResult pR -> Signature acc (PLC.toTypeAst pR)
+               PLC.TypeSchemeArrow pA schB ->
+                   toSig (acc ++ [Type $ PLC.toTypeAst pA]) schB
+               PLC.TypeSchemeAll proxy schK ->
+                   case proxy of
+                     (_ :: Proxy '(text, uniq, kind)) ->
+                         toSig (acc ++ [QVar $ symbolVal @text Proxy]) (schK Proxy)
+
+runPrintBuiltinTypes :: IO ()
+runPrintBuiltinTypes = do
+  let builtins = [minBound..maxBound] :: [UPLC.DefaultFun]
+  mapM_ (\x -> putStr (printf "%-25s: %s\n" (show $ PP.pretty x) (show $ getSignature x))) builtins
+      where getSignature (PLC.toBuiltinMeaning @_ @_ @PlcTerm -> PLC.BuiltinMeaning sch _ _) = typeSchemeToSignature sch
+
+

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -609,7 +609,7 @@ instance Show Signature where
                   showMultiTyApp =
                       \case
                         []     -> "<empty type application>"   -- Should never happen
-                        op:tys -> showTy op ++ " (" ++ intercalate ", " (map showTy tys) ++ ")"
+                        op:tys -> showTy op ++ "(" ++ intercalate ", " (map showTy tys) ++ ")"
 
 typeSchemeToSignature :: PLC.TypeScheme PlcTerm args res -> Signature
 typeSchemeToSignature = toSig []

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -624,8 +624,8 @@ typeSchemeToSignature = toSig []
                      (_ :: Proxy '(text, uniq, kind)) ->
                          toSig (acc ++ [QVar $ symbolVal @text Proxy]) (schK Proxy)
 
-runPrintBuiltinTypes :: IO ()
-runPrintBuiltinTypes = do
+runPrintBuiltinSignatures :: IO ()
+runPrintBuiltinSignatures = do
   let builtins = [minBound..maxBound] :: [UPLC.DefaultFun]
   mapM_ (\x -> putStr (printf "%-25s: %s\n" (show $ PP.pretty x) (show $ getSignature x))) builtins
       where getSignature (PLC.toBuiltinMeaning @_ @_ @PlcTerm -> PLC.BuiltinMeaning sch _ _) = typeSchemeToSignature sch

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -38,6 +38,8 @@ data Command = Apply     ApplyOptions
              | Example   ExampleOptions
              | Erase     EraseOptions
              | Eval      EvalOptions
+             | DumpModel
+             | PrintBuiltinTypes
 
 ---------------- Option parsers ----------------
 
@@ -87,6 +89,12 @@ plutusOpts = hsubparser (
     <> command "evaluate"
            (info (Eval <$> evalOpts)
             (progDesc "Evaluate a typed Plutus Core program using the CK machine."))
+    <> command "dump-model"
+           (info (pure DumpModel)
+            (progDesc "Dump the cost model parameters"))
+    <> command "print-builtin-types"
+           (info (pure PrintBuiltinTypes)
+            (progDesc "Print the types of the built-in functions"))
   )
 
 ---------------- Script application ----------------
@@ -161,14 +169,17 @@ runConvert (ConvertOptions inp ifmt outp ofmt mode) = do
     writeProgram outp ofmt mode program
 
 ---------------- Driver ----------------
+
 main :: IO ()
 main = do
     options <- customExecParser (prefs showHelpOnEmpty) plcInfoCommand
     case options of
-        Apply     opts -> runApply        opts
-        Typecheck opts -> runTypecheck    opts
-        Eval      opts -> runEval         opts
-        Example   opts -> runPlcPrintExample opts
-        Erase     opts -> runErase        opts
-        Print     opts -> runPrint        opts
-        Convert   opts -> runConvert      opts
+        Apply     opts    -> runApply        opts
+        Typecheck opts    -> runTypecheck    opts
+        Eval      opts    -> runEval         opts
+        Example   opts    -> runPlcPrintExample opts
+        Erase     opts    -> runErase        opts
+        Print     opts    -> runPrint        opts
+        Convert   opts    -> runConvert      opts
+        DumpModel         -> runDumpModel
+        PrintBuiltinTypes -> runPrintBuiltinTypes

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -39,7 +39,7 @@ data Command = Apply     ApplyOptions
              | Erase     EraseOptions
              | Eval      EvalOptions
              | DumpModel
-             | PrintBuiltinTypes
+             | PrintBuiltinSignatures
 
 ---------------- Option parsers ----------------
 
@@ -92,9 +92,9 @@ plutusOpts = hsubparser (
     <> command "dump-model"
            (info (pure DumpModel)
             (progDesc "Dump the cost model parameters"))
-    <> command "print-builtin-types"
-           (info (pure PrintBuiltinTypes)
-            (progDesc "Print the types of the built-in functions"))
+    <> command "print-builtin-signatures"
+           (info (pure PrintBuiltinSignatures)
+            (progDesc "Print the signatures of the built-in functions"))
   )
 
 ---------------- Script application ----------------
@@ -174,12 +174,12 @@ main :: IO ()
 main = do
     options <- customExecParser (prefs showHelpOnEmpty) plcInfoCommand
     case options of
-        Apply     opts    -> runApply        opts
-        Typecheck opts    -> runTypecheck    opts
-        Eval      opts    -> runEval         opts
-        Example   opts    -> runPlcPrintExample opts
-        Erase     opts    -> runErase        opts
-        Print     opts    -> runPrint        opts
-        Convert   opts    -> runConvert      opts
-        DumpModel         -> runDumpModel
-        PrintBuiltinTypes -> runPrintBuiltinTypes
+        Apply     opts         -> runApply        opts
+        Typecheck opts         -> runTypecheck    opts
+        Eval      opts         -> runEval         opts
+        Example   opts         -> runPlcPrintExample opts
+        Erase     opts         -> runErase        opts
+        Print     opts         -> runPrint        opts
+        Convert   opts         -> runConvert      opts
+        DumpModel              -> runDumpModel
+        PrintBuiltinSignatures -> runPrintBuiltinSignatures

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -47,7 +47,7 @@ data Command = Apply     ApplyOptions
              | Example   ExampleOptions
              | Eval      EvalOptions
              | DumpModel
-             | PrintBuiltinTypes
+             | PrintBuiltinSignatures
 
 ---------------- Option parsers ----------------
 
@@ -143,9 +143,9 @@ plutusOpts = hsubparser (
     <> command "dump-model"
            (info (pure DumpModel)
             (progDesc "Dump the cost model parameters"))
-    <> command "print-builtin-types"
-           (info (pure PrintBuiltinTypes)
-            (progDesc "Print the types of the built-in functions"))
+    <> command "print-builtin-signatures"
+           (info (pure PrintBuiltinSignatures)
+            (progDesc "Print the signatures of the built-in functions"))
   )
 
 
@@ -229,10 +229,10 @@ main :: IO ()
 main = do
     options <- customExecParser (prefs showHelpOnEmpty) uplcInfoCommand
     case options of
-        Apply     opts    -> runApply        opts
-        Eval      opts    -> runEval         opts
-        Example   opts    -> runUplcPrintExample opts
-        Print     opts    -> runPrint        opts
-        Convert   opts    -> runConvert      opts
-        DumpModel         -> runDumpModel
-        PrintBuiltinTypes -> runPrintBuiltinTypes
+        Apply     opts         -> runApply        opts
+        Eval      opts         -> runEval         opts
+        Example   opts         -> runUplcPrintExample opts
+        Print     opts         -> runPrint        opts
+        Convert   opts         -> runConvert      opts
+        DumpModel              -> runDumpModel
+        PrintBuiltinSignatures -> runPrintBuiltinSignatures

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -438,6 +438,7 @@ executable plc
         Parsers
     build-depends:
         plutus-core -any,
+        aeson -any,
         base <5,
         bytestring -any,
         deepseq -any,

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -481,6 +481,7 @@ executable pir
         Parsers
     build-depends:
         plutus-core -any,
+        aeson -any,
         base <5,
         bytestring -any,
         flat -any,

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -65,7 +65,7 @@ data BuiltinMeaning term cost =
 -- reasons (there isn't much point in caching a value of a type with a constraint as it becomes a
 -- function at runtime anyway, due to constraints being compiled as dictionaries).
 
--- We tried instantiating 'BuiltinMeaning' on the fly and that was sloer than precaching
+-- We tried instantiating 'BuiltinMeaning' on the fly and that was slower than precaching
 -- 'BuiltinRuntime's.
 -- | A 'BuiltinRuntime' represents a possibly partial builtin application.
 -- We get an initial 'BuiltinRuntime' representing an empty builtin application (i.e. just the

--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE FunctionalDependencies    #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE StandaloneKindSignatures  #-}
 {-# LANGUAGE TypeApplications          #-}


### PR DESCRIPTION
A small PR to add an option to `uplc` to print out the default builtins and their signatures.  This makes it a bit easier to see what's going on without hunting through the source code.

The output's included below.  I wouldn't mind getting rid of all the "con"s and just printing the actual types.

```
$ cabal exec uplc print-builtin-types
addInteger               : { (con integer), (con integer) } -> (con integer)
subtractInteger          : { (con integer), (con integer) } -> (con integer)
multiplyInteger          : { (con integer), (con integer) } -> (con integer)
divideInteger            : { (con integer), (con integer) } -> (con integer)
quotientInteger          : { (con integer), (con integer) } -> (con integer)
remainderInteger         : { (con integer), (con integer) } -> (con integer)
modInteger               : { (con integer), (con integer) } -> (con integer)
equalsInteger            : { (con integer), (con integer) } -> (con bool)
lessThanInteger          : { (con integer), (con integer) } -> (con bool)
lessThanEqualsInteger    : { (con integer), (con integer) } -> (con bool)
appendByteString         : { (con bytestring), (con bytestring) } -> (con bytestring)
consByteString           : { (con integer), (con bytestring) } -> (con bytestring)
sliceByteString          : { (con integer), (con integer), (con bytestring) } -> (con bytestring)
lengthOfByteString       : { (con bytestring) } -> (con integer)
indexByteString          : { (con bytestring), (con integer) } -> (con integer)
equalsByteString         : { (con bytestring), (con bytestring) } -> (con bool)
lessThanByteString       : { (con bytestring), (con bytestring) } -> (con bool)
lessThanEqualsByteString : { (con bytestring), (con bytestring) } -> (con bool)
sha2_256                 : { (con bytestring) } -> (con bytestring)
sha3_256                 : { (con bytestring) } -> (con bytestring)
blake2b_256              : { (con bytestring) } -> (con bytestring)
verifySignature          : { (con bytestring), (con bytestring), (con bytestring) } -> (con bool)
appendString             : { (con string), (con string) } -> (con string)
equalsString             : { (con string), (con string) } -> (con bool)
encodeUtf8               : { (con string) } -> (con bytestring)
decodeUtf8               : { (con bytestring) } -> (con string)
ifThenElse               : { forall a, (con bool), a, a } -> a
chooseUnit               : { forall a, (con unit), a } -> a
trace                    : { forall a, (con string), a } -> a
fstPair                  : { forall a, forall b, [ [ (con pair) a ] b ] } -> a
sndPair                  : { forall a, forall b, [ [ (con pair) a ] b ] } -> b
chooseList               : { forall a, forall b, [ (con list) a ], b, b } -> b
mkCons                   : { forall a, a, [ (con list) a ] } -> [ (con list) a ]
headList                 : { forall a, [ (con list) a ] } -> a
tailList                 : { forall a, [ (con list) a ] } -> [ (con list) a ]
nullList                 : { forall a, [ (con list) a ] } -> (con bool)
chooseData               : { forall a, (con data), a, a, a, a, a } -> a
constrData               : { (con integer), (con list (data)) } -> (con data)
mapData                  : { (con list (pair (data) (data))) } -> (con data)
listData                 : { (con list (data)) } -> (con data)
iData                    : { (con integer) } -> (con data)
bData                    : { (con bytestring) } -> (con data)
unConstrData             : { (con data) } -> (con pair (integer) (list (data)))
unMapData                : { (con data) } -> (con list (pair (data) (data)))
unListData               : { (con data) } -> (con list (data))
unIData                  : { (con data) } -> (con integer)
unBData                  : { (con data) } -> (con bytestring)
equalsData               : { (con data), (con data) } -> (con bool)
mkPairData               : { (con data), (con data) } -> (con pair (data) (data))
mkNilData                : { (con unit) } -> (con list (data))
mkNilPairData            : { (con unit) } -> (con list (pair (data) (data)))
```


<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
