### PR TITLE
PLT-724: Remove transaction inputs from plutus-ledger-api

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
@@ -29,16 +29,6 @@ module PlutusLedgerApi.V2.Tx
     , outDatum
     , outReferenceScript
     , pubKeyHashTxOut
-    -- * Transaction inputs
-    , TxInType(..)
-    , TxIn(..)
-    , inRef
-    , inType
-    , inScripts
-    , pubKeyTxIn
-    , scriptTxIn
-    , pubKeyTxIns
-    , scriptTxIns
     ) where
 
 import Control.DeepSeq (NFData)


### PR DESCRIPTION
`TxIn` is not part of `ScriptContext` and is not used by the ledger. If Plutus Tools needs it, it should be moved to plutus-apps.