### PR TITLE
PLT-572 Check alpha-equivalence of programs in conformance tests

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -38,24 +38,24 @@ agdaEvalUplcProg (UPLC.Program () version tmU) =
 -- | These tests are currently failing so they are marked as expected to fail.
 -- Once a fix for a test is pushed, the test will fail. Remove it from this list.
 failingTests :: [FilePath]
-failingTests = [ --TODO
-    "mkNilPairData"
-    , "chooseUnit"
-    , "mkNilData"
-    , "churchZero"
-    , "force-lam"
-    , "succInteger"
-    , "DivideByZero"
-    , "DivideByZeroDrop"
-    , "churchSucc"
-    , "lam"
-    , "delay-lam"
-    , "error"
-    , "ifThenElse-no-force"
+failingTests = [
+    "test-cases/uplc/evaluation/builtin/mkNilPairData"
+    , "test-cases/uplc/evaluation/builtin/chooseUnit"
+    , "test-cases/uplc/evaluation/builtin/mkNilData"
+    , "test-cases/uplc/evaluation/example/churchZero"
+    , "test-cases/uplc/evaluation/example/force-lam"
+    , "test-cases/uplc/evaluation/example/succInteger"
+    , "test-cases/uplc/evaluation/example/DivideByZero"
+    , "test-cases/uplc/evaluation/example/DivideByZeroDrop"
+    , "test-cases/uplc/evaluation/example/churchSucc"
+    , "test-cases/uplc/evaluation/term/lam"
+    , "test-cases/uplc/evaluation/term/delay-lam"
+    , "test-cases/uplc/evaluation/term/error"
+    , "test-cases/uplc/evaluation/failure/ifThenElse-no-force"
     ]
 
 main :: IO ()
 main =
     -- UPLC evaluation tests
-    runUplcEvalTests agdaEvalUplcProg (\dir -> elem (takeBaseName dir) failingTests)
+    runUplcEvalTests agdaEvalUplcProg (\dir -> elem dir failingTests)
 

--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -24,16 +24,19 @@ agdaEvalUplcProg (UPLC.Program () version tmU) =
         Left _ -> Nothing
         -- evaluate the untyped term with CEK
         Right tmUDBSuccess ->
-            case runUAgda tmUDBSuccess of
-                Left _ -> Nothing
-                Right tmEvaluated ->
-                    let tmNamed = runQuote $ runExceptT $
-                            withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
-                    in
-                    -- turn it back into a named term
-                    case tmNamed of
-                        Left _          -> Nothing
-                        Right namedTerm -> Just $ UPLC.Program () version namedTerm
+            -- case runUAgda tmUDBSuccess of
+            --     Left _ -> Nothing
+            --     Right tmEvaluated ->
+            --         let tmNamed = runQuote $ runExceptT $
+            --                 withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
+            --         in
+            --         -- turn it back into a named term
+                    -- case tmNamed of
+                    --     Left _          -> Nothing
+                    --     Right namedTerm -> Just $ UPLC.Program () version namedTerm
+            case runQuote $ runExceptT $ withExceptT FreeVariableErrorE $ unDeBruijnTerm tmUDBSuccess of
+                Left _      -> Nothing
+                Right named -> Just $ UPLC.Program () version named
 
 -- | These tests are currently failing so they are marked as expected to fail.
 -- Once a fix for a test is pushed, the test will fail. Remove it from this list.

--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -24,19 +24,16 @@ agdaEvalUplcProg (UPLC.Program () version tmU) =
         Left _ -> Nothing
         -- evaluate the untyped term with CEK
         Right tmUDBSuccess ->
-            -- case runUAgda tmUDBSuccess of
-            --     Left _ -> Nothing
-            --     Right tmEvaluated ->
-            --         let tmNamed = runQuote $ runExceptT $
-            --                 withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
-            --         in
-            --         -- turn it back into a named term
-                    -- case tmNamed of
-                    --     Left _          -> Nothing
-                    --     Right namedTerm -> Just $ UPLC.Program () version namedTerm
-            case runQuote $ runExceptT $ withExceptT FreeVariableErrorE $ unDeBruijnTerm tmUDBSuccess of
-                Left _      -> Nothing
-                Right named -> Just $ UPLC.Program () version named
+            case runUAgda tmUDBSuccess of
+                Left _ -> Nothing
+                Right tmEvaluated ->
+                    let tmNamed = runQuote $ runExceptT $
+                            withExceptT FreeVariableErrorE $ unDeBruijnTerm tmEvaluated
+                    in
+                    -- turn it back into a named term
+                    case tmNamed of
+                        Left _          -> Nothing
+                        Right namedTerm -> Just $ UPLC.Program () version namedTerm
 
 -- | These tests are currently failing so they are marked as expected to fail.
 -- Once a fix for a test is pushed, the test will fail. Remove it from this list.

--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -37,8 +37,8 @@ agdaEvalUplcProg (UPLC.Program () version tmU) =
 
 -- | These tests are currently failing so they are marked as expected to fail.
 -- Once a fix for a test is pushed, the test will fail. Remove it from this list.
-failingTests :: [String]
-failingTests = [
+failingTests :: [FilePath]
+failingTests = [ --TODO
     "mkNilPairData"
     , "chooseUnit"
     , "mkNilData"
@@ -57,5 +57,5 @@ failingTests = [
 main :: IO ()
 main =
     -- UPLC evaluation tests
-    runUplcEvalTests agdaEvalUplcProg failingTests
+    runUplcEvalTests agdaEvalUplcProg (\dir -> elem (takeBaseName dir) failingTests)
 

--- a/plutus-conformance/haskell/Spec.hs
+++ b/plutus-conformance/haskell/Spec.hs
@@ -4,8 +4,11 @@ module Main (main) where
 
 import PlutusConformance.Common
 
+failingTests :: [FilePath]
+failingTests = []
+
 main :: IO ()
 main =
     -- UPLC evaluation tests
-    runUplcEvalTests evalUplcProg []
+    runUplcEvalTests evalUplcProg (\dir -> elem dir failingTests)
 

--- a/plutus-conformance/haskell/Spec.hs
+++ b/plutus-conformance/haskell/Spec.hs
@@ -11,4 +11,3 @@ main :: IO ()
 main =
     -- UPLC evaluation tests
     runUplcEvalTests evalUplcProg (\dir -> elem dir failingTests)
-

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -54,6 +54,7 @@ library
     , plutus-core
     , tasty
     , tasty-expected-failure
+    , tasty-golden
     , text
     , witherable
 

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -30,9 +30,45 @@ import Witherable
 
 -- Common functions for all tests
 
+{- | The default shown text when a parse error occurs.
+We don't want to show the detailed parse errors so that
+users of the test suite can produce the expected output more easily. -}
+shownParseError :: T.Text
+shownParseError = "parse error"
+
+-- | The default shown text when evaluation fails.
+shownEvaluationFailure :: T.Text
+shownEvaluationFailure = "evaluation failure"
+
+-- | The default parser to parse UPLC program inputs.
+parseTxt ::
+    T.Text
+    -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
+parseTxt resTxt = runQuoteT $ UPLC.parseProgram resTxt
+
+-- | The input/output UPLC program type.
+type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()
+
+-- UPLC evaluation test functions
+
+-- | The evaluator to be tested. It should either return a program if the evaluation is successful,
+-- or `Nothing` if not.
+type UplcEvaluator = UplcProg -> Maybe UplcProg
+
+-- | The type the tests are comparing.
+data RawTxtOrDebruijnTerm
+    = MkRawTxtOrDebruijnTerm {
+        raw              :: T.Text
+        -- ^ Either parse or evaluation error or, for the expected value, the raw text.
+        -- We can't parse `data` currently so we need to keep the raw text of some of the
+        -- expected values for comparison to not have parse errors.
+        , inDebruijnTerm :: UPLC.Term NamedDeBruijn DefaultUni DefaultFun ()
+        -- ^ The program in the form of DeBruijn term. This is to facilitate checking of alpha-eq.
+    }
+
 -- | Walk a file tree, making test groups for directories with subdirectories,
 -- and test cases for directories without.
-discoverTests :: UplcEvaluator
+discoverTests :: UplcEvaluator -- ^ The evaluator to be tested.
     -> (FilePath -> Bool)
     -- ^ A function that takes a test name and returns
     -- whether it should labelled as `ExpectedFailure`.
@@ -48,102 +84,23 @@ discoverTests eval expectedFailureFn dir = do
     if null subdirs
     -- no children, this is a test case directory
     then do
-        goldenFile <- findByExtension [".expected"] dir
-        case goldenFile of
-            [] -> error $ "Golden file missing in " <> dir --TODO this may mess up the accept opt
-            _:_:_ -> error $ "More than 1 golden files in " <> dir
-            _ -> do
-                let goldenFilePath = head goldenFile
-                    mkGoldenTest =
-                            goldenTest
-                                name -- test name
-                                -- get the golden test value
-                                (fmap expectedToProg $ T.readFile goldenFilePath)
-                                -- get the tested value
-                                (getTestedValue eval dir)
-                                compareAlphaEq -- comparison function
-                                (updateGoldenFile goldenFilePath) -- update the golden file (we don't need to do this)
-                -- if the test is one that is expected to fail, mark it so.
-                if expectedFailureFn dir
-                then pure $ expectFail mkGoldenTest
-                -- the test is not one that is expected to fail, make the test tree as usual.
-                else pure mkGoldenTest
+            let goldenFilePath = dir </> name <> ".uplc.expected"
+                mkGoldenTest =
+                        goldenTest
+                            name -- test name
+                            -- get the golden test value
+                            (fmap expectedToProg $ T.readFile goldenFilePath)
+                            -- get the tested value
+                            (getTestedValue eval dir)
+                            compareAlphaEq -- comparison function
+                            (updateGoldenFile goldenFilePath) -- update the golden file
+            -- if the test is expected to fail, mark it so.
+            if expectedFailureFn dir
+            then pure $ expectFail mkGoldenTest
+            -- the test isn't expected to fail, make the `TestTree` as usual.
+            else pure mkGoldenTest
     -- has children, so it's a grouping directory
     else testGroup name <$> traverse (discoverTests eval expectedFailureFn) subdirs
-
--- | Update the golden file with the tested value.
-updateGoldenFile ::
-    FilePath -- ^ the path to write the golden file to
-    -> Either T.Text RawTxtOrDebruijnTerm -> IO ()
-updateGoldenFile goldenPath (Left txt) = T.writeFile goldenPath txt
-updateGoldenFile goldenPath (Right p)  = T.writeFile goldenPath (raw p)
-
--- | The comparison function used for the golden test.
--- This function checks alpha-equivalence of programs.
-compareAlphaEq ::
-    Either T.Text RawTxtOrDebruijnTerm -- ^ golden value
-    -> Either T.Text RawTxtOrDebruijnTerm -- ^ tested value
-    -> IO (Maybe String)
-    -- ^ If two values are the same, it returns `Nothing`.
-    -- If they are different, it returns an error that will be printed to the user.
-compareAlphaEq (Left expectedTxt) (Left actualTxt) =
-    if actualTxt == expectedTxt
-    then pure Nothing
-    else pure $ Just $ "Test failed, the output is: " <> T.unpack actualTxt
-compareAlphaEq (Right expected) (Right actual) =
-    if inDebruijnTerm actual == inDebruijnTerm expected
-    then pure Nothing
-    else pure $
-        Just $ "Test failed, the output was successfully parsed, but its not as expected. "
-        <> "The output program is: "
-        <> (display $ raw actual)
-        <> "The output program, in Debruijn indexes is:"
-        <> (show $ inDebruijnTerm actual)
-        -- the user can look at the .expected file, but they can't see it in Debruijn term
-        <> ". But the expected result in Debruijn indexes is: "
-        <> (show $ inDebruijnTerm expected)
-compareAlphaEq (Right expected) (Left actualTxt) =
-    pure $ Just $ "Test failed, the output is: "
-        <> T.unpack actualTxt
-        <> ". But the expected result in Debruijn indexes is: "
-        <> (show $ inDebruijnTerm expected)
-compareAlphaEq (Left txt) (Right actual) =
-    if txt == raw actual then pure Nothing
-    else
-        pure $ Just $ "Test failed, the output was successfully parsed, but its not as expected. "
-            <> "The output program is: "
-            <> (display $ raw actual)
-            <> ". But the expected result is: "
-            <> T.unpack txt
-
-data RawTxtOrDebruijnTerm
-    = MkRawTxtOrDebruijnTerm {
-        raw              :: T.Text
-        , inDebruijnTerm :: UPLC.Term NamedDeBruijn DefaultUni DefaultFun ()
-    }
-
--- | Get the tested value.
-getTestedValue ::
-    UplcEvaluator
-    -> FilePath
-    -> IO (Either T.Text RawTxtOrDebruijnTerm)
-getTestedValue eval dir = do
-    inputFile <- findByExtension [".uplc"] dir
-    case inputFile of
-        [] -> error $ "Input file missing in " <> dir
-        _:_:_ -> error $ "More than 1 input files in " <> dir
-        _ -> do
-            input <- T.readFile $ head inputFile
-            case parseTxt input of
-                Left _ -> pure $ Left shownParseError
-                Right p -> do
-                    case eval (void p) of
-                        Nothing                           -> pure $ Left shownEvaluationFailure
-                        Just prog@(UPLC.Program () _version tm) -> do
-                            case UPLC.deBruijnTerm tm of
-                                Left (_ :: UPLC.FreeVariableError) -> pure $ Left shownEvaluationFailure
-                                Right dbTm                         ->
-                                    pure $ Right $ MkRawTxtOrDebruijnTerm (display prog) dbTm
 
 -- | Turn the expected file content in text to a `UplcProg` in Debruijn unless the expected result
 -- is a parse or evaluation error.
@@ -162,30 +119,76 @@ expectedToProg txt
                 Right dbTm                         ->
                     Right $ MkRawTxtOrDebruijnTerm txt dbTm
 
-{- | The default shown text when a parse error occurs.
-We don't want to show the detailed parse errors so that
-users of the test suite can produce the expected output more easily. -}
-shownParseError :: T.Text
-shownParseError = "parse error"
+-- | Get the tested value (in `Either T.Text RawTxtOrDebruijnTerm`).
+getTestedValue ::
+    UplcEvaluator
+    -> FilePath
+    -> IO (Either T.Text RawTxtOrDebruijnTerm)
+getTestedValue eval dir = do
+    inputFile <- findByExtension [".uplc"] dir
+    case inputFile of
+        [] -> error $ "Input file missing in " <> dir
+        _:_:_ -> error $ "More than 1 input files in " <> dir
+        [file] -> do
+            input <- T.readFile file
+            case parseTxt input of
+                Left _ -> pure $ Left shownParseError
+                Right p -> do
+                    case eval (void p) of
+                        Nothing                           -> pure $ Left shownEvaluationFailure
+                        Just prog@(UPLC.Program () _version tm) -> do
+                            case UPLC.deBruijnTerm tm of
+                                Left (_ :: UPLC.FreeVariableError) ->
+                                    pure $ Left shownEvaluationFailure
+                                Right dbTm                         ->
+                                    pure $ Right $ MkRawTxtOrDebruijnTerm (display prog) dbTm
 
--- | The default shown text when evaluation fails.
-shownEvaluationFailure :: T.Text
-shownEvaluationFailure = "evaluation failure"
+-- | The comparison function used for the golden test.
+-- This function checks alpha-equivalence of programs when the output is a program.
+compareAlphaEq ::
+    Either T.Text RawTxtOrDebruijnTerm -- ^ golden value
+    -> Either T.Text RawTxtOrDebruijnTerm -- ^ tested value
+    -> IO (Maybe String)
+    -- ^ If two values are the same, it returns `Nothing`.
+    -- If they are different, it returns an error that will be printed to the user.
+compareAlphaEq (Left expectedTxt) (Left actualTxt) =
+    if actualTxt == expectedTxt
+    then pure Nothing
+    else pure $ Just $
+        "Test failed, the output failed to parse or evaluate: \n"
+        <> T.unpack actualTxt
+compareAlphaEq (Right expected) (Right actual) =
+    if inDebruijnTerm actual == inDebruijnTerm expected
+    then pure Nothing
+    else pure $ Just $
+        "Test failed, the output was successfully parsed and evaluated, but it isn't as expected. "
+        <> "The output program is: \n"
+        <> (display $ raw actual)
+        <> "\n The output program, in Debruijn indexes is: \n"
+        <> (show $ inDebruijnTerm actual)
+        -- the user can look at the .expected file, but they can't see it in Debruijn term
+        <> "\n But the expected result in Debruijn indexes is: \n"
+        <> (show $ inDebruijnTerm expected)
+compareAlphaEq (Right expected) (Left actualTxt) =
+    pure $ Just $ "Test failed, the output failed to parse or evaluate: \n"
+        <> T.unpack actualTxt
+        <> "\n But the expected result in Debruijn indexes is: \n"
+        <> (show $ inDebruijnTerm expected)
+compareAlphaEq (Left txt) (Right actual) =
+    if txt == raw actual then pure Nothing
+    else pure $ Just $
+        "Test failed, the output was successfully parsed and evaluated, but it isn't as expected. "
+        <> "The output program is: "
+        <> (display $ raw actual)
+        <> ". But the expected result is: "
+        <> T.unpack txt
 
--- UPLC evaluation test functions
-
-type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()
-
-type UplcEvaluator = UplcProg -> Maybe UplcProg
-
--- | A UPLC evaluation test suite.
-data UplcEvaluationTest =
-    MkUplcEvaluationTest {
-       -- | The evaluator function to use for the test.
-       evaluator :: UplcEvaluator
-       -- | The test directory in which the test files are located.
-       , testDir :: FilePath
-    }
+-- | Update the golden file with the tested value. TODO abstract out for other tests.
+updateGoldenFile ::
+    FilePath -- ^ the path to write the golden file to
+    -> Either T.Text RawTxtOrDebruijnTerm -> IO ()
+updateGoldenFile goldenPath (Left txt) = T.writeFile goldenPath txt
+updateGoldenFile goldenPath (Right p)  = T.writeFile goldenPath (raw p)
 
 -- | Our `evaluator` for the Haskell UPLC tests is the CEK machine.
 evalUplcProg :: UplcEvaluator
@@ -200,16 +203,13 @@ evalUplcProg = traverseOf UPLC.progTerm eval
             Left _     -> Nothing
             Right prog -> Just prog
 
--- | The default parser to parse the UPLC program inputs.
-parseTxt ::
-    T.Text
-    -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
-parseTxt resTxt = runQuoteT $ UPLC.parseProgram resTxt
 
 -- | Run the UPLC evaluation tests given an `evaluator` that evaluates UPLC programs.
 runUplcEvalTests ::
     UplcEvaluator -- ^ The action to run the input through for the tests.
     -> (FilePath -> Bool)
+    -- ^ A function that takes a test name and returns
+    -- whether it should labelled as `ExpectedFailure`.
     -> IO ()
 runUplcEvalTests eval expectedFailTests = do
     tests <-

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -80,7 +80,7 @@ discoverTests eval expectedFailureFn dir = do
                             (expectedToProg <$> T.readFile goldenFilePath)
                             -- get the tested value
                             (getTestedValue eval dir)
-                            compareAlphaEq -- comparison function
+                            (\ x y -> pure $ compareAlphaEq x y) -- comparison function
                             (updateGoldenFile goldenFilePath) -- update the golden file
             -- if the test is expected to fail, mark it so.
             if expectedFailureFn dir
@@ -135,19 +135,19 @@ getTestedValue eval dir = do
 compareAlphaEq ::
     Either T.Text UplcProg -- ^ golden value
     -> Either T.Text UplcProg -- ^ tested value
-    -> IO (Maybe String)
+    -> Maybe String
     -- ^ If two values are the same, it returns `Nothing`.
     -- If they are different, it returns an error that will be printed to the user.
 compareAlphaEq (Left expectedTxt) (Left actualTxt) =
     if actualTxt == expectedTxt
-    then pure Nothing
-    else pure $ Just $
+    then Nothing
+    else Just $
         "Test failed, the output failed to parse or evaluate: \n"
         <> T.unpack actualTxt
 compareAlphaEq (Right expected) (Right actual) =
     if actual == expected
-    then pure Nothing
-    else pure $ Just $
+    then Nothing
+    else Just $
         "Test failed, the output was successfully parsed and evaluated, but it isn't as expected. "
         <> "The output program is: \n"
         <> display actual
@@ -158,7 +158,7 @@ compareAlphaEq (Right expected) (Right actual) =
         <> "\n But the expected result, with the unique names shown is: \n"
         <> show expected
 compareAlphaEq (Right expected) (Left actualTxt) =
-    pure $ Just $ "Test failed, the output failed to parse or evaluate: \n"
+    pure $ "Test failed, the output failed to parse or evaluate: \n"
         <> T.unpack actualTxt
         <> "\n But the expected result, with the unique names shown is: \n"
         <> show expected
@@ -166,8 +166,8 @@ compareAlphaEq (Left txt) (Right actual) =
     {- this is the case when the expected program failed to parse because
     our parser doesn't support `data` atm. In these cases, if the textual program is the same
     as the actual, the tests succeed. -}
-    if txt == display actual then pure Nothing
-    else pure $ Just $
+    if txt == display actual then Nothing
+    else Just $
         "Test failed, the output was successfully parsed and evaluated, but it isn't as expected. "
         <> "The output program is: "
         <> display actual

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -98,15 +98,15 @@ compareAlphaEq (Right expected) (Right actual) =
         <> "The output program is: "
         <> (display $ raw actual)
         <> "The output program, in Debruijn indexes is:"
-        <> (display $ inDebruijnTerm actual)
+        <> (show $ inDebruijnTerm actual)
         -- the user can look at the .expected file, but they can't see it in Debruijn term
         <> ". But the expected result in Debruijn indexes is: "
-        <> (display $ inDebruijnTerm expected)
+        <> (show $ inDebruijnTerm expected)
 compareAlphaEq (Right expected) (Left actualTxt) =
     pure $ Just $ "Test failed, the output is: "
         <> T.unpack actualTxt
         <> ". But the expected result in Debruijn indexes is: "
-        <> (display $ inDebruijnTerm expected)
+        <> (show $ inDebruijnTerm expected)
 compareAlphaEq (Left txt) (Right actual) =
     if txt == raw actual then pure Nothing
     else


### PR DESCRIPTION
- refactored into using the golden test function instead of a custom `IsTest` instance. This is cleaner especially when we add more types of tests down the road.
- the expected to fail tests are now marked with their filepath, not their names.
- the UPLC evaluation tests now test alpha-equivalence of programs instead of comparing them textually. This **hasn't** fixed the failing Agda `churchZero` test yet because the Agda evaluator is actually returning a not alpha-equivalent program to the expected one. It seems the Agda evaluator has a bug relating to the off-by-one debruijn discrepancy we have in plutus-core.
- with this merged once we fix the bug `churchZero` should be fixed. If not, there's a bug in checking the alpha-equivalence and we should fix it.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
