### PR TITLE
[Refactoring] Clean up reexports of 'PlutusCore'

### DIFF
--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -17,6 +17,7 @@ module Main (main) where
 import Prelude qualified as Haskell
 
 import PlutusCore
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Pretty qualified as PP
 import PlutusTx qualified as Tx
 import PlutusTx.Prelude as Tx

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -24,6 +24,7 @@ import PlutusTx qualified as Tx
 
 import PlutusCore qualified as PLC
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
 

--- a/plutus-benchmark/lists/exe/Main.hs
+++ b/plutus-benchmark/lists/exe/Main.hs
@@ -13,6 +13,7 @@ import PlutusBenchmark.Lists.Sort
 
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -29,6 +29,7 @@ import PlutusBenchmark.NoFib.Queens qualified as Queens
 import PlutusCore qualified as PLC
 import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Pretty (prettyPlcClassicDebug)
 import PlutusTx (getPlc)

--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -13,6 +13,7 @@ import PlutusBenchmark.NaturalSort
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.Exception
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -19,6 +19,7 @@ import Generators (randBool, randNwords)
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.BuiltinCostModel hiding (BuiltinCostModel)
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.ExMemory (ExMemoryUsage)
 import PlutusCore.Evaluation.Machine.MachineParameters (CostModel (..), MachineParameters, mkMachineParameters)
 import PlutusCore.Pretty

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -10,6 +10,7 @@ where
 
 import PlutusCore
 import PlutusCore.Data
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.MkPlc

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -16,6 +16,7 @@ import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Check.Uniques as PLC (checkProgram)
 import PlutusCore.Error (AsUniqueError, ParserErrorBundle, UniqueError)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..), ExRestrictingBudget (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Generators qualified as Gen
 import PlutusCore.Generators.Interesting qualified as Gen

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -7,6 +7,7 @@ import Common
 import Parsers
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.Ck qualified as Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Pretty qualified as PP
 
 import UntypedPlutusCore qualified as UPLC (eraseProgram)

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -9,6 +9,7 @@ import Common
 import Parsers
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..), ExRestrictingBudget (..))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 
 import Data.Foldable (asum)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -40,14 +40,14 @@ library
     import: lang
     exposed-modules:
         PlutusCore
-        PlutusCore.Check.Normal
-        PlutusCore.Check.Scoping
-        PlutusCore.Check.Uniques
-        PlutusCore.Check.Value
         PlutusCore.Builtin
         PlutusCore.Builtin.Debug
         PlutusCore.Builtin.Elaborate
         PlutusCore.Builtin.Emitter
+        PlutusCore.Check.Normal
+        PlutusCore.Check.Scoping
+        PlutusCore.Check.Uniques
+        PlutusCore.Check.Value
         PlutusCore.Core
         PlutusCore.Data
         PlutusCore.DataFilePaths
@@ -60,6 +60,7 @@ library
         PlutusCore.Evaluation.Machine.CostingFun.Core
         PlutusCore.Evaluation.Machine.CostingFun.JSON
         PlutusCore.Evaluation.Machine.ExBudget
+        PlutusCore.Evaluation.Machine.ExBudgetingDefaults
         PlutusCore.Evaluation.Machine.ExMemory
         PlutusCore.Evaluation.Machine.Exception
         PlutusCore.Evaluation.Machine.MachineParameters
@@ -138,16 +139,17 @@ library
         PlutusIR.TypeCheck
 
         UntypedPlutusCore
-        UntypedPlutusCore.DeBruijn
-        UntypedPlutusCore.Evaluation.Machine.Cek
-        UntypedPlutusCore.Evaluation.Machine.Cek.Internal
-        UntypedPlutusCore.Parser
-        UntypedPlutusCore.Rename
-        UntypedPlutusCore.MkUPlc
         UntypedPlutusCore.Check.Scope
         UntypedPlutusCore.Check.Uniques
         UntypedPlutusCore.Core
         UntypedPlutusCore.Core.Type
+        UntypedPlutusCore.DeBruijn
+        UntypedPlutusCore.Evaluation.Machine.Cek
+        UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+        UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+        UntypedPlutusCore.MkUPlc
+        UntypedPlutusCore.Parser
+        UntypedPlutusCore.Rename
 
         Crypto
         Data.ByteString.Hash
@@ -191,7 +193,6 @@ library
         PlutusCore.Default.Builtins
         PlutusCore.Default.Universe
         PlutusCore.Eq
