### PR TITLE
Fix CSV file output problem in cost model benchmarking

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -1,3 +1,4 @@
+-- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase #-}
 
 module CriterionExtensions (criterionMainWith, BenchmarkingPhase(..)) where

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-module CriterionExtensions (criterionMainWith) where
+module CriterionExtensions (criterionMainWith, BenchmarkingPhase(..)) where
 
 import Control.Monad (unless)
 import Control.Monad.Trans (liftIO)
@@ -9,11 +9,10 @@ import Criterion.Internal (runAndAnalyse, runFixedIters)
 import Criterion.Main (makeMatcher)
 import Criterion.Main.Options (MatchType (..), Mode (..), describe, versionInfo)
 import Criterion.Measurement (initializeTime)
-import Criterion.Monad (withConfig)
+import Criterion.Monad (Criterion, withConfig)
 import Criterion.Types
 
 import Data.List (sort)
-import Data.Maybe (fromJust)
 import Data.Time.Clock (getCurrentTime)
 import Options.Applicative (execParser)
 import System.Directory (doesFileExist, renameFile)
@@ -23,67 +22,74 @@ import System.FilePath ((<.>))
 import System.IO (hPutStrLn, stderr)
 
 
+{- | The first time we call criterionMainWith we want to check that the CSV file
+   exists and if it does we make a backup and open a new version, writing a
+   header to the it.  If we call criterionMainWith again then we just want to
+   append to the existing file: this type tells us which of these things we want
+   to do.
+-}
+data BenchmarkingPhase = Start | Continue
+
 {- | We require the user to specify a CSV output file: without this, Criterion
    won't save the output that we really need.  We previously wrote the data to a
-   fixed location, but that was too inflexible. If the output file already
-   exists then we move it to a backup file because by default Criterion will
-   just append data to the existing file (including a new header).
+   fixed location, but that was too inflexible. If the phase is Start and the
+   output file already exists then we move it to a backup file because by
+   default Criterion will just append data to the existing file (including a new
+   header).
 -}
-checkCsvSet :: Config -> IO ()
-checkCsvSet cfg =
+initCsvFile :: BenchmarkingPhase -> Config -> Criterion ()
+initCsvFile phase cfg =
     let putStrLnErr = hPutStrLn stderr
     in case csvFile cfg of
-         Nothing -> do
-           prog <- getProgName
-           putStrLnErr ""
-           putStrLnErr "ERROR: a CSV output file must be specified for the benchmarking results."
-           putStrLnErr "Use"
-           putStrLnErr ""
-           putStrLnErr $ "   cabal run " ++ prog ++ " -- --csv <file>"
-           putStrLnErr ""
-           putStrLnErr "The CSV file location will be relative to the current shell directory."
-           exitFailure
+         Nothing ->
+           liftIO $ do
+             prog <- getProgName
+             putStrLnErr ""
+             putStrLnErr "ERROR: a CSV output file must be specified for the benchmarking results."
+             putStrLnErr "Use"
+             putStrLnErr ""
+             putStrLnErr $ "   cabal run " ++ prog ++ " -- --csv <file>"
+             putStrLnErr ""
+             putStrLnErr "The CSV file location will be relative to the current shell directory."
+             exitFailure
          Just file  -> do
-           csvExists <- doesFileExist file
-           if csvExists
-           then renameFile file (file <.> "backup")
-           else pure ()
-
+           case phase of
+              Start -> do
+                 csvExists <- liftIO $ doesFileExist file
+                 if csvExists
+                 then liftIO $ renameFile file (file <.> "backup")
+                 else pure ()
+                 time <- liftIO getCurrentTime
+                 liftIO $ appendFile file $ "# Plutus Core cost model benchmark results\n"
+                 liftIO $ appendFile file $ "# Started at " ++ show time ++ "\n"
+                 writeCsv ("Benchmark","t","t.mean.lb","t.mean.ub","t.sd","t.sd.lb", "t.sd.ub")
+              Continue -> pure ()
 
 {- | A modified version of Criterion's 'defaultMainWith' function. We want to be
    able to run different benchmarks with different time limits, but that doesn't
    work with the original version because the relevant function appends output
    to a CSV file but writes a header into the file every time it's called.  This
    adds an option to stop it doing that so we only get one header (at the top,
-   where it belongs).  This also calls `checkCsvSet` to make sure that a CSV
+   where it belongs).  This also calls `initCsvFile` to make sure that a CSV
    output file has been specified. -}
 -- TODO: bypass Criterion's command line parser altogether.
