### PR TITLE
[TypeCheck] Clean up constraints

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Normalize.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Normalize.hs
@@ -9,27 +9,25 @@ module PlutusCore.Normalize
 import PlutusCore.Core
 import PlutusCore.Name
 import PlutusCore.Normalize.Internal
-import PlutusCore.Quote
 import PlutusCore.Rename
 
 import Control.Monad ((>=>))
-import Universe
 
 -- See Note [Normalization].
 -- | Normalize a 'Type'.
 normalizeType
-    :: (HasUnique tyname TypeUnique, MonadQuote m, HasUniApply uni)
+    :: (HasUnique tyname TypeUnique, MonadNormalizeType uni m)
     => Type tyname uni ann -> m (Normalized (Type tyname uni ann))
 normalizeType = rename >=> runNormalizeTypeT . normalizeTypeM
 
 -- | Normalize every 'Type' in a 'Term'.
 normalizeTypesIn
-    :: (HasUnique tyname TypeUnique, HasUnique name TermUnique, MonadQuote m, HasUniApply uni)
+    :: (HasUnique tyname TypeUnique, HasUnique name TermUnique, MonadNormalizeType uni m)
     => Term tyname name uni fun ann -> m (Term tyname name uni fun ann)
 normalizeTypesIn = rename >=> runNormalizeTypeT . normalizeTypesInM
 
 -- | Normalize every 'Type' in a 'Program'.
 normalizeTypesInProgram
