### PR TITLE
SCP-3696: fix ThunkRecursions for impure RHSs

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -178,6 +178,8 @@ compileReadableToPlc =
     >=> through check
     >=> (<$ logVerbose "  !!! thunkRecursions")
     >=> (pure . ThunkRec.thunkRecursions)
+    -- Thunking recursions breaks global uniqueness
+    >=> PLC.rename
     >=> through check
     -- Process only the non-strict bindings created by 'thunkRecursions' with unit delay/forces
     -- See Note [Using unit versus force/delay]

--- a/plutus-core/plutus-ir/test/Spec.hs
+++ b/plutus-core/plutus-ir/test/Spec.hs
@@ -70,6 +70,7 @@ recursion = testNested "recursion"
     , goldenEvalPir pTerm "even3Eval"
     , goldenPlcFromPir pTerm "stupidZero"
     , goldenPlcFromPir pTerm "mutuallyRecursiveValues"
+    , goldenEvalPir pTerm "errorBinding"
     ]
 
 serialization :: TestNested

--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -51,6 +51,7 @@ thunkRecursions = testNested "thunkRecursions"
     $ map (goldenPir ThunkRec.thunkRecursions pTerm)
     [ "listFold"
     , "monoMap"
+    , "errorBinding"
     ]
 
 nonStrict :: TestNested

--- a/plutus-core/plutus-ir/test/recursion/errorBinding
+++ b/plutus-core/plutus-ir/test/recursion/errorBinding
@@ -1,0 +1,5 @@
+(let (rec)
+  (termbind (strict) (vardecl x (con integer)) (error (con integer)))
+  (termbind (nonstrict) (vardecl y (con integer)) x)
+  (con integer 1)
+)

--- a/plutus-core/plutus-ir/test/recursion/errorBinding.golden
+++ b/plutus-core/plutus-ir/test/recursion/errorBinding.golden
@@ -1,0 +1,1 @@
+Failure

--- a/plutus-core/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
+++ b/plutus-core/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
@@ -36,7 +36,10 @@
                 (all a_i0 (type) (fun a_i1 a_i1))
                 (all a_i0 (type) (fun a_i1 a_i1))
               )
-              [ x_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+              [
+                (lam x_i0 (all a_i0 (type) (fun a_i1 a_i1)) x_i1)
+                [ x_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+              ]
             )
             [
               {

--- a/plutus-core/plutus-ir/test/transform/thunkRecursions/errorBinding
+++ b/plutus-core/plutus-ir/test/transform/thunkRecursions/errorBinding
@@ -1,0 +1,5 @@
+(let (rec)
+  (termbind (strict) (vardecl x (con integer)) (error (con integer)))
+  (termbind (nonstrict) (vardecl y (con integer)) x)
+  (con integer 1)
+)

--- a/plutus-core/plutus-ir/test/transform/thunkRecursions/errorBinding.golden
+++ b/plutus-core/plutus-ir/test/transform/thunkRecursions/errorBinding.golden
@@ -1,0 +1,6 @@
+(let
+  (rec)
+  (termbind (nonstrict) (vardecl x (con integer)) (error (con integer)))
+  (termbind (nonstrict) (vardecl y (con integer)) x)
+  (let (nonrec) (termbind (strict) (vardecl x (con integer)) x) (con integer 1))
+)


### PR DESCRIPTION
Identified by Max from Quviq.

The issue is that we were turning strict bindings into non-strict
bindings, which obviously... changes their strictness properties. We can
fix this by forcing the value again immediately afterwards.

I decided to be a bit more conservative and only do this when the
binding RHS might be impure, so I expect this will not change
compilation output in the vast majority of cases.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
