### PR TITLE
Make BuiltinByteString (and others) more opaque

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-tx-plugin.nix
@@ -113,6 +113,7 @@
             "Plugin/Typeclasses/Spec"
             "Plugin/Typeclasses/Lib"
             "Plugin/Coverage/Spec"
+            "Plugin/Strict/Spec"
             "Plugin/Lib"
             "StdLib/Spec"
             "TH/Spec"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-tx-plugin.nix
@@ -113,6 +113,7 @@
             "Plugin/Typeclasses/Spec"
             "Plugin/Typeclasses/Lib"
             "Plugin/Coverage/Spec"
+            "Plugin/Strict/Spec"
             "Plugin/Lib"
             "StdLib/Spec"
             "TH/Spec"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-tx-plugin.nix
@@ -113,6 +113,7 @@
             "Plugin/Typeclasses/Spec"
             "Plugin/Typeclasses/Lib"
             "Plugin/Coverage/Spec"
+            "Plugin/Strict/Spec"
             "Plugin/Lib"
             "StdLib/Spec"
             "TH/Spec"

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -102,6 +102,7 @@ test-suite plutus-tx-tests
         Plugin.Typeclasses.Spec
         Plugin.Typeclasses.Lib
         Plugin.Coverage.Spec
+        Plugin.Strict.Spec
         Plugin.Lib
         StdLib.Spec
         TH.Spec

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -26,6 +26,7 @@ import PlutusTx.Plugin.Utils
 import PlutusTx.Trace
 
 import GhcPlugins qualified as GHC
+import OccurAnal qualified as GHC
 import Panic qualified as GHC
 
 import PlutusCore qualified as PLC
@@ -353,8 +354,10 @@ compileMarkedExpr locStr codeTy origE = do
             ccCurDef = Nothing,
             ccModBreaks = modBreaks
             }
+    -- See Note [Occurrence analysis]
+    let origE' = GHC.occurAnalyseExpr origE
 
-    ((pirP,uplcP), covIdx) <- runWriterT . runQuoteT . flip runReaderT ctx $ withContextM 1 (sdToTxt $ "Compiling expr at" GHC.<+> GHC.text locStr) $ runCompiler moduleNameStr opts origE
+    ((pirP,uplcP), covIdx) <- runWriterT . runQuoteT . flip runReaderT ctx $ withContextM 1 (sdToTxt $ "Compiling expr at" GHC.<+> GHC.text locStr) $ runCompiler moduleNameStr opts origE'
 
     -- serialize the PIR, PLC, and coverageindex outputs into a bytestring.
     bsPir <- makeByteStringLiteral $ flat pirP

--- a/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
+++ b/plutus-tx-plugin/test/IsData/unsafeDeconstructData.plc.golden
@@ -99,16 +99,15 @@
               (vardecl x [ [ Tuple2 a ] b ])
               [
                 { error [ [ Tuple2 a ] b ] }
-                [
-                  {
-                    [
-                      Unit_match
-                      [ [ { trace Unit } reconstructCaseError ] Unit ]
-                    ]
-                    (con unit)
-                  }
+                (let
+                  (nonrec)
+                  (termbind
+                    (strict)
+                    (vardecl wild Unit)
+                    [ [ { trace Unit } reconstructCaseError ] Unit ]
+                  )
                   unitval
-                ]
+                )
               ]
             )
             (lam
@@ -272,15 +271,15 @@
             (vardecl x [ Maybe a ])
             [
               { error [ Maybe a ] }
-              [
-                {
-                  [
-                    Unit_match [ [ { trace Unit } reconstructCaseError ] Unit ]
-                  ]
-                  (con unit)
-                }
+              (let
+                (nonrec)
+                (termbind
+                  (strict)
+                  (vardecl wild Unit)
+                  [ [ { trace Unit } reconstructCaseError ] Unit ]
+                )
                 unitval
-              ]
+              )
             ]
           )
           (lam

--- a/plutus-tx-plugin/test/Plugin/Data/monomorphic/nonValueCase.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/monomorphic/nonValueCase.plc.golden
@@ -21,11 +21,7 @@
     (termbind
       (strict)
       (vardecl error (all a (type) (fun Unit a)))
-      (abs
-        a
-        (type)
-        (lam x Unit [ { error a } [ { [ Unit_match x ] (con unit) } unitval ] ])
-      )
+      (abs a (type) (lam x Unit [ { error a } unitval ]))
     )
     (lam
       ds

--- a/plutus-tx-plugin/test/Plugin/NoTrace/traceComplex.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/traceComplex.plc.golden
@@ -20,19 +20,7 @@
           [
             { [ Bool_match ds ] (all dead (type) Unit) } (abs dead (type) Unit)
           ]
-          (abs
-            dead
-            (type)
-            (let
-              (nonrec)
-              (termbind
-                (strict)
-                (vardecl thunk (con unit))
-                [ { [ Unit_match Unit ] (con unit) } (con unit ()) ]
-              )
-              (error Unit)
-            )
-          )
+          (abs dead (type) (error Unit))
         ]
         (all dead (type) dead)
       }

