### PR TITLE
[NameHandling] Use a specialized 'deBruijnTerm'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -164,6 +164,7 @@ data Levels = Levels
 declareUnique :: (MonadReader Levels m, HasUnique name unique) => name -> m a -> m a
 declareUnique n =
     local $ \(Levels current ls) -> Levels current $ BM.insert (n ^. theUnique) current ls
+{-# INLINE declareUnique #-}
 
 {-| Declares a new binder by assigning a fresh unique to the *current level*.
 Maintains invariant-B of 'Levels' (that only positive levels are stored),

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+
 -- | Support for using de Bruijn indices for term names.
 module UntypedPlutusCore.DeBruijn
     ( Index (..)
@@ -12,6 +13,7 @@ module UntypedPlutusCore.DeBruijn
     , FreeVariableError (..)
     , AsFreeVariableError (..)
     , deBruijnTerm
+    , deBruijnTermEither
     , unDeBruijnTerm
     , unNameDeBruijn
     , fakeNameDeBruijn
@@ -43,6 +45,14 @@ deBruijnTerm
     => Term Name uni fun ann -> m (Term NamedDeBruijn uni fun ann)
 deBruijnTerm = deBruijnTermWith freeUniqueThrow
 
+-- | Convert a 'Term' with 'Name's into a 'Term' with 'DeBruijn's.
+-- Will throw an error if a free variable is encountered.
+deBruijnTermEither
+    :: AsFreeVariableError e
+    => Term Name uni fun ann -> Either e (Term NamedDeBruijn uni fun ann)
+deBruijnTermEither = deBruijnTermWith freeUniqueThrow
+{-# INLINE deBruijnTerm #-}
+
 -- | Convert a 'Term' with 'DeBruijn's into a 'Term' with 'Name's.
 -- Will throw an error if a free variable is encountered.
 unDeBruijnTerm
@@ -57,6 +67,7 @@ deBruijnTermWith
     -> Term Name uni fun ann
     -> m (Term NamedDeBruijn uni fun ann)
 deBruijnTermWith = (runDeBruijnT .) . deBruijnTermWithM
+{-# INLINE deBruijnTermWith #-}
 
 -- | Takes a "handler" function to execute when encountering free variables.
 unDeBruijnTermWith
@@ -88,6 +99,7 @@ deBruijnTermWithM h = go
        Constant ann con -> pure $ Constant ann con
        Builtin ann bn -> pure $ Builtin ann bn
        Error ann -> pure $ Error ann
+{-# INLINE deBruijnTermWithM #-}
 
 -- | Takes a "handler" function to execute when encountering free variables.
 unDeBruijnTermWithM

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -69,7 +69,6 @@ import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Quote
 
-import Control.Monad.Except
 import Control.Monad.State
 import Data.Bifunctor
 import Data.Ix (Ix)
@@ -100,7 +99,7 @@ runCek
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost, [Text])
 runCek params mode emitMode term =
     -- translating input
-    case runExcept @FreeVariableError $ deBruijnTerm term of
+    case deBruijnTermEither @FreeVariableError term of
         Left fvError -> throw fvError
         Right dbt -> do
             -- Don't use 'let': https://github.com/input-output-hk/plutus/issues/3876


### PR DESCRIPTION
Given that `deBruijnTerm` is linear in the size of the program, specializing it may help, who knows.