### PR TITLE
PLT-370: Make EvaluationContext more strict

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -282,5 +282,6 @@ toBuiltinsRuntime
     :: (cost ~ CostingPart uni fun, ToBuiltinMeaning uni fun, HasMeaningIn uni val)
     => UnliftingMode -> cost -> BuiltinsRuntime fun val
 toBuiltinsRuntime unlMode cost =
-    BuiltinsRuntime . tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
+    let arr = tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
+     in case foldr seq () arr of () -> BuiltinsRuntime arr
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -283,5 +283,6 @@ toBuiltinsRuntime
     => UnliftingMode -> cost -> BuiltinsRuntime fun val
 toBuiltinsRuntime unlMode cost =
     let arr = tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
-     in case foldr seq () arr of () -> BuiltinsRuntime arr
+     in -- Force array elements to WHNF
+        case foldr seq () arr of () -> BuiltinsRuntime arr
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -284,5 +284,5 @@ toBuiltinsRuntime
 toBuiltinsRuntime unlMode cost =
     let arr = tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
      in -- Force array elements to WHNF
-        case foldr seq () arr of () -> BuiltinsRuntime arr
+        foldr seq (BuiltinsRuntime arr) arr
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
+{-# LANGUAGE StrictData        #-}
+
 module PlutusLedgerApi.Common.Eval where
 
 import PlutusCore


### PR DESCRIPTION
Doesn't really make much of a difference in terms of performance as shown by benchmarking, but this makes it so that there's fewer thunks in `EvaluationContext`, which makes writing `NoThunks` instance easier.