### PR TITLE
[Builtins] Inline 'toBuiltinMeaning' in 'toBuiltinsRuntime'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Constant/Meaning.hs
@@ -106,18 +106,18 @@ class (Bounded fun, Enum fun, Ix fun) => ToBuiltinMeaning uni fun where
     -- | Get the 'BuiltinMeaning' of a built-in function.
     toBuiltinMeaning :: HasConstantIn uni term => fun -> BuiltinMeaning term (CostingPart uni fun)
 
+    -- | Calculate runtime info for all built-in functions given denotations of builtins
+    -- and a cost model.
+    toBuiltinsRuntime
+        :: (cost ~ CostingPart uni fun, HasConstantIn uni term)
+        => cost -> BuiltinsRuntime fun term
+    toBuiltinsRuntime cost =
+        BuiltinsRuntime . tabulateArray $ toBuiltinRuntime cost . toBuiltinMeaning
+
 -- | Get the type of a built-in function.
 typeOfBuiltinFunction :: ToBuiltinMeaning uni fun => fun -> Type TyName uni ()
 typeOfBuiltinFunction fun = case toBuiltinMeaning @_ @_ @(Term TyName Name _ _ ()) fun of
     BuiltinMeaning sch _ _ -> typeSchemeToType sch
-
--- | Calculate runtime info for all built-in functions given denotations of builtins
--- and a cost model.
-toBuiltinsRuntime
-    :: (cost ~ CostingPart uni fun, HasConstantIn uni term, ToBuiltinMeaning uni fun)
-    => cost -> BuiltinsRuntime fun term
-toBuiltinsRuntime cost =
-    BuiltinsRuntime . tabulateArray $ toBuiltinRuntime cost . toBuiltinMeaning
 
 -- | Look up the runtime info of a built-in function during evaluation.
 lookupBuiltin

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -434,6 +434,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
         makeBuiltinMeaning
             (\() -> [] @(Data,Data))
             (runCostingFunOneArgument . paramMkNilPairData)
+    {-# INLINE toBuiltinMeaning #-}
 
 -- It's set deliberately to give us "extra room" in the binary format to add things without running
 -- out of space for tags (expanding the space would change the binary format for people who're


### PR DESCRIPTION
Here's a funny trick: moving `toBuiltinsRuntime` inside `ToBuiltinMeaning` allows us to inline `toBuiltinsRuntime` there. This is probably not going to affect evaluation times, because it mostly affects just startup time, but let's check. Core looks good and it might be a good starting point for finally removing the stupid arrays business.

Do we have any way of checking how much startup costs us? Is startup time included in the current benchmarks?