### PR TITLE
Josfaj/plt 758 remove refs to secp256k1sig builtins

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,8 +22,8 @@ if rtd_version not in ["stable", "latest"]:
 
 # -- Project information -----------------------------------------------------
 
-project = 'Plutus'
-copyright = '2021, IOHK'
+project = 'Plutus Programming and Reference Guide'
+copyright = '2022, IOHK'
 author = 'IOHK'
 
 # The full version, including alpha/beta/rc tags

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ if rtd_version not in ["stable", "latest"]:
 
 # -- Project information -----------------------------------------------------
 
-project = 'Plutus Programming and Reference Guide'
+project = 'Plutus Core and Plutus Tx User Guide'
 copyright = '2022, IOHK'
 author = 'IOHK'
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,24 +5,31 @@ About Plutus
 --------------------
 
 Plutus is the programming language and compiler (Plutus Tx) that is used to write 
-Plutus scripts that run on the Cardano blockchain. Plutus Tx is the compiler plugin 
-for writing Plutus Core programs in Haskell. Compiled Plutus Core programs are able to 
-interact with the Cardano ledger through the ledger interface. 
+Plutus scripts that run on the Cardano blockchain. Compiled Plutus Core programs 
+are able to interact with the Cardano ledger through the ledger interface. 
+
+The Plutus Core Repository
+----------------------------------
+
+The `Plutus Core Repository <https://github.com/input-output-hk/plutus>`_ contains 
+the implementation, specification, and mechanized metatheory of Plutus Core. 
+It contains Plutus Tx, which takes the Haskell source code and compiles it into 
+Plutus Core (PLC). 
 
 About This Documentation
 ---------------------------------
 
 The purpose of this documentation is to serve as an introduction to the Plutus language 
-and to programming in Plutus. It is also meant to be educational, so it includes tutorials 
-and how-to instructions. It may also serve as a reference for beginning and experienced 
+and to programming in Plutus. It is meant to be educational, so it includes tutorials 
+and how-to instructions. It is also intended as a reference for beginning and experienced 
 developers. 
 
 Intended Audience
 ---------------------------
 
-The intended audience of this documentation is DApp developers, Plutus developers, 
+The intended audience of this documentation includes DApp developers, Plutus developers, 
 developers writing smart contracts, Haskell developers who want to write Plutus scripts, 
-and developers who want to learn to use the compiler Plutus Tx. 
+and developers who want to learn to use the compiler, Plutus Tx. 
 
 It is also intended for developers who want to learn Plutus from the definitive 
 source: the team that developed the Plutus language, which is built on top of Haskell. 
@@ -30,17 +37,8 @@ source: the team that developed the Plutus language, which is built on top of Ha
 While it is helpful to have a background in Haskell, this document is also intended 
 for developers who may not know Haskell very well. 
 
-This document is also intended for people who need to reference and access specifications, 
-along with certification companies, certification auditors, and anyone doing certification 
-and auditing. 
-
-The Plutus Core Repository
-----------------------------------
-
-The `Plutus Core Repository <https://github.com/input-output-hk/plutus>`_ contains 
-the implementation, specification, and mechanized metatheory of Plutus Core. 
-It contains Plutus Tx, the compiler from Haskell source code to Plutus Core. 
-Plutus Tx takes the Haskell source code and compiles it into PLC Plutus Core. 
+This guide is also intended for people who need to reference and access specifications, 
+along with certification companies and certification auditors. 
 
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,44 +1,49 @@
-Plutus Programming and Reference Guide
-=============================================
-
-About Plutus
---------------------
-
-The Plutus project consists of Plutus Core, the programming language used for scripts on Cardano; tooling and compilers for compiling various intermediate languages into Plutus Core;
-and Plutus Tx, the compiler that compiles the Haskell source code into Plutus Core 
-to form the on-chain part of a contract application. All of this is used in combination 
-to write Plutus Core scripts that run on the Cardano blockchain. Compiled Plutus Core 
-scripts are able to interact with the Cardano ledger through the 
-ledger interface. 
-
-The Plutus Core Repository
-----------------------------------
-
-The `Plutus Core Repository <https://github.com/input-output-hk/plutus>`_ contains 
-the implementation, specification, and mechanized metatheory of Plutus Core. 
-It also contains Plutus Tx. 
-
-About This Documentation
----------------------------------
-
-The purpose of this documentation is to serve as an introduction to the Plutus language 
-and to programming using Plutus Tx. It is meant to be educational, so it includes explanations, 
-tutorials and how-to instructions. It is also intended as a reference for beginning and 
-experienced developers. 
+Plutus Core and Plutus Tx User Guide
+==================================================
 
 Intended Audience
 ---------------------------
 
