### PR TITLE
SCP-3591: Add case for undefined behavior indexOne(Zero)

### DIFF
--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinary.hs
@@ -21,7 +21,7 @@ import Data.Maybe
 import Data.Word
 import GHC.Exts
 
--- | βA complete binary tree.
+-- | A complete binary tree.
 -- Note: the size of the tree is not stored/cached,
 -- unless it appears as a root tree in 'RAList', which the size is stored inside the Cons.
 data Tree a = Leaf a
@@ -40,7 +40,6 @@ data RAList a = BHead
              -- because binary skew numbers have unique representation
              -- and hence all trees of the same size will have the same structure
              deriving stock (Eq, Show)
-
 
 instance IsList (RAList a) where
   type Item (RAList a) = a
@@ -124,7 +123,6 @@ safeIndexZero (BHead w t ts) !i  =
            else indexTree halfSize (offset - 1 - halfSize) t2
 
 -- 1-based
--- NOTE: no check if zero 0 index is passed, if 0 is passed it MAY overflow the index
 unsafeIndexOne :: RAList a -> Word64 -> a
 unsafeIndexOne Nil _ = error "out of bounds"
 unsafeIndexOne (BHead w t ts) !i =
@@ -133,6 +131,7 @@ unsafeIndexOne (BHead w t ts) !i =
     else unsafeIndexOne ts (i-w)
   where
     indexTree :: Word64 -> Word64 -> Tree a -> a
+    indexTree _ 0 _ = error "index zero"
     indexTree 1 1 (Leaf x) = x
     indexTree _ _ (Leaf _) = error "out of bounds"
     indexTree _ 1 (Node x _ _) = x
@@ -144,7 +143,6 @@ unsafeIndexOne (BHead w t ts) !i =
            else indexTree halfSize (offset' - halfSize) t2
 
 -- 1-based
--- NOTE: no check if zero 0 index is passed, if 0 is passed it MAY overflow the index
 safeIndexOne :: RAList a -> Word64 -> Maybe a
 safeIndexOne Nil _ = Nothing
 safeIndexOne (BHead w t ts) !i =
@@ -153,6 +151,7 @@ safeIndexOne (BHead w t ts) !i =
     else safeIndexOne ts (i-w)
   where
     indexTree :: Word64 -> Word64 -> Tree a -> Maybe a
+    indexTree _ 0 _ = Nothing -- "index zero"
     indexTree 1 1 (Leaf x) = Just x
     indexTree _ _ (Leaf _) = Nothing
     indexTree _ 1 (Node x _ _) = Just x

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -687,7 +687,7 @@ library index-envs
     build-depends:
         base -any,
         containers -any,
-        -- broken for ral-0.2 conflic with  cardano-binary:recursion-schemes
+        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
         ral == 0.1
 
 benchmark index-envs-bench
@@ -701,7 +701,7 @@ benchmark index-envs-bench
         index-envs -any,
         criterion >= 1.5.9.0,
         random >= 1.2.0,
-        -- broken for ral-0.2 conflic with  cardano-binary:recursion-schemes
+        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
         ral == 0.1
 
 test-suite index-envs-test


### PR DESCRIPTION
The skewbinary's safeIndexOne and unsafeIndexOne function lacked a case when the passed index is equal to zero.
This is fine currently for the on-chain execution, since scopechecking makes sure that the AST does not contain (Var 0) and the discharge does behave correctly.

Offchain via plutus-tx cannot trigger this, because it will abort compilation upon freevariable (0). Handcrafted uplc off-chain execution can trigger this, however.

If we follow the plan and remove scopechecking in plutus-v2, then the problem will arise. Fix it for v2 (master) but backport it as well, since it does have negligible performance impact.


Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