-    :: (HasUnique tyname TypeUnique, HasUnique name TermUnique, MonadQuote m, HasUniApply uni)
+    :: (HasUnique tyname TypeUnique, HasUnique name TermUnique, MonadNormalizeType uni m)
     => Program tyname name uni fun ann -> m (Program tyname name uni fun ann)
 normalizeTypesInProgram (Program x v t) = Program x v <$> normalizeTypesIn t

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
@@ -5,6 +5,8 @@
 
 module PlutusCore.TypeCheck
     ( ToKind
+    , MonadKindCheck
+    , MonadTypeCheck
     , Typecheckable
     -- * Configuration.
     , BuiltinTypes (..)
@@ -25,23 +27,27 @@ import PlutusPrelude
 
 import PlutusCore.Builtin
 import PlutusCore.Core
-import PlutusCore.Error
 import PlutusCore.Name
 import PlutusCore.Normalize
 import PlutusCore.Quote
 import PlutusCore.Rename
 import PlutusCore.TypeCheck.Internal
 
-import Control.Monad.Except
-import Data.Array
 import Universe
 
+-- | The constraint for built-in types/functions are kind/type-checkable.
+--
+-- We keep this separate from 'MonadKindCheck'/'MonadTypeCheck', because those mainly constrain the
+-- monad and 'Typecheckable' constraints only the builtins. In particular useful when the monad gets
+-- instantiated and builtins don't. Another reason is that 'Typecheckable' is not required during
+-- type checking, since it's only needed for computing 'BuiltinTypes', which is passed as a regular
+-- argument to the worker of the type checker.
 type Typecheckable uni fun = (ToKind uni, HasUniApply uni, ToBuiltinMeaning uni fun)
 
 -- | Extract the 'TypeScheme' from a 'BuiltinMeaning' and convert it to the
 -- corresponding 'Type' for each built-in function.
 builtinMeaningsToTypes
-    :: (MonadError err m, AsTypeError err term uni fun ann, Typecheckable uni fun)
+    :: (MonadKindCheck err term uni fun ann m, Typecheckable uni fun)
     => ann -> m (BuiltinTypes uni fun)
 builtinMeaningsToTypes ann =
     runQuoteT . fmap BuiltinTypes . sequence . tabulateArray $ \fun -> do
@@ -51,13 +57,13 @@ builtinMeaningsToTypes ann =
 
 -- | Get the default type checking config.
 getDefTypeCheckConfig
-    :: (MonadError err m, AsTypeError err term uni fun ann, Typecheckable uni fun)
+    :: (MonadKindCheck err term uni fun ann m, Typecheckable uni fun)
     => ann -> m (TypeCheckConfig uni fun)
 getDefTypeCheckConfig ann = TypeCheckConfig <$> builtinMeaningsToTypes ann
 
 -- | Infer the kind of a type.
 inferKind
-    :: (MonadQuote m, MonadError err m, AsTypeError err term uni fun ann, ToKind uni)
+    :: MonadKindCheck err term uni fun ann m
     => Type TyName uni ann -> m (Kind ())
 inferKind = runTypeCheckM () . inferKindM
 
@@ -65,16 +71,13 @@ inferKind = runTypeCheckM () . inferKindM
 -- Infers the kind of the type and checks that it's equal to the given kind
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkKind
-    :: (MonadQuote m, MonadError err m, AsTypeError err term uni fun ann, ToKind uni)
+    :: MonadKindCheck err term uni fun ann m
     => ann -> Type TyName uni ann -> Kind () -> m ()
 checkKind ann ty = runTypeCheckM () . checkKindM ann ty
 
 -- | Infer the type of a term.
 inferType
-    :: ( MonadError err m, MonadQuote m
-       , AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , GEq uni, Ix fun
-       )
+    :: MonadTypeCheckPlc err uni fun ann m
     => TypeCheckConfig uni fun -> Term TyName Name uni fun ann -> m (Normalized (Type TyName uni ()))
 inferType config = rename >=> runTypeCheckM config . inferTypeM
 
@@ -82,10 +85,7 @@ inferType config = rename >=> runTypeCheckM config . inferTypeM
 -- Infers the type of the term and checks that it's equal to the given type
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkType
-    :: ( MonadError err m, MonadQuote m
-       , AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , GEq uni, Ix fun
-       )
+    :: MonadTypeCheckPlc err uni fun ann m
     => TypeCheckConfig uni fun
     -> ann
     -> Term TyName Name uni fun ann
@@ -97,10 +97,7 @@ checkType config ann term ty = do
 
 -- | Infer the type of a program.
 inferTypeOfProgram
-    :: ( MonadError err m, MonadQuote m
-       , AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , GEq uni, Ix fun
-       )
+    :: MonadTypeCheckPlc err uni fun ann m
     => TypeCheckConfig uni fun
     -> Program TyName Name uni fun ann
     -> m (Normalized (Type TyName uni ()))
@@ -110,10 +107,7 @@ inferTypeOfProgram config (Program _ _ term) = inferType config term
 -- Infers the type of the program and checks that it's equal to the given type
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkTypeOfProgram
-    :: ( MonadError err m, MonadQuote m
-       , AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , GEq uni, Ix fun
-       )
+    :: MonadTypeCheckPlc err uni fun ann m
     => TypeCheckConfig uni fun
     -> ann
     -> Program TyName Name uni fun ann

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -1,9 +1,7 @@
 -- | The internal module of the type checker that defines the actual algorithms,
 -- but not the user-facing API.
 
--- 'makeLenses' produces an unused lens.
-{-# OPTIONS_GHC -fno-warn-unused-binds #-}
-
+{-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE OverloadedStrings      #-}
@@ -12,14 +10,17 @@
 {-# LANGUAGE TypeOperators          #-}
 
 module PlutusCore.TypeCheck.Internal
-  -- export all because a lot are used by the pir-typechecker
-  where
+    ( -- export all because a lot are used by the pir-typechecker
+      module PlutusCore.TypeCheck.Internal
+    , MonadNormalizeType
+    ) where
 
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Error
 import PlutusCore.MkPlc
 import PlutusCore.Name
+import PlutusCore.Normalize.Internal (MonadNormalizeType)
 import PlutusCore.Normalize.Internal qualified as Norm
 import PlutusCore.Quote
 import PlutusCore.Rename
@@ -28,7 +29,9 @@ import PlutusPrelude
 import Control.Lens
 import Control.Monad.Error.Lens
 import Control.Monad.Except
-import Control.Monad.Reader
+-- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
+-- on 'local'.
+import Control.Monad.Trans.Reader
 import Data.Array
 import Universe
 
@@ -103,7 +106,28 @@ makeLenses ''TypeCheckEnv
 
 -- | The type checking monad that the type checker runs in.
 -- In contains a 'TypeCheckEnv' and allows to throw 'TypeError's.
-type TypeCheckM uni fun cfg err = ReaderT (TypeCheckEnv uni fun cfg) (ExceptT err Quote)
+type TypeCheckT uni fun cfg m = ReaderT (TypeCheckEnv uni fun cfg) m
+
+-- | The constraints that are required for kind checking.
+type MonadKindCheck err term uni fun ann m =
+    ( MonadError err m                  -- Kind/type checking can fail
+    , AsTypeError err term uni fun ann  -- with a 'TypeError'.
+    , ToKind uni                        -- For getting the kind of a built-in type.
+    )
+
+-- | The general constraints that are required for type checking a Plutus AST.
+type MonadTypeCheck err term uni fun ann m =
+    ( MonadKindCheck err term uni fun ann m  -- Kind checking is run during type checking
+                                             -- (this includes the constraint for throwing errors).
+    , Norm.MonadNormalizeType uni m          -- Type lambdas open up type computation.
+    , GEq uni                                -- For checking equality of built-in types.
+    , Ix fun                                 -- For indexing into the precomputed array of types of
+                                             -- built-in functions.
+    )
+
+-- | The constraints that are required for type checking Plutus Core.
+type MonadTypeCheckPlc err uni fun ann m =
+    MonadTypeCheck err (Term TyName Name uni fun ()) uni fun ann m
 
 -- #########################
 -- ## Auxiliary functions ##
@@ -117,19 +141,17 @@ type TypeCheckM uni fun cfg err = ReaderT (TypeCheckEnv uni fun cfg) (ExceptT er
 -- while kind checking doesn't, hence we keep the kind checker fully polymorphic over the type of
 -- config, so that the kinder checker can be run with an empty config (such as @()@) and access to
 -- a 'TypeCheckConfig' is not needed.
-runTypeCheckM :: (MonadError err m, MonadQuote m) => cfg -> TypeCheckM uni fun cfg err a -> m a
-runTypeCheckM config a =
-    liftEither =<< liftQuote (runExceptT $ runReaderT a env) where
-        env = TypeCheckEnv config mempty mempty
+runTypeCheckM :: cfg -> TypeCheckT uni fun cfg m a -> m a
+runTypeCheckM config a = runReaderT a $ TypeCheckEnv config mempty mempty
 
 -- | Extend the context of a 'TypeCheckM' computation with a kinded variable.
-withTyVar :: TyName -> Kind () -> TypeCheckM uni fun cfg err a -> TypeCheckM uni fun cfg err a
+withTyVar :: TyName -> Kind () -> TypeCheckT uni fun cfg m a -> TypeCheckT uni fun cfg m a
 withTyVar name = local . over tceTyVarKinds . insertByName name
 
 -- | Look up the type of a built-in function.
 lookupBuiltinM
-    :: (AsTypeError err term uni fun ann, HasTypeCheckConfig cfg uni fun, Ix fun)
-    => ann -> fun -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ()))
+    :: (MonadTypeCheck err term uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    => ann -> fun -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 lookupBuiltinM ann fun = do
     BuiltinTypes arr <- view $ tceTypeCheckConfig . tccBuiltinTypes
     -- Believe it or not, but 'Data.Array' doesn't seem to expose any way of indexing into an array
@@ -139,13 +161,17 @@ lookupBuiltinM ann fun = do
         Just ty -> liftDupable ty
 
 -- | Extend the context of a 'TypeCheckM' computation with a typed variable.
-withVar :: Name -> Normalized (Type TyName uni ()) -> TypeCheckM uni fun cfg err a -> TypeCheckM uni fun cfg err a
+withVar
+    :: Name
+    -> Normalized (Type TyName uni ())
+    -> TypeCheckT uni fun cfg m a
+    -> TypeCheckT uni fun cfg m a
 withVar name = local . over tceVarTypes . insertByName name . dupable
 
 -- | Look up a type variable in the current context.
 lookupTyVarM
-    :: (AsTypeError err term uni fun ann)
-    => ann -> TyName -> TypeCheckM uni fun cfg err (Kind ())
+    :: MonadKindCheck err term uni fun ann m
+    => ann -> TyName -> TypeCheckT uni fun cfg m (Kind ())
 lookupTyVarM ann name = do
     mayKind <- asks $ lookupName name . _tceTyVarKinds
     case mayKind of
@@ -154,8 +180,8 @@ lookupTyVarM ann name = do
 
 -- | Look up a term variable in the current context.
 lookupVarM
-    :: AsTypeError err term uni fun ann
-    => ann -> Name -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ()))
+    :: MonadTypeCheck err term uni fun ann m
+    => ann -> Name -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 lookupVarM ann name = do
     mayTy <- asks $ lookupName name . _tceVarTypes
     case mayTy of
@@ -184,18 +210,18 @@ dummyType = TyVar () dummyTyName
 
 -- | Normalize a 'Type'.
 normalizeTypeM
-    :: HasUniApply uni
+    :: MonadNormalizeType uni m
     => Type TyName uni ann
-    -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ann))
+    -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ann))
 normalizeTypeM ty = Norm.runNormalizeTypeT $ Norm.normalizeTypeM ty
 
 -- | Substitute a type for a variable in a type and normalize the result.
 substNormalizeTypeM
