### PR TITLE
SCP-3409: Change Flat Index from Natural to Word64 encode/decode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,10 +34,12 @@ extra-packages: ieee, filemanip
 
 -- https://github.com/Quid2/flat/pull/22 fixes a potential exception
 -- when decoding invalid (e.g. malicious) text literals.
+-- https://github.com/Quid2/flat/pull/29 fixes a potential overflow
+-- when unflat @Word64 . flat @Natural
 source-repository-package
   type: git
-  location: https://github.com/Quid2/flat.git
-  tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
+  location: https://github.com/bezirg/flat.git
+  tag: baafd8b7738b208b0a572ab3bbdd39f737e98ef7
 
 source-repository-package
   type: git

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -42,7 +42,7 @@ let
     # If true, we check that the generated files are correct. Set in the CI so we don't make mistakes.
     inherit checkMaterialization;
     sha256map = {
-      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm";
+      "https://github.com/bezirg/flat.git"."baafd8b7738b208b0a572ab3bbdd39f737e98ef7" = "13fl50b84wy157np4487yzpsbkrh4x3pyk2l023yim9m8qzwal4v";
       "https://github.com/input-output-hk/cardano-base"."0b1b5b37e305c4bb10791f843bc8c81686a0cba4" = "1z98f3m4skmqy782dpcpd3y0k7hccdrz5yl1fjgjs524swh4vv56";
       "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3";
       "https://github.com/input-output-hk/cardano-prelude"."fd773f7a58412131512b9f694ab95653ac430852" = "02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6";

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -553,6 +553,7 @@
             "DeBruijn/Scope"
             "DeBruijn/Spec"
             "DeBruijn/UnDeBruijnify"
+            "DeBruijn/FlatNatWord"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -553,6 +553,7 @@
             "DeBruijn/Scope"
             "DeBruijn/Spec"
             "DeBruijn/UnDeBruijnify"
+            "DeBruijn/FlatNatWord"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -553,6 +553,7 @@
             "DeBruijn/Scope"
             "DeBruijn/Spec"
             "DeBruijn/UnDeBruijnify"
+            "DeBruijn/FlatNatWord"
             ];
           hsSourceDirs = [ "untyped-plutus-core/test" ];
           mainPath = [ "Spec.hs" ];

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -450,6 +450,7 @@ test-suite untyped-plutus-core-test
         DeBruijn.Scope
         DeBruijn.Spec
         DeBruijn.UnDeBruijnify
+        DeBruijn.FlatNatWord
     build-depends:
         base >=4.9 && <5,
         bytestring -any,

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/FlatNatWord.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/FlatNatWord.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE TypeApplications #-}
+module DeBruijn.FlatNatWord (test_flatNatWord) where
+
+import Data.Either (isLeft)
+import Data.Word
+import Flat
+import Numeric.Natural
+import PlutusCore.Flat ()
+
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.Hedgehog
+
+
+
+{- NOTE: [DeBruijjn index flat format]
+In the debruijn branch we are transitioning the debruijn index to be a Word instead of Natural, for CEK performance reasons.
+
+This means the types of `Script`,`Program`,`Term` change and so does the flat "interface".
+
+This module tests that although the interface/types change,
+the underlying flat encoding/decoding remains the same,
+so there is no need to issue a new plutus language version increase.
+-}
+
+test_flatNatWord :: TestTree
+test_flatNatWord = testGroup "FlatNatWord"
+    [ testCase "compatible minbound" test_MinBound
+    , testCase "compatible maxbound" test_MaxBound
+    , testProperty "compatible inside bounds" prop_CompatInBounds
+    , testProperty "dec outside bounds" prop_DecLarger
+    ]
+
+-- test that Natural and Word64 are compatible inside
+-- the (minBound,maxBound) bounds of Word64
+prop_CompatInBounds :: Property
+prop_CompatInBounds = property $ do
+    -- test that their encodings are byte-to-byte the same
+    w <- forAll $ Gen.word64 Range.linearBounded
+    let n :: Natural = fromIntegral w
+    flat w === flat n
+
+    -- Tripping from encoded as natural to decoded as word
+    tripping w (flat @Natural . fromIntegral) unflat
+
+    -- Tripping from encoded as word to decoded as natural
+    tripping n (flat @Word64 . fromIntegral) unflat
+
+prop_DecLarger :: Property
+prop_DecLarger = property $ do
+    let maxWord64AsNat = fromIntegral @Word64 @Natural maxBound
+    n <- forAll $ Gen.integral $ Range.linear (maxWord64AsNat+1) (maxWord64AsNat*10)
+    Hedgehog.assert $ isLeft $ unflat @Word64 $ flat @Natural n
+
+test_MinBound :: Assertion
+test_MinBound = do
+    let w = minBound @Word64
+        n :: Natural = fromIntegral w
+    flat w == flat n @? "enc minbound does not match"
+    -- Tripping from encoded as natural to decoded as word
+    Right w == (unflat $ flat n)  @? "tripping1 minbound failed"
+    -- Tripping from encoded as word to decoded as natural
+    Right n == (unflat $ flat w) @? "tripping1 minbound failed"
+
+test_MaxBound :: Assertion
+test_MaxBound = do
+    let w = maxBound @Word64
+        n :: Natural = fromIntegral w
+    flat w == flat n @? "enc maxbound does not match"
+    -- Tripping from encoded as natural to decoded as word
+    Right w == (unflat $ flat n)  @? "tripping1 maxbound failed"
+    -- Tripping from encoded as word to decoded as natural
+    Right n == (unflat $ flat w) @? "tripping1 maxbound failed"

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Spec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module DeBruijn.Spec (test_debruijn) where
 
+import DeBruijn.FlatNatWord (test_flatNatWord)
 import DeBruijn.Scope (test_scope)
 import DeBruijn.UnDeBruijnify (test_undebruijnify)
 import Test.Tasty
@@ -11,4 +12,5 @@ test_debruijn = runTestNestedIn ["untyped-plutus-core","test"] $
                testNested "DeBruijn"
                 [ test_undebruijnify
                 , test_scope
+                , pure test_flatNatWord
                 ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -63,8 +63,8 @@ extra-deps:
 
 # cabal.project is the source of truth for these pins, they are explained there
 # and need to be kept in sync.
-- git: https://github.com/michaelpj/flat.git
-  commit: ee59880f47ab835dbd73bea0847dab7869fc20d8
+- git: https://github.com/bezirg/flat.git
+  commit: baafd8b7738b208b0a572ab3bbdd39f737e98ef7
 - git: https://github.com/input-output-hk/cardano-crypto.git
   commit: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
 - git: https://github.com/input-output-hk/cardano-prelude


### PR DESCRIPTION
In the debruijn branch we are transitioning the debruijn index to be a Word instead of Natural, for CEK performance reasons.

This means the types of `Script`,`Program`,`Term` change and so does the flat "interface".

This module tests that although the interface/types change,
the underlying flat encoding/decoding remains the same,
so there is no need to issue a new plutus language version increase.



<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
