### PR TITLE
Kwxm/plt 585/update verify ed25519 signature return type

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -475,7 +475,7 @@ test-suite untyped-plutus-core-test
     Evaluation.Builtins.Common
     Evaluation.Builtins.Definition
     Evaluation.Builtins.MakeRead
-    Evaluation.Builtins.SECP256k1
+    Evaluation.Builtins.SignatureVerification
     Evaluation.FreeVars
     Evaluation.Golden
     Evaluation.Machines

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1099,7 +1099,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             (runCostingFunOneArgument . paramBlake2b_256)
     toBuiltinMeaning VerifyEd25519Signature =
         makeBuiltinMeaning
-            (verifyEd25519Signature @EvaluationResult)
+            verifyEd25519Signature
             (runCostingFunThreeArguments . paramVerifyEd25519Signature)
     {- Note [ECDSA secp256k1 signature verification].  An ECDSA signature
        consists of a pair of values (r,s), and for each value of r there are in

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -32,7 +32,7 @@ import PlutusCore.StdLib.Data.ScottList qualified as Scott
 import PlutusCore.StdLib.Data.Unit
 
 import Evaluation.Builtins.Common
-import Evaluation.Builtins.SECP256k1 (ecdsaSecp256k1Prop, schnorrSecp256k1Prop)
+import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519Prop, schnorrSecp256k1Prop)
 
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
@@ -577,14 +577,19 @@ fails b args =
         typecheckEvaluateCekNoEmit defaultCekParameters actualExp
 
 -- Test that the SECP256k1 builtins are behaving correctly
-testSECP256k1 :: TestTree
-testSECP256k1 =
+-- Test that the SECP256k1 builtins are behaving correctly
+test_SignatureVerification :: TestTree
+test_SignatureVerification =
   adjustOption (\x -> max x . HedgehogTestLimit . Just $ 8000) .
-  testGroup "Signatures on the SECP256k1 curve" $ [
-    testProperty "ECDSA verification behaves correctly on all inputs" . property $ ecdsaSecp256k1Prop,
-    testProperty "Schnorr verification behaves correctly on all inputs" . property $ schnorrSecp256k1Prop
-    ]
-
+  testGroup "Signature verification" $ [
+                 testGroup "Ed25519 signatures" $ [
+                                testProperty "Ed25519 verification behaves correctly on all inputs" . property $ ed25519Prop
+                               ],
+                 testGroup "Signatures on the SECP256k1 curve" $ [
+                                testProperty "ECDSA verification behaves correctly on all inputs" . property $ ecdsaSecp256k1Prop,
+                                testProperty "Schnorr verification behaves correctly on all inputs" . property $ schnorrSecp256k1Prop
+                               ]
+                ]
 test_definition :: TestTree
 test_definition =
     testGroup "definition"
@@ -608,6 +613,6 @@ test_definition =
         , test_List
         , test_Data
         , test_Crypto
-        , testSECP256k1
+        , test_SignatureVerification
         , test_Other
         ]

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -1,13 +1,15 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Evaluation.Builtins.SECP256k1 (
+module Evaluation.Builtins.SignatureVerification (
   ecdsaSecp256k1Prop,
+  ed25519Prop,
   schnorrSecp256k1Prop,
   ) where
 
@@ -15,6 +17,7 @@ import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, SignKeyDSIGN, S
                                    rawDeserialiseSigDSIGN, rawDeserialiseVerKeyDSIGN, rawSerialiseSigDSIGN,
                                    rawSerialiseVerKeyDSIGN, signDSIGN)
 import Cardano.Crypto.DSIGN.EcdsaSecp256k1 (EcdsaSecp256k1DSIGN, SigDSIGN, VerKeyDSIGN)
+import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Control.Lens.Extras (is)
@@ -29,12 +32,43 @@ import Evaluation.Builtins.Common (typecheckEvaluateCek)
 import Hedgehog (Gen, PropertyT, annotateShow, cover, failure, forAllWith, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifySchnorrSecp256k1Signature),
+import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifyEd25519Signature, VerifySchnorrSecp256k1Signature),
                    EvaluationResult (EvaluationFailure, EvaluationSuccess))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCekParameters)
-
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
 import Text.Show.Pretty (ppShow)
