### PR TITLE
Make `CompileError` annotation-polymorphic

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -29,13 +29,21 @@ first.
 variable *last* (so it is on the outside, so will be first when applying).
 -}
 
-withVarScoped :: CompilingDefault uni fun m => GHC.Var -> (PIR.VarDecl PIR.TyName PIR.Name uni fun () -> m a) -> m a
+withVarScoped ::
+    CompilingDefault uni fun m ann =>
+    GHC.Var ->
+    (PIR.VarDecl PIR.TyName PIR.Name uni fun () -> m a) ->
+    m a
 withVarScoped v k = do
     let ghcName = GHC.getName v
     var <- compileVarFresh v
     local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
 
-withVarsScoped :: CompilingDefault uni fun m => [GHC.Var] -> ([PIR.VarDecl PIR.TyName PIR.Name uni fun ()] -> m a) -> m a
+withVarsScoped ::
+    CompilingDefault uni fun m ann =>
+    [GHC.Var] ->
+    ([PIR.VarDecl PIR.TyName PIR.Name uni fun ()] -> m a) ->
+    m a
 withVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
@@ -43,13 +51,13 @@ withVarsScoped vs k = do
         pure (name, var')
     local (\c -> c {ccScopes=pushNames vars (ccScopes c)}) (k (fmap snd vars))
 
-withTyVarScoped :: Compiling uni fun m => GHC.Var -> (PIR.TyVarDecl PIR.TyName () -> m a) -> m a
+withTyVarScoped :: Compiling uni fun m ann => GHC.Var -> (PIR.TyVarDecl PIR.TyName () -> m a) -> m a
 withTyVarScoped v k = do
     let ghcName = GHC.getName v
     var <- compileTyVarFresh v
     local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) (k var)
 
-withTyVarsScoped :: Compiling uni fun m => [GHC.Var] -> ([PIR.TyVarDecl PIR.TyName ()] -> m a) -> m a
+withTyVarsScoped :: Compiling uni fun m ann => [GHC.Var] -> ([PIR.TyVarDecl PIR.TyName ()] -> m a) -> m a
 withTyVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
@@ -59,32 +67,32 @@ withTyVarsScoped vs k = do
 
 -- | Builds a lambda, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkLamAbsScoped :: CompilingDefault uni fun m => GHC.Var -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
+mkLamAbsScoped :: CompilingDefault uni fun m ann => GHC.Var -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkLamAbsScoped v body = withVarScoped v $ \(PIR.VarDecl _ n t) -> PIR.LamAbs () n t <$> body
 
-mkIterLamAbsScoped :: CompilingDefault uni fun m => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
+mkIterLamAbsScoped :: CompilingDefault uni fun m ann => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
 
 -- | Builds a type abstraction, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyAbsScoped :: Compiling uni fun m => GHC.Var -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
+mkTyAbsScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkTyAbsScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyAbs () t k <$> body
 
-mkIterTyAbsScoped :: Compiling uni fun m => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
+mkIterTyAbsScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
 
 -- | Builds a forall, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyForallScoped :: Compiling uni fun m => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
+mkTyForallScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
 mkTyForallScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyForall () t k <$> body
 
-mkIterTyForallScoped :: Compiling uni fun m => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
+mkIterTyForallScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
 mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body vars
 
 -- | Builds a type lambda, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyLamScoped :: Compiling uni fun m => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
+mkTyLamScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
 mkTyLamScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyLam () t k <$> body
 
-mkIterTyLamScoped :: Compiling uni fun m => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
+mkIterTyLamScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
 mkIterTyLamScoped vars body = foldr (\v acc -> mkTyLamScoped v acc) body vars

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -238,7 +238,7 @@ builtinNames = [
     , 'Builtins.unsafeDataAsI
     ]
 
-defineBuiltinTerm :: CompilingDefault uni fun m => TH.Name -> PIRTerm uni fun -> m ()
+defineBuiltinTerm :: CompilingDefault uni fun m ann => TH.Name -> PIRTerm uni fun -> m ()
 defineBuiltinTerm name term = do
     ghcId <- GHC.tyThingId <$> getThing name
     var <- compileVarFresh ghcId
@@ -248,7 +248,7 @@ defineBuiltinTerm name term = do
     PIR.defineTerm (LexName $ GHC.getName ghcId) def mempty
 
 -- | Add definitions for all the builtin types to the environment.
