### PR TITLE
Refactor conformance test infrastructure a little

### DIFF
--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -48,13 +48,14 @@ library
   build-depends:
     , base
     , deepseq
+    , directory
+    , filepath
+    , lens
     , megaparsec
     , plutus-core
     , tasty
-    , tasty-golden
-    , tasty-hunit
     , text
-    , unliftio
+    , witherable
 
 executable add-test-output
   import:         lang

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -47,7 +47,6 @@ library
   exposed-modules: PlutusConformance.Common
   build-depends:
     , base
-    , deepseq
     , directory
     , filepath
     , lens
@@ -65,14 +64,12 @@ executable add-test-output
   other-modules:
   build-depends:
     , base                  >=4.9 && <5
-    , deepseq
     , directory
     , optparse-applicative
     , plutus-conformance
     , plutus-core
     , tasty-golden
     , text
-    , unliftio
 
 test-suite uplc-eval-test
   import:         lang

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -38,6 +38,8 @@ data UplcEvaluationTest =
        , testDir :: FilePath
     }
 
+-- Tells 'tasty' that 'UplcEvaluationTest' "is" a test that can be run,
+-- by specifying how to run it and what custom options it might expect.
 instance IsTest UplcEvaluationTest where
     run _ MkUplcEvaluationTest{testDir,evaluator} _ = do
         let name = takeBaseName testDir

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -1,61 +1,63 @@
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- | Plutus conformance test suite library. -}
 module PlutusConformance.Common where
 
-import Control.DeepSeq (force)
+import Control.Lens (traverseOf)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import PlutusCore.Core (defaultVersion)
 import PlutusCore.Default (DefaultFun, DefaultUni)
-import PlutusCore.Error (ParserErrorBundle (ParseErrorB))
+import PlutusCore.Error (ParserErrorBundle)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParameters)
 import PlutusCore.Name (Name)
 import PlutusCore.Quote (runQuoteT)
 import PlutusPrelude
+import System.Directory
+import System.FilePath (takeBaseName, (</>))
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.Golden (findByExtension)
-import Test.Tasty.HUnit (testCase, (@=?))
 import Test.Tasty.Providers
 import Text.Megaparsec (SourcePos)
-import UnliftIO.Exception
+import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Core.Type qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek (evaluateCekNoEmit)
 import UntypedPlutusCore.Parser qualified as UPLC
+import Witherable
 
--- Common functions for all tests
+type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()
 
--- | A TestContent contains the input file path, input and output file contents.
-data TestContent =
-   MkTestContent {
-       -- | The path of the input file. This is also used to name the test.
-       testName    :: FilePath
-       -- | The expected output of the test in `Text`.
-       , expected  :: T.Text
-       -- | The input to be tested, in `Text`.
-       , inputProg :: T.Text
-   }
+type UplcEvaluator = UplcProg -> Maybe UplcProg
 
