### PR TITLE
[Builtins] Factor causes out of the builtins machinery

### DIFF
--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -141,7 +141,7 @@ type Term = UPLC.Term UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()
 peelDataArguments :: Term -> (Term, [PLC.Data])
 peelDataArguments = go []
     where
-        go acc t@(UPLC.Apply () t' arg) = case PLC.readKnown Nothing arg of
+        go acc t@(UPLC.Apply () t' arg) = case PLC.readKnown arg of
             Left _  -> (t, acc)
             Right d -> go (d:acc) t'
         go acc t = (t, acc)

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -152,9 +152,9 @@ instance KnownTypeAst DefaultUni Void where
         a <- freshTyName "a"
         pure $ TyForall () a (Type ()) $ TyVar () a
 instance UniOf term ~ DefaultUni => MakeKnownIn DefaultUni term Void where
-    makeKnown _ = absurd
+    makeKnown = absurd
 instance UniOf term ~ DefaultUni => ReadKnownIn DefaultUni term Void where
-    readKnown mayCause _ = throwingWithCause _UnliftingError "Can't unlift a 'Void'" mayCause
+    readKnown _ = throwing _UnliftingError "Can't unlift a 'Void'"
 
 data BuiltinErrorCall = BuiltinErrorCall
     deriving stock (Show, Eq)
@@ -207,7 +207,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
       where
         idAssumeCheckBoolPlc :: Opaque val Bool -> EvaluationResult Bool
         idAssumeCheckBoolPlc val =
-            case asConstant @_ @UnliftingError Nothing val of
+            case asConstant val of
                 Right (Some (ValueOf DefaultUniBool b)) -> EvaluationSuccess b
                 _                                       -> EvaluationFailure
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module PlutusCore.Builtin.HasConstant
-    ( throwNotAConstant
+    ( KnownTypeError (..)
+    , throwNotAConstant
     , HasConstant (..)
     , HasConstantIn
     ) where
@@ -14,24 +13,15 @@ import PlutusCore.Core
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Name
 
-import Control.Monad.Except
 import Type.Reflection
 import Universe
-
--- | Throw an 'UnliftingError' saying that the received argument is not a constant.
-throwNotAConstant
-    :: (MonadError (ErrorWithCause err cause) m, AsUnliftingError err)
-    => Maybe cause -> m r
-throwNotAConstant = throwingWithCause _UnliftingError "Not a constant"
 
 -- | Ensures that @term@ has a 'Constant'-like constructor to lift values to and unlift values from.
 class HasConstant term where
     -- Switching from 'MonadError' to 'Either' here gave us a speedup of 2-4%.
     -- | Unlift from the 'Constant' constructor throwing an 'UnliftingError' if the provided @term@
     -- is not a 'Constant'.
-    asConstant
-        :: AsUnliftingError err
-        => Maybe cause -> term -> Either (ErrorWithCause err cause) (Some (ValueOf (UniOf term)))
+    asConstant :: term -> Either KnownTypeError (Some (ValueOf (UniOf term)))
 
     -- | Wrap a Haskell value as a @term@.
     fromConstant :: Some (ValueOf (UniOf term)) -> term
@@ -41,7 +31,7 @@ class HasConstant term where
 type HasConstantIn uni term = (UniOf term ~ uni, Typeable term, HasConstant term)
 
 instance HasConstant (Term TyName Name uni fun ()) where
-    asConstant _        (Constant _ val) = pure val
-    asConstant mayCause _                = throwNotAConstant mayCause
+    asConstant (Constant _ val) = pure val
+    asConstant _                = throwNotAConstant
 
     fromConstant = Constant ()

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -160,7 +160,7 @@ class KnownMonotype val args res a | args res -> a, a -> res where
     -- The argument is in 'ReadKnownM', because that's what deferred unlifting amounts to:
     -- passing the action returning the builtin application around until full saturation, which is
     -- when the action actually gets run.
-    toDeferredF :: ReadKnownM () (FoldArgs args res) -> ToRuntimeDenotationType val (Length args)
+    toDeferredF :: ReadKnownM (FoldArgs args res) -> ToRuntimeDenotationType val (Length args)
 
 -- | Once we've run out of term-level arguments, we return a 'TypeSchemeResult'.
 instance (res ~ res', Typeable res, KnownTypeAst (UniOf val) res, MakeKnown val res) =>
@@ -168,12 +168,12 @@ instance (res ~ res', Typeable res, KnownTypeAst (UniOf val) res, MakeKnown val 
     knownMonotype = TypeSchemeResult
     knownMonoruntime = RuntimeSchemeResult
 
-    toImmediateF = makeKnown (Just ())
+    toImmediateF = makeKnown
     {-# INLINE toImmediateF #-}
 
     -- For deferred unlifting we need to lift the 'ReadKnownM' action into 'MakeKnownM',
     -- hence 'liftEither'.
-    toDeferredF getRes = liftEither getRes >>= makeKnown (Just ())
+    toDeferredF getRes = liftEither getRes >>= makeKnown
     {-# INLINE toDeferredF #-}
 
 -- | Every term-level argument becomes as 'TypeSchemeArrow'.
@@ -185,7 +185,7 @@ instance
     knownMonoruntime = RuntimeSchemeArrow $ knownMonoruntime @val @args @res
 
     -- Unlift, then recurse.
-    toImmediateF f = fmap (toImmediateF @val @args @res . f) . readKnown (Just ())
+    toImmediateF f = fmap (toImmediateF @val @args @res . f) . readKnown
     {-# INLINE toImmediateF #-}
 
     -- Grow the builtin application within the received action and recurse on the result.
@@ -201,7 +201,7 @@ instance
         -- of how unlifting is aligned.
         --
         -- 'pure' signifies that no failure can occur at this point.
-        pure . toDeferredF @val @args @res $! getF <*> readKnown (Just ()) arg
+        pure . toDeferredF @val @args @res $! getF <*> readKnown arg
     {-# INLINE toDeferredF #-}
 
 -- | A class that allows us to derive a polytype for a builtin.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -51,12 +51,12 @@ instance NFData (RuntimeScheme n) where
 -- argument of the denotation and calling 'makeKnown' over its result.
 type ToRuntimeDenotationType :: GHC.Type -> Peano -> GHC.Type
 type family ToRuntimeDenotationType val n where
-    ToRuntimeDenotationType val 'Z     = MakeKnownM () val
+    ToRuntimeDenotationType val 'Z     = MakeKnownM val
     -- 'ReadKnownM' is required here only for immediate unlifting, because deferred unlifting
     -- doesn't need the ability to fail in the middle of a builtin application, but having a uniform
     -- interface for both the ways of doing unlifting is way too convenient, hence we decided to pay
     -- the price (about 1-2% of total evaluation time) for now.
-    ToRuntimeDenotationType val ('S n) = val -> ReadKnownM () (ToRuntimeDenotationType val n)
+    ToRuntimeDenotationType val ('S n) = val -> ReadKnownM (ToRuntimeDenotationType val n)
 
 -- | Compute the costing type for a builtin given the number of arguments that the builtin takes.
 type ToCostingType :: Peano -> GHC.Type

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -254,18 +254,18 @@ instance KnownTypeAst DefaultUni Int64 where
 
 -- See Note [Int as Integer].
 instance HasConstantIn DefaultUni term => MakeKnownIn DefaultUni term Int64 where
-    makeKnown mayCause = makeKnown mayCause . toInteger
+    makeKnown = makeKnown . toInteger
     {-# INLINE makeKnown #-}
 
 instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Int64 where
-    readKnown mayCause term =
+    readKnown term =
         -- See Note [Performance of KnownTypeIn instances].
         -- Funnily, we don't need 'inline' here, unlike in the default implementation of 'readKnown'
         -- (go figure why).
-        inline readKnownConstant mayCause term >>= oneShot \(i :: Integer) ->
+        inline readKnownConstant term >>= oneShot \(i :: Integer) ->
             if fromIntegral (minBound :: Int64) <= i && i <= fromIntegral (maxBound :: Int64)
                 then pure $ fromIntegral i
-                else throwingWithCause _EvaluationFailure () mayCause
+                else throwing_ _EvaluationFailure
     {-# INLINE readKnown #-}
 
 instance KnownTypeAst DefaultUni Int where
@@ -275,11 +275,11 @@ instance KnownTypeAst DefaultUni Int where
 instance HasConstantIn DefaultUni term => MakeKnownIn DefaultUni term Int where
     -- This could safely just be toInteger, but this way is more explicit and it'll
     -- turn into the same thing anyway.
-    makeKnown mayCause = makeKnown mayCause . intCastEq @Int @Int64
+    makeKnown = makeKnown . intCastEq @Int @Int64
     {-# INLINE makeKnown #-}
 
 instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Int where
-    readKnown mayCause term = intCastEq @Int64 @Int <$> readKnown mayCause term
+    readKnown term = intCastEq @Int64 @Int <$> readKnown term
     {-# INLINE readKnown #-}
 
 {- Note [Stable encoding of tags]

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -71,7 +71,7 @@ evalBuiltinApp term runtime@(BuiltinRuntime sch getX _) = case sch of
         let (errOrRes, logs) = runEmitter $ runExceptT getX
         emitCkM logs
         case errOrRes of
-            Left err  -> throwKnownTypeErrorWithCause $ term <$ err
+            Left err  -> throwKnownTypeErrorWithCause term err
             Right res -> pure res
     _ -> pure $ VBuiltin term runtime
 
@@ -125,8 +125,8 @@ emitCkM logs = do
 type instance UniOf (CkValue uni fun) = uni
 
 instance HasConstant (CkValue uni fun) where
-    asConstant _        (VCon val) = pure val
-    asConstant mayCause _          = throwNotAConstant mayCause
+    asConstant (VCon val) = pure val
+    asConstant _          = throwNotAConstant
 
     fromConstant = VCon
 
@@ -307,7 +307,7 @@ applyEvaluate stack (VBuiltin term (BuiltinRuntime sch f exF)) arg = do
         -- It's only possible to apply a builtin application if the builtin expects a term
         -- argument next.
         RuntimeSchemeArrow schB -> case f arg of
-            Left err -> throwKnownTypeErrorWithCause $ argTerm <$ err
+            Left err -> throwKnownTypeErrorWithCause argTerm err
             Right y  -> do
                 -- The CK machine does not support costing, so we just apply the costing function
                 -- to 'mempty'.

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -130,8 +130,8 @@ data Term tyname name uni fun a =
 type instance UniOf (Term tyname name uni fun ann) = uni
 
 instance HasConstant (Term tyname name uni fun ()) where
-    asConstant _        (Constant _ val) = pure val
-    asConstant mayCause _                = throwNotAConstant mayCause
+    asConstant (Constant _ val) = pure val
+    asConstant _                = throwNotAConstant
 
     fromConstant = Constant ()
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -106,8 +106,8 @@ instance TermLike (Term name uni fun) TPLC.TyName name uni fun where
     error    = \ann _ -> Error ann
 
 instance TPLC.HasConstant (Term name uni fun ()) where
-    asConstant _        (Constant _ val) = pure val
-    asConstant mayCause _                = TPLC.throwNotAConstant mayCause
+    asConstant (Constant _ val) = pure val
+    asConstant _                = TPLC.throwNotAConstant
 
     fromConstant = Constant ()
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -492,8 +492,8 @@ instance (Closed uni, GShow uni, uni `Everywhere` PrettyConst, Pretty fun) =>
 type instance UniOf (CekValue uni fun) = uni
 
 instance HasConstant (CekValue uni fun) where
-    asConstant _        (VCon val) = pure val
-    asConstant mayCause _          = throwNotAConstant mayCause
+    asConstant (VCon val) = pure val
+    asConstant _          = throwNotAConstant
 
     fromConstant = VCon
 
@@ -568,7 +568,7 @@ evalBuiltinApp fun term env runtime@(BuiltinRuntime sch getX cost) = case sch of
         let !(errOrRes, logs) = runEmitter $ runExceptT getX
         ?cekEmitter logs
         case errOrRes of
-            Left err  -> throwKnownTypeErrorWithCause $ term <$ err
+            Left err  -> throwKnownTypeErrorWithCause term err
             Right res -> pure res
     _ -> pure $ VBuiltin fun term env runtime
 {-# INLINE evalBuiltinApp #-}
@@ -710,7 +710,7 @@ enterComputeCek = computeCek (toWordArray 0) where
             -- It's only possible to apply a builtin application if the builtin expects a term
             -- argument next.
             RuntimeSchemeArrow schB -> case f arg of
-                Left err -> throwKnownTypeErrorWithCause $ argTerm <$ err
+                Left err -> throwKnownTypeErrorWithCause argTerm err
                 Right y  -> do
                     -- TODO: should we bother computing that 'ExMemory' eagerly? We may not need it.
                     -- We pattern match on @arg@ twice: in 'readKnown' and in 'toExMemory'.


### PR DESCRIPTION
Returning an `ErrorWithCause` from the builtins machinery was a mistake from day 1.
This PR fixes that by attaching the cause of an actual failure (not a potential one
like before) to the error message at the call site.