### PR TITLE
PLT-249: add line-length checker to CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,18 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
-end_of_line = lf
+
+[*.{nix, hs, lagda, agda}]
 charset = utf-8
+max_line_length = 100
+end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.nix]
+indent_size = 2
+
 [*.hs]
-indent_size = 4
-max_line_length = 120
+max_line_length = 100
+# Wildly inconsistent, we should decide on one
+#indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,6 @@ indent_size = 2
 [*.hs]
 max_line_length = 100
 # Wildly inconsistent, we should decide on one
+# Especially it looks like we have lots of disagreement
+# over how much indentation to use for 'where' clauses
 #indent_size = 4

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,6 +16,7 @@ This includes a variety of useful tools:
 * Agda with the right libraries set up to build our Agda code
 * `stylish-haskell`
 * `haskell-language-server`
+* `editorconfig-checker`
 * ... and more
 
 Have a look in `shell.nix` to see what's there.

--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -18,7 +18,7 @@ The contents of this document are “recommendations”, that is:
 
 === Basic formatting
 
-Use 4 spaces for indentation. Avoid lines over 120 characters. This is codified in `.editorconfig`.
+Use 4 spaces for indentation. Avoid lines over 100 characters. This is codified in `.editorconfig`.
 
 Format Haskell source with `stylish-haskell` (config in `.stylish-haskell.yaml`).
 

--- a/ci.nix
+++ b/ci.nix
@@ -1,11 +1,16 @@
 {
-  # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
-  # on a machine with e.g. no way to build the Darwin IFDs you need!
+  # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when
+  # you're evaluting on a machine with e.g. no way to build the Darwin IFDs you need!
   supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , rootsOnly ? false
 }:
 let
-  inherit (import ./nix/lib/ci.nix) dimension platformFilterGeneric filterAttrsOnlyRecursive filterSystems;
+  inherit
+    (import ./nix/lib/ci.nix)
+    dimension
+    platformFilterGeneric
+    filterAttrsOnlyRecursive
+    filterSystems;
   # limit supportedSystems to what the CI can actually build
   # currently that is linux and darwin.
   systems = filterSystems supportedSystems;
@@ -70,8 +75,8 @@ let
             };
         in
         filterAttrsOnlyRecursive (_: drv: isBuildable drv) ({
-          # The haskell.nix IFD roots for the Haskell project. We include these so they won't be GCd and will be in the
-          # cache for users
+          # The haskell.nix IFD roots for the Haskell project. We include these so they won't
+          # be GCd and will be in the # cache for users
           inherit (plutus.haskell.project) roots;
         } // pkgs.lib.optionalAttrs (!rootsOnly) (filterCross {
           # build relevant top level attributes from default.nix

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,9 @@
       hackage = sources.hackage-nix;
     };
   }
