### PR TITLE
[Evaluation] Make 'EvaluationResult' strict

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Result.hs
@@ -53,7 +53,7 @@ _EvaluationFailureVia failure = prism (const failure) $ \a -> when (a /= failure
 -- On the PLC side this becomes (via @makeKnown@) either a call to 'Error' or
 -- a value of the PLC counterpart of type @a@.
 data EvaluationResult a
-    = EvaluationSuccess a
+    = EvaluationSuccess !a
     | EvaluationFailure
     deriving stock (Show, Eq, Generic, Functor, Foldable, Traversable)
     deriving anyclass (NFData)


### PR DESCRIPTION
I was looking at Core and that popped up. Let's see.