-The intended audience of this documentation includes DApp developers, Plutus developers, 
-developers writing smart contracts, Haskell developers who want to write Plutus scripts, 
-and developers who want to learn to use the compiler, Plutus Tx. It is also designed for 
-developers who want to learn Plutus directly from the team that developed the Plutus language. 
+The intended audience of this documentation includes people who need to implement 
+smart contracts on the Cardano blockchain. This involves using Plutus Tx to write 
+scripts, requiring some knowledge of the Haskell programming language. 
 
-Because Plutus Tx is built on top of Haskell, it is helpful to have a background in Haskell. 
-However, this document is also intended for developers who may not know Haskell very well. 
+This guide is also meant for certification companies, certification auditors, 
+and people who need to reference specifications, such as the 
+`Cardano Ledger Specification <https://github.com/input-output-hk/cardano-ledger#cardano-ledger>`_ 
+and the `Plutus Core Specification <https://github.com/input-output-hk/plutus#specifications-and-design>`_. 
 
-This guide is also meant for people who need to reference and access specifications, 
-as well as for certification companies and certification auditors. 
+About this Documentation
+-----------------------------
+
+This documentation introduces the Plutus Core programming language and programming 
+with Plutus Tx. It is meant to be educational, so it includes explanations, tutorials 
+and how-to instructions. 
+
+Plutus Core
+====================
+
+The Plutus project consists of Plutus Core, the programming language used for 
+scripts on Cardano; tooling and compilers for compiling various intermediate 
+languages into Plutus Core; and Plutus Tx, the compiler that compiles the Haskell 
+source code into Plutus Core to form the on-chain part of a contract application. 
+All of this is used in combination to write Plutus Core scripts that run on the 
+Cardano blockchain. The Cardano ledger is able to interact with compiled Plutus Core 
+scripts through the ledger interface. 
+
+The Plutus Repository
+----------------------------------
+
+The `Plutus Repository <https://github.com/input-output-hk/plutus>`_ contains 
+the implementation, specification, and mechanized metatheory of Plutus Core. 
+It also contains the Plutus Tx compiler and the libraries, such as ``PlutusTx.List``, for writing Haskell code 
+that can be compiled to Plutus Core. 
+
+Public Plutus Libraries Documentation
+-------------------------------------------
+
+See also the `public Plutus libraries documentation <https://playground.plutus.iohkdev.io/doc/haddock/>`_ 
+to access Haddock-generated documentation of all the code, including Plutus Core. 
 
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,9 +9,10 @@ smart contracts on the Cardano blockchain. This involves using Plutus Tx to writ
 scripts, requiring some knowledge of the Haskell programming language. 
 
 This guide is also meant for certification companies, certification auditors, 
-and people who need to reference specifications, such as the 
-`Cardano Ledger Specification <https://github.com/input-output-hk/cardano-ledger#cardano-ledger>`_ 
-and the `Plutus Core Specification <https://github.com/input-output-hk/plutus#specifications-and-design>`_. 
+and people who need to reference specifications, such as: 
+
+* the `Cardano Ledger Specification <https://github.com/input-output-hk/cardano-ledger#cardano-ledger>`_ and 
+* the `Plutus Core Specification <https://github.com/input-output-hk/plutus#specifications-and-design>`_. 
 
 About this Documentation
 -----------------------------
@@ -43,7 +44,7 @@ Public Plutus Libraries Documentation
 -------------------------------------------
 
 See also the `public Plutus libraries documentation <https://playground.plutus.iohkdev.io/doc/haddock/>`_ 
