### PR TITLE
removed references to the two secp256k1 builtins

### DIFF
--- a/doc/reference/cardano/language-changes.rst
+++ b/doc/reference/cardano/language-changes.rst
@@ -44,8 +44,6 @@ Vasil
 
 All of the built-in types and functions from ``PlutusV1`` were added to ``PlutusV2``.
 
-The following built-in functions were added to ``PlutusV2`` only (i.e. they are not available in ``PlutusV1``).
+The following built-in function was added to ``PlutusV2`` only (i.e., it is not available in ``PlutusV1``).
 
 - ``serializeData`` (proposed in CIP-42)
-- ``verifyEcdsaSecp256k1Signature`` (proposed in CIP-49)
-- ``verifySchnorrSecp256k1Signature`` (proposed in CIP-49)


### PR DESCRIPTION
This is my cleaned-up "take 2" version of this PR. The only change is to this file: 

language-changes.rst

in order to remove the two references to the secp256k1 builtins. 