-defineBuiltinType :: forall uni fun m. Compiling uni fun m => TH.Name -> PIRType uni -> m ()
+defineBuiltinType :: forall uni fun m ann. Compiling uni fun m ann => TH.Name -> PIRType uni -> m ()
 defineBuiltinType name ty = do
     tc <- GHC.tyThingTyCon <$> getThing name
     var <- compileTcTyVarFresh tc
@@ -257,7 +257,7 @@ defineBuiltinType name ty = do
     PIR.recordAlias @LexName @uni @fun @() (LexName $ GHC.getName tc)
 
 -- | Add definitions for all the builtin terms to the environment.
-defineBuiltinTerms :: CompilingDefault uni fun m => m ()
+defineBuiltinTerms :: CompilingDefault uni fun m ann => m ()
 defineBuiltinTerms = do
     CompileContext {ccOpts=compileOpts} <- ask
 
@@ -359,7 +359,7 @@ defineBuiltinTerms = do
     defineBuiltinTerm 'Builtins.serialiseData $ mkBuiltin PLC.SerialiseData
 
 defineBuiltinTypes
-    :: CompilingDefault uni fun m
+    :: CompilingDefault uni fun m ann
     => m ()
 defineBuiltinTypes = do
     defineBuiltinType ''Builtins.BuiltinByteString $ PLC.toTypeAst $ Proxy @BS.ByteString
@@ -372,7 +372,7 @@ defineBuiltinTypes = do
     defineBuiltinType ''Builtins.BuiltinList $ PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoList)
 
 -- | Lookup a builtin term by its TH name. These are assumed to be present, so fails if it cannot find it.
-lookupBuiltinTerm :: Compiling uni fun m => TH.Name -> m (PIRTerm uni fun)
+lookupBuiltinTerm :: Compiling uni fun m ann => TH.Name -> m (PIRTerm uni fun)
 lookupBuiltinTerm name = do
     ghcName <- GHC.getName <$> getThing name
     maybeTerm <- PIR.lookupTerm () (LexName ghcName)
@@ -381,7 +381,7 @@ lookupBuiltinTerm name = do
         Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
 
 -- | Lookup a builtin type by its TH name. These are assumed to be present, so fails if it is cannot find it.
-lookupBuiltinType :: Compiling uni fun m => TH.Name -> m (PIRType uni)
+lookupBuiltinType :: Compiling uni fun m ann => TH.Name -> m (PIRType uni)
 lookupBuiltinType name = do
     ghcName <- GHC.getName <$> getThing name
     maybeType <- PIR.lookupType () (LexName ghcName)
@@ -390,13 +390,13 @@ lookupBuiltinType name = do
         Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
 
 -- | The function 'error :: forall a . a'.
-errorFunc :: Compiling uni fun m => m (PIRTerm uni fun)
+errorFunc :: Compiling uni fun m ann => m (PIRTerm uni fun)
 errorFunc = do
     n <- safeFreshTyName "e"
     pure $ PIR.TyAbs () n (PIR.Type ()) (PIR.Error () (PIR.TyVar () n))
 
 -- | The delayed error function 'error :: forall a . () -> a'.
-delayedErrorFunc :: CompilingDefault uni fun m => m (PIRTerm uni fun)
+delayedErrorFunc :: CompilingDefault uni fun m ann => m (PIRTerm uni fun)
 delayedErrorFunc = do
     n <- safeFreshTyName "a"
     t <- liftQuote (freshName "thunk")

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
@@ -36,9 +36,9 @@ data WithContext c e = NoContext e | WithContextC Int c (WithContext c e)
     deriving stock Functor
 makeClassyPrisms ''WithContext
 
-type CompileError uni fun = WithContext T.Text (Error uni fun ())
+type CompileError uni fun ann = WithContext T.Text (Error uni fun ann)
 
-instance HasErrorCode (CompileError _a _b) where
+instance HasErrorCode (CompileError _a _b _c) where
     errorCode (NoContext e)        = errorCode e
     errorCode (WithContextC _ _ w) = errorCode w
 
@@ -67,13 +67,14 @@ instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
             "Context:" PP.<+> (PP.align $ PP.pretty c)
             ]
 