-to access Haddock-generated documentation of all the code, including Plutus Core. 
+to access Haddock-generated documentation of all the code. 
 
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,9 +22,9 @@ About This Documentation
 ---------------------------------
 
 The purpose of this documentation is to serve as an introduction to the Plutus language 
-and to programming in Plutus. It is meant to be educational, so it includes tutorials 
-and how-to instructions. It is also intended as a reference for beginning and experienced 
-developers. 
+and to programming in Plutus. It is meant to be educational, so it includes explanations, 
+tutorials and how-to instructions. It is also intended as a reference for beginning and 
+experienced developers. 
 
 Intended Audience
 ---------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,7 +34,7 @@ developers writing smart contracts, Haskell developers who want to write Plutus 
 and developers who want to learn to use the compiler, Plutus Tx. It is also designed for 
 developers who want to learn Plutus directly from the team that developed the Plutus language. 
 
-Because Plutus is built on top of Haskell, it is helpful to have a background in Haskell. 
+Because Plutus Tx is built on top of Haskell, it is helpful to have a background in Haskell. 
 However, this document is also intended for developers who may not know Haskell very well. 
 
 This guide is also meant for people who need to reference and access specifications, 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,7 +22,7 @@ About This Documentation
 ---------------------------------
 
 The purpose of this documentation is to serve as an introduction to the Plutus language 
-and to programming in Plutus. It is meant to be educational, so it includes explanations, 
+and to programming using Plutus Tx. It is meant to be educational, so it includes explanations, 
 tutorials and how-to instructions. It is also intended as a reference for beginning and 
 experienced developers. 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,47 @@
-Plutus
-======
+Plutus Programming and Reference Guide
+=============================================
 
-Plutus provides the support for writing scripts that run on the Cardano blockchain.
-To read more about the overall architecture of writing applications using Plutus, see :ref:`what_is_the_plutus_platform`.
+About Plutus
+--------------------
+
+Plutus is the programming language and compiler (Plutus Tx) that is used to write 
+Plutus scripts that run on the Cardano blockchain. Plutus Tx is the compiler plugin 
+for writing Plutus Core programs in Haskell. Compiled Plutus Core programs are able to 
+interact with the Cardano ledger through the ledger interface. 
+
+About This Documentation
+---------------------------------
+
+The purpose of this documentation is to serve as an introduction to the Plutus language 
+and to programming in Plutus. It is also meant to be educational, so it includes tutorials 
+and how-to instructions. It may also serve as a reference for beginning and experienced 
+developers. 
+
+Intended Audience
+---------------------------
+
+The intended audience of this documentation is DApp developers, Plutus developers, 
+developers writing smart contracts, Haskell developers who want to write Plutus scripts, 
+and developers who want to learn to use the compiler Plutus Tx. 
+
+It is also intended for developers who want to learn Plutus from the definitive 
+source: the team that developed the Plutus language, which is built on top of Haskell. 
+
+While it is helpful to have a background in Haskell, this document is also intended 
+for developers who may not know Haskell very well. 
+
+This document is also intended for people who need to reference and access specifications, 
+along with certification companies, certification auditors, and anyone doing certification 
+and auditing. 
+
+The Plutus Core Repository
+----------------------------------
+
+The `Plutus Core Repository <https://github.com/input-output-hk/plutus>`_ contains 
+the implementation, specification, and mechanized metatheory of Plutus Core. 
+It contains Plutus Tx, the compiler from Haskell source code to Plutus Core. 
+Plutus Tx takes the Haskell source code and compiles it into PLC Plutus Core. 
+
 
 .. toctree::
    :caption: Explore Plutus

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ The Plutus project consists of Plutus Core, the programming language used for sc
 and Plutus Tx, the compiler that compiles the Haskell source code into Plutus Core 
 to form the on-chain part of a contract application. All of this is used in combination 
 to write Plutus Core scripts that run on the Cardano blockchain. Compiled Plutus Core 
