### PR TITLE
Rewrite some functions to be Folds/Traversals

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -248,6 +248,7 @@ library
         Data.Aeson.Flatten
         Data.Aeson.THReader
         Data.Functor.Foldable.Monadic
+        Data.MultiSet.Lens
         Universe.Core
         GHC.Natural.Extras
     build-depends:
@@ -285,6 +286,7 @@ library
         mmorph -any,
         monoidal-containers,
         mtl -any,
+        multiset -any,
         parser-combinators >= 0.4.0,
         prettyprinter >=1.1.0.1,
         prettyprinter-configurable -any,

--- a/plutus-core/plutus-core/src/Data/MultiSet/Lens.hs
+++ b/plutus-core/plutus-core/src/Data/MultiSet/Lens.hs
@@ -1,0 +1,10 @@
+module Data.MultiSet.Lens (multiSetOf) where
+
+import Control.Lens
+
+import Data.MultiSet
+
+-- | Create a 'MultiSet' from a 'Getter', 'Fold', etc.
+multiSetOf :: Getting (MultiSet a) s a -> s -> MultiSet a
+-- same as 'setOf'
+multiSetOf l = views l singleton

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
@@ -24,16 +24,12 @@ module PlutusCore.Core.Plated
     , termUniquesDeep
     ) where
 
+import PlutusPrelude ((<^>))
+
 import PlutusCore.Core.Type
 import PlutusCore.Name
 
 import Control.Lens
-
-infixr 6 <^>
-
--- | Compose two folds to make them run in parallel. The results are concatenated.
-(<^>) :: Fold s a -> Fold s a -> Fold s a
-(f1 <^> f2) g s = f1 g s *> f2 g s
 
 kindSubkinds :: Traversal' (Kind ann) (Kind ann)
 kindSubkinds f kind0 = case kind0 of

--- a/plutus-core/plutus-core/src/PlutusCore/Mark.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Mark.hs
@@ -4,24 +4,24 @@ module PlutusCore.Mark
     , markNonFreshProgram
     ) where
 
+import Data.Set.Lens (setOf)
 import PlutusCore.Core
 import PlutusCore.Name
 import PlutusCore.Quote
-import PlutusCore.Subst
 
 -- | Marks all the 'Unique's in a type as used, so they will not be generated in future. Useful if you
 -- have a type which was not generated in 'Quote'.
 markNonFreshType
     :: (HasUniques (Type tyname uni ann), MonadQuote m)
     => Type tyname uni ann -> m ()
-markNonFreshType = markNonFreshMax . uniquesType
+markNonFreshType = markNonFreshMax . setOf typeUniquesDeep
 
 -- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
 -- have a term which was not generated in 'Quote'.
 markNonFreshTerm
     :: (HasUniques (Term tyname name uni fun ann), MonadQuote m)
     => Term tyname name uni fun ann -> m ()
-markNonFreshTerm = markNonFreshMax . uniquesTerm
+markNonFreshTerm = markNonFreshMax . setOf termUniquesDeep
 
 -- | Marks all the 'Unique's in a program as used, so they will not be generated in future. Useful if you
 -- have a program which was not generated in 'Quote'.

--- a/plutus-core/plutus-core/src/PlutusCore/Subst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Subst.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 module PlutusCore.Subst
     ( substTyVarA
     , substVarA
@@ -14,11 +16,10 @@ module PlutusCore.Subst
     , fvTerm
     , ftvTerm
     , ftvTy
+    , ftvTyCtx
     , vTerm
     , tvTerm
     , tvTy
-    , uniquesType
-    , uniquesTerm
     ) where
 
 import PlutusPrelude
@@ -27,9 +28,8 @@ import PlutusCore.Core
 import PlutusCore.Name
 
 import Control.Lens
-import Data.Functor.Foldable (cata)
+import Control.Lens.Unsound qualified as Unsound
 import Data.Set as Set
-import Data.Set.Lens (setOf)
 
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d
 purely = coerce
@@ -147,65 +147,46 @@ termSubstFreeNames = purely termSubstFreeNamesA
 -- Free variables
 
 -- | Get all the free term variables in a term.
-fvTerm :: Ord name => Term tyname name uni fun ann -> Set name
-fvTerm = cata f
-  where
-    f (VarF _ n)        = singleton n
-    f (TyAbsF _ _ _ t)  = t
-    f (LamAbsF _ n _ t) = delete n t
-    f (ApplyF _ t1 t2)  = t1 `union` t2
-    f (TyInstF _ t _)   = t
-    f (UnwrapF _ t)     = t
-    f (IWrapF _ _ _ t)  = t
-    f ConstantF{}       = Set.empty
-    f BuiltinF{}        = Set.empty
-    f ErrorF{}          = Set.empty
+fvTerm :: Ord name => Traversal' (Term tyname name uni fun ann) name
+fvTerm = fvTermCtx mempty
+
+fvTermCtx :: Ord name => Set.Set name -> Traversal' (Term tyname name uni fun ann) name
+fvTermCtx bound f = \case
+    Var a n         -> Var a <$> (if Set.member n bound then pure n else f n)
+    LamAbs a n ty t -> LamAbs a n ty <$> fvTermCtx (Set.insert n bound) f t
+    t               -> (termSubterms . fvTermCtx bound) f t
 
 -- | Get all the free type variables in a term.
