### PR TITLE
Improve error reporting of the builtin function parser.

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -38,8 +38,10 @@ import PlutusCore.Pretty
 import Control.Lens hiding (use)
 import Control.Monad.Error.Lens
 import Control.Monad.Except
+import Data.Map (Map)
 import Data.Text qualified as T
 import ErrorCode
+import PlutusCore.Default (DefaultFun)
 import Prettyprinter (hardline, indent, squotes, (<+>))
 import Text.Megaparsec as M
 import Universe (Closed (Everywhere), GEq, GShow)
@@ -54,7 +56,7 @@ throwingEither r e = case e of
 data ParserError
     = UnknownBuiltinType T.Text SourcePos
     | BuiltinTypeNotAStar T.Text SourcePos
-    | UnknownBuiltinFunction T.Text SourcePos
+    | UnknownBuiltinFunction T.Text SourcePos (Map T.Text DefaultFun)
     | InvalidBuiltinConstant T.Text T.Text SourcePos
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (NFData)
@@ -117,7 +119,7 @@ instance Pretty SourcePos where
 instance Pretty ParserError where
     pretty (UnknownBuiltinType s loc)       = "Unknown built-in type" <+> squotes (pretty s) <+> "at" <+> pretty loc
     pretty (BuiltinTypeNotAStar ty loc)     = "Expected a type of kind star (to later parse a constant), but got:" <+> squotes (pretty ty) <+> "at" <+> pretty loc
-    pretty (UnknownBuiltinFunction s loc)   = "Unknown built-in function" <+> squotes (pretty s) <+> "at" <+> pretty loc
+    pretty (UnknownBuiltinFunction s loc lBuiltin)   = "Unknown built-in function" <+> squotes (pretty s) <+> "at" <+> pretty loc <+> ". Parsable functions are " <+> pretty (show lBuiltin)
     pretty (InvalidBuiltinConstant c s loc) = "Invalid constant" <+> squotes (pretty c) <+> "of type" <+> squotes (pretty s) <+> "at" <+> pretty loc
 
 instance ShowErrorComponent ParserError where

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -38,10 +38,8 @@ import PlutusCore.Pretty
 import Control.Lens hiding (use)
 import Control.Monad.Error.Lens
 import Control.Monad.Except
-import Data.Map (Map)
 import Data.Text qualified as T
 import ErrorCode
-import PlutusCore.Default (DefaultFun)
 import Prettyprinter (hardline, indent, squotes, (<+>))
 import Text.Megaparsec as M
 import Universe (Closed (Everywhere), GEq, GShow)
@@ -56,7 +54,7 @@ throwingEither r e = case e of
 data ParserError
     = UnknownBuiltinType T.Text SourcePos
     | BuiltinTypeNotAStar T.Text SourcePos
-    | UnknownBuiltinFunction T.Text SourcePos (Map T.Text DefaultFun)
+    | UnknownBuiltinFunction T.Text SourcePos [T.Text]
     | InvalidBuiltinConstant T.Text T.Text SourcePos
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (NFData)
@@ -119,7 +117,7 @@ instance Pretty SourcePos where
 instance Pretty ParserError where
     pretty (UnknownBuiltinType s loc)       = "Unknown built-in type" <+> squotes (pretty s) <+> "at" <+> pretty loc
     pretty (BuiltinTypeNotAStar ty loc)     = "Expected a type of kind star (to later parse a constant), but got:" <+> squotes (pretty ty) <+> "at" <+> pretty loc
-    pretty (UnknownBuiltinFunction s loc lBuiltin)   = "Unknown built-in function" <+> squotes (pretty s) <+> "at" <+> pretty loc <+> ". Parsable functions are " <+> pretty (show lBuiltin)
+    pretty (UnknownBuiltinFunction s loc lBuiltin)   = "Unknown built-in function" <+> squotes (pretty s) <+> "at" <+> pretty loc <+> ". Parsable functions are " <+> pretty lBuiltin
     pretty (InvalidBuiltinConstant c s loc) = "Invalid constant" <+> squotes (pretty c) <+> "of type" <+> squotes (pretty s) <+> "at" <+> pretty loc
 
 instance ShowErrorComponent ParserError where


### PR DESCRIPTION
Follow up on #4546. More proper error reporting for the builtin function parser. The parser can only deal with `DefaultFun` atm anyway so adding a `DefaultFun` specific type parameter to `UnknownBuiltinFunction` shouldn't be a problem? As we make the parser work on more functions we'll need to have `ParserError` take a `fun` argument though.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
