### PR TITLE
Fix the default implementation of consSlab

### DIFF
--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/plutus-core.nix
@@ -653,6 +653,7 @@
             (hsPkgs."plutus-core".components.sublibs.index-envs or (errorHandler.buildDepError "plutus-core:index-envs"))
             (hsPkgs."nonempty-vector" or (errorHandler.buildDepError "nonempty-vector"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/plutus-core.nix
@@ -653,6 +653,7 @@
             (hsPkgs."plutus-core".components.sublibs.index-envs or (errorHandler.buildDepError "plutus-core:index-envs"))
             (hsPkgs."nonempty-vector" or (errorHandler.buildDepError "nonempty-vector"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/plutus-core.nix
@@ -653,6 +653,7 @@
             (hsPkgs."plutus-core".components.sublibs.index-envs or (errorHandler.buildDepError "plutus-core:index-envs"))
             (hsPkgs."nonempty-vector" or (errorHandler.buildDepError "nonempty-vector"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             ];

--- a/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/Class.hs
@@ -41,7 +41,7 @@ class RandomAccessList e where
     -- | Prepend many elements to the list. Has a default implementation, but
     -- implementations can provide more efficient ones.
     consSlab :: NEV.NonEmptyVector (Element e) -> e -> e
-    consSlab vec e = NEV.foldl' (\env val -> cons val env) e vec
+    consSlab vec e = NEV.foldr cons e vec
 
     {-# INLINABLE indexZero #-}
     -- | Lookup an element in the list. 0-based index.
@@ -72,7 +72,7 @@ head = fst . fromMaybe (error "empty list") . uncons
 {-# INLINABLE tail #-}
 -- O(1) worst-case
 tail :: (RandomAccessList e) => e -> e
-tail = snd. fromMaybe (error "empty list") . uncons
+tail = snd . fromMaybe (error "empty list") . uncons
 
 instance RandomAccessList [a] where
     type Element [a] = a

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -726,5 +726,6 @@ test-suite index-envs-test
         index-envs -any,
         nonempty-vector -any,
         QuickCheck -any,
+        quickcheck-instances -any,
         tasty -any,
         tasty-quickcheck -any


### PR DESCRIPTION
It was appending things in the wrong order! In practice, this meant that
the `consSlab` property should have been failing, since it relied on the
default implementation for `List`, which should have been different.
Eventually I realised that it wasn't because for some reason I was doing
all the tests with lists of `()`, so order didn't matter! Changing it to
`Integer` caused the test to fail (and only that one, phew), and the fix
fixes it.