+
+{- | Tests for the built-in digital signature verification functions
+ VerifyEd25519Signature, VerifyEcdsaSecp256k1Signature, and
+ VerifySchnorrSecp256k1Signature.  These use the DSIGN infrastructure to test
+ that the functions behave correctly when given correct and incorrect
+ combinations of public keys, messages, and signatures.
+-}
+
+{- We can make the tests generic over Ed25519DSIGN and SchnorrSecp256k1DSIGN
+ with the constraints below, which hold for both.  However EcdsaSecp256k1DSIGN
+ requires a 32-byte message wrapped in SECP.Msg (the other two take
+ arbitrary-length messages), so we can't use this code for that.  We also
+ need some extra tests for the message size in the case of EcdsaSecp256k1DSIGN
+-}
+
+type Common a = (DSIGNAlgorithm a, Signable a ByteString, ContextDSIGN a ~ ())
+
+commonVerificationProp :: forall (a::Type) . Common a => DefaultFun -> PropertyT IO ()
+commonVerificationProp f = do
+  testCase <- forAllWith ppShow (genCommonCase @a)
+  cover 18 "malformed verification key" . is (_ShouldError . _BadVerKey) $ testCase
+  cover 18 "malformed signature" . is (_ShouldError . _BadSignature) $ testCase
+  cover 18 "mismatch of signing key and verification key" . is (_Shouldn'tError . _WrongVerKey) $ testCase
+  cover 18 "mismatch of message and signature" . is (_Shouldn'tError . _WrongSignature) $ testCase
+  cover 18 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
+  runTestDataWith testCase id f
+
+ed25519Prop :: PropertyT IO ()
+ed25519Prop = commonVerificationProp @Ed25519DSIGN VerifyEd25519Signature
+
+schnorrSecp256k1Prop :: PropertyT IO ()
+schnorrSecp256k1Prop = commonVerificationProp @SchnorrSecp256k1DSIGN VerifySchnorrSecp256k1Signature
 
 ecdsaSecp256k1Prop :: PropertyT IO ()
 ecdsaSecp256k1Prop = do
@@ -46,16 +80,6 @@ ecdsaSecp256k1Prop = do
   cover 14 "mismatch of message and signature" . is (_Shouldn'tError . _WrongSignature) $ testCase
   cover 14 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
   runTestDataWith testCase SECP.getMsg VerifyEcdsaSecp256k1Signature
-
-schnorrSecp256k1Prop :: PropertyT IO ()
-schnorrSecp256k1Prop = do
-  testCase <- forAllWith ppShow genSchnorrCase
-  cover 18 "malformed verification key" . is (_ShouldError . _BadVerKey) $ testCase
-  cover 18 "malformed signature" . is (_ShouldError . _BadSignature) $ testCase
-  cover 18 "mismatch of signing key and verification key" . is (_Shouldn'tError . _WrongVerKey) $ testCase
-  cover 18 "mismatch of message and signature" . is (_Shouldn'tError . _WrongSignature) $ testCase
-  cover 18 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
-  runTestDataWith testCase id VerifySchnorrSecp256k1Signature
 
 -- Helpers
 
@@ -225,6 +249,48 @@ getCaseData f = \case
 
 -- Generators
 
+genCommonErrorCase :: forall (a::Type) . Common a => Gen (ErrorCase a ByteString)
+genCommonErrorCase =
+  Gen.prune . Gen.choice $ [
+    review _BadVerKey <$> mkBadVerKeyBits,
+    review _BadSignature <$> mkBadSignatureBits
+    ]
+  where
+    mkBadVerKeyBits :: Gen (ByteString,
+                            ByteString,
+                            SigDSIGN a)
+    mkBadVerKeyBits = (,,) <$> genBadVerKey @a <*>
+                               genArbitraryMsg <*>
+                               genCommonSig
+    mkBadSignatureBits :: Gen (VerKeyDSIGN a,
+                               ByteString,
+                               ByteString)
+    mkBadSignatureBits = (,,) <$> genVerKey <*>
+                                  genArbitraryMsg <*>
+                                  genBadSig @a
+
+genCommonNoErrorCase :: forall (a::Type) . Common a => Gen (NoErrorCase a ByteString)
+genCommonNoErrorCase = do
+  sk <- genSignKey
+  let vk = deriveVerKeyDSIGN sk
+  msg <- genArbitraryMsg
+  Gen.prune . Gen.choice $ [
+    review _WrongVerKey <$> mkWrongKeyBits sk vk msg,
+    review _WrongSignature <$> mkWrongSignatureBits sk vk msg,
+    pure . review _AllGood $ (vk, msg, signDSIGN () msg sk)
+    ]
+  where
+    mkWrongSignatureBits ::
+      SignKeyDSIGN a ->
+      VerKeyDSIGN a ->
+      ByteString ->
+      Gen (VerKeyDSIGN a,
+           ByteString,
+           SigDSIGN a)
+    mkWrongSignatureBits sk vk msg = do
+      msgBad <- Gen.filter (/= msg) genArbitraryMsg
+      pure (vk, msg, signDSIGN () msgBad sk)
+
 genEcdsaErrorCase :: Gen (ErrorCase EcdsaSecp256k1DSIGN SECP.Msg)
 genEcdsaErrorCase =
   Gen.prune . Gen.choice $ [
@@ -250,25 +316,6 @@ genEcdsaErrorCase =
                                   genEcdsaMsg <*>
                                   genBadSig @EcdsaSecp256k1DSIGN
 
-genSchnorrErrorCase :: Gen (ErrorCase SchnorrSecp256k1DSIGN ByteString)
-genSchnorrErrorCase = Gen.choice [
-  review _BadVerKey <$> mkBadVerKeyBits,
-  review _BadSignature <$> mkBadSignatureBits
-  ]
-  where
-    mkBadVerKeyBits :: Gen (ByteString,
-                            ByteString,
-                            SigDSIGN SchnorrSecp256k1DSIGN)
-    mkBadVerKeyBits = (,,) <$> genBadVerKey @SchnorrSecp256k1DSIGN <*>
-                              (Gen.bytes . Range.linear 0 $ 64) <*>
-                              genSchnorrSig
-    mkBadSignatureBits :: Gen (VerKeyDSIGN SchnorrSecp256k1DSIGN,
-                               ByteString,
-                               ByteString)
-    mkBadSignatureBits = (,,) <$> genVerKey <*>
-                                  (Gen.bytes . Range.linear 0 $ 64) <*>
-                                  genBadSig @SchnorrSecp256k1DSIGN
-
 genEcdsaNoErrorCase :: Gen (NoErrorCase EcdsaSecp256k1DSIGN SECP.Msg)
 genEcdsaNoErrorCase = do
   sk <- genSignKey
@@ -291,38 +338,16 @@ genEcdsaNoErrorCase = do
       msgBad <- Gen.filter (/= msg) genEcdsaMsg
       pure (vk, msg, signDSIGN () msgBad sk)
 
-genSchnorrNoErrorCase :: Gen (NoErrorCase SchnorrSecp256k1DSIGN ByteString)
-genSchnorrNoErrorCase = do
-  sk <- genSignKey
-  let vk = deriveVerKeyDSIGN sk
-  msg <- Gen.bytes . Range.linear 0 $ 64
-  Gen.choice [
-    review _WrongVerKey <$> mkWrongKeyBits sk vk msg,
-    review _WrongSignature <$> mkWrongSignatureBits sk vk msg,
-    pure . review _AllGood $ (vk, msg, signDSIGN () msg sk)
-    ]
-  where
-    mkWrongSignatureBits ::
-      SignKeyDSIGN SchnorrSecp256k1DSIGN ->
-      VerKeyDSIGN SchnorrSecp256k1DSIGN ->
-      ByteString ->
-      Gen (VerKeyDSIGN SchnorrSecp256k1DSIGN,
-           ByteString,
-           SigDSIGN SchnorrSecp256k1DSIGN)
-    mkWrongSignatureBits sk vk msg = do
-      msgBad <- Gen.filter (/= msg) (Gen.bytes . Range.linear 0 $ 64)
-      pure (vk, msg, signDSIGN () msgBad sk)
+genCommonCase :: Common a => Gen (Case a ByteString)
+genCommonCase = Gen.prune . Gen.frequency $ [
+  (6, review _Shouldn'tError <$> genCommonNoErrorCase),
+  (4, review _ShouldError <$> genCommonErrorCase)
+  ]
 
 genEcdsaCase :: Gen (Case EcdsaSecp256k1DSIGN SECP.Msg)
 genEcdsaCase = Gen.prune . Gen.choice $ [
   review _Shouldn'tError <$> genEcdsaNoErrorCase,
   review _ShouldError <$> genEcdsaErrorCase
-  ]
-
-genSchnorrCase :: Gen (Case SchnorrSecp256k1DSIGN ByteString)
-genSchnorrCase = Gen.prune . Gen.frequency $ [
-  (6, review _Shouldn'tError <$> genSchnorrNoErrorCase),
-  (4, review _ShouldError <$> genSchnorrErrorCase)
   ]
 
 mkWrongKeyBits :: forall (a :: Type) (msg :: Type) .
@@ -338,10 +363,19 @@ mkWrongKeyBits sk vk msg = do
 genBadVerKey :: forall (a :: Type) .
   (DSIGNAlgorithm a) => Gen ByteString
 genBadVerKey = Gen.filter (isNothing . rawDeserialiseVerKeyDSIGN @a)
-                          (Gen.bytes . Range.linear 0 $ 64)
+               (Gen.bytes $ Range.linear 0 64)
+
+genArbitraryMsg :: Gen ByteString
+genArbitraryMsg = Gen.bytes $ Range.linear 0 100
 
 genEcdsaMsg :: Gen SECP.Msg
 genEcdsaMsg = Gen.mapMaybe SECP.msg (Gen.bytes . Range.singleton $ 32)
+
+genCommonSig :: Common a => Gen (SigDSIGN a)
+genCommonSig = do
+  sk <- genSignKey
+  msg <- genArbitraryMsg
+  pure . signDSIGN () msg $ sk
 
 genEcdsaSig :: Gen (SigDSIGN EcdsaSecp256k1DSIGN)
 genEcdsaSig = do
@@ -349,17 +383,11 @@ genEcdsaSig = do
   msg <- genEcdsaMsg
   pure . signDSIGN () msg $ sk
 
-genSchnorrSig :: Gen (SigDSIGN SchnorrSecp256k1DSIGN)
-genSchnorrSig = do
-  sk <- genSignKey
-  msg <- Gen.bytes . Range.linear 0 $ 64
-  pure . signDSIGN () msg $ sk
-
 genVerKey :: forall (a :: Type) . (DSIGNAlgorithm a) => Gen (VerKeyDSIGN a)
 genVerKey = deriveVerKeyDSIGN <$> genSignKey
 
 genBadEcdsaMsg :: Gen ByteString
-genBadEcdsaMsg = Gen.filter (isNothing . SECP.msg) (Gen.bytes . Range.linear 0 $ 64)
+genBadEcdsaMsg = Gen.filter (isNothing . SECP.msg) genArbitraryMsg
 
 genBadSig :: forall (a :: Type) . (DSIGNAlgorithm a) => Gen ByteString
 genBadSig = Gen.filter (isNothing . rawDeserialiseSigDSIGN @a)

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -219,7 +219,7 @@ postulate
 {-# FOREIGN GHC import PlutusCore.Evaluation.Result (EvaluationResult (EvaluationSuccess, EvaluationFailure)) #-}
 {-# FOREIGN GHC emitterResultToMaybe = \e -> case fst e of {EvaluationSuccess r -> Just r; EvaluationFailure -> Nothing} #-}
 
-{-# COMPILE GHC verifyEd25519Sig = verifyEd25519Signature #-}
+{-# COMPILE GHC verifyEd25519Sig = \k m s -> emitterResultToMaybe . runEmitter $ verifyEd25519Signature k m s #-}
 {-# COMPILE GHC verifyEcdsaSecp256k1Sig = \k m s -> emitterResultToMaybe . runEmitter $ verifyEcdsaSecp256k1Signature k m s #-}
 {-# COMPILE GHC verifySchnorrSecp256k1Sig = \k m s -> emitterResultToMaybe . runEmitter $ verifySchnorrSecp256k1Signature k m s #-}
 

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -28,7 +28,6 @@ import Data.Data
 import Data.Foldable qualified as Foldable
 import Data.Hashable (Hashable (..))
 import Data.Kind (Type)
-import Data.Maybe (fromMaybe)
 import Data.Text as Text (Text, empty)
 import Data.Text.Encoding as Text (decodeUtf8, encodeUtf8)
 import PlutusCore.Builtin.Emitter (Emitter (Emitter))
@@ -241,8 +240,12 @@ blake2b_256 (BuiltinByteString b) = BuiltinByteString $ Hash.blake2b_256 b
 
 {-# NOINLINE verifyEd25519Signature #-}
 verifyEd25519Signature :: BuiltinByteString -> BuiltinByteString -> BuiltinByteString -> BuiltinBool
-verifyEd25519Signature (BuiltinByteString pubKey) (BuiltinByteString message) (BuiltinByteString signature) =
-  BuiltinBool (fromMaybe False (Crypto.verifyEd25519Signature pubKey message signature))
+verifyEd25519Signature (BuiltinByteString vk) (BuiltinByteString msg) (BuiltinByteString sig) =
+  case Crypto.verifyEd25519Signature vk msg sig of
+    Emitter f -> case runWriter f of
+      (res, logs) -> traceAll logs $ case res of
+        EvaluationFailure   -> mustBeReplaced "ECDSA SECP256k1 signature verification errored."
+        EvaluationSuccess b -> BuiltinBool b
 
 {-# NOINLINE verifyEcdsaSecp256k1Signature #-}
 verifyEcdsaSecp256k1Signature ::


### PR DESCRIPTION
This is PLT-586 (wrong issue number in the branch name).  It changes the return type of the current version of `verifyEd25519Signature` from `Maybe Bool` to `Emitter (EvaluationResult Bool)`.  This (a) makes it compatible with the `Secp256k1` verification signature verification functions (which log details if something goes wrong, like encountering a malformed signature or a public key of the wrong size (hence the `Emitter` type)), and (b) will make it easier to update to a different implementation using `libsodium` (PLT-162), since both versions will have the same type. 

When/if we merge this I'll close #4606 and replace it with a PR with a much smaller diff.