### PR TITLE
SCP-3527: Address remaining PR#4349 comments

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -126,6 +126,8 @@
           "PlutusCore/Evaluation/Machine/ExBudgetingDefaults"
           "PlutusCore/InlineUtils"
           "PlutusCore/Parser/ParserCommon"
+          "PlutusCore/Parser/Type"
+          "PlutusCore/Parser/Builtin"
           "PlutusCore/Pretty/Classic"
           "PlutusCore/Pretty/ConfigName"
           "PlutusCore/Pretty/Default"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -126,6 +126,8 @@
           "PlutusCore/Evaluation/Machine/ExBudgetingDefaults"
           "PlutusCore/InlineUtils"
           "PlutusCore/Parser/ParserCommon"
+          "PlutusCore/Parser/Type"
+          "PlutusCore/Parser/Builtin"
           "PlutusCore/Pretty/Classic"
           "PlutusCore/Pretty/ConfigName"
           "PlutusCore/Pretty/Default"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -126,6 +126,8 @@
           "PlutusCore/Evaluation/Machine/ExBudgetingDefaults"
           "PlutusCore/InlineUtils"
           "PlutusCore/Parser/ParserCommon"
+          "PlutusCore/Parser/Type"
+          "PlutusCore/Parser/Builtin"
           "PlutusCore/Pretty/Classic"
           "PlutusCore/Pretty/ConfigName"
           "PlutusCore/Pretty/Default"

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -74,7 +74,7 @@ class Executable p where
   -- | Parse a program.
   parseProgram ::
     BSL.ByteString ->
-      Either (ParseErrorBundle T.Text PLC.ParseError) (p PLC.SourcePos)
+      Either (ParseErrorBundle T.Text PLC.ParserError) (p PLC.SourcePos)
 
   -- | Check a program for unique names.
   -- Throws a @UniqueError@ when not all names are unique.
@@ -285,7 +285,7 @@ parseInput inp = do
     -- parse the UPLC program
     case parseProgram bsContents of
       -- when fail, pretty print the parse errors.
-      Left (err :: ParseErrorBundle T.Text PLC.ParseError) ->
+      Left (err :: ParseErrorBundle T.Text PLC.ParserError) ->
         errorWithoutStackTrace $ errorBundlePretty err
       -- otherwise,
       Right p -> do

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -190,6 +190,8 @@ library
         PlutusCore.Evaluation.Machine.ExBudgetingDefaults
         PlutusCore.InlineUtils
         PlutusCore.Parser.ParserCommon
+        PlutusCore.Parser.Type
+        PlutusCore.Parser.Builtin
         PlutusCore.Pretty.Classic
         PlutusCore.Pretty.ConfigName
         PlutusCore.Pretty.ConfigName

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -46,7 +46,7 @@ module PlutusCore
     , Type (..)
     , typeSubtypes
     , Kind (..)
