### PR TITLE
[Builtins] Update 'BuiltinRuntime' to store the costing function strictly

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -64,9 +64,7 @@ data BuiltinRuntime val =
         (RuntimeScheme val args res)
         ~(FoldArgs args res)  -- Must be lazy, because we don't want to compute the denotation when
                               -- it's fully saturated before figuring out what it's going to cost.
-        ~(FoldArgsEx args)    -- We make this lazy, so that evaluators that don't care about costing
-                              -- can put @undefined@ here. TODO: we should test if making this
-                              -- strict introduces any measurable speedup.
+        (FoldArgsEx args)
 
 instance NFData (BuiltinRuntime val) where
     rnf (BuiltinRuntime rs f exF) = rnf rs `seq` f `seq` rwhnf exF

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -300,7 +300,7 @@ applyEvaluate
     -> CkValue uni fun
     -> CkM uni fun s (Term TyName Name uni fun ())
 applyEvaluate stack (VLamAbs name _ body) arg = stack |> substituteDb name (ckValueToTerm arg) body
-applyEvaluate stack (VBuiltin term (BuiltinRuntime sch f _)) arg = do
+applyEvaluate stack (VBuiltin term (BuiltinRuntime sch f exF)) arg = do
     let argTerm = ckValueToTerm arg
         term' = Apply () term argTerm
     case sch of
@@ -309,8 +309,9 @@ applyEvaluate stack (VBuiltin term (BuiltinRuntime sch f _)) arg = do
         RuntimeSchemeArrow schB -> case readKnown (Just argTerm) arg  of
             Left err -> throwReadKnownErrorWithCause err
             Right x  -> do
-                let noCosting = error "The CK machine does not support costing"
-                    runtime' = BuiltinRuntime schB (f x) noCosting
+                -- The CK machine does not support costing, so we just apply the costing function
+                -- to 'mempty'.
+                let runtime' = BuiltinRuntime schB (f x) (exF mempty)
                 res <- evalBuiltinApp term' runtime'
                 stack <| res
         _ ->


### PR DESCRIPTION
Since the HOAS evaluator is gone, we don't need that laziness anymore.