### PR TITLE
SCP-3519: Added API.EvaluationContext to cache costmodel computation

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-ledger-api.nix
@@ -68,6 +68,7 @@
           "Plutus/V1/Ledger/Tx"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V1/Ledger/EvaluationContext"
           "Plutus/V2/Ledger/Api"
           "Plutus/V2/Ledger/Contexts"
           "Plutus/V2/Ledger/Tx"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-ledger-api.nix
@@ -68,6 +68,7 @@
           "Plutus/V1/Ledger/Tx"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V1/Ledger/EvaluationContext"
           "Plutus/V2/Ledger/Api"
           "Plutus/V2/Ledger/Contexts"
           "Plutus/V2/Ledger/Tx"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-ledger-api.nix
@@ -68,6 +68,7 @@
           "Plutus/V1/Ledger/Tx"
           "Plutus/V1/Ledger/Time"
           "Plutus/V1/Ledger/Value"
+          "Plutus/V1/Ledger/EvaluationContext"
           "Plutus/V2/Ledger/Api"
           "Plutus/V2/Ledger/Contexts"
           "Plutus/V2/Ledger/Tx"

--- a/plutus-benchmark/validation/BenchDec.hs
+++ b/plutus-benchmark/validation/BenchDec.hs
@@ -27,5 +27,5 @@ main = benchWith mkDecBM
             bslCBOR :: BSL.ByteString = Serialise.serialise bsFlat
             -- strictify and "short" the result cbor to create a real `SerializedScript`
             benchScript :: SerializedScript = toShort . BSL.toStrict $ bslCBOR
-        in whnf validateScript benchScript
+        in whnf isScriptWellFormed benchScript
 

--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -1,5 +1,9 @@
-{-# LANGUAGE TypeApplications #-}
 module Main where
+
+import Plutus.V1.Ledger.Api
+import Plutus.V1.Ledger.EvaluationContext (evalCtxForTesting)
+import Plutus.V1.Ledger.Scripts
+
 
 import Codec.Serialise qualified as Serialise (serialise)
 import Common
@@ -7,8 +11,6 @@ import Criterion
 import Data.ByteString as BS
 import Data.ByteString.Lazy as BSL
 import Data.ByteString.Short (toShort)
-import Plutus.V1.Ledger.Api
-import Plutus.V1.Ledger.Scripts
 
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
@@ -54,11 +56,11 @@ main = benchWith mkFullBM
             bslCBOR :: BSL.ByteString = Serialise.serialise (Script $ UPLC.Program () v term)
             -- strictify and "short" the result cbor to create a real `SerializedScript`
             benchScript :: SerializedScript = toShort . BSL.toStrict $ bslCBOR
+
         in  whnf (\ script -> snd $ evaluateScriptCounting
                         -- no logs
                         Quiet
-                        -- no need to pass chain params
-                        mempty
+                        evalCtxForTesting
                         script
                         args
                  )

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -84,7 +84,7 @@ nopCostModel =
     }
 
 nopCostParameters :: MachineParameters CekMachineCosts CekValue DefaultUni NopFuns
-nopCostParameters = toMachineParameters $ CostModel defaultCekMachineCosts nopCostModel
+nopCostParameters = mkMachineParameters $ CostModel defaultCekMachineCosts nopCostModel
 
 {- | The meanings of the builtins.  Each one takes a number of integer arguments
    and returns an integer without doing any other work.  We could have used

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -75,10 +75,10 @@ defaultCostModelParams :: Maybe CostModelParams
 defaultCostModelParams = extractCostModelParams defaultCekCostModel
 
 defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
-defaultCekParameters = toMachineParameters defaultCekCostModel
+defaultCekParameters = mkMachineParameters defaultCekCostModel
 
 unitCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
-unitCekParameters = toMachineParameters (CostModel unitCekMachineCosts unitCostBuiltinCostModel)
+unitCekParameters = mkMachineParameters (CostModel unitCekMachineCosts unitCostBuiltinCostModel)
 
 defaultBuiltinsRuntime :: HasConstantIn DefaultUni term => BuiltinsRuntime DefaultFun term
 defaultBuiltinsRuntime = toBuiltinsRuntime defaultBuiltinCostModel

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -37,7 +37,7 @@ data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
     }
 
 {-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}
