### PR TITLE
[Builtins] Fuse 'AsConstant' and 'FromConstant' into 'HasConstantIn'

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -6,7 +6,8 @@
 
 module PlutusCore.Builtin.HasConstant
     ( throwNotAConstant
-    , HasConstantIn (..)
+    , HasConstant (..)
+    , HasConstantIn
     ) where
 
 import PlutusCore.Core
@@ -22,20 +23,23 @@ throwNotAConstant
     => Maybe cause -> m r
 throwNotAConstant = throwingWithCause _UnliftingError "Not a constant"
 
--- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from
--- and connects @term@ and its @uni@.
-class uni ~ UniOf term => HasConstantIn uni term where
+-- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from.
+class HasConstant term where
     -- Switching from 'MonadError' to 'Either' here gave us a speedup of 2-4%.
     -- | Unlift from the 'Constant' constructor throwing an 'UnliftingError' if the provided @term@
     -- is not a 'Constant'.
     asConstant
         :: AsUnliftingError err
-        => Maybe cause -> term -> Either (ErrorWithCause err cause) (Some (ValueOf uni))
+        => Maybe cause -> term -> Either (ErrorWithCause err cause) (Some (ValueOf (UniOf term)))
 
     -- | Wrap a Haskell value as a @term@.
     fromConstant :: Some (ValueOf (UniOf term)) -> term
 
