### PR TITLE
PLT-110: Expose V1/V2 cost model param names as fixed enumeration

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -100,6 +100,8 @@ data CostModelApplyError =
       -- ^ internal error when we are transforming the applyParams' input to json (should not happen)
     | CMInternalWriteError String
       -- ^ internal error when we are transforming the applied params from json with given jsonstring error (should not happen)
+    | CMWrongNumberOfParams Int Int
+      -- ^ the ledger is supposed to pass the full list of params, no more, no less params.
     deriving stock Show
     deriving anyclass Exception
 
@@ -108,6 +110,7 @@ instance Pretty CostModelApplyError where
         CMUnknownParamError k -> "Unknown cost model parameter:" <+> pretty k
         CMInternalReadError      -> "Internal problem occurred upon reading the given cost model parameteres"
         CMInternalWriteError str     -> "Internal problem occurred upon generating the applied cost model parameters with JSON error:" <+> pretty str
+        CMWrongNumberOfParams expected actual     -> "Wrong number of cost model parameters passed, expected" <+> pretty expected <+> "but got" <+> pretty actual
       where
           preamble = "applyParams error:"
 

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -78,7 +78,7 @@ library
         deepseq -any,
         tagged -any,
         lens -any,
-        barbies -any
+        extra -any
 
 library plutus-ledger-api-testlib
     import: lang
@@ -106,6 +106,7 @@ test-suite plutus-ledger-api-test
         Spec.Interval
         Spec.Eval
         Spec.Builtins
+        Spec.CostModelParams
     build-depends:
         base >=4.9 && <5,
         mtl -any,
@@ -119,4 +120,8 @@ test-suite plutus-ledger-api-test
         tasty-hunit -any,
         tasty-quickcheck -any,
         bytestring -any,
-        serialise -any
+        serialise -any,
+        lens -any,
+        barbies -any,
+        text -any,
+        extra -any

