### PR TITLE
Forgot to update memory usage for serialiseData

### DIFF
--- a/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
+++ b/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
@@ -682,7 +682,7 @@ equalsData cpuModelR = do
 serialiseData :: MonadR m => (SomeSEXP (Region m)) -> m (CostingFun ModelOneArgument)
 serialiseData cpuModelR = do
   cpuModel <- ModelOneArgumentLinearCost <$> readModelLinearInX cpuModelR
-  let memModel = ModelOneArgumentLinearCost $ ModelLinearSize 0 0
+  let memModel = ModelOneArgumentLinearCost $ ModelLinearSize 0 2
   pure $ CostingFun cpuModel memModel
 
 ---------------- Misc constructors ----------------


### PR DESCRIPTION
This fixes a stupid mistake.  When I added the costing function for `serialiseData` I forgot about the memory usage component (I think maybe @bezirg  pointed this out).  I "fixed" it in #4486 by modifying `builtinCostModel.json`, which is where the cost model gets read in from.  However, I failed to modify the code that produces the JSON file, so regenerating the JSON sets the memory costing function back to zero.  We haven't actually regenerated the cost model since then, so there shouldn't be a model in use anywhere that has the wrong costing function.  This PR ensures that a sensible memory cost function should be generated in future.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
