### PR TITLE
[TypeCheck] Remove all calls to 'rename' from the PIR type checker

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -27,7 +27,6 @@ import Data.Ix
 import PlutusCore (ToKind, tyVarDeclName, typeAnn)
 import PlutusCore.Error as PLC
 import PlutusCore.Quote
-import PlutusCore.Rename as PLC
 import PlutusIR
 import PlutusIR.Compiler.Datatype
 import PlutusIR.Compiler.Provenance
@@ -373,13 +372,13 @@ withVarsOfBinding r (DatatypeBind _ dt) k = do
     (_tyconstrDef, constrDefs, destrDef) <- compileDatatypeDefs r (original dt)
     -- ignore the generated rhs terms of constructors/destructor
     let structorDecls = PIR.defVar <$> destrDef:constrDefs
-    -- normalize, then rename, then only introduce the vardecl to scope
     foldr normRenameScope k structorDecls
     where
+      -- normalize, then introduce the vardecl to scope
       normRenameScope :: VarDecl TyName Name uni fun (Provenance a)
                       -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
       normRenameScope v acc = do
-          normRenamedTy <- rename =<< (normalizeTypeM $ _varDeclType v)
+          normRenamedTy <- normalizeTypeM $ _varDeclType v
           withVar (_varDeclName v) (void <$> normRenamedTy) acc
 
 

--- a/plutus-core/plutus-ir/test/types/listMatch.golden
+++ b/plutus-core/plutus-ir/test/types/listMatch.golden
@@ -1,1 +1,1 @@
-(fun (con integer) (all a_49 (type) (fun a_49 a_49)))
+(fun (con integer) (all a_45 (type) (fun a_45 a_45)))

--- a/plutus-core/plutus-ir/test/types/maybe.golden
+++ b/plutus-core/plutus-ir/test/types/maybe.golden
@@ -1,1 +1,1 @@
-(fun (con integer) [ Maybe_9 (all a_32 (type) (fun a_32 a_32)) ])
+(fun (con integer) [ Maybe_9 (all a_28 (type) (fun a_28 a_28)) ])

--- a/plutus-core/plutus-ir/test/types/mutuallyRecursiveTypes.golden
+++ b/plutus-core/plutus-ir/test/types/mutuallyRecursiveTypes.golden
@@ -1,1 +1,1 @@
-[ Forest_11 (all a_44 (type) (fun a_44 a_44)) ]
+[ Forest_11 (all a_37 (type) (fun a_37 a_37)) ]


### PR DESCRIPTION
This removes all calls to `rename` (1 of them) from the PIR type checker.