### PR TITLE
PLT-279: Make compileVarFresh take an annotation

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Annotation.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Annotation.hs
@@ -4,9 +4,14 @@ import GHC.Generics
 import Prettyprinter
 
 data Ann
-    = -- | When a term `t` has this annotation, the inliner will inline bindings `var = t`.
-      -- This is currently used to make sure builtin functions `trace` (when `remove-trace`
-      -- is specified) and `error` are inlined.
+    = -- | When calling @PlutusIR.Compiler.Definitions.defineTerm@ to add a new term definition,
+      -- if we annotation the var on the LHS of the definition with `AnnInline`, the inliner will
+      -- always inline that var.
+      --
+      -- This is currently used to ensure builtin functions such as @trace@ (when the @remove-trace@
+      -- flag is on and @trace@ is rewritten to @const@) are inlined, because the inliner would
+      -- otherwise not inline them. To achieve that, we annotate the definition with `AnnInline`
+      -- when defining @trace@, i.e., @trace <AnnInline> = \_ a -> a@.
       AnnInline
     | AnnOther
     deriving stock (Eq, Ord, Generic, Show)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -36,7 +36,7 @@ withVarScoped ::
     m a
 withVarScoped v k = do
     let ghcName = GHC.getName v
-    var <- compileVarFresh v
+    var <- compileVarFresh AnnOther v
     local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
 
 withVarsScoped ::
@@ -47,7 +47,7 @@ withVarsScoped ::
 withVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
