### PR TITLE
Add a comment about why we're not making ExMemoryUsage strict for Data (SCP-3065)

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -218,6 +218,11 @@ instance ExMemoryUsage a => ExMemoryUsage [a] where
    processing the contents of nodes: the implementation below compromises by charging
    four units per node, but we may wish to revise this after experimentation.
 -}
+{- This code runs on the chain and hence should be as efficient as possible. To
+   that end it's tempting to make these functions strict and tail recursive (and
+   similarly in the instance for lists above), but experiments showed that that
+   didn't improve matters and in fact some versions led to a slight slowdown.
+-}
 instance ExMemoryUsage Data where
     memoryUsage = sizeData
         where sizeData d =


### PR DESCRIPTION
PR #4341 experimented with making the `ExMemoryUsage` instances for `Data` and lists strict and tail recursive, but that didn't cause any improvement (and a couple of attempts caused a slight slowdown).  This just adds a comment to explain that we tried this an it didn't help.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