--- a/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
+++ b/plutus-ledger-api/src/Plutus/V1/Ledger/EvaluationContext.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingVia      #-}
+{-# LANGUAGE TypeApplications #-}
 module Plutus.V1.Ledger.EvaluationContext
     ( EvaluationContext
     , mkEvaluationContext
@@ -8,39 +10,201 @@ module Plutus.V1.Ledger.EvaluationContext
     , toMachineParameters
     , costModelParamNames
     , CostModelApplyError (..)
+    , ParamName -- abstract
     ) where
 
 import Plutus.ApiCommon
-import PlutusCore.Evaluation.Machine.BuiltinCostModel as Plutus
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutus
-import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
 
-import Barbies
-import Control.Lens
-import Data.Map as Map
-import Data.Maybe
-import Data.Set as Set
+import Control.Monad
+import Control.Monad.Except
+import Data.Ix
+import Data.List.Extra
 import Data.Text qualified as Text
+import GHC.Generics
 
 -- | The set of valid names that a cost model parameter can take for this language version.
--- It is used for the deserialization of `CostModelParams`.
-costModelParamNames :: Set.Set Text.Text
-costModelParamNames = Map.keysSet $ fromJust $ extractCostModelParams $
-   defaultCekCostModel
-   & builtinCostModel
-   -- here we rely on 'Deriving.Aeson.OmitNothingFields'
-   -- to skip jsonifying any fields which are cleared.
-   %~ omitV2Builtins
-  where
-    -- "clears" some fields of builtincostmodel by setting them to Nothing. See 'MCostingFun'.
-    omitV2Builtins :: BuiltinCostModel -> BuiltinCostModelBase MCostingFun
-    omitV2Builtins bcm =
-            -- transform all costing-functions to (Just costingFun)
-            (bmap (MCostingFun . Just) bcm)
-            {
-              -- 'SerialiseData','EcdsaSecp256k1',SchnorrSecp256k1 builtins not available in V1
-              paramSerialiseData = mempty
-            , paramVerifyEcdsaSecp256k1Signature = mempty
-            , paramVerifySchnorrSecp256k1Signature = mempty
-            }
+-- It is used for the deserialization of `CostModelParams` and their order in the list is fixed.
+costModelParamNames :: [Text.Text]
+costModelParamNames = Text.pack . showParamName <$> enumerate @ParamName
+
+{-| The enumeration of all possible cost model parameter names for this language version.
+IMPORTANT: The order of appearance of the data constructors here matters. DO NOT REORDER.
+See Note [Quotation marks in cost model parameter constructors]
+-}
+data ParamName =
+    AddInteger'cpu'arguments'intercept
+  | AddInteger'cpu'arguments'slope
+  | AddInteger'memory'arguments'intercept
+  | AddInteger'memory'arguments'slope
+  | AppendByteString'cpu'arguments'intercept
+  | AppendByteString'cpu'arguments'slope
+  | AppendByteString'memory'arguments'intercept
+  | AppendByteString'memory'arguments'slope
+  | AppendString'cpu'arguments'intercept
+  | AppendString'cpu'arguments'slope
+  | AppendString'memory'arguments'intercept
+  | AppendString'memory'arguments'slope
+  | BData'cpu'arguments
+  | BData'memory'arguments
+  | Blake2b_256'cpu'arguments'intercept
+  | Blake2b_256'cpu'arguments'slope
+  | Blake2b_256'memory'arguments
+  | CekApplyCost'exBudgetCPU
+  | CekApplyCost'exBudgetMemory
+  | CekBuiltinCost'exBudgetCPU
+  | CekBuiltinCost'exBudgetMemory
+  | CekConstCost'exBudgetCPU
+  | CekConstCost'exBudgetMemory
+  | CekDelayCost'exBudgetCPU
+  | CekDelayCost'exBudgetMemory
+  | CekForceCost'exBudgetCPU
+  | CekForceCost'exBudgetMemory
+  | CekLamCost'exBudgetCPU
+  | CekLamCost'exBudgetMemory
+  | CekStartupCost'exBudgetCPU
+  | CekStartupCost'exBudgetMemory
+  | CekVarCost'exBudgetCPU
+  | CekVarCost'exBudgetMemory
+  | ChooseData'cpu'arguments
+  | ChooseData'memory'arguments
+  | ChooseList'cpu'arguments
+  | ChooseList'memory'arguments
+  | ChooseUnit'cpu'arguments
+  | ChooseUnit'memory'arguments
+  | ConsByteString'cpu'arguments'intercept
+  | ConsByteString'cpu'arguments'slope
+  | ConsByteString'memory'arguments'intercept
+  | ConsByteString'memory'arguments'slope
+  | ConstrData'cpu'arguments
+  | ConstrData'memory'arguments
+  | DecodeUtf8'cpu'arguments'intercept
+  | DecodeUtf8'cpu'arguments'slope
+  | DecodeUtf8'memory'arguments'intercept
+  | DecodeUtf8'memory'arguments'slope
+  | DivideInteger'cpu'arguments'constant
+  | DivideInteger'cpu'arguments'model'arguments'intercept
+  | DivideInteger'cpu'arguments'model'arguments'slope
+  | DivideInteger'memory'arguments'intercept
+  | DivideInteger'memory'arguments'minimum
+  | DivideInteger'memory'arguments'slope
+  | EncodeUtf8'cpu'arguments'intercept
+  | EncodeUtf8'cpu'arguments'slope
+  | EncodeUtf8'memory'arguments'intercept
+  | EncodeUtf8'memory'arguments'slope
+  | EqualsByteString'cpu'arguments'constant
+  | EqualsByteString'cpu'arguments'intercept
+  | EqualsByteString'cpu'arguments'slope
+  | EqualsByteString'memory'arguments
+  | EqualsData'cpu'arguments'intercept
+  | EqualsData'cpu'arguments'slope
+  | EqualsData'memory'arguments
+  | EqualsInteger'cpu'arguments'intercept
+  | EqualsInteger'cpu'arguments'slope
+  | EqualsInteger'memory'arguments
+  | EqualsString'cpu'arguments'constant
+  | EqualsString'cpu'arguments'intercept
+  | EqualsString'cpu'arguments'slope
+  | EqualsString'memory'arguments
+  | FstPair'cpu'arguments
+  | FstPair'memory'arguments
+  | HeadList'cpu'arguments
+  | HeadList'memory'arguments
+  | IData'cpu'arguments
+  | IData'memory'arguments
+  | IfThenElse'cpu'arguments
+  | IfThenElse'memory'arguments
+  | IndexByteString'cpu'arguments
+  | IndexByteString'memory'arguments
+  | LengthOfByteString'cpu'arguments
+  | LengthOfByteString'memory'arguments
+  | LessThanByteString'cpu'arguments'intercept
+  | LessThanByteString'cpu'arguments'slope
+  | LessThanByteString'memory'arguments
+  | LessThanEqualsByteString'cpu'arguments'intercept
+  | LessThanEqualsByteString'cpu'arguments'slope
+  | LessThanEqualsByteString'memory'arguments
+  | LessThanEqualsInteger'cpu'arguments'intercept
+  | LessThanEqualsInteger'cpu'arguments'slope
+  | LessThanEqualsInteger'memory'arguments
+  | LessThanInteger'cpu'arguments'intercept
+  | LessThanInteger'cpu'arguments'slope
+  | LessThanInteger'memory'arguments
+  | ListData'cpu'arguments
+  | ListData'memory'arguments
+  | MapData'cpu'arguments
+  | MapData'memory'arguments
+  | MkCons'cpu'arguments
+  | MkCons'memory'arguments
+  | MkNilData'cpu'arguments
+  | MkNilData'memory'arguments
+  | MkNilPairData'cpu'arguments
+  | MkNilPairData'memory'arguments
+  | MkPairData'cpu'arguments
+  | MkPairData'memory'arguments
+  | ModInteger'cpu'arguments'constant
+  | ModInteger'cpu'arguments'model'arguments'intercept
+  | ModInteger'cpu'arguments'model'arguments'slope
+  | ModInteger'memory'arguments'intercept
+  | ModInteger'memory'arguments'minimum
+  | ModInteger'memory'arguments'slope
+  | MultiplyInteger'cpu'arguments'intercept
+  | MultiplyInteger'cpu'arguments'slope
+  | MultiplyInteger'memory'arguments'intercept
+  | MultiplyInteger'memory'arguments'slope
+  | NullList'cpu'arguments
+  | NullList'memory'arguments
+  | QuotientInteger'cpu'arguments'constant
+  | QuotientInteger'cpu'arguments'model'arguments'intercept
+  | QuotientInteger'cpu'arguments'model'arguments'slope
+  | QuotientInteger'memory'arguments'intercept
+  | QuotientInteger'memory'arguments'minimum
+  | QuotientInteger'memory'arguments'slope
+  | RemainderInteger'cpu'arguments'constant
+  | RemainderInteger'cpu'arguments'model'arguments'intercept
+  | RemainderInteger'cpu'arguments'model'arguments'slope
+  | RemainderInteger'memory'arguments'intercept
+  | RemainderInteger'memory'arguments'minimum
+  | RemainderInteger'memory'arguments'slope
+  | Sha2_256'cpu'arguments'intercept
+  | Sha2_256'cpu'arguments'slope
+  | Sha2_256'memory'arguments
+  | Sha3_256'cpu'arguments'intercept
+  | Sha3_256'cpu'arguments'slope
+  | Sha3_256'memory'arguments
+  | SliceByteString'cpu'arguments'intercept
+  | SliceByteString'cpu'arguments'slope
+  | SliceByteString'memory'arguments'intercept
+  | SliceByteString'memory'arguments'slope
+  | SndPair'cpu'arguments
+  | SndPair'memory'arguments
+  | SubtractInteger'cpu'arguments'intercept
+  | SubtractInteger'cpu'arguments'slope
+  | SubtractInteger'memory'arguments'intercept
+  | SubtractInteger'memory'arguments'slope
+  | TailList'cpu'arguments
+  | TailList'memory'arguments
+  | Trace'cpu'arguments
+  | Trace'memory'arguments
+  | UnBData'cpu'arguments
+  | UnBData'memory'arguments
+  | UnConstrData'cpu'arguments
+  | UnConstrData'memory'arguments
+  | UnIData'cpu'arguments
+  | UnIData'memory'arguments
+  | UnListData'cpu'arguments
+  | UnListData'memory'arguments
+  | UnMapData'cpu'arguments
+  | UnMapData'memory'arguments
+  | VerifyEd25519Signature'cpu'arguments'intercept
+  | VerifyEd25519Signature'cpu'arguments'slope
+  | VerifyEd25519Signature'memory'arguments
+    deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
+    deriving IsParamName via (GenericParamName ParamName)
+
+{-|  Build the 'EvaluationContext'.
+
+The input is a list of integer values passed from the ledger and are expected to appear in correct order.
+-}
+mkEvaluationContext :: MonadError CostModelApplyError m => [Integer] -> m EvaluationContext
+mkEvaluationContext = mkDynEvaluationContext . toCostModelParams <=< tagWithParamNames @ParamName

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/Api.hs
@@ -116,7 +116,7 @@ module Plutus.V2.Ledger.Api (
 import Plutus.ApiCommon as Common hiding (evaluateScriptCounting, evaluateScriptRestricting, isScriptWellFormed)
 import Plutus.ApiCommon qualified as Common (evaluateScriptCounting, evaluateScriptRestricting, isScriptWellFormed)
 import Plutus.V1.Ledger.Api hiding (ScriptContext (..), TxInInfo (..), TxInfo (..), TxOut (..), costModelParamNames,
-                             evaluateScriptCounting, evaluateScriptRestricting, isScriptWellFormed)
+                             evaluateScriptCounting, evaluateScriptRestricting, isScriptWellFormed, mkEvaluationContext)
 import Plutus.V1.Ledger.Scripts (ScriptHash (..))
 import Plutus.V2.Ledger.Contexts
 import Plutus.V2.Ledger.EvaluationContext

--- a/plutus-ledger-api/src/Plutus/V2/Ledger/EvaluationContext.hs
+++ b/plutus-ledger-api/src/Plutus/V2/Ledger/EvaluationContext.hs
@@ -1,18 +1,214 @@
+{-# LANGUAGE DerivingVia      #-}
+{-# LANGUAGE TypeApplications #-}
 module Plutus.V2.Ledger.EvaluationContext
     ( module V1.EvaluationContext
+    , mkEvaluationContext
     , costModelParamNames
+    , ParamName -- abstract
     ) where
 
-import Plutus.V1.Ledger.EvaluationContext as V1.EvaluationContext hiding (costModelParamNames)
-import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus (defaultCostModelParams)
+import Plutus.ApiCommon
+import Plutus.V1.Ledger.EvaluationContext as V1.EvaluationContext hiding (ParamName, costModelParamNames,
+                                                                   mkEvaluationContext)
 
-import Data.Map qualified as Map
-import Data.Maybe
-import Data.Set qualified as Set
+import Control.Monad
+import Control.Monad.Except
+import Data.Ix
+import Data.List.Extra
 import Data.Text qualified as Text
+import GHC.Generics
 
 -- | The set of valid names that a cost model parameter can take for this language version.
--- It is used for the deserialization of `CostModelParams`.
-costModelParamNames :: Set.Set Text.Text
-costModelParamNames = Map.keysSet $ fromJust Plutus.defaultCostModelParams
+-- It is used for the deserialization of `CostModelParams` and their order in the list is fixed.
+costModelParamNames :: [Text.Text]
+costModelParamNames = Text.pack . showParamName <$> enumerate @ParamName
 
+{-| The enumeration of all possible cost model parameter names for this language version.
+IMPORTANT: The order of appearance of the data constructors here matters. DO NOT REORDER.
+See Note [Quotation marks in cost model parameter constructors]
+-}
+data ParamName =
+    AddInteger'cpu'arguments'intercept
+  | AddInteger'cpu'arguments'slope
+  | AddInteger'memory'arguments'intercept
+  | AddInteger'memory'arguments'slope
+  | AppendByteString'cpu'arguments'intercept
+  | AppendByteString'cpu'arguments'slope
+  | AppendByteString'memory'arguments'intercept
+  | AppendByteString'memory'arguments'slope
+  | AppendString'cpu'arguments'intercept
+  | AppendString'cpu'arguments'slope
+  | AppendString'memory'arguments'intercept
+  | AppendString'memory'arguments'slope
+  | BData'cpu'arguments
+  | BData'memory'arguments
+  | Blake2b_256'cpu'arguments'intercept
+  | Blake2b_256'cpu'arguments'slope
+  | Blake2b_256'memory'arguments
+  | CekApplyCost'exBudgetCPU
+  | CekApplyCost'exBudgetMemory
+  | CekBuiltinCost'exBudgetCPU
+  | CekBuiltinCost'exBudgetMemory
+  | CekConstCost'exBudgetCPU
+  | CekConstCost'exBudgetMemory
+  | CekDelayCost'exBudgetCPU
+  | CekDelayCost'exBudgetMemory
+  | CekForceCost'exBudgetCPU
+  | CekForceCost'exBudgetMemory
+  | CekLamCost'exBudgetCPU
+  | CekLamCost'exBudgetMemory
+  | CekStartupCost'exBudgetCPU
+  | CekStartupCost'exBudgetMemory
+  | CekVarCost'exBudgetCPU
+  | CekVarCost'exBudgetMemory
+  | ChooseData'cpu'arguments
+  | ChooseData'memory'arguments
+  | ChooseList'cpu'arguments
+  | ChooseList'memory'arguments
+  | ChooseUnit'cpu'arguments
+  | ChooseUnit'memory'arguments
+  | ConsByteString'cpu'arguments'intercept
+  | ConsByteString'cpu'arguments'slope
+  | ConsByteString'memory'arguments'intercept
+  | ConsByteString'memory'arguments'slope
+  | ConstrData'cpu'arguments
+  | ConstrData'memory'arguments
+  | DecodeUtf8'cpu'arguments'intercept
+  | DecodeUtf8'cpu'arguments'slope
+  | DecodeUtf8'memory'arguments'intercept
+  | DecodeUtf8'memory'arguments'slope
+  | DivideInteger'cpu'arguments'constant
+  | DivideInteger'cpu'arguments'model'arguments'intercept
+  | DivideInteger'cpu'arguments'model'arguments'slope
+  | DivideInteger'memory'arguments'intercept
+  | DivideInteger'memory'arguments'minimum
+  | DivideInteger'memory'arguments'slope
+  | EncodeUtf8'cpu'arguments'intercept
+  | EncodeUtf8'cpu'arguments'slope
+  | EncodeUtf8'memory'arguments'intercept
+  | EncodeUtf8'memory'arguments'slope
+  | EqualsByteString'cpu'arguments'constant
+  | EqualsByteString'cpu'arguments'intercept
+  | EqualsByteString'cpu'arguments'slope
+  | EqualsByteString'memory'arguments
+  | EqualsData'cpu'arguments'intercept
+  | EqualsData'cpu'arguments'slope
+  | EqualsData'memory'arguments
+  | EqualsInteger'cpu'arguments'intercept
+  | EqualsInteger'cpu'arguments'slope
+  | EqualsInteger'memory'arguments
+  | EqualsString'cpu'arguments'constant
+  | EqualsString'cpu'arguments'intercept
+  | EqualsString'cpu'arguments'slope
+  | EqualsString'memory'arguments
+  | FstPair'cpu'arguments
+  | FstPair'memory'arguments
+  | HeadList'cpu'arguments
+  | HeadList'memory'arguments
+  | IData'cpu'arguments
+  | IData'memory'arguments
+  | IfThenElse'cpu'arguments
+  | IfThenElse'memory'arguments
+  | IndexByteString'cpu'arguments
+  | IndexByteString'memory'arguments
+  | LengthOfByteString'cpu'arguments
+  | LengthOfByteString'memory'arguments
+  | LessThanByteString'cpu'arguments'intercept
+  | LessThanByteString'cpu'arguments'slope
+  | LessThanByteString'memory'arguments
+  | LessThanEqualsByteString'cpu'arguments'intercept
+  | LessThanEqualsByteString'cpu'arguments'slope
+  | LessThanEqualsByteString'memory'arguments
+  | LessThanEqualsInteger'cpu'arguments'intercept
+  | LessThanEqualsInteger'cpu'arguments'slope
+  | LessThanEqualsInteger'memory'arguments
+  | LessThanInteger'cpu'arguments'intercept
+  | LessThanInteger'cpu'arguments'slope
+  | LessThanInteger'memory'arguments
+  | ListData'cpu'arguments
+  | ListData'memory'arguments
+  | MapData'cpu'arguments
+  | MapData'memory'arguments
+  | MkCons'cpu'arguments
+  | MkCons'memory'arguments
+  | MkNilData'cpu'arguments
+  | MkNilData'memory'arguments
+  | MkNilPairData'cpu'arguments
+  | MkNilPairData'memory'arguments
+  | MkPairData'cpu'arguments
+  | MkPairData'memory'arguments
+  | ModInteger'cpu'arguments'constant
+  | ModInteger'cpu'arguments'model'arguments'intercept
+  | ModInteger'cpu'arguments'model'arguments'slope
+  | ModInteger'memory'arguments'intercept
+  | ModInteger'memory'arguments'minimum
+  | ModInteger'memory'arguments'slope
+  | MultiplyInteger'cpu'arguments'intercept
+  | MultiplyInteger'cpu'arguments'slope
+  | MultiplyInteger'memory'arguments'intercept
+  | MultiplyInteger'memory'arguments'slope
+  | NullList'cpu'arguments
+  | NullList'memory'arguments
+  | QuotientInteger'cpu'arguments'constant
+  | QuotientInteger'cpu'arguments'model'arguments'intercept
+  | QuotientInteger'cpu'arguments'model'arguments'slope
+  | QuotientInteger'memory'arguments'intercept
+  | QuotientInteger'memory'arguments'minimum
+  | QuotientInteger'memory'arguments'slope
+  | RemainderInteger'cpu'arguments'constant
+  | RemainderInteger'cpu'arguments'model'arguments'intercept
+  | RemainderInteger'cpu'arguments'model'arguments'slope
+  | RemainderInteger'memory'arguments'intercept
+  | RemainderInteger'memory'arguments'minimum
+  | RemainderInteger'memory'arguments'slope
+  | SerialiseData'cpu'arguments'intercept
+  | SerialiseData'cpu'arguments'slope
+  | SerialiseData'memory'arguments'intercept
+  | SerialiseData'memory'arguments'slope
+  | Sha2_256'cpu'arguments'intercept
+  | Sha2_256'cpu'arguments'slope
+  | Sha2_256'memory'arguments
+  | Sha3_256'cpu'arguments'intercept
+  | Sha3_256'cpu'arguments'slope
+  | Sha3_256'memory'arguments
+  | SliceByteString'cpu'arguments'intercept
+  | SliceByteString'cpu'arguments'slope
+  | SliceByteString'memory'arguments'intercept
+  | SliceByteString'memory'arguments'slope
+  | SndPair'cpu'arguments
+  | SndPair'memory'arguments
+  | SubtractInteger'cpu'arguments'intercept
+  | SubtractInteger'cpu'arguments'slope
+  | SubtractInteger'memory'arguments'intercept
+  | SubtractInteger'memory'arguments'slope
+  | TailList'cpu'arguments
+  | TailList'memory'arguments
+  | Trace'cpu'arguments
+  | Trace'memory'arguments
+  | UnBData'cpu'arguments
+  | UnBData'memory'arguments
+  | UnConstrData'cpu'arguments
+  | UnConstrData'memory'arguments
+  | UnIData'cpu'arguments
+  | UnIData'memory'arguments
+  | UnListData'cpu'arguments
+  | UnListData'memory'arguments
+  | UnMapData'cpu'arguments
+  | UnMapData'memory'arguments
+  | VerifyEcdsaSecp256k1Signature'cpu'arguments
+  | VerifyEcdsaSecp256k1Signature'memory'arguments
+  | VerifyEd25519Signature'cpu'arguments'intercept
+  | VerifyEd25519Signature'cpu'arguments'slope
+  | VerifyEd25519Signature'memory'arguments
+  | VerifySchnorrSecp256k1Signature'cpu'arguments'intercept
+  | VerifySchnorrSecp256k1Signature'cpu'arguments'slope
+  | VerifySchnorrSecp256k1Signature'memory'arguments
+    deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
+    deriving IsParamName via (GenericParamName ParamName)
+
+{-|  Build the 'EvaluationContext'.
+
+The input is a list of integer values passed from the ledger and are expected to appear in correct order.
+-}
+mkEvaluationContext :: MonadError CostModelApplyError m => [Integer] -> m EvaluationContext
+mkEvaluationContext = mkDynEvaluationContext . toCostModelParams <=< tagWithParamNames @ParamName

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -12,6 +12,7 @@ import Plutus.Ledger.Test.Examples
 import Plutus.Ledger.Test.ProtocolVersions
 import Plutus.V1.Ledger.Api
 import Spec.Builtins qualified
+import Spec.CostModelParams qualified
 import Spec.Eval qualified
 import Spec.Interval qualified
 
@@ -90,4 +91,5 @@ tests = testGroup "plutus-ledger-api" [
     , Spec.Interval.tests
     , Spec.Eval.tests
     , Spec.Builtins.tests
+    , Spec.CostModelParams.tests
     ]

--- a/plutus-ledger-api/test/Spec/Builtins.hs
+++ b/plutus-ledger-api/test/Spec/Builtins.hs
@@ -51,7 +51,7 @@ tests =
          assertBool "not in l2,Vasil" $ V2.isScriptWellFormed vasilPV serialiseDataExScript
     , testCase "cost model parameters" $
          -- v1 is missing some cost model parameters because new builtins are added in v2
-         assertBool "v1 params is proper subset of v2 params" $ V1.costModelParamNames `Set.isProperSubsetOf` V2.costModelParamNames
+         assertBool "v1 params is proper subset of v2 params" $ Set.fromList V1.costModelParamNames `Set.isProperSubsetOf` Set.fromList V2.costModelParamNames
     , testCase "size check" $ do
          assertBool "not in l1" $ V1.isScriptWellFormed vasilPV bigConstant
          assertBool "in l2" $ not $ V2.isScriptWellFormed vasilPV bigConstant

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE TypeApplications #-}
+module Spec.CostModelParams where
+
+import Plutus.V1.Ledger.EvaluationContext as V1
+import Plutus.V2.Ledger.EvaluationContext as V2
+
+import PlutusCore.Evaluation.Machine.BuiltinCostModel as Plutus
+import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults as Plutus
+import PlutusCore.Evaluation.Machine.MachineParameters as Plutus
+
+
+import Barbies
+import Control.Lens
+import Data.Either
+import Data.List.Extra
+import Data.Map as Map
+import Data.Maybe
+import Data.Text qualified as Text
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup
+    "costModelParams"
+    [ testCase "length" $ do
+            166 @=? length (enumerate @V1.ParamName)
+            166 @=? length V1.costModelParamNames
+            175 @=? length (enumerate @V2.ParamName)
+            175 @=? length V2.costModelParamNames
+    , testCase "text" $ do
+            -- this depends on the fact that V1/V2 are alphabetically-ordered; does not have to hold for future versions
+            altV1CostModelParamNames @=? V1.costModelParamNames
+            -- this depends on the fact that V1/V2 are alphabetically-ordered; does not have to hold for future versions
+            Map.keys (fromJust Plutus.defaultCostModelParams) @=? V2.costModelParamNames
+    , testCase "context length" $ do
+            let defaultCostValues = Map.elems $ fromJust defaultCostModelParams
+            -- the defaultcostmodelparams reflects only the latest version V2, so this should succeed because the lengths match
+            assertBool "wrong number of arguments in V2.mkContext" $ isRight $ V2.mkEvaluationContext defaultCostValues
+            -- this one should not succeed because V1 evaluation-context expects less number of arguments.
+            assertBool "wrong number of arguments in V1.mkContext" $ isLeft $ V1.mkEvaluationContext defaultCostValues
+    ]
+
+
+-- | An alternative, older implementation of calculating V1's costmodelparamnames.
+altV1CostModelParamNames :: [Text.Text]
+altV1CostModelParamNames = Map.keys $ fromJust $ extractCostModelParams $
+   defaultCekCostModel
+   & builtinCostModel
+   -- here we rely on 'Deriving.Aeson.OmitNothingFields'
+   -- to skip jsonifying any fields which are cleared.
+   %~ omitV2Builtins
+  where
+    -- "clears" some fields of builtincostmodel by setting them to Nothing. See 'MCostingFun'.
+    omitV2Builtins :: BuiltinCostModel -> BuiltinCostModelBase MCostingFun
+    omitV2Builtins bcm =
+            -- transform all costing-functions to (Just costingFun)
+            (bmap (MCostingFun . Just) bcm)
+            {
+              -- 'SerialiseData','EcdsaSecp256k1',SchnorrSecp256k1 builtins not available in V1
+              paramSerialiseData = mempty
+            , paramVerifyEcdsaSecp256k1Signature = mempty
+            , paramVerifySchnorrSecp256k1Signature = mempty
+            }

--- a/plutus-ledger-api/testlib/Plutus/Ledger/Test/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/Plutus/Ledger/Test/EvaluationContext.hs
@@ -3,7 +3,7 @@ module Plutus.Ledger.Test.EvaluationContext
     , evalCtxForTesting
     ) where
 
-import Plutus.V1.Ledger.EvaluationContext
+import Plutus.ApiCommon
 import PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as Plutus
 
@@ -16,4 +16,4 @@ costModelParamsForTesting = fromJust Plutus.defaultCostModelParams
 
 -- | only to be for testing purposes: make an evaluation context by applying an empty set of protocol parameters
 evalCtxForTesting :: EvaluationContext
-evalCtxForTesting = either throw id $ mkEvaluationContext mempty
+evalCtxForTesting = either throw id $ mkDynEvaluationContext costModelParamsForTesting


### PR DESCRIPTION
For each api version, we create an enumeration datatype that attaches a "tag/label" to the otherwise
untyped array of costmodel params coming from the ledger , i.e. `[Integer]`.

Each tag/label is a nullary constructor in the enumeration datatype and the order of its appearance matters.
Also some "dt-generic" code to derive a human-readable/JSON key name for such nullary constructors (tags).

This will hopefully allow us to be more flexible in future versions (V3) , so that we can define our own costmodel param ordering and not rely/assume/expect an alphabetical order of cost model parameter names.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