-    :: HasUniApply uni
+    :: MonadNormalizeType uni m
     => Normalized (Type TyName uni ())  -- ^ @ty@
     -> TyName                           -- ^ @name@
     -> Type TyName uni ()               -- ^ @body@
-    -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ()))
+    -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 substNormalizeTypeM ty name body = Norm.runNormalizeTypeT $ Norm.substNormalizeTypeM ty name body
 
 -- ###################
@@ -204,8 +230,8 @@ substNormalizeTypeM ty name body = Norm.runNormalizeTypeT $ Norm.substNormalizeT
 
 -- | Infer the kind of a type.
 inferKindM
-    :: (AsTypeError err term uni fun ann, ToKind uni)
-    => Type TyName uni ann -> TypeCheckM uni fun cfg err (Kind ())
+    :: MonadKindCheck err term uni fun ann m
+    => Type TyName uni ann -> TypeCheckT uni fun cfg m (Kind ())
 
 -- b :: k
 -- ------------------------
@@ -262,8 +288,8 @@ inferKindM (TyIFix ann pat arg)    = do
 
 -- | Check a 'Type' against a 'Kind'.
 checkKindM
-    :: (AsTypeError err term uni fun ann, ToKind uni)
-    => ann -> Type TyName uni ann -> Kind () -> TypeCheckM uni fun cfg err ()
+    :: MonadKindCheck err term uni fun ann m
+    => ann -> Type TyName uni ann -> Kind () -> TypeCheckT uni fun cfg m ()
 
 -- [infer| G !- ty : tyK]    tyK ~ k
 -- ---------------------------------
