### PR TITLE
Add pre-commit to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -59,6 +59,7 @@ let
     editorconfig-core-c
     ghcid
     jq
+    pre-commit
     nixFlakesAlias
     nixpkgs-fmt
     shellcheck
@@ -91,7 +92,7 @@ haskell.project.shellFor {
     ${pre-commit-check.shellHook}
   '';
 
-  # This is no longer set automatically as of more recent `haskell.nix` revisions, 
+  # This is no longer set automatically as of more recent `haskell.nix` revisions,
   # but is useful for users with LANG settings.
   LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -59,6 +59,7 @@ let
     editorconfig-core-c
     ghcid
     jq
+    # See https://github.com/cachix/pre-commit-hooks.nix/issues/148 for why we need this
     pre-commit
     nixFlakesAlias
     nixpkgs-fmt


### PR DESCRIPTION
so that in the nix shell we have nix's pre-commit, not the one in your `.local/bin` installed from pip, which for some reason doesn't work in the nix shell.