### PR TITLE
SCP-3383: Added plutus-benchmark-validation-full

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-benchmark.nix
@@ -202,6 +202,24 @@
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             ];
           buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "validation" ];
+          };
+        "validation-full" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "validation" ];
           };
         "cek-calibration" = {

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -867,6 +867,7 @@
           "fin".components.library.planned = lib.mkOverride 900 true;
           "base-orphans".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "plutus-benchmark".components.benchmarks."validation-full".planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "cardano-slotting".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-benchmark.nix
@@ -202,6 +202,24 @@
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             ];
           buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "validation" ];
+          };
+        "validation-full" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "validation" ];
           };
         "cek-calibration" = {

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -867,6 +867,7 @@
           "fin".components.library.planned = lib.mkOverride 900 true;
           "base-orphans".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "plutus-benchmark".components.benchmarks."validation-full".planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "cardano-slotting".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-benchmark.nix
@@ -202,6 +202,24 @@
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             ];
           buildable = true;
+          modules = [ "Common" ];
+          hsSourceDirs = [ "validation" ];
+          };
+        "validation-full" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          modules = [ "Common" ];
           hsSourceDirs = [ "validation" ];
           };
         "cek-calibration" = {

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -840,6 +840,7 @@
           "fin".components.library.planned = lib.mkOverride 900 true;
           "base-orphans".components.library.planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
+          "plutus-benchmark".components.benchmarks."validation-full".planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
           "cardano-slotting".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;

--- a/plutus-benchmark/README.md
+++ b/plutus-benchmark/README.md
@@ -1,6 +1,6 @@
 ## Plutus Benchmarks
 
-This directory contains three sets of benchmarks:
+This directory contains four sets of benchmarks:
 
 * `nofib`: Plutus versions of some of Haskell's `nofib` benchmarks from https://github.com/ghc/nofib.
 
@@ -55,6 +55,8 @@ This directory contains three sets of benchmarks:
      minutes to run the entire suite (again, this will depend on the hardware).
 
 * `lists`: some simple algorithms on lists.  See [lists/README.md](./lists/README.md) for more information.
+
+* `validation-full`: a clone of the above that also measures the script setup time before CEK evaluation starts; currently that is script deserialization and scope checking.
 
 See also [nofib/README.md](./nofib/README.md) and [validation/README.md](./validation/README.md).
 

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -207,15 +207,16 @@ test-suite plutus-benchmark-lists-tests
       , tasty -any
       , tasty-quickcheck -any
 
-
 ---------------- validation ----------------
 
 benchmark validation
   import: lang
   type: exitcode-stdio-1.0
-  main-is: Bench.hs
+  main-is: BenchCek.hs
   hs-source-dirs:
       validation
+  other-modules:
+      Common
   build-depends:
       base >=4.7 && <5
     , plutus-benchmark-common
@@ -228,6 +229,27 @@ benchmark validation
     , flat -any
     , optparse-applicative -any
 
+---------------- validation-full ----------------
+
+benchmark validation-full
+  import: lang
+  type: exitcode-stdio-1.0
+  main-is: BenchFull.hs
+  hs-source-dirs:
+      validation
+  other-modules:
+      Common
+  build-depends:
+      base >=4.7 && <5
+    , plutus-benchmark-common
+    , plutus-core -any
+    , bytestring -any
+    , criterion >= 1.5.9.0
+    , deepseq -any
+    , directory -any
+    , filepath -any
+    , flat -any
+    , optparse-applicative -any
 
 ---------------- Cek cost model calibration ----------------
 

--- a/plutus-benchmark/validation/BenchCek.hs
+++ b/plutus-benchmark/validation/BenchCek.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Common
+
+-- | benchmarks only for the CEK execution time of the data/*.flat validation scripts
+main :: IO ()
+main = validationBench CekOnly

--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Common
+
+-- | for each data/*.flat validation script, it benchmarks
+-- the whole time taken from script deserialization to script execution result.
+main :: IO ()
+main = validationBench Full


### PR DESCRIPTION
Clone benchmark:validation to validation-full that measures also unflatting , mapping to fakename and undebruijining.
I/O to `readFile` the scripts is  (hopefully) not measured.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