-{- | Create a list of `TestContent` with the given lists.
-The lengths of the input lists have to be the same, otherwise, an error occurs. -}
-mkTestContents ::
-    [FilePath] -- ^ The list of paths of the input files.
-    -> [T.Text] -- ^ The list of expected outputs.
-    -> [T.Text] -- ^ The list of the inputs.
-    -> [TestContent]
-mkTestContents lFilepaths lRes lProgs =
-    case zipWith3Exact (\f r p -> MkTestContent f r p) lFilepaths lRes lProgs of
-        Just tests -> tests
-        Nothing -> error $ unlines
-            ["mkTestContents: Cannot run the tests because the number of input and output programs are not the same. "
-            , "Number of input files: "
-            , show (length lProgs)
-            , " Number of output files: "
-            , show (length lRes)
-            , " Make sure all your input programs have an accompanying .expected file."
-            ]
+-- | A UPLC evaluation test suite.
+data UplcEvaluationTest =
+    MkUplcEvaluationTest {
+       -- | The evaluator function to use for the test.
+       evaluator :: UplcEvaluator
+       -- | The test directory in which the test files are located.
+       , testDir :: FilePath
+    }
+
+instance IsTest UplcEvaluationTest where
+    run _ MkUplcEvaluationTest{testDir,evaluator} _ = do
+        let name = takeBaseName testDir
+        input <- T.readFile $ testDir </> name <> ".uplc"
+        let parsed = parseTxt input
+
+        expected <- T.readFile $ testDir </> name <> ".uplc.expected"
+        let checkContents c | c == expected = pure (testPassed "")
+            checkContents c = pure (testFailed (show c))
+
+        case parsed of
+            Left _ -> checkContents shownParseError
+            Right p -> do
+               case evaluator (void p) of
+                   Nothing -> checkContents shownEvaluationFailure
+                   Just p' -> checkContents (display p')
+
+    testOptions = pure []
+
 
 {- | The default shown text when a parse error occurs.
 We don't want to show the detailed parse errors so that
@@ -69,62 +71,47 @@ shownEvaluationFailure = "evaluation failure"
 
 -- For UPLC evaluation tests
 
-type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()
-
-termToProg :: UPLC.Term Name DefaultUni DefaultFun () -> UplcProg
-termToProg = UPLC.Program () (defaultVersion ())
-
--- | Our `runner` for the UPLC tests is the CEK machine.
-evalUplcProg :: UplcProg -> Maybe UplcProg
-evalUplcProg p =
-    let eitherExceptionProg =
-            fmap
-                termToProg
-                (evaluateCekNoEmit defaultCekParameters (UPLC._progTerm p))
-    in
-        case eitherExceptionProg of
-            Left _     -> Nothing
-            Right prog -> Just prog
-
-{- | Run an input with the `runner` and return the result, in `Text`.
-When fail, the result is either the default text for parse error or evaluation failure. -}
-mkResult ::
-    (UplcProg -> Maybe UplcProg) -- ^ The `runner` to run the test inputs with.
-    -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
-    -- ^ The result of parsing.
-    -> IO T.Text -- ^ The result of the `runner` in `Text`.
-mkResult _ (Left (ParseErrorB _err)) = pure shownParseError
-mkResult runner (Right prog)        = do
-    -- catch exceptions from `runner` and keep going unless it's an async exception.
-    maybeException <- try (evaluate $ force $ runner (() <$ prog)):: IO (Either SomeException (Maybe UplcProg))
-    case maybeException of
-        Left _         -> pure shownEvaluationFailure
-        -- it doesn't matter how the evaluation fail, they're all "evaluation failure"
-        Right Nothing  -> pure shownEvaluationFailure
-        Right (Just a) -> pure $ display a
-
 -- | The default parser to parse the inputs.
 parseTxt ::
     T.Text
     -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
 parseTxt resTxt = runQuoteT $ UPLC.parseProgram resTxt
 
--- | Build a test given the runner and a `TestContent`.
--- TODO maybe abstract this for other tests too if it takes in `mkResult`.
-mkUplcTestCase :: (UplcProg -> Maybe UplcProg) -> TestContent -> TestTree
-mkUplcTestCase runner test =
-    testCase (testName test) (
-        do r <- mkResult runner (parseTxt (inputProg test))
-           expected test @=? r)
+-- | Our `evaluator` for the UPLC tests is the CEK machine.
+evalUplcProg :: UplcEvaluator
+evalUplcProg = traverseOf UPLC.progTerm eval
+  where
+    eval t = do
+        -- The evaluator throws if the term has free variables
+        case UPLC.deBruijnTerm t of
+            Left (_ :: UPLC.FreeVariableError) -> Nothing
+            Right _                            -> Just ()
+        case evaluateCekNoEmit defaultCekParameters t of
+            Left _     -> Nothing
+            Right prog -> Just prog
 
--- | Run the tests given a `runner` that evaluates UPLC programs.
+-- | Run the tests given a `evaluator` that evaluates UPLC programs.
 runUplcEvalTests ::
-    (UplcProg -> Maybe UplcProg)-- ^ The action to run the input through for the tests.
+    UplcEvaluator -- ^ The action to run the input through for the tests.
     -> IO ()
-runUplcEvalTests runner = do
-    inputFiles <- findByExtension [".uplc"] "uplc/evaluation/"
-    outputFiles <- findByExtension [".expected"] "uplc/evaluation/"
-    lProgTxt <- for inputFiles T.readFile
-    lEvaluatedRes <- for outputFiles T.readFile
-    let testContents = mkTestContents inputFiles lEvaluatedRes lProgTxt
-    defaultMain $ testGroup "UPLC evaluation tests" $ fmap (mkUplcTestCase runner) testContents
+runUplcEvalTests evaluator = do
+    tests <- discoverTests (\dir -> MkUplcEvaluationTest evaluator dir) "uplc/evaluation"
+    defaultMain $ testGroup "UPLC evaluation tests" [tests]
+
+-- Common functions for all tests
+
+-- | Walk a file tree, making test groups for directories with subdirectores,
+-- and test cases for directories without.
+discoverTests :: IsTest t => (FilePath -> t) -> FilePath -> IO TestTree
+discoverTests tester dir = do
+    let name = takeBaseName dir
+    children <- listDirectory dir
+    subdirs <- (flip wither) children $ \child -> do
+        let fullPath = dir </> child
+        isDir <- doesDirectoryExist fullPath
+        pure $ if isDir then Just fullPath else Nothing
+    if null subdirs
+    -- no children, this is a test case directory
+    then pure $ singleTest name $ tester dir
+    -- has children, so it's a grouping directory
+    else testGroup name <$> traverse (discoverTests tester) subdirs

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -21,7 +21,6 @@ import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.Providers
 import Text.Megaparsec (SourcePos)
 import UntypedPlutusCore qualified as UPLC
-import UntypedPlutusCore.Core.Type qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek (evaluateCekNoEmit)
 import UntypedPlutusCore.Parser qualified as UPLC
 import Witherable
@@ -100,13 +99,13 @@ runUplcEvalTests evaluator = do
 
 -- Common functions for all tests
 
--- | Walk a file tree, making test groups for directories with subdirectores,
+-- | Walk a file tree, making test groups for directories with subdirectories,
 -- and test cases for directories without.
 discoverTests :: IsTest t => (FilePath -> t) -> FilePath -> IO TestTree
 discoverTests tester dir = do
     let name = takeBaseName dir
     children <- listDirectory dir
-    subdirs <- (flip wither) children $ \child -> do
+    subdirs <- flip wither children $ \child -> do
         let fullPath = dir </> child
         isDir <- doesDirectoryExist fullPath
         pure $ if isDir then Just fullPath else Nothing

--- a/plutus-conformance/uplc/evaluation/builtin/appendByteString/appendByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/appendByteString/appendByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bytestring #00ff00ff))
+(program 0.0.0 (con bytestring #00ff00ff))

--- a/plutus-conformance/uplc/evaluation/builtin/appendString/appendString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/appendString/appendString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con string "Ola mundo!"))
+(program 0.0.0 (con string "Ola mundo!"))

--- a/plutus-conformance/uplc/evaluation/builtin/blake2b/blake2b.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/blake2b/blake2b.uplc.expected
@@ -1,5 +1,5 @@
 (program
-  1.0.0
+  0.0.0
   (con
     bytestring #60148fe5896674cb7b0d5f0b3af81853fae328c4ae224f248d392ae28774b2ff
   )

--- a/plutus-conformance/uplc/evaluation/builtin/chooseUnit/chooseUnit.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/chooseUnit/chooseUnit.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con integer 2))
+(program 0.0.0 (con integer 2))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/conByteString/conByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/conByteString/conByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bytestring #00ff))
+(program 0.0.0 (con bytestring #00ff))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/conFalse/conFalse.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/conFalse/conFalse.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool False))
+(program 0.0.0 (con bool False))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/conInteger/conInteger.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/conInteger/conInteger.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con integer 0))
+(program 0.0.0 (con integer 0))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/conTrue/conTrue.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/conTrue/conTrue.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/conUnit/conUnit.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/conUnit/conUnit.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con unit ()))
+(program 0.0.0 (con unit ()))