-data Error uni fun a = PLCError (PLC.Error uni fun a)
-                 | PIRError (PIR.Error uni fun (PIR.Provenance a))
-                 | CompilationError T.Text
-                 | UnsupportedError T.Text
-                 | FreeVariableError T.Text
-                 | InvalidMarkerError String
-                 | CoreNameLookupError TH.Name
+data Error uni fun a
+    = PLCError (PLC.Error uni fun a)
+    | PIRError (PIR.Error uni fun (PIR.Provenance a))
+    | CompilationError T.Text
+    | UnsupportedError T.Text
+    | FreeVariableError T.Text
+    | InvalidMarkerError String
+    | CoreNameLookupError TH.Name
 makeClassyPrisms ''Error
 
 instance HasErrorCode (Error _a _b _c) where
@@ -89,23 +90,34 @@ instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, P
             PP.Pretty (Error uni fun a) where
     pretty = PLC.prettyPlcClassicDebug
 
-instance uni1 ~ uni2 => PLC.AsTypeError (CompileError uni1 fun) (PIR.Term PIR.TyName PIR.Name uni2 fun ()) uni2 fun (PIR.Provenance ()) where
+instance
+    (uni1 ~ uni2, b ~ PIR.Provenance a) =>
+    PLC.AsTypeError (CompileError uni1 fun a) (PIR.Term PIR.TyName PIR.Name uni2 fun ()) uni2 fun b
+    where
     _TypeError = _NoContext . _PIRError . PIR._TypeError
 
-instance uni1 ~ uni2 => PIR.AsTypeErrorExt (CompileError uni1 fun) uni2 (PIR.Provenance ()) where
+instance
+    (uni1 ~ uni2, b ~ PIR.Provenance a) =>
+    PIR.AsTypeErrorExt (CompileError uni1 fun a) uni2 b
+    where
     _TypeErrorExt = _NoContext . _PIRError . PIR._TypeErrorExt
 
-instance uni1 ~ uni2 => PLC.AsNormCheckError (CompileError uni1 fun) PLC.TyName PLC.Name uni2 fun () where
+instance uni1 ~ uni2 => PLC.AsNormCheckError (CompileError uni1 fun a) PLC.TyName PLC.Name uni2 fun a where
     _NormCheckError = _NoContext . _PLCError . PLC._NormCheckError
 
-instance PLC.AsUniqueError (CompileError uni fun) () where
+instance PLC.AsUniqueError (CompileError uni fun a) a where
     _UniqueError = _NoContext . _PLCError . PLC._UniqueError
 
-instance uni1 ~ uni2 => PIR.AsError (CompileError uni1 fun) uni2 fun (PIR.Provenance ()) where
+instance
+    (uni1 ~ uni2, b ~ PIR.Provenance a) =>
+    PIR.AsError (CompileError uni1 fun a) uni2 fun b
+    where
     _Error = _NoContext . _PIRError
 
-instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty fun, PP.Pretty a) =>
-            PLC.PrettyBy PLC.PrettyConfigPlc (Error uni fun a) where
+instance
+    (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, PP.Pretty fun, PP.Pretty a) =>
+    PLC.PrettyBy PLC.PrettyConfigPlc (Error uni fun a)
+    where
     prettyBy config = \case
         PLCError e -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
         PIRError e -> PP.vsep [ "Error from the PIR compiler:", PLC.prettyBy config e ]

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
@@ -13,7 +13,7 @@ import GhcPlugins qualified as GHC
 
 import PlutusCore qualified as PLC
 
-compileKind :: Compiling uni fun m => GHC.Kind -> m (PLC.Kind ())
+compileKind :: Compiling uni fun m ann => GHC.Kind -> m (PLC.Kind ())
 compileKind k = withContextM 2 (sdToTxt $ "Compiling kind:" GHC.<+> GHC.ppr k) $ case k of
     -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
     (GHC.isLiftedTypeKind -> True)         -> pure $ PLC.Type ()

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
@@ -24,35 +24,35 @@ with the standard library because it makes the generated terms simpler without t
 a simplifier pass. Also, PLC isn't lazy, so combinators work less well.
 -}
 
-delay :: Compiling uni fun m => PIRTerm uni fun -> m (PIRTerm uni fun)
+delay :: Compiling uni fun m ann => PIRTerm uni fun -> m (PIRTerm uni fun)
 delay body = PIR.TyAbs () <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type ()) <*> pure body
 
