### PR TITLE
Fix ExMemoryUsage bug for bytestring

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -173,7 +173,7 @@ instance ExMemoryUsage Integer where
    1 + (toInteger $ BS.length bs) `div` 8, which would count one extra for
    things whose sizes are multiples of 8. -}
 instance ExMemoryUsage BS.ByteString where
-  memoryUsage bs = ExMemory $ ((n-1) `div` 8) + 1
+  memoryUsage bs = ExMemory $ ((n-1) `quot` 8) + 1  -- Don't use `div` here!  That gives 1 instead of 0 for n=0.
       where n = fromIntegral $ BS.length bs :: SatInt
 
 {- Text objects are UTF-16 encoded, which uses two bytes per character (strictly,


### PR DESCRIPTION
In commit https://github.com/input-output-hk/plutus/commit/9c75e5265ba346a7b389036ee9596a7c58d52ecc I tidied up the size function for the `bytestring` type but I introduced a bug because the memory usage of the empty bytestring increased from 0 to 1, causing some previously OK scripts to fail validation because the cost increased slightly (specifically, the cost of calling `equalsByteString`.  This should fix that.

Here's the change that caused the problem:
![ExMemoryChange](https://user-images.githubusercontent.com/2124565/154107742-a395ce4a-4728-416c-81d2-0a25878afb71.png)


<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