--- a/plutus-tx-plugin/test/Plugin/Primitives/error.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/error.plc.golden
@@ -1,9 +1,7 @@
 (program
   (let
     (nonrec)
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
+    (typebind (tyvardecl Unit (type)) (all a (type) (fun a a)))
     (termbind
       (strict)
       (vardecl error (all a (type) (fun (con unit) a)))
@@ -13,11 +11,7 @@
     (termbind
       (strict)
       (vardecl error (all a (type) (fun Unit a)))
-      (abs
-        a
-        (type)
-        (lam x Unit [ { error a } [ { [ Unit_match x ] (con unit) } unitval ] ])
-      )
+      (abs a (type) (lam x Unit [ { error a } unitval ]))
     )
     { error (con integer) }
   )

--- a/plutus-tx-plugin/test/Plugin/Primitives/traceComplex.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/traceComplex.plc.golden
@@ -39,10 +39,13 @@
           (con string)
           [
             { error a }
-            [
-              { [ Unit_match [ [ { trace Unit } str ] Unit ] ] (con unit) }
+            (let
+              (nonrec)
+              (termbind
+                (strict) (vardecl wild Unit) [ [ { trace Unit } str ] Unit ]
+              )
               unitval
-            ]
+            )
           ]
         )
       )

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -11,6 +11,7 @@ import Plugin.Laziness.Spec
 import Plugin.NoTrace.Spec
 import Plugin.Primitives.Spec
 import Plugin.Profiling.Spec
+import Plugin.Strict.Spec
 import Plugin.Typeclasses.Spec
 
 tests :: TestNested
@@ -23,6 +24,7 @@ tests = testNested "Plugin" [
   , noTrace
   , errors
   , typeclasses
+  , strict
   , profiling
   , coverage
   ]