--- a/plutus-conformance/uplc/evaluation/builtin/constant/consByteString/consByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/constant/consByteString/consByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bytestring #aa00ff))
+(program 0.0.0 (con bytestring #aa00ff))

--- a/plutus-conformance/uplc/evaluation/builtin/data/bData/bData.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/data/bData/bData.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con data #420afd))
+(program 0.0.0 (con data #420afd))

--- a/plutus-conformance/uplc/evaluation/builtin/decodeUtf8/decodeUtf8.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/decodeUtf8/decodeUtf8.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con string "Ola"))
+(program 0.0.0 (con string "Ola"))

--- a/plutus-conformance/uplc/evaluation/builtin/encodeUtf8/encodeUtf8.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/encodeUtf8/encodeUtf8.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bytestring #4f6c61))
+(program 0.0.0 (con bytestring #4f6c61))

--- a/plutus-conformance/uplc/evaluation/builtin/equalsByteString/equalsByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/equalsByteString/equalsByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/equalsString/equalsString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/equalsString/equalsString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool False))
+(program 0.0.0 (con bool False))

--- a/plutus-conformance/uplc/evaluation/builtin/iData/iData.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/iData/iData.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con data #00))
+(program 0.0.0 (con data #00))

--- a/plutus-conformance/uplc/evaluation/builtin/indexByteString/indexByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/indexByteString/indexByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con integer 255))
+(program 0.0.0 (con integer 255))

--- a/plutus-conformance/uplc/evaluation/builtin/lengthOfByteString/lengthOfByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/lengthOfByteString/lengthOfByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con integer 3))
+(program 0.0.0 (con integer 3))

--- a/plutus-conformance/uplc/evaluation/builtin/lessThanByteString/lessThanByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/lessThanByteString/lessThanByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/lessThanEqualsByteString/lessThanEqualsByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/lessThanEqualsByteString/lessThanEqualsByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool False))
+(program 0.0.0 (con bool False))