-toMachineParameters ::
+mkMachineParameters ::
     ( -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
       CostingPart uni fun ~ builtincosts
     , HasConstantIn uni (val uni fun)
@@ -45,5 +45,5 @@ toMachineParameters ::
     )
     => CostModel machinecosts builtincosts
     -> MachineParameters machinecosts val uni fun
-toMachineParameters (CostModel mchnCosts builtinCosts) =
+mkMachineParameters (CostModel mchnCosts builtinCosts) =
     MachineParameters mchnCosts (toBuiltinsRuntime builtinCosts)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -48,7 +48,7 @@ import Test.Tasty.Hedgehog
 defaultCekParametersExt
     :: MachineParameters CekMachineCosts CekValue DefaultUni (Either DefaultFun ExtensionFun)
 defaultCekParametersExt =
-    toMachineParameters $ CostModel defaultCekMachineCosts (defaultBuiltinCostModel, ())
+    mkMachineParameters $ CostModel defaultCekMachineCosts (defaultBuiltinCostModel, ())
 
 -- | Check that 'Factorial' from the above computes to the same thing as
 -- a factorial defined in PLC itself.

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -51,6 +51,7 @@ library
         Plutus.V1.Ledger.Tx
         Plutus.V1.Ledger.Time
         Plutus.V1.Ledger.Value
