### PR TITLE
[Builtins] Inline 'mkMachineParameters' in its full glory

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -994,6 +994,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
         makeBuiltinMeaning
             (\() -> [] @(Data,Data))
             (runCostingFunOneArgument . paramMkNilPairData)
+    -- See Note [Inlining meanings of builtins].
+    {-# INLINE toBuiltinMeaning #-}
 
 -- It's set deliberately to give us "extra room" in the binary format to add things without running
 -- out of space for tags (expanding the space would change the binary format for people who're

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -12,6 +12,7 @@ import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.ExBudget ()
 
 import Control.DeepSeq
+import GHC.Exts (inline)
 import GHC.Generics
 import GHC.Types (Type)
 
@@ -42,6 +43,7 @@ data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
     deriving stock Generic
     deriving anyclass NFData
 
+-- See Note [Inlining meanings of builtins].
 {-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}
 mkMachineParameters ::
     ( -- In Cek.Internal we have `type instance UniOf (CekValue uni fun) = uni`, but we don't know that here.
@@ -52,4 +54,5 @@ mkMachineParameters ::
     => CostModel machinecosts builtincosts
     -> MachineParameters machinecosts val uni fun
 mkMachineParameters (CostModel mchnCosts builtinCosts) =
-    MachineParameters mchnCosts (toBuiltinsRuntime builtinCosts)
+    MachineParameters mchnCosts (inline toBuiltinsRuntime builtinCosts)
+{-# INLINE mkMachineParameters #-}


### PR DESCRIPTION
A minimal version of #4435, no `readKnown` inlining, no nothing.