### PR TITLE
Remove the V2 size limit

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -474,7 +474,6 @@ test-suite untyped-plutus-core-test
         bytestring -any,
         cardano-crypto-class -any,
         hedgehog -any,
-        flat -any,
         lens -any,
         mtl -any,
         plutus-core -any,

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
@@ -17,12 +17,8 @@ import PlutusCore.Pretty
 import Data.Word (Word8)
 import Flat
 import Flat.Decoder
-import Flat.Decoder.Types
 import Flat.Encoder
 import Universe
-
-import Data.Primitive (Ptr)
-import Foreign (minusPtr)
 
 {-
 The definitions in this file rely on some Flat instances defined for typed plutus core.
@@ -79,12 +75,12 @@ By default, Flat does not use any space to serialise `()`.
 -}
 
 {- Note [Deserialization size limits]
-In order to prevent people encoding copyright or otherwise illegal data on the chain, we restrict the
-amount of space which can be used for a leaf serialized node to 64 bytes, and we enforce this during
-deserialization.
-
-We do this by asking Flat how far through the input it is before and after parsing a constant. That way
-we can tell generically how much data was used to parse a constant.
+In order to prevent people encoding copyright or otherwise illegal data on the chain, we would like to
+restrict the amount of data that can be controlled in an unrestricted fashion by the user. Fortunately,
+most of the encoding does no allow much leeway for a user to control its content (when accounting for the
+structure of the format itself). The main thing to worry about is bytestrings, but even there, the flat
+encoding of bytestrings is a a sequence of 255-byte chunks. This is okay, since user-controlled data will
+be broken up by the chunk metadata.
 -}
 
 -- | Using 4 bits to encode term tags.
@@ -119,8 +115,6 @@ encodeTerm = \case
     Error    ann      -> encodeTermTag 6 <> encode ann
     Builtin  ann bn   -> encodeTermTag 7 <> encode ann <> encode bn
 
-data SizeLimit = NoLimit | Limit Integer
-
 decodeTerm
     :: forall name uni fun ann
     . ( Closed uni
@@ -131,34 +125,16 @@ decodeTerm
     , Flat name
     , Flat (Binder name)
     )
-    => SizeLimit
-    -> (fun -> Bool)
+    => (fun -> Bool)
     -> Get (Term name uni fun ann)
-decodeTerm sizeLimit builtinPred = go
+decodeTerm builtinPred = go
     where
         go = handleTerm =<< decodeTermTag
         handleTerm 0 = Var      <$> decode <*> decode
         handleTerm 1 = Delay    <$> decode <*> go
         handleTerm 2 = LamAbs   <$> decode <*> (unBinder <$> decode) <*> go
         handleTerm 3 = Apply    <$> decode <*> go <*> go
-        handleTerm 4 = do
-            ann <- decode
-
-            -- See Note [Deserialization size limits]
-            posPre <- getCurPtr
-            con <- decode
-            posPost <- getCurPtr
-            let usedBytes = posPost `minusPtr` posPre
-
-            let t :: Term name uni fun ann
-                t = Constant ann con
-            case sizeLimit of
-                Limit n | fromIntegral usedBytes > n -> fail $ "Used more than " ++ show n ++ " bytes decoding the constant: " ++ show (prettyPlcDef t)
-                _ -> pure t
-            where
-                -- Get the pointer where flat is currently decoding from. Requires digging into the innards of flat a bit.
-                getCurPtr :: Get (Ptr Word8)
-                getCurPtr = Get $ \_ s@S{currPtr} -> pure $ GetResult s currPtr
+        handleTerm 4 = Constant <$> decode <*> decode
         handleTerm 5 = Force    <$> decode <*> go
         handleTerm 6 = Error    <$> decode
         handleTerm 7 = do
@@ -204,10 +180,9 @@ decodeProgram
     , Flat name
     , Flat (Binder name)
     )
