### PR TITLE
Make validation-full benchmark apply arguments

### DIFF
--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -8,6 +8,23 @@ import Data.ByteString as BS
 import Data.ByteString.Lazy as BSL
 import Data.ByteString.Short (toShort)
 import Plutus.V1.Ledger.Api
+import Plutus.V1.Ledger.Scripts
+
+import PlutusCore.Builtin qualified as PLC
+import PlutusCore.Data qualified as PLC
+import UntypedPlutusCore qualified as UPLC
+
+type Term = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
+
+-- | If the term is an application of something to some arguments, peel off
+-- those arguments which are 'Data' constants.
+peelDataArguments :: Term -> (Term, [PLC.Data])
+peelDataArguments = go []
+    where
+        go acc t@(UPLC.Apply () t' arg) = case PLC.readKnown Nothing arg of
+            Left _  -> (t, acc)
+            Right d -> go (d:acc) t'
+        go acc t = (t, acc)
 
 {-|
 for each data/*.flat validation script, it benchmarks
@@ -22,10 +39,19 @@ main :: IO ()
 main = benchWith mkFullBM
   where
     mkFullBM :: FilePath -> BS.ByteString -> Benchmarkable
-    mkFullBM _file bsFlat =
+    mkFullBM file bsFlat =
         let
-            -- just "envelope" the flat strict-bytestring into a cbor's lazy serialised bytestring
-            bslCBOR :: BSL.ByteString = Serialise.serialise bsFlat
+            body :: Term
+            (UPLC.Program _ v body) = unsafeUnflat file bsFlat
+
+            -- We make some effort to mimic what happens on-chain, including the provision of the
+            -- script arguments. However, the inputs we have are *fully applied*. So we try and reverse
+            -- that by stripping off the arguments here. Conveniently, we know that they will be
+            -- Data constants. Annoyingly we can't just assume it's the first 3 arguments, since some
+            -- of them are policy scripts with only 2.
+            (term, args) = peelDataArguments body
+
+            bslCBOR :: BSL.ByteString = Serialise.serialise (Script $ UPLC.Program () v term)
             -- strictify and "short" the result cbor to create a real `SerializedScript`
             benchScript :: SerializedScript = toShort . BSL.toStrict $ bslCBOR
         in  whnf (\ script -> snd $ evaluateScriptCounting
@@ -34,7 +60,6 @@ main = benchWith mkFullBM
                         -- no need to pass chain params
                         mempty
                         script
-                        -- no data args to apply to script
-                        []
+                        args
                  )
             benchScript


### PR DESCRIPTION
This brings us even closer to what actually happens, by peeling off the
`Data` arguments and re-applyign them. Importantly, this means that the
`Data` constants created from the arguments don't cause the size check
to fail.