### PR TITLE
Adding an exponent function for integers to the prelude.

### DIFF
--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -27,6 +27,7 @@ module PlutusTx.Builtins (
                                 , subtractInteger
                                 , multiplyInteger
                                 , divideInteger
+                                , exponentInteger
                                 , modInteger
                                 , quotientInteger
                                 , remainderInteger
@@ -183,6 +184,10 @@ multiplyInteger x y = fromBuiltin (BI.multiplyInteger (toBuiltin x) (toBuiltin y
 -- | Divide two integers.
 divideInteger :: Integer -> Integer -> Integer
 divideInteger x y = fromBuiltin (BI.divideInteger (toBuiltin x) (toBuiltin y))
+
+{-# INLINABLE exponentInteger #-}
+exponentInteger :: Integer -> Integer -> Integer
+exponentInteger x y = fromBuiltin (BI.exponentInteger (toBuiltin x) (toBuiltin y))
 
 {-# INLINABLE modInteger #-}
 -- | Integer modulo operation.

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -138,6 +138,10 @@ multiplyInteger = coerce ((*) @Integer)
 divideInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 divideInteger = coerce (div @Integer)
 
+{-# NOINLINE exponentInteger #-}
+exponentInteger :: BuiltinInteger -> BuildinInteger -> BuildinInteger
+exponentInteger = coerce ((^) @Integer)
+
 {-# NOINLINE modInteger #-}
 modInteger :: BuiltinInteger -> BuiltinInteger -> BuiltinInteger
 modInteger = coerce (mod @Integer)

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -41,10 +41,12 @@ module PlutusTx.Prelude (
     -- * Integer numbers
     Integer,
     divide,
+    exponent,
     modulo,
     quotient,
     remainder,
     even,
+    odd,
     -- * Maybe
     module Maybe,
     -- * Either
@@ -138,6 +140,15 @@ check b = if b then () else traceError checkHasFailedError
 divide :: Integer -> Integer -> Integer
 divide = Builtins.divideInteger
 
+{-# INLINABLE exponent #-}
+-- | Integer exponentiation
+--
+--   >>> exponent 5 2
+--   25 
+--
+exponent :: Integer -> Integer -> Integer
+exponent = Builtins.exponentInteger
+
 {-# INLINABLE modulo #-}
 -- | Integer remainder, always positive for a positive divisor
 --
@@ -153,7 +164,6 @@ modulo = Builtins.modInteger
 --   >>> quotient (-41) 5
 --   -8
 --
-
 quotient :: Integer -> Integer -> Integer
 quotient = Builtins.quotientInteger
 
@@ -169,6 +179,10 @@ remainder = Builtins.remainderInteger
 {-# INLINABLE even #-}
 even :: Integer -> Bool
 even n = if modulo n 2 == 0 then True else False
+
+{-# INLINABLE odd #-}
+odd :: Integer -> Bool
+odd n = if even n then False else True
 
 {-# INLINABLE takeByteString #-}
 -- | Returns the n length prefix of a 'ByteString'.


### PR DESCRIPTION
Adding an integer exponent function to the PlutusTx.prelude. Please check that this addition is performed correct. I tried to follow the style where functions are defined in the Builtins for off-chain use.