### PR TITLE
Kwxm/ed25519-v1-v2 (PLT-585)

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1119,6 +1119,9 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                   _            -> verifyEd25519Signature_V2
         in makeBuiltinMeaning
            verifyEd25519Signature
+           -- Benchmarks indicate that the two versions have very similar
+           -- execution times, so it's safe to use the same costing function for
+           -- both.
            (runCostingFunThreeArguments . paramVerifyEd25519Signature)
     {- Note [ECDSA secp256k1 signature verification].  An ECDSA signature
        consists of a pair of values (r,s), and for each value of r there are in

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -25,7 +25,8 @@ import PlutusCore.Evaluation.Result
 import PlutusCore.Pretty
 
 import Codec.Serialise (serialise)
-import Crypto (verifyEcdsaSecp256k1Signature, verifyEd25519Signature_V1, verifySchnorrSecp256k1Signature)
+import Crypto (verifyEcdsaSecp256k1Signature, verifyEd25519Signature_V1, verifyEd25519Signature_V2,
+               verifySchnorrSecp256k1Signature)
 import Data.ByteString qualified as BS
 import Data.ByteString.Hash qualified as Hash
 import Data.ByteString.Lazy qualified as BS (toStrict)
@@ -1111,10 +1112,14 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
         makeBuiltinMeaning
             Hash.blake2b_256
             (runCostingFunOneArgument . paramBlake2b_256)
-    toBuiltinMeaning _ver VerifyEd25519Signature =
-        makeBuiltinMeaning
-            verifyEd25519Signature_V1   -- TODO: also allow verifyEd25519Signature_V2
-            (runCostingFunThreeArguments . paramVerifyEd25519Signature)
+    toBuiltinMeaning ver VerifyEd25519Signature =
+        let verifyEd25519Signature =
+                case ver of
+                  DefaultFunV1 -> verifyEd25519Signature_V1
+                  _            -> verifyEd25519Signature_V2
+        in makeBuiltinMeaning
+           verifyEd25519Signature
+           (runCostingFunThreeArguments . paramVerifyEd25519Signature)
     {- Note [ECDSA secp256k1 signature verification].  An ECDSA signature
        consists of a pair of values (r,s), and for each value of r there are in
        fact two valid values of s, one effectively the negative of the other.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -34,7 +34,8 @@ import PlutusCore.StdLib.Data.ScottList qualified as Scott
 import PlutusCore.StdLib.Data.Unit
 
 import Evaluation.Builtins.Common
-import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519Prop, schnorrSecp256k1Prop)
+import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519PropV1, ed25519PropV2,
+                                                  schnorrSecp256k1Prop)
 
 import Control.Exception
 import Data.ByteString (ByteString)
@@ -602,8 +603,11 @@ test_SignatureVerification :: TestTree
 test_SignatureVerification =
   adjustOption (\x -> max x . HedgehogTestLimit . Just $ 8000) .
   testGroup "Signature verification" $ [
-                 testGroup "Ed25519 signatures" $ [
-                                testPropertyNamed "Ed25519 verification behaves correctly on all inputs" "ed25519_correct" . property $ ed25519Prop
+                 testGroup "Ed25519 signatures (V1)" $ [
+                                testPropertyNamed "Ed25519 verification behaves correctly on all inputs" "ed25519_correct" . property $ ed25519PropV1
+                               ],
+                 testGroup "Ed25519 signatures (V2)" $ [
+                                testPropertyNamed "Ed25519 verification behaves correctly on all inputs" "ed25519_correct" . property $ ed25519PropV2
                                ],
                  testGroup "Signatures on the SECP256k1 curve" $ [
                                 testPropertyNamed "ECDSA verification behaves correctly on all inputs" "ecdsa_correct" . property $ ecdsaSecp256k1Prop,

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -34,7 +34,7 @@ import PlutusCore.StdLib.Data.ScottList qualified as Scott
 import PlutusCore.StdLib.Data.Unit
 
 import Evaluation.Builtins.Common
-import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519PropV1, ed25519PropV2,
+import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519_V1Prop, ed25519_V2Prop,
                                                   schnorrSecp256k1Prop)
 
 import Control.Exception
@@ -604,10 +604,10 @@ test_SignatureVerification =
   adjustOption (\x -> max x . HedgehogTestLimit . Just $ 8000) .
   testGroup "Signature verification" $ [
                  testGroup "Ed25519 signatures (V1)" $ [
-                                testPropertyNamed "Ed25519 verification behaves correctly on all inputs" "ed25519_correct" . property $ ed25519PropV1
+                                testPropertyNamed "Ed25519_V1 verification behaves correctly on all inputs" "ed25519_V1_correct" . property $ ed25519_V1Prop
                                ],
                  testGroup "Ed25519 signatures (V2)" $ [
-                                testPropertyNamed "Ed25519 verification behaves correctly on all inputs" "ed25519_correct" . property $ ed25519PropV2
+                                testPropertyNamed "Ed25519_V2 verification behaves correctly on all inputs" "ed25519_V2_correct" . property $ ed25519_V2Prop
                                ],
                  testGroup "Signatures on the SECP256k1 curve" $ [
                                 testPropertyNamed "ECDSA verification behaves correctly on all inputs" "ecdsa_correct" . property $ ecdsaSecp256k1Prop,

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -9,8 +9,8 @@
 
 module Evaluation.Builtins.SignatureVerification (
   ecdsaSecp256k1Prop,
-  ed25519PropV1,
-  ed25519PropV2,
+  ed25519_V1Prop,
+  ed25519_V2Prop,
   schnorrSecp256k1Prop,
   ) where
 
@@ -73,11 +73,11 @@ ed25519Prop ver = do
   cover 18 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
   runTestDataWith ver testCase id VerifyEd25519Signature
 
-ed25519PropV1 :: PropertyT IO ()
-ed25519PropV1 = ed25519Prop DefaultFunV1
+ed25519_V1Prop :: PropertyT IO ()
+ed25519_V1Prop = ed25519Prop DefaultFunV1
 
-ed25519PropV2 :: PropertyT IO ()
-ed25519PropV2 = ed25519Prop DefaultFunV2
+ed25519_V2Prop :: PropertyT IO ()
+ed25519_V2Prop = ed25519Prop DefaultFunV2
 
 -- Helpers
 


### PR DESCRIPTION
This is PLT-585.  Previously PLT-167 (#4771) added an alternative implementation for `verifyEd25519Signature` which uses `caradno-base` instead of `cardano-crypto`; this just hooks it up to Nikos' versioned builtins PR, so it's pretty straightforward. See PLT-728 for a path towards getting rid of the old version completely. 

The most complicated part was updating the tests to test both versions.  The tests are based on those provided by Koz Ross for the SCP functions and are quite extensive (they take about 40 seconds per function on my laptop).  I've added a separate test for each version of `verifyEd255519Signature`. Having two lots of tests might add some maintenance burden since we'll need to make sure that they stay synchronised with the various `DefaultFun` versions.  @effectfully suggested before that we should run all of the tests for all builtin versions. That would probably be the safest thing to do, but would be expensive: we should think about that as a separate issue.