### PR TITLE
Forgot the memory usage cost for serialiseData

### DIFF
--- a/plutus-core/cost-model/data/builtinCostModel.json
+++ b/plutus-core/cost-model/data/builtinCostModel.json
@@ -513,7 +513,7 @@
         "memory": {
             "arguments": {
                 "intercept": 0,
-                "slope": 0
+                "slope": 2
             },
             "type": "linear_cost"
         }


### PR DESCRIPTION
A massive PR for the memory cost of `serialiseData`, which I forgot to do in #4480.  We have to account for the size of the serialized object as a function of the size of the input, so I've gone for a factor of 2 to account for any overhead.  A factor of 1 would probably be safe anyway though.