-, packages ? import ./nix { inherit system sources crossSystem config sourcesOverride haskellNix enableHaskellProfiling; }
+, packages ? import ./nix {
+    inherit system sources crossSystem config sourcesOverride haskellNix enableHaskellProfiling;
+  }
   # Whether to build our Haskell packages (and their dependencies) with profiling enabled.
 , enableHaskellProfiling ? false
 }:

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, lib, pythonPackages, sphinxcontrib-domaintools, sphinxcontrib-haddock, sphinx-markdown-tables, sphinxemoji, combined-haddock, ... }:
+{ stdenv
+, lib
+, pythonPackages
+, sphinxcontrib-domaintools
+, sphinxcontrib-haddoc
+, sphinx-markdown-tables
+, sphinxemoji
+, combined-haddock
+, ...
+}:
 stdenv.mkDerivation {
   name = "plutus-docs";
   src = lib.sourceFilesBySuffices ./. [ ".py" ".rst" ".hs" ".png" ".svg" ".bib" ".csv" ".css" ];

--- a/doc/tutorials/BasicPolicies.hs
+++ b/doc/tutorials/BasicPolicies.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/doc/tutorials/BasicValidators.hs
+++ b/doc/tutorials/BasicValidators.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -10,7 +10,8 @@ let
       files = lib.sourceFilesBySuffices src [ ".adoc" ".png" ".PNG" ".gif" ".ico" ".css" ];
       outFile = (lib.strings.removeSuffix ".adoc" file) + ".html";
     in
-    pkgs.runCommand "build-asciidoc-html" { buildInputs = [ pkgs.python2 pkgs.asciidoctor ] ++ deps; } ''
+    pkgs.runCommand "build-asciidoc-html"
+      { buildInputs = [ pkgs.python2 pkgs.asciidoctor ] ++ deps; } ''
       mkdir -p $out
       asciidoctor --failure-level ERROR ${files}/${file} -o $out/${outFile}
       cp -aR ${files}/images $out || true
@@ -54,7 +55,8 @@ pkgs.recurseIntoAttrs {
     eutxoma = import ../papers/eutxoma { inherit buildLatexDoc; };
     # This paper cannot be built via `buildLatexDoc` as the others because it features
     # a somewhat more complex setup including some additional artifact that has to be compiled.
-    unraveling-recursion = pkgs.callPackage ../papers/unraveling-recursion/default.nix { agda = agdaWithStdlib; inherit latex; };
+    unraveling-recursion = pkgs.callPackage ../papers/unraveling-recursion/default.nix
+      { agda = agdaWithStdlib; inherit latex; };
   };
 
   plutus-core-spec = import ../plutus-core-spec { inherit buildLatexDoc; };

--- a/nix/lib/ci.nix
+++ b/nix/lib/ci.nix
@@ -4,7 +4,7 @@ let
   lib = pkgs.lib;
 in
 rec {
-  # Borrowed from https://github.com/cachix/ghcide-nix/pull/4/files#diff-70bfff902f4dec33e545cac10ee5844d
+  # Borrowed from https://github.com/cachix/ghcide-nix/pull/4/files#diff-70bfff902f4dec33e545cac10ee5844d # editorconfig-checker-disable-line
   # Tweaked to use builtins.mapAttrs instead of needing the one from nixpkgs lib
   /*
     dimension: name -> attrs -> function -> attrs
@@ -12,7 +12,7 @@ rec {
       function: keyText -> value -> attrsOf package
 
     WARNING: Attribute names must not contain periods (".").
-             See https://github.com/NixOS/nix/issues/3088
+    See https://github.com/NixOS/nix/issues/3088
 
     NOTE: The dimension name will be picked up by agent and web ui soon.
 
@@ -164,18 +164,21 @@ rec {
     else true;
 
   # Hydra doesn't like these attributes hanging around in "jobsets": it thinks they're jobs!
-  stripAttrsForHydra = filterAttrsOnlyRecursive (n: _: n != "recurseForDerivations" && n != "dimension");
+  stripAttrsForHydra =
+    filterAttrsOnlyRecursive (n: _: n != "recurseForDerivations" && n != "dimension");
 
-  # Keep derivations and attrsets with 'recurseForDerivations'. This ensures that we match the
-  # derivations that Hercules will see, and prevents Hydra from trying to pick up all sorts of bad stuff
-  # (like attrsets that contain themselves!).
-  filterDerivations = filterAttrsOnlyRecursive (n: attrs: lib.isDerivation attrs || attrs.recurseForDerivations or false);
+  # Keep derivations and attrsets with 'recurseForDerivations'. This ensures that we match
+  # the derivations that Hercules will see, and prevents Hydra from trying to pick up all
+  # sorts of bad stuff (like attrsets that contain themselves!).
+  filterDerivations =
+    filterAttrsOnlyRecursive
+      (n: attrs: lib.isDerivation attrs || attrs.recurseForDerivations or false);
 
-  # A version of 'filterAttrsRecursive' that doesn't recurse into derivations. This prevents us from going into an infinite
-  # loop with the 'out' attribute on derivations.
-  # TODO: Surely this shouldn't be necessary. I think normal 'filterAttrsRecursive' will effectively cause infinite loops
-  # if you keep derivations and your predicate forces the value of the attribute, as this then triggers a loop on the
-  # 'out' attribute. Weird.
+  # A version of 'filterAttrsRecursive' that doesn't recurse into derivations.
+  # This prevents us from going into an infinite # loop with the 'out' attribute on derivations.
+  # TODO: Surely this shouldn't be necessary. I think normal 'filterAttrsRecursive'
+  # will effectively cause infinite loops if you keep derivations and your predicate forces
+  # the value of the attribute, as this then triggers a loop on the 'out' attribute. Weird.
   filterAttrsOnlyRecursive = pred: set:
     lib.listToAttrs (
       lib.concatMap

--- a/nix/lib/haddock-combine.nix
+++ b/nix/lib/haddock-combine.nix
@@ -69,7 +69,7 @@ runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
     sed -i -r "s,^\#search-results \{,\#search-results \{ max-height:80%;overflow-y:scroll;," "$f"
   done
 
-  # Following: https://github.com/input-output-hk/ouroboros-network/blob/2068d091bc7dcd3f4538fb76f1b598f219d1e0c8/scripts/haddocs.sh#L87
+  # Following: https://github.com/input-output-hk/ouroboros-network/blob/2068d091bc7dcd3f4538fb76f1b598f219d1e0c8/scripts/haddocs.sh#L87 # editorconfig-checker-disable-line
   # Assemble a toplevel `doc-index.json` from package level ones.
   shopt -s globstar
   echo "[]" > "doc-index.json"

--- a/nix/lib/latex.nix
+++ b/nix/lib/latex.nix
@@ -21,8 +21,8 @@
         runHook preBuild
         mkdir -p ${buildDir}
         # The bibtex_fudge setting is because our version of latexmk has an issue with bibtex
-        # and explicit output directories, which should be fixed in v4.70b: 
-        # https://tex.stackexchange.com/questions/564626/latexmk-4-70a-doesnt-compile-document-with-bibtex-citation
+        # and explicit output directories, which should be fixed in v4.70b:
+        # https://tex.stackexchange.com/questions/564626/latexmk-4-70a-doesnt-compile-document-with-bibtex-citation # editorconfig-checker-disable-line
         latexmk \
           -e '$bibtex_fudge=1' \
           -outdir=${buildDir} \
@@ -42,6 +42,8 @@
         runHook postInstall
       '';
     });
-  # A typical good filter for latex sources. This also includes files for cases where agda sources are being compiled
-  filterLatex = src: lib.sourceFilesBySuffices src [ ".tex" ".bib" ".cls" ".bst" ".pdf" ".png" ".agda" ".agda-lib" ".lagda" ];
+  # A typical good filter for latex sources. This also includes files for cases where
+  # agda sources are being compiled
+  filterLatex = src: lib.sourceFilesBySuffices src
+    [ ".tex" ".bib" ".cls" ".bst" ".pdf" ".png" ".agda" ".agda-lib" ".lagda" ];
 }

--- a/nix/overlays/r.nix
+++ b/nix/overlays/r.nix
@@ -10,9 +10,12 @@ self: super: {
   R = super.R.overrideAttrs (oldAttrs: {
     # Backport https://github.com/NixOS/nixpkgs/pull/99570
     prePatch = super.lib.optionalString super.stdenv.isDarwin ''
-      substituteInPlace configure --replace "-install_name libRblas.dylib" "-install_name $out/lib/R/lib/libRblas.dylib"
-      substituteInPlace configure --replace "-install_name libRlapack.dylib" "-install_name $out/lib/R/lib/libRlapack.dylib"
-      substituteInPlace configure --replace "-install_name libR.dylib" "-install_name $out/lib/R/lib/libR.dylib"
+      substituteInPlace configure --replace \
+        "-install_name libRblas.dylib" "-install_name $out/lib/R/lib/libRblas.dylib"
+      substituteInPlace configure --replace \
+        "-install_name libRlapack.dylib" "-install_name $out/lib/R/lib/libRlapack.dylib"
+      substituteInPlace configure --replace \
+        "-install_name libR.dylib" "-install_name $out/lib/R/lib/libR.dylib"
     '';
   });
 

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -29,7 +29,10 @@ let
   cabal-fmt = exeFromExtras "cabal-fmt";
   hlint = exeFromExtras "hlint";
   haskell-language-server = exeFromExtras "haskell-language-server";
-  haskell-language-server-wrapper = pkgs.writeShellScriptBin "haskell-language-server-wrapper" ''${haskell-language-server}/bin/haskell-language-server "$@"'';
+  haskell-language-server-wrapper =
+    pkgs.writeShellScriptBin
+      "haskell-language-server-wrapper"
+      ''${haskell-language-server}/bin/haskell-language-server "$@"'';
   hie-bios = exeFromExtras "hie-bios";
   haskellNixAgda = haskell.extraPackages.Agda;
 
@@ -57,7 +60,12 @@ let
           haskellNixAgda.components.exes.agda-mode
         ];
       }) // { version = haskellNixAgda.identifier.version; };
-      frankenPkgs = pkgs // { haskellPackages = pkgs.haskellPackages // { ghcWithPackages = haskell.project.ghcWithPackages; }; };
+      frankenPkgs =
+        pkgs //
+        {
+          haskellPackages = pkgs.haskellPackages //
+          { ghcWithPackages = haskell.project.ghcWithPackages; };
+        };
     in
     pkgs.agdaPackages.override { Agda = frankenAgda; pkgs = frankenPkgs; };
 
@@ -71,10 +79,11 @@ let
         rev = "v${version}";
         sha256 = "14h3jprm6924g9576v25axn9v6xnip354hvpzlcqsc5qqyj7zzjs";
       };
-      # This is preConfigure is copied from more recent nixpkgs that also uses version 1.7 of standard-library
-      # Old nixpkgs (that used 1.4) had a preConfigure step that worked with 1.7
-      # Less old nixpkgs (that used 1.6) had a preConfigure step that attempts to `rm` files that are now in the
-      # .gitignore list for 1.7
+      # This is preConfigure is copied from more recent nixpkgs that also
+      # uses version 1.7 of standard-library. Old nixpkgs (that used 1.4)
+      # had a preConfigure step that worked with 1.7. Less old nixpkgs
+      # (that used 1.6) had a preConfigure step that attempts to `rm`
+      # files that are now in the .gitignore list for 1.
       preConfigure = ''
         runhaskell GenerateEverything.hs
         # We will only build/consider Everything.agda, in particular we don't want Everything*.agda
@@ -107,7 +116,8 @@ let
   });
 
   # sphinx haddock support
-  sphinxcontrib-haddock = pkgs.callPackage (sources.sphinxcontrib-haddock) { pythonPackages = pkgs.python3Packages; };
+  sphinxcontrib-haddock =
+    pkgs.callPackage (sources.sphinxcontrib-haddock) { pythonPackages = pkgs.python3Packages; };
 
   # combined haddock documentation for all public plutus libraries
   plutus-haddock-combined =
@@ -125,7 +135,8 @@ let
   # Collect everything to be exported under `plutus.lib`: builders/functions/utils
   lib = rec {
     inherit gitignore-nix;
-    haddock-combine = pkgs.callPackage ../lib/haddock-combine.nix { inherit sphinxcontrib-haddock; };
+    haddock-combine =
+      pkgs.callPackage ../lib/haddock-combine.nix { inherit sphinxcontrib-haddock; };
     latex = pkgs.callPackage ../lib/latex.nix { };
   };
 
@@ -133,7 +144,9 @@ in
 {
   inherit sphinx-markdown-tables sphinxemoji sphinxcontrib-haddock;
   inherit nix-pre-commit-hooks;
-  inherit haskell agdaPackages cabal-install cardano-repo-tool stylish-haskell hlint haskell-language-server haskell-language-server-wrapper hie-bios cabal-fmt;
+  inherit haskell agdaPackages cabal-install cardano-repo-tool;
+  inherit stylish-haskell hlint cabal-fmt;
+  inherit haskell-language-server haskell-language-server-wrapper hie-bios;
   inherit fixStylishHaskell fixPngOptimization fixCabalFmt;
   inherit plutus-haddock-combined;
   inherit agdaWithStdlib;

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -58,6 +58,7 @@ let
 
 in
 rec {
-  inherit index-state compiler-nix-name project projectAllHaddock projectPackages projectPackagesAllHaddock packages;
+  inherit index-state compiler-nix-name;
+  inherit project projectAllHaddock projectPackages projectPackagesAllHaddock packages;
   inherit extraPackages;
 }

--- a/nix/pkgs/haskell/extra.nix
+++ b/nix/pkgs/haskell/extra.nix
@@ -19,15 +19,16 @@ let
     version = "2.6.2.1";
     inherit compiler-nix-name;
     modules = [{
-      # Agda is a huge pain. They have a special custom setup that compiles the interface files for
-      # the Agda that ships with the compiler. These go in the data files for the *library*, but they
-      # require the *executable* to compile them, which depends on the library!
-      # They get away with it by using the old-style builds and building everything together, we can't
+      # Agda is a huge pain. They have a special custom setup that compiles the
+      # interface files for the Agda that ships with the compiler. These go in
+      # the data files for the *library*, but they require the *executable* to
+      # compile them, which depends on the library! They get away with it by
+      # using the old-style builds and building everything together, we can't
       # do that.
       # So we work around it:
       # - turn off the custom setup
-      # - manually compile the executable (fortunately it has no extra dependencies!) and do the
-      # compilation at the end of the library derivation.
+      # - manually compile the executable (fortunately it has no extra
+      # dependencies!) and do the compilation at the end of the library derivation.
       packages.Agda.package.buildType = lib.mkForce "Simple";
       packages.Agda.components.library.enableSeparateDataOutput = lib.mkForce true;
       packages.Agda.components.library.postInstall = ''
@@ -55,7 +56,7 @@ let
       sha256 = "04w1dy83ml7wgm5ay1rd4kiwfmdd9sc2y8bp3l0ja7xwvh4fgkmr";
     };
     # # Cabal is a boot library, so haskell.nix would normally use the one coming
-    # # from the compiler-nix-name (currently 3.2). However cabal-fmt depends on 
+    # # from the compiler-nix-name (currently 3.2). However cabal-fmt depends on
     # # Cabal library version 3.6, hence we add this line.
     modules = [{ reinstallableLibGhc = true; }];
     inherit compiler-nix-name index-state;
@@ -69,16 +70,21 @@ let
     src = sources.cardano-repo-tool;
     inherit compiler-nix-name index-state;
     sha256map = {
-      "https://github.com/input-output-hk/nix-archive"."7dcf21b2af54d0ab267f127b6bd8fa0b31cfa49d" = "0mhw896nfqbd2iwibzymydjlb3yivi9gm0v2g1nrjfdll4f7d8ly";
+      "https://github.com/input-output-hk/nix-archive"."7dcf21b2af54d0ab267f127b6bd8fa0b31cfa49d" = "0mhw896nfqbd2iwibzymydjlb3yivi9gm0v2g1nrjfdll4f7d8ly"; # editorconfig-checker-disable-line
     };
   };
   hlsProject = haskell-nix.cabalProject' {
     # See https://github.com/haskell/haskell-language-server/issues/411.
-    # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools *and* through HLS. But we need to have consistent versions in both
-    # cases, otherwise e.g. you could format the code in HLS and then have the CI complain that it's wrong.
+    # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools
+    # *and* through HLS. But we need to have consistent versions in both cases,
+    # otherwise e.g. you could format the code in HLS and then have the CI
+    # complain that it's wrong
+    #
     # The solution we use here is to:
-    # a) Where we care (mostly just formatters), constrain the versions of tools which HLS uses explicitly
-    # b) pull out the tools themselves from the HLS project so we can use them elsewhere
+    # a) Where we care (mostly just formatters), constrain the versions of
+    #    tools which HLS uses explicitly
+    # b) Pull out the tools themselves from the HLS project so we can use
+    #    them elsewhere
     cabalProjectLocal = ''
       constraints: stylish-haskell==0.13.0.0, hlint==3.2.8
     '';

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -19,7 +19,8 @@ let
   r-packages = with rPackages; [ R tidyverse dplyr stringr MASS plotly shiny shinyjs purrr ];
   project = haskell-nix.cabalProject' ({ pkgs, ... }: {
     inherit compiler-nix-name;
-    # This is incredibly difficult to get right, almost everything goes wrong, see https://github.com/input-output-hk/haskell.nix/issues/496
+    # This is incredibly difficult to get right, almost everything goes wrong,
+    # see https://github.com/input-output-hk/haskell.nix/issues/496
     src = let root = ../../../.; in
       haskell-nix.haskellLib.cleanSourceWith {
         filter = gitignore-nix.gitignoreFilter root;
@@ -29,11 +30,11 @@ let
         name = "plutus";
       };
     sha256map = {
-      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm";
-      "https://github.com/input-output-hk/cardano-base"."1587462ac8b2e50af2691f5ad93d3c2aa4674ed1" = "sha256-jrSDD2fXgHf4wo5THzfK/6tolvt8y9rNuJWYfBooqaQ=";
-      "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3";
-      "https://github.com/input-output-hk/cardano-prelude"."fd773f7a58412131512b9f694ab95653ac430852" = "02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6";
-      "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx";
+      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm"; # editorconfig-checker-disable-line
+      "https://github.com/input-output-hk/cardano-base"."1587462ac8b2e50af2691f5ad93d3c2aa4674ed1" = "sha256-jrSDD2fXgHf4wo5THzfK/6tolvt8y9rNuJWYfBooqaQ="; # editorconfig-checker-disable-line
+      "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3"; # editorconfig-checker-disable-line
+      "https://github.com/input-output-hk/cardano-prelude"."fd773f7a58412131512b9f694ab95653ac430852" = "02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6"; # editorconfig-checker-disable-line
+      "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx"; # editorconfig-checker-disable-line
     };
     # Configuration settings needed for cabal configure to work when cross compiling
     # for windows. We can't use `modules` for these as `modules` are only applied
@@ -69,9 +70,15 @@ let
           # of the components with we are going to run.
           # We should try to find a way to automate this will in haskell.nix.
           symlinkDlls = ''
-            ln -s ${pkgs.buildPackages.gcc.cc}/x86_64-w64-mingw32/lib/libgcc_s_seh-1.dll $out/bin/libgcc_s_seh-1.dll
-            ln -s ${pkgs.buildPackages.gcc.cc}/x86_64-w64-mingw32/lib/libstdc++-6.dll $out/bin/libstdc++-6.dll
-            ln -s ${pkgs.windows.mcfgthreads}/bin/mcfgthread-12.dll $out/bin/mcfgthread-12.dll
+            ln -s \
+              ${pkgs.buildPackages.gcc.cc}/x86_64-w64-mingw32/lib/libgcc_s_seh-1.dll \
+              $out/bin/libgcc_s_seh-1.dll
+            ln -s \
+              ${pkgs.buildPackages.gcc.cc}/x86_64-w64-mingw32/lib/libstdc++-6.dll \
+              $out/bin/libstdc++-6.dll
+            ln -s \
+              ${pkgs.windows.mcfgthreads}/bin/mcfgthread-12.dll \
+              $out/bin/mcfgthread-12.dll
           '';
         in
         lib.mkIf (pkgs.stdenv.hostPlatform.isWindows) {
@@ -82,11 +89,15 @@ let
             plutus-core.components.tests.untyped-plutus-core-test.postInstall = symlinkDlls;
             plutus-ledger-api.components.tests.plutus-ledger-api-test.postInstall = symlinkDlls;
 
-            # These three tests try to use `diff` and the following could be used to make the
-            # linux version of diff available.  Unfortunately the paths passed to it are windows style.
-            # plutus-core.components.tests.plutus-core-test.build-tools = [ pkgs.buildPackages.diffutils ];
-            # plutus-core.components.tests.plutus-ir-test.build-tools = [ pkgs.buildPackages.diffutils ];
-            # plutus-core.components.tests.untyped-plutus-core-test.build-tools = [ pkgs.buildPackages.diffutils ];
+            # These three tests try to use `diff` and the following could be used to make
+            # the linux version of diff available.  Unfortunately the paths passed to it
+            # are windows style.
+            # plutus-core.components.tests.plutus-core-test.build-tools =
+            #   [ pkgs.buildPackages.diffutils ];
+            # plutus-core.components.tests.plutus-ir-test.build-tools =
+            #   [ pkgs.buildPackages.diffutils ];
+            # plutus-core.components.tests.untyped-plutus-core-test.build-tools =
+            #   [ pkgs.buildPackages.diffutils ];
             plutus-core.components.tests.plutus-core-test.buildable = lib.mkForce false;
             plutus-core.components.tests.plutus-ir-test.buildable = lib.mkForce false;
             plutus-core.components.tests.untyped-plutus-core-test.buildable = lib.mkForce false;
@@ -110,16 +121,21 @@ let
           # FIXME: Haddock mysteriously gives a spurious missing-home-modules warning
           plutus-tx-plugin.doHaddock = false;
 
-          # In this case we can just propagate the native dependencies for the build of the test executable,
-          # which are actually set up right (we have a build-tool-depends on the executable we need)
+          # In this case we can just propagate the native dependencies for the build of
+          # the test executable, which are actually set up right (we have a
+          # build-tool-depends on the executable we need)
           # I'm slightly surprised this works, hooray for laziness!
-          plutus-metatheory.components.tests.test1.preCheck = ''
-            PATH=${lib.makeBinPath project.hsPkgs.plutus-metatheory.components.tests.test1.executableToolDepends }:$PATH
-          '';
+          plutus-metatheory.components.tests.test1.preCheck =
+            let
+              cmp = project.hsPkgs.plutus-metatheory.components.tests.test1;
+              deps = cmp.executableToolDepends;
+            in
+            ''PATH=${lib.makeBinPath deps }:$PATH'';
           # FIXME: Somehow this is broken even with setting the path up as above
           plutus-metatheory.components.tests.test2.doCheck = false;
           # plutus-metatheory needs agda with the stdlib around for the custom setup
-          # I can't figure out a way to apply this as a blanket change for all the components in the package, oh well
+          # I can't figure out a way to apply this as a blanket change for all the
+          # components in the package, oh well
           plutus-metatheory.components.library.build-tools = [ agdaWithStdlib ];
           plutus-metatheory.components.exes.plc-agda.build-tools = [ agdaWithStdlib ];
           plutus-metatheory.components.tests.test1.build-tools = [ agdaWithStdlib ];
@@ -127,7 +143,8 @@ let
           plutus-metatheory.components.tests.test3.build-tools = [ agdaWithStdlib ];
 
           # Relies on cabal-doctest, just turn it off in the Nix build
-          prettyprinter-configurable.components.tests.prettyprinter-configurable-doctest.buildable = lib.mkForce false;
+          prettyprinter-configurable.components.tests.prettyprinter-configurable-doctest.buildable =
+            lib.mkForce false;
 
           plutus-core.components.benchmarks.update-cost-model = {
             build-tools = r-packages;
@@ -141,7 +158,8 @@ let
             platforms = lib.platforms.linux;
           };
 
-          # Werror everything. This is a pain, see https://github.com/input-output-hk/haskell.nix/issues/519
+          # Werror everything. This is a pain, see
+          # https://github.com/input-output-hk/haskell.nix/issues/519
           plutus-core.ghcOptions = [ "-Werror" ];
           # FIXME: has warnings in generated code
           #plutus-metatheory.package.ghcOptions = "-Werror";

--- a/nix/pkgs/plutus-haddock-combined/default.nix
+++ b/nix/pkgs/plutus-haddock-combined/default.nix
@@ -1,3 +1,4 @@
+# editorconfig-checker-disable-file
 { haddock-combine, haskell, haskell-nix, writeTextFile }:
 let
   toHaddock = haskell-nix.haskellLib.collectComponents' "library" haskell.projectPackagesAllHaddock;
@@ -15,7 +16,7 @@ haddock-combine {
         * "PlutusTx.Prelude": Haskell prelude replacement compatible with PLC.
         * "Plutus.Contract": Writing Plutus apps (off-chain code).
         * "Ledger.Constraints": Constructing and validating Plutus
-           transactions. Built on "PlutusTx" and 
+           transactions. Built on "PlutusTx" and
            "Plutus.Contract".
         * "Ledger.Typed.Scripts": A type-safe interface for spending and
            producing script outputs. Built on "PlutusTx".

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -29,6 +29,11 @@ pkgs.recurseIntoAttrs {
     inherit fixCabalFmt;
   };
 
+  editorconfig-checker = pkgs.callPackage ./editorconfig-checker.nix {
+    src = cleanSrc;
+    inherit (pkgs) editorconfig-checker;
+  };
+
   pngOptimization = pkgs.callPackage ./png-optimization.nix {
     src = cleanSrc;
     inherit fixPngOptimization;

--- a/nix/tests/editorconfig-checker.nix
+++ b/nix/tests/editorconfig-checker.nix
@@ -1,0 +1,23 @@
+{ runCommand, editorconfig-checker, src }:
+
+# Runs `editorconfig-checker` on ${src}. If there are errors,
+# they are written to `$out/nix-support/hydra-build-products`
+runCommand "editorconfig-checker"
+{
+  buildInputs = [ editorconfig-checker ];
+} ''
+  set +e
+  mkdir -p $out/nix-support
+
+  -- changing to the directory and then running it gives better output than
+  -- passing the directory to check, since file names are shorter
+  cd ${src}
+  editorconfig-checker 2>&1 | tee $out/nix-support/editorconfig-checker.log
+
+  if [ $? -ne 0 ]; then
+    echo "*** editorconfig-checker found files that don't match the configuration"
+    exit 1
+  else
+    echo 0 > $out
+  fi
+''

--- a/nix/tests/stylish-haskell.nix
+++ b/nix/tests/stylish-haskell.nix
@@ -9,7 +9,8 @@ let
         (
           (type == "regular" && hasSuffix ".hs" baseName) ||
           (type == "regular" && hasSuffix ".yaml" baseName) ||
-          (type == "directory" && (baseName != "dist-newstyle" && baseName != "dist" && baseName != ".stack-work"))
+          (type == "directory" &&
+          (baseName != "dist-newstyle" && baseName != "dist" && baseName != ".stack-work"))
         );
   };
 in
@@ -25,7 +26,7 @@ runCommand "stylish-check"
   fix-stylish-haskell
   EXIT_CODE=$?
   if [[ $EXIT_CODE != 0 ]]
-  then 
+  then
     echo "*** stylish-haskell failed to format some files"
     exit $EXIT_CODE
   fi

--- a/notes/fomega/cek-cps-experiments/src/CekMachine.cps.hs
+++ b/notes/fomega/cek-cps-experiments/src/CekMachine.cps.hs
@@ -1,3 +1,5 @@
+-- editorconfig-checker-disable-file
+
 -- This file contains a version of the CEK machine in
 -- continuation-passing-style, where the frames and return
 -- operation of the original version are replaced with explicit

--- a/notes/fomega/cek-cps-experiments/src/CekMachine.original.hs
+++ b/notes/fomega/cek-cps-experiments/src/CekMachine.original.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The CEK machine.
 -- Rules are the same as for the CK machine from "PlutusCore.Evaluation.CkMachine",
 -- except we do not use substitution and use environments instead.

--- a/notes/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
+++ b/notes/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns #-}
 
 -- This file contains a version of the CEK machine in

--- a/notes/fomega/cek-cps-experiments/src/LMachine.hs
+++ b/notes/fomega/cek-cps-experiments/src/LMachine.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | The L machine

--- a/notes/fomega/src/AlgTypes.hs
+++ b/notes/fomega/src/AlgTypes.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs           #-}
 {-# LANGUAGE QuasiQuotes     #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/notes/fomega/src/Examples.hs
+++ b/notes/fomega/src/Examples.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs       #-}
 {-# LANGUAGE QuasiQuotes #-}
 module Examples where

--- a/notes/fomega/src/Large.hs
+++ b/notes/fomega/src/Large.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE QuasiQuotes     #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/notes/fomega/src/Solver.hs
+++ b/notes/fomega/src/Solver.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Solver where
 
 import AlgTypes

--- a/notes/fomega/src/SystemF.hs
+++ b/notes/fomega/src/SystemF.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs #-}
 
 

--- a/notes/model/UTxO.hsproj/UTxO.hs
+++ b/notes/model/UTxO.hsproj/UTxO.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns    #-}
 {-# LANGUAGE PackageImports  #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/notes/model/UTxO.hsproj/Witness.hs
+++ b/notes/model/UTxO.hsproj/Witness.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE PackageImports       #-}

--- a/plutus-benchmark/cek-calibration/Main.hs
+++ b/plutus-benchmark/cek-calibration/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}

--- a/plutus-benchmark/lists/bench/Bench.hs
+++ b/plutus-benchmark/lists/bench/Bench.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- | Plutus benchmarks for some simple list algortihms.  See README.md for more information. -}
 
 module Main (main) where

--- a/plutus-benchmark/lists/exe/Main.hs
+++ b/plutus-benchmark/lists/exe/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | This compiles several list-sorting algorithms to Plutus Core and runs them on

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/Compiled.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/HandWritten.hs
+++ b/plutus-benchmark/lists/src/PlutusBenchmark/Lists/Sum/HandWritten.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 
 module PlutusBenchmark.Lists.Sum.HandWritten where

--- a/plutus-benchmark/lists/test/Sort/Spec.hs
+++ b/plutus-benchmark/lists/test/Sort/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Sort.Spec (tests) where
 
 import Test.Tasty

--- a/plutus-benchmark/lists/test/Sum/Spec.hs
+++ b/plutus-benchmark/lists/test/Sum/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Sum.Spec (tests) where
 
 import Test.Tasty

--- a/plutus-benchmark/nofib/bench/BenchPlc.hs
+++ b/plutus-benchmark/nofib/bench/BenchPlc.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- | Plutus benchmarks based on some nofib examples. -}
 module Main where
 

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Knights/ChessSetList.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE NoImplicitPrelude #-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Prime.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-% Primality testing functions taken from nofib/spectral/primetest.
   Most of the literate Haskell stuff has been removed and everything's
   been put into one file for simplicity. %-}

--- a/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
+++ b/plutus-benchmark/nofib/src/PlutusBenchmark/NoFib/Queens.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-% nofib/spectral/constraints converted to Plutus.
     Renamed to avoid conflict with existing package. %-}
 {-# LANGUAGE DataKinds             #-}

--- a/plutus-benchmark/nofib/test/Spec.hs
+++ b/plutus-benchmark/nofib/test/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- | Tests for the Plutus nofib benchmarks, mostly comparing the result of Plutus
 evaluation with the result of Haskell evaluation. Lastpiece is currently omitted
 because its memory consumption as a Plutus program is too great to allow it to

--- a/plutus-benchmark/validation/BenchDec.hs
+++ b/plutus-benchmark/validation/BenchDec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Main where
 
 import PlutusLedgerApi.V1

--- a/plutus-benchmark/validation/BenchFull.hs
+++ b/plutus-benchmark/validation/BenchFull.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Main where
 
 import PlutusCore.Evaluation.Machine.ExBudget

--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 module Common (
     benchWith

--- a/plutus-conformance/add-test-output/Spec.hs
+++ b/plutus-conformance/add-test-output/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 {- | This executable is for easy addition of tests. When run with the option `-- --missing`,

--- a/plutus-core/common/ErrorCode.hs
+++ b/plutus-core/common/ErrorCode.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module ErrorCode
     ( HasErrorCode(..)
     , ErrorCode(..)

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Benchmarks.ByteStrings (makeBenchmarks) where
 
 import Common

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/CryptoAndHashes.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/CryptoAndHashes.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Integers.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Integers.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Benchmarks.Integers (makeBenchmarks) where
 
 import Common

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Lists.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Lists.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Benchmarks.Lists (makeBenchmarks) where
 
 import Common

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- | Benchmarks for string builtins.  Remember that "strings" are actually Text. -}
 
 module Benchmarks.Strings (makeSizedTextStrings, makeBenchmarks) where

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE TypeApplications #-}

--- a/plutus-core/cost-model/budgeting-bench/Generators.hs
+++ b/plutus-core/cost-model/budgeting-bench/Generators.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- |  Generators for various types of data for benchmarking built-in functions -}
 
 module Generators where

--- a/plutus-core/cost-model/budgeting-bench/Main.hs
+++ b/plutus-core/cost-model/budgeting-bench/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeOperators #-}
 
 -- See CostModelGeneration.md

--- a/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
+++ b/plutus-core/cost-model/create-cost-model/CreateBuiltinCostModel.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}

--- a/plutus-core/cost-model/create-cost-model/Main.hs
+++ b/plutus-core/cost-model/create-cost-model/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Main where
 
 import CreateBuiltinCostModel (createBuiltinCostModel)

--- a/plutus-core/cost-model/print-cost-model/Main.hs
+++ b/plutus-core/cost-model/print-cost-model/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/plutus-core/executables/Parsers.hs
+++ b/plutus-core/executables/Parsers.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase #-}
 
 -- | Common option parsers for executables

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase   #-}
 

--- a/plutus-core/executables/traceToStacks/Common.hs
+++ b/plutus-core/executables/traceToStacks/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase                #-}

--- a/plutus-core/index-envs/bench/Main.hs
+++ b/plutus-core/index-envs/bench/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}

--- a/plutus-core/index-envs/src/Data/RandomAccessList/RelativizedMap.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/RelativizedMap.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Data.RandomAccessList.RelativizedMap (RelativizedMap (..))where

--- a/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
+++ b/plutus-core/index-envs/src/Data/RandomAccessList/SkewBinarySlab.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE PatternSynonyms      #-}

--- a/plutus-core/index-envs/test/RAList/Spec.hs
+++ b/plutus-core/index-envs/test/RAList/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE Rank2Types           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-core/satint-test/TestSatInt.hs
+++ b/plutus-core/plutus-core/satint-test/TestSatInt.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}

--- a/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
+++ b/plutus-core/plutus-core/src/Data/Aeson/Flatten.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE CPP #-}
 module Data.Aeson.Flatten
     ( flattenObject

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {- |
 Adapted from 'Data.SafeInt' to perform saturating arithmetic (i.e. returning max or min bounds) instead of throwing on overflow.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- GHC doesn't like the definition of 'TrySpecializeAsVar'.
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BlockArguments        #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes       #-}
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE DataKinds                 #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | This module assigns types to built-ins.
 -- See the @plutus/plutus-core/docs/Constant application.md@
 -- article for how this emerged.

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Eq.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | 'Eq' instances for core data types.
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Instance/Pretty/Readable.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | A "readable" Agda-like way to pretty-print PLC entities.
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Plated.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE RankNTypes #-}
 
 module PlutusCore.Core.Plated

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE DeriveAnyClass           #-}
 {-# LANGUAGE DerivingVia              #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The universe used by default and its instances.
 
 {-# OPTIONS -fno-warn-missing-pattern-synonym-signatures #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Eq.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Eq.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | An internal module that defines functions for deciding equality of values of data types
 -- that encode things with binders.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Error.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Error.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass         #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Ck.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The CK machine.
 
 {-# LANGUAGE DeriveAnyClass            #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostingFun/Core.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns   #-}
 {-# LANGUAGE DeriveAnyClass #-}
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies    #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingVia           #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/Exception.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The exceptions that an abstract machine can throw.
 
 -- appears in the generated instances

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE StrictData      #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Flat.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Flat.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE FlexibleInstances    #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Mark.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Mark.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusCore.Mark
     ( markNonFreshTerm
     , markNonFreshType

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE FlexibleInstances      #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Name.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE DeriveAnyClass         #-}
 {-# LANGUAGE FlexibleInstances      #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Normalize/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The internals of the normalizer.
 
 {-# LANGUAGE ConstraintKinds #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Parsers for PLC terms in DefaultUni.

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/ConfigName.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/ConfigName.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusCore.Pretty.ConfigName
     ( PrettyConfigName (..)
     , HasPrettyConfigName (..)

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/PrettyConst.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE ConstraintKinds       #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | A "readable" Agda-like way to pretty-print PLC entities.
 
 {-# LANGUAGE ConstraintKinds   #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Quote.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Quote.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Rename.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Rename.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The user-facing API of the renamer.
 
 {-# LANGUAGE DerivingVia          #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Rename/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Rename/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The internal module of the renamer that defines the actual algorithms,
 -- but not the user-facing API.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Subst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Subst.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusCore.Subst
     ( substTyVarA
     , substVarA

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Kind/type inference/checking.
 
 {-# LANGUAGE ConstraintKinds #-}

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The internal module of the type checker that defines the actual algorithms,
 -- but not the user-facing API.
 

--- a/plutus-core/plutus-core/src/Prettyprinter/Custom.hs
+++ b/plutus-core/plutus-core/src/Prettyprinter/Custom.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 module Prettyprinter.Custom ( brackets'

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE FlexibleInstances        #-}

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Built-in @pair@ and related functions.
 
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Function.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Function.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Combinators.
 
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | @tuple@s of various sizes and related functions.
 
 {-# LANGUAGE GADTs             #-}

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | This module defines Haskell data types that simplify construction of PLC types and terms.
 
 {-# LANGUAGE DeriveAnyClass    #-}

--- a/plutus-core/plutus-core/test/CBOR/DataStability.hs
+++ b/plutus-core/plutus-core/test/CBOR/DataStability.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-core/plutus-core/test/Check/Spec.hs
+++ b/plutus-core/plutus-core/test/Check/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
+++ b/plutus-core/plutus-core/test/CostModelInterface/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-core/plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Machines.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeFamilies #-}
 
 module Evaluation.Machines

--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TypeApplications    #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Dependencies.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/Usages.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts #-}
 -- | Functions for computing variable usage inside terms and types.
 module PlutusIR.Analysis.Usages (runTermUsages, runTypeUsages, Usages, getUsageCount, allUsed) where

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE FlexibleContexts       #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Error.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass         #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Lower.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Recursion.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Plated.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE LambdaCase    #-}
 {-# LANGUAGE RankNTypes    #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Error.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Error.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE DeriveAnyClass         #-}
 {-# LANGUAGE FlexibleInstances      #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Mark.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusIR.Mark
     ( markNonFreshTerm
     , markNonFreshType

--- a/plutus-core/plutus-ir/src/PlutusIR/Normalize.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Normalize.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts #-}
 -- | PlutusIR versions of the functions in PlutusCore.Normalize
 module PlutusIR.Normalize

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Parsers for PIR terms in DefaultUni.

--- a/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE ViewPatterns #-}
 {-|

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE LambdaCase        #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloat.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Rename.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Substitute.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns     #-}
 -- | Implements naive substitution functions for replacing type and term variables.

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase       #-}
 -- | Implements a PIR-to-PIR transformation that makes all recursive term definitions

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeFamilies  #-}
 {-# LANGUAGE TypeOperators #-}
 -- | Kind/type inference/checking, mirroring PlutusCore.TypeCheck

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The internal module of the type checker that defines the actual algorithms,
 -- but not the user-facing API.
 

--- a/plutus-core/plutus-ir/test/ParserSpec.hs
+++ b/plutus-core/plutus-ir/test/ParserSpec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/plutus-core/plutus-ir/test/Spec.hs
+++ b/plutus-core/plutus-ir/test/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/testlib/PlutusCore/Generators/AST.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/AST.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 
 module PlutusCore.Generators.AST

--- a/plutus-core/testlib/PlutusCore/Generators/Interesting.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Interesting.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Sample generators used for tests.
 
 {-# LANGUAGE DataKinds         #-}

--- a/plutus-core/testlib/PlutusCore/Generators/Internal/Entity.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Internal/Entity.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Generators of various PLC things: 'Builtin's, 'IterApp's, 'Term's, etc.
 
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/testlib/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | This module defines types and functions related to "type-eval checking".
 
 {-# LANGUAGE DataKinds              #-}

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-| Description : Property based testing for Plutus Core
 
 This file contains the tests and some associated machinery but not the

--- a/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/NEAT/Term.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-| Description: PLC Syntax, typechecker,semantics property based testing.
 
 This file contains

--- a/plutus-core/testlib/PlutusCore/Generators/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Test.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | This module defines functions useful for testing.
 
 {-# LANGUAGE TypeFamilies #-}

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RankNTypes             #-}

--- a/plutus-core/testlib/PlutusIR/Generators/AST.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/AST.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | This module defines generators for PIR syntax trees for testing purposes.
 -- It should only contain those generators that can't be reused from PLC
 -- (PIR-exclusive constructs, Term, and Program)

--- a/plutus-core/testlib/PlutusIR/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Test.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Analysis/Usages.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts #-}
 -- | Functions for computing variable usage inside terms.
 module UntypedPlutusCore.Analysis.Usages (runTermUsages, Usages, getUsageCount, allUsed) where

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Check/Scope.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Eq.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE FlexibleInstances    #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Instance/Flat.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE KindSignatures       #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Type.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The API to the CEK machine.
 
 {-# LANGUAGE DataKinds        #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/ExBudgetMode.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The CEK machine.
 -- The CEK machine relies on variables having non-equal 'Unique's whenever they have non-equal
 -- string names. I.e. 'Unique's are used instead of string names. This is for efficiency reasons.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Mark.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module UntypedPlutusCore.Mark
     ( markNonFreshTerm
     , markNonFreshProgram

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module UntypedPlutusCore.MkUPlc (UVarDecl (..), uvarDeclName, uvarDeclAnn, mkVar, mkIterApp, mkIterLamAbs, Def(..), UTermDef) where
 
 import Data.List

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 module UntypedPlutusCore.Parser

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Simplify.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TemplateHaskell #-}
 module UntypedPlutusCore.Simplify ( simplifyTerm, simplifyProgram, SimplifyOpts (..), soMaxSimplifierIterations, soInlineHints, defaultSimplifyOpts, InlineHints (..) ) where
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Subst.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Subst.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module UntypedPlutusCore.Subst

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Common.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies     #-}
 module DeBruijn.Common where

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 module DeBruijn.UnDeBruijnify (test_undebruijnify) where
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Tests for all kinds of built-in functions.
 
 {-# LANGUAGE OverloadedStrings     #-}

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SECP256k1.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SECP256k1.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}

--- a/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies     #-}
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeOperators     #-}

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies     #-}
 

--- a/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 module Transform.Simplify where

--- a/plutus-errors/exe-bootstrap/Errors/TH/Bootstrap.hs
+++ b/plutus-errors/exe-bootstrap/Errors/TH/Bootstrap.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | (Re)generate ErrorCode instances for initial errors
 {-# LANGUAGE TemplateHaskell #-}
 module Errors.TH.Bootstrap (

--- a/plutus-errors/src/Errors.hs
+++ b/plutus-errors/src/Errors.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_HADDOCK hide #-}
 -- | The catalogue of all Plutus errors, obsolete or not.

--- a/plutus-errors/src/Errors/TH/GenDocs.hs
+++ b/plutus-errors/src/Errors/TH/GenDocs.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Errors.TH.GenDocs (genDocs) where

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ParamName.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/ProtocolVersions.hs
@@ -14,7 +14,8 @@ data ProtocolVersion = ProtocolVersion { pvMajor :: Int, pvMinor :: Int }
 
 instance Ord ProtocolVersion where
     -- same as deriving Ord, just for having it explicitly
-    compare (ProtocolVersion major minor) (ProtocolVersion major' minor') = compare major major' <> compare minor minor'
+    compare (ProtocolVersion major minor) (ProtocolVersion major' minor') =
+        compare major major' <> compare minor minor'
 
 instance Pretty ProtocolVersion where
     pretty (ProtocolVersion major minor) = pretty major <> "." <> pretty minor

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/SerialisedScript.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusLedgerApi.Common.SerialisedScript
     ( SerialisedScript
     , scriptCBORDecoder

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Versions.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 module PlutusLedgerApi.Common.Versions
     ( module PlutusLedgerApi.Common.ProtocolVersions

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The interface to Plutus V1 for the ledger.
 module PlutusLedgerApi.V1 (
     -- * Scripts

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Address.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Address.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Bytes.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Bytes.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE DerivingVia     #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Contexts.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE NoImplicitPrelude #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Credential.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Credential.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Crypto.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Crypto.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE DerivingVia     #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 module PlutusLedgerApi.V1.EvaluationContext
     ( EvaluationContext

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Scripts.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NoImplicitPrelude #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Time.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingVia        #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | The interface to Plutus V2 for the ledger.
 module PlutusLedgerApi.V2 (
     -- * Scripts

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Contexts.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE NoImplicitPrelude #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingVia      #-}
 {-# LANGUAGE TypeApplications #-}
 module PlutusLedgerApi.V2.EvaluationContext

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -1,3 +1,5 @@
+-- editorconfig-checker-disable-file
+
 -- | The interface to Plutus V3 for the ledger.
 module PlutusLedgerApi.V3 (
     -- * Scripts

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -21,7 +21,8 @@ import Control.Monad.Except
 
 {-|  Build the 'EvaluationContext'.
 
-The input is a list of integer values passed from the ledger and are expected to appear in correct order.
+The input is a list of integer values passed from the ledger and are expected to appear in
+correct order.
 -}
 mkEvaluationContext :: MonadError CostModelApplyError m => [Integer] -> m EvaluationContext
 mkEvaluationContext = mkDynEvaluationContext . toCostModelParams <=< tagWithParamNames @V3.ParamName

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Main where
 
 import PlutusLedgerApi.Common.Versions

--- a/plutus-ledger-api/test/Spec/Builtins.hs
+++ b/plutus-ledger-api/test/Spec/Builtins.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 module Spec.Builtins where
 

--- a/plutus-ledger-api/test/Spec/CostModelParams.hs
+++ b/plutus-ledger-api/test/Spec/CostModelParams.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 module Spec.CostModelParams where
 

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies     #-}
 module Spec.Eval (tests) where

--- a/plutus-ledger-api/test/Spec/Interval.hs
+++ b/plutus-ledger-api/test/Spec/Interval.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationContext.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationContext.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusLedgerApi.Test.EvaluationContext
     ( costModelParamsForTesting
     , evalCtxForTesting

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Examples.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Examples.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TypeApplications #-}
 -- | This module contains example values to be used for testing. These should NOT be used in non-test code!
 module PlutusLedgerApi.Test.Examples (alwaysSucceedingNAryFunction, alwaysFailingNAryFunction, summingFunction, saltFunction) where

--- a/plutus-metatheory/Setup.hs
+++ b/plutus-metatheory/Setup.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 import Data.Functor
 import Distribution.Simple

--- a/plutus-metatheory/src/Opts.hs
+++ b/plutus-metatheory/src/Opts.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Opts where
 
 import Data.Semigroup ((<>))

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}

--- a/plutus-metatheory/test/TestDetailed.hs
+++ b/plutus-metatheory/test/TestDetailed.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase #-}
 module TestDetailed where
 import Control.Exception

--- a/plutus-metatheory/test/TestNEAT.hs
+++ b/plutus-metatheory/test/TestNEAT.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Main where
 
 import Control.Monad.Except

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Error.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Kind.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}

--- a/plutus-tx-plugin/test/Lift/Spec.hs
+++ b/plutus-tx-plugin/test/Lift/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MagicHash           #-}

--- a/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE MagicHash           #-}

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-tx-plugin/test/Plugin/Lib.hs
+++ b/plutus-tx-plugin/test/Plugin/Lib.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/NoTrace/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedStrings   #-}

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-tx-plugin/test/TH/TestTH.hs
+++ b/plutus-tx-plugin/test/TH/TestTH.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/plutus-tx/src/PlutusTx.hs
+++ b/plutus-tx/src/PlutusTx.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusTx (
     module Export,
     CompiledCode,

--- a/plutus-tx/src/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/PlutusTx/AssocMap.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE DeriveGeneric         #-}

--- a/plutus-tx/src/PlutusTx/Builtins.hs
+++ b/plutus-tx/src/PlutusTx/Builtins.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 

--- a/plutus-tx/src/PlutusTx/Builtins/Class.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Class.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE FunctionalDependencies   #-}
 {-# LANGUAGE MultiParamTypeClasses    #-}

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingStrategies #-}

--- a/plutus-tx/src/PlutusTx/Code.hs
+++ b/plutus-tx/src/PlutusTx/Code.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingStrategies    #-}

--- a/plutus-tx/src/PlutusTx/Coverage.hs
+++ b/plutus-tx/src/PlutusTx/Coverage.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia        #-}

--- a/plutus-tx/src/PlutusTx/Integer.hs
+++ b/plutus-tx/src/PlutusTx/Integer.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusTx.Integer (Integer) where
 
 {-

--- a/plutus-tx/src/PlutusTx/IsData/Class.hs
+++ b/plutus-tx/src/PlutusTx/IsData/Class.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE OverloadedStrings    #-}

--- a/plutus-tx/src/PlutusTx/IsData/Instances.hs
+++ b/plutus-tx/src/PlutusTx/IsData/Instances.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell   #-}

--- a/plutus-tx/src/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/PlutusTx/IsData/TH.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 module PlutusTx.IsData.TH (unstableMakeIsData, makeIsDataIndexed) where

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE PartialTypeSignatures #-}

--- a/plutus-tx/src/PlutusTx/Lift/Class.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Class.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DefaultSignatures     #-}

--- a/plutus-tx/src/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Instances.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE DeriveAnyClass        #-}

--- a/plutus-tx/src/PlutusTx/Lift/THUtils.hs
+++ b/plutus-tx/src/PlutusTx/Lift/THUtils.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE TemplateHaskell #-}
 module PlutusTx.Lift.THUtils where

--- a/plutus-tx/src/PlutusTx/List.hs
+++ b/plutus-tx/src/PlutusTx/List.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.List (

--- a/plutus-tx/src/PlutusTx/Numeric.hs
+++ b/plutus-tx/src/PlutusTx/Numeric.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}

--- a/plutus-tx/src/PlutusTx/Ord.hs
+++ b/plutus-tx/src/PlutusTx/Ord.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Ord (Ord(..), Ordering(..)) where

--- a/plutus-tx/src/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/PlutusTx/Prelude.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- Need some extra imports from the Prelude for doctests, annoyingly
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}

--- a/plutus-tx/src/PlutusTx/Traversable.hs
+++ b/plutus-tx/src/PlutusTx/Traversable.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Traversable (Traversable(..), sequenceA, mapM, sequence, for, fmapDefault, foldMapDefault) where

--- a/plutus-tx/src/PlutusTx/Utils.hs
+++ b/plutus-tx/src/PlutusTx/Utils.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module PlutusTx.Utils where
 
 -- We do not use qualified import because the whole module contains off-chain code

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}

--- a/plutus-tx/test/Suites/Laws/Construction.hs
+++ b/plutus-tx/test/Suites/Laws/Construction.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
 

--- a/plutus-tx/test/Suites/Laws/Eq.hs
+++ b/plutus-tx/test/Suites/Laws/Eq.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Suites.Laws.Eq (eqLaws) where
 
 import Hedgehog (Property, PropertyT, property, success, (===))

--- a/plutus-tx/test/Suites/Laws/Helpers.hs
+++ b/plutus-tx/test/Suites/Laws/Helpers.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE KindSignatures    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/plutus-tx/test/Suites/Laws/Ord.hs
+++ b/plutus-tx/test/Suites/Laws/Ord.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 module Suites.Laws.Ord (ordLaws) where
 
 import Hedgehog (Property, PropertyT, property, success, (/==), (===))

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE KindSignatures        #-}

--- a/prettyprinter-configurable/src/Text/Fixity/Internal.hs
+++ b/prettyprinter-configurable/src/Text/Fixity/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Precedence-general machinery for deciding whether an expression needs to be wrapped in
 -- parentheses or not. Source code has comments on the approach used and how it compares to some
 -- other known approaches.

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DataKinds                  #-}

--- a/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
+++ b/prettyprinter-configurable/src/Text/PrettyBy/Internal/Utils.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 -- | Utils used internally.
 
 module Text.PrettyBy.Internal.Utils

--- a/release.nix
+++ b/release.nix
@@ -13,8 +13,9 @@ let
   inherit (import ./nix/lib/ci.nix) stripAttrsForHydra filterDerivations derivationAggregate;
 
   ci = import ./ci.nix { inherit supportedSystems rootsOnly; };
-  # ci.nix is a set of attributes that work fine as jobs (albeit in a slightly different structure, the platform comes
-  # first), but we mainly just need to get rid of some extra attributes.
+  # ci.nix is a set of attributes that work fine as jobs (albeit in a slightly different
+  # structure, the platform comes # first), but we mainly just need to get rid of some
+  # extra attributes.
   ciJobsets = stripAttrsForHydra (filterDerivations ci);
   # Don't filter anyting out of required for now
   requiredJobsets = ciJobsets;

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,8 @@
 let
   inherit (packages) pkgs plutus docs;
   inherit (pkgs) stdenv lib utillinux python3 nixpkgs-fmt glibcLocales;
-  inherit (plutus) haskell agdaPackages stylish-haskell sphinxcontrib-haddock sphinx-markdown-tables sphinxemoji nix-pre-commit-hooks cabal-fmt;
+  inherit (plutus) haskell agdaPackages stylish-haskell cabal-fmt;
+  inherit (plutus) sphinxcontrib-haddock sphinx-markdown-tables sphinxemoji nix-pre-commit-hooks;
   inherit (plutus) agdaWithStdlib;
 
   # For Sphinx, and ad-hoc usage
@@ -36,7 +37,12 @@ let
         # While nixpkgs-fmt does exclude patterns specified in `.ignore` this
         # does not appear to work inside the hook. For now we have to thus
         # maintain excludes here *and* in `./.ignore` and *keep them in sync*.
-        excludes = [ ".*nix/pkgs/haskell/materialized.*/.*" ".*/spago-packages.nix$" ".*/packages.nix$" ];
+        excludes =
+          [
+            ".*nix/pkgs/haskell/materialized.*/.*"
+            ".*/spago-packages.nix$"
+            ".*/packages.nix$"
+          ];
       };
       cabal-fmt.enable = true;
       shellcheck.enable = true;
@@ -63,6 +69,7 @@ let
     bzip2
     cacert
     editorconfig-core-c
+    editorconfig-checker
     ghcid
     jq
     # See https://github.com/cachix/pre-commit-hooks.nix/issues/148 for why we need this
@@ -103,5 +110,7 @@ haskell.project.shellFor {
 
   # This is no longer set automatically as of more recent `haskell.nix` revisions,
   # but is useful for users with LANG settings.
-  LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = lib.optionalString
+    (stdenv.hostPlatform.libc == "glibc")
+    "${glibcLocales}/lib/locale/locale-archive";
 }

--- a/stubs/plutus-ghc-stub/src/StubTypes.hs
+++ b/stubs/plutus-ghc-stub/src/StubTypes.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}

--- a/word-array/bench/Main.hs
+++ b/word-array/bench/Main.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}

--- a/word-array/src/Data/Word64Array/Word8.hs
+++ b/word-array/src/Data/Word64Array/Word8.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE BinaryLiterals      #-}
 {-# LANGUAGE DataKinds           #-}


### PR DESCRIPTION
This uses `editorconfig-checker` to enforce line lengths.

Notes:
- I just went and fixed most of the issues in Nix files
- There were too many broken Haskell files, instead I just automatically went through them and added an ignore comment. Then we can remove them as we go to improve the situation.
- I split up the config so we can enforce indent size only on Haskell, which is probably what we want.
- I didn't actually try and enforce an indent size, because it's wildly inconsistent. In particular, people do a lot of "half-indenting" `where` clauses, and I'm not sure what to do about that.
    - If we're willing to commit to really seriously using 4 for real everywhere, I can do the same thing that I did for the line length and automatically ignore the files that don't conform.

Where clause example:
```
-- what we often do today, this effectively avoids paying "two" indentations for the where clause
foo = bar
  where 
    -- this bit ends up indented by 4 spaces
    bar = 1

-- vs actually using 4 consistently
foo = bar
    where
        bar = 1
```