-        PlutusCore.Evaluation.Machine.ExBudgetingDefaults
         PlutusCore.InlineUtils
         PlutusCore.Parser.ParserCommon
         PlutusCore.Parser.Type
@@ -233,7 +234,6 @@ library
         UntypedPlutusCore.Core.Instance.Pretty.Readable
         UntypedPlutusCore.Core.Instance.Recursive
         UntypedPlutusCore.Core.Plated
-        UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
         UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
         UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
         UntypedPlutusCore.Mark

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -20,6 +20,7 @@ module PlutusCore.Examples.Builtins where
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Pretty
 

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -1,6 +1,5 @@
 -- Why is it needed here, but not in "Universe.Core"?
 {-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternSynonyms    #-}
 
 module PlutusCore
@@ -118,18 +117,6 @@ module PlutusCore
     , kindSize
     , programSize
     , serialisedSize
-    -- * Budgeting defaults
-    , defaultBuiltinCostModel
-    , defaultBuiltinsRuntime
-    , defaultCekCostModel
-    , defaultCekMachineCosts
-    , defaultCekParameters
-    , defaultCostModelParams
-    , defaultUnliftingMode
-    , unitCekParameters
-    -- * CEK machine costs
-    , cekMachineCostsPrefix
-    , CekMachineCosts (..)
     ) where
 
 
@@ -139,7 +126,6 @@ import PlutusCore.DeBruijn
 import PlutusCore.Default
 import PlutusCore.Error
 import PlutusCore.Evaluation.Machine.Ck
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Flat ()
 import PlutusCore.Name
 import PlutusCore.Normalize
@@ -149,12 +135,13 @@ import PlutusCore.Rename
 import PlutusCore.Size
 import PlutusCore.TypeCheck as TypeCheck
 
-import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
-
 -- | Take one PLC program and apply it to another.
 applyProgram
     :: Monoid a
     => Program tyname name uni fun a
     -> Program tyname name uni fun a
     -> Program tyname name uni fun a
-applyProgram (Program a1 _ t1) (Program a2 _ t2) = Program (a1 <> a2) (defaultVersion mempty) (Apply mempty t1 t2)
+-- TODO: 'mappend' annotations, ignore versions and return the default one (whatever that means),
+-- what a mess. Needs to be fixed.
+applyProgram (Program a1 _ t1) (Program a2 _ t2) =
+    Program (a1 <> a2) (defaultVersion mempty) (Apply mempty t1 t2)

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -6,11 +6,13 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 module CostModelInterface.Spec (test_costModelInterface) where
 
-import PlutusCore
 import PlutusCore.Evaluation.Machine.BuiltinCostModel
 import PlutusCore.Evaluation.Machine.CostModelInterface
 import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.MachineParameters
+
+import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
 
 import Data.Aeson
 import Data.ByteString.Lazy qualified as BSL

--- a/plutus-core/plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Machines.hs
@@ -7,6 +7,7 @@ where
 
 import PlutusCore
 import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Generators.Interesting
 import PlutusCore.Generators.Test

--- a/plutus-core/testlib/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -26,6 +26,7 @@ import PlutusCore.Generators.Internal.Utils
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Normalize
 import PlutusCore.Pretty

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -31,6 +31,7 @@ module PlutusCore.Generators.NEAT.Spec
 
 import PlutusCore
 import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Generators.NEAT.Common
 import PlutusCore.Generators.NEAT.Term
 import PlutusCore.Normalize

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -47,6 +47,7 @@ import PlutusCore qualified as TPLC
 import PlutusCore.Check.Scoping
 import PlutusCore.DeBruijn
 import PlutusCore.Evaluation.Machine.Ck qualified as TPLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as TPLC
 import PlutusCore.Generators
 import PlutusCore.Generators.AST
 import PlutusCore.Pretty

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -14,6 +14,7 @@ module Evaluation.Builtins.Definition
 import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Data
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.Generators.Interesting
 import PlutusCore.MkPlc hiding (error)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
@@ -8,6 +8,7 @@ module Evaluation.Builtins.MakeRead
 import PlutusCore qualified as TPLC
 import PlutusCore.Builtin
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as TPLC
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Result
 import PlutusCore.MkPlc hiding (error)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SECP256k1.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SECP256k1.hs
