### PR TITLE
Use the standard deriving Show instance for Value

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -54,13 +54,11 @@ import Prelude qualified as Haskell
 import Control.DeepSeq (NFData)
 import Data.ByteString qualified as BS
 import Data.Data
-import Data.List qualified (sortBy)
 import Data.String (IsString (fromString))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as E
 import GHC.Generics (Generic)
-import GHC.Show (showList__)
 import PlutusLedgerApi.V1.Bytes (LedgerBytes (LedgerBytes), encodeByteString)
 import PlutusLedgerApi.V1.Scripts
 import PlutusTx qualified as PlutusTx

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Value.hs
@@ -163,26 +163,10 @@ assetClass s t = AssetClass (s, t)
 --
 -- See note [Currencies] for more details.
 newtype Value = Value { getValue :: Map.Map CurrencySymbol (Map.Map TokenName Integer) }
-    deriving stock (Generic, Data)
+    deriving stock (Generic, Data, Haskell.Show)
     deriving anyclass (NFData)
     deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
     deriving Pretty via (PrettyShow Value)
-
-instance Haskell.Show Value where
-    showsPrec d v =
-        Haskell.showParen (d Haskell.== 11) $
-            Haskell.showString "Value " . (Haskell.showParen True (showsMap (showPair (showsMap Haskell.shows)) rep))
-        where Value rep = normalizeValue v
-              showsMap sh m = Haskell.showString "Map " . showList__ sh (Map.toList m)
-              showPair s (x,y) = Haskell.showParen True $ Haskell.shows x . Haskell.showString "," . s y
-
-normalizeValue :: Value -> Value
-normalizeValue = Value . Map.fromList . sort . filterRange (/=Map.empty)
-               . mapRange normalizeTokenMap . Map.toList . getValue
-  where normalizeTokenMap = Map.fromList . sort . filterRange (/=0) . Map.toList
-        filterRange p kvs = [(k,v) | (k,v) <- kvs, p v]
-        mapRange f xys = [(x,f y) | (x,y) <- xys]
-        sort xs = Data.List.sortBy compare xs
 
 instance Haskell.Eq Value where
     (==) = eq


### PR DESCRIPTION
In #2880, the standard `Show` instance for `Value` was replaced with a normalizing one.

Recently, it was discovered that it might be confusing to deal with values:

```
> A.singleton "0abc" "0abc" 1
Value (Map [(0abc,Map [("0abc",1)])])

> lovelaceValueOf 0 <> A.singleton "0abc" "0abc" 1
Value (Map [(0abc,Map [("0abc",1)])])

> getValue $ lovelaceValueOf 0 <> A.singleton "0abc" "0abc" 1
Map {unMap = [(,Map {unMap = [("",0)]}),(0abc,Map {unMap = [("0abc",1)]})]}

> getValue $ A.singleton "0abc" "0abc" 1
Map {unMap = [(0abc,Map {unMap = [("0abc",1)]})]}
```
it hides the evidence about zero tokens (with any symbol, not only ada) and contradicts the usual expectation of `Show`'s behaviour to be able to see the whole structure as is.

---

**Before:**

```
> singleton adaSymbol adaToken 0
Value (Map [])
> singleton adaSymbol adaToken 1
Value (Map [(,Map [("",1)])])
```

**After:**

```
> singleton adaSymbol adaToken 0
Value {getValue = Map {unMap = [(,Map {unMap = [("",0)]})]}}
> singleton adaSymbol adaToken 1
Value {getValue = Map {unMap = [(,Map {unMap = [("",1)]})]}}
```

---

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
