### PR TITLE
Fix add-test-output's help text formatting.

### DIFF
--- a/plutus-conformance/add-test-output/Spec.hs
+++ b/plutus-conformance/add-test-output/Spec.hs
@@ -17,6 +17,7 @@ import Control.Monad (filterM)
 import Data.Foldable (for_)
 import Data.Text.IO qualified as T
 import Options.Applicative
+import Options.Applicative.Help.Pretty (Doc, string)
 import PlutusConformance.Common
 import PlutusCore.Error (ParserErrorBundle (ParseErrorB))
 import PlutusCore.Pretty (Pretty (pretty), Render (render))
@@ -82,20 +83,25 @@ allOrMissing = missing <|> allInputs
 
 args :: ParserInfo Args
 args = info ((MkArgs <$> ext <*> dir <*> runner <*> allOrMissing) <**> helper)
-  (fullDesc <> progDesc helpText)
+  (fullDesc <> progDescDoc (Just helpText))
 
-helpText :: String
-helpText = unlines
+helpText :: Doc
+helpText = string $ unlines
   ["This program adds test outputs to specified inputs."
-  , "To run the program, input the following 4 arguments: "
-  , "(1) file extension to be searched "
-  , "(2) directory to be searched "
-  , "(3) the action to run the input files through; eval (for evaluation tests) or typecheck (for typechecking tests). "
+  , "To run the program, input the following 4 arguments:"
+  , "(1) file extension to be searched"
+  , "(2) directory to be searched"
+  , "(3) the action to run the input files through;"
+  , "eval (for evaluation tests) or typecheck (for typechecking tests)."
   , "(4) whether to write output files to all inputs or only the ones missing output files."
-  , "E.g. run "
-  , "`cabal run add-test-output .uplc plutus-conformance/uplc/ eval` -- --missing"
-  , "to have the executable search for files with extension `.uplc` in the /uplc directory that are missing output files. "
-  , " It will evaluate and create output files for them."
+  , "E.g. run \n"
+  , "cabal run add-test-output .uplc plutus-conformance/uplc/ eval -- --missing \n"
+  , "to have the executable search for files with extension `.uplc`"
+  , "in the /uplc directory that are missing output files."
+  , "It will evaluate and create output files for them."
+  , "Or run \n"
+  , "cabal run add-test-output .uplc plutus-conformance/uplc/ eval -- --all \n"
+  , "to update all files."
   ]
 
 main :: IO ()

--- a/plutus-conformance/add-test-output/Spec.hs
+++ b/plutus-conformance/add-test-output/Spec.hs
@@ -83,6 +83,7 @@ allOrMissing = missing <|> allInputs
 
 args :: ParserInfo Args
 args = info ((MkArgs <$> ext <*> dir <*> runner <*> allOrMissing) <**> helper)
+  -- using progDescDoc instead of progDesc because progDesc messes up the formatting.
   (fullDesc <> progDescDoc (Just helpText))
 
 helpText :: Doc


### PR DESCRIPTION
I've checked locally that this looks a lot better than before even though we now don't have word-wrapping. 

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