@@ -29,7 +29,9 @@ import Hedgehog (Gen, PropertyT, annotateShow, cover, failure, forAllWith, (===)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifySchnorrSecp256k1Signature),
-                   EvaluationResult (EvaluationFailure, EvaluationSuccess), defaultCekParameters)
+                   EvaluationResult (EvaluationFailure, EvaluationSuccess))
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParameters)
+
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
 import Text.Show.Pretty (ppShow)
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
@@ -10,8 +10,8 @@ import Test.Tasty.HUnit
 
 import Data.Either
 import Data.RandomAccessList.Class qualified as Env
-import PlutusCore qualified as PLC
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.MkPlc
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -18,6 +18,7 @@ import PlutusCore.StdLib.Type
 
 import PlutusCore
 import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Generators.Interesting
 import PlutusCore.MkPlc
 import PlutusCore.Pretty

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -14,6 +14,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
 import PlutusCore qualified as Plc
 import PlutusCore.Builtin
 import PlutusCore.Default
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plc
 import PlutusCore.Evaluation.Machine.Exception
 import PlutusCore.Evaluation.Machine.MachineParameters
 import PlutusCore.FsTree

--- a/plutus-ledger-api/src/Plutus/ApiCommon.hs
+++ b/plutus-ledger-api/src/Plutus/ApiCommon.hs
@@ -14,6 +14,7 @@ import PlutusCore as ScriptPlutus (Version)
 import PlutusCore.Data as Plutus
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import PlutusCore.Evaluation.Machine.ExBudget as Plutus
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
 import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
 import PlutusCore.MkPlc qualified as UPLC
 import UntypedPlutusCore qualified as UPLC

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
@@ -10,9 +10,9 @@ module Plutus.V1.Ledger.EvaluationContext
     ) where
 
 import Plutus.ApiCommon
-import PlutusCore as Plutus
 import PlutusCore.Evaluation.Machine.BuiltinCostModel as Plutus
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutus
 import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
 
 import Barbies

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/Scripts.hs
@@ -71,6 +71,7 @@ import Plutus.V1.Ledger.Bytes (LedgerBytes (..))
 import PlutusCore qualified as PLC
 import PlutusCore.Data qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.Exception (ErrorWithCause (..), EvaluationError (..))
 import PlutusCore.MkPlc qualified as PLC
 import PlutusTx (CompiledCode, FromData (..), ToData (..), UnsafeFromData (..), getPlc, makeLift)

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/EvaluationContext.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/EvaluationContext.hs
@@ -4,7 +4,7 @@ module Plutus.V2.Ledger.EvaluationContext
     ) where
 
 import Plutus.V1.Ledger.EvaluationContext as V1.EvaluationContext hiding (costModelParamNames)
-import PlutusCore as Plutus (defaultCostModelParams)
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus (defaultCostModelParams)
 
 import Data.Map qualified as Map
 import Data.Maybe

--- a/plutus-ledger-api/testlib/Plutus/Ledger/Test/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/Plutus/Ledger/Test/EvaluationContext.hs
@@ -4,8 +4,8 @@ module Plutus.Ledger.Test.EvaluationContext
     ) where
 
 import Plutus.V1.Ledger.EvaluationContext
-import PlutusCore as Plutus
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
 
 import Data.Maybe
 

--- a/plutus-metatheory/test/TestNEAT.hs
+++ b/plutus-metatheory/test/TestNEAT.hs
@@ -6,6 +6,7 @@ import Data.Either
 import Data.List
 import PlutusCore
 import PlutusCore.Evaluation.Machine.Ck
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Generators.NEAT.Spec
 import PlutusCore.Generators.NEAT.Term
 import PlutusCore.Normalize

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -22,6 +22,7 @@ import PlutusCore.Test
 import PlutusTx.Code
 
 import PlutusCore qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Pretty
 
 import UntypedPlutusCore qualified as UPLC

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -43,6 +43,7 @@ import Type.Reflection (Typeable)
 
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.ExBudget qualified as PLC
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Pretty
 import PlutusCore.Test
 import PlutusTx.Code (CompiledCode, CompiledCodeIn, getPir, getPlc, sizePlc)


### PR DESCRIPTION
This cleans up the reexports of `PlutusCore` slightly more. I didn't like the fact that it was reexporting budgeting defaults that, strictly speaking, are not even defaults. `PlutusCore` now only imports and reexports stuff from modules with the `PlutusCore` prefix.