### PR TITLE
Improve the error messages from the CEK machine (#4667)

### DIFF
--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -434,8 +434,13 @@ instance AsEvaluationFailure CekUserError where
 
 instance Pretty CekUserError where
     pretty (CekOutOfExError (ExRestrictingBudget res)) =
-        group $ "The budget was overspent. Final negative state:" <+> pretty res
-    pretty CekEvaluationFailure = "The provided Plutus code called 'error'."
+        cat
+          [ "The machine terminated part way through evaluation due to overspending the budget."
+          , "The budget when the machine terminated was:"
+          , pretty res
+          , "Negative numbers indicate the overspent budget; note that this only indicatessthe budget that was needed for the next step, not to run the program to completion."
+          ]
+    pretty CekEvaluationFailure = "The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'."
 
 spendBudgetCek :: GivenCekSpender uni fun s => ExBudgetCategory fun -> ExBudget -> CekM uni fun s ()
 spendBudgetCek = let (CekBudgetSpender spend) = ?cekBudgetSpender in spend

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden/diFullyApplied.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden/diFullyApplied.uplc.golden
@@ -1,3 +1,3 @@
 (Left An error has occurred:  User error:
-The provided Plutus code called 'error'.
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
 Caused by: [ [ (builtin divideInteger) (con integer 1) ] (con integer 0) ])

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.uplc.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden/polyErrorInst.uplc.golden
@@ -1,2 +1,2 @@
 (Left An error has occurred:  User error:
-The provided Plutus code called 'error'.)
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.)


### PR DESCRIPTION
In particular, try to make it obvious that the overspent budget error
arises in the middle of execution, and that the budget state printed
just represents the immediate overspent budget, and not the amount
needed to run the script to completion.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
