### PR TITLE
Base64-encode ByteString in `Pretty Data`

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -261,6 +261,7 @@ library
         array -any,
         barbies -any,
         base >=4.9 && <5,
+        base64-bytestring -any,
         bimap -any,
         bytestring -any,
         cardano-crypto,
@@ -700,7 +701,7 @@ benchmark cost-model-test
     other-modules:
         CreateBuiltinCostModel
 
-executable print-cost-model           
+executable print-cost-model
     import: lang
     main-is: Main.hs
     hs-source-dirs: cost-model/print-cost-model

--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -19,8 +19,10 @@ import Control.DeepSeq (NFData)
 import Control.Monad.Except
 import Data.Bits (shiftR)
 import Data.ByteString qualified as BS
+import Data.ByteString.Base64 qualified as Base64
 import Data.ByteString.Lazy qualified as BSL
 import Data.Data qualified
+import Data.Text.Encoding qualified as Text
 import Data.Word (Word64, Word8)
 import GHC.Generics
 import Prelude
@@ -49,7 +51,7 @@ instance Pretty Data where
         Map entries -> braces (sep (punctuate comma (fmap (\(k, v) -> pretty k <> ":" <+> pretty v) entries)))
         List ds     -> brackets (sep (punctuate comma (fmap pretty ds)))
         I i         -> pretty i
-        B b         -> viaShow b
+        B b         -> pretty (Text.decodeLatin1 (Base64.encode b))
 
 {- Note [Encoding via Term]
 We want to write a custom encoder/decoder for Data (i.e. not use the Generic version), but actually

--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -51,7 +51,9 @@ instance Pretty Data where
         Map entries -> braces (sep (punctuate comma (fmap (\(k, v) -> pretty k <> ":" <+> pretty v) entries)))
         List ds     -> brackets (sep (punctuate comma (fmap pretty ds)))
         I i         -> pretty i
-        B b         -> pretty (Text.decodeLatin1 (Base64.encode b))
+        B b         ->
+            -- Base64 encode the ByteString since it may contain arbitrary bytes
+            pretty (Text.decodeLatin1 (Base64.encode b))
 
 {- Note [Encoding via Term]
 We want to write a custom encoder/decoder for Data (i.e. not use the Generic version), but actually


### PR DESCRIPTION
The ByteString can have arbitrary bytes, and printing via `Show` isn't very pretty.