### PR TITLE
Avoid newtype field accessors in `base`

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -89,6 +89,16 @@ unconditionally which we pretty much are.
 See https://gitlab.haskell.org/ghc/ghc/issues/16615 for upstream discussion.
 -}
 
+{- Note [newtype field accessors in `base`]
+For some unknown reason, newtype field accessors in `base`, such as `getFirst`, `appEndo` and
+`getDual`, cause Cabal build and Nix build to behave differently. In Cabal build, these
+field accessors' unfoldings are available to the GHC simplifier, and so the simplifier inlines
+them into `Coercion`s. But in Nix build, somehow their unfoldings aren't available.
+
+This started to happen after a seemingly innocent PR (#4552), and it eventually led to different
+PIRs, PLCs and UPLCs, causing test failures. Replacing them with `coerce` avoids the problem.
+-}
+
 plugin :: GHC.Plugin
 plugin = GHC.defaultPlugin { GHC.pluginRecompile = GHC.flagRecompile
                            , GHC.installCoreToDos = install

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -55,16 +55,6 @@ import PlutusTx.Semigroup ((<>))
 
 import Prelude qualified as Haskell (Monad, return, (>>), (>>=))
 
-{- Note [newtype field accessors in `base`]
-For some unknown reason, newtype field accessors in `base`, such as `getFirst`, `appEndo` and
-`getDual`, cause Cabal build and Nix build to behave differently. In Cabal build, these
-field accessors' unfoldings are available to the GHC simplifier, and so the simplifier inlines
-them into `Coercion`s. But in Nix build, somehow their unfoldings aren't available.
-
-This started to happen after a seemingly innocent PR (#4552), and it eventually led to different
-PIRs, PLCs and UPLCs, causing test failures. Replacing them with `coerce` avoids the problem.
--}
-
 -- | Plutus Tx version of 'Data.Foldable.Foldable'.
 class Foldable t where
     -- | Plutus Tx version of 'Data.Foldable.foldMap'.


### PR DESCRIPTION
See the added note for the reason.

This will need to be cherry-picked to `release/node-1.34`