### PR TITLE
Strict example

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -101,6 +101,7 @@ test-suite plutus-tx-tests
         Plugin.Typeclasses.Spec
         Plugin.Typeclasses.Lib
         Plugin.Coverage.Spec
+        Plugin.Strict.Spec
         Plugin.Lib
         StdLib.Spec
         TH.Spec

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -35,6 +35,12 @@ withVarScoped v k = do
     var <- compileVarFresh v
     local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
 
+withVarScopedType :: CompilingDefault uni fun m => GHC.Var -> GHC.Type -> (PIR.VarDecl PIR.TyName PIR.Name uni fun () -> m a) -> m a
+withVarScopedType v t k = do
+    let ghcName = GHC.getName v
+    var <- compileVarFreshType v t
+    local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
+
 withVarsScoped :: CompilingDefault uni fun m => [GHC.Var] -> ([PIR.VarDecl PIR.TyName PIR.Name uni fun ()] -> m a) -> m a
 withVarsScoped vs k = do
     vars <- for vs $ \v -> do

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -12,6 +12,7 @@ import Plugin.NoTrace.Spec
 import Plugin.Primitives.Spec
 import Plugin.Profiling.Spec
 import Plugin.Typeclasses.Spec
+import Plugin.Strict.Spec
 
 tests :: TestNested
 tests = testNested "Plugin" [
@@ -25,4 +26,5 @@ tests = testNested "Plugin" [
   , typeclasses
   , profiling
   , coverage
+  , strict
   ]

--- a/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
@@ -15,10 +15,8 @@ import Test.Tasty.Extras
 import PlutusCore.Test
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Code
-import PlutusTx.Lift
 import PlutusTx.Plugin
 import PlutusTx.Prelude qualified as P
-import PlutusTx.Test
 
 import Data.Proxy
 
@@ -26,6 +24,7 @@ strict :: TestNested
 strict = testNested "Strict" [
     goldenPir "strictAdd" strictAdd
   , goldenPir "strictAppend" strictAppend
+  , goldenPir "strictAppend2" strictAppend2
   ]
 
 strictAdd :: CompiledCode (Integer -> Integer -> Integer)
@@ -39,3 +38,12 @@ strictAppend = plc (Proxy @"strictLet") strictAppendExample
 
 strictAppendExample :: P.BuiltinByteString -> P.BuiltinByteString -> P.BuiltinByteString
 strictAppendExample !x !y = Builtins.appendByteString x y
+
+strictAppend2 :: CompiledCode (Wrapper -> Wrapper -> Wrapper)
+strictAppend2 = plc (Proxy @"strictLet") strictAppend2Example
+
+strictAppend2Example :: Wrapper -> Wrapper -> Wrapper
+strictAppend2Example !(Wrapper x) !(Wrapper y) = Wrapper (Builtins.appendByteString x y)
+
+-- Wrapper, like PubKeyHash etc.
+newtype Wrapper = Wrapper P.BuiltinByteString

--- a/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -ddump-simpl -dsuppress-all #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+
+module Plugin.Strict.Spec (strict, strictAddExample, strictAppendExample) where
+
+import Test.Tasty.Extras
+
+import PlutusCore.Test
+import PlutusTx.Builtins qualified as Builtins
+import PlutusTx.Code
+import PlutusTx.Lift
+import PlutusTx.Plugin
+import PlutusTx.Prelude qualified as P
+import PlutusTx.Test
+
+import Data.Proxy
+
+strict :: TestNested
+strict = testNested "Strict" [
+    goldenPir "strictAdd" strictAdd
+  , goldenPir "strictAppend" strictAppend
+  ]
+
+strictAdd :: CompiledCode (Integer -> Integer -> Integer)
+strictAdd = plc (Proxy @"strictLet") strictAddExample
+
+strictAddExample :: Integer -> Integer -> Integer
+strictAddExample !x !y = Builtins.addInteger x y
+
+strictAppend :: CompiledCode (P.BuiltinByteString -> P.BuiltinByteString -> P.BuiltinByteString)
+strictAppend = plc (Proxy @"strictLet") strictAppendExample
+
+strictAppendExample :: P.BuiltinByteString -> P.BuiltinByteString -> P.BuiltinByteString
+strictAppendExample !x !y = Builtins.appendByteString x y

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAdd.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAdd.plc.golden
@@ -1,0 +1,3 @@
+(program
+  (lam x (con integer) (lam y (con integer) [ [ (builtin addInteger) x ] y ]))
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAppend.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAppend.plc.golden
@@ -1,0 +1,7 @@
+(program
+  (lam
+    x
+    (con bytestring)
+    (lam y (con bytestring) [ [ (builtin appendByteString) x ] y ])
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAppend2.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAppend2.plc.golden
@@ -1,0 +1,7 @@
+(program
+  (lam
+    ds
+    (con bytestring)
+    (lam ds (con bytestring) [ [ (builtin appendByteString) ds ] ds ])
+  )
+)


### PR DESCRIPTION
This tries to solve https://github.com/input-output-hk/plutus/issues/4193 using different approach then https://github.com/input-output-hk/plutus/pull/4206.

#4206 tries to complicate the code so GHC doesn't see through. I rather take the different approach, telling the GHC that `BuiltinByteString` is a type it shouldn't know anything about representation other that it's lifted (= `Any`), and then change `plutus-tx` compiler just enough to handle the outcome.