-        var' <- compileVarFresh v
+        var' <- compileVarFresh AnnOther v
         pure (name, var')
     local (\c -> c {ccScopes=pushNames vars (ccScopes c)}) (k (fmap snd vars))
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -242,7 +242,7 @@ builtinNames = [
 defineBuiltinTerm :: CompilingDefault uni fun m ann => Ann -> TH.Name -> PIRTerm uni fun -> m ()
 defineBuiltinTerm ann name term = do
     ghcId <- GHC.tyThingId <$> getThing name
-    var <- ($> ann) <$> compileVarFresh ghcId
+    var <- compileVarFresh ann ghcId
     -- See Note [Builtin terms and values]
     let strictness = if PIR.isPure (const PIR.NonStrict) term then PIR.Strict else PIR.NonStrict
         def = PIR.Def var (term, strictness)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -48,12 +48,12 @@ import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Pretty qualified as PP
 import PlutusCore.Subst qualified as PLC
 
+import Control.Lens ((&), (.~), (<&>))
 import Control.Monad
 import Control.Monad.Reader (MonadReader (ask))
 
 import Data.Array qualified as Array
 import Data.ByteString qualified as BS
-import Data.Functor ((<&>))
 import Data.List (elemIndex)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
@@ -453,7 +453,7 @@ hoistExpr var t = do
         Just term -> pure term
         -- See Note [Dependency tracking]
         Nothing -> withCurDef lexName $ withContextM 1 (sdToTxt $ "Compiling definition of:" GHC.<+> GHC.ppr var) $ do
-            var' <- compileVarFresh var
+            var' <- compileVarFresh AnnOther var
             -- See Note [Occurrences of recursive names]
             PIR.defineTerm
                 lexName
@@ -461,10 +461,15 @@ hoistExpr var t = do
                 mempty
 
             t' <- maybeProfileRhs var' =<< compileExpr t
-            -- See Note [Non-strict let-bindings]
+                -- See Note [Non-strict let-bindings]
             let strict = PIR.isPure (const PIR.NonStrict) t'
-
-            PIR.modifyTermDef lexName (const $ PIR.Def var' (t', if strict then PIR.Strict else PIR.NonStrict))
+                -- Use `t'`'s annotation on `varAnnotated`, which ensures that if `t'` is marked
+                -- `AnnInline`, so is `varAnnotated`.
+                -- See Note [Annotations on Bindings]
+                varAnnotated = var' & PLC.varDeclAnn .~ PIR.termAnn t'
+            PIR.modifyTermDef
+                lexName
+                (const $ PIR.Def varAnnotated (t', if strict then PIR.Strict else PIR.NonStrict))
             pure $ PIR.mkVar AnnOther var'
 
 maybeProfileRhs :: CompilingDefault uni fun m ann => PLCVar uni fun -> PIRTerm uni fun -> m (PIRTerm uni fun)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -755,14 +755,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             let strict = PIR.isPure (const PIR.NonStrict) rhs'
             withVarScoped b $ \v -> do
                 rhs'' <- maybeProfileRhs v rhs'
-                let binds =
-                        pure $
-                            PIR.TermBind
-                                -- Ensure that if `rhs''` is marked `AnnInline`, so is the bind.
-                                (PIR.termAnn rhs'')
-                                (if strict then PIR.Strict else PIR.NonStrict)
-                                v
-                                rhs''
+                let binds = pure $ PIR.TermBind AnnOther (if strict then PIR.Strict else PIR.NonStrict) v rhs''
                 body' <- compileExpr body
                 pure $ PIR.Let AnnOther PIR.NonRec binds body'
         GHC.Let (GHC.Rec bs) body ->
@@ -784,14 +777,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             withVarScoped b $ \v -> do
                 body' <- compileExpr body
                 -- See Note [At patterns]
-                let binds =
-                        [ PIR.TermBind
-                            -- Ensure that if `scrutinee'` is marked `AnnInline`, so is the bind.
-                            (PIR.termAnn scrutinee')
-                            PIR.Strict
-                            v
-                            scrutinee'
-                        ]
+                let binds = [ PIR.TermBind AnnOther PIR.Strict v scrutinee' ]
                 pure $ PIR.mkLet AnnOther PIR.NonRec binds body'
         GHC.Case scrutinee b t alts -> do
             -- See Note [At patterns]
@@ -833,14 +819,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
                 mainCase <- maybeForce lazyCase applied
 
                 -- See Note [At patterns]
-                let binds =
-                        pure $
-                            PIR.TermBind
-                                -- Ensure that if `scrutinee'` is marked `AnnInline`, so is the bind.
-                                (PIR.termAnn scrutinee')
-                                PIR.NonStrict
-                                v
-                                scrutinee'
+                let binds = pure $ PIR.TermBind AnnOther PIR.NonStrict v scrutinee'
                 pure $ PIR.Let AnnOther PIR.NonRec binds mainCase
 
         -- we can use source notes to get a better context for the inner expression

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
@@ -52,11 +52,11 @@ getUntidiedOccString n = dropWhileEnd isDigit (GHC.getOccString n)
 compileNameFresh :: MonadQuote m => GHC.Name -> m PLC.Name
 compileNameFresh n = safeFreshName $ T.pack $ getUntidiedOccString n
 
-compileVarFresh :: CompilingDefault uni fun m ann => GHC.Var -> m (PLCVar uni fun)
-compileVarFresh v = do
+compileVarFresh :: CompilingDefault uni fun m ann => Ann -> GHC.Var -> m (PLCVar uni fun)
+compileVarFresh ann v = do
     t' <- compileTypeNorm $ GHC.varType v
     n' <- compileNameFresh $ GHC.getName v
-    pure $ PLC.VarDecl AnnOther n' t'
+    pure $ PLC.VarDecl ann n' t'
 
 lookupTyName :: Scope uni fun -> GHC.Name -> Maybe PLCTyVar
 lookupTyName (Scope _ tyns) n = Map.lookup n tyns


### PR DESCRIPTION
`compileVarFresh` should not assume that the `VarDecl` it creates should be annotated `AnnOther`. The caller should decide that.

This PR also makes sure all calls to `TermBind` constructor uses the correct annotation, since that's what the inliner looks at. This doesn't affect any existing test because we aren't inlining many things, but it's the right thing to do.