### PR TITLE
Allow spaces in unit constants

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -65,7 +65,7 @@ conText = do
 
 -- | Parser for unit.
 conUnit :: Parser (Some (ValueOf DefaultUni))
-conUnit = someValue () <$ symbol "()"
+conUnit = someValue () <$ (char '(' *> whitespace *> char ')')
 
 -- | Parser for bool.
 conBool :: Parser (Some (ValueOf DefaultUni))
@@ -87,4 +87,3 @@ constant = do
             SomeTypeIn DefaultUniBool       -> conBool
     whitespace
     pure con
-

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -65,7 +65,7 @@ conText = do
 
 -- | Parser for unit.
 conUnit :: Parser (Some (ValueOf DefaultUni))
-conUnit = someValue () <$ (char '(' *> whitespace *> char ')')
+conUnit = someValue () <$ (symbol "(" *> symbol ")")
 
 -- | Parser for bool.
 conBool :: Parser (Some (ValueOf DefaultUni))

--- a/plutus-core/testlib/PlutusCore/Generators/AST.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/AST.hs
@@ -82,7 +82,8 @@ genBuiltin = Gen.element [minBound .. maxBound]
 
 genConstant :: AstGen (Some (ValueOf DefaultUni))
 genConstant = Gen.choice
-    [ someValue @Integer <$> Gen.integral_ (Range.linear (-10000000) 10000000)
+    [ pure (someValue ())
+    , someValue @Integer <$> Gen.integral_ (Range.linear (-10000000) 10000000)
     , someValue <$> Gen.utf8 (Range.linear 0 40) Gen.unicode
     ]
 


### PR DESCRIPTION
Make `(con unit ( <spaces> ))` legal.