### PR TITLE
SCP-3493: change validation-full&decode to use the Ledger.Api

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-benchmark.nix
@@ -221,6 +221,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];
@@ -238,6 +240,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-benchmark.nix
@@ -221,6 +221,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];
@@ -238,6 +240,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-benchmark.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-benchmark.nix
@@ -221,6 +221,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];
@@ -238,6 +240,8 @@
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           modules = [ "Common" ];

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -254,6 +254,8 @@ benchmark validation-decode
     , flat -any
     , optparse-applicative -any
     , mtl -any
+    , plutus-ledger-api -any
+    , serialise -any
 
 ---------------- validation-full ----------------
 
@@ -276,6 +278,8 @@ benchmark validation-full
     , flat -any
     , optparse-applicative -any
     , mtl -any
+    , plutus-ledger-api -any
+    , serialise -any
 
 ---------------- Cek cost model calibration ----------------
 

--- a/plutus-benchmark/validation/BenchCek.hs
+++ b/plutus-benchmark/validation/BenchCek.hs
@@ -5,6 +5,7 @@ import Common
 import Control.DeepSeq (force)
 import Criterion
 import PlutusBenchmark.Common
+import UntypedPlutusCore as UPLC
 
 {-|
  Benchmarks only for the CEK execution time of the data/*.flat validation scripts
@@ -20,6 +21,6 @@ main = benchWith mkCekBM
    mkCekBM file program =
        -- don't count the undebruijn . unflat cost
        -- `force` to try to ensure that deserialiation is not included in benchmarking time.
-       let !nterm = force (throughCheckScope $ toNamedDeBruijnTerm $ unsafeUnflat file program)
+       let !nterm = force (throughCheckScope $ toNamedDeBruijnTerm $ UPLC._progTerm $ unsafeUnflat file program)
        in whnf unsafeEvaluateCekNoEmit' nterm
 

--- a/plutus-benchmark/validation/BenchDec.hs
+++ b/plutus-benchmark/validation/BenchDec.hs
@@ -1,7 +1,12 @@
 module Main where
 
+import Codec.Serialise qualified as Serialise (serialise)
 import Common
 import Criterion
+import Data.ByteString as BS
+import Data.ByteString.Lazy as BSL
+import Data.ByteString.Short (toShort)
+import Plutus.V1.Ledger.Api
 
 {-|
 for each data/*.flat validation script, it benchmarks
@@ -15,5 +20,12 @@ the time taken to only flat-deserialize the script
 main :: IO ()
 main = benchWith mkDecBM
   where
-    mkDecBM file scriptBS = nf (unsafeUnflat file) scriptBS
+    mkDecBM :: FilePath -> BS.ByteString -> Benchmarkable
+    mkDecBM _file bsFlat =
+        let
+            -- just "envelope" the flat strict-bytestring into a cbor's lazy serialised bytestring
+            bslCBOR :: BSL.ByteString = Serialise.serialise bsFlat
+            -- strictify and "short" the result cbor to create a real `SerializedScript`
+            benchScript :: SerializedScript = toShort . BSL.toStrict $ bslCBOR
+        in whnf validateScript benchScript
 

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -91,6 +91,12 @@ testSelfUpdate model = do
   updated <- applyParams model params
   updated @?= model
 
+-- Update a model with its no parameters and check that we get the same model back
+testUpdateEmpty :: CekCostModel -> IO ()
+testUpdateEmpty model = do
+  updated <- applyParams model mempty
+  updated @?= model
+
 -- Update a model model1 with the parameters from model2 and check that we get model2
 testOverwrite :: CekCostModel -> CekCostModel -> IO ()
 testOverwrite model1 model2 = do
@@ -177,6 +183,10 @@ test_costModelInterface =
        , testGroup "self-update is identity"
              [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testSelfUpdate defaultCekCostModel
              , testCase "randomCekCostModel  <- randomCekCostModel"  $ testSelfUpdate randomCekCostModel
+             ]
+       , testGroup "update-empty is identity"
+             [ testCase "defaultCekCostModel <- defaultCekCostModel" $ testUpdateEmpty defaultCekCostModel
+             , testCase "randomCekCostModel  <- randomCekCostModel"  $ testUpdateEmpty randomCekCostModel
              ]
        , testGroup "overwriting works"
              [ testCase "defaultCekCostModel <- randomCekCostModel"  $ testOverwrite defaultCekCostModel randomCekCostModel


### PR DESCRIPTION
Changes the validation-full&decode from handcrafted code to Ledger.Api module calls.
I would also like to change the normal validation module to use the `Scripts.evaluateScript` but then it would incur a performance penaly since that function would have to account for (fakename pass + scope checking).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
