### PR TITLE
[Builtins] Add 'Proxy' to the default universe

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -142,6 +142,9 @@ instance PrettyBy config ExCPU where
 class ExMemoryUsage a where
     memoryUsage :: a -> ExMemory -- ^ How much memory does 'a' use?
 
+instance ExMemoryUsage (Proxy a) where
+    memoryUsage _ = 1
+
 instance (ExMemoryUsage a, ExMemoryUsage b) => ExMemoryUsage (a, b) where
     memoryUsage (a, b) = 1 <> memoryUsage a <> memoryUsage b
 instance ExMemoryUsage SatInt where

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -116,6 +116,7 @@ decodeConstant :: Get Word8
 decodeConstant = dBEBits8 constantWidth
 
 deriving via AsSerialize Data instance Flat Data
+deriving via AsSerialize (Proxy a) instance Flat (Proxy a)
 
 decodeKindedUniFlat :: Closed uni => Get (SomeTypeIn (Kinded uni))
 decodeKindedUniFlat =

--- a/plutus-core/plutus-core/src/PlutusCore/Parsable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parsable.hs
@@ -24,6 +24,7 @@ import Data.Bits (shiftL, (.|.))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS (pack)
 import Data.Char (ord)
+import Data.Proxy
 import Data.Text qualified as T
 import Text.Read
 
@@ -108,6 +109,9 @@ deriving via AsRead Char    instance Parsable Char
 deriving via AsRead Integer instance Parsable Integer
 deriving via AsRead ()      instance Parsable ()
 deriving via AsRead T.Text instance Parsable T.Text
+
+instance Parsable (Proxy a) where
+    parse = error "Parsing for Proxy is not implemented"
 
 instance Parsable (a, b) where
     parse = error "Parsing for tuples is not implemented"

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
@@ -118,6 +118,9 @@ asBytes x = Text 2 $ T.pack $ addLeadingZero $ showHex x mempty
 instance PrettyBy ConstConfig Data where
     prettyBy c d = prettyBy c $ BSL.toStrict $ serialise d
 
+instance PrettyBy ConstConfig (Proxy a) where
+    prettyBy _ Proxy = "Proxy"
+
 instance GShow uni => Pretty (SomeTypeIn uni) where
     pretty (SomeTypeIn uni) = pretty $ gshow uni
 

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
@@ -6,6 +6,8 @@
 
 module PlutusCore.StdLib.Data.Data
     ( dataTy
+    , mkNilData
+    , mkNilPairData
     , caseData
     ) where
 
@@ -19,6 +21,7 @@ import PlutusCore.Name
 import PlutusCore.Quote
 
 import Data.ByteString (ByteString)
+import Data.Proxy
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Pair
 import PlutusCore.StdLib.Data.Unit
@@ -26,6 +29,19 @@ import PlutusCore.StdLib.Data.Unit
 -- | @Data@ as a built-in PLC type.
 dataTy :: uni `Contains` Data => Type TyName uni ()
 dataTy = mkTyBuiltin @_ @Data ()
+
+mkNilAt
+    :: (DefaultUni `Contains` a, TermLike term TyName Name DefaultUni DefaultFun)
+    => Proxy a -> term ()
+mkNilAt (proxyA :: Proxy a)
+    = apply () (tyInst () (builtin () MkNil) $ mkTyBuiltin @_ @a ())
+    $ constant () (someValue proxyA)
+
+mkNilData :: TermLike term TyName Name DefaultUni DefaultFun => term ()
+mkNilData = mkNilAt $ Proxy @Data
+
+mkNilPairData :: TermLike term TyName Name DefaultUni DefaultFun => term ()
+mkNilPairData = mkNilAt $ Proxy @(Data, Data)
 
 -- | Pattern matching over 'Data' inside PLC.
 --

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Everything.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Everything.hs
@@ -69,8 +69,10 @@ stdLib =
                   , plcTermFile "FoldList"  Builtin.foldList
                   ]
               , treeFolderContents "Data"
-                  [ plcTypeFile "Data"     dataTy
-                  , plcTermFile "caseData" caseData
+                  [ plcTypeFile "Data"          dataTy
+                  , plcTermFile "mkNilData"     mkNilData
+                  , plcTermFile "mkNilPairData" mkNilPairData
+                  , plcTermFile "caseData"      caseData
                   ]
               , treeFolderContents "ScottList"
                   [ plcTypeFile "List"       listTy

--- a/plutus-core/plutus-core/test/Pretty/Golden/Readable/StdLib/Data/Data/mkNilData.plc.golden
+++ b/plutus-core/plutus-core/test/Pretty/Golden/Readable/StdLib/Data/Data/mkNilData.plc.golden
@@ -1,0 +1,1 @@
+mkNil {data} Proxy

--- a/plutus-core/plutus-core/test/Pretty/Golden/Readable/StdLib/Data/Data/mkNilPairData.plc.golden
+++ b/plutus-core/plutus-core/test/Pretty/Golden/Readable/StdLib/Data/Data/mkNilPairData.plc.golden
@@ -1,0 +1,1 @@
+mkNil {pair (data) (data)} Proxy

--- a/plutus-core/plutus-core/test/TypeSynthesis/Golden/MkNil.plc.golden
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Golden/MkNil.plc.golden
@@ -1,0 +1,1 @@
+(all a (type) (fun [ (con proxy) a ] [ (con list) a ]))

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -453,8 +453,8 @@ test_Data = testCase "Data" $ do
     evals (B "hello world") BData [cons @ByteString "hello world"]
     evals (I 3) IData [cons @Integer 3]
     evals (B "hello world") BData [cons @ByteString "hello world"]
-    evals @[Data] [] MkNilData [cons ()]
-    evals @[(Data,Data)] [] MkNilPairData [cons ()]
+    evals' @[Data] [] mkNilData
+    evals' @[(Data,Data)] [] mkNilPairData
 
     -- equality
     evals True EqualsData [cons $ B "hello world", cons $ B "hello world"]
@@ -561,6 +561,12 @@ evals :: Contains DefaultUni a => a -> DefaultFun -> [Term TyName Name DefaultUn
 evals expectedVal b args =
     let actualExp = mkIterApp () (builtin () b) args
     in  Right (EvaluationSuccess $ cons expectedVal)
+        @=?
+        typecheckEvaluateCekNoEmit defaultCekParameters actualExp
+
+evals' :: Contains DefaultUni a => a -> Term TyName Name DefaultUni DefaultFun () -> Assertion
+evals' expectedVal actualExp =
+    Right (EvaluationSuccess $ cons expectedVal)
         @=?
         typecheckEvaluateCekNoEmit defaultCekParameters actualExp
 


### PR DESCRIPTION
This shows how to add `Proxy` to the default universe, so that we can have only only one built-in `MkNil` and express the two that we currently have in terms of it.

This is unpolished, 'cause I'm not sure if we want this or not, I just thought it would be easy to implement it, so I did that.