-instance HasConstantIn uni (Term TyName Name uni fun ()) where
+-- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from
+-- and connects @term@ and its @uni@.
+type HasConstantIn uni term = (UniOf term ~ uni, HasConstant term)
+
+instance HasConstant (Term TyName Name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = throwNotAConstant mayCause
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -1,14 +1,12 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module PlutusCore.Builtin.HasConstant
     ( throwNotAConstant
-    , AsConstant (..)
-    , FromConstant (..)
-    , HasConstant
-    , HasConstantIn
+    , HasConstantIn (..)
     ) where
 
 import PlutusCore.Core
@@ -24,33 +22,21 @@ throwNotAConstant
     => Maybe cause -> m r
 throwNotAConstant = throwingWithCause _UnliftingError "Not a constant"
 
-class AsConstant term where
+-- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from
+-- and connects @term@ and its @uni@.
+class uni ~ UniOf term => HasConstantIn uni term where
     -- Switching from 'MonadError' to 'Either' here gave us a speedup of 2-4%.
     -- | Unlift from the 'Constant' constructor throwing an 'UnliftingError' if the provided @term@
     -- is not a 'Constant'.
     asConstant
         :: AsUnliftingError err
-        => Maybe cause -> term -> Either (ErrorWithCause err cause) (Some (ValueOf (UniOf term)))
+        => Maybe cause -> term -> Either (ErrorWithCause err cause) (Some (ValueOf uni))
 
-class FromConstant term where
     -- | Wrap a Haskell value as a @term@.
     fromConstant :: Some (ValueOf (UniOf term)) -> term
 
-instance AsConstant (Term TyName Name uni fun ann) where
+instance HasConstantIn uni (Term TyName Name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = throwNotAConstant mayCause
 
-instance FromConstant (Term tyname name uni fun ()) where
     fromConstant = Constant ()
-
--- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from.
---
--- 'AsConstant' and 'FromConstant' are separate, because we need only one instance of 'AsConstant'
--- per 'Term'-like type and 'FromConstant' requires as many instances as there are different kinds
--- of annotations (we're mostly interested in 'ExMemory' and @()@). Originally we had a single type
--- class but it proved to be less efficient than having two of them.
-type HasConstant term = (AsConstant term, FromConstant term)
-
--- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from
--- and connects @term@ and its @uni@.
-type HasConstantIn uni term = (UniOf term ~ uni, HasConstant term)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
@@ -54,7 +54,7 @@ We need to support polymorphism for built-in functions for these reasons:
 -- Haskell and back and instead can keep it intact.
 newtype Opaque val (rep :: GHC.Type) = Opaque
     { unOpaque :: val
-    } deriving newtype (Pretty, AsConstant, FromConstant)
+    } deriving newtype (Pretty, HasConstantIn uni)
 
 type instance UniOf (Opaque val rep) = UniOf val
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
@@ -54,7 +54,7 @@ We need to support polymorphism for built-in functions for these reasons:
 -- Haskell and back and instead can keep it intact.
 newtype Opaque val (rep :: GHC.Type) = Opaque
     { unOpaque :: val
-    } deriving newtype (Pretty, HasConstantIn uni)
+    } deriving newtype (Pretty, HasConstant)
 
 type instance UniOf (Opaque val rep) = UniOf val
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -117,7 +117,7 @@ emitCkM str = do
 
 type instance UniOf (CkValue uni fun) = uni
 
-instance HasConstantIn uni (CkValue uni fun) where
+instance HasConstant (CkValue uni fun) where
     asConstant _        (VCon val) = pure val
     asConstant mayCause _          = throwNotAConstant mayCause
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -117,12 +117,11 @@ emitCkM str = do
 
 type instance UniOf (CkValue uni fun) = uni
 
-instance FromConstant (CkValue uni fun) where
-    fromConstant = VCon
-
-instance AsConstant (CkValue uni fun) where
+instance HasConstantIn uni (CkValue uni fun) where
     asConstant _        (VCon val) = pure val
     asConstant mayCause _          = throwNotAConstant mayCause
+
+    fromConstant = VCon
 
 data Frame uni fun
     = FrameApplyFun (CkValue uni fun)                       -- ^ @[V _]@

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -7,7 +7,6 @@ where
 
 import PlutusCore.Builtin
 
-import PlutusCore.Core.Type hiding (Type)
 import PlutusCore.Evaluation.Machine.ExBudget ()
 
 import GHC.Types (Type)
@@ -39,10 +38,9 @@ data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
 
 {-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}
 toMachineParameters ::
-    ( UniOf (val uni fun) ~ uni
-      -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
-    , CostingPart uni fun ~ builtincosts
-    , HasConstant (val uni fun)
+    ( -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
+      CostingPart uni fun ~ builtincosts
+    , HasConstantIn uni (val uni fun)
     , ToBuiltinMeaning uni fun
     )
     => CostModel machinecosts builtincosts

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -30,7 +30,7 @@ import PlutusPrelude
 import Control.Lens.TH
 import PlutusCore (Kind, Name, TyName, Type (..))
 import PlutusCore qualified as PLC
-import PlutusCore.Builtin (AsConstant (..), FromConstant (..), throwNotAConstant)
+import PlutusCore.Builtin (HasConstantIn (..), throwNotAConstant)
 import PlutusCore.Core (UniOf)
 import PlutusCore.Flat ()
 import PlutusCore.MkPlc (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
@@ -129,11 +129,10 @@ data Term tyname name uni fun a =
 
 type instance UniOf (Term tyname name uni fun ann) = uni
 
-instance AsConstant (Term tyname name uni fun ann) where
+instance HasConstantIn uni (Term tyname name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = throwNotAConstant mayCause
 
-instance FromConstant (Term tyname name uni fun ()) where
     fromConstant = Constant ()
 
 instance TermLike (Term tyname name uni fun) tyname name uni fun where

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -30,7 +30,7 @@ import PlutusPrelude
 import Control.Lens.TH
 import PlutusCore (Kind, Name, TyName, Type (..))
 import PlutusCore qualified as PLC
-import PlutusCore.Builtin (HasConstantIn (..), throwNotAConstant)
+import PlutusCore.Builtin (HasConstant (..), throwNotAConstant)
 import PlutusCore.Core (UniOf)
 import PlutusCore.Flat ()
 import PlutusCore.MkPlc (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
@@ -129,7 +129,7 @@ data Term tyname name uni fun a =
 
 type instance UniOf (Term tyname name uni fun ann) = uni
 
-instance HasConstantIn uni (Term tyname name uni fun ()) where
+instance HasConstant (Term tyname name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = throwNotAConstant mayCause
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -105,7 +105,7 @@ instance TermLike (Term name uni fun) TPLC.TyName name uni fun where
     iWrap    = \_ _ _ -> id
     error    = \ann _ -> Error ann
 
-instance TPLC.HasConstantIn uni (Term name uni fun ()) where
+instance TPLC.HasConstant (Term name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = TPLC.throwNotAConstant mayCause
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -105,11 +105,10 @@ instance TermLike (Term name uni fun) TPLC.TyName name uni fun where
     iWrap    = \_ _ _ -> id
     error    = \ann _ -> Error ann
 
-instance TPLC.AsConstant (Term name uni fun ann) where
+instance TPLC.HasConstantIn uni (Term name uni fun ()) where
     asConstant _        (Constant _ val) = pure val
     asConstant mayCause _                = TPLC.throwNotAConstant mayCause
 
-instance TPLC.FromConstant (Term name uni fun ()) where
     fromConstant = Constant ()
 
 type instance TPLC.HasUniques (Term name uni fun ann) = TPLC.HasUnique name TPLC.TermUnique

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -480,12 +480,11 @@ instance (Closed uni, GShow uni, uni `Everywhere` PrettyConst, Pretty fun) =>
 
 type instance UniOf (CekValue uni fun) = uni
 
-instance FromConstant (CekValue uni fun) where
-    fromConstant = VCon
-
-instance AsConstant (CekValue uni fun) where
+instance HasConstantIn uni (CekValue uni fun) where
     asConstant _        (VCon val) = pure val
     asConstant mayCause _          = throwNotAConstant mayCause
+
+    fromConstant = VCon
 
 {-|
 The context in which the machine operates.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -480,7 +480,7 @@ instance (Closed uni, GShow uni, uni `Everywhere` PrettyConst, Pretty fun) =>
 
 type instance UniOf (CekValue uni fun) = uni
 
-instance HasConstantIn uni (CekValue uni fun) where
+instance HasConstant (CekValue uni fun) where
     asConstant _        (VCon val) = pure val
     asConstant mayCause _          = throwNotAConstant mayCause
 


### PR DESCRIPTION
We had to have two classes because of the way costing was aligned,
but that has changed, so now we can unite these classes.

I also dropped `HasConstant`, because we don't need it.