### PR TITLE
[Builtins] Add 'TestTypesFromTheUniverseAreAllContained'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -175,6 +175,9 @@ instance DefaultUni `Contains` []            where knownUni = DefaultUniProtoLis
 instance DefaultUni `Contains` (,)           where knownUni = DefaultUniProtoPair
 instance DefaultUni `Contains` Data          where knownUni = DefaultUniData
 
+-- If this tells you a 'Contains' instance is missing, add it right above, following the pattern.
+instance TestTypesFromTheUniverseAreAllContained DefaultUni
+
 instance (DefaultUni `Contains` f, DefaultUni `Contains` a) => DefaultUni `Contains` f a where
     knownUni = knownUni `DefaultUniApply` knownUni
 

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -32,6 +32,7 @@ module Universe.Core
     , Permits
     , EverywhereAll
     , type (<:)
+    , TestTypesFromTheUniverseAreAllContained
     , HasUniApply (..)
     , checkStar
     , withApplicable
@@ -544,6 +545,10 @@ type family uni `EverywhereAll` constrs where
 
 -- | A constraint for \"@uni1@ is a subuniverse of @uni2@\".
 type uni1 <: uni2 = uni1 `Everywhere` Includes uni2
+
+-- | An instance of this class not having any constraints ensures that every type
+-- (according to 'Everywhere') from the universe has a 'Contains' instance.
+class uni <: uni => TestTypesFromTheUniverseAreAllContained uni
 
 -- | A class for \"@uni@ has general type application\".
 class HasUniApply (uni :: Type -> Type) where


### PR DESCRIPTION
I realized that we check whether all types from the universe implement `KnownBuiltinTypeIn`, but don't check where each of them has a `Contains` instance. This PR fixes that.