### PR TITLE
Add cabal clean before running benchmark.

### DIFF
--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -40,6 +40,9 @@ PR_BRANCH_REF=$(git rev-parse --short HEAD)
 echo "[ci-plutus-benchmark]: Updating cabal database ..."
 cabal update
 
+echo "[ci-plutus-benchmark]: Clearing caches with cabal clean ..."
+cabal clean
+
 echo "[ci-plutus-benchmark]: Running benchmark for PR branch ..."
 nix-shell --run "cabal bench $BENCHMARK_NAME >bench-PR.log 2>&1"
 
@@ -49,6 +52,10 @@ git fetch origin
 echo "[ci-plutus-benchmark]: Switching branches ..."
 git checkout "$(git merge-base HEAD origin/master)"
 BASE_BRANCH_REF=$(git rev-parse --short HEAD)
+
+
+echo "[ci-plutus-benchmark]: Clearing caches with cabal clean ..."
+cabal clean
 
 echo "[ci-plutus-benchmark]: Running benchmark for base branch ..."
 nix-shell --run "cabal bench $BENCHMARK_NAME >bench-base.log 2>&1"


### PR DESCRIPTION
We have [some reasons](https://github.com/input-output-hk/plutus/pull/4650#issuecomment-1139545881) to believe that this may make the benchmark more accurate.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
