### PR TITLE
Adding documentation for `BuiltinByteString` size limit error and its workaround

### DIFF
--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -71,21 +71,22 @@ BuiltinByteString size limit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Currently the maximum size of a `BuiltinByteString` is limited to slightly less than 64 bytes. When such a bytestring is encoded into the script or used as part of a Datum or a Redeemer, the script will fail with the following error:
 
-```
-DeserialiseFailure 175 "BadEncoding (0x00000042000d60ff,S {currPtr = 0x00000042000d60da, usedBits = 0}) \"Used more than 64 bytes decoding the constant: (con\\n  bytestring\\n  #048379352db5140c4a39137dd08c69193af732a7ceee3e6ff8cb07e37ce82e035579551734d7d9e4b6853d45c4a7846d5ef570e56f0353f83dad3b478a5f6699\\n)\""
+::
+
+  DeserialiseFailure 175 "BadEncoding (0x00000042000d60ff,S {currPtr = 0x00000042000d60da, usedBits = 0}) \"Used more than 64 bytes decoding the constant: (con\\n  bytestring\\n  #048379352db5140c4a39137dd08c69193af732a7ceee3e6ff8cb07e37ce82e035579551734d7d9e4b6853d45c4a7846d5ef570e56f0353f83dad3b478a5f6699\\n)\""
 
 However, we sometimes need more than this. For example ECDSA SECP256k1 signatures use a 64 byte verification key. To mitigate this problem, we could split the bytestring into multiple pieces, and concatenate them on-chain.
 
 **Off-chain code:**
-```haskell
-let datum = bimap PlutusTx.Builtins.toBuiltin PlutusTx.Builtins.toBuiltin $ ByteString.splitAt 32 vkey
-```
+::
+  let datum = bimap PlutusTx.Builtins.toBuiltin PlutusTx.Builtins.toBuiltin $ ByteString.splitAt 32 vkey
+
 
 **On-chain code:**
-```haskell
-let (vkey1, vkey2) = datum
-    vkey = PlutusTx.Builtins.appendByteString vkey1 vkey2
-```
+::
+  let (vkey1, vkey2) = datum
+      vkey = PlutusTx.Builtins.appendByteString vkey1 vkey2
+
 
 There is a plan to remove this limitation in a later version:
 https://github.com/input-output-hk/plutus/issues/4697

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -176,6 +176,8 @@ decodeUtf8 = BI.decodeUtf8
 -- The verification key, the signature, and the message hash must all be of
 -- appropriate form and length. This function will error if any of
 -- these are not the case.
+--
+-- The ESDSA SECP256k1 verification key is 64 bytes, but currently there is a limitation for BuiltinByteString sizes. See [Troubleshooting](https://github.com/input-output-hk/plutus/blob/master/doc/troubleshooting.rst#builtinbytestring-size-limit) for more information.
 verifyEcdsaSecp256k1Signature
   :: BuiltinByteString -- ^ Verification key (64 bytes)
   -> BuiltinByteString -- ^ Message hash (32 bytes)
@@ -193,6 +195,8 @@ verifyEcdsaSecp256k1Signature vk msg sig =
 --
 -- The verification key and signature must all be of appropriate form and
 -- length. This function will error if this is not the case.
+--
+-- The Schnorr SECP256k1 verification key is 64 bytes, but currently there is a limitation for BuiltinByteString sizes. See [Troubleshooting](https://github.com/input-output-hk/plutus/blob/master/doc/troubleshooting.rst#builtinbytestring-size-limit) for more information.
 verifySchnorrSecp256k1Signature
   :: BuiltinByteString -- ^ Verification key (64 bytes)
   -> BuiltinByteString -- ^ Message


### PR DESCRIPTION
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
This PR is adding some document about the `BuiltinByteString` limit and its workaround.
Related issue: #4697 

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