-delayType :: Compiling uni fun m => PIRType uni -> m (PIRType uni)
+delayType :: Compiling uni fun m ann => PIRType uni -> m (PIRType uni)
 delayType orig = PIR.TyForall () <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type ()) <*> pure orig
 
-delayVar :: Compiling uni fun m => PIRVar uni fun -> m (PIRVar uni fun)
+delayVar :: Compiling uni fun m ann => PIRVar uni fun -> m (PIRVar uni fun)
 delayVar (PIR.VarDecl () n ty) = do
     ty' <- delayType ty
     pure $ PIR.VarDecl () n ty'
 
 force
-    :: CompilingDefault uni fun m
+    :: CompilingDefault uni fun m ann
     => PIRTerm uni fun -> m (PIRTerm uni fun)
 force thunk = do
     a <- liftQuote (freshTyName "dead")
     let fakeTy = PIR.TyForall () a (PIR.Type ()) (PIR.TyVar () a)
     pure $ PIR.TyInst () thunk fakeTy
 
-maybeDelay :: Compiling uni fun m => Bool -> PIRTerm uni fun -> m (PIRTerm uni fun)
+maybeDelay :: Compiling uni fun m ann => Bool -> PIRTerm uni fun -> m (PIRTerm uni fun)
 maybeDelay yes t = if yes then delay t else pure t
 
-maybeDelayVar :: Compiling uni fun m => Bool -> PIRVar uni fun -> m (PIRVar uni fun)
+maybeDelayVar :: Compiling uni fun m ann => Bool -> PIRVar uni fun -> m (PIRVar uni fun)
 maybeDelayVar yes v = if yes then delayVar v else pure v
 
-maybeDelayType :: Compiling uni fun m => Bool -> PIRType uni -> m (PIRType uni)
+maybeDelayType :: Compiling uni fun m ann => Bool -> PIRType uni -> m (PIRType uni)
 maybeDelayType yes t = if yes then delayType t else pure t
 
 maybeForce
-    :: CompilingDefault uni fun m
+    :: CompilingDefault uni fun m ann
     => Bool -> PIRTerm uni fun -> m (PIRTerm uni fun)
 maybeForce yes t = if yes then force t else pure t

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
@@ -51,7 +51,7 @@ getUntidiedOccString n = dropWhileEnd isDigit (GHC.getOccString n)
 compileNameFresh :: MonadQuote m => GHC.Name -> m PLC.Name
 compileNameFresh n = safeFreshName $ T.pack $ getUntidiedOccString n
 
-compileVarFresh :: CompilingDefault uni fun m => GHC.Var -> m (PLCVar uni fun)
+compileVarFresh :: CompilingDefault uni fun m ann => GHC.Var -> m (PLCVar uni fun)
 compileVarFresh v = do
     t' <- compileTypeNorm $ GHC.varType v
     n' <- compileNameFresh $ GHC.getName v
@@ -63,13 +63,13 @@ lookupTyName (Scope _ tyns) n = Map.lookup n tyns
 compileTyNameFresh :: MonadQuote m => GHC.Name -> m PLC.TyName
 compileTyNameFresh n = safeFreshTyName $ T.pack $ getUntidiedOccString n
 
-compileTyVarFresh :: Compiling uni fun m => GHC.TyVar -> m PLCTyVar
+compileTyVarFresh :: Compiling uni fun m ann => GHC.TyVar -> m PLCTyVar
 compileTyVarFresh v = do
     k' <- compileKind $ GHC.tyVarKind v
     t' <- compileTyNameFresh $ GHC.getName v
     pure $ PLC.TyVarDecl () t' k'
 
-compileTcTyVarFresh :: Compiling uni fun m => GHC.TyCon -> m PLCTyVar
+compileTcTyVarFresh :: Compiling uni fun m ann => GHC.TyCon -> m PLCTyVar
 compileTcTyVarFresh tc = do
     k' <- compileKind $ GHC.tyConKind tc
     t' <- compileTyNameFresh $ GHC.getName tc

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -65,7 +65,7 @@ is dealing with recursive newtypes.
 -- Generally, we need to call this whenever we are compiling a "new" type from the program.
 -- If we are compiling a part of a type we are already processing then it has likely been
 -- normalized and we can just use 'compileType'