-ftvTerm :: Ord tyname => Term tyname name uni fun ann -> Set tyname
-ftvTerm = cata f
-  where
-    f (TyAbsF _ ty _ t)    = delete ty t
-    f (LamAbsF _ _ ty t)   = ftvTy ty `union` t
-    f (ApplyF _ t1 t2)     = t1 `union` t2
-    f (TyInstF _ t ty)     = t `union` ftvTy ty
-    f (UnwrapF _ t)        = t
-    f (IWrapF _ pat arg t) = ftvTy pat `union` ftvTy arg `union` t
-    f (ErrorF _ ty)        = ftvTy ty
-    f VarF{}               = Set.empty
-    f ConstantF{}          = Set.empty
-    f BuiltinF{}           = Set.empty
+ftvTerm :: Ord tyname => Traversal' (Term tyname name uni fun ann) tyname
+ftvTerm = ftvTermCtx mempty
+
+ftvTermCtx :: Ord tyname => Set.Set tyname -> Traversal' (Term tyname name uni fun ann) tyname
+ftvTermCtx bound f = \case
+    TyAbs a ty k t -> TyAbs a ty k <$> ftvTermCtx (Set.insert ty bound) f t
+    -- sound because the subterms and subtypes are disjoint
+    t              -> ((termSubterms . ftvTermCtx bound) `Unsound.adjoin` (termSubtypes . ftvTyCtx bound)) f t
 
 -- | Get all the free type variables in a type.
-ftvTy :: Ord tyname => Type tyname uni ann -> Set tyname
-ftvTy = cata f
-  where
-    f (TyVarF _ ty)          = singleton ty
-    f (TyFunF _ i o)         = i `union` o
-    f (TyIFixF _ pat arg)    = pat `union` arg
-    f (TyForallF _ bnd _ ty) = delete bnd ty
-    f (TyLamF _ bnd _ ty)    = delete bnd ty
-    f (TyAppF _ ty1 ty2)     = ty1 `union` ty2
-    f TyBuiltinF{}           = Set.empty
+ftvTy :: Ord tyname => Traversal' (Type tyname uni ann) tyname
+ftvTy = ftvTyCtx mempty
 
+ftvTyCtx :: Ord tyname => Set.Set tyname -> Traversal' (Type tyname uni ann) tyname
+ftvTyCtx bound f = \case
+    TyVar a ty          -> TyVar a <$> (if Set.member ty bound then pure ty else f ty)
+    TyForall a bnd k ty -> TyForall a bnd k <$> ftvTyCtx (Set.insert bnd bound) f ty
+    TyLam a bnd k ty    -> TyLam a bnd k <$> ftvTyCtx (Set.insert bnd bound) f ty
+    t                   -> (typeSubtypes . ftvTyCtx bound) f t
+
+
+-- TODO: these could be Traversals
 -- | Get all the term variables in a term.
-vTerm :: Ord name => Term tyname name uni fun ann -> Set name
-vTerm = setOf $ termSubtermsDeep . termVars
+vTerm :: Fold (Term tyname name uni fun ann) name
+vTerm = termSubtermsDeep . termVars
 
 -- | Get all the type variables in a term.
-tvTerm :: Ord tyname => Term tyname name uni fun ann -> Set tyname
-tvTerm = setOf $ termSubtypesDeep . typeTyVars
+tvTerm :: Fold (Term tyname name uni fun ann) tyname
+tvTerm = termSubtypesDeep . typeTyVars
 
 -- | Get all the type variables in a type.
-tvTy :: Ord tyname => Type tyname uni ann -> Set tyname
-tvTy = setOf $ typeSubtypesDeep . typeTyVars
-
--- All uniques
-
--- | Get all the uniques in a type.
-uniquesType :: HasUniques (Type tyname uni ann) => Type tyname uni ann -> Set Unique
-uniquesType = setOf typeUniquesDeep
-
--- | Get all the uniques in a term (including the type-level ones).
-uniquesTerm :: HasUniques (Term tyname name uni fun ann) => Term tyname name uni fun ann -> Set Unique
-uniquesTerm = setOf termUniquesDeep
+tvTy :: Fold (Type tyname uni ann) tyname
+tvTy = typeSubtypesDeep . typeTyVars

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
@@ -242,5 +242,5 @@ typeDeps
 typeDeps ty =
     -- The dependency graph of a type is very simple since it doesn't have any internal let-bindings. So we just
     -- need to find all the used variables and mark them as dependencies of the current node.
