### PR TITLE
[Builtins] Introduce 'RuntimeScheme'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -67,8 +67,8 @@ evalBuiltinApp
     -> BuiltinRuntime (CkValue uni fun)
     -> CkM uni fun s (CkValue uni fun)
 evalBuiltinApp term runtime@(BuiltinRuntime sch x _) = case sch of
-    TypeSchemeResult -> makeKnown emitCkM (Just term) x
-    _                -> pure $ VBuiltin term runtime
+    RuntimeSchemeResult -> makeKnown emitCkM (Just term) x
+    _                   -> pure $ VBuiltin term runtime
 
 ckValueToTerm :: CkValue uni fun -> Term TyName Name uni fun ()
 ckValueToTerm = \case
@@ -274,7 +274,7 @@ instantiateEvaluate stack ty (VBuiltin term (BuiltinRuntime sch f exF)) = do
         -- We allow a type argument to appear last in the type of a built-in function,
         -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
         -- application.
-        TypeSchemeAll  _ schK -> do
+        RuntimeSchemeAll schK -> do
             let runtime' = BuiltinRuntime schK f exF
             res <- evalBuiltinApp term' runtime'
             stack <| res
@@ -300,7 +300,7 @@ applyEvaluate stack (VBuiltin term (BuiltinRuntime sch f _)) arg = do
     case sch of
         -- It's only possible to apply a builtin application if the builtin expects a term
         -- argument next.
-        TypeSchemeArrow schB -> do
+        RuntimeSchemeArrow schB -> do
             x <- liftEither $ readKnown (Just argTerm) arg
             let noCosting = error "The CK machine does not support costing"
                 runtime' = BuiltinRuntime schB (f x) noCosting

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -539,7 +539,7 @@ evalBuiltinApp
     -> BuiltinRuntime (CekValue uni fun)
     -> CekM uni fun s (CekValue uni fun)
 evalBuiltinApp fun term env runtime@(BuiltinRuntime sch x cost) = case sch of
-    TypeSchemeResult -> do
+    RuntimeSchemeResult -> do
         spendBudgetCek (BBuiltinApp fun) cost
         makeKnown ?cekEmitter (Just term) x
     _ -> pure $ VBuiltin fun term env runtime
@@ -646,7 +646,7 @@ enterComputeCek = computeCek (toWordArray 0) where
         case sch of
             -- It's only possible to force a builtin application if the builtin expects a type
             -- argument next.
-            TypeSchemeAll  _ schK -> do
+            RuntimeSchemeAll schK -> do
                 let runtime' = BuiltinRuntime schK f exF
                 -- We allow a type argument to appear last in the type of a built-in function,
                 -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
@@ -681,7 +681,7 @@ enterComputeCek = computeCek (toWordArray 0) where
         case sch of
             -- It's only possible to apply a builtin application if the builtin expects a term
             -- argument next.
-            TypeSchemeArrow schB -> do
+            RuntimeSchemeArrow schB -> do
                 x <- liftEither $ readKnown (Just argTerm) arg
                 -- TODO: should we bother computing that 'ExMemory' eagerly? We may not need it.
                 -- We pattern match on @arg@ twice: in 'readKnown' and in 'toExMemory'.


### PR DESCRIPTION
This one introduces `RuntimeScheme` which is akin to `TypeScheme` except it doesn't
contain a bunch of irrelevant types stuff that we don't need during evaluation.

The `RuntimeScheme` introduced here is not optimal performance-wise, which is future work.