@@ -274,11 +300,11 @@ checkKindM ann ty k = do
 
 -- | Check that the kind of a pattern functor is @(k -> *) -> k -> *@.
 checkKindOfPatternFunctorM
-    :: (AsTypeError err term uni fun ann, ToKind uni)
+    :: MonadKindCheck err term uni fun ann m
     => ann
     -> Type TyName uni ann  -- ^ A pattern functor.
     -> Kind ()              -- ^ @k@.
-    -> TypeCheckM uni fun cfg err ()
+    -> TypeCheckT uni fun cfg m ()
 checkKindOfPatternFunctorM ann pat k =
     checkKindM ann pat $ KindArrow () (KindArrow () k (Type ())) (KindArrow () k (Type ()))
 
@@ -288,11 +314,11 @@ checkKindOfPatternFunctorM ann pat k =
 
 -- | @unfoldIFixOf pat arg k = NORM (vPat (\(a :: k) -> ifix vPat a) arg)@
 unfoldIFixOf
-    :: HasUniApply uni
+    :: MonadNormalizeType uni m
     => Normalized (Type TyName uni ())  -- ^ @vPat@
     -> Normalized (Type TyName uni ())  -- ^ @vArg@
     -> Kind ()                          -- ^ @k@
-    -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ()))
+    -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 unfoldIFixOf pat arg k = do
     let vPat = unNormalized pat
         vArg = unNormalized arg