-criterionMainWith :: Bool ->  Config -> [Benchmark] -> IO ()
-criterionMainWith writeHeader defCfg bs =
+criterionMainWith :: BenchmarkingPhase ->  Config -> [Benchmark] -> IO ()
+criterionMainWith phase defCfg bs =
   execParser (describe defCfg) >>=
      \case
       List -> mapM_ putStrLn . sort . concatMap benchNames $ bs
       Version -> putStrLn versionInfo
       RunIters cfg iters matchType benches ->
-          do
-            () <- checkCsvSet cfg
-            shouldRun <- selectBenches matchType benches bsgroup
-            withConfig cfg $ runFixedIters iters shouldRun bsgroup
+          withConfig cfg $ do
+            () <- initCsvFile phase cfg
+            shouldRun <- liftIO $ selectBenches matchType benches bsgroup
+            runFixedIters iters shouldRun bsgroup
       Run cfg matchType benches ->
-          do
-            () <- checkCsvSet cfg
-            shouldRun <- selectBenches matchType benches bsgroup
-            withConfig cfg $ do
-              if writeHeader
-              then do
-                let file = fromJust $ csvFile cfg  -- OK because of checkCsvSet
-                time <- liftIO getCurrentTime
-                liftIO $ appendFile file $ "# Plutus Core cost model benchmark results\n"
-                liftIO $ appendFile file $ "# Started at " ++ show time ++ "\n"
-                writeCsv ("Benchmark","t","t.mean.lb","t.mean.ub","t.sd","t.sd.lb", "t.sd.ub")
-              else return ()
-              liftIO initializeTime
-              runAndAnalyse shouldRun bsgroup
+          withConfig cfg $ do
+            () <- initCsvFile phase cfg
+            shouldRun <- liftIO $ selectBenches matchType benches bsgroup
+            liftIO initializeTime
+            runAndAnalyse shouldRun bsgroup
       where bsgroup = BenchGroup "" bs
 
 selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -63,7 +63,7 @@ initCsvFile phase cfg =
                  time <- liftIO getCurrentTime
                  liftIO $ appendFile file $ "# Plutus Core cost model benchmark results\n"
                  liftIO $ appendFile file $ "# Started at " ++ show time ++ "\n"
-                 writeCsv ("Benchmark","t","t.mean.lb","t.mean.ub","t.sd","t.sd.lb", "t.sd.ub")
+                 writeCsv ("benchmark","t","t.mean.lb","t.mean.ub","t.sd","t.sd.lb", "t.sd.ub")
               Continue -> pure ()  -- Criterion will append output to the CSV file specified in `cfg`.
 
 {- | A modified version of Criterion's 'defaultMainWith' function. We want to be

--- a/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
+++ b/plutus-core/cost-model/budgeting-bench/CriterionExtensions.hs
@@ -63,7 +63,7 @@ initCsvFile phase cfg =
                  liftIO $ appendFile file $ "# Plutus Core cost model benchmark results\n"
                  liftIO $ appendFile file $ "# Started at " ++ show time ++ "\n"
                  writeCsv ("Benchmark","t","t.mean.lb","t.mean.ub","t.sd","t.sd.lb", "t.sd.ub")
-              Continue -> pure ()
+              Continue -> pure ()  -- Criterion will append output to the CSV file specified in `cfg`.
 
 {- | A modified version of Criterion's 'defaultMainWith' function. We want to be
    able to run different benchmarks with different time limits, but that doesn't

--- a/plutus-core/cost-model/budgeting-bench/Main.hs
+++ b/plutus-core/cost-model/budgeting-bench/Main.hs
@@ -4,7 +4,7 @@
 -- See CostModelGeneration.md
 module Main (main) where
 
-import CriterionExtensions (criterionMainWith)
+import CriterionExtensions (BenchmarkingPhase (Continue, Start), criterionMainWith)
 
 import Benchmarks.Bool qualified
 import Benchmarks.ByteStrings qualified
@@ -45,7 +45,7 @@ main = do
   gen <- System.Random.getStdGen  -- We use the initial state of gen repeatedly below, but that doesn't matter.
 
   criterionMainWith
-       True
+       Start
        defaultConfig $
             Benchmarks.Bool.makeBenchmarks            gen
         <>  Benchmarks.ByteStrings.makeBenchmarks     gen
@@ -67,6 +67,6 @@ main = do
   -- data will still be generated and saved in benching.csv).
 
   criterionMainWith
-       False
+       Continue
        (defaultConfig { C.timeLimit = 30 }) $
        Benchmarks.Nops.makeBenchmarks gen


### PR DESCRIPTION
This fixes a problem where the CSV output from the cost model benchmarking process was being split into two files. This is a quick fix: PLT-202 should provide a better solution when we get round to it.
