### PR TITLE
Change enableExecutableProfiling to enableProfiling

### DIFF
--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -172,7 +172,7 @@ let
       })
     ] ++ lib.optional enableHaskellProfiling {
       enableLibraryProfiling = true;
-      enableExecutableProfiling = true;
+      enableProfiling = true;
     };
   });
 


### PR DESCRIPTION
Fix `enableHaskellProfiling`. Doesn't work since https://github.com/input-output-hk/haskell.nix/commit/0e2ae928e296a68ec16adbed5e7d4f7dca815b14

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