-compileTypeNorm :: CompilingDefault uni fun m => GHC.Type -> m (PIRType uni)
+compileTypeNorm :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRType uni)
 compileTypeNorm ty = do
     CompileContext {ccFamInstEnvs=envs} <- ask
     -- See Note [Type families and normalizing types]
@@ -73,7 +73,7 @@ compileTypeNorm ty = do
     compileType ty'
 
 -- | Compile a type.
-compileType :: CompilingDefault uni fun m => GHC.Type -> m (PIRType uni)
+compileType :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRType uni)
 compileType t = withContextM 2 (sdToTxt $ "Compiling type:" GHC.<+> GHC.ppr t) $ do
     -- See Note [Scopes]
     CompileContext {ccScopes=stack} <- ask
@@ -109,7 +109,7 @@ we just have to ban recursive newtypes, and we do this by blackholing the name w
 definition, and dying if we see it again.
 -}
 
-compileTyCon :: forall uni fun m. CompilingDefault uni fun m => GHC.TyCon -> m (PIRType uni)
+compileTyCon :: forall uni fun m ann. CompilingDefault uni fun m ann => GHC.TyCon -> m (PIRType uni)
 compileTyCon tc
     | tc == GHC.intTyCon = throwPlain $ UnsupportedError "Int: use Integer instead"
     | tc == GHC.intPrimTyCon = throwPlain $ UnsupportedError "Int#: unboxed integers are not supported"
@@ -223,7 +223,7 @@ sortConstructors tc cs =
     let sorted = sortBy (\dc1 dc2 -> compare (GHC.getOccName dc1) (GHC.getOccName dc2)) cs
     in if tc == GHC.boolTyCon || tc == GHC.listTyCon then reverse sorted else sorted
 
-getDataCons :: Compiling uni fun m =>  GHC.TyCon -> m [GHC.DataCon]
+getDataCons :: Compiling uni fun m ann =>  GHC.TyCon -> m [GHC.DataCon]
 getDataCons tc' = sortConstructors tc' <$> extractDcs tc'
     where
         extractDcs tc
@@ -249,7 +249,7 @@ the type of the original code without that information.
 -}
 
 -- | Makes the type of the constructor corresponding to the given 'DataCon', with the type variables free.
-mkConstructorType :: CompilingDefault uni fun m => GHC.DataCon -> m (PIRType uni)
+mkConstructorType :: CompilingDefault uni fun m ann => GHC.DataCon -> m (PIRType uni)
 mkConstructorType dc =
     -- see Note [On data constructor workers and wrappers]
     let argTys = GHC.dataConRepArgTys dc
@@ -265,7 +265,7 @@ ghcStrictnessNote :: GHC.SDoc
 ghcStrictnessNote = "Note: GHC can generate these unexpectedly, you may need '-fno-strictness', '-fno-specialise', or '-fno-spec-constr'"
 
 -- | Get the constructors of the given 'TyCon' as PLC terms.
-getConstructors :: CompilingDefault uni fun m => GHC.TyCon -> m [PIRTerm uni fun]
+getConstructors :: CompilingDefault uni fun m ann => GHC.TyCon -> m [PIRTerm uni fun]
 getConstructors tc = do
     -- make sure the constructors have been created
     _ <- compileTyCon tc
@@ -275,7 +275,7 @@ getConstructors tc = do
         Nothing      -> throwSd UnsupportedError $ "Cannot construct a value of type:" GHC.<+> GHC.ppr tc GHC.$+$ ghcStrictnessNote
 
 -- | Get the matcher of the given 'TyCon' as a PLC term
-getMatch :: CompilingDefault uni fun m => GHC.TyCon -> m (PIRTerm uni fun)
+getMatch :: CompilingDefault uni fun m ann => GHC.TyCon -> m (PIRTerm uni fun)
 getMatch tc = do
     -- ensure the tycon has been compiled, which will create the matcher
     _ <- compileTyCon tc
@@ -286,7 +286,7 @@ getMatch tc = do
 
 -- | Get the matcher of the given 'Type' (which must be equal to a type constructor application) as a PLC term instantiated for
 -- the type constructor argument types.
