### PR TITLE
[Refactoring] Move junk out of 'PlutusCore'

### DIFF
--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -444,7 +444,7 @@ toTypedTermExample term = TypedTermExample ty term where
     program = PLC.Program () (PLC.defaultVersion ()) term
     errOrTy = PLC.runQuote . runExceptT $ do
         tcConfig <- PLC.getDefTypeCheckConfig ()
-        PLC.typecheckPipeline tcConfig program
+        PLC.inferTypeOfProgram tcConfig program
     ty = case errOrTy of
         Left (err :: PLC.Error PLC.DefaultUni PLC.DefaultFun ()) -> errorWithoutStackTrace $ PP.displayPlcDef err
         Right vTy                                                -> PLC.unNormalized vTy

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -116,7 +116,7 @@ runTypecheck (TypecheckOptions inp fmt) = do
   prog <- getProgram fmt inp
   case PLC.runQuoteT $ do
     tcConfig <- PLC.getDefTypeCheckConfig ()
-    PLC.typecheckPipeline tcConfig (void prog)
+    PLC.inferTypeOfProgram tcConfig (void prog)
     of
       Left (e :: PLC.Error PLC.DefaultUni PLC.DefaultFun ()) ->
         errorWithoutStackTrace $ PP.displayPlcDef e

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -7,6 +7,7 @@ module PlutusCore.Parser
     , parseProgram
     , parseTerm
     , parseType
+    , SourcePos
     , ParserError(..)
     ) where
 

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -21,6 +21,9 @@ import PlutusCore.Error
 import PlutusCore.Name
 import PlutusCore.Quote
 
+topSourcePos :: SourcePos
+topSourcePos = initialPos "top"
+
 newtype ParserState = ParserState { identifiers :: M.Map T.Text Unique }
     deriving stock (Show)
 

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -21,14 +21,16 @@ import Pretty.Readable
 import TypeSynthesis.Spec (test_typecheck)
 
 import PlutusCore
+import PlutusCore.Check.Uniques qualified as Uniques
 import PlutusCore.DeBruijn
-import PlutusCore.Error (ParserErrorBundle)
+import PlutusCore.Error
 import PlutusCore.Generators
 import PlutusCore.Generators.AST as AST
 import PlutusCore.Generators.NEAT.Spec qualified as NEAT
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
 
+import Control.Monad.Except
 import Data.ByteString.Lazy qualified as BSL
 import Data.Either (isLeft)
 import Data.Foldable (for_)
@@ -203,8 +205,32 @@ asGolden f file = goldenVsString file (file ++ ".golden") (asIO f file)
 -- TODO: evaluation tests should go under the 'Evaluation' module,
 -- normalization tests -- under 'Normalization', etc.
 
+-- | Parse and rewrite so that names are globally unique, not just unique within
+-- their scope.
+-- don't require there to be no free variables at this point, we might be parsing an open term
+parseScoped :: (AsParserErrorBundle e, AsUniqueError e SourcePos,
+        MonadError e m, MonadQuote m) =>
+    T.Text
+    -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
+-- don't require there to be no free variables at this point, we might be parsing an open term
+parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram
+
+printType ::(AsParserErrorBundle e, AsUniqueError e SourcePos, AsTypeError e (Term TyName Name DefaultUni DefaultFun ()) DefaultUni DefaultFun SourcePos,
+        MonadError e m)
+    => T.Text
+    -> m T.Text
+printType txt = runQuoteT $ T.pack . show . pretty <$> do
+    scoped <- parseScoped txt
+    config <- getDefTypeCheckConfig topSourcePos
+    inferTypeOfProgram config scoped
+
 testsType :: [FilePath] -> TestTree
 testsType = testGroup "golden type synthesis tests" . fmap (asGolden printType)
+
+format
+    :: (AsParserErrorBundle e, MonadError e m)
+    => PrettyConfigPlc -> T.Text -> m T.Text
+format cfg = runQuoteT . fmap (displayBy cfg) . (rename <=< parseProgram)
 
 testsGolden :: [FilePath] -> TestTree
 testsGolden

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -10,6 +10,7 @@ module PlutusIR.Parser
     , parseProgram
     , Parser
     , SourcePos
+    , topSourcePos
     ) where
 
 import PlutusCore.Default qualified as PLC (DefaultFun, DefaultUni)

--- a/plutus-core/testlib/Test/Tasty/Extras.hs
+++ b/plutus-core/testlib/Test/Tasty/Extras.hs
@@ -11,7 +11,6 @@ module Test.Tasty.Extras
     , nestedGoldenVsTextM
     , nestedGoldenVsDoc
     , nestedGoldenVsDocM
-    , topSourcePos
     ) where
 
 import PlutusPrelude
@@ -20,7 +19,6 @@ import Control.Monad.Reader
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
-import PlutusCore (topSourcePos)
 import System.FilePath ((</>))
 import Test.Tasty
 import Test.Tasty.Golden

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -373,7 +373,7 @@ runCompiler moduleName opts expr = do
 
     -- We do this after dumping the programs so that if we fail typechecking we still get the dump.
     when (_posDoTypecheck opts) . void $
-        liftExcept $ PLC.typecheckPipeline plcTcConfig plcP
+        liftExcept $ PLC.inferTypeOfProgram plcTcConfig plcP
 
     uplcT <- liftExcept $ UPLC.deBruijnTerm =<< UPLC.simplifyTerm uplcSimplOpts (UPLC.erase plcT)
     let uplcP = UPLC.Program () (PLC.defaultVersion ()) $ void uplcT


### PR DESCRIPTION
Contributing my two cents against the global entropy.

This just moves stuff around and drops `typecheckPipeline`. No attempt to improve the moved stuff is performed.