### PR TITLE
Try forcing defaultCekParameters

### DIFF
--- a/plutus-benchmark/validation/Bench.hs
+++ b/plutus-benchmark/validation/Bench.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
@@ -84,7 +85,9 @@ loadFlat file = do
         -- `force` to try to ensure that deserialiation is not included in benchmarking time.
 
 mkCekBM :: Term -> Benchmarkable
-mkCekBM program = whnf (UPLC.unsafeEvaluateCekNoEmit PLC.defaultCekParameters) program
+mkCekBM program =
+    let !params = PLC.defaultCekParameters
+    in whnf (UPLC.unsafeEvaluateCekNoEmit params) program
 
 mkScriptBM :: FilePath -> FilePath -> Benchmark
 mkScriptBM dir file =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns    #-}
 {-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies    #-}
@@ -66,7 +67,10 @@ defaultCekMachineCosts =
   $$(readJSONFromFile DFP.cekMachineCostsFile)
 
 defaultCekCostModel :: CostModel CekMachineCosts BuiltinCostModel
-defaultCekCostModel = CostModel defaultCekMachineCosts defaultBuiltinCostModel
+defaultCekCostModel =
+    let !costs = defaultCekMachineCosts
+        !model = defaultBuiltinCostModel
+    in CostModel costs model
 --- defaultCekMachineCosts is CekMachineCosts
 
 -- | The default cost model data.  This is exposed to the ledger, so let's not
@@ -75,7 +79,9 @@ defaultCostModelParams :: Maybe CostModelParams
 defaultCostModelParams = extractCostModelParams defaultCekCostModel
 
 defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
-defaultCekParameters = toMachineParameters defaultCekCostModel
+defaultCekParameters =
+    let !model = defaultCekCostModel
+    in toMachineParameters model
 
 unitCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
 unitCekParameters = toMachineParameters (CostModel unitCekMachineCosts unitCostBuiltinCostModel)


### PR DESCRIPTION
A quick experiment to see if forcing `deafultCekParameters` in the validation benchmarks makes any difference to the results (prompted by #4320).  I'm trying to see if the overhead of `toBuiltinsRuntime` is significant; this probably isn't the right way to do it, but it might give us a hint.  I think that what's happening at the moment is that `defaultCekParameters` is evaluated the first time a given benchmark is run and then shared between subsequent runs (perhaps even between runs of _different_ benchmarks), so any overhead incurred will be effectively averaged away to zero over multiple benchmark executions.  This PR attempts to take it out of the benchmarking process entirely, so probably won't make a lot of difference.  Let's check anyway. 

I tried to use `force` but that was going to need an `NFData` instance for `BuiltinRuntime` which was problematic because of existential types in the definitition, so I gave up and stuck in bang patters everywhere I could think of instead.  