+        Plutus.V1.Ledger.EvaluationContext
 
         Plutus.V2.Ledger.Api
         Plutus.V2.Ledger.Contexts

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
@@ -1,0 +1,37 @@
+module Plutus.V1.Ledger.EvaluationContext
+    ( EvaluationContext
+    , mkEvaluationContext
+    , evalCtxForTesting
+    , CostModelParams
+    , isCostModelParamsWellFormed
+    , toMachineParameters
+    ) where
+
+import PlutusCore as Plutus (DefaultFun, DefaultUni, defaultCekCostModel)
+import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
+import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
+import UntypedPlutusCore.Evaluation.Machine.Cek as Plutus
+
+import Data.Maybe
+
+-- | An opaque type that contains all the static parameters that the evaluator needs to evaluate a script.
+-- This is so that they can be computed once and cached, rather than recomputed on every evaluation.
+newtype EvaluationContext = EvaluationContext
+    { toMachineParameters :: Plutus.MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun }
+
+-- | Build the 'EvaluationContext'.
+--
+-- The input is a `Map` of strings to cost integer values (aka `Plutus.CostModelParams`, `Alonzo.CostModel`)
+mkEvaluationContext :: Plutus.CostModelParams
+                    -> Maybe EvaluationContext
+mkEvaluationContext newCMP =
+    EvaluationContext . Plutus.mkMachineParameters <$> Plutus.applyCostModelParams Plutus.defaultCekCostModel newCMP
+
+-- | Comparably expensive to `mkEvaluationContext`, so it should only be used sparingly.
+isCostModelParamsWellFormed :: Plutus.CostModelParams -> Bool
+isCostModelParamsWellFormed = isJust . Plutus.applyCostModelParams Plutus.defaultCekCostModel
+
+-- only used for testing purposes: make an evaluation context by applying
+-- an emptys set of protocol parameters
+evalCtxForTesting :: EvaluationContext
+evalCtxForTesting = fromJust $ mkEvaluationContext mempty

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
@@ -8,7 +8,7 @@ module Plutus.V2.Ledger.Api (
     , Script
     , fromCompiledCode
     -- * Validating scripts
-    , validateScript
+    , isScriptWellFormed
     -- * Running scripts
     , evaluateScriptRestricting
     , evaluateScriptCounting
@@ -21,9 +21,10 @@ module Plutus.V2.Ledger.Api (
     , ExMemory (..)
     , SatInt
     -- ** Cost model
-    , validateCostModelParams
-    , defaultCostModelParams
+    , EvaluationContext
+    , mkEvaluationContext
     , CostModelParams
+    , isCostModelParamsWellFormed
     -- * Context types
     , ScriptContext(..)
     , ScriptPurpose(..)

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -6,9 +6,9 @@ import Test.Tasty.QuickCheck
 
 import Control.Monad (void)
 import Data.Either
-import Data.Maybe
 import Data.Word (Word8)
 import Plutus.V1.Ledger.Api
+import Plutus.V1.Ledger.EvaluationContext (evalCtxForTesting)
 import Plutus.V1.Ledger.Examples
 import Spec.Eval qualified
 import Spec.Interval qualified
@@ -18,19 +18,19 @@ main = defaultMain tests
 
 alwaysTrue :: TestTree
 alwaysTrue = testCase "always true script returns true" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysSucceedingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet evalCtxForTesting (alwaysSucceedingNAryFunction 2) [I 1, I 2]
     in assertBool "succeeds" (isRight res)
 
 alwaysFalse :: TestTree
 alwaysFalse = testCase "always false script returns false" $
-    let (_, res) = evaluateScriptCounting Quiet (fromJust defaultCostModelParams) (alwaysFailingNAryFunction 2) [I 1, I 2]
+    let (_, res) = evaluateScriptCounting Quiet evalCtxForTesting (alwaysFailingNAryFunction 2) [I 1, I 2]
     in assertBool "fails" (isLeft res)
 
 saltedFunction :: TestTree
 saltedFunction =
     let evaluate f f' args =
-            ( evaluateScriptCounting Quiet (fromJust defaultCostModelParams) f args
-            , evaluateScriptCounting Quiet (fromJust defaultCostModelParams) f' args
+            ( evaluateScriptCounting Quiet evalCtxForTesting f args
+            , evaluateScriptCounting Quiet evalCtxForTesting f' args
             )
     in testGroup "salted function"
     [ testProperty "saturated" $ \(n :: Word8) salt fWhich ->

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -7,8 +7,8 @@ import Control.Monad.Except
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Short qualified as BSS
 import Data.Either
-import Data.Maybe
 import Plutus.V1.Ledger.Api as Api
+import Plutus.V1.Ledger.EvaluationContext (evalCtxForTesting)
 import Plutus.V1.Ledger.Scripts as Scripts
 import PlutusCore qualified as PLC
 import PlutusCore.Default
@@ -130,7 +130,7 @@ testAPI = "v1-api" `testWith` evalAPI
       evalAPI t =
           -- handcraft a serialized script
           let s :: SerializedScript = BSS.toShort . BSL.toStrict . CBOR.serialise $ Script $ mkProg t
-          in isRight $ snd $ Api.evaluateScriptRestricting Quiet (fromJust defaultCostModelParams) (unExRestrictingBudget enormousBudget) s []
+          in isRight $ snd $ Api.evaluateScriptRestricting Quiet evalCtxForTesting (unExRestrictingBudget enormousBudget) s []
 
 -- Test a given eval function against the expected results.
 testWith :: String -> (UPLC.Term DeBruijn DefaultUni DefaultFun () -> Bool) -> TestNested


### PR DESCRIPTION
We would like to cache the result of computing the plutus costmodel
as long as the ledger protocol parameters do not change.

This adds an extra abstract datatype `EvaluationContext` and a
 constructor `mkEvaluationContext` to make the transition to using a cache easier.

It is the responsibility of the ledger/node software to

1) read the cached value and pass it to the `API.evaluateScript*`
2) when receiving new protocol parameters, update the cache with the value of `mkEvaluationContext(new_protocol_parameters)`

**note to plutus devs**: this caches the typed `CostModel` as well the `MachineParameters` derived from it.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
