### PR TITLE
SCP-3410: Fuse map (fakeNameDeBruijn) into the flat deserialization process

### DIFF
--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -3,6 +3,7 @@ module Main where
 import Common
 import Criterion
 import PlutusBenchmark.Common
+
 {-|
 for each data/*.flat validation script, it benchmarks
 the whole time taken from script deserialization to script execution result.

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -134,7 +134,6 @@ toNamedDeBruijn prog =
     Left e  -> errorWithoutStackTrace $ show e
     Right p -> return p
 
-
 ---------------- Printing budgets and costs ----------------
 
 printBudgetStateBudget :: CekModel -> ExBudget -> IO ()

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
@@ -9,6 +9,7 @@ module PlutusCore.DeBruijn
     , HasIndex (..)
     , DeBruijn (..)
     , NamedDeBruijn (..)
+    , FakeNamedDeBruijn (..)
     , TyDeBruijn (..)
     , NamedTyDeBruijn (..)
     , FreeVariableError (..)
@@ -27,6 +28,7 @@ module PlutusCore.DeBruijn
     , unDeBruijnTermWith
     , freeIndexAsConsistentLevel
     , deBruijnInitIndex
+    , fromFake, toFake
     ) where
 
 import PlutusCore.DeBruijn.Internal

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -32,6 +32,10 @@ deriving instance
 
 deriving instance
    (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann) =>
+   Eq (Term FakeNamedDeBruijn uni fun ann)
+
+deriving instance
+   (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann) =>
    Eq (Term DeBruijn uni fun ann)
 
 deriving instance (GEq uni, Closed uni, uni `Everywhere` Eq, Eq fun, Eq ann,

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/DeBruijn.hs
@@ -9,6 +9,7 @@ module UntypedPlutusCore.DeBruijn
     , HasIndex (..)
     , DeBruijn (..)
     , NamedDeBruijn (..)
+    , FakeNamedDeBruijn (..)
     , FreeVariableError (..)
     , AsFreeVariableError (..)
     , deBruijnTerm

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Api.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
+
 {- |
 The interface to Plutus V1 for the ledger.
 -}
@@ -133,7 +136,9 @@ import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
 import PlutusCore.Evaluation.Machine.ExBudget qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Pretty
+import PlutusPrelude (through)
 import PlutusTx (FromData (..), ToData (..), UnsafeFromData (..), fromData, toData)
 import PlutusTx.Builtins.Internal (BuiltinData (..), builtinDataToData, dataToBuiltinData)
 import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
@@ -191,17 +196,25 @@ instance Pretty EvaluationError where
     pretty (IncompatibleVersionError actual) = "This version of the Plutus Core interface does not support the version indicated by the AST:" <+> pretty actual
     pretty CostModelParameterMismatch = "Cost model parameters were not as we expected"
 
+{-| A variant of `Script` with a specialized `Serialise` instance
+that decodes the names directly into `NamedDeBruijn`s rather than `DeBruijn`s.
+This is needed because the CEK machine expects `NameDeBruijn`s, but there are obviously no names in the serialized form of a `Script`.
+Rather than traversing the term and inserting fake names after deserializing, this lets us do at the same time as deserializing.
+-}
+newtype ScriptForExecution = ScriptForExecution (UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ())
+  -- Identical to the deriving instance for `Script`, *except* that it specifies `FakeNamedDeBruijn`
+  deriving CBOR.Serialise via (SerialiseViaFlat (UPLC.WithSizeLimits 64 (UPLC.Program UPLC.FakeNamedDeBruijn PLC.DefaultUni PLC.DefaultFun ())))
+
 -- | Shared helper for the evaluation functions, deserializes the 'SerializedScript' , applies it to its arguments, puts fakenamedebruijns, and scope-checks it.
 mkTermToEvaluate :: (MonadError EvaluationError m) => SerializedScript -> [PLC.Data] -> m (UPLC.Term UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ())
 mkTermToEvaluate bs args = do
-    s@(Script (UPLC.Program _ v _)) <- liftEither $ first CodecError $ CBOR.deserialiseOrFail $ fromStrict $ fromShort bs
+    -- It decodes the program through the optimized ScriptForExecution. See `ScriptForExecution`.
+    ScriptForExecution (UPLC.Program _ v t) <- liftEither $ first CodecError $ CBOR.deserialiseOrFail $ fromStrict $ fromShort bs
     unless (v == PLC.defaultVersion ()) $ throwError $ IncompatibleVersionError v
-    let appliedScript = unScript $ Scripts.applyArguments s args
-        -- add fake names to keep the api working on NamedDeBruijn
-        namedT = UPLC.termMapNames UPLC.fakeNameDeBruijn $ UPLC._progTerm appliedScript
+    let termArgs = fmap (PLC.mkConstant ()) args
+        appliedT = PLC.mkIterApp () t termArgs
     -- make sure that term is closed, i.e. well-scoped
-    liftEither $ first DeBruijnError $ UPLC.checkScope namedT
-    pure namedT
+    through (liftEither . first DeBruijnError . UPLC.checkScope) appliedT
 
 -- | Evaluates a script, with a cost model and a budget that restricts how many
 -- resources it can use according to the cost model. Also returns the budget that

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -23,6 +23,7 @@
 module Plutus.V1.Ledger.Scripts(
     -- * Scripts
     Script (..),
+    SerialiseViaFlat (..),
     scriptSize,
     fromCompiledCode,
     ScriptError (..),
@@ -64,6 +65,7 @@ import Prelude qualified as Haskell
 import Codec.CBOR.Decoding (decodeBytes)
 import Codec.Serialise (Serialise, decode, encode, serialise)
 import Control.DeepSeq (NFData)
+import Control.Lens hiding (Context)
 import Control.Monad.Except (MonadError, throwError)
 import Data.ByteString.Lazy qualified as BSL
 import Data.String
@@ -88,7 +90,8 @@ import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
 -- | A script on the chain. This is an opaque type as far as the chain is concerned.
 newtype Script = Script { unScript :: UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun () }
-  deriving stock Generic
+  deriving stock (Generic)
+  deriving anyclass (NFData)
   -- See Note [Using Flat inside CBOR instance of Script]
   -- Important to go via 'WithSizeLimits' to ensure we enforce the size limits for constants
   deriving Serialise via (SerialiseViaFlat (UPLC.WithSizeLimits 64 (UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ())))
@@ -147,8 +150,6 @@ instance Haskell.Ord Script where
 instance Haskell.Show Script where
     showsPrec _ _ = Haskell.showString "<Script>"
 
-instance NFData Script
-
 -- | The size of a 'Script'. No particular interpretation is given to this, other than that it is
 -- proportional to the serialized size of the script.
 scriptSize :: Script -> Integer
@@ -157,12 +158,11 @@ scriptSize (Script s) = UPLC.programSize s
 -- See Note [Normalized types in Scripts]
 -- | Turn a 'CompiledCode' (usually produced by 'compile') into a 'Script' for use with this package.
 fromCompiledCode :: CompiledCode a -> Script
-fromCompiledCode = fromPlc . getPlc
-
-fromPlc :: UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun () -> Script
-fromPlc (UPLC.Program a v t) =
-    let nameless = UPLC.termMapNames UPLC.unNameDeBruijn t
-    in Script $ UPLC.Program a v nameless
+fromCompiledCode = Script . toNameless . getPlc
+    where
+      toNameless :: UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
+                 -> UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()
+      toNameless = over UPLC.progTerm $ UPLC.termMapNames UPLC.unNameDeBruijn
 
 data ScriptError =
     EvaluationError [Text] Haskell.String -- ^ Expected behavior of the engine (e.g. user-provided error)
@@ -170,10 +170,10 @@ data ScriptError =
     deriving (Haskell.Show, Haskell.Eq, Generic, NFData)
 
 applyArguments :: Script -> [PLC.Data] -> Script
-applyArguments (Script (UPLC.Program a v t)) args =
+applyArguments (Script p) args =
     let termArgs = Haskell.fmap (PLC.mkConstant ()) args
-        applied = PLC.mkIterApp () t termArgs
-    in Script (UPLC.Program a v applied)
+        applied t = PLC.mkIterApp () t termArgs
+    in Script $ over UPLC.progTerm applied p
 
 -- | Evaluate a script, returning the trace log.
 evaluateScript :: forall m . (MonadError ScriptError m) => Script -> m (PLC.ExBudget, [Text])


### PR DESCRIPTION
Adds a fakename newtype wrapper to fuse the `map fakeName` inside the flat-decoding that happens
exactly before script execution.

Note: plutus-ledger-api has been updated but not yet the validation benchmarks (separate PR).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