-    , ParseError (..)
+    , ParserError (..)
     , Version (..)
     , Program (..)
     , Name (..)

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -15,7 +15,7 @@
 
 module PlutusCore.Error
     ( ParserError (..)
-    -- , AsParserError (..)
+    , AsParserError (..)
     , NormCheckError (..)
     , AsNormCheckError (..)
     , UniqueError (..)
@@ -60,6 +60,7 @@ data ParserError
     | InvalidBuiltinConstant T.Text T.Text SourcePos
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (NFData)
+makeClassyPrisms ''ParserError
 
 instance Show ParserError
     where

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -112,8 +112,8 @@ data Error uni fun ann
 makeClassyPrisms ''Error
 deriving stock instance (Show fun, Show ann, Closed uni, Everywhere uni Show, GShow uni, Show ParserError) => Show (Error uni fun ann)
 
--- instance AsParseError (Error uni fun ann) where
---     _ParseError = _ParseErrorE
+-- instance AsParserError (Error uni fun ann) where
+--     _ParserError = _ParseErrorE
 
 instance AsUniqueError (Error uni fun ann) ann where
     _UniqueError = _UniqueCoherencyErrorE
@@ -196,6 +196,12 @@ instance (GShow uni, Closed uni, uni `Everywhere` PrettyConst, Pretty fun, Prett
     prettyBy config (TypeErrorE e)            = prettyBy config e
     prettyBy config (NormCheckErrorE e)       = prettyBy config e
     prettyBy _      (FreeVariableErrorE e)    = pretty e
+
+instance HasErrorCode ParserError where
+    errorCode InvalidBuiltinConstant {} = ErrorCode 10
+    errorCode UnknownBuiltinFunction {} = ErrorCode 9
+    errorCode UnknownBuiltinType {}     = ErrorCode 8
+    errorCode BuiltinTypeNotAStar {}    = ErrorCode 51
 
 instance HasErrorCode (ParseErrorBundle T.Text ParserError) where
     errorCode (ParseErrorBundle (NE.head -> (FancyError _ (Set.findMin -> (ErrorCustom InvalidBuiltinConstant {})))) _) = ErrorCode 10

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -3,7 +3,8 @@
 -- | Parsers for PLC terms in DefaultUni.
 
 module PlutusCore.Parser
-    ( parseProgram
+    ( module Export
+    , parseProgram
     , parseTerm
     , parseType
     , ParserError(..)
@@ -16,7 +17,9 @@ import PlutusCore.Default
 import PlutusCore.Error (ParserError (..))
 import PlutusCore.MkPlc (mkIterApp, mkIterInst)
 import PlutusCore.Name (Name, TyName)
-import PlutusCore.Parser.ParserCommon
+import PlutusCore.Parser.Builtin as Export
+import PlutusCore.Parser.ParserCommon as Export
+import PlutusCore.Parser.Type as Export
 import Text.Megaparsec (MonadParsec (notFollowedBy), SourcePos, anySingle, choice, getSourcePos, many, some, try)
 import Text.Megaparsec.Error (ParseErrorBundle)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -6,14 +6,14 @@ module PlutusCore.Parser
     ( parseProgram
     , parseTerm
     , parseType
-    , ParseError(..)
+    , ParserError(..)
     ) where
 
 import Data.ByteString.Lazy (ByteString)
 import Data.Text qualified as T
 import PlutusCore.Core (Program (..), Term (..), Type)
 import PlutusCore.Default
-import PlutusCore.Error (ParseError (..))
+import PlutusCore.Error (ParserError (..))
 import PlutusCore.MkPlc (mkIterApp, mkIterInst)
 import PlutusCore.Name (Name, TyName)
 import PlutusCore.Parser.ParserCommon
@@ -76,7 +76,7 @@ term = choice $ map try
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseProgram ::
-    ByteString -> Either (ParseErrorBundle T.Text ParseError) (Program TyName Name DefaultUni DefaultFun SourcePos)
+    ByteString -> Either (ParseErrorBundle T.Text ParserError) (Program TyName Name DefaultUni DefaultFun SourcePos)
 parseProgram = parseGen program
 
 -- | Parser for PLC programs.
@@ -90,12 +90,12 @@ program = whitespace >> do
 -- of handling any parse errors.
 parseTerm ::
     ByteString ->
-        Either (ParseErrorBundle T.Text ParseError) (Term TyName Name DefaultUni DefaultFun SourcePos)
+        Either (ParseErrorBundle T.Text ParserError) (Term TyName Name DefaultUni DefaultFun SourcePos)
 parseTerm = parseGen term
 
 -- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseType ::
     ByteString ->
-        Either (ParseErrorBundle T.Text ParseError) (Type TyName DefaultUni SourcePos)
+        Either (ParseErrorBundle T.Text ParserError) (Type TyName DefaultUni SourcePos)
 parseType = parseGen pType

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -68,6 +68,7 @@ builtinFnList =
     , (UnIData,"unIData")
     , (UnBData,"unBData")
     , (EqualsData,"equalsData")
+    , (SerialiseData,"serialiseData")
     , (MkPairData,"mkPairData")
     , (MkNilData,"mkNilData")
     , (MkNilPairData,"mkNilPairData")

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module PlutusCore.Parser.Builtin where
+
+import Data.Text qualified as T
+import Data.Text.Internal.Read (hexDigitToInt)
+import PlutusPrelude
+import Text.Megaparsec hiding (ParseError, State, parse, some)
+import Text.Megaparsec.Char (char, hexDigitChar)
+import Text.Megaparsec.Char.Lexer qualified as Lex hiding (hexadecimal)
+
+import Data.ByteString (pack)
+import PlutusCore.Default
+import PlutusCore.Parser.ParserCommon (Parser, lexeme, symbol, whitespace)
+import PlutusCore.Parser.Type (defaultUniType)
+
+
+-- | The list of parsable default functions and their pretty print correspondence.
+builtinFnList :: [(DefaultFun, T.Text)]
+builtinFnList =
+    [ (AddInteger,"addInteger")
+    , (SubtractInteger,"subtractInteger")
+    , (MultiplyInteger,"multiplyInteger")
+    , (DivideInteger,"divideInteger")
+    , (QuotientInteger,"quotientInteger")
+    , (RemainderInteger,"remainderInteger")
+    , (ModInteger,"modInteger")
+    , (EqualsInteger,"equalsInteger")
+    , (LessThanInteger,"lessThanInteger")
+    , (LessThanEqualsInteger,"lessThanEqualsInteger")
+    , (AppendByteString,"appendByteString")
+    , (ConsByteString,"consByteString")
+    , (SliceByteString,"sliceByteString")
+    , (LengthOfByteString,"lengthOfByteString")
+    , (IndexByteString,"indexByteString")
+    , (EqualsByteString,"equalsByteString")
+    , (LessThanByteString,"lessThanByteString")
+    , (LessThanEqualsByteString,"lessThanEqualsByteString")
+    , (Sha2_256,"sha2_256")
+    , (Sha3_256,"sha3_256")
+    , (Blake2b_256,"blake2b_256")
+    , (VerifySignature,"verifySignature")
+    , (AppendString,"appendString")
+    , (EqualsString,"equalsString")
+    , (EncodeUtf8,"encodeUtf8")
+    , (DecodeUtf8,"decodeUtf8")
+    , (IfThenElse,"ifThenElse")
+    , (ChooseUnit,"chooseUnit")
+    , (Trace,"trace")
+    , (FstPair,"fstPair")
+    , (SndPair,"sndPair")
+    , (ChooseList,"chooseList")
+    , (MkCons,"mkCons")
+    , (HeadList,"headList")
+    , (TailList,"tailList")
+    , (NullList,"nullList")
+    , (ChooseData,"chooseData")
+    , (ConstrData,"constrData")
+    , (MapData,"mapData")
+    , (ListData,"listData")
+    , (IData,"iData")
+    , (BData,"bData")
+    , (UnConstrData,"unConstrData")
+    , (UnMapData,"unMapData")
+    , (UnListData,"unListData")
+    , (UnIData,"unIData")
+    , (UnBData,"unBData")
+    , (EqualsData,"equalsData")
+    , (MkPairData,"mkPairData")
+    , (MkNilData,"mkNilData")
+    , (MkNilPairData,"mkNilPairData")
+    ]
+
+builtinFunction :: Parser DefaultFun
+builtinFunction =
+    choice $
+        map
+            (try . (\(fn, text) -> fn <$ symbol text))
+            builtinFnList
+
+signedInteger :: Parser Integer
+signedInteger = Lex.signed whitespace (lexeme Lex.decimal)
+
+-- | Parser for integer constants.
+conInt :: Parser (Some (ValueOf DefaultUni))
+conInt = do
+    con::Integer <- signedInteger
+    pure $ someValue con
+
+-- | Parser for a pair of hex digits to a Word8.
+hexByte :: Parser Word8
+hexByte = do
+    high <- hexDigitChar
+    low <- hexDigitChar
+    return $ fromIntegral (hexDigitToInt high * 16 + hexDigitToInt low)
+
+-- | Parser for bytestring constants. They start with "#".
+conBS :: Parser (Some (ValueOf DefaultUni))
+conBS = do
+    _ <- char '#'
+    bytes <- Text.Megaparsec.many hexByte
+    pure $ someValue $ pack bytes
+
+-- | Parser for string constants. They are wrapped in double quotes.
+conText :: Parser (Some (ValueOf DefaultUni))
+conText = do
+    con <- char '\"' *> manyTill Lex.charLiteral (char '\"')
+    pure $ someValue $ T.pack con
+
+-- | Parser for unit.
+conUnit :: Parser (Some (ValueOf DefaultUni))
+conUnit = someValue () <$ symbol "()"
+
+-- | Parser for bool.
+conBool :: Parser (Some (ValueOf DefaultUni))
+conBool = choice
+    [ someValue True <$ symbol "True"
+    , someValue False <$ symbol "False"
+    ]
+
+-- | Parser for a constant term. Currently the syntax is "con defaultUniType val".
+constant :: Parser (Some (ValueOf DefaultUni))
+constant = do
+    conTy <- defaultUniType
+    con <-
+        case conTy of --TODO add Lists, Pairs, Data, App
+            SomeTypeIn DefaultUniInteger    -> conInt
+            SomeTypeIn DefaultUniByteString -> conBS
+            SomeTypeIn DefaultUniString     -> conText
+            SomeTypeIn DefaultUniUnit       -> conUnit
+            SomeTypeIn DefaultUniBool       -> conBool
+    whitespace
+    pure con
+

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -31,7 +31,7 @@ newtype ParserState = ParserState { identifiers :: M.Map T.Text Unique }
     deriving stock (Show)
 
 type Parser =
-    ParsecT ParseError T.Text (StateT ParserState Quote)
+    ParsecT ParserError T.Text (StateT ParserState Quote)
 
 instance (Stream s, MonadQuote m) => MonadQuote (ParsecT e s m)
 
@@ -53,16 +53,16 @@ intern n = do
             put $ ParserState identifiers'
             return fresh
 
-parse :: Parser a -> String -> T.Text -> Either (ParseErrorBundle T.Text ParseError) a
+parse :: Parser a -> String -> T.Text -> Either (ParseErrorBundle T.Text ParserError) a
 parse p file str = runQuote $ parseQuoted p file str
 
 -- | Generic parser function.
-parseGen :: Parser a -> ByteString -> Either (ParseErrorBundle T.Text ParseError) a
+parseGen :: Parser a -> ByteString -> Either (ParseErrorBundle T.Text ParserError) a
 parseGen stuff bs = parse stuff "test" $ (T.pack . unpackChars) bs
 
 parseQuoted ::
     Parser a -> String -> T.Text ->
-        Quote (Either (ParseErrorBundle T.Text ParseError) a)
+        Quote (Either (ParseErrorBundle T.Text ParserError) a)
 parseQuoted p file str = flip evalStateT initial $ runParserT p file str
 
 -- | Space consumer.
@@ -240,7 +240,7 @@ enforce p = do
     guard . not $ T.null input
     pure x
 
-signedInteger :: ParsecT ParseError T.Text (StateT ParserState Quote) Integer
+signedInteger :: ParsecT ParserError T.Text (StateT ParserState Quote) Integer
 signedInteger = Lex.signed whitespace (lexeme Lex.decimal)
 
 -- | Parser for integer constants.

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 -- | Common functions for parsers of UPLC, PLC, and PIR.
 
 module PlutusCore.Parser.ParserCommon where
@@ -10,20 +9,16 @@ module PlutusCore.Parser.ParserCommon where
 import Data.Char (isAlphaNum)
 import Data.Map qualified as M
 import Data.Text qualified as T
-import Data.Text.Internal.Read (hexDigitToInt)
 import PlutusPrelude
 import Text.Megaparsec hiding (ParseError, State, parse, some)
-import Text.Megaparsec.Char (char, hexDigitChar, letterChar, space1)
+import Text.Megaparsec.Char (char, letterChar, space1)
 import Text.Megaparsec.Char.Lexer qualified as Lex hiding (hexadecimal)
 
 import Control.Monad.State (MonadState (get, put), StateT, evalStateT)
-import Data.ByteString (pack)
 import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Lazy.Internal (unpackChars)
 import PlutusCore.Core.Type
-import PlutusCore.Default
 import PlutusCore.Error
-import PlutusCore.MkPlc (mkIterTyApp)
 import PlutusCore.Name
 import PlutusCore.Quote
 
@@ -75,63 +70,6 @@ lexeme = Lex.lexeme whitespace
 symbol :: T.Text -> Parser T.Text
 symbol = Lex.symbol whitespace
 
--- | A PLC @Type@ to be parsed. ATM the parser only works
--- for types in the @DefaultUni@ with @DefaultFun@.
-type PType = Type TyName DefaultUni SourcePos
-
-varType :: Parser PType
-varType = TyVar <$> getSourcePos <*> tyName
-
-funType :: Parser PType
-funType = inParens $ TyFun <$> wordPos "fun" <*> pType <*> pType
-
-allType :: Parser PType
-allType = inParens $ TyForall <$> wordPos "all" <*> tyName <*> kind <*> pType
-
-lamType :: Parser PType
-lamType = inParens $ TyLam <$> wordPos "lam" <*> tyName <*> kind <*> pType
-
-ifixType :: Parser PType
-ifixType = inParens $ TyIFix <$> wordPos "ifix" <*> pType <*> pType
-
-builtinType :: Parser PType
-builtinType = inParens $ TyBuiltin <$> wordPos "con" <*> defaultUniType
-
-appType :: Parser PType
-appType = inBrackets $ do
-    pos  <- getSourcePos
-    fn   <- pType
-    args <- some pType
-    pure $ mkIterTyApp pos fn args
-
-kind :: Parser (Kind SourcePos)
-kind = inParens (typeKind <|> funKind)
-    where
-        typeKind = Type <$> wordPos "type"
-        funKind  = KindArrow <$> wordPos "fun" <*> kind <*> kind
-
--- | Parser for @PType@.
-pType :: Parser PType
-pType = choice $ map try
-    [ funType
-    , ifixType
-    , allType
-    , builtinType
-    , lamType
-    , appType
-    , varType
-    ]
-
-defaultUniType :: Parser (SomeTypeIn DefaultUni)
-defaultUniType = choice $ map try
-  [ inParens defaultUniType
-  , SomeTypeIn DefaultUniInteger <$ symbol "integer"
-  , SomeTypeIn DefaultUniByteString <$ symbol "bytestring"
-  , SomeTypeIn DefaultUniString <$ symbol "string"
-  , SomeTypeIn DefaultUniUnit <$ symbol "unit"
-  , SomeTypeIn DefaultUniBool <$ symbol "bool"
-  ] --TODO complete all defaultUni types
-
 inParens :: Parser a -> Parser a
 inParens = between (symbol "(") (symbol ")")
 
@@ -151,70 +89,6 @@ wordPos ::
     T.Text -> Parser SourcePos
 wordPos w = lexeme $ try $ getSourcePos <* symbol w
 
--- | The list of parsable default functions and their pretty print correspondence.
-builtinFnList :: [(DefaultFun, T.Text)]
-builtinFnList =
-    [ (AddInteger,"addInteger")
-    , (SubtractInteger,"subtractInteger")
-    , (MultiplyInteger,"multiplyInteger")
-    , (DivideInteger,"divideInteger")
-    , (QuotientInteger,"quotientInteger")
-    , (RemainderInteger,"remainderInteger")
-    , (ModInteger,"modInteger")
-    , (EqualsInteger,"equalsInteger")
-    , (LessThanInteger,"lessThanInteger")
-    , (LessThanEqualsInteger,"lessThanEqualsInteger")
-    , (AppendByteString,"appendByteString")
-    , (ConsByteString,"consByteString")
-    , (SliceByteString,"sliceByteString")
-    , (LengthOfByteString,"lengthOfByteString")
-    , (IndexByteString,"indexByteString")
-    , (EqualsByteString,"equalsByteString")
-    , (LessThanByteString,"lessThanByteString")
-    , (LessThanEqualsByteString,"lessThanEqualsByteString")
-    , (Sha2_256,"sha2_256")
-    , (Sha3_256,"sha3_256")
-    , (Blake2b_256,"blake2b_256")
-    , (VerifySignature,"verifySignature")
-    , (AppendString,"appendString")
-    , (EqualsString,"equalsString")
-    , (EncodeUtf8,"encodeUtf8")
-    , (DecodeUtf8,"decodeUtf8")
-    , (IfThenElse,"ifThenElse")
-    , (ChooseUnit,"chooseUnit")
-    , (Trace,"trace")
-    , (FstPair,"fstPair")
-    , (SndPair,"sndPair")
-    , (ChooseList,"chooseList")
-    , (MkCons,"mkCons")
-    , (HeadList,"headList")
-    , (TailList,"tailList")
-    , (NullList,"nullList")
-    , (ChooseData,"chooseData")
-    , (ConstrData,"constrData")
-    , (MapData,"mapData")
-    , (ListData,"listData")
-    , (IData,"iData")
-    , (BData,"bData")
-    , (UnConstrData,"unConstrData")
-    , (UnMapData,"unMapData")
-    , (UnListData,"unListData")
-    , (UnIData,"unIData")
-    , (UnBData,"unBData")
-    , (EqualsData,"equalsData")
-    , (SerialiseData,"serialiseData")
-    , (MkPairData,"mkPairData")
-    , (MkNilData,"mkNilData")
-    , (MkNilPairData,"mkNilPairData")
-    ]
-
-builtinFunction :: Parser DefaultFun
-builtinFunction =
-    choice $
-        map
-            (try . (\(fn, text) -> fn <$ symbol text))
-            builtinFnList
-
 version :: Parser (Version SourcePos)
 version = lexeme $ do
     p <- getSourcePos
@@ -230,66 +104,3 @@ name = lexeme $ try $ do
     str <- takeWhileP (Just "identifier") isIdentifierChar
     Name str <$> intern str
 
-tyName :: Parser TyName
-tyName = TyName <$> name
-
--- | Turn a parser that can succeed without consuming any input into one that fails in this case.
-enforce :: Parser a -> Parser a
-enforce p = do
-    (input, x) <- match p
-    guard . not $ T.null input
-    pure x
-
-signedInteger :: ParsecT ParserError T.Text (StateT ParserState Quote) Integer
-signedInteger = Lex.signed whitespace (lexeme Lex.decimal)
-
--- | Parser for integer constants.
-conInt :: Parser (Some (ValueOf DefaultUni))
-conInt = do
-    con::Integer <- signedInteger
-    pure $ someValue con
-
--- | Parser for a pair of hex digits to a Word8.
-hexByte :: Parser Word8
-hexByte = do
-    high <- hexDigitChar
-    low <- hexDigitChar
-    return $ fromIntegral (hexDigitToInt high * 16 + hexDigitToInt low)
-
--- | Parser for bytestring constants. They start with "#".
-conBS :: Parser (Some (ValueOf DefaultUni))
-conBS = do
-    _ <- char '#'
-    bytes <- Text.Megaparsec.many hexByte
-    pure $ someValue $ pack bytes
-
--- | Parser for string constants. They are wrapped in double quotes.
-conText :: Parser (Some (ValueOf DefaultUni))
-conText = do
-    con <- char '\"' *> manyTill Lex.charLiteral (char '\"')
-    pure $ someValue $ T.pack con
-
--- | Parser for unit.
-conUnit :: Parser (Some (ValueOf DefaultUni))
-conUnit = someValue () <$ symbol "()"
-
--- | Parser for bool.
-conBool :: Parser (Some (ValueOf DefaultUni))
-conBool = choice
-    [ someValue True <$ symbol "True"
-    , someValue False <$ symbol "False"
-    ]
-
--- | Parser for a constant term. Currently the syntax is "con defaultUniType val".
-constant :: Parser (Some (ValueOf DefaultUni))
-constant = do
-    conTy <- defaultUniType
-    con <-
-        case conTy of --TODO add Lists, Pairs, Data, App
-            SomeTypeIn DefaultUniInteger    -> conInt
-            SomeTypeIn DefaultUniByteString -> conBS
-            SomeTypeIn DefaultUniString     -> conText
-            SomeTypeIn DefaultUniUnit       -> conUnit
-            SomeTypeIn DefaultUniBool       -> conBool
-    whitespace
-    pure con

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module PlutusCore.Parser.Type where
+
+import PlutusPrelude
+import Text.Megaparsec hiding (ParseError, State, parse, some)
+
+import PlutusCore.Core.Type
+import PlutusCore.Default
+import PlutusCore.MkPlc (mkIterTyApp)
+import PlutusCore.Name
+import PlutusCore.Parser.ParserCommon
+
+-- | A PLC @Type@ to be parsed. ATM the parser only works
+-- for types in the @DefaultUni@ with @DefaultFun@.
+type PType = Type TyName DefaultUni SourcePos
+
+varType :: Parser PType
+varType = TyVar <$> getSourcePos <*> tyName
+
+funType :: Parser PType
+funType = inParens $ TyFun <$> wordPos "fun" <*> pType <*> pType
+
+allType :: Parser PType
+allType = inParens $ TyForall <$> wordPos "all" <*> tyName <*> kind <*> pType
+
+lamType :: Parser PType
+lamType = inParens $ TyLam <$> wordPos "lam" <*> tyName <*> kind <*> pType
+
+ifixType :: Parser PType
+ifixType = inParens $ TyIFix <$> wordPos "ifix" <*> pType <*> pType
+
+builtinType :: Parser PType
+builtinType = inParens $ TyBuiltin <$> wordPos "con" <*> defaultUniType
+
+appType :: Parser PType
+appType = inBrackets $ do
+    pos  <- getSourcePos
+    fn   <- pType
+    args <- some pType
+    pure $ mkIterTyApp pos fn args
+
+kind :: Parser (Kind SourcePos)
+kind = inParens (typeKind <|> funKind)
+    where
+        typeKind = Type <$> wordPos "type"
+        funKind  = KindArrow <$> wordPos "fun" <*> kind <*> kind
+
+-- | Parser for @PType@.
+pType :: Parser PType
+pType = choice $ map try
+    [ funType
+    , ifixType
+    , allType
+    , builtinType
+    , lamType
+    , appType
+    , varType
+    ]
+
+defaultUniType :: Parser (SomeTypeIn DefaultUni)
+defaultUniType = choice $ map try
+  [ inParens defaultUniType
+  , SomeTypeIn DefaultUniInteger <$ symbol "integer"
+  , SomeTypeIn DefaultUniByteString <$ symbol "bytestring"
+  , SomeTypeIn DefaultUniString <$ symbol "string"
+  , SomeTypeIn DefaultUniUnit <$ symbol "unit"
+  , SomeTypeIn DefaultUniBool <$ symbol "bool"
+  ] --TODO complete all defaultUni types
+
+tyName :: Parser TyName
+tyName = TyName <$> name

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -217,7 +217,7 @@ tests = testCase "example programs" $ fold
     , fmt "(program 0.1.0 doesn't)" @?= Right "(program 0.1.0 doesn't)"
     ]
     where
-        fmt :: BSL.ByteString -> Either ParseError T.Text
+        fmt :: BSL.ByteString -> Either ParserError T.Text
         fmt = format cfg
         cfg = defPrettyConfigPlcClassic defPrettyConfigPlcOptions
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -13,7 +13,7 @@ module PlutusIR.Parser
     ) where
 
 import PlutusCore.Default qualified as PLC (DefaultFun, DefaultUni)
-import PlutusCore.Parser.ParserCommon
+import PlutusCore.Parser
 import PlutusIR as PIR
 import PlutusIR.MkPir qualified as PIR
 import PlutusPrelude

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -80,21 +80,21 @@ program = whitespace >> do
 -- | Parse a UPLC term. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseTerm :: ByteString ->
-    Either (ParseErrorBundle T.Text PLC.ParseError) PTerm
+    Either (ParseErrorBundle T.Text PLC.ParserError) PTerm
 parseTerm = parseGen term
 
 -- | Parse a UPLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
 parseProgram :: ByteString ->
-    Either (ParseErrorBundle T.Text PLC.ParseError) (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
+    Either (ParseErrorBundle T.Text PLC.ParserError) (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
 parseProgram = parseGen program
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped ::
-    (PLC.MonadQuote (Either (ParseErrorBundle T.Text PLC.ParseError)),
-    PLC.AsUniqueError (ParseErrorBundle T.Text PLC.ParseError) SourcePos)
+    (PLC.MonadQuote (Either (ParseErrorBundle T.Text PLC.ParserError)),
+    PLC.AsUniqueError (ParseErrorBundle T.Text PLC.ParserError) SourcePos)
     => ByteString
-    -> Either (ParseErrorBundle T.Text PLC.ParseError) (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
+    -> Either (ParseErrorBundle T.Text PLC.ParserError) (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
 -- don't require there to be no free variables at this point, we might be parsing an open term
 parseScoped = through (checkProgram (const True)) <=< rename <=< parseProgram

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -25,7 +25,7 @@ import UntypedPlutusCore.Rename (Rename (rename))
 
 import Data.ByteString.Lazy (ByteString)
 import Data.Text qualified as T
-import PlutusCore.Parser.ParserCommon
+import PlutusCore.Parser hiding (parseProgram, parseTerm)
 
 -- Parsers for UPLC terms
 

--- a/plutus-errors/src/Errors/TH/GenCodes.hs
+++ b/plutus-errors/src/Errors/TH/GenCodes.hs
@@ -7,8 +7,8 @@ import ErrorCode
 import Language.Haskell.TH as TH
 import Language.Haskell.TH.Datatype as TH
 
--- | Takes a list of errors names (dataconstructors)
--- and maps it to a list that will evaluate to their actuall error codes :: [Natural]
+-- | Takes a list of errors names (data constructors)
+-- and maps it to a list that will evaluate to their actual error codes :: [Natural]
 genCodes :: [TH.Name] -> Q TH.Exp
 genCodes cs = do
    method <- [| errorCode |]    -- the errorCode method

--- a/plutus-errors/src/Errors/TH/GenDocs.hs
+++ b/plutus-errors/src/Errors/TH/GenDocs.hs
@@ -10,7 +10,7 @@ import Language.Haskell.TH as TH
 import Prettyprinter qualified as PP
 
 -- | Generate haddock documentation for all errors and their codes,
--- by creating type-synonyms to lifted dataconstructors using a DataKinds trick.
+-- by creating type-synonyms to lifted data constructors using a DataKinds trick.
 -- Note: Template Haskell cannot currently generate Haddock comments. See: <https://gitlab.haskell.org/ghc/ghc/-/issues/5467>
 genDocs :: Q [TH.Dec]
 genDocs = let allCodes = $(genCodes allErrors)

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -148,7 +148,7 @@ postulate
 {-# COMPILE GHC unconvTm = unconv 0 #-}
 {-# FOREIGN GHC import Data.Bifunctor #-}
 {-# FOREIGN GHC import Data.Functor #-}
-{-# COMPILE GHC ParseError = type Text.Megaparsec.Error.ParseErrorBundle T.Text PlutusCore.ParseError #-}
+{-# COMPILE GHC ParseError = type Text.Megaparsec.Error.ParseErrorBundle T.Text PlutusCore.ParserError #-}
 
 {-# COMPILE GHC parse = parseProgram  #-}
 {-# COMPILE GHC parseU = U.parseProgram  #-}

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -158,7 +158,7 @@ unconv i (RUnWrap t)       = Unwrap () (unconv i t)
 -- imported in multiple places
 
 data ERROR = TypeError T.Text
-           | ParseError (M.ParseErrorBundle T.Text ParseError)
+           | ParseError (M.ParseErrorBundle T.Text ParserError)
            | ScopeError ScopeError
            | RuntimeError RuntimeError
            deriving Show


### PR DESCRIPTION
- [x] (not a comment) renamed `ParseError` to `ParserError` to avoid clash with `megaparsec`'s `ParseError`.
- [ ] switched `ParseErrorE` to carry `ParseErrorBundle Text ParserError` instead of `ParserError`.
- [ ] put the parsers back in `MonadQuote`. `ParseScoped` etc should bubble up errors like before.
- [x] separate `ParserCommon.hs` into `Parser.Type`, `Parser.Builtin`, `Parser.Term` and re-export them from `Parser`.
- [ ] make `ParseGen` take a filename instead of a static one. Also it should maybe take `Text` instead of `ByteString`.
- [x] should we allow the types be wrapped in parens? The parser (`pType`) currently allows it because tests would be broken otherwise. (Update: dealt with in PR #4422 )

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