-scripts or programs are able to interact with the Cardano ledger through the 
+scripts are able to interact with the Cardano ledger through the 
 ledger interface. 
 
 The Plutus Core Repository

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ About Plutus
 The Plutus project consists of Plutus Core, the programming language used for scripts on Cardano; tooling and compilers for compiling various intermediate languages into Plutus Core;
 and Plutus Tx, the compiler that compiles the Haskell source code into Plutus Core 
 to form the on-chain part of a contract application. All of this is used in combination 
-to write Plutus scripts that run on the Cardano blockchain. Compiled Plutus Core 
+to write Plutus Core scripts that run on the Cardano blockchain. Compiled Plutus Core 
 scripts or programs are able to interact with the Cardano ledger through the 
 ledger interface. 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@ Plutus Programming and Reference Guide
 About Plutus
 --------------------
 
-Plutus consists of Plutus Core, the programming, scripting and assembly language; 
+The Plutus project consists of Plutus Core, the programming language used for scripts on Cardano; tooling and compilers for compiling various intermediate languages into Plutus Core;
 and Plutus Tx, the compiler that compiles the Haskell source code into Plutus Core 
 to form the on-chain part of a contract application. All of this is used in combination 
 to write Plutus scripts that run on the Cardano blockchain. Compiled Plutus Core 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,17 +4,19 @@ Plutus Programming and Reference Guide
 About Plutus
 --------------------
 
-Plutus is the programming language and compiler (Plutus Tx) that is used to write 
-Plutus scripts that run on the Cardano blockchain. Compiled Plutus Core programs 
-are able to interact with the Cardano ledger through the ledger interface. 
+Plutus consists of Plutus Core, the programming, scripting and assembly language; 
+and Plutus Tx, the compiler that compiles the Haskell source code into Plutus Core 
+to form the on-chain part of a contract application. All of this is used in combination 
+to write Plutus scripts that run on the Cardano blockchain. Compiled Plutus Core 
+scripts or programs are able to interact with the Cardano ledger through the 
+ledger interface. 
 
 The Plutus Core Repository
 ----------------------------------
 
 The `Plutus Core Repository <https://github.com/input-output-hk/plutus>`_ contains 
 the implementation, specification, and mechanized metatheory of Plutus Core. 
-It contains Plutus Tx, which takes the Haskell source code and compiles it into 
-Plutus Core (PLC). 
+It also contains Plutus Tx. 
 
 About This Documentation
 ---------------------------------
@@ -29,16 +31,14 @@ Intended Audience
 
 The intended audience of this documentation includes DApp developers, Plutus developers, 
 developers writing smart contracts, Haskell developers who want to write Plutus scripts, 
-and developers who want to learn to use the compiler, Plutus Tx. 
+and developers who want to learn to use the compiler, Plutus Tx. It is also designed for 
+developers who want to learn Plutus directly from the team that developed the Plutus language. 
 
-It is also intended for developers who want to learn Plutus from the definitive 
-source: the team that developed the Plutus language, which is built on top of Haskell. 
+Because Plutus is built on top of Haskell, it is helpful to have a background in Haskell. 
+However, this document is also intended for developers who may not know Haskell very well. 
 
-While it is helpful to have a background in Haskell, this document is also intended 
-for developers who may not know Haskell very well. 
-
-This guide is also intended for people who need to reference and access specifications, 
-along with certification companies and certification auditors. 
+This guide is also meant for people who need to reference and access specifications, 
+as well as for certification companies and certification auditors. 
 
 
 .. toctree::

--- a/doc/reference/cardano/language-changes.rst
+++ b/doc/reference/cardano/language-changes.rst
@@ -44,8 +44,6 @@ Vasil
 
 All of the built-in types and functions from ``PlutusV1`` were added to ``PlutusV2``.
 
-The following built-in functions were added to ``PlutusV2`` only (i.e. they are not available in ``PlutusV1``).
+The following built-in function was added to ``PlutusV2`` only (i.e., it is not available in ``PlutusV1``).
 
 - ``serializeData`` (proposed in CIP-42)
-- ``verifyEcdsaSecp256k1Signature`` (proposed in CIP-49)
-- ``verifySchnorrSecp256k1Signature`` (proposed in CIP-49)


### PR DESCRIPTION
This edit is limited to removing references to the two Secp256k1signature built-ins that were pulled out of the Vasil HF. 