### PR TITLE
Improve plugin option parsing

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -54,12 +54,15 @@ library
         PlutusTx.Compiler.Type
         PlutusTx.Compiler.Types
         PlutusTx.Compiler.Utils
+        PlutusTx.Options
         PlutusTx.PIRTypes
         PlutusTx.PLCTypes
     build-depends:
+        PyF -any,
         base >=4.9 && <5,
         bytestring -any,
         containers -any,
+        either -any,
         extra -any,
         flat -any,
         ghc-prim -any,

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -57,7 +57,7 @@ data CompileContext uni fun = CompileContext {
 data ProfileOpts =
     All -- set this with -fplugin-opt PlutusTx.Plugin:profile-all
     | None
-    deriving stock (Eq)
+    deriving stock (Eq, Show)
 
 -- | Coverage options
 -- See Note [Coverage annotations]

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -1,0 +1,234 @@
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE StrictData        #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module PlutusTx.Options where
+
+import PlutusIR.Compiler qualified as PIR
+import PlutusTx.Compiler.Types
+
+import Control.Exception
+import Control.Lens
+import Data.Bifunctor (first)
+import Data.Either.Validation
+import Data.Foldable (foldl', toList)
+import Data.List qualified as List
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Proxy
+import Data.Text (Text)
+import Data.Text qualified as Text
+import GhcPlugins qualified as GHC
+import PyF (fmt)
+import Text.Read (readMaybe)
+import Type.Reflection
+
+data PluginOptions = PluginOptions
+    { _poDoTypecheck                    :: Bool
+    , _poDeferErrors                    :: Bool
+    , _poContextLevel                   :: Int
+    , _poDumpPir                        :: Bool
+    , _poDumpPlc                        :: Bool
+    , _poDumpUPlc                       :: Bool
+    , _poOptimize                       :: Bool
+    , _poPedantic                       :: Bool
+    , _poVerbose                        :: Bool
+    , _poDebug                          :: Bool
+    , _poMaxSimplifierIterations        :: Int
+    , _poDoSimplifierUnwrapCancel       :: Bool
+    , _poDoSimplifierBeta               :: Bool
+    , _poDoSimplifierInline             :: Bool
+    , _poDoSimplifierRemoveDeadBindings :: Bool
+    , _poProfile                        :: ProfileOpts
+    , _poCoverageAll                    :: Bool
+    , _poCoverageLocation               :: Bool
+    , _poCoverageBoolean                :: Bool
+    , -- Setting to `True` defines `trace` as `\_ a -> a` instead of the builtin version.
+      -- Which effectively ignores the trace text.
+      _poRemoveTrace                    :: Bool
+    }
+
+makeLenses ''PluginOptions
+
+type OptionKey = Text
+type OptionValue = Text
+
+-- | A plugin option definition for a `PluginOptions` field of type @a@.
+data PluginOption
+    = forall a.
+        PluginOption
+        (TypeRep a)
+        -- ^ `TypeRep` used for pretty printing the option.
+        (Maybe OptionValue -> Validation ParseError (a -> a))
+        -- ^ Consumes an optional value, and either updates the field or reports an error.
+        (Lens' PluginOptions a)
+        -- ^ Lens focusing on the field. This is for modifying the field, as well as
+        -- getting the field value from `defaultPluginOptions` for pretty printing.
+        (a -> Text)
+        -- ^ Display the field value.
+        Text
+        -- ^ A description of the option.
+
+data ParseError
+    = CannotParseValue OptionKey OptionValue SomeTypeRep
+    | UnexpectedValue OptionKey OptionValue
+    | MissingValue OptionKey
+    | UnrecognisedOption OptionKey [OptionKey]
+    deriving stock (Show)
+
+newtype ParseErrors = ParseErrors (NonEmpty ParseError)
+    deriving newtype (Semigroup)
+
+instance Show ParseErrors where
+    show (ParseErrors errs) =
+        [fmt|PlutusTx.Plugin: failed to parse options:
+{Text.intercalate "\n" (fmap renderParseError (toList errs))}|]
+
+instance Exception ParseErrors
+
+renderParseError :: ParseError -> Text
+renderParseError = \case
+    CannotParseValue k v tr ->
+        [fmt|Cannot parse value {v} for option {k} into type {show tr}.|]
+    UnexpectedValue k v ->
+        [fmt|Option {k} is a flag and does not take a value, but was given {v}.|]
+    MissingValue k ->
+        [fmt|Option {k} needs a value.|]
+    UnrecognisedOption k suggs ->
+        [fmt|Unrecgonised option: {k}.|] <> case suggs of
+            [] -> ""
+            _ ->
+                [fmt|
+Did you mean one of:
+{Text.intercalate "\n" suggs}|]
+
+{- | Definition of plugin options.
+
+ TODO: write a description for each option.
+-}
+pluginOptions :: Map OptionKey PluginOption
+pluginOptions =
+    Map.fromList
+        [ let k = "no-typecheck"
+           in (k, PluginOption typeRep (setFalse k) poDoTypecheck showText mempty)
+        , let k = "defer-errors"
+           in (k, PluginOption typeRep (setTrue k) poDeferErrors showText mempty)
+        , let k = "no-context"
+           in (k, PluginOption typeRep (flag (const 0) k) poContextLevel showText mempty)
+        , let k = "debug-context"
+           in (k, PluginOption typeRep (flag (const 3) k) poContextLevel showText mempty)
+        , let k = "dump-pir"
+           in (k, PluginOption typeRep (setTrue k) poDumpPir showText mempty)
+        , let k = "dump-plc"
+           in (k, PluginOption typeRep (setTrue k) poDumpPlc showText mempty)
+        , let k = "dump-uplc"
+           in (k, PluginOption typeRep (setTrue k) poDumpUPlc showText mempty)
+        , let k = "no-optimize"
+           in (k, PluginOption typeRep (setFalse k) poOptimize showText mempty)
+        , let k = "pedantic"
+           in (k, PluginOption typeRep (setTrue k) poPedantic showText mempty)
+        , let k = "verbose"
+           in (k, PluginOption typeRep (setTrue k) poVerbose showText mempty)
+        , let k = "debug"
+           in (k, PluginOption typeRep (setTrue k) poDebug showText mempty)
+        , let k = "max-simplifier-iterations"
+           in (k, PluginOption typeRep (intOption k) poMaxSimplifierIterations showText mempty)
+        , let k = "no-simplifier-unwrap-cancel"
+           in (k, PluginOption typeRep (setFalse k) poDoSimplifierUnwrapCancel showText mempty)
+        , let k = "no-simplifier-beta"
+           in (k, PluginOption typeRep (setFalse k) poDoSimplifierBeta showText mempty)
+        , let k = "no-simplifier-inline"
+           in (k, PluginOption typeRep (setFalse k) poDoSimplifierInline showText mempty)
+        , let k = "no-simplifier-remove-dead-bindings"
+           in (k, PluginOption typeRep (setFalse k) poDoSimplifierRemoveDeadBindings showText mempty)
+        , let k = "profile-all"
+           in (k, PluginOption typeRep (flag (const All) k) poProfile showText mempty)
+        , let k = "coverage-all"
+           in (k, PluginOption typeRep (setTrue k) poCoverageAll showText mempty)
+        , let k = "coverage-location"
+           in (k, PluginOption typeRep (setTrue k) poCoverageLocation showText mempty)
+        , let k = "coverage-boolean"
+           in (k, PluginOption typeRep (setTrue k) poCoverageBoolean showText mempty)
+        , let k = "remove-trace"
+           in (k, PluginOption typeRep (setTrue k) poRemoveTrace showText mempty)
+        ]
+  where
+    showText :: Show a => a -> Text
+    showText = Text.pack . show
+
+flag :: (a -> a) -> OptionKey -> Maybe OptionValue -> Validation ParseError (a -> a)
+flag f k = maybe (Success f) (Failure . UnexpectedValue k)
+
+setTrue :: OptionKey -> Maybe OptionValue -> Validation ParseError (Bool -> Bool)
+setTrue = flag (const True)
+
+setFalse :: OptionKey -> Maybe OptionValue -> Validation ParseError (Bool -> Bool)
+setFalse = flag (const False)
+
+intOption :: OptionKey -> Maybe OptionValue -> Validation ParseError (Int -> Int)
+intOption k = \case
+    Just v ->
+        maybe
+            (Failure (CannotParseValue k v (someTypeRep (Proxy @Int))))
+            (Success . const)
+            (readMaybe (Text.unpack v))
+    Nothing -> Failure (MissingValue k)
+
+defaultPluginOptions :: PluginOptions
+defaultPluginOptions =
+    PluginOptions
+        { _poDoTypecheck = True
+        , _poDeferErrors = False
+        , _poContextLevel = 1
+        , _poDumpPir = False
+        , _poDumpPlc = False
+        , _poDumpUPlc = False
+        , _poOptimize = True
+        , _poPedantic = False
+        , _poVerbose = False
+        , _poDebug = False
+        , _poMaxSimplifierIterations = view PIR.coMaxSimplifierIterations PIR.defaultCompilationOpts
+        , _poDoSimplifierUnwrapCancel = True
+        , _poDoSimplifierBeta = True
+        , _poDoSimplifierInline = True
+        , _poDoSimplifierRemoveDeadBindings = True
+        , _poProfile = None
+        , _poCoverageAll = False
+        , _poCoverageLocation = False
+        , _poCoverageBoolean = False
+        , _poRemoveTrace = False
+        }
+
+processOne ::
+    OptionKey ->
+    Maybe OptionValue ->
+    Validation ParseError (PluginOptions -> PluginOptions)
+processOne key val = case Map.lookup key pluginOptions of
+    Just (PluginOption _ f field _ _) -> over field <$> f val
+    Nothing ->
+        let suggs =
+                Text.pack
+                    <$> GHC.fuzzyMatch (Text.unpack key) (Text.unpack <$> Map.keys pluginOptions)
+         in Failure (UnrecognisedOption key suggs)
+
+processAll ::
+    [(OptionKey, Maybe OptionValue)] ->
+    Validation ParseErrors [PluginOptions -> PluginOptions]
+processAll = traverse $ first (ParseErrors . pure) . uncurry processOne
+
+toKeyValue :: GHC.CommandLineOption -> (OptionKey, Maybe OptionValue)
+toKeyValue opt =
+    maybe (Text.pack opt, Nothing) (bimap Text.pack (Just . Text.pack)) $
+        fmap (drop 1) . flip splitAt opt <$> List.elemIndex '=' opt
+
+{- | Parses the arguments that were given to ghc at commandline as
+ "-fplugin-opt PlutusTx.Plugin:opt" or "-fplugin-opt PlutusTx.Plugin:opt=val"
+-}
+parsePluginOptions :: [GHC.CommandLineOption] -> Validation ParseErrors PluginOptions
+parsePluginOptions = fmap (foldl' (flip ($)) defaultPluginOptions) . processAll . fmap toKeyValue

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -38,9 +38,11 @@ import UntypedPlutusCore qualified as UPLC
 import PlutusIR qualified as PIR
 import PlutusIR.Compiler qualified as PIR
 import PlutusIR.Compiler.Definitions qualified as PIR
+import PlutusTx.Options
 
 import Language.Haskell.TH.Syntax as TH hiding (lift)
 
+import Control.Exception (throwIO)
 import Control.Lens
 import Control.Monad
 import Control.Monad.Except
@@ -50,43 +52,16 @@ import Flat (Flat, flat, unflat)
 
 import Data.ByteString qualified as BS
 import Data.ByteString.Unsafe qualified as BSUnsafe
+import Data.Either.Validation
 import Data.Foldable (fold)
-import Data.List (isPrefixOf)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Traversable (for)
 import ErrorCode
 import FamInstEnv qualified as GHC
 import Prettyprinter qualified as PP
-import Text.Read (readMaybe)
-
 import System.IO (openTempFile)
 import System.IO.Unsafe (unsafePerformIO)
-
-data PluginOptions = PluginOptions {
-    poDoTypecheck                      :: Bool
-    , poDeferErrors                    :: Bool
-    , poContextLevel                   :: Int
-    , poDumpPir                        :: Bool
-    , poDumpPlc                        :: Bool
-    , poDumpUPlc                       :: Bool
-    , poOptimize                       :: Bool
-    , poPedantic                       :: Bool
-    , poVerbose                        :: Bool
-    , poDebug                          :: Bool
-    , poMaxSimplifierIterations        :: Int
-    , poDoSimplifierUnwrapCancel       :: Bool
-    , poDoSimplifierBeta               :: Bool
-    , poDoSimplifierInline             :: Bool
-    , poDoSimplifierRemoveDeadBindings :: Bool
-    , poProfile                        :: ProfileOpts
-    , poCoverage                       :: CoverageOpts
-
-    -- Setting to `True` defines `trace` as `\_ a -> a` instead of the builtin version.
-    -- Which effectively ignores the trace text.
-    , poRemoveTrace                    :: Bool
-    }
 
 data PluginCtx = PluginCtx
     { pcOpts            :: PluginOptions
@@ -123,7 +98,9 @@ plugin = GHC.defaultPlugin { GHC.pluginRecompile = GHC.flagRecompile
           -- create simplifier pass to be placed at the front
           simplPass <- mkSimplPass <$> GHC.getDynFlags
           -- instantiate our plugin pass
-          pluginPass <- mkPluginPass <$> parsePluginArgs args
+          pluginPass <- mkPluginPass <$> case parsePluginOptions args of
+              Success opts -> pure opts
+              Failure errs -> liftIO $ throwIO errs
           -- return the pipeline
           pure $
              simplPass
@@ -144,56 +121,6 @@ mkSimplPass flags =
             , GHC.sm_case_case = False
             , GHC.sm_eta_expand = False
             }
-
--- | Parses the arguments that were given to ghc at commandline as "-fplugin-opt PlutusTx.Plugin:arg1"
-parsePluginArgs :: [GHC.CommandLineOption] -> GHC.CoreM PluginOptions
-parsePluginArgs args = do
-    let opts = PluginOptions {
-            poDoTypecheck = notElem' "no-typecheck"
-            , poDeferErrors = elem' "defer-errors"
-            , poContextLevel = if elem' "no-context" then 0 else if elem "debug-context" args then 3 else 1
-            , poDumpPir = elem' "dump-pir"
-            , poDumpPlc = elem' "dump-plc"
-            , poDumpUPlc = elem' "dump-uplc"
-            , poOptimize = notElem' "no-optimize"
-            , poPedantic = elem' "pedantic"
-            , poVerbose = elem' "verbose"
-            , poDebug = elem' "debug"
-            , poMaxSimplifierIterations = maxIterations
-            -- Simplifier Passes
-            , poDoSimplifierUnwrapCancel = notElem' "no-simplifier-unwrap-cancel"
-            , poDoSimplifierBeta = notElem' "no-simplifier-beta"
-            , poDoSimplifierInline = notElem' "no-simplifier-inline"
-            , poDoSimplifierRemoveDeadBindings = notElem' "no-simplifier-remove-dead-bindings"
-            -- profiling: @profile-all@ turns on profiling for everything
-            , poProfile =
-                if elem' "profile-all"
-                then All
-                else None
-            , poCoverage = CoverageOpts . Set.fromList $
-                   [ l | l <- [minBound .. maxBound], elem' "coverage-all" ]
-                ++ [ LocationCoverage  | elem' "coverage-location"  ]
-                ++ [ BooleanCoverage  | elem' "coverage-boolean"  ]
-            , poRemoveTrace = elem' "remove-trace"
-            }
-    -- TODO: better parsing with failures
-    pure opts
-    where
-        elem' :: String -> Bool
-        elem' = flip elem args
-        notElem' :: String -> Bool
-        notElem' = flip notElem args
-        prefix :: String
-        prefix = "max-simplifier-iterations="
-        defaultIterations :: Int
-        defaultIterations = view PIR.coMaxSimplifierIterations PIR.defaultCompilationOpts
-        maxIterations :: Int
-        maxIterations = case filter (isPrefixOf prefix) args of
-            match : _ ->
-                let val = drop (length prefix) match in
-                    fromMaybe defaultIterations (readMaybe val)
-            _ -> defaultIterations
-
 
 {- Note [Marker resolution]
 We use TH's 'foo exact syntax for resolving the 'plc marker's ghc name, as
@@ -315,7 +242,7 @@ compileMarkedExprOrDefer :: String -> GHC.Type -> GHC.CoreExpr -> PluginM PLC.De
 compileMarkedExprOrDefer locStr codeTy origE = do
     opts <- asks pcOpts
     let compileAct = compileMarkedExpr locStr codeTy origE
-    if poDeferErrors opts
+    if _poDeferErrors opts
       -- TODO: we could perhaps move this catchError to the "runExceptT" module-level, but
       -- it leads to uglier code and difficulty of handling other pure errors
       then compileAct `catchError` emitRuntimeError codeTy
@@ -326,7 +253,7 @@ emitRuntimeError :: (PLC.GShow uni, PLC.Closed uni, PP.Pretty fun, PLC.Everywher
                  => GHC.Type -> CompileError uni fun -> PluginM uni fun GHC.CoreExpr
 emitRuntimeError codeTy e = do
     opts <- asks pcOpts
-    let shown = show $ PP.pretty (pruneContext (poContextLevel opts) e)
+    let shown = show $ PP.pretty (pruneContext (_poContextLevel opts) e)
     tcName <- thNameToGhcNameOrFail ''CompiledCode
     tc <- lift . lift $ GHC.lookupTyCon tcName
     pure $ GHC.mkRuntimeErrorApp GHC.rUNTIME_ERROR_ID (GHC.mkTyConApp tc [codeTy]) shown
@@ -344,8 +271,12 @@ compileMarkedExpr locStr codeTy origE = do
     -- We need to do this out here, since it has to run in CoreM
     nameInfo <- makePrimitiveNameInfo $ builtinNames ++ [''Bool, 'False, 'True, 'traceBool]
     modBreaks <- asks pcModuleModBreaks
+    let coverage = CoverageOpts . Set.fromList $
+                   [ l | _poCoverageAll opts, l <- [minBound .. maxBound]]
+                ++ [ LocationCoverage  | _poCoverageLocation opts  ]
+                ++ [ BooleanCoverage  | _poCoverageBoolean opts  ]
     let ctx = CompileContext {
-            ccOpts = CompileOptions {coProfile=poProfile opts,coCoverage=poCoverage opts,coRemoveTrace=poRemoveTrace opts},
+            ccOpts = CompileOptions {coProfile=_poProfile opts,coCoverage=coverage,coRemoveTrace=_poRemoveTrace opts},
             ccFlags = flags,
             ccFamInstEnvs = famEnvs,
             ccNameInfo = nameInfo,
@@ -398,47 +329,47 @@ runCompiler moduleName opts expr = do
             PIR.DatatypeComponent PIR.Destructor _ -> True
             _                                      -> False
     -- Compilation configuration
-    let pirTcConfig = if poDoTypecheck opts
+    let pirTcConfig = if _poDoTypecheck opts
                       -- pir's tc-config is based on plc tcconfig
                       then Just $ PIR.PirTCConfig plcTcConfig PIR.YesEscape
                       else Nothing
         pirCtx = PIR.toDefaultCompilationCtx plcTcConfig
-                 & set (PIR.ccOpts . PIR.coOptimize) (poOptimize opts)
-                 & set (PIR.ccOpts . PIR.coPedantic) (poPedantic opts)
-                 & set (PIR.ccOpts . PIR.coVerbose) (poVerbose opts)
-                 & set (PIR.ccOpts . PIR.coDebug) (poDebug opts)
-                 & set (PIR.ccOpts . PIR.coMaxSimplifierIterations) (poMaxSimplifierIterations opts)
+                 & set (PIR.ccOpts . PIR.coOptimize) (_poOptimize opts)
+                 & set (PIR.ccOpts . PIR.coPedantic) (_poPedantic opts)
+                 & set (PIR.ccOpts . PIR.coVerbose) (_poVerbose opts)
+                 & set (PIR.ccOpts . PIR.coDebug) (_poDebug opts)
+                 & set (PIR.ccOpts . PIR.coMaxSimplifierIterations) (_poMaxSimplifierIterations opts)
                  & set PIR.ccTypeCheckConfig pirTcConfig
                  -- Simplifier options
-                 & set (PIR.ccOpts . PIR.coDoSimplifierUnwrapCancel)       (poDoSimplifierUnwrapCancel opts)
-                 & set (PIR.ccOpts . PIR.coDoSimplifierBeta)               (poDoSimplifierBeta opts)
-                 & set (PIR.ccOpts . PIR.coDoSimplifierInline)             (poDoSimplifierInline opts)
+                 & set (PIR.ccOpts . PIR.coDoSimplifierUnwrapCancel)       (_poDoSimplifierUnwrapCancel opts)
+                 & set (PIR.ccOpts . PIR.coDoSimplifierBeta)               (_poDoSimplifierBeta opts)
+                 & set (PIR.ccOpts . PIR.coDoSimplifierInline)             (_poDoSimplifierInline opts)
                  & set (PIR.ccOpts . PIR.coInlineHints)                    hints
         uplcSimplOpts = UPLC.defaultSimplifyOpts
-            & set UPLC.soMaxSimplifierIterations (poMaxSimplifierIterations opts)
+            & set UPLC.soMaxSimplifierIterations (_poMaxSimplifierIterations opts)
             & set UPLC.soInlineHints hints
 
     -- GHC.Core -> Pir translation.
     pirT <- PIR.runDefT () $ compileExprWithDefs expr
-    when (poDumpPir opts) . liftIO $ dumpFlat (PIR.Program () pirT) "initial PIR program" (moduleName ++ ".pir-initial.flat")
+    when (_poDumpPir opts) . liftIO $ dumpFlat (PIR.Program () pirT) "initial PIR program" (moduleName ++ ".pir-initial.flat")
 
     -- Pir -> (Simplified) Pir pass. We can then dump/store a more legible PIR program.
     spirT <- flip runReaderT pirCtx $ PIR.compileToReadable pirT
     let spirP = PIR.Program () . void $ spirT
-    when (poDumpPir opts) . liftIO $ dumpFlat spirP "simplified PIR program" (moduleName ++ ".pir-simplified.flat")
+    when (_poDumpPir opts) . liftIO $ dumpFlat spirP "simplified PIR program" (moduleName ++ ".pir-simplified.flat")
 
     -- (Simplified) Pir -> Plc translation.
     plcT <- flip runReaderT pirCtx $ PIR.compileReadableToPlc spirT
     let plcP = PLC.Program () (PLC.defaultVersion ()) $ void plcT
-    when (poDumpPlc opts) . liftIO $ dumpFlat plcP "typed PLC program" (moduleName ++ ".plc.flat")
+    when (_poDumpPlc opts) . liftIO $ dumpFlat plcP "typed PLC program" (moduleName ++ ".plc.flat")
 
     -- We do this after dumping the programs so that if we fail typechecking we still get the dump.
-    when (poDoTypecheck opts) . void $
+    when (_poDoTypecheck opts) . void $
         liftExcept $ PLC.typecheckPipeline plcTcConfig plcP
 
     uplcT <- liftExcept $ UPLC.deBruijnTerm =<< UPLC.simplifyTerm uplcSimplOpts (UPLC.erase plcT)
     let uplcP = UPLC.Program () (PLC.defaultVersion ()) $ void uplcT
-    when (poDumpUPlc opts) . liftIO $ dumpFlat uplcP "untyped PLC program" (moduleName ++ ".uplc.flat")
+    when (_poDumpUPlc opts) . liftIO $ dumpFlat uplcP "untyped PLC program" (moduleName ++ ".uplc.flat")
     pure (spirP, uplcP)
 
   where


### PR DESCRIPTION
Rewrote plugin option parsing with a number of improvements:

- It is now much easier to programmatically generate documentation for the options - all we need is the `pluginOptions` map, plus `defaultPluginOptions`.
- It now reports errors, such as unrecognised flag and incorrect value type, rather than silently using the default values in those cases.
- It allows specifying the same option multiple times. This is useful for options with multiple values, or in cases where an option that appears later should override those that appear earlier.
- If in the future we wish to allow the "no-" option pattern (e.g., `dump-pir` vs. `no-dump-pir`), it would be very easy to adapt it to do so.

The next steps are:
- generate documentation
- adds a CI task that checks the documentation is up to date
- add more plugin options