@@ -315,10 +341,8 @@ unfoldIFixOf pat arg k = do
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Synthesize the type of a term, returning a normalized type.
 inferTypeM
-    :: ( AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , HasTypeCheckConfig cfg uni fun, GEq uni, Ix fun
-       )
-    => Term TyName Name uni fun ann -> TypeCheckM uni fun cfg err (Normalized (Type TyName uni ()))
+    :: (MonadTypeCheckPlc err uni fun ann m, HasTypeCheckConfig cfg uni fun)
+    => Term TyName Name uni fun ann -> TypeCheckT uni fun cfg m (Normalized (Type TyName uni ()))
 
 -- c : vTy
 -- -------------------------
@@ -412,13 +436,11 @@ inferTypeM (Error ann ty) = do
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Check a 'Term' against a 'NormalizedType'.
 checkTypeM
-    :: ( AsTypeError err (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni
-       , HasTypeCheckConfig cfg uni fun, GEq uni, Ix fun
-       )
+    :: (MonadTypeCheckPlc err uni fun ann m, HasTypeCheckConfig cfg uni fun)
     => ann
     -> Term TyName Name uni fun ann
     -> Normalized (Type TyName uni ())
-    -> TypeCheckM uni fun cfg err ()
+    -> TypeCheckT uni fun cfg m ()
 
 -- [infer| G !- term : vTermTy]    vTermTy ~ vTy
 -- ---------------------------------------------

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -1,6 +1,7 @@
 -- | The internal module of the type checker that defines the actual algorithms,
 -- but not the user-facing API.
 
+{-# LANGUAGE ConstraintKinds    #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -9,7 +10,10 @@
 module PlutusIR.TypeCheck.Internal
     ( BuiltinTypes (..)
     , TypeCheckConfig (..)
-    , TypeCheckM
+    , TypeCheckT
+    , MonadKindCheck
+    , MonadTypeCheck
+    , MonadTypeCheckPir
     , tccBuiltinTypes
     , PirTCConfig (..)
     , AllowEscape (..)
@@ -19,26 +23,27 @@ module PlutusIR.TypeCheck.Internal
     ) where
 
 
-import Control.Monad.Error.Lens
-import Control.Monad.Except
-import Control.Monad.Reader
-import Data.Foldable
-import Data.Ix
-import PlutusCore (ToKind, tyVarDeclName, typeAnn)
-import PlutusCore.Error as PLC
-import PlutusCore.Quote
+import PlutusPrelude
+
 import PlutusIR
 import PlutusIR.Compiler.Datatype
 import PlutusIR.Compiler.Provenance
 import PlutusIR.Compiler.Types
 import PlutusIR.Error
+import PlutusIR.MkPir qualified as PIR
 import PlutusIR.Transform.Rename ()
-import PlutusPrelude
 
+import PlutusCore (tyVarDeclName, typeAnn)
+import PlutusCore.Error as PLC
 -- we mirror inferTypeM, checkTypeM of plc-tc and extend it for plutus-ir terms
 import PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
-import PlutusIR.MkPir qualified as PIR
 
+import Control.Monad.Error.Lens
+import Control.Monad.Except
+-- Using @transformers@ rather than @mtl@, because the former doesn't impose the 'Monad' constraint
+-- on 'local'.
+import Control.Monad.Trans.Reader
+import Data.Foldable
 import Universe
 
 {- Note [PLC Typechecker code reuse]
@@ -90,7 +95,13 @@ when typechecking inside a let termbind's rhs term.
 -}
 
 -- | a shorthand for our pir-specialized tc functions
-type PirTCEnv uni fun e a = TypeCheckM uni fun (PirTCConfig uni fun) e a
+type PirTCEnv uni fun m = TypeCheckT uni fun (PirTCConfig uni fun) m
+
+-- | The constraints that are required for type checking Plutus IR.
+type MonadTypeCheckPir err uni fun ann m =
+    ( MonadTypeCheck err (Term TyName Name uni fun ()) uni fun ann m
+    , AsTypeErrorExt err uni ann  -- Plutus IR has additional type errors, see 'TypeErrorExt'.
+    )
 
 -- ###########################
 -- ## Port of Type checking ##
@@ -100,8 +111,12 @@ type PirTCEnv uni fun e a = TypeCheckM uni fun (PirTCConfig uni fun) e a
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Check a 'Term' against a 'NormalizedType'.
 checkTypeM
-    :: (GEq uni, Ix fun, AsTypeErrorExt e uni ann, AsTypeError e (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni)
-    => ann -> Term TyName Name uni fun ann -> Normalized (Type TyName uni ()) -> PirTCEnv uni fun e ()
+    :: MonadTypeCheckPir err uni fun ann m
+    => ann
+    -> Term TyName Name uni fun ann
+    -> Normalized (Type TyName uni ())
+    -> PirTCEnv uni fun m ()
+
 -- [infer| G !- term : vTermTy]    vTermTy ~ vTy
 -- ---------------------------------------------
 -- [check| G !- term : vTy]
@@ -112,8 +127,9 @@ checkTypeM ann term vTy = do
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Synthesize the type of a term, returning a normalized type.
 inferTypeM
-    :: forall uni fun ann e. (GEq uni, Ix fun, AsTypeError e (Term TyName Name uni fun ()) uni fun ann, ToKind uni, HasUniApply uni, AsTypeErrorExt e uni ann)
-    => Term TyName Name uni fun ann -> PirTCEnv uni fun e (Normalized (Type TyName uni ()))
+    :: forall err m uni fun ann.
+       MonadTypeCheckPir err uni fun ann m
+    => Term TyName Name uni fun ann -> PirTCEnv uni fun m (Normalized (Type TyName uni ()))
 -- c : vTy
 -- -------------------------
 -- [infer| G !- con c : vTy]
@@ -223,7 +239,7 @@ inferTypeM (Let ann r@NonRec bs inTerm) = do
     checkStarInferred ann ty
     pure ty
   where
-    checkBindingThenScope :: Binding TyName Name uni fun ann -> PirTCEnv uni fun e res -> PirTCEnv uni fun e res
+    checkBindingThenScope :: Binding TyName Name uni fun ann -> PirTCEnv uni fun m a -> PirTCEnv uni fun m a
     checkBindingThenScope b acc = do
         -- check that the kinds of the declared types are correct
         checkKindFromBinding b
@@ -266,10 +282,11 @@ inferTypeM (Let ann r@Rec bs inTerm) = do
 --------------------------------------------------------------------------------------
 checkKindFromBinding(G,b)
 -}
-checkKindFromBinding :: forall e uni fun ann.
-                   (AsTypeError e (Term TyName Name uni fun ()) uni fun ann, ToKind uni)
-                 => Binding TyName Name uni fun ann
-                 -> PirTCEnv uni fun e ()
+checkKindFromBinding
+    :: forall err m uni fun ann.
+       MonadKindCheck err (Term TyName Name uni fun ()) uni fun ann m
+    => Binding TyName Name uni fun ann
+    -> PirTCEnv uni fun m ()
 checkKindFromBinding = \case
     -- For a type binding, correct means that the the RHS is indeed kinded by the declared kind.
     TypeBind _ (TyVarDecl ann _ k) rhs ->
@@ -297,8 +314,10 @@ checkKindFromBinding = \case
 ---------------------------------------------------
 checkTypeFromBinding(G,b)
 -}
-checkTypeFromBinding :: forall e uni fun a. (GEq uni, Ix fun, AsTypeError e (Term TyName Name uni fun ()) uni fun a, ToKind uni, HasUniApply uni, AsTypeErrorExt e uni a)
-                 => Recursivity -> Binding TyName Name uni fun a -> PirTCEnv uni fun e ()
+checkTypeFromBinding
+    :: forall err m uni fun ann.
+       MonadTypeCheckPir err uni fun ann m
+    => Recursivity -> Binding TyName Name uni fun ann -> PirTCEnv uni fun m ()
 checkTypeFromBinding recurs = \case
     TypeBind{} -> pure () -- no types to check
     TermBind _ _ (VarDecl ann _ ty) rhs ->
@@ -308,8 +327,8 @@ checkTypeFromBinding recurs = \case
         for_ (_varDeclType <$> constrs) $
             \ ty -> checkConRes ty *> checkNonRecScope ty
       where
-       appliedTyCon :: Type TyName uni a = mkDatatypeValueType ann dt
-       checkConRes :: Type TyName uni a -> PirTCEnv uni fun e ()
+       appliedTyCon :: Type TyName uni ann = mkDatatypeValueType ann dt
+       checkConRes :: Type TyName uni ann -> PirTCEnv uni fun m ()
        checkConRes ty =
            -- We earlier checked that datacons' type is *-kinded (using checkKindBinding), but this is not enough:
            -- we must also check that its result type is EXACTLY `[[TypeCon tyarg1] ... tyargn]` (ignoring annotations)
@@ -317,7 +336,7 @@ checkTypeFromBinding recurs = \case
                throwing _TypeErrorExt $ MalformedDataConstrResType ann appliedTyCon
 
        -- if nonrec binding, make sure that type-constructor is not part of the data-constructor's argument types.
-       checkNonRecScope :: Type TyName uni a -> PirTCEnv uni fun e ()
+       checkNonRecScope :: Type TyName uni ann -> PirTCEnv uni fun m ()
        checkNonRecScope ty = case recurs of
            Rec -> pure ()
            NonRec ->
@@ -328,8 +347,9 @@ checkTypeFromBinding recurs = \case
 
 -- | Check that the in-Term's inferred type of a Let has kind *.
 -- Skip this check at the top-level, to allow top-level types to escape; see Note [PIR vs Paper Escaping Types Difference].
-checkStarInferred :: (AsTypeError e term uni fun ann, ToKind uni)
-                  => ann -> Normalized (Type TyName uni b) -> PirTCEnv uni fun e ()
+checkStarInferred
+    :: MonadKindCheck err (Term TyName Name uni fun ()) uni fun ann m
+    => ann -> Normalized (Type TyName uni ()) -> PirTCEnv uni fun m ()
 checkStarInferred ann t = do
     allowEscape <- view $ tceTypeCheckConfig . pirConfigAllowEscape
     case allowEscape of
@@ -340,16 +360,13 @@ checkStarInferred ann t = do
 
 
 -- | Changes the flag in nested-lets so to disallow returning a type outside of the type's scope
-withNoEscapingTypes :: PirTCEnv uni fun e a -> PirTCEnv uni fun e a
+withNoEscapingTypes :: PirTCEnv uni fun m a -> PirTCEnv uni fun m a
 withNoEscapingTypes = local $ set (tceTypeCheckConfig.pirConfigAllowEscape) NoEscape
 
 -- | Run a 'TypeCheckM' computation by supplying a 'TypeCheckConfig' to it.
 -- Differs from its PLC version in that is passes an extra env flag 'YesEscape'.
-runTypeCheckM :: (MonadError e m, MonadQuote m)
-              => PirTCConfig uni fun -> PirTCEnv uni fun e a -> m a
-runTypeCheckM config a =
-    liftEither =<< liftQuote (runExceptT $ runReaderT a env) where
-        env = TypeCheckEnv config mempty mempty
+runTypeCheckM :: PirTCConfig uni fun -> PirTCEnv uni fun m a -> m a
+runTypeCheckM config a = runReaderT a $ TypeCheckEnv config mempty mempty
 
 -- Helpers
 ----------
@@ -359,9 +376,13 @@ runTypeCheckM config a =
 -- Newly-declared term variables are: variables of termbinds, constructors, destructor
 -- Note: Assumes that the input is globally-unique and preserves global-uniqueness
 -- Note to self: actually passing here recursivity is unnecessary, but we do it for sake of compiler/datatype.hs api
-withVarsOfBinding :: forall uni fun c e a res. HasUniApply uni =>
-                    Recursivity -> Binding TyName Name uni fun a
-                  -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
+withVarsOfBinding
+    :: forall uni fun cfg ann m a.
+       MonadNormalizeType uni m
+    => Recursivity
+    -> Binding TyName Name uni fun ann
+    -> TypeCheckT uni fun cfg m a
+    -> TypeCheckT uni fun cfg m a
 withVarsOfBinding _ TypeBind{} k = k
 withVarsOfBinding _ (TermBind _ _ vdecl _) k = do
     vTy <- normalizeTypeM $ _varDeclType vdecl
@@ -375,39 +396,50 @@ withVarsOfBinding r (DatatypeBind _ dt) k = do
     foldr normRenameScope k structorDecls
     where
       -- normalize, then introduce the vardecl to scope
-      normRenameScope :: VarDecl TyName Name uni fun (Provenance a)
-                      -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
+      normRenameScope :: VarDecl TyName Name uni fun (Provenance ann)
+                      -> TypeCheckT uni fun cfg m a -> TypeCheckT uni fun cfg m a
       normRenameScope v acc = do
           normRenamedTy <- normalizeTypeM $ _varDeclType v
           withVar (_varDeclName v) (void <$> normRenamedTy) acc
 
 
-withVarsOfBindings :: (Foldable t, HasUniApply uni) => Recursivity -> t (Binding TyName Name uni fun a)
-                   -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
+withVarsOfBindings
+    :: (MonadNormalizeType uni m, Foldable t)
+    => Recursivity
+    -> t (Binding TyName Name uni fun ann)
+    -> TypeCheckT uni fun cfg m a
+    -> TypeCheckT uni fun cfg m a
 withVarsOfBindings r bs k = foldr (withVarsOfBinding r) k bs
 
 -- | Scope a typechecking computation with the given binding's newly-introducing type (if there is one)
-withTyVarsOfBinding :: Binding TyName name uni fun ann -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
+withTyVarsOfBinding
+    :: Binding TyName name uni fun ann
+    -> TypeCheckT uni fun cfg m a
+    -> TypeCheckT uni fun cfg m a
 withTyVarsOfBinding = \case
        TypeBind _ tvdecl _                      -> withTyVarDecls [tvdecl]
        DatatypeBind _ (Datatype _ tvdecl _ _ _) -> withTyVarDecls [tvdecl]
        TermBind{}                               -> id -- no type to introduce
 
 -- | Extend the typecheck reader environment with the kinds of the newly-introduced type variables of a binding.
-withTyVarsOfBindings :: Foldable f => f (Binding TyName name uni fun ann) -> TypeCheckM uni fun c e res -> TypeCheckM uni fun c e res
+withTyVarsOfBindings
+    :: Foldable f
+    => f (Binding TyName name uni fun ann)
+    -> TypeCheckT uni fun cfg m a
+    -> TypeCheckT uni fun cfg m a
 withTyVarsOfBindings = flip $ foldr withTyVarsOfBinding
 
 -- | Helper to add type variables into a computation's environment.
-withTyVarDecls :: [TyVarDecl TyName ann] -> TypeCheckM uni fun c e a -> TypeCheckM uni fun c e a
+withTyVarDecls :: [TyVarDecl TyName ann] -> TypeCheckT uni fun cfg m a -> TypeCheckT uni fun cfg m a
 withTyVarDecls = flip . foldr $ \(TyVarDecl _ n k) -> withTyVar n $ void k
 
 -- | Substitute `TypeBind`s from the given list of `Binding`s in the given `Type`.
 -- This is so that @let a = (con integer) in \(x : a) -> x@ typechecks.
 substTypeBinds ::
-    HasUniApply uni =>
+    MonadNormalizeType uni m =>
     NonEmpty (Binding TyName Name uni fun ann) ->
     Normalized (Type TyName uni ()) ->
-    PirTCEnv uni fun e (Normalized (Type TyName uni ()))
+    PirTCEnv uni fun m (Normalized (Type TyName uni ()))
 substTypeBinds = flip . foldrM $ \b ty -> case b of
     TypeBind _ tvar rhs -> do
         rhs' <- normalizeTypeM (void rhs)


### PR DESCRIPTION
I wanted to remove the unnecessary `MonadQuote` from the kind checker, but ended up refactoring the type checker constraints in general.