--- a/plutus-conformance/uplc/evaluation/builtin/mkNilData/mkNilData.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/mkNilData/mkNilData.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con list data []))
+(program 0.0.0 (con list data []))

--- a/plutus-conformance/uplc/evaluation/builtin/mkNilPairData/mkNilPairData.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/mkNilPairData/mkNilPairData.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con list (pair data data) []))
+(program 0.0.0 (con list (pair data data) []))

--- a/plutus-conformance/uplc/evaluation/builtin/sha2/sha2.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/sha2/sha2.uplc.expected
@@ -1,5 +1,5 @@
 (program
-  1.0.0
+  0.0.0
   (con
     bytestring #5a6e7a4754af8e7f47fc9493040d853e7b01e39d537cb1dd353c93b7ae58eb3d
   )

--- a/plutus-conformance/uplc/evaluation/builtin/sha3/sha3.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/sha3/sha3.uplc.expected
@@ -1,5 +1,5 @@
 (program
-  1.0.0
+  0.0.0
   (con
     bytestring #c1e33ba6c01f90b43d50963dc8358f8779885f0db90bc3b11c542fab710308b8
   )

--- a/plutus-conformance/uplc/evaluation/builtin/sliceByteString/sliceByteString.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/sliceByteString/sliceByteString.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bytestring #ffaa))
+(program 0.0.0 (con bytestring #ffaa))

--- a/plutus-conformance/uplc/evaluation/builtin/trace/trace.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/trace/trace.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con integer 2))
+(program 0.0.0 (con integer 2))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature1/verifySignature1.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature1/verifySignature1.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature10/verifySignature10.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature10/verifySignature10.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature11/verifySignature11.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature11/verifySignature11.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature12/verifySignature12.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature12/verifySignature12.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature13/verifySignature13.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature13/verifySignature13.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature14/verifySignature14.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature14/verifySignature14.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature15/verifySignature15.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature15/verifySignature15.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature16/verifySignature16.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature16/verifySignature16.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature17/verifySignature17.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature17/verifySignature17.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature18/verifySignature18.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature18/verifySignature18.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature19/verifySignature19.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature19/verifySignature19.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature2/verifySignature2.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature2/verifySignature2.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature20/verifySignature20.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature20/verifySignature20.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature21/verifySignature21.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature21/verifySignature21.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature22/verifySignature22.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature22/verifySignature22.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature23/verifySignature23.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature23/verifySignature23.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature24/verifySignature24.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature24/verifySignature24.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature25/verifySignature25.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature25/verifySignature25.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature26/verifySignature26.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature26/verifySignature26.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature27/verifySignature27.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature27/verifySignature27.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature28/verifySignature28.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature28/verifySignature28.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature29/verifySignature29.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature29/verifySignature29.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature3/verifySignature3.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature3/verifySignature3.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature30/verifySignature30.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature30/verifySignature30.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature31/verifySignature31.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature31/verifySignature31.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature4/verifySignature4.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature4/verifySignature4.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature5/verifySignature5.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature5/verifySignature5.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool False))
+(program 0.0.0 (con bool False))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature6/verifySignature6.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature6/verifySignature6.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature7/verifySignature7.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature7/verifySignature7.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature8/verifySignature8.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature8/verifySignature8.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature9/verifySignature9.uplc.expected
+++ b/plutus-conformance/uplc/evaluation/builtin/verifySignature/verifySignature9/verifySignature9.uplc.expected
@@ -1,1 +1,1 @@
-(program 1.0.0 (con bool True))
+(program 0.0.0 (con bool True))

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -84,8 +84,6 @@ module PlutusPrelude
     , printPretty
     -- * Text
     , showText
-    -- * safe zip
-    , zipWith3Exact
     ) where
 
 import Control.Applicative (Alternative (..), liftA2)
@@ -216,8 +214,3 @@ printPretty = print . pretty
 
 showText :: Show a => a -> T.Text
 showText = T.pack . show
-
-zipWith3Exact :: (a -> b -> c -> d) -> [a] -> [b] -> [c]-> Maybe [d]
-zipWith3Exact _ [] [] []             = Just []
-zipWith3Exact f (a:as) (b:bs) (c:cs) = (:) (f a b c) <$> zipWith3Exact f as bs cs
-zipWith3Exact _ _ _ _                = Nothing


### PR DESCRIPTION
- Use `IsTest` to define tests
- Provide a helper for discovering a hierarchy of tests
- Fix the issue with the "safe" eval function throwing exceptions. As it
says in its Haddock, it's partial if the input has free variables, so we
need to check that.
- Use the version from the input program, not the default one. The
previous behaviour seems wrong. This required re-generating the output
files.