-    let used = Usages.allUsed $ Usages.runTypeUsages ty
+    let used = Usages.allUsed $ Usages.typeUsages ty
     in currentDependsOn (Set.toList used)

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
@@ -1,64 +1,40 @@
 {-# LANGUAGE FlexibleContexts #-}
 -- | Functions for computing variable usage inside terms and types.
-module PlutusIR.Analysis.Usages (runTermUsages, runTypeUsages, Usages, getUsageCount, allUsed) where
+module PlutusIR.Analysis.Usages (termUsages, typeUsages, Usages, getUsageCount, allUsed) where
+
+import PlutusPrelude ((<^>))
 
 import PlutusIR
+import PlutusIR.Subst
 
 import PlutusCore qualified as PLC
 import PlutusCore.Name qualified as PLC
 
 import Control.Lens
-import Control.Monad.State
 
-import Data.Coerce
-import Data.Foldable
-import Data.Map qualified as Map
+import Data.MultiSet qualified as MSet
+import Data.MultiSet.Lens
 import Data.Set qualified as Set
 
--- | Variable uses, as a map from the 'PLC.Unique' to its usage count. Unused variables may be missing
--- or have usage count 0.
-type Usages = Map.Map PLC.Unique Int
-
-addUsage :: (PLC.HasUnique n unique) => n -> Usages -> Usages
-addUsage n usages =
-    let
-        u = coerce $ n ^. PLC.unique
-        old = Map.findWithDefault 0 u usages
-    in Map.insert u (old+1) usages
+type Usages = MSet.MultiSet PLC.Unique
 
 -- | Get the usage count of @n@.
 getUsageCount :: (PLC.HasUnique n unique) => n -> Usages -> Int
-getUsageCount n usages = Map.findWithDefault 0 (n ^. PLC.unique . coerced) usages
+getUsageCount n = MSet.occur (n ^. PLC.unique . coerced)
 
 -- | Get a set of @n@s which are used at least once.
 allUsed :: Usages -> Set.Set PLC.Unique
-allUsed usages = Map.keysSet $ Map.filter (> 0) usages
+allUsed = MSet.toSet
 
--- | Compute the 'Usages' for a 'Term'.
-runTermUsages
+termUsages
     :: (PLC.HasUnique name PLC.TermUnique, PLC.HasUnique tyname PLC.TypeUnique)
     => Term tyname name uni fun a
     -> Usages
-runTermUsages term = execState (termUsages term) mempty
-
--- | Compute the 'Usages' for a 'Type'.
-runTypeUsages
-    ::(PLC.HasUnique tyname PLC.TypeUnique)
-    => Type tyname uni a
-    -> Usages
-runTypeUsages ty = execState (typeUsages ty) mempty
-
-termUsages
-    :: (MonadState Usages m, PLC.HasUnique name PLC.TermUnique, PLC.HasUnique tyname PLC.TypeUnique)
-    => Term tyname name uni fun a
-    -> m ()
-termUsages (Var _ n) = modify (addUsage n)
-termUsages term      = traverse_ termUsages (term ^.. termSubterms) >> traverse_ typeUsages (term ^.. termSubtypes)
+termUsages = multiSetOf (vTerm . PLC.theUnique <^> tvTerm . PLC.theUnique)
 
 -- TODO: move to plutus-core
 typeUsages
-    :: (MonadState Usages m, PLC.HasUnique tyname PLC.TypeUnique)
+    :: (PLC.HasUnique tyname PLC.TypeUnique)
     => Type tyname uni a
-    -> m ()
-typeUsages (TyVar _ n) = modify (addUsage n)
-typeUsages ty          = traverse_ typeUsages (ty ^.. typeSubtypes)
+    -> Usages
+typeUsages = multiSetOf (tvTy . PLC.theUnique)

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
@@ -8,6 +8,7 @@ module PlutusIR.Core.Plated
     , termSubtypesDeep
     , termSubkinds
     , termBindings
+    , termVars
     , typeSubtypes
     , typeSubtypesDeep
     , typeSubkinds
@@ -15,6 +16,7 @@ module PlutusIR.Core.Plated
     , typeUniquesDeep
     , datatypeSubtypes
     , datatypeSubkinds
+    , datatypeTyNames
     , bindingSubterms
     , bindingSubtypes
     , bindingSubkinds
@@ -70,6 +72,16 @@ datatypeSubkinds f (Datatype a n vs m cs) = do
     n' <- tyVarDeclSubkinds f n
     vs' <- traverse (tyVarDeclSubkinds f) vs
     pure $ Datatype a n' vs' m cs
+
+{-# INLINE datatypeTyNames #-}
+-- | Get all the type-names introduces by a datatype
+datatypeTyNames :: Traversal' (Datatype tyname name uni fun a) tyname
+datatypeTyNames f (Datatype a2 tvdecl tvdecls n vdecls) =
+    Datatype a2
+        <$> PLC.tyVarDeclName f tvdecl
+        <*> traverse (PLC.tyVarDeclName f) tvdecls
+        <*> pure n
+        <*> pure vdecls
 
 {-# INLINE bindingSubkinds #-}
 -- | Get all the direct child 'Kind's of the given 'Binding'.
@@ -168,7 +180,6 @@ termBindings f = \case
     Let x r bs t -> Let x r <$> traverse f bs <*> pure t
     t            -> pure t
 
-
 -- | Get all the direct child 'Unique's of the given 'Term' (including the type-level ones).
 termUniques
     :: PLC.HasUniques (Term tyname name uni fun ann)
@@ -185,6 +196,12 @@ termUniques f = \case
     e@Error{}         -> pure e
     i@IWrap{}         -> pure i
     u@Unwrap{}        -> pure u
+
+-- | Get all the direct child 'name a's of the given 'Term' from 'Var's.
+termVars :: Traversal' (Term tyname name uni fun ann) name
+termVars f term0 = case term0 of
+    Var ann n -> Var ann <$> f n
+    t         -> pure t
 
 -- | Get all the transitive child 'Unique's of the given 'Term' (including the type-level ones).
 termUniquesDeep
@@ -206,12 +223,6 @@ bindingNames f = \case
 -- | Get all the type-names introduces by a binding
 bindingTyNames :: Traversal' (Binding tyname name uni fun a) tyname
 bindingTyNames f = \case
-   TypeBind a d ty -> TypeBind a <$> PLC.tyVarDeclName f d <*> pure ty
-   DatatypeBind a1 (Datatype a2 tvdecl tvdecls n vdecls) ->
-     DatatypeBind a1 <$>
-       (Datatype a2 <$> PLC.tyVarDeclName f tvdecl
-                    <*> traverse (PLC.tyVarDeclName f) tvdecls
-                    <*> pure n
-                    <*> pure vdecls)
-   b@TermBind{} -> pure b
-
+   TypeBind a d ty   -> TypeBind a <$> PLC.tyVarDeclName f d <*> pure ty
+   DatatypeBind a1 d -> DatatypeBind a1 <$> datatypeTyNames f d
+   b@TermBind{}      -> pure b

--- a/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
@@ -9,22 +9,22 @@ import PlutusCore.Name qualified as PLC
 
 import PlutusCore.Quote
 
+import Data.Set.Lens (setOf)
 import PlutusIR.Core
-import PlutusIR.Subst
 
 -- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
 -- have a term which was not generated in 'Quote'.
 markNonFreshTerm
     :: (PLC.HasUniques (Term tyname name uni fun ann), MonadQuote m)
     => Term tyname name uni fun ann -> m ()
-markNonFreshTerm = markNonFreshMax . uniquesTerm
+markNonFreshTerm = markNonFreshMax . setOf termUniquesDeep
 
 -- | Marks all the 'Unique's in a type as used, so they will not be generated in future. Useful if you
 -- have a type which was not generated in 'Quote'.
 markNonFreshType
     :: (PLC.HasUniques (Type tyname uni ann), MonadQuote m)
     => Type tyname uni ann -> m ()
-markNonFreshType = markNonFreshMax . uniquesType
+markNonFreshType = markNonFreshMax . setOf typeUniquesDeep
 
 -- | Marks all the 'Unique's in a program as used, so they will not be generated in future. Useful if you
 -- have a program which was not generated in 'Quote'.

--- a/plutus-core/plutus-ir/src/PlutusIR/Subst.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Subst.hs
@@ -1,99 +1,124 @@
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module PlutusIR.Subst
-    ( uniquesTerm
-    , uniquesType
-    , fvTerm
+    ( fvTerm
     , ftvTerm
     , fvBinding
     , ftvBinding
     , ftvTy
+    , vTerm
+    , tvTerm
+    , tvTy
     ) where
 
 import PlutusCore.Core.Type qualified as PLC
-import PlutusCore.Name qualified as PLC
-import PlutusCore.Subst (ftvTy, uniquesType)
+import PlutusCore.Subst (ftvTy, ftvTyCtx, tvTy)
 
-import PlutusIR.Compiler.Datatype
 import PlutusIR.Core
 
 import Control.Lens
+import Control.Lens.Unsound qualified as Unsound
 import Data.Set as S hiding (foldr)
 import Data.Set.Lens (setOf)
-
-uniquesTerm
-    :: PLC.HasUniques (Term tyname name uni fun ann)
-    => Term tyname name uni fun ann -> Set PLC.Unique
-uniquesTerm = setOf termUniquesDeep
+import Data.Traversable (mapAccumL)
+import PlutusCore.Core.Plated (typeTyVars)
 
 -- | Get all the free term variables in a PIR term.
-fvTerm :: Ord name => Term tyname name uni fun ann -> Set name
-fvTerm = \case
-    Let _ NonRec bs tIn ->
-        let fvLinearScope b acc = fvBinding b
-                                   <> (acc \\ setOf bindingNames b)
-        in foldr fvLinearScope (fvTerm tIn) bs
+fvTerm :: Ord name => Traversal' (Term tyname name uni fun ann) name
+fvTerm = fvTermCtx mempty
 
-    Let _ Rec bs tIn ->
-        (foldMap fvBinding bs <> fvTerm tIn)
-        \\ setOf (traversed.bindingNames) bs
+fvTermCtx :: Ord name => S.Set name -> Traversal' (Term tyname name uni fun ann) name
+fvTermCtx bound f = \case
+    Let a r@NonRec bs tIn ->
+        let fvLinearScope bound' b = (bound' `union` setOf bindingNames b, fvBindingCtx bound' f b)
+            (bound'', bs') = mapAccumL fvLinearScope bound bs
+        in Let a r <$> sequenceA bs' <*> fvTermCtx bound'' f tIn
+    Let a r@Rec bs tIn ->
+        let bound' = bound `union` setOf (traversed . bindingNames) bs
+        in Let a r <$> traverse (fvBindingCtx bound f) bs <*> fvTermCtx bound' f tIn
 
-    LamAbs _ n _ t -> delete n $ fvTerm t
-    Apply _ t1 t2 -> fvTerm t1 <> fvTerm t2
-    Var _ n -> singleton n
-    TyAbs _ _ _ t ->   fvTerm t
-    TyInst _ t _ ->    fvTerm t
-    Unwrap _ t ->      fvTerm t
-    IWrap _ _ _ t ->   fvTerm t
-    Constant{}       -> mempty
-    Builtin{}        -> mempty
-    Error{}          -> mempty
+    Var a n         -> Var a <$> (if S.member n bound then pure n else f n)
+    LamAbs a n ty t -> LamAbs a n ty <$> fvTermCtx (S.insert n bound) f t
+    t -> (termSubterms . fvTermCtx bound) f t
 
 -- | Get all the free type variables in a PIR term.
-ftvTerm :: Ord tyname => Term tyname name uni fun ann -> Set tyname
-ftvTerm = \case
-    Let _ r@NonRec bs tIn ->
-        let ftvLinearScope b acc = ftvBinding r b
-                                   <> (acc \\ setOf bindingTyNames b)
-        in foldr ftvLinearScope (ftvTerm tIn) bs
+ftvTerm :: Ord tyname => Traversal' (Term tyname name uni fun ann) tyname
+ftvTerm = ftvTermCtx mempty
 
-    Let _ r@Rec bs tIn ->
-        (ftvTerm tIn <> foldMap (ftvBinding r) bs)
-        \\ setOf (traversed.bindingTyNames) bs
-    TyAbs _ ty _ t    -> delete ty $ ftvTerm t
-    LamAbs _ _ ty t   -> ftvTy ty <> ftvTerm t
-    Apply _ t1 t2     -> ftvTerm t1 <> ftvTerm t2
-    TyInst _ t ty     -> ftvTerm t <> ftvTy ty
-    Unwrap _ t        -> ftvTerm t
-    IWrap _ pat arg t -> ftvTy pat <> ftvTy arg <> ftvTerm t
-    Error _ ty        -> ftvTy ty
-    Var{}               -> mempty
-    Constant{}          -> mempty
-    Builtin{}           -> mempty
+ftvTermCtx :: Ord tyname => Set tyname -> Traversal' (Term tyname name uni fun ann) tyname
+ftvTermCtx bound f = \case
+    Let a r@NonRec bs tIn ->
+        let ftvLinearScope bound' b = (bound' `union` setOf bindingTyNames b, ftvBindingCtx r bound' f b)
+            (bound'', bs') = mapAccumL ftvLinearScope bound bs
+        in Let a r <$> sequenceA bs' <*> ftvTermCtx bound'' f tIn
+
+    Let a r@Rec bs tIn ->
+        let bound' = bound `union` setOf (traversed . bindingTyNames) bs
+        in Let a r <$> traverse (ftvBindingCtx r bound f) bs <*> ftvTermCtx bound' f tIn
+
+    TyAbs a tn k t    -> TyAbs a tn k <$> ftvTermCtx (S.insert tn bound) f t
+    -- sound because the subterms and subtypes are disjoint
+    t -> ((termSubterms . ftvTermCtx bound) `Unsound.adjoin` (termSubtypes . ftvTyCtx bound)) f t
 
 -- | Get all the free variables in a PIR single let-binding.
-fvBinding :: Ord name => Binding tyname name uni fun ann -> Set name
-fvBinding b = mconcat $ fvTerm <$> ( b^..bindingSubterms)
+fvBinding :: Ord name => Traversal' (Binding tyname name uni fun ann) name
+fvBinding = fvBindingCtx mempty
+
+fvBindingCtx :: Ord name => Set name -> Traversal' (Binding tyname name uni fun ann) name
+fvBindingCtx bound = bindingSubterms . fvTermCtx bound
 
 -- | Get all the free type variables in a PIR single let-binding.
-ftvBinding :: forall tyname name uni fun ann.
-             Ord tyname => Recursivity -> Binding tyname name uni fun ann -> Set tyname
-ftvBinding r b = mconcat $ ftvTs ++ ftvTys
- where
-    ftvTs = ftvTerm <$> b^..bindingSubterms
-    ftvTys = ftvTyDataSpecial <$> b^..bindingSubtypes
+ftvBinding :: Ord tyname => Recursivity -> Traversal' (Binding tyname name uni fun ann) tyname
+ftvBinding r = ftvBindingCtx r mempty
 
-    -- like ftvTy but specialized for the datatypebind case
-    ftvTyDataSpecial :: Type tyname uni ann -> Set tyname
-    ftvTyDataSpecial ty = case b of
-        DatatypeBind _ (Datatype _ tyconstr tyvars _ _) -> case r of
-            -- for rec, both tyconstr+tyvars are in scope in *WHOLE* dataconstructors
-            Rec -> ftvTy ty \\ setOf bindingTyNames b
-            NonRec ->
-                let tyvarsNames = setOf (traversed.PLC.tyVarDeclName) tyvars
-                    ftvDom = mconcat $ ftvTy <$> funTyArgs ty
-                    -- tyconstr is in scope *only* in the result type codomain
-                    ftvCod = ftvTy (funResultType ty) \\ setOf PLC.tyVarDeclName tyconstr
-                -- for nonrec, the tyvars are in scope in *WHOLE* dataconstructors
-                in (ftvDom <> ftvCod) \\ tyvarsNames
-        _ -> ftvTy ty
+ftvBindingCtx :: Ord tyname => Recursivity -> Set tyname -> Traversal' (Binding tyname name uni fun ann) tyname
+ftvBindingCtx r bound f = \case
+    DatatypeBind a d -> DatatypeBind a <$> ftvDatatypeCtx r bound f d
+    -- sound because the subterms and subtypes are disjoint
+    b                -> ((bindingSubterms . ftvTermCtx bound) `Unsound.adjoin` (bindingSubtypes . ftvTyCtx bound)) f b
+
+ftvDatatypeCtx :: Ord tyname => Recursivity -> Set tyname -> Traversal' (Datatype tyname name uni fun ann) tyname
+ftvDatatypeCtx r bound f d@(Datatype a tyconstr tyvars destr constrs) =
+    let
+        tyConstr = setOf PLC.tyVarDeclName tyconstr
+        tyVars = setOf (traversed.PLC.tyVarDeclName) tyvars
+        allBound = bound `union` tyConstr `union` tyVars
+        varsBound = bound `union` tyVars
+    in case r of
+        -- recursive: introduced names are in scope throughout
+        Rec -> (datatypeSubtypes . ftvTyCtx allBound) f d
+        -- nonrecursive: type constructor is in scope only in the result type of the constructors
+        NonRec ->
+            let
+                combinedTraversal =
+                    -- type arguments are in scope in the argument types
+                    (funArgs . ftvTyCtx varsBound)
+                    -- sound because the argument types and result type are disjoint
+                    `Unsound.adjoin`
+                    -- type constructor and arguments are in scope in the result type
+                    (funRes . ftvTyCtx allBound)
+                constrs' = traverseOf (traversed . PLC.varDeclType . combinedTraversal) f constrs
+            in Datatype a tyconstr tyvars destr <$> constrs'
+
+-- | Traverse the arguments of a function type (nothing if the type is not a function type).
+funArgs :: Traversal' (Type tyname uni a) (Type tyname uni a)
+funArgs f = \case
+    TyFun a dom cod@TyFun{} -> TyFun a <$> f dom <*> funArgs f cod
+    TyFun a dom res         -> TyFun a <$> f dom <*> pure res
+    t                       -> pure t
+
+-- | Traverse the result type of a function type (the type itself if it is not a function type).
+funRes :: Lens' (Type tyname uni a) (Type tyname uni a)
+funRes f = \case
+    TyFun a dom cod -> TyFun a dom <$> funRes f cod
+    t               -> f t
+
+-- TODO: these could be Traversals
+-- | Get all the term variables in a term.
+vTerm :: Fold (Term tyname name uni fun ann) name
+vTerm = termSubtermsDeep . termVars
+
+-- | Get all the type variables in a term.
+tvTerm :: Fold (Term tyname name uni fun ann) tyname
+tvTerm = termSubtypesDeep . typeTyVars

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
@@ -213,8 +213,8 @@ inline hints t = let
         -- We actually just want the variable strictness information here!
         deps :: (G.Graph Deps.Node, Map.Map PLC.Unique Strictness)
         deps = Deps.runTermDeps t
-        usgs :: Map.Map Unique Int
-        usgs = Usages.runTermUsages t
+        usgs :: Usages.Usages
+        usgs = Usages.termUsages t
     in liftQuote $ flip evalStateT mempty $ flip runReaderT inlineInfo $ processTerm t
 
 {- Note [Removing inlined bindings]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
@@ -254,9 +254,8 @@ calcFreeVars (BindingGrp _ r bs) = foldMap1 calcBinding bs
     -- given a binding return all its free term *AND* free type variables
     calcBinding :: Binding tyname name uni fun a -> S.Set PLC.Unique
     calcBinding b =
-        -- OPTIMIZE: safe to change to S.mapMonotonic?
-        S.map (^.PLC.theUnique) (fvBinding b)
-        <> S.map (^.PLC.theUnique) (ftvBinding r b)
+        setOf (fvBinding . PLC.theUnique) b
+        <> setOf (ftvBinding r . PLC.theUnique) b
 
 -- | The second pass of cleaning the term of the floatable lets, and placing them in a separate map
 -- OPTIMIZE: use State for building the FloatTable, and for reducing the Marks

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
@@ -20,7 +20,9 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Semigroup.Foldable
 import Data.Set qualified as S
+import Data.Set.Lens (setOf)
 import PlutusIR.MkPir (mkLet)
+import PlutusPrelude ((<^>))
 
 {- Note [LetRec splitting pass]
 
@@ -126,13 +128,12 @@ buildLocalDepGraph bs =
       bindingSubGraph :: Binding tyname name uni fun a -> AM.AdjacencyMap PLC.Unique
       bindingSubGraph b =
           -- the free uniques (variables or tyvariables) that occur inside this binding
-          let freeUniques = S.map (^.PLC.theUnique) (fvBinding b)
-                            -- Special case for datatype bindings:
-                            -- To find out if the binding is self-recursive,
-                            -- we treat it like it was originally belonging to a let-nonrec (`ftvBinding NonRec`).
-                            -- Then, if it the datatype is indeed self-recursive, the call to `ftvBinding NonRec` will return
-                            -- its typeconstructor as free.
-                            <> S.map (^.PLC.theUnique) (ftvBinding NonRec b)
+          -- Special case for datatype bindings:
+          -- To find out if the binding is self-recursive,
+          -- we treat it like it was originally belonging to a let-nonrec (`ftvBinding NonRec`).
+          -- Then, if it the datatype is indeed self-recursive, the call to `ftvBinding NonRec` will return
+          -- its typeconstructor as free.
+          let freeUniques = setOf (fvBinding . PLC.theUnique <^> ftvBinding NonRec . PLC.theUnique) b
               -- the "local" dependencies
               occursIds = M.keysSet idTable `S.intersection` freeUniques
               -- maps the ids of the "local" dependencies to their principal uniques.

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 module PlutusPrelude
@@ -51,6 +52,7 @@ module PlutusPrelude
     , set
     , (%~)
     , over
+    , (<^>)
     -- * Debugging
     , traceShowId
     , trace
@@ -116,6 +118,7 @@ import Text.PrettyBy.Internal
 
 infixr 2 ?
 infixl 4 <<$>>, <<*>>
+infixr 6 <^>
 
 -- | A newtype wrapper around @a@ whose point is to provide a 'Show' instance
 -- for anything that has a 'Pretty' instance.
@@ -194,3 +197,7 @@ printPretty = print . pretty
 
 showText :: Show a => a -> T.Text
 showText = T.pack . show
+
+-- | Compose two folds to make them run in parallel. The results are concatenated.
+(<^>) :: Fold s a -> Fold s a -> Fold s a
+(f1 <^> f2) g s = f1 g s *> f2 g s

--- a/plutus-core/testlib/PlutusCore/Generators/AST.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/AST.hs
@@ -22,10 +22,12 @@ import PlutusPrelude
 import PlutusCore
 import PlutusCore.Subst
 
+import Control.Lens (coerced)
 import Control.Monad.Morph (hoist)
 import Control.Monad.Reader
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Set.Lens (setOf)
 import Hedgehog hiding (Size, Var)
 import Hedgehog.Internal.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
@@ -154,7 +156,7 @@ substAllNames ren =
 
 -- See Note [ScopeHandling].
 allTermNames :: Term TyName Name DefaultUni DefaultFun () -> Set Name
-allTermNames term = vTerm term <> Set.map coerce (tvTerm term)
+allTermNames = setOf (vTerm <^> tvTerm . coerced)
 
 -- See Note [Name mangling]
 mangleNames :: Term TyName Name DefaultUni DefaultFun () -> AstGen (Maybe (Term TyName Name DefaultUni DefaultFun ()))

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
@@ -1,50 +1,31 @@
 {-# LANGUAGE FlexibleContexts #-}
 -- | Functions for computing variable usage inside terms.
-module UntypedPlutusCore.Analysis.Usages (runTermUsages, Usages, getUsageCount, allUsed) where
+module UntypedPlutusCore.Analysis.Usages (termUsages, Usages, getUsageCount, allUsed) where
 
-import UntypedPlutusCore.Core.Plated
 import UntypedPlutusCore.Core.Type
+import UntypedPlutusCore.Subst
 
 import PlutusCore qualified as PLC
 import PlutusCore.Name qualified as PLC
 
 import Control.Lens
-import Control.Monad.State
 
-import Data.Coerce
-import Data.Foldable
-import Data.Map qualified as Map
+import Data.MultiSet qualified as MSet
+import Data.MultiSet.Lens
 import Data.Set qualified as Set
 
--- | Variable uses, as a map from the 'PLC.Unique' to its usage count. Unused variables may be missing
--- or have usage count 0.
-type Usages = Map.Map PLC.Unique Int
-
-addUsage :: (PLC.HasUnique n unique) => n -> Usages -> Usages
-addUsage n usages =
-    let
-        u = coerce $ n ^. PLC.unique
-        old = Map.findWithDefault 0 u usages
-    in Map.insert u (old+1) usages
+type Usages = MSet.MultiSet PLC.Unique
 
 -- | Get the usage count of @n@.
 getUsageCount :: (PLC.HasUnique n unique) => n -> Usages -> Int
-getUsageCount n usages = Map.findWithDefault 0 (n ^. PLC.unique . coerced) usages
+getUsageCount n = MSet.occur (n ^. PLC.unique . coerced)
 
 -- | Get a set of @n@s which are used at least once.
 allUsed :: Usages -> Set.Set PLC.Unique
-allUsed usages = Map.keysSet $ Map.filter (> 0) usages
+allUsed = MSet.toSet
 
--- | Compute the 'Usages' for a 'Term'.
-runTermUsages
+termUsages
     :: (PLC.HasUnique name PLC.TermUnique)
     => Term name uni fun a
     -> Usages
-runTermUsages term = execState (termUsages term) mempty
-
-termUsages
-    :: (MonadState Usages m, PLC.HasUnique name PLC.TermUnique)
-    => Term name uni fun a
-    -> m ()
-termUsages (Var _ n) = modify (addUsage n)
-termUsages term      = traverse_ termUsages (term ^.. termSubterms)
+termUsages = multiSetOf (vTerm . PLC.theUnique)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
@@ -3,18 +3,18 @@ module UntypedPlutusCore.Mark
     , markNonFreshProgram
     ) where
 
+import Data.Set.Lens (setOf)
 import PlutusCore.Core (HasUniques)
 import PlutusCore.Name
 import PlutusCore.Quote
 import UntypedPlutusCore.Core
-import UntypedPlutusCore.Subst
 
 -- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
 -- have a term which was not generated in 'Quote'.
 markNonFreshTerm
     :: (HasUniques (Term name uni fun ann), MonadQuote m)
     => Term name uni fun ann -> m ()
-markNonFreshTerm = markNonFreshMax . uniquesTerm
+markNonFreshTerm = markNonFreshMax . setOf termUniquesDeep
 
 -- | Marks all the 'Unique's in a program as used, so they will not be generated in future. Useful if you
 -- have a program which was not generated in 'Quote'.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Subst.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Subst.hs
@@ -9,19 +9,16 @@ module UntypedPlutusCore.Subst
     , termSubstFreeNames
     , termMapNames
     , programMapNames
-    , uniquesTerm
     , vTerm
     ) where
 
 import PlutusPrelude
 
-import PlutusCore.Core (HasUniques)
 import PlutusCore.Name
 import UntypedPlutusCore.Core
 
 import Control.Lens
 import Data.Set as Set
-import Data.Set.Lens (setOf)
 
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d
 purely = coerce
@@ -113,12 +110,7 @@ programMapNames
     -> Program name' uni fun ann
 programMapNames f (Program a v term) = Program a v (termMapNames f term)
 
+-- TODO: this could be a Traversal
 -- | Get all the term variables in a term.
-vTerm :: Ord name => Term name uni fun ann -> Set name
-vTerm = setOf $ termSubtermsDeep . termVars
-
--- All uniques
-
--- | Get all the uniques in a term
-uniquesTerm :: HasUniques (Term name uni fun ann) => Term name uni fun ann -> Set Unique
-uniquesTerm = setOf termUniquesDeep
+vTerm :: Fold (Term name uni fun ann) name
+vTerm = termSubtermsDeep . termVars

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -39,7 +39,6 @@ import Control.Lens hiding (Strict)
 import Control.Monad.Reader
 import Control.Monad.State
 
-import Data.Map qualified as Map
 import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Witherable
 
@@ -109,8 +108,8 @@ inline
 inline hints t = let
         inlineInfo :: InlineInfo name a
         inlineInfo = InlineInfo usgs hints
-        usgs :: Map.Map Unique Int
-        usgs = Usages.runTermUsages t
+        usgs :: Usages.Usages
+        usgs = Usages.termUsages t
     in liftQuote $ flip evalStateT mempty $ flip runReaderT inlineInfo $ processTerm t
 
 -- See Note [Differences from PIR inliner] 3


### PR DESCRIPTION
Apart from being neat, this gives us some additional power:
- It's trivial to do other folds, such as creating a multiset rather
than a set. We can use this in `Usages` and it's also what Quviq need.
- In principle we can actually replace free variables now. I think with
a bit more work I could replace the naive substitution functions with
just a setter over the traversal, but I'm already too deep down this
rabbit hole.

There is some fiddly stuff in the PIR traversals for let-bindings, but I've attempted to make it as clear as possible.

Also, our lenses are generally rather untidy. Random mix of stuff in `Plated` and `Subst`. Might try and tidy that up later.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
