### PR TITLE
Inline trivial lambda bindings, to beta-reduce later on for smaller scripts

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
@@ -344,11 +344,13 @@ maybeAddTySubst tn rhs = do
 -- | Is this a an utterly trivial term which might as well be inlined?
 trivialTerm :: Term tyname name uni fun a -> Bool
 trivialTerm = \case
-    Builtin{}  -> True
-    Var{}      -> True
+    Builtin{}      -> True
+    Var{}          -> True
     -- TODO: Should this depend on the size of the constant?
-    Constant{} -> True
-    _          -> False
+    Constant{}     -> True
+    TyAbs _ _ _ t  -> trivialTerm t
+    LamAbs _ _ _ t -> trivialTerm t
+    _              -> False
 
 -- | Is this a an utterly trivial type which might as well be inlined?
 trivialType :: Type tyname uni a -> Bool

--- a/plutus-core/plutus-ir/test/transform/inline/single
+++ b/plutus-core/plutus-ir/test/transform/inline/single
@@ -37,7 +37,7 @@
 
   (termbind
     (strict)
-    (vardecl noInline (con integer))
+    (vardecl trivialLambda (con integer))
     (let
       (nonrec)
       (termbind

--- a/plutus-core/plutus-ir/test/transform/inline/single.golden
+++ b/plutus-core/plutus-ir/test/transform/inline/single.golden
@@ -12,16 +12,8 @@
   )
   (termbind
     (strict)
-    (vardecl noInline (con integer))
-    (let
-      (nonrec)
-      (termbind
-        (strict)
-        (vardecl f (fun (con integer) (con integer)))
-        (lam y (con integer) y)
-      )
-      [ f [ f (con integer 1) ] ]
-    )
+    (vardecl trivialLambda (con integer))
+    [ (lam y (con integer) y) [ (lam y (con integer) y) (con integer 1) ] ]
   )
   (termbind
     (strict)

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -82,8 +82,6 @@ data PluginOptions = PluginOptions {
 
     -- Setting to `True` defines `trace` as `\_ a -> a` instead of the builtin version.
     -- Which effectively ignores the trace text.
-    -- TODO: when simpilers are enabled, we should reduce and inline a `\_ a -> a` call to just `a`.
-    -- Reducing `test/Plugin/NoTrace/traceComplex.plc.golden` is a good start.
     , poRemoveTrace                    :: Bool
     }
 

--- a/plutus-tx-plugin/test/Plugin/NoTrace/traceComplex.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/traceComplex.plc.golden
@@ -12,19 +12,13 @@
     (datatypebind
       (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
     )
-    (termbind
-      (strict)
-      (vardecl trace (all a (type) (fun (con string) (fun a a))))
-      (abs a (type) (lam t (con string) (lam a a a)))
-    )
     (lam
       ds
       Bool
       {
         [
           [
-            { [ Bool_match ds ] (all dead (type) Unit) }
-            (abs dead (type) [ [ { trace Unit } (con string "yes") ] Unit ])
+            { [ Bool_match ds ] (all dead (type) Unit) } (abs dead (type) Unit)
           ]
           (abs
             dead
@@ -34,13 +28,7 @@
               (termbind
                 (strict)
                 (vardecl thunk (con unit))
-                [
-                  {
-                    [ Unit_match [ [ { trace Unit } (con string "no") ] Unit ] ]
-                    (con unit)
-                  }
-                  (con unit ())
-                ]
+                [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
               )
               (error Unit)
             )


### PR DESCRIPTION
A long-overdue continuation of #4219.

The back-story is that we wanted to have a flag that removes traces for slightly smaller scripts without changing the source code. However, #4219 only ignores the trace text and more or less keeps the trace bindings intact, only removing trace messages and reducing little CPU usage at run time.

To inline and later beta-reduce the new definition for actual smaller scripts, we would need a very specific case in `trivialTerm`:
https://github.com/input-output-hk/plutus/blob/c8c5183f7facd967d48fe07b3b14465b8dd48fe7/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs#L312-L325

```haskell
TyAbs _ _ _ (LamAbs _ _ _ (LamAbs _ n _ (Var _ n'))) | n ^. theUnique == n' ^. theUnique -> True
```

This can be generalized as followed like in this PR:
```haskell
TyAbs _ _ _ t  -> trivialTerm t
LamAbs _ _ _ t -> trivialTerm t
```

Meaning we would like to inline (to later beta reduce) trivial lambda bindings. This looks pretty scary at a glance without any depth check or concrete definition of triviality, but early experiments suggest that there are not many such bindings in practice:
https://github.com/input-output-hk/plutus-apps/pull/219.

I guess this is more of an issue with code samples than an actual PR. Would love to receive some inputs before continuing it. Another adventurous line is to try inlining bindings that are applications, like in:
https://github.com/input-output-hk/plutus/blob/c8c5183f7facd967d48fe07b3b14465b8dd48fe7/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs#L48-L51

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