--- a/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+
+module Plugin.Strict.Spec (strict) where
+
+import Test.Tasty.Extras
+
+import PlutusTx.Builtins qualified as Builtins
+import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.Code
+import PlutusTx.Plugin
+import PlutusTx.Prelude qualified as P
+import PlutusTx.Test
+
+import Data.Proxy
+
+strict :: TestNested
+strict = testNested "Strict" [
+    goldenPir "strictAdd" strictAdd
+  , goldenPir "strictAppend" strictAppend
+  , goldenPir "strictAppend2" strictAppend2
+  , goldenPir "strictAppendString" strictAppendString
+  , goldenPir "strictITE" strictITE
+  , goldenPir "strictPair" strictPair
+  , goldenPir "strictList" strictList
+  , goldenPir "strictData" strictData
+  ]
+
+strictAdd :: CompiledCode (Integer -> Integer -> Integer)
+strictAdd = plc (Proxy @"strictLet") strictAddExample
+
+strictAddExample :: Integer -> Integer -> Integer
+strictAddExample !x !y = Builtins.addInteger x y
+
+strictAppend :: CompiledCode (P.BuiltinByteString -> P.BuiltinByteString -> P.BuiltinByteString)
+strictAppend = plc (Proxy @"strictLet") strictAppendExample
+
+strictAppendExample :: P.BuiltinByteString -> P.BuiltinByteString -> P.BuiltinByteString
+strictAppendExample !x !y = Builtins.appendByteString x y
+
+strictAppend2 :: CompiledCode (Wrapper -> Wrapper -> Wrapper)
+strictAppend2 = plc (Proxy @"strictLet") strictAppend2Example
+
+strictAppend2Example :: Wrapper -> Wrapper -> Wrapper
+strictAppend2Example !(Wrapper x) !(Wrapper y) = Wrapper (Builtins.appendByteString x y)
+
+-- Wrapper, like PubKeyHash etc.
+newtype Wrapper = Wrapper P.BuiltinByteString
+
+strictAppendString :: CompiledCode (P.BuiltinString -> P.BuiltinString -> P.BuiltinString)
+strictAppendString = plc (Proxy @"strictAppendString") strictAppendStringExample
+
+strictAppendStringExample :: P.BuiltinString -> P.BuiltinString -> P.BuiltinString
+strictAppendStringExample !x !y = Builtins.appendString x y
+
+strictITE :: CompiledCode (BI.BuiltinBool -> Integer -> Integer -> Integer)
+strictITE = plc (Proxy @"strictITE") strictITEExample
+
+strictITEExample :: BI.BuiltinBool -> Integer -> Integer -> Integer
+strictITEExample !x !y !z = BI.ifThenElse x y z
+
+strictPair :: CompiledCode (BI.BuiltinPair Integer Integer -> Integer)
+strictPair = plc (Proxy @"strictPair") strictPairExample
+
+strictPairExample :: BI.BuiltinPair Integer Integer -> Integer
+strictPairExample !p = BI.fst p
+
+strictList :: CompiledCode (BI.BuiltinList Integer -> Integer)
+strictList = plc (Proxy @"strictList") strictListExample
+
+strictListExample :: BI.BuiltinList Integer -> Integer
+strictListExample !p = BI.head p
+
+strictData :: CompiledCode (BI.BuiltinData -> Integer)
+strictData = plc (Proxy @"strictData") strictDataExample
+
+strictDataExample :: BI.BuiltinData -> Integer
+strictDataExample !d = BI.unsafeDataAsI d

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAdd.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAdd.plc.golden
@@ -1,0 +1,3 @@
+(program
+  (lam x (con integer) (lam y (con integer) [ [ (builtin addInteger) x ] y ]))
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAppend.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAppend.plc.golden
@@ -1,0 +1,7 @@
+(program
+  (lam
+    x
+    (con bytestring)
+    (lam y (con bytestring) [ [ (builtin appendByteString) x ] y ])
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAppend2.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAppend2.plc.golden
@@ -1,0 +1,7 @@
+(program
+  (lam
+    ds
+    (con bytestring)
+    (lam ds (con bytestring) [ [ (builtin appendByteString) ds ] ds ])
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictAppendString.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictAppendString.plc.golden
@@ -1,0 +1,3 @@
+(program
+  (lam x (con string) (lam y (con string) [ [ (builtin appendString) x ] y ]))
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictData.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictData.plc.golden
@@ -1,0 +1,1 @@
+(program (lam d (con data) [ (builtin unIData) d ]))

--- a/plutus-tx-plugin/test/Plugin/Strict/strictITE.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictITE.plc.golden
@@ -1,0 +1,13 @@
+(program
+  (lam
+    x
+    (con bool)
+    (lam
+      y
+      (con integer)
+      (lam
+        z (con integer) [ [ [ { (builtin ifThenElse) (con integer) } x ] y ] z ]
+      )
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictList.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictList.plc.golden
@@ -1,0 +1,5 @@
+(program
+  (lam
+    p [ (con list) (con integer) ] [ { (builtin headList) (con integer) } p ]
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/Strict/strictPair.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Strict/strictPair.plc.golden
@@ -1,0 +1,7 @@
+(program
+  (lam
+    p
+    [ [ (con pair) (con integer) ] (con integer) ]
+    [ { { (builtin fstPair) (con integer) } (con integer) } p ]
+  )
+)

--- a/plutus-tx-plugin/test/StdLib/errorTrace.plc.golden
+++ b/plutus-tx-plugin/test/StdLib/errorTrace.plc.golden
@@ -26,10 +26,13 @@
           (con string)
           [
             { error a }
-            [
-              { [ Unit_match [ [ { trace Unit } str ] Unit ] ] (con unit) }
+            (let
+              (nonrec)
+              (termbind
+                (strict) (vardecl wild Unit) [ [ { trace Unit } str ] Unit ]
+              )
               unitval
-            ]
+            )
           ]
         )
       )

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -13,17 +13,16 @@
 module PlutusTx.Builtins.Internal where
 
 import Codec.Serialise
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData (..))
 import Crypto qualified
 import Data.ByteArray qualified as BA
 import Data.ByteString as BS
 import Data.ByteString.Hash qualified as Hash
 import Data.Coerce (coerce)
-import Data.Hashable (Hashable)
+import Data.Hashable (Hashable (..))
 import Data.Maybe (fromMaybe)
 import Data.Text as Text (Text, empty)
 import Data.Text.Encoding as Text (decodeUtf8, encodeUtf8)
-import GHC.Generics (Generic)
 import PlutusCore.Data qualified as PLC
 import PlutusTx.Utils (mustBeReplaced)
 import Prettyprinter (Pretty (..), viaShow)
@@ -61,6 +60,18 @@ for most of our functions it's not a *semantic* problem. Here, however,
 it is a problem. So we just expose the delayed version as the builtin.
 -}
 
+{- Note [Opaque builtin types]
+We have some opaque types that we use to represent the Plutus builtin types
+in Haskell.
+
+We want them to be opaque so that our users don't do anything with them that
+we can't handle, but also so that GHC doesn't look inside and try and get clever.
+
+In particular, we need to use 'data' rather than 'newtype' even for simple wrappers,
+otherwise GHC gets very keen to optimize through the newtype and e.g. our users
+see 'Addr#' popping up everywhere.
+-}
+
 {-# NOINLINE error #-}
 error :: BuiltinUnit -> a
 error = mustBeReplaced "error"
@@ -69,15 +80,16 @@ error = mustBeReplaced "error"
 BOOL
 -}
 
-newtype BuiltinBool = BuiltinBool Bool
+-- See Note [Opaque builtin types]
+data BuiltinBool = BuiltinBool Bool
 
 {-# NOINLINE true #-}
 true :: BuiltinBool
-true = coerce True
+true = BuiltinBool True
 
 {-# NOINLINE false #-}
 false :: BuiltinBool
-false = coerce False
+false = BuiltinBool False
 
 {-# NOINLINE ifThenElse #-}
 ifThenElse :: BuiltinBool -> a -> a -> a
@@ -87,7 +99,8 @@ ifThenElse (BuiltinBool b) x y = if b then x else y
 UNIT
 -}
 
-newtype BuiltinUnit = BuiltinUnit ()
+-- See Note [Opaque builtin types]
+data BuiltinUnit = BuiltinUnit ()
 
 {-# NOINLINE unitval #-}
 unitval :: BuiltinUnit
@@ -101,6 +114,9 @@ chooseUnit (BuiltinUnit ()) a = a
 INTEGER
 -}
 
+-- I'm somewhat surprised that this works despite not being opaque! GHC doesn't seem to
+-- mess with 'Integer', which is suspicious to me. Probably we *should* make 'BuiltinInteger'
+-- opaque, but that's going to really mess with our users' code...
 type BuiltinInteger = Integer
 
 {-# NOINLINE addInteger #-}
@@ -133,25 +149,46 @@ remainderInteger = coerce (rem @Integer)
 
 {-# NOINLINE lessThanInteger #-}
 lessThanInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
-lessThanInteger = coerce ((<) @Integer)
+lessThanInteger x y = BuiltinBool $ coerce ((<) @Integer) x  y
 
 {-# NOINLINE lessThanEqualsInteger #-}
 lessThanEqualsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
-lessThanEqualsInteger = coerce ((<=) @Integer)
+lessThanEqualsInteger x y = BuiltinBool $ coerce ((<=) @Integer) x y
 
 {-# NOINLINE equalsInteger #-}
 equalsInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinBool
-equalsInteger = coerce ((==) @Integer)
+equalsInteger x y = BuiltinBool $ coerce ((==) @Integer) x y
 
 {-
 BYTESTRING
 -}
 
+-- See Note [Opaque builtin types]
 -- | An opaque type representing Plutus Core ByteStrings.
-newtype BuiltinByteString = BuiltinByteString ByteString
-  deriving stock (Generic)
-  deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord, Haskell.Semigroup, Haskell.Monoid)
-  deriving newtype (Hashable, Serialise, NFData, BA.ByteArrayAccess, BA.ByteArray)
+data BuiltinByteString = BuiltinByteString ByteString
+
+instance Haskell.Show BuiltinByteString where
+    show (BuiltinByteString bs) = show bs
+instance Haskell.Eq BuiltinByteString where
+    (==) (BuiltinByteString bs) (BuiltinByteString bs') = (==) bs bs'
+instance Haskell.Ord BuiltinByteString where
+    compare (BuiltinByteString bs) (BuiltinByteString bs') = compare bs bs'
+instance Haskell.Semigroup BuiltinByteString where
+    (<>) (BuiltinByteString bs) (BuiltinByteString bs') = BuiltinByteString $ (<>) bs bs'
+instance Haskell.Monoid BuiltinByteString where
+    mempty = BuiltinByteString mempty
+instance Hashable BuiltinByteString where
+    hashWithSalt s (BuiltinByteString bs )= hashWithSalt s bs
+instance Serialise BuiltinByteString where
+    encode (BuiltinByteString bs) = encode bs
+    decode = BuiltinByteString <$> decode
+instance NFData BuiltinByteString where
+    rnf (BuiltinByteString bs) = rnf bs
+instance BA.ByteArrayAccess BuiltinByteString where
+    length (BuiltinByteString bs) = BA.length bs
+    withByteArray (BuiltinByteString bs) = BA.withByteArray bs
+instance BA.ByteArray BuiltinByteString where
+    allocRet i p = fmap (fmap BuiltinByteString) $ BA.allocRet i p
 
 instance Pretty BuiltinByteString where
     pretty = viaShow
@@ -195,19 +232,19 @@ blake2b_256 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b b
 {-# NOINLINE verifySignature #-}
 verifySignature :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString -> BuiltinBool
 verifySignature (BuiltinByteString pubKey) (BuiltinByteString message) (BuiltinByteString signature) =
-  coerce (fromMaybe False (Crypto.verifySignature pubKey message signature))
+  BuiltinBool (fromMaybe False (Crypto.verifySignature pubKey message signature))
 
 {-# NOINLINE equalsByteString #-}
 equalsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
-equalsByteString (BuiltinByteString b1) (BuiltinByteString b2) = coerce $ ((==) @ByteString) b1 b2
+equalsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 == b2
 
 {-# NOINLINE lessThanByteString #-}
 lessThanByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
-lessThanByteString (BuiltinByteString b1) (BuiltinByteString b2) = coerce $ ((<) @ByteString) b1 b2
+lessThanByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 < b2
 
 {-# NOINLINE lessThanEqualsByteString #-}
 lessThanEqualsByteString :: BuiltinByteString -> BuiltinByteString -> BuiltinBool
-lessThanEqualsByteString (BuiltinByteString b1) (BuiltinByteString b2) = coerce $ ((<=) @ByteString) b1 b2
+lessThanEqualsByteString (BuiltinByteString b1) (BuiltinByteString b2) = BuiltinBool $ b1 <= b2
 
 {-# NOINLINE decodeUtf8 #-}
 decodeUtf8 :: BuiltinByteString -> BuiltinString
@@ -217,8 +254,15 @@ decodeUtf8 (BuiltinByteString b) = BuiltinString $ Text.decodeUtf8 b
 STRING
 -}
 
-newtype BuiltinString = BuiltinString Text
-    deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord)
+-- See Note [Opaque builtin types]
+data BuiltinString = BuiltinString Text
+
+instance Haskell.Show BuiltinString where
+    show (BuiltinString t) = show t
+instance Haskell.Eq BuiltinString where
+    (==) (BuiltinString t) (BuiltinString t') = (==) t t'
+instance Haskell.Ord BuiltinString where
+    compare (BuiltinString t) (BuiltinString t') = compare t t'
 
 {-# NOINLINE appendString #-}
 appendString :: BuiltinString -> BuiltinString -> BuiltinString
@@ -230,7 +274,7 @@ emptyString = BuiltinString Text.empty
 
 {-# NOINLINE equalsString #-}
 equalsString :: BuiltinString -> BuiltinString -> BuiltinBool
-equalsString (BuiltinString s1) (BuiltinString s2) = coerce $ ((==) @Text) s1 s2
+equalsString (BuiltinString s1) (BuiltinString s2) = BuiltinBool $ s1 == s2
 
 {-# NOINLINE trace #-}
 trace :: BuiltinString -> a -> a
@@ -244,8 +288,15 @@ encodeUtf8 (BuiltinString s) = BuiltinByteString $ Text.encodeUtf8 s
 PAIR
 -}
 
-newtype BuiltinPair a b = BuiltinPair (a, b)
-    deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord)
+-- See Note [Opaque builtin types]
+data BuiltinPair a b = BuiltinPair (a, b)
+
+instance (Haskell.Show a, Haskell.Show b) => Haskell.Show (BuiltinPair a b) where
+    show (BuiltinPair p) = show p
+instance (Haskell.Eq a, Haskell.Eq b) => Haskell.Eq (BuiltinPair a b) where
+    (==) (BuiltinPair p) (BuiltinPair p') = (==) p p'
+instance (Haskell.Ord a, Haskell.Ord b) => Haskell.Ord (BuiltinPair a b) where
+    compare (BuiltinPair p) (BuiltinPair p') = compare p p'
 
 {-# NOINLINE fst #-}
 fst :: BuiltinPair a b -> a
@@ -263,13 +314,20 @@ mkPairData d1 d2 = BuiltinPair (d1, d2)
 LIST
 -}
 
-newtype BuiltinList a = BuiltinList [a]
-    deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord)
+-- See Note [Opaque builtin types]
+data BuiltinList a = BuiltinList [a]
+
+instance Haskell.Show a => Haskell.Show (BuiltinList a) where
+    show (BuiltinList l) = show l
+instance Haskell.Eq a => Haskell.Eq (BuiltinList a) where
+    (==) (BuiltinList l) (BuiltinList l') = (==) l l'
+instance Haskell.Ord a => Haskell.Ord (BuiltinList a) where
+    compare (BuiltinList l) (BuiltinList l') = compare l l'
 
 {-# NOINLINE null #-}
 null :: BuiltinList a -> BuiltinBool
-null (BuiltinList (_:_)) = coerce False
-null (BuiltinList [])    = coerce True
+null (BuiltinList (_:_)) = BuiltinBool False
+null (BuiltinList [])    = BuiltinBool True
 
 {-# NOINLINE head #-}
 head :: BuiltinList a -> a
@@ -278,7 +336,7 @@ head (BuiltinList [])    = Haskell.error "empty list"
 
 {-# NOINLINE tail #-}
 tail :: BuiltinList a -> BuiltinList a
-tail (BuiltinList (_:xs)) = coerce xs
+tail (BuiltinList (_:xs)) = BuiltinList xs
 tail (BuiltinList [])     = Haskell.error "empty list"
 
 {-# NOINLINE chooseList #-}
@@ -314,8 +372,14 @@ that you want to be representable on-chain.
 For off-chain usage, there are conversion functions 'builtinDataToData' and
 'dataToBuiltinData', but note that these will not work on-chain.
 -}
-newtype BuiltinData = BuiltinData PLC.Data
-    deriving newtype (Haskell.Show, Haskell.Eq, Haskell.Ord)
+data BuiltinData = BuiltinData PLC.Data
+
+instance Haskell.Show BuiltinData where
+    show (BuiltinData d) = show d
+instance Haskell.Eq BuiltinData where
+    (==) (BuiltinData d) (BuiltinData d') = (==) d d'
+instance Haskell.Ord BuiltinData where
+    compare (BuiltinData d) (BuiltinData d') = compare d d'
 
 -- NOT a builtin, only safe off-chain, hence the NOINLINE
 {-# NOINLINE builtinDataToData #-}
@@ -340,15 +404,17 @@ chooseData (BuiltinData d) constrCase mapCase listCase iCase bCase = case d of
 
 {-# NOINLINE mkConstr #-}
 mkConstr :: BuiltinInteger -> BuiltinList BuiltinData -> BuiltinData
-mkConstr i args = BuiltinData (PLC.Constr i (coerce args))
+mkConstr i (BuiltinList args) = BuiltinData (PLC.Constr i (fmap builtinDataToData args))
 
 {-# NOINLINE mkMap #-}
 mkMap :: BuiltinList (BuiltinPair BuiltinData BuiltinData) -> BuiltinData
-mkMap es = BuiltinData (PLC.Map (coerce es))
+mkMap (BuiltinList es) = BuiltinData (PLC.Map $ (fmap p2p es))
+  where
+      p2p (BuiltinPair (d, d')) = (builtinDataToData d, builtinDataToData d')
 
 {-# NOINLINE mkList #-}
 mkList :: BuiltinList BuiltinData -> BuiltinData
-mkList l = BuiltinData (PLC.List (coerce l))
+mkList (BuiltinList l) = BuiltinData (PLC.List (fmap builtinDataToData l))
 
 {-# NOINLINE mkI #-}
 mkI :: BuiltinInteger -> BuiltinData
@@ -360,17 +426,19 @@ mkB (BuiltinByteString b) = BuiltinData (PLC.B b)
 
 {-# NOINLINE unsafeDataAsConstr #-}
 unsafeDataAsConstr :: BuiltinData -> BuiltinPair BuiltinInteger (BuiltinList BuiltinData)
-unsafeDataAsConstr (BuiltinData (PLC.Constr i args)) = BuiltinPair (i, coerce args)
+unsafeDataAsConstr (BuiltinData (PLC.Constr i args)) = BuiltinPair (i, BuiltinList $ fmap dataToBuiltinData args)
 unsafeDataAsConstr _                                 = Haskell.error "not a Constr"
 
 {-# NOINLINE unsafeDataAsMap #-}
 unsafeDataAsMap :: BuiltinData -> BuiltinList (BuiltinPair BuiltinData BuiltinData)
-unsafeDataAsMap (BuiltinData (PLC.Map m)) = coerce m
+unsafeDataAsMap (BuiltinData (PLC.Map m)) = BuiltinList (fmap p2p m)
+  where
+      p2p (d, d') = BuiltinPair (dataToBuiltinData d, dataToBuiltinData d')
 unsafeDataAsMap _                         = Haskell.error "not a Map"
 
 {-# NOINLINE unsafeDataAsList #-}
 unsafeDataAsList :: BuiltinData -> BuiltinList BuiltinData
-unsafeDataAsList (BuiltinData (PLC.List l)) = coerce l
+unsafeDataAsList (BuiltinData (PLC.List l)) = BuiltinList (fmap dataToBuiltinData l)
 unsafeDataAsList _                          = Haskell.error "not a List"
 
 {-# NOINLINE unsafeDataAsI #-}
@@ -385,4 +453,4 @@ unsafeDataAsB _                       = Haskell.error "not a B"
 
 {-# NOINLINE equalsData #-}
 equalsData :: BuiltinData -> BuiltinData -> BuiltinBool
-equalsData (BuiltinData b1) (BuiltinData b2) = coerce $ b1 Haskell.== b2
+equalsData (BuiltinData b1) (BuiltinData b2) = BuiltinBool $ b1 Haskell.== b2


### PR DESCRIPTION
In the presence of bang patterns, GHC will very aggressively take apart
`BuiltinByteString`s and look into the underlying `ByteString`. This is
bad for our users.

We can avoid this by making `BuiltinByteString` `data` instead of
`newtype` (at the cost of writing some tedious instnaces). (Also
applies to the other `Builtin*` types that were supposed to be opaque.)

However, that doesn't save us entirely. GHC will still generate pattern
matches on `BuiltinByteString` to evaluate it. For some reason, it
doesn't generate default-only matches (which we already handle), even
though it doesn't use any of the variables that it binds.

Fortunatley, we can easily adapt the code to handle the more general
case of single-alternative case expressions which don't use any of the
bound variables.

(I scratched my head about why this wasn't working for a while until I
came to the realisation recorded in `Note [Occurrence analysis]`.)

As a bonus, this also generates slightly better code for the common case
of matching on `Unit`, which happens to generate such pattern matches
also!

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
