### PR TITLE
Backport NoThunks for EvaluationContext to release/1.0.0

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,657 +1,669 @@
-cabal-version: 3.0
-name: plutus-core
-version: 1.0.0.0
-license: Apache-2.0
+cabal-version:      3.0
+name:               plutus-core
+version:            1.0.0.0
+license:            Apache-2.0
 license-files:
   LICENSE
   NOTICE
-maintainer: michael.peyton-jones@iohk.io
-author: Plutus Core Team
-synopsis: Language library for Plutus Core
-description:
-    Pretty-printer, parser, and typechecker for Plutus Core.
-category: Language, Plutus
-build-type: Simple
-extra-doc-files: README.md
+
+maintainer:         michael.peyton-jones@iohk.io
+author:             Plutus Core Team
+synopsis:           Language library for Plutus Core
+description:        Pretty-printer, parser, and typechecker for Plutus Core.
+category:           Language, Plutus
+build-type:         Simple
+extra-doc-files:    README.md
 extra-source-files:
-    cost-model/data/builtinCostModel.json
-    cost-model/data/cekMachineCosts.json
-    cost-model/data/benching.csv
-    cost-model/data/*.R
-    plutus-core/test/CostModelInterface/defaultCostModelParams.json
+  cost-model/data/*.R
+  cost-model/data/benching.csv
+  cost-model/data/builtinCostModel.json
+  cost-model/data/cekMachineCosts.json
+  plutus-core/test/CostModelInterface/defaultCostModelParams.json
 
 source-repository head
-    type: git
-    location: https://github.com/input-output-hk/plutus
+  type:     git
+  location: https://github.com/input-output-hk/plutus
 
 common lang
-    default-language: Haskell2010
-    default-extensions: ExplicitForAll FlexibleContexts ScopedTypeVariables
-                        DeriveGeneric StandaloneDeriving DeriveLift
-                        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
-                        DeriveTraversable DerivingStrategies DerivingVia
-                        ImportQualifiedPost
-    ghc-options: -Wall -Wnoncanonical-monad-instances
-                 -Wincomplete-uni-patterns -Wincomplete-record-updates
-                 -Wredundant-constraints -Widentities -Wunused-packages
-                 -Wmissing-deriving-strategies
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
 
 library
-    import: lang
-    exposed-modules:
-        PlutusCore
-        PlutusCore.Check.Normal
-        PlutusCore.Check.Scoping
-        PlutusCore.Check.Uniques
-        PlutusCore.Check.Value
-        PlutusCore.Builtin
-        PlutusCore.Builtin.Debug
-        PlutusCore.Builtin.Elaborate
-        PlutusCore.Builtin.Emitter
-        PlutusCore.Core
-        PlutusCore.Data
-        PlutusCore.DataFilePaths
-        PlutusCore.DeBruijn
-        PlutusCore.Default
-        PlutusCore.Error
-        PlutusCore.Evaluation.Machine.BuiltinCostModel
-        PlutusCore.Evaluation.Machine.Ck
-        PlutusCore.Evaluation.Machine.CostModelInterface
-        PlutusCore.Evaluation.Machine.ExBudget
-        PlutusCore.Evaluation.Machine.ExMemory
-        PlutusCore.Evaluation.Machine.Exception
-        PlutusCore.Evaluation.Machine.MachineParameters
-        PlutusCore.Evaluation.Result
-        PlutusCore.Examples.Builtins
-        PlutusCore.Examples.Data.Data
-        PlutusCore.Examples.Data.InterList
-        PlutusCore.Examples.Data.List
-        PlutusCore.Examples.Data.Pair
-        PlutusCore.Examples.Data.Shad
-        PlutusCore.Examples.Data.TreeForest
-        PlutusCore.Examples.Data.Vec
-        PlutusCore.Examples.Everything
-        PlutusCore.Flat
-        PlutusCore.FsTree
-        PlutusCore.Mark
-        PlutusCore.MkPlc
-        PlutusCore.Name
-        PlutusCore.Normalize
-        PlutusCore.Normalize.Internal
-        PlutusCore.Parser
-        PlutusCore.Pretty
-        PlutusCore.Quote
-        PlutusCore.Rename
-        PlutusCore.Rename.Internal
-        PlutusCore.Rename.Monad
-        PlutusCore.StdLib.Data.Bool
-        PlutusCore.StdLib.Data.ChurchNat
-        PlutusCore.StdLib.Data.Data
-        PlutusCore.StdLib.Data.Function
-        PlutusCore.StdLib.Data.Integer
-        PlutusCore.StdLib.Data.List
-        PlutusCore.StdLib.Data.Nat
-        PlutusCore.StdLib.Data.Pair
-        PlutusCore.StdLib.Data.ScottList
-        PlutusCore.StdLib.Data.ScottUnit
-        PlutusCore.StdLib.Data.Sum
-        PlutusCore.StdLib.Data.Unit
-        PlutusCore.StdLib.Everything
-        PlutusCore.StdLib.Meta
-        PlutusCore.StdLib.Meta.Data.Function
-        PlutusCore.StdLib.Meta.Data.Tuple
-        PlutusCore.StdLib.Type
-        PlutusCore.Subst
+  import:          lang
+  exposed-modules:
+    Crypto
+    Data.ByteString.Hash
+    Data.SatInt
+    ErrorCode
+    PlutusCore
+    PlutusCore.Builtin
+    PlutusCore.Builtin.Debug
+    PlutusCore.Builtin.Elaborate
+    PlutusCore.Builtin.Emitter
+    PlutusCore.Check.Normal
+    PlutusCore.Check.Scoping
+    PlutusCore.Check.Uniques
+    PlutusCore.Check.Value
+    PlutusCore.Core
+    PlutusCore.Data
+    PlutusCore.DataFilePaths
+    PlutusCore.DeBruijn
+    PlutusCore.Default
+    PlutusCore.Error
+    PlutusCore.Evaluation.Machine.BuiltinCostModel
+    PlutusCore.Evaluation.Machine.Ck
+    PlutusCore.Evaluation.Machine.CostModelInterface
+    PlutusCore.Evaluation.Machine.ExBudget
+    PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+    PlutusCore.Evaluation.Machine.Exception
+    PlutusCore.Evaluation.Machine.ExMemory
+    PlutusCore.Evaluation.Machine.MachineParameters
+    PlutusCore.Evaluation.Result
+    PlutusCore.Examples.Builtins
+    PlutusCore.Examples.Data.Data
+    PlutusCore.Examples.Data.InterList
+    PlutusCore.Examples.Data.List
+    PlutusCore.Examples.Data.Pair
+    PlutusCore.Examples.Data.Shad
+    PlutusCore.Examples.Data.TreeForest
+    PlutusCore.Examples.Data.Vec
+    PlutusCore.Examples.Everything
+    PlutusCore.Flat
+    PlutusCore.FsTree
+    PlutusCore.Mark
+    PlutusCore.MkPlc
+    PlutusCore.Name
+    PlutusCore.Normalize
+    PlutusCore.Normalize.Internal
+    PlutusCore.Parser
+    PlutusCore.Pretty
+    PlutusCore.Quote
+    PlutusCore.Rename
+    PlutusCore.Rename.Internal
+    PlutusCore.Rename.Monad
+    PlutusCore.StdLib.Data.Bool
+    PlutusCore.StdLib.Data.ChurchNat
+    PlutusCore.StdLib.Data.Data
+    PlutusCore.StdLib.Data.Function
+    PlutusCore.StdLib.Data.Integer
+    PlutusCore.StdLib.Data.List
+    PlutusCore.StdLib.Data.Nat
+    PlutusCore.StdLib.Data.Pair
+    PlutusCore.StdLib.Data.ScottList
+    PlutusCore.StdLib.Data.ScottUnit
+    PlutusCore.StdLib.Data.Sum
+    PlutusCore.StdLib.Data.Unit
+    PlutusCore.StdLib.Everything
+    PlutusCore.StdLib.Meta
+    PlutusCore.StdLib.Meta.Data.Function
+    PlutusCore.StdLib.Meta.Data.Tuple
+    PlutusCore.StdLib.Type
+    PlutusCore.Subst
+    PlutusIR
+    PlutusIR.Analysis.RetainedSize
+    PlutusIR.Compiler
+    PlutusIR.Compiler.Definitions
+    PlutusIR.Compiler.Names
+    PlutusIR.Core
+    PlutusIR.Core.Instance
+    PlutusIR.Core.Instance.Flat
+    PlutusIR.Core.Instance.Pretty
+    PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Plated
+    PlutusIR.Core.Type
+    PlutusIR.Error
+    PlutusIR.Mark
+    PlutusIR.MkPir
+    PlutusIR.Parser
+    PlutusIR.Purity
+    PlutusIR.Subst
+    PlutusIR.Transform.Beta
+    PlutusIR.Transform.DeadCode
+    PlutusIR.Transform.Inline
+    PlutusIR.Transform.LetFloat
+    PlutusIR.Transform.LetMerge
+    PlutusIR.Transform.NonStrict
+    PlutusIR.Transform.RecSplit
+    PlutusIR.Transform.Rename
+    PlutusIR.Transform.Substitute
+    PlutusIR.Transform.ThunkRecursions
+    PlutusIR.Transform.Unwrap
+    PlutusIR.TypeCheck
+    PlutusPrelude
+    Prettyprinter.Custom
+    Universe
+    UntypedPlutusCore
+    UntypedPlutusCore.Check.Scope
+    UntypedPlutusCore.Check.Uniques
+    UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.DeBruijn
+    UntypedPlutusCore.Evaluation.Machine.Cek
+    UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    UntypedPlutusCore.MkUPlc
+    UntypedPlutusCore.Parser
+    UntypedPlutusCore.Rename
 
-        PlutusIR
-        PlutusIR.Analysis.RetainedSize
-        PlutusIR.Compiler
-        PlutusIR.Compiler.Definitions
-        PlutusIR.Compiler.Names
-        PlutusIR.Core
-        PlutusIR.Core.Instance
-        PlutusIR.Core.Instance.Flat
-        PlutusIR.Core.Instance.Pretty
-        PlutusIR.Core.Instance.Scoping
-        PlutusIR.Core.Plated
-        PlutusIR.Core.Type
-        PlutusIR.Error
-        PlutusIR.Mark
-        PlutusIR.MkPir
-        PlutusIR.Parser
-        PlutusIR.Purity
-        PlutusIR.Subst
-        PlutusIR.Transform.Beta
-        PlutusIR.Transform.DeadCode
-        PlutusIR.Transform.Inline
-        PlutusIR.Transform.LetFloat
-        PlutusIR.Transform.LetMerge
-        PlutusIR.Transform.RecSplit
-        PlutusIR.Transform.NonStrict
-        PlutusIR.Transform.Rename
-        PlutusIR.Transform.Substitute
-        PlutusIR.Transform.ThunkRecursions
-        PlutusIR.Transform.Unwrap
-        PlutusIR.TypeCheck
+  hs-source-dirs:
+    plutus-core/src plutus-core/stdlib plutus-core/examples
+    plutus-ir/src untyped-plutus-core/src prelude common
 
-        UntypedPlutusCore
-        UntypedPlutusCore.DeBruijn
-        UntypedPlutusCore.Evaluation.Machine.Cek
-        UntypedPlutusCore.Evaluation.Machine.Cek.Internal
-        UntypedPlutusCore.Parser
-        UntypedPlutusCore.Rename
-        UntypedPlutusCore.MkUPlc
-        UntypedPlutusCore.Check.Scope
-        UntypedPlutusCore.Check.Uniques
-        UntypedPlutusCore.Core
-        UntypedPlutusCore.Core.Type
+  other-modules:
+    Data.Aeson.Flatten
+    Data.Aeson.THReader
+    Data.Functor.Foldable.Monadic
+    GHC.Natural.Extras
+    PlutusCore.Analysis.Definitions
+    PlutusCore.Builtin.HasConstant
+    PlutusCore.Builtin.KnownKind
+    PlutusCore.Builtin.KnownType
+    PlutusCore.Builtin.KnownTypeAst
+    PlutusCore.Builtin.Meaning
+    PlutusCore.Builtin.Polymorphism
+    PlutusCore.Builtin.Runtime
+    PlutusCore.Builtin.TestKnown
+    PlutusCore.Builtin.TypeScheme
+    PlutusCore.Core.Instance
+    PlutusCore.Core.Instance.Eq
+    PlutusCore.Core.Instance.Pretty
+    PlutusCore.Core.Instance.Pretty.Classic
+    PlutusCore.Core.Instance.Pretty.Common
+    PlutusCore.Core.Instance.Pretty.Default
+    PlutusCore.Core.Instance.Pretty.Plc
+    PlutusCore.Core.Instance.Pretty.Readable
+    PlutusCore.Core.Instance.Recursive
+    PlutusCore.Core.Instance.Scoping
+    PlutusCore.Core.Plated
+    PlutusCore.Core.Type
+    PlutusCore.DeBruijn.Internal
+    PlutusCore.Default.Builtins
+    PlutusCore.Default.Universe
+    PlutusCore.Eq
+    PlutusCore.InlineUtils
+    PlutusCore.Parser.ParserCommon
+    PlutusCore.Pretty.Classic
+    PlutusCore.Pretty.ConfigName
+    PlutusCore.Pretty.Default
+    PlutusCore.Pretty.Plc
+    PlutusCore.Pretty.PrettyConst
+    PlutusCore.Pretty.Readable
+    PlutusCore.Pretty.Utils
+    PlutusCore.Size
+    PlutusCore.TypeCheck
+    PlutusCore.TypeCheck.Internal
+    PlutusIR.Analysis.Dependencies
+    PlutusIR.Analysis.Size
+    PlutusIR.Analysis.Usages
+    PlutusIR.Compiler.Datatype
+    PlutusIR.Compiler.Error
+    PlutusIR.Compiler.Let
+    PlutusIR.Compiler.Lower
+    PlutusIR.Compiler.Provenance
+    PlutusIR.Compiler.Recursion
+    PlutusIR.Compiler.Types
+    PlutusIR.Normalize
+    PlutusIR.TypeCheck.Internal
+    Universe.Core
+    UntypedPlutusCore.Analysis.Definitions
+    UntypedPlutusCore.Analysis.Usages
+    UntypedPlutusCore.Core.Instance
+    UntypedPlutusCore.Core.Instance.Eq
+    UntypedPlutusCore.Core.Instance.Flat
+    UntypedPlutusCore.Core.Instance.Pretty
+    UntypedPlutusCore.Core.Instance.Pretty.Classic
+    UntypedPlutusCore.Core.Instance.Pretty.Default
+    UntypedPlutusCore.Core.Instance.Pretty.Plc
+    UntypedPlutusCore.Core.Instance.Pretty.Readable
+    UntypedPlutusCore.Core.Instance.Recursive
+    UntypedPlutusCore.Core.Plated
+    UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+    UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+    UntypedPlutusCore.Mark
+    UntypedPlutusCore.Rename.Internal
+    UntypedPlutusCore.Simplify
+    UntypedPlutusCore.Size
+    UntypedPlutusCore.Subst
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
 
-        Crypto
-        Data.ByteString.Hash
-        Data.SatInt
-        Prettyprinter.Custom
-        ErrorCode
-        PlutusPrelude
-        Universe
-    hs-source-dirs:
-        plutus-core/src
-        plutus-core/stdlib
-        plutus-core/examples
-        plutus-ir/src
-        untyped-plutus-core/src
-        prelude
-        common
-    other-modules:
-        PlutusCore.Analysis.Definitions
-        PlutusCore.Builtin.HasConstant
-        PlutusCore.Builtin.KnownKind
-        PlutusCore.Builtin.KnownType
-        PlutusCore.Builtin.KnownTypeAst
-        PlutusCore.Builtin.Meaning
-        PlutusCore.Builtin.Polymorphism
-        PlutusCore.Builtin.Runtime
-        PlutusCore.Builtin.TestKnown
-        PlutusCore.Builtin.TypeScheme
-        PlutusCore.Core.Instance
-        PlutusCore.Core.Instance.Eq
-        PlutusCore.Core.Instance.Pretty
-        PlutusCore.Core.Instance.Pretty.Classic
-        PlutusCore.Core.Instance.Pretty.Common
-        PlutusCore.Core.Instance.Pretty.Default
-        PlutusCore.Core.Instance.Pretty.Plc
-        PlutusCore.Core.Instance.Pretty.Readable
-        PlutusCore.Core.Instance.Recursive
-        PlutusCore.Core.Instance.Scoping
-        PlutusCore.Core.Plated
-        PlutusCore.Core.Type
-        PlutusCore.DeBruijn.Internal
-        PlutusCore.Default.Builtins
-        PlutusCore.Default.Universe
-        PlutusCore.Eq
-        PlutusCore.Evaluation.Machine.ExBudgetingDefaults
-        PlutusCore.InlineUtils
-        PlutusCore.Parser.ParserCommon
-        PlutusCore.Pretty.Classic
-        PlutusCore.Pretty.ConfigName
-        PlutusCore.Pretty.ConfigName
-        PlutusCore.Pretty.Default
-        PlutusCore.Pretty.Plc
-        PlutusCore.Pretty.PrettyConst
-        PlutusCore.Pretty.Readable
-        PlutusCore.Pretty.Utils
-        PlutusCore.Size
-        PlutusCore.TypeCheck
-        PlutusCore.TypeCheck.Internal
-
-        PlutusIR.Analysis.Dependencies
-        PlutusIR.Analysis.Size
-        PlutusIR.Analysis.Usages
-        PlutusIR.Compiler.Datatype
-        PlutusIR.Compiler.Error
-        PlutusIR.Compiler.Let
-        PlutusIR.Compiler.Lower
-        PlutusIR.Compiler.Provenance
-        PlutusIR.Compiler.Recursion
-        PlutusIR.Compiler.Types
-        PlutusIR.Normalize
-        PlutusIR.TypeCheck.Internal
-
-        UntypedPlutusCore.Analysis.Definitions
-        UntypedPlutusCore.Analysis.Usages
-        UntypedPlutusCore.Core.Instance
-        UntypedPlutusCore.Core.Instance.Eq
-        UntypedPlutusCore.Core.Instance.Flat
-        UntypedPlutusCore.Core.Instance.Pretty
-        UntypedPlutusCore.Core.Instance.Pretty.Classic
-        UntypedPlutusCore.Core.Instance.Pretty.Default
-        UntypedPlutusCore.Core.Instance.Pretty.Plc
-        UntypedPlutusCore.Core.Instance.Pretty.Readable
-        UntypedPlutusCore.Core.Instance.Recursive
-        UntypedPlutusCore.Core.Plated
-        UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
-        UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
-        UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
-        UntypedPlutusCore.Mark
-        UntypedPlutusCore.Rename.Internal
-        UntypedPlutusCore.Simplify
-        UntypedPlutusCore.Size
-        UntypedPlutusCore.Subst
-        UntypedPlutusCore.Transform.ForceDelay
-        UntypedPlutusCore.Transform.Inline
-
-        Data.Aeson.Flatten
-        Data.Aeson.THReader
-        Data.Functor.Foldable.Monadic
-        Universe.Core
-        GHC.Natural.Extras
-    build-depends:
-        aeson -any,
-        algebraic-graphs >= 0.3,
-        array -any,
-        barbies -any,
-        base >=4.9 && <5,
-        bimap -any,
-        bytestring -any,
-        cardano-crypto,
-        cassava -any,
-        cborg -any,
-        composition-prelude >=1.1.0.1,
-        containers -any,
-        cryptonite -any,
-        data-default-class -any,
-        deepseq -any,
-        dependent-sum-template -any,
-        deriving-aeson >= 0.2.3,
-        deriving-compat -any,
-        dlist -any,
-        dom-lt -any,
-        exceptions -any,
-        extra -any,
-        filepath -any,
-        flat -any,
-        ghc-prim -any,
-        hashable,
-        hedgehog >=1.0,
-        int-cast -any,
-        integer-gmp -any,
-        lens -any,
-        megaparsec -any,
-        mmorph -any,
-        monoidal-containers,
-        mtl -any,
-        parser-combinators >= 0.4.0,
-        prettyprinter >=1.1.0.1,
-        prettyprinter-configurable -any,
-        primitive -any,
-        recursion-schemes -any,
-        secp256k1-haskell -any,
-        semigroupoids -any,
-        semigroups >=0.19.1,
-        serialise -any,
-        some < 1.0.3,
-        template-haskell -any,
-        th-compat -any,
-        text -any,
-        th-lift -any,
-        th-lift-instances -any,
-        th-utilities -any,
-        time -any,
-        transformers -any,
-        unordered-containers -any,
-        witherable -any,
-        word-array -any,
-        cardano-crypto-class -any,
-        index-envs
+  build-depends:
+    , aeson
+    , algebraic-graphs            >=0.3
+    , array
+    , barbies
+    , base                        >=4.9     && <5
+    , bimap
+    , bytestring
+    , cardano-crypto
+    , cardano-crypto-class
+    , cassava
+    , cborg
+    , composition-prelude         >=1.1.0.1
+    , containers
+    , cryptonite
+    , data-default-class
+    , deepseq
+    , dependent-sum-template
+    , deriving-aeson              >=0.2.3
+    , deriving-compat
+    , dlist
+    , dom-lt
+    , exceptions
+    , extra
+    , filepath
+    , flat
+    , ghc-prim
+    , hashable
+    , hedgehog                    >=1.0
+    , index-envs
+    , int-cast
+    , integer-gmp
+    , lens
+    , megaparsec
+    , mmorph
+    , monoidal-containers
+    , mtl
+    , nothunks
+    , parser-combinators          >=0.4.0
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , primitive
+    , recursion-schemes
+    , secp256k1-haskell
+    , semigroupoids
+    , semigroups                  >=0.19.1
+    , serialise
+    , some                        <1.0.3
+    , template-haskell
+    , text
+    , th-compat
+    , th-lift
+    , th-lift-instances
+    , th-utilities
+    , time
+    , transformers
+    , unordered-containers
+    , witherable
+    , word-array
 
 -- could split this up if we split up the main library for UPLC/PLC/PIR
 library plutus-core-testlib
-    import: lang
-    visibility: public
-    hs-source-dirs: testlib
-    exposed-modules:
-        PlutusCore.Test
-        PlutusCore.Generators
-        PlutusCore.Generators.AST
-        PlutusCore.Generators.Interesting
-        PlutusCore.Generators.NEAT.Common
-        PlutusCore.Generators.NEAT.Spec
-        PlutusCore.Generators.NEAT.Term
-        PlutusCore.Generators.NEAT.Type
-        PlutusCore.Generators.Test
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  testlib
+  exposed-modules:
+    PlutusCore.Generators
+    PlutusCore.Generators.AST
+    PlutusCore.Generators.Interesting
+    PlutusCore.Generators.NEAT.Common
+    PlutusCore.Generators.NEAT.Spec
+    PlutusCore.Generators.NEAT.Term
+    PlutusCore.Generators.NEAT.Type
+    PlutusCore.Generators.Test
+    PlutusCore.Test
+    PlutusIR.Generators.AST
+    PlutusIR.Test
+    Test.Tasty.Extras
 
-        PlutusIR.Test
-        PlutusIR.Generators.AST
+  other-modules:
+    PlutusCore.Generators.Internal.Denotation
+    PlutusCore.Generators.Internal.Dependent
+    PlutusCore.Generators.Internal.Entity
+    PlutusCore.Generators.Internal.TypedBuiltinGen
+    PlutusCore.Generators.Internal.TypeEvalCheck
+    PlutusCore.Generators.Internal.Utils
 
-        Test.Tasty.Extras
-    other-modules:
-        PlutusCore.Generators.Internal.Denotation
-        PlutusCore.Generators.Internal.Dependent
-        PlutusCore.Generators.Internal.Entity
-        PlutusCore.Generators.Internal.TypeEvalCheck
-        PlutusCore.Generators.Internal.TypedBuiltinGen
-        PlutusCore.Generators.Internal.Utils
-    build-depends:
-        base >=4.9 && <5,
-        bifunctors -any,
-        bytestring -any,
-        containers -any,
-        dependent-map >=0.4.0.0,
-        filepath -any,
-        ghc-prim -any,
-        hedgehog >=1.0,
-        integer-gmp -any,
-        lazy-search -any,
-        lens -any,
-        megaparsec -any,
-        mmorph -any,
-        mtl -any,
-        plutus-core -any,
-        prettyprinter >=1.1.0.1,
-        prettyprinter-configurable -any,
-        size-based -any,
-        some < 1.0.3,
-        Stream -any,
-        tasty -any,
-        tasty-golden -any,
-        tasty-hedgehog -any,
-        tasty-hunit -any,
-        text -any,
-        transformers -any
+  build-depends:
+    , base                        >=4.9     && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , dependent-map               >=0.4.0.0
+    , filepath
+    , ghc-prim
+    , hedgehog                    >=1.0
+    , integer-gmp
+    , lazy-search
+    , lens
+    , megaparsec
+    , mmorph
+    , mtl
+    , plutus-core
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , size-based
+    , some                        <1.0.3
+    , Stream
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+    , transformers
 
 test-suite satint-test
-  import: lang
-  type:              exitcode-stdio-1.0
-  main-is:           TestSatInt.hs
-  ghc-options:       -Wall
-  build-depends:     base >=4.9 && <5,
-                     test-framework,
-                     test-framework-hunit,
-                     test-framework-quickcheck2,
-                     HUnit,
-                     QuickCheck,
-                     plutus-core
-  default-language:  Haskell2010
-  hs-source-dirs:    plutus-core/satint-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestSatInt.hs
+  ghc-options:      -Wall
+  build-depends:
+    , base                        >=4.9 && <5
+    , HUnit
+    , plutus-core
+    , QuickCheck
+    , test-framework
+    , test-framework-hunit
+    , test-framework-quickcheck2
+
+  default-language: Haskell2010
+  hs-source-dirs:   plutus-core/satint-test
 
 test-suite plutus-core-test
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: Spec.hs
-    hs-source-dirs: plutus-core/test
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N
-    other-modules:
-        Check.Spec
-        CostModelInterface.Spec
-        Evaluation.Machines
-        Evaluation.Spec
-        Names.Spec
-        Normalization.Check
-        Normalization.Type
-        Pretty.Readable
-        TypeSynthesis.Spec
-    default-language: Haskell2010
-    build-depends:
-        base -any,
-        bytestring -any,
-        containers -any,
-        filepath -any,
-        flat -any,
-        hedgehog -any,
-        plutus-core -any,
-        plutus-core-testlib -any,
-        mmorph -any,
-        mtl -any,
-        prettyprinter -any,
-        tasty -any,
-        tasty-golden -any,
-        tasty-hedgehog -any,
-        tasty-hunit -any,
-        text -any,
-        transformers -any,
-        aeson -any,
-        template-haskell -any,
-        th-lift-instances -any,
-        th-utilities -any,
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   plutus-core/test
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    Check.Spec
+    CostModelInterface.Spec
+    Evaluation.Machines
+    Evaluation.Spec
+    Names.Spec
+    Normalization.Check
+    Normalization.Type
+    Pretty.Readable
+    TypeSynthesis.Spec
+
+  default-language: Haskell2010
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , containers
+    , filepath
+    , flat
+    , hedgehog
+    , mmorph
+    , mtl
+    , plutus-core
+    , plutus-core-testlib
+    , prettyprinter
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , template-haskell
+    , text
+    , th-lift-instances
+    , th-utilities
+    , transformers
 
 test-suite plutus-ir-test
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: Spec.hs
-    hs-source-dirs: plutus-ir/test
-    other-modules:
-        NamesSpec
-        ParserSpec
-        TransformSpec
-        TypeSpec
-    build-depends:
-        base >=4.9 && <5,
-        plutus-core -any,
-        plutus-core-testlib -any,
-        flat -any,
-        hedgehog -any,
-        megaparsec -any,
-        tasty -any,
-        tasty-hedgehog -any,
-        text -any
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: plutus-ir/test
+  other-modules:
+    NamesSpec
+    ParserSpec
+    TransformSpec
+    TypeSpec
+
+  build-depends:
+    , base                 >=4.9 && <5
+    , flat
+    , hedgehog
+    , megaparsec
+    , plutus-core
+    , plutus-core-testlib
+    , tasty
+    , tasty-hedgehog
+    , text
 
 test-suite untyped-plutus-core-test
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: Spec.hs
-    hs-source-dirs: untyped-plutus-core/test
-    ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-N
-    other-modules:
-        Evaluation.Builtins
-        Evaluation.Builtins.Coherence
-        Evaluation.Builtins.Common
-        Evaluation.Builtins.Definition
-        Evaluation.Builtins.MakeRead
-        Evaluation.Builtins.SECP256k1
-        Evaluation.FreeVars
-        Evaluation.Golden
-        Evaluation.Machines
-        Transform.Simplify
-        DeBruijn.Common
-        DeBruijn.Scope
-        DeBruijn.Spec
-        DeBruijn.UnDeBruijnify
-    build-depends:
-        base >=4.9 && <5,
-        bytestring -any,
-        cardano-crypto-class -any,
-        hedgehog -any,
-        lens -any,
-        mtl -any,
-        plutus-core -any,
-        plutus-core-testlib -any,
-        index-envs -any,
-        prettyprinter -any,
-        pretty-show -any,
-        secp256k1-haskell -any,
-        tasty -any,
-        tasty-golden -any,
-        tasty-hedgehog -any,
-        tasty-hunit -any,
-        text -any
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: untyped-plutus-core/test
+  ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    DeBruijn.Common
+    DeBruijn.Scope
+    DeBruijn.Spec
+    DeBruijn.UnDeBruijnify
+    Evaluation.Builtins
+    Evaluation.Builtins.Coherence
+    Evaluation.Builtins.Common
+    Evaluation.Builtins.Definition
+    Evaluation.Builtins.MakeRead
+    Evaluation.Builtins.SECP256k1
+    Evaluation.FreeVars
+    Evaluation.Golden
+    Evaluation.Machines
+    Transform.Simplify
+
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cardano-crypto-class
+    , hedgehog
+    , index-envs
+    , lens
+    , mtl
+    , plutus-core
+    , plutus-core-testlib
+    , pretty-show
+    , prettyprinter
+    , secp256k1-haskell
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
 
 executable plc
-    import: lang
-    main-is: plc/Main.hs
-    hs-source-dirs: executables
-    other-modules:
-        Common
-        Parsers
-    build-depends:
-        plutus-core -any,
-        plutus-core-testlib -any,
-        aeson -any,
-        base <5,
-        bytestring -any,
-        deepseq -any,
-        flat -any,
-        monoidal-containers -any,
-        mtl -any,
-        optparse-applicative -any,
-        prettyprinter -any,
-        text -any,
-        transformers -any,
-        lens -any,
-        megaparsec -any
+  import:         lang
+  main-is:        plc/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  <5
+    , bytestring
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core
+    , plutus-core-testlib
+    , prettyprinter
+    , text
+    , transformers
 
 executable uplc
-    import: lang
-    main-is: uplc/Main.hs
-    hs-source-dirs: executables
-    other-modules:
-        Common
-        Parsers
-    build-depends:
-        plutus-core -any,
-        plutus-core-testlib -any,
-        aeson -any,
-        base <5,
-        bytestring -any,
-        deepseq -any,
-        flat -any,
-        monoidal-containers -any,
-        mtl -any,
-        optparse-applicative -any,
-        prettyprinter -any,
-        split -any,
-        text -any,
-        transformers -any,
-        lens -any,
-        megaparsec -any
+  import:         lang
+  main-is:        uplc/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  <5
+    , bytestring
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core
+    , plutus-core-testlib
+    , prettyprinter
+    , split
+    , text
+    , transformers
 
 executable pir
-    import: lang
-    main-is: pir/Main.hs
-    hs-source-dirs: executables
-    other-modules:
-        Common
-        Parsers
-    build-depends:
-        plutus-core -any,
-        plutus-core-testlib -any,
-        aeson -any,
-        base <5,
-        bytestring -any,
-        flat -any,
-        lens -any,
-        deepseq -any,
-        monoidal-containers -any,
-        optparse-applicative -any,
-        mtl -any,
-        transformers -any,
-        bytestring -any,
-        containers -any,
-        prettyprinter -any,
-        cassava -any,
-        text -any,
-        megaparsec -any
+  import:         lang
+  main-is:        pir/Main.hs
+  hs-source-dirs: executables
+  other-modules:
+    Common
+    Parsers
+
+  build-depends:
+    , aeson
+    , base                  <5
+    , bytestring
+    , cassava
+    , containers
+    , deepseq
+    , flat
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core
+    , plutus-core-testlib
+    , prettyprinter
+    , text
+    , transformers
 
 executable traceToStacks
-    import: lang
-    main-is: Main.hs
-    hs-source-dirs: executables/traceToStacks
-    other-modules:
-        Common
-    build-depends:
-        base >=4.9 && <5,
-        cassava -any,
-        integer-gmp -any,
-        bytestring -any,
-        optparse-applicative -any,
-        text -any,
-        vector -any,
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: executables/traceToStacks
+  other-modules:  Common
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , integer-gmp
+    , optparse-applicative
+    , text
+    , vector
 
 -- Tests for functions called by @traceToStacks@.
 test-suite traceToStacks-test
-    import: lang
-    type: exitcode-stdio-1.0
-    hs-source-dirs: executables/traceToStacks
-    default-language: Haskell2010
-    main-is: TestGetStacks.hs
-    other-modules:
-        Common
-    build-depends:
-        base -any,
-        bytestring -any,
-        cassava -any,
-        tasty -any,
-        tasty-hunit -any,
-        text -any,
-        vector -any,
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   executables/traceToStacks
+  default-language: Haskell2010
+  main-is:          TestGetStacks.hs
+  other-modules:    Common
+  build-depends:
+    , base
+    , bytestring
+    , cassava
+    , tasty
+    , tasty-hunit
+    , text
+    , vector
 
 -- This runs the microbenchmarks used to generate the cost models for built-in functions,
 -- saving the results in cost-model/data/benching.csv.  It will take several hours.
 benchmark cost-model-budgeting-bench
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: Main.hs
-    other-modules:
-        Common
-        CriterionExtensions
-        Generators
-        Benchmarks.Bool
-        Benchmarks.ByteStrings
-        Benchmarks.CryptoAndHashes
-        Benchmarks.Data
-        Benchmarks.Integers
-        Benchmarks.Lists
-        Benchmarks.Misc
-        Benchmarks.Nops
-        Benchmarks.Pairs
-        Benchmarks.Strings
-        Benchmarks.Tracing
-        Benchmarks.Unit
-    hs-source-dirs: cost-model/budgeting-bench
-    default-language: Haskell2010
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
-                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
-    build-depends:
-        plutus-core -any,
-        base -any,
-        bytestring -any,
-        criterion -any,
-        criterion-measurement -any,
-        deepseq -any,
-        directory -any,
-        hedgehog -any,
-        mtl -any,
-        optparse-applicative -any,
-        QuickCheck -any,
-        quickcheck-instances -any,
-        random -any,
-        text -any,
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          Main.hs
+  other-modules:
+    Benchmarks.Bool
+    Benchmarks.ByteStrings
+    Benchmarks.CryptoAndHashes
+    Benchmarks.Data
+    Benchmarks.Integers
+    Benchmarks.Lists
+    Benchmarks.Misc
+    Benchmarks.Nops
+    Benchmarks.Pairs
+    Benchmarks.Strings
+    Benchmarks.Tracing
+    Benchmarks.Unit
+    Common
+    CriterionExtensions
+    Generators
 
+  hs-source-dirs:   cost-model/budgeting-bench
+  default-language: Haskell2010
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+  build-depends:
+    , base
+    , bytestring
+    , criterion
+    , criterion-measurement
+    , deepseq
+    , directory
+    , hedgehog
+    , mtl
+    , optparse-applicative
+    , plutus-core
+    , QuickCheck
+    , quickcheck-instances
+    , random
+    , text
 
 -- This reads the CSV data generated by cost-model-budgeting-bench, builds the models
 -- using R, and saces them in cost-model/data/costModel.json
 -- Benchmark sets the correct PWD and doesn't get run by `stack test`
 benchmark update-cost-model
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: UpdateCostModel.hs
-    -- cost-model-creation should be its own library, but stack + HIE really don't like sub-libraries.
-    hs-source-dirs: cost-model/create-cost-model
-    default-language: Haskell2010
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
-                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
-    build-depends:
-        plutus-core -any,
-        aeson-pretty -any,
-        barbies -any,
-        base -any,
-        bytestring -any,
-        cassava -any,
-        exceptions -any,
-        extra -any,
-        inline-r -any,
-        text -any,
-        vector -any
-    other-modules:
-        CostModelCreation
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          UpdateCostModel.hs
+
+  -- cost-model-creation should be its own library, but stack + HIE really don't like sub-libraries.
+  hs-source-dirs:   cost-model/create-cost-model
+  default-language: Haskell2010
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+  build-depends:
+    , aeson-pretty
+    , barbies
+    , base
+    , bytestring
+    , cassava
+    , exceptions
+    , extra
+    , inline-r
+    , plutus-core
+    , text
+    , vector
+
+  other-modules:    CostModelCreation
 
 -- The cost models for builtins are generated using R and converted into a JSON
 -- form that can later be used to construct Haskell functions.  This tests that
@@ -663,67 +675,70 @@ benchmark update-cost-model
 -- (unlike `cabal run` for exectuables, which sets the working directory to the
 -- current shell directory).
 benchmark cost-model-test
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: TestCostModels.hs
-    other-modules: TH
-    hs-source-dirs: cost-model/test, cost-model/create-cost-model
-    default-language: Haskell2010
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
-                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
-    build-depends:
-        base -any,
-        plutus-core -any,
-        barbies -any,
-        bytestring -any,
-        cassava -any,
-        exceptions -any,
-        extra -any,
-        hedgehog -any,
-        inline-r -any,
-        mmorph -any,
-        template-haskell -any,
-        text -any,
-        vector -any
-    other-modules:
-        CostModelCreation
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestCostModels.hs
+  other-modules:    TH
+  hs-source-dirs:   cost-model/test cost-model/create-cost-model
+  default-language: Haskell2010
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N -Wall -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+
+  build-depends:
+    , barbies
+    , base
+    , bytestring
+    , cassava
+    , exceptions
+    , extra
+    , hedgehog
+    , inline-r
+    , mmorph
+    , plutus-core
+    , template-haskell
+    , text
+    , vector
+
+  other-modules:    CostModelCreation
 
 library index-envs
-    import: lang
-    hs-source-dirs: index-envs/src
-    default-language: Haskell2010
-    exposed-modules:
-      Data.DeBruijnEnv
-      Data.RandomAccessList.SkewBinary
-    build-depends:
-        base -any,
-        containers -any,
-        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
-        ral == 0.1
+  import:           lang
+  hs-source-dirs:   index-envs/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.DeBruijnEnv
+    Data.RandomAccessList.SkewBinary
 
+  build-depends:
+    , base
+    , containers
+    , ral         ==0.1
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
 benchmark index-envs-bench
-    import: lang
-    type: exitcode-stdio-1.0
-    hs-source-dirs: index-envs/bench
-    default-language: Haskell2010
-    main-is: Main.hs
-    build-depends:
-        base -any,
-        index-envs -any,
-        criterion >= 1.5.9.0,
-        random >= 1.2.0,
-        -- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
-        ral == 0.1
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/bench
+  default-language: Haskell2010
+  main-is:          Main.hs
+  build-depends:
+    , base
+    , criterion   >=1.5.9.0
+    , index-envs
+    , ral         ==0.1
+    , random      >=1.2.0
 
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
 test-suite index-envs-test
-    import: lang
-    type: exitcode-stdio-1.0
-    hs-source-dirs: index-envs/test
-    default-language: Haskell2010
-    main-is: TestRAList.hs
-    build-depends:
-        base -any,
-        index-envs -any,
-        tasty -any,
-        tasty-hunit -any,
-        tasty-quickcheck -any
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/test
+  default-language: Haskell2010
+  main-is:          TestRAList.hs
+  build-depends:
+    , base
+    , index-envs
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck

--- a/plutus-core/plutus-core/src/Data/SatInt.hs
+++ b/plutus-core/plutus-core/src/Data/SatInt.hs
@@ -6,6 +6,7 @@ This is not quite as fast as using 'Int' or 'Int64' directly, but we need the sa
 {-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MagicHash          #-}
 {-# LANGUAGE UnboxedTuples      #-}
@@ -24,12 +25,14 @@ import GHC.Integer (smallInteger)
 import GHC.Num
 import GHC.Real
 import Language.Haskell.TH.Syntax (Lift)
+import NoThunks.Class
 
 newtype SatInt = SI { unSatInt :: Int }
     deriving newtype (NFData, Bits, FiniteBits, Prim)
     deriving stock (Lift, Generic)
     deriving (FromJSON, ToJSON) via Int
     deriving FromField via Int  -- For reading cost model data from CSV input
+    deriving anyclass NoThunks
 
 instance Show SatInt where
   showsPrec p x = showsPrec p (unSatInt x)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -260,5 +260,7 @@ toBuiltinsRuntime
     :: (cost ~ CostingPart uni fun, HasConstantIn uni val, ToBuiltinMeaning uni fun)
     => UnliftingMode -> cost -> BuiltinsRuntime fun val
 toBuiltinsRuntime unlMode cost =
-    BuiltinsRuntime . tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
+    let arr = tabulateArray $ toBuiltinRuntime unlMode cost . inline toBuiltinMeaning
+     in -- Force array elements to WHNF
+        foldr seq (BuiltinsRuntime arr) arr
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Runtime.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE LambdaCase               #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# LANGUAGE TypeOperators            #-}
@@ -10,6 +11,7 @@ module PlutusCore.Builtin.Runtime where
 
 import PlutusPrelude
 
+import PlutusCore.Builtin.KnownType
 import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusCore.Evaluation.Machine.Exception
@@ -19,7 +21,7 @@ import Control.Lens (ix, (^?))
 import Control.Monad.Except
 import Data.Array
 import Data.Kind qualified as GHC (Type)
-import PlutusCore.Builtin.KnownType
+import NoThunks.Class as NoThunks
 
 -- | Peano numbers. Normally called @Nat@, but that is already reserved by @base@.
 data Peano
@@ -42,6 +44,13 @@ instance NFData (RuntimeScheme n) where
         RuntimeSchemeResult    -> rwhnf r
         RuntimeSchemeArrow arg -> rnf arg
         RuntimeSchemeAll arg   -> rnf arg
+
+instance NoThunks (RuntimeScheme n) where
+    wNoThunks ctx = \case
+        RuntimeSchemeResult  -> pure Nothing
+        RuntimeSchemeArrow s -> noThunks ctx s
+        RuntimeSchemeAll s   -> noThunks ctx s
+    showTypeOf = const "PlutusCore.Builtin.Runtime.RuntimeScheme"
 
 -- | Compute the runtime denotation type of a builtin given the type of values and the number of
 -- arguments that the builtin takes. A \"runtime denotation type\" is different from a regular
@@ -89,6 +98,32 @@ data BuiltinRuntime val =
                                           -- out what it's going to cost.
         (ToCostingType n)
 
+instance NoThunks (BuiltinRuntime val) where
+    -- Skipping `_denot` in `allNoThunks` check, since it is supposed to be lazy and
+    -- is allowed to contain thunks.
+    wNoThunks ctx (BuiltinRuntime sch _denot costing) =
+        allNoThunks
+            [ -- The order here is important: we must first check that `sch` doesn't have
+              -- thunks, before inspecting it in `noThunksInCosting`.
+              noThunks ctx sch
+            , noThunksInCosting ctx costing sch
+            ]
+
+    showTypeOf = const "PlutusCore.Builtin.Runtime.BuiltinRuntime"
+
+-- | Check whether the given `ToCostingType n` contains thunks. The `RuntimeScheme n` is used to
+-- refine `n`.
+noThunksInCosting :: NoThunks.Context -> ToCostingType n -> RuntimeScheme n -> IO (Maybe ThunkInfo)
+noThunksInCosting ctx costing = \case
+    -- @n ~ 'Z@, and @ToCostingType n ~ ExBudget@, which should not be a thunk or contain
+    -- nested thunks.
+    RuntimeSchemeResult ->
+        noThunks ctx costing
+    RuntimeSchemeArrow _ ->
+        noThunks ctx costing
+    RuntimeSchemeAll sch ->
+        noThunksInCosting ctx costing sch
+
 -- | Determines how to unlift arguments. The difference is that with 'UnliftingImmediate' unlifting
 -- is performed immediately after a builtin gets the argument and so can fail immediately too, while
 -- with deferred unlifting all arguments are unlifted upon full saturation, hence no failure can
@@ -129,6 +164,10 @@ newtype BuiltinsRuntime fun val = BuiltinsRuntime
     }
 
 deriving newtype instance (NFData fun) => NFData (BuiltinsRuntime fun val)
+
+instance NoThunks (BuiltinsRuntime fun val) where
+    wNoThunks ctx (BuiltinsRuntime arr) = allNoThunks (noThunks ctx <$> elems arr)
+    showTypeOf = const "PlutusCore.Builtin.Runtime.BuiltinsRuntime"
 
 -- | Look up the runtime info of a built-in function during evaluation.
 lookupBuiltin

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -145,13 +145,14 @@ module PlutusCore.Evaluation.Machine.ExBudget
     )
 where
 
+import PlutusCore.Evaluation.Machine.ExMemory
 import PlutusPrelude hiding (toList)
 
 import Data.Char (toLower)
 import Data.Semigroup
 import Deriving.Aeson
 import Language.Haskell.TH.Lift (Lift)
-import PlutusCore.Evaluation.Machine.ExMemory
+import NoThunks.Class
 import Prettyprinter
 
 
@@ -175,7 +176,7 @@ instance ExBudgetBuiltin fun () where
 
 data ExBudget = ExBudget { exBudgetCPU :: ExCPU, exBudgetMemory :: ExMemory }
     deriving stock (Eq, Show, Generic, Lift)
-    deriving anyclass (PrettyBy config, NFData)
+    deriving anyclass (PrettyBy config, NFData, NoThunks)
     deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier LowerIntialCharacter] ExBudget
     -- LowerIntialCharacter won't actually do anything here, but let's have it in case we change the field names.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -31,6 +32,7 @@ import GHC.Integer
 import GHC.Integer.Logarithms
 import GHC.Prim
 import Language.Haskell.TH.Syntax (Lift)
+import NoThunks.Class
 import Universe
 
 {-
@@ -104,6 +106,7 @@ newtype ExMemory = ExMemory CostingInteger
   deriving newtype (Num, NFData)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
+  deriving anyclass NoThunks
 instance Pretty ExMemory where
     pretty (ExMemory i) = pretty (toInteger i)
 instance PrettyBy config ExMemory where
@@ -116,6 +119,7 @@ newtype ExCPU = ExCPU CostingInteger
   deriving newtype (Num, NFData)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
+  deriving anyclass NoThunks
 instance Pretty ExCPU where
     pretty (ExCPU i) = pretty (toInteger i)
 instance PrettyBy config ExCPU where

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -16,6 +16,7 @@ import Control.Lens
 import GHC.Exts (inline)
 import GHC.Generics
 import GHC.Types (Type)
+import NoThunks.Class
 
 {-| We need to account for the costs of evaluator steps and also built-in function
    evaluation.  The models for these have different structures and are used in
@@ -43,7 +44,7 @@ data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
     , builtinsRuntime :: BuiltinsRuntime fun (term uni fun)
     }
     deriving stock Generic
-    deriving anyclass NFData
+    deriving anyclass (NFData, NoThunks)
 
 -- See Note [Inlining meanings of builtins].
 {-| This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime. -}

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/CekMachineCosts.hs
@@ -16,6 +16,7 @@ import Control.DeepSeq
 import Data.Text qualified as Text
 import Deriving.Aeson
 import Language.Haskell.TH.Syntax (Lift)
+import NoThunks.Class
 
 -- | The prefix of the field names in the CekMachineCosts type, used for
 -- extracting the CekMachineCosts component of the ledger's cost model
@@ -40,7 +41,7 @@ data CekMachineCosts =
     -- happen if calling 'Error' caused the budget to be exceeded?
     }
     deriving stock (Eq, Show, Generic, Lift)
-    deriving anyclass NFData
+    deriving anyclass (NFData, NoThunks)
     deriving (FromJSON, ToJSON) via CustomJSON '[FieldLabelModifier LowerIntialCharacter] CekMachineCosts
 
 -- Charge a unit CPU cost for AST nodes: this allows us to count the number of

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,106 +1,123 @@
 cabal-version: 3.0
-name: plutus-ledger-api
-version: 1.0.0.0
-license: Apache-2.0
+name:          plutus-ledger-api
+version:       1.0.0.0
+license:       Apache-2.0
 license-files:
   LICENSE
   NOTICE
-maintainer: michael.peyton-jones@iohk.io
-author: Michael Peyton Jones, Jann Mueller
-synopsis: Interface to the Plutus ledger for the Cardano ledger.
+
+maintainer:    michael.peyton-jones@iohk.io
+author:        Michael Peyton Jones, Jann Mueller
+synopsis:      Interface to the Plutus ledger for the Cardano ledger.
 description:
-    Interface to the Plutus scripting support for the Cardano ledger.
-category: Language
-build-type: Simple
+  Interface to the Plutus scripting support for the Cardano ledger.
+
+category:      Language
+build-type:    Simple
 
 source-repository head
-    type: git
-    location: https://github.com/input-output-hk/plutus
+  type:     git
+  location: https://github.com/input-output-hk/plutus
 
 common lang
-    default-language: Haskell2010
-    default-extensions: ExplicitForAll ScopedTypeVariables
-                        DeriveGeneric StandaloneDeriving DeriveLift
-                        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
-                        DeriveTraversable MultiParamTypeClasses FlexibleContexts
-                        ImportQualifiedPost DerivingStrategies
-    ghc-options: -Wall -Wnoncanonical-monad-instances
-                 -Wincomplete-uni-patterns -Wincomplete-record-updates
-                 -Wredundant-constraints -Widentities -Wunused-packages
-                 -Wmissing-deriving-strategies
-                 -- See Plutus Tx readme
-                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    MultiParamTypeClasses
+    ScopedTypeVariables
+    StandaloneDeriving
 
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies -fobject-code
+    -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+
+-- See Plutus Tx readme
 library
-    import: lang
-    hs-source-dirs: src
-    default-language: Haskell2010
-    exposed-modules:
-        Plutus.V1.Ledger.Address
-        Plutus.V1.Ledger.Api
-        Plutus.V1.Ledger.Bytes
-        Plutus.V1.Ledger.Contexts
-        Plutus.V1.Ledger.Credential
-        Plutus.V1.Ledger.Crypto
-        Plutus.V1.Ledger.DCert
-        Plutus.V1.Ledger.Examples
-        Plutus.V1.Ledger.Interval
-        Plutus.V1.Ledger.Scripts
-        Plutus.V1.Ledger.Tx
-        Plutus.V1.Ledger.Time
-        Plutus.V1.Ledger.Value
-        Plutus.V1.Ledger.EvaluationContext
-        Plutus.V1.Ledger.ProtocolVersions
+  import:           lang
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  exposed-modules:
+    Plutus.ApiCommon
+    Plutus.V1.Ledger.Address
+    Plutus.V1.Ledger.Api
+    Plutus.V1.Ledger.Bytes
+    Plutus.V1.Ledger.Contexts
+    Plutus.V1.Ledger.Credential
+    Plutus.V1.Ledger.Crypto
+    Plutus.V1.Ledger.DCert
+    Plutus.V1.Ledger.EvaluationContext
+    Plutus.V1.Ledger.Examples
+    Plutus.V1.Ledger.Interval
+    Plutus.V1.Ledger.ProtocolVersions
+    Plutus.V1.Ledger.Scripts
+    Plutus.V1.Ledger.Time
+    Plutus.V1.Ledger.Tx
+    Plutus.V1.Ledger.Value
+    Plutus.V2.Ledger.Api
+    Plutus.V2.Ledger.Contexts
+    Plutus.V2.Ledger.EvaluationContext
+    Plutus.V2.Ledger.Tx
 
-        Plutus.V2.Ledger.Api
-        Plutus.V2.Ledger.Contexts
-        Plutus.V2.Ledger.Tx
-        Plutus.V2.Ledger.EvaluationContext
+  other-modules:
+    Codec.CBOR.Extras
+    Data.Either.Extras
+    Prettyprinter.Extras
 
-        Plutus.ApiCommon
-    other-modules:
-        Codec.CBOR.Extras
-        Data.Either.Extras
-        Prettyprinter.Extras
-    build-depends:
-        base >=4.9 && <5,
-        bytestring -any,
-        cborg -any,
-        containers -any,
-        flat -any,
-        plutus-core ^>=1.0,
-        mtl -any,
-        plutus-tx ^>=1.0,
-        serialise -any,
-        template-haskell -any,
-        text -any,
-        prettyprinter -any,
-        transformers -any,
-        base16-bytestring >= 1,
-        deepseq -any,
-        tagged -any,
-        lens -any,
-        barbies -any
+  build-depends:
+    , barbies
+    , base               >=4.9 && <5
+    , base16-bytestring  >=1
+    , bytestring
+    , cborg
+    , containers
+    , deepseq
+    , flat
+    , lens
+    , mtl
+    , nothunks
+    , plutus-core        ^>=1.0
+    , plutus-tx          ^>=1.0
+    , prettyprinter
+    , serialise
+    , tagged
+    , template-haskell
+    , text
+    , transformers
 
 test-suite plutus-ledger-api-test
-    import: lang
-    type: exitcode-stdio-1.0
-    main-is: Spec.hs
-    hs-source-dirs: test
-    other-modules:
-        Spec.Interval
-        Spec.Eval
-        Spec.Builtins
-    build-depends:
-        base >=4.9 && <5,
-        mtl -any,
-        containers -any,
-        plutus-core ^>=1.0,
-        plutus-ledger-api ^>=1.0,
-        hedgehog -any,
-        tasty -any,
-        tasty-hedgehog -any,
-        tasty-hunit -any,
-        tasty-quickcheck -any,
-        bytestring -any,
-        serialise -any
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: test
+  other-modules:
+    Spec.Builtins
+    Spec.Eval
+    Spec.Interval
+    Spec.NoThunks
+
+  build-depends:
+    , base               >=4.9 && <5
+    , bytestring
+    , containers
+    , extra
+    , hedgehog
+    , mtl
+    , nothunks
+    , plutus-core        ^>=1.0
+    , plutus-ledger-api  ^>=1.0
+    , serialise
+    , tasty
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck

--- a/plutus-ledger-api/src/Plutus/ApiCommon.hs
+++ b/plutus-ledger-api/src/Plutus/ApiCommon.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
+{-# LANGUAGE StrictData        #-}
+
 -- GHC is asked to do quite a lot of optimization in this module, so we're increasing the amount of
 -- ticks for the simplifier not to run out of them.
 {-# OPTIONS_GHC -fsimpl-tick-factor=200 #-}

--- a/plutus-ledger-api/src/Plutus/ApiCommon.hs
+++ b/plutus-ledger-api/src/Plutus/ApiCommon.hs
@@ -40,6 +40,7 @@ import Data.Text
 import Data.Tuple
 import GHC.Exts (inline)
 import GHC.Generics
+import NoThunks.Class
 import PlutusCore.Pretty
 import PlutusPrelude (through)
 import Prettyprinter
@@ -263,7 +264,7 @@ data EvaluationContext = EvaluationContext
     , machineParametersDeferred  :: DefaultMachineParameters
     }
     deriving stock Generic
-    deriving anyclass NFData
+    deriving anyclass (NFData, NoThunks)
 
 {-|  Build the 'EvaluationContext'.
 

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -14,6 +14,7 @@ import Plutus.V1.Ledger.ProtocolVersions
 import Spec.Builtins qualified
 import Spec.Eval qualified
 import Spec.Interval qualified
+import Spec.NoThunks qualified
 
 main :: IO ()
 main = defaultMain tests
@@ -90,4 +91,5 @@ tests = testGroup "plutus-ledger-api" [
     , Spec.Interval.tests
     , Spec.Eval.tests
     , Spec.Builtins.tests
+    , Spec.NoThunks.tests
     ]

--- a/plutus-ledger-api/test/Spec/NoThunks.hs
+++ b/plutus-ledger-api/test/Spec/NoThunks.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Spec.NoThunks (tests) where
+
+import Plutus.ApiCommon (mkEvaluationContext)
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCostModelParams)
+import PlutusCore.Pretty
+
+import Control.Monad.Extra (whenJust)
+import Data.Maybe (fromJust)
+import NoThunks.Class
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+    testGroup
+        "NoThunks"
+        [ testCase "EvaluationContext V1" evaluationContextV1
+        ]
+
+evaluationContextV1 :: Assertion
+evaluationContextV1 = do
+    !evalCtx <-
+        either (assertFailure . display) pure $
+            mkEvaluationContext (fromJust defaultCostModelParams)
+    failIfThunk =<< noThunks [] evalCtx
+
+failIfThunk :: Show a => Maybe a -> IO ()
+failIfThunk mbThunkInfo =
+    whenJust mbThunkInfo $ \thunkInfo ->
+        assertFailure $ "Unexpected thunk: " <> show thunkInfo


### PR DESCRIPTION
This backports #4740 and #4734.

The cabal files are all re-formatted - I'm not sure why `cabal-fmt` is triggered, since this branch shouldn't have it.