### PR TITLE
Cek experiment

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
 
-module PlutusCore.Data  where
+module PlutusCore.Data (Data (..)) where
 
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Decoding qualified as CBOR

--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
 
-module PlutusCore.Data (Data (..)) where
+module PlutusCore.Data  where
 
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Decoding qualified as CBOR


### PR DESCRIPTION
A quick experiment to see if it makes any difference if we change the main functions in the CEK machine to have a big case expression instead of separate clauses for each term/value type.  Surely not, but let's check.