### PR TITLE
plutus-core: Fix support for GHC 9.2.1 and hashable 1.4

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -82,6 +82,7 @@
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
           (hsPkgs."some" or (errorHandler.buildDepError "some"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."th-lift" or (errorHandler.buildDepError "th-lift"))
           (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx.nix
@@ -37,6 +37,7 @@
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -82,6 +82,7 @@
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
           (hsPkgs."some" or (errorHandler.buildDepError "some"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."th-lift" or (errorHandler.buildDepError "th-lift"))
           (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx.nix
@@ -37,6 +37,7 @@
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -82,6 +82,7 @@
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
           (hsPkgs."some" or (errorHandler.buildDepError "some"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."th-lift" or (errorHandler.buildDepError "th-lift"))
           (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx.nix
@@ -37,6 +37,7 @@
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-compat" or (errorHandler.buildDepError "th-compat"))
           (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -288,6 +288,7 @@ library
         serialise -any,
         some < 1.0.3,
         template-haskell -any,
+        th-compat -any,
         text -any,
         th-lift -any,
         th-lift-instances -any,

--- a/plutus-core/plutus-core/src/Data/Aeson/THReader.hs
+++ b/plutus-core/plutus-core/src/Data/Aeson/THReader.hs
@@ -2,13 +2,13 @@
 module Data.Aeson.THReader where
 
 import Data.Aeson
-import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
+import Language.Haskell.TH.Syntax.Compat
 import TH.RelativePaths
 
-readJSONFromFile :: (FromJSON a, Lift a) => String -> Q (TExp a)
-readJSONFromFile name = do
+readJSONFromFile :: (FromJSON a, Lift a) => String -> SpliceQ a
+readJSONFromFile name = liftSplice $ do
     contents <- qReadFileLBS name
     case (eitherDecode contents) of
         Left err  -> fail err
-        Right res -> [||res||]
+        Right res -> examineSplice [||res||]

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -4,6 +4,7 @@ Adapted from 'Data.SafeInt' to perform saturating arithmetic (i.e. returning max
 This is not quite as fast as using 'Int' or 'Int64' directly, but we need the safety.
 -}
 {-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MagicHash          #-}
@@ -17,6 +18,9 @@ import Data.Csv
 import Data.Primitive (Prim)
 import GHC.Base
 import GHC.Generics
+#if MIN_VERSION_base(4,16,0)
+import GHC.Integer (smallInteger)
+#endif
 import GHC.Num
 import GHC.Real
 import Language.Haskell.TH.Syntax (Lift)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownKind.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownKind.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE GADTs            #-}
 {-# LANGUAGE PolyKinds        #-}
 {-# LANGUAGE RankNTypes       #-}
@@ -23,7 +25,7 @@ class KnownKind k where
     knownKind :: SingKind k
 
 -- | Plutus only supports lifted types, hence the equality constraint.
-instance rep ~ 'LiftedRep => KnownKind (TYPE rep) where
+instance rep ~ LiftedRep => KnownKind (TYPE rep) where
     knownKind = SingType
 
 instance (KnownKind dom, KnownKind cod) => KnownKind (dom -> cod) where

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
@@ -72,7 +72,7 @@ data Type tyname uni ann
     | TyBuiltin ann (SomeTypeIn uni) -- ^ Builtin type
     | TyLam ann tyname (Kind ann) (Type tyname uni ann)
     | TyApp ann (Type tyname uni ann) (Type tyname uni ann)
-    deriving (Show, Functor, Generic, NFData, Hashable)
+    deriving (Show, Functor, Generic, NFData)
 
 data Term tyname name uni fun ann
     = Var ann name -- ^ a named variable
@@ -85,7 +85,7 @@ data Term tyname name uni fun ann
     | Unwrap ann (Term tyname name uni fun ann)
     | IWrap ann (Type tyname uni ann) (Type tyname uni ann) (Term tyname name uni fun ann)
     | Error ann (Type tyname uni ann)
-    deriving (Show, Functor, Generic, NFData, Hashable)
+    deriving (Show, Functor, Generic, NFData)
 
 -- | Version of Plutus Core to be used for the program.
 data Version ann
@@ -98,7 +98,7 @@ data Program tyname name uni fun ann = Program
     , _progVer  :: Version ann
     , _progTerm :: Term tyname name uni fun ann
     }
-    deriving (Show, Functor, Generic, NFData, Hashable)
+    deriving (Show, Functor, Generic, NFData)
 makeLenses ''Program
 
 -- | Extract the universe from a type.

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -64,10 +64,6 @@ data ParseError ann
 
 makeClassyPrisms ''ParseError
 
-instance Pretty ann => Show (ParseError ann)
-    where
-      show = show . pretty
-
 data UniqueError ann
     = MultiplyDefined Unique ann ann
     | IncoherentUsage Unique ann ann
@@ -105,8 +101,9 @@ data Error uni fun ann
     | TypeErrorE (TypeError (Term TyName Name uni fun ()) uni fun ann)
     | NormCheckErrorE (NormCheckError TyName Name uni fun ann)
     | FreeVariableErrorE FreeVariableError
-    deriving (Show, Eq, Generic, NFData, Functor)
+    deriving (Eq, Generic, NFData, Functor)
 makeClassyPrisms ''Error
+deriving instance (Show fun, Show ann, Closed uni, Everywhere uni Show, GShow uni, Show (ParseError ann)) => Show (Error uni fun ann)
 
 instance AsParseError (Error uni fun ann) ann where
     _ParseError = _ParseErrorE
@@ -134,6 +131,10 @@ instance Pretty ann => Pretty (ParseError ann) where
     pretty (BuiltinTypeNotAStar loc ty)     = "Expected a type of kind star (to later parse a constant), but got:" <+> squotes (pretty ty) <+> "at" <+> pretty loc
     pretty (UnknownBuiltinFunction loc s)   = "Unknown built-in function" <+> squotes (pretty s) <+> "at" <+> pretty loc
     pretty (InvalidBuiltinConstant loc c s) = "Invalid constant" <+> squotes (pretty c) <+> "of type" <+> squotes (pretty s) <+> "at" <+> pretty loc
+
+instance Pretty ann => Show (ParseError ann)
+    where
+      show = show . pretty
 
 instance Pretty ann => Pretty (UniqueError ann) where
     pretty (MultiplyDefined u def redef) =

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -52,7 +52,6 @@ import Data.GADT.Compare
 import Data.GADT.Compare.TH
 import Data.GADT.DeepSeq
 import Data.GADT.Show
-import Data.Hashable
 import Data.Kind
 import Data.Proxy
 import Data.Some.Newtype
@@ -764,15 +763,3 @@ instance Closed uni => NFData (SomeTypeIn uni) where
 
 instance (Closed uni, uni `Everywhere` NFData) => NFData (ValueOf uni a) where
     rnf = grnf
-
--------------------- 'Hashable'
-
-instance Closed uni => Hashable (SomeTypeIn uni) where
-    hashWithSalt salt (SomeTypeIn uni) = hashWithSalt salt $ encodeUni uni
-
-instance (Closed uni, uni `Everywhere` Hashable) => Hashable (ValueOf uni a) where
-    hashWithSalt salt (ValueOf uni x) =
-        bring (Proxy @Hashable) uni $ hashWithSalt salt (SomeTypeIn uni, x)
-
-instance (Closed uni, uni `Everywhere` Hashable) => Hashable (Some (ValueOf uni)) where
-    hashWithSalt salt (Some s) = hashWithSalt salt s

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
@@ -114,11 +114,11 @@ data TermConstantG = TmIntegerG Integer
                    | TmDataG Data
                    deriving (Show, Eq)
 
+deriveEnumerable ''Data
+
 deriveEnumerable ''TermConstantG
 
 deriveEnumerable ''DefaultFun
-
-deriveEnumerable ''Data
 
 data TermG tyname name
     = VarG

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Contexts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Contexts.hs
@@ -332,9 +332,6 @@ makeIsDataIndexed ''TxInInfo [('TxInInfo,0)]
 makeLift ''TxInfo
 makeIsDataIndexed ''TxInfo [('TxInfo,0)]
 
-makeLift ''ScriptContext
-makeIsDataIndexed ''ScriptContext [('ScriptContext,0)]
-
 
 makeLift ''ScriptPurpose
 makeIsDataIndexed ''ScriptPurpose
@@ -343,3 +340,6 @@ makeIsDataIndexed ''ScriptPurpose
     , ('Rewarding,2)
     , ('Certifying,3)
     ]
+
+makeLift ''ScriptContext
+makeIsDataIndexed ''ScriptContext [('ScriptContext,0)]

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Credential.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Credential.hs
@@ -66,7 +66,7 @@ instance PlutusTx.Eq Credential where
     ScriptCredential a == ScriptCredential a' = a PlutusTx.== a'
     _ == _                                    = False
 
-PlutusTx.makeIsDataIndexed ''StakingCredential [('StakingHash,0), ('StakingPtr,1)]
 PlutusTx.makeIsDataIndexed ''Credential [('PubKeyCredential,0), ('ScriptCredential,1)]
-PlutusTx.makeLift ''StakingCredential
+PlutusTx.makeIsDataIndexed ''StakingCredential [('StakingHash,0), ('StakingPtr,1)]
 PlutusTx.makeLift ''Credential
+PlutusTx.makeLift ''StakingCredential

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Tx.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Tx.hs
@@ -335,7 +335,7 @@ pubKeyTxIns = folding (Set.filter (\TxIn{ txInType = t } -> t == Just ConsumePub
 
 -- | Filter to get only the script inputs.
 scriptTxIns :: Fold (Set.Set TxIn) TxIn
-scriptTxIns = folding . Set.filter $ \case
+scriptTxIns = (\x -> folding x) . Set.filter $ \case
     TxIn{ txInType = Just ConsumeScriptAddress{} } -> True
     _                                              -> False
 

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Value.hs
@@ -84,14 +84,14 @@ newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: PlutusTx.BuiltinBy
     deriving anyclass (Hashable, ToJSONKey, FromJSONKey,  NFData)
 
 instance ToJSON CurrencySymbol where
-  toJSON currencySymbol =
+  toJSON c =
     JSON.object
       [ ( "unCurrencySymbol"
         , JSON.String .
           JSON.encodeByteString .
           PlutusTx.fromBuiltin .
           unCurrencySymbol $
-          currencySymbol)
+          c)
       ]
 
 instance FromJSON CurrencySymbol where
@@ -100,8 +100,6 @@ instance FromJSON CurrencySymbol where
       raw <- object .: "unCurrencySymbol"
       bytes <- JSON.decodeByteString raw
       Haskell.pure $ CurrencySymbol $ PlutusTx.toBuiltin bytes
-
-makeLift ''CurrencySymbol
 
 {-# INLINABLE mpsSymbol #-}
 -- | The currency symbol of a monetay policy hash
@@ -178,8 +176,6 @@ instance FromJSON TokenName where
                 "\NUL\NUL\NUL" -> Haskell.pure . fromText . Text.drop 2 $ t
                 _              -> Haskell.pure . fromText $ t
 
-makeLift ''TokenName
-
 -- | An asset class, identified by currency symbol and token name.
 newtype AssetClass = AssetClass { unAssetClass :: (CurrencySymbol, TokenName) }
     deriving stock (Generic)
@@ -190,8 +186,6 @@ newtype AssetClass = AssetClass { unAssetClass :: (CurrencySymbol, TokenName) }
 {-# INLINABLE assetClass #-}
 assetClass :: CurrencySymbol -> TokenName -> AssetClass
 assetClass s t = AssetClass (s, t)
-
-makeLift ''AssetClass
 
 -- | A cryptocurrency value. This is a map from 'CurrencySymbol's to a
 -- quantity of that currency.
@@ -239,8 +233,6 @@ instance (FromJSON v, FromJSON k) => FromJSON (Map.Map k v) where
 
 deriving anyclass instance (Hashable k, Hashable v) => Hashable (Map.Map k v)
 deriving anyclass instance (Serialise k, Serialise v) => Serialise (Map.Map k v)
-
-makeLift ''Value
 
 instance Haskell.Eq Value where
     (==) = eq
@@ -442,3 +434,8 @@ split (Value mp) = (negate (Value neg), Value pos) where
   splitIntl :: Map.Map TokenName Integer -> These (Map.Map TokenName Integer) (Map.Map TokenName Integer)
   splitIntl mp' = These l r where
     (l, r) = Map.mapThese (\i -> if i <= 0 then This i else That i) mp'
+
+makeLift ''CurrencySymbol
+makeLift ''TokenName
+makeLift ''AssetClass
+makeLift ''Value

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -83,6 +83,7 @@ library
         bytestring -any,
         deepseq -any,
         template-haskell >=2.13.0.0,
+        th-compat -any,
         th-abstraction -any,
         prettyprinter -any,
         text -any,

--- a/plutus-tx/src/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/PlutusTx/IsData/TH.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 module PlutusTx.IsData.TH (unstableMakeIsData, makeIsDataIndexed) where
 
@@ -160,5 +161,10 @@ makeIsDataIndexed name indices = do
 
     pure [toDataInst, fromDataInst, unsafeFromDataInst]
     where
-        tyvarbndrName (TH.PlainTV n)    = n
-        tyvarbndrName (TH.KindedTV n _) = n
+#if MIN_VERSION_template_haskell(2,17,0)
+        tyvarbndrName (TH.PlainTV n _)    = n
+        tyvarbndrName (TH.KindedTV n _ _) = n
+#else
+        tyvarbndrName (TH.PlainTV n)      = n
+        tyvarbndrName (TH.KindedTV n _)   = n
+#endif

--- a/plutus-tx/src/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Instances.hs
@@ -118,7 +118,6 @@ instance (FromBuiltin arep a, uni `PLC.Includes` [a]) => Lift uni (BuiltinList a
 -- Standard types
 -- These need to be in a separate file for TH staging reasons
 
-makeLift ''Data
 makeLift ''Bool
 makeLift ''Maybe
 makeLift ''Either
@@ -129,3 +128,4 @@ makeLift ''(,)
 makeLift ''(,,)
 makeLift ''(,,,)
 makeLift ''(,,,,)
+makeLift ''Data


### PR DESCRIPTION
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

This doesn't fix #4303 but it's a step in that direction.

Half of the changes are due to `Eq` being a superclass of `Hashable` now, the other half are TH related.