-getMatchInstantiated :: CompilingDefault uni fun m => GHC.Type -> m (PIRTerm uni fun)
+getMatchInstantiated :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRTerm uni fun)
 getMatchInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated matcher for type:" GHC.<+> GHC.ppr t) $ case t of
     (GHC.splitTyConApp_maybe -> Just (tc, args)) -> do
         match <- getMatch tc

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs-boot
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs-boot
@@ -8,7 +8,7 @@ import PlutusTx.PIRTypes
 
 import qualified GhcPlugins                               as GHC
 
-compileTypeNorm :: CompilingDefault uni fun m => GHC.Type -> m (PIRType uni)
-compileType :: CompilingDefault uni fun m => GHC.Type -> m (PIRType uni)
+compileTypeNorm :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRType uni)
+compileType :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRType uni)
 
-getMatchInstantiated :: CompilingDefault uni fun m => GHC.Type -> m (PIRTerm uni fun)
+getMatchInstantiated :: CompilingDefault uni fun m ann => GHC.Type -> m (PIRTerm uni fun)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -155,9 +155,9 @@ stableModuleCmp m1 m2 =
     (GHC.moduleUnitId m1 `GHC.stableUnitIdCmp` GHC.moduleUnitId m2)
 
 -- See Note [Scopes]
-type Compiling uni fun m =
+type Compiling uni fun m ann =
     ( Monad m
-    , MonadError (CompileError uni fun) m
+    , MonadError (CompileError uni fun ann) m
     , MonadQuote m
     , MonadReader (CompileContext uni fun) m
     , MonadDefs LexName uni fun () m
@@ -170,10 +170,10 @@ type Compiling uni fun m =
 -- we don't need to write 'PLC.DefaultUni' everywhere (in 'PIRTerm', 'PIRType' etc) and instead
 -- can write the short @uni@ and know that it actually means 'PLC.DefaultUni'. Same regarding
 -- 'DefaultFun'.
-type CompilingDefault uni fun m =
+type CompilingDefault uni fun m ann =
     ( uni ~ PLC.DefaultUni
     , fun ~ PLC.DefaultFun
-    , Compiling uni fun m
+    , Compiling uni fun m ann
     )
 
 blackhole :: MonadReader (CompileContext uni fun) m => GHC.Name -> m a -> m a
@@ -199,10 +199,10 @@ type ScopeStack uni fun = NE.NonEmpty (Scope uni fun)
 initialScopeStack :: ScopeStack uni fun
 initialScopeStack = pure $ Scope Map.empty Map.empty
 
-withCurDef :: Compiling uni fun m => LexName -> m a -> m a
+withCurDef :: Compiling uni fun m ann => LexName -> m a -> m a
 withCurDef name = local (\cc -> cc {ccCurDef=Just name})
 
-modifyCurDeps :: Compiling uni fun m => (Set.Set LexName -> Set.Set LexName) -> m ()
+modifyCurDeps :: Compiling uni fun m ann => (Set.Set LexName -> Set.Set LexName) -> m ()
 modifyCurDeps f = do
     cur <- asks ccCurDef
     case cur of

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Utils.hs
@@ -21,7 +21,7 @@ import Data.Text qualified as T
 
 -- | Get the 'GHC.TyThing' for a given 'TH.Name' which was stored in the builtin name info,
 -- failing if it is missing.
-getThing :: Compiling uni fun m => TH.Name -> m GHC.TyThing
+getThing :: Compiling uni fun m ann => TH.Name -> m GHC.TyThing
 getThing name = do
     CompileContext{ccNameInfo=names} <- ask
     case Map.lookup name names of
@@ -33,7 +33,11 @@ sdToTxt sd = do
   CompileContext { ccFlags=flags } <- ask
   pure $ T.pack $ GHC.showSDocForUser flags GHC.alwaysQualify sd
 
-throwSd :: (MonadError (CompileError uni fun) m, MonadReader (CompileContext uni fun) m) => (T.Text -> Error uni fun ()) -> GHC.SDoc -> m a
+throwSd ::
+    (MonadError (CompileError uni fun ann) m, MonadReader (CompileContext uni fun) m) =>
+    (T.Text -> Error uni fun ann) ->
+    GHC.SDoc ->
+    m a
 throwSd constr = (throwPlain . constr) <=< sdToTxt
 
 tyConsOfExpr :: GHC.CoreExpr -> GHC.UniqSet GHC.TyCon


### PR DESCRIPTION
This makes it possible to compile with non-unit annotations.