### PR TITLE
PLT-108: Script evaluation regression test runner

### DIFF
--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -135,3 +135,27 @@ test-suite plutus-ledger-api-test
         barbies -any,
         text -any,
         extra -any
+
+executable evaluation-test
+    import: lang
+    main-is: Main.hs
+    other-modules:
+        Plutus.Script.Evaluation.Test.Options
+    hs-source-dirs:
+        test-onchain-evaluation
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    build-depends:
+        PyF -any,
+        base >=4.7 && <5,
+        base16-bytestring -any,
+        bytestring -any,
+        extra -any,
+        filepath -any,
+        parallel-io -any,
+        optparse-applicative -any,
+        plutus-core -any,
+        plutus-ledger-api -any,
+        plutus-ledger-api-testlib -any,
+        serialise -any,
+        text -any,
+    default-language: Haskell2010

--- a/plutus-ledger-api/test-onchain-evaluation/Main.hs
+++ b/plutus-ledger-api/test-onchain-evaluation/Main.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE QuasiQuotes      #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import Codec.Serialise qualified as CBOR
+import Control.Concurrent.ParallelIO.Local qualified as Concurrent
+import Control.Exception (evaluate)
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as Lazy
+import Data.Foldable (for_)
+import Data.List (intercalate)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
+import Options.Applicative qualified as OA
+import Plutus.Script.Evaluation.Test.Options qualified as O
+import PlutusCore.Evaluation.Machine.CostModelInterface (CostModelApplyError)
+import PlutusLedgerApi.Test.EvaluationEvent (ScriptEvaluationData (..), ScriptEvaluationEvent (..),
+                                             ScriptEvaluationResult (..))
+import PlutusLedgerApi.V1 qualified as V1
+import PlutusLedgerApi.V2 qualified as V2
+import PyF (fmt)
+import System.Directory.Extra (listFiles)
+import System.Exit (die)
+import System.FilePath (isExtensionOf, (<.>))
+import System.IO.Extra (withTempDir)
+import System.Process.Extra (system_)
+
+data TestFailure
+    = InvalidEvaluationResult
+        Text
+        -- ^ Serialised `ScriptEvaluationEvent`
+        ScriptEvaluationResult
+    | InvalidCostParams
+        Text
+        -- ^ Serialised `ScriptEvaluationEvent`
+        CostModelApplyError
+    deriving stock (Show)
+
+main :: IO ()
+main = do
+    opts <- OA.execParser O.parserInfo
+    let extZipped = O.optsEventFileExt opts <.> "bz2"
+    withTempDir $ \dir -> do
+        putStrLn "Downloading event dump files"
+        let s3DownloadCmd :: String
+            s3DownloadCmd = [fmt|{keyId} {secretKey} {region} aws {endpoint} s3 cp {s3Path} {dir} {options}|]
+              where
+                keyId = [fmt|AWS_ACCESS_KEY_ID={O.optsS3AccessKeyId opts}|]
+                secretKey = [fmt|AWS_SECRET_ACCESS_KEY={O.optsS3SecretAccessKey opts}|]
+                region = [fmt|AWS_DEFAULT_REGION={O.optsS3Region opts}|]
+                endpoint = [fmt|--endpoint-url {O.optsS3Endpoint opts}|]
+                s3Path = [fmt|s3://{O.optsS3Bucket opts}/{O.optsS3Prefix opts}|]
+                options = [fmt|--recursive --exclude "*" --include "*.{extZipped}"|]
+        putStrLn $ "Running: " <> s3DownloadCmd
+        -- It would be better to use amazonka, but the version bounds don't quite line up
+        -- (e.g., amazonka-core has aeson <1.6)
+        system_ s3DownloadCmd
+        eventFilesZipped <- filter (extZipped `isExtensionOf`) <$> listFiles dir
+        for_ eventFilesZipped $ \zipped -> do
+            putStrLn $ "Unzipping " <> zipped
+            system_ $ "bunzip2 " <> zipped
+        eventFiles <- filter (O.optsEventFileExt opts `isExtensionOf`) <$> listFiles dir
+        for_ (zip [1 :: Int ..] eventFiles) $ \(i, eventFile) -> do
+            putStrLn [fmt|Processing event file {i}: {eventFile}|]
+            events <- CBOR.readFileDeserialise @[ScriptEvaluationEvent] eventFile
+            mbErrs <- Concurrent.withPool (O.optsConcurrency opts) $ \pool -> do
+                Concurrent.parallel pool $ fmap (evaluate . checkEvaluationEvent) events
+            case catMaybes mbErrs of
+                [] -> putStrLn "All tests passed"
+                errs ->
+                    die
+                        [fmt|
+Script evaluation regression test failed.
+Number of failed test cases: {length errs}
+{intercalate "\n" (show <$> errs)}
+|]
+
+checkEvaluationEvent :: ScriptEvaluationEvent -> Maybe TestFailure
+checkEvaluationEvent ev = case ev of
+    PlutusV1Event ScriptEvaluationData{..} expected ->
+        case V1.mkEvaluationContext dataCostParams of
+            Left err -> Just $ InvalidCostParams ev' err
+            Right ctx ->
+                let (_, actual) =
+                        V1.evaluateScriptRestricting
+                            dataProtocolVersion
+                            V1.Quiet
+                            ctx
+                            dataBudget
+                            dataScript
+                            dataInputs
+                 in case (expected, actual) of
+                        (ScriptEvaluationSuccess, Left _) ->
+                            Just $ InvalidEvaluationResult ev' ScriptEvaluationFailure
+                        (ScriptEvaluationFailure, Right _) ->
+                            Just $ InvalidEvaluationResult ev' ScriptEvaluationSuccess
+                        _ -> Nothing
+    PlutusV2Event ScriptEvaluationData{..} expected ->
+        case V2.mkEvaluationContext dataCostParams of
+            Left err -> Just $ InvalidCostParams ev' err
+            Right ctx ->
+                let (_, actual) =
+                        V2.evaluateScriptRestricting
+                            dataProtocolVersion
+                            V2.Quiet
+                            ctx
+                            dataBudget
+                            dataScript
+                            dataInputs
+                 in case (expected, actual) of
+                        (ScriptEvaluationSuccess, Left _) ->
+                            Just $ InvalidEvaluationResult ev' ScriptEvaluationFailure
+                        (ScriptEvaluationFailure, Right _) ->
+                            Just $ InvalidEvaluationResult ev' ScriptEvaluationSuccess
+                        _ -> Nothing
+  where
+    ev' :: Text
+    ev' = Text.decodeLatin1 . B16.encode . Lazy.toStrict $ CBOR.serialise ev

--- a/plutus-ledger-api/test-onchain-evaluation/Plutus/Script/Evaluation/Test/Options.hs
+++ b/plutus-ledger-api/test-onchain-evaluation/Plutus/Script/Evaluation/Test/Options.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE ApplicativeDo   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData      #-}
+
+module Plutus.Script.Evaluation.Test.Options (
+    Options (..),
+    parseOptions,
+    parserInfo,
+) where
+
+import GHC.Conc (numCapabilities)
+import Options.Applicative qualified as O
+
+data Options = Options
+    { optsS3Endpoint        :: String
+    , optsS3AccessKeyId     :: String
+    , optsS3SecretAccessKey :: String
+    , optsS3Region          :: String
+    , optsS3Bucket          :: String
+    , optsS3Prefix          :: String
+    , optsEventFileExt      :: String
+    , optsConcurrency       :: Int
+    }
+
+parseOptions :: O.Parser Options
+parseOptions = do
+    optsS3Endpoint <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-endpoint"
+                , O.value "https://s3.devx.iog.io"
+                , O.metavar "S3_ENDPOINT"
+                ]
+    optsS3AccessKeyId <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-access-key-id"
+                , O.value "plutus"
+                , O.metavar "S3_ACCESS_KEY_ID"
+                ]
+    optsS3SecretAccessKey <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-secret-access-key"
+                , O.value "plutuskey"
+                , O.metavar "S3_SECRET_ACCESS_KEY"
+                ]
+    optsS3Region <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-region"
+                , O.value "us-east-1"
+                , O.metavar "S3_REGION"
+                ]
+    optsS3Bucket <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-bucket"
+                , O.value "plutus"
+                , O.metavar "S3_BUCKET"
+                ]
+    optsS3Prefix <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-prefix"
+                , O.value "script-evaluation-dump/"
+                , O.metavar "S3_PREFIX"
+                ]
+    optsEventFileExt <-
+        O.option O.str $
+            mconcat
+                [ O.long "s3-event-file-extension"
+                , O.value "event"
+                , O.metavar "S3_EVENT_FILE_EXTENSION"
+                ]
+    optsConcurrency <-
+        O.option O.auto $
+            mconcat
+                [ O.long "concurrency"
+                , O.value numCapabilities
+                , O.metavar "CONCURRENCY"
+                , O.help "How many threads to use"
+                ]
+    pure Options{..}
+
+parserInfo :: O.ParserInfo Options
+parserInfo =
+    O.info
+        (parseOptions O.<**> O.helper)
+        (O.fullDesc <> O.header "Run script evaluation regression test")

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
@@ -14,7 +14,7 @@ import Codec.Serialise (Serialise (..))
 import GHC.Generics (Generic)
 
 data ScriptEvaluationResult = ScriptEvaluationSuccess | ScriptEvaluationFailure
-    deriving stock (Generic)
+    deriving stock (Show, Generic)
     deriving anyclass (Serialise)
 
 data ScriptEvaluationData = ScriptEvaluationData

--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,10 @@ let
 
   # build inputs from nixpkgs ( -> ./nix/default.nix )
   nixpkgsInputs = (with pkgs; [
+    # For plutus-ledger-api:evaluation-test
+    awscli2
+    # For plutus-ledger-api:evaluation-test
+    bzip2
     cacert
     editorconfig-core-c
     ghcid


### PR DESCRIPTION
The runner downloads event dump files, unzips them, and checks the evaluations.

We have about 20k script evaluations per 10k blocks, which, on my 16-core machine, takes between 30s to 1min to check.