-    => SizeLimit
-    -> (fun -> Bool)
+    => (fun -> Bool)
     -> Get (Program name uni fun ann)
-decodeProgram sizeLimit builtinPred = Program <$> decode <*> decode <*> decodeTerm sizeLimit builtinPred
+decodeProgram builtinPred = Program <$> decode <*> decode <*> decodeTerm builtinPred
 
 {- Note [Deserialization on the chain]
 As discussed in Note [Deserialization size limits], we want to limit how big constants are when deserializing.
@@ -227,7 +202,7 @@ instance ( Closed uni
          , Flat (Binder name)
          ) => Flat (Term name uni fun ann) where
     encode = encodeTerm
-    decode = decodeTerm NoLimit (const True)
+    decode = decodeTerm (const True)
     size = sizeTerm
 
 -- This instance could probably be derived, but better to write it explicitly ourselves so we have control!

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -12,17 +12,7 @@ import Evaluation.Golden (test_golden)
 import Evaluation.Machines
 import Transform.Simplify (test_simplify)
 
-import Data.ByteString as BS
-import Data.Either
-
 import Test.Tasty
-import Test.Tasty.HUnit
-
-import PlutusCore.MkPlc qualified as UPLC
-import UntypedPlutusCore qualified as UPLC
-
-import Flat qualified
-import Flat.Decoder qualified as Flat
 
 main :: IO ()
 main = do
@@ -34,60 +24,7 @@ main = do
     , test_golden
     , test_tallying
     , test_simplify
-    , test_deserializingBigConstants
     , test_debruijn
     , test_freevars
     ]
 
-test_deserializingBigConstants :: TestTree
-test_deserializingBigConstants = testGroup "64-byte deserialization limit"
-    [ test_bigInteger
-    , test_bigByteString
-    , test_nested
-    ]
-
-type Term = UPLC.Term UPLC.Name UPLC.DefaultUni UPLC.DefaultFun ()
-
-limitedDecoder :: Flat.Get Term
-limitedDecoder = UPLC.decodeTerm (UPLC.Limit 64) (const True)
-
-test_bigInteger :: TestTree
-test_bigInteger = testCase "big integer" $ do
-    let  -- A 64-byte integer
-        justOver :: Integer
-        justOver = 2 ^ (64 * 8 :: Integer)
-        -- Something that flat actually encodes in under 64 bytes
-        -- It's surprising that this is so much under 64 bytes of content...
-        justUnder :: Integer
-        justUnder = 2 ^ (55 * 8 :: Integer) - 1
-        t1 :: Term
-        t1 = UPLC.mkConstant () justOver
-        t2 :: Term
-        t2 = UPLC.mkConstant () justUnder
-    assertBool "justOver" (isLeft $ Flat.unflatWith limitedDecoder (Flat.flat t1))
-    assertBool "justUnder" (isRight $ Flat.unflatWith limitedDecoder (Flat.flat t2))
-
-test_bigByteString :: TestTree
-test_bigByteString = testCase "big bytestring" $ do
-    let -- A 64-byte bytestring
-        justOver :: ByteString
-        justOver = BS.replicate 64 1
-        -- Something that flat actually encodes in under 64 bytes
-        -- It's surprising that this is so much under 64 bytes of content...
-        justUnder :: ByteString
-        justUnder = BS.replicate 60 1
-        t1 :: Term
-        t1 = UPLC.mkConstant () justOver
-        t2 :: Term
-        t2 = UPLC.mkConstant () justUnder
-    assertBool "justOver" (isLeft $ Flat.unflatWith limitedDecoder (Flat.flat t1))
-    assertBool "justUnder" (isRight $ Flat.unflatWith limitedDecoder (Flat.flat t2))
-
-test_nested :: TestTree
-test_nested = testCase "nested" $ do
-    let  -- A 64-byte integer
-        justOver :: Integer
-        justOver = 2 ^ (64 * 8 :: Integer)
-        t1 :: Term
-        t1 = UPLC.Delay () $ UPLC.mkConstant () justOver
-    assertBool "delayed" (isLeft $ Flat.unflatWith limitedDecoder (Flat.flat t1))

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
@@ -43,10 +43,8 @@ scriptCBORDecoder :: LedgerPlutusVersion -> ProtocolVersion -> CBOR.Decoder s Sc
 scriptCBORDecoder lv pv =
     -- See Note [New builtins and protocol versions]
     let availableBuiltins = builtinsAvailableIn lv pv
-        -- See Note [Size checking of constants in PLC programs]
-        sizeLimit = if lv < PlutusV2 then UPLC.NoLimit else UPLC.Limit 64
         -- TODO: optimize this by using a better datastructure e.g. 'IntSet'
-        flatDecoder = UPLC.decodeProgram sizeLimit (\f -> f `Set.member` availableBuiltins)
+        flatDecoder = UPLC.decodeProgram (\f -> f `Set.member` availableBuiltins)
     in do
         -- Deserialise using 'FakeNamedDeBruijn' to get the fake names added
         (p :: UPLC.Program UPLC.FakeNamedDeBruijn DefaultUni DefaultFun ()) <- decodeViaFlat flatDecoder

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
@@ -78,7 +78,6 @@ newtype Script = Script { unScript :: UPLC.Program UPLC.DeBruijn PLC.DefaultUni 
   deriving stock (Generic)
   deriving anyclass (NFData)
   -- See Note [Using Flat inside CBOR instance of Script]
-  -- Important to go via 'WithSizeLimits' to ensure we enforce the size limits for constants
   -- Currently, this is off because the old implementation didn't actually work, so we need to be careful
   -- about introducing a working version
   deriving Serialise via (SerialiseViaFlat (UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()))

--- a/plutus-ledger-api/test/Spec/Builtins.hs
+++ b/plutus-ledger-api/test/Spec/Builtins.hs
@@ -18,7 +18,6 @@ import Data.ByteString.Short
 import Data.Foldable (fold, for_)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import PlutusCore.MkPlc qualified as UPLC
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -28,13 +27,6 @@ serialiseDataExScript = toShort . toStrict $ serialise serialiseDataEx
       serialiseDataEx :: Script
       serialiseDataEx = Script $ UPLC.Program () (PLC.defaultVersion ()) $
                              UPLC.Apply () (UPLC.Builtin () PLC.SerialiseData) (PLC.mkConstant () $ I 1)
-
-bigConstant :: SerialisedScript
-bigConstant = toShort . toStrict $ serialise bigConstantS
-    where
-      -- A big constant, with a bit of term in the way just to make sure we're actually checking the whole tree
-      bigConstantS :: Script
-      bigConstantS = Script $ UPLC.Program () (PLC.defaultVersion ()) $ UPLC.Delay () $ UPLC.mkConstant @Integer () (2^((64::Integer)*8))
 
 tests :: TestTree
 tests =
@@ -52,8 +44,4 @@ tests =
          assertBool "in l3,Alonzo" $ not $ V3.isScriptWellFormed alonzoPV serialiseDataExScript
          assertBool "not in l2,Vasil" $ V2.isScriptWellFormed vasilPV serialiseDataExScript
          assertBool "not in l3,Chang" $ V3.isScriptWellFormed changPV serialiseDataExScript
-    , testCase "size check" $ do
-         assertBool "not in l1" $ V1.isScriptWellFormed vasilPV bigConstant
-         assertBool "in l2" $ not $ V2.isScriptWellFormed vasilPV bigConstant
-         assertBool "in l3" $ not $ V3.isScriptWellFormed changPV bigConstant
     ]


### PR DESCRIPTION
The way flat encodes bytestrings _already_ effects a size limit. This is good enough for our purposes, so we can just remove the size limit entirely.
