### PR TITLE
Kwxm/parser/minor fixes

### DIFF
--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -43,7 +43,7 @@ shownEvaluationFailure = "evaluation failure"
 parseTxt ::
     T.Text
     -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
-parseTxt resTxt = runQuoteT $ UPLC.parseProgram "conformance-tests" resTxt
+parseTxt resTxt = runQuoteT $ UPLC.parseProgram resTxt
 
 -- | The input/output UPLC program type.
 type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()

--- a/plutus-conformance/src/PlutusConformance/Common.hs
+++ b/plutus-conformance/src/PlutusConformance/Common.hs
@@ -43,7 +43,7 @@ shownEvaluationFailure = "evaluation failure"
 parseTxt ::
     T.Text
     -> Either ParserErrorBundle (UPLC.Program Name DefaultUni DefaultFun SourcePos)
-parseTxt resTxt = runQuoteT $ UPLC.parseProgram resTxt
+parseTxt resTxt = runQuoteT $ UPLC.parseProgram "conformance-tests" resTxt
 
 -- | The input/output UPLC program type.
 type UplcProg = UPLC.Program Name DefaultUni DefaultFun ()

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -16,7 +16,7 @@ import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Check.Uniques as PLC (checkProgram)
 import PlutusCore.Compiler.Erase qualified as PLC
-import PlutusCore.Error (AsUniqueError, ParserErrorBundle, UniqueError)
+import PlutusCore.Error (AsUniqueError, ParserErrorBundle (..), UniqueError)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..), ExRestrictingBudget (..))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
@@ -55,6 +55,7 @@ import UntypedPlutusCore.Parser qualified as UPLC (parseProgram)
 import System.CPUTime (getCPUTime)
 import System.Exit (exitFailure, exitSuccess)
 import System.Mem (performGC)
+import Text.Megaparsec (errorBundlePretty)
 import Text.Printf (printf)
 
 ----------- Executable type class -----------
@@ -288,8 +289,8 @@ parseInput inp = do
     -- parse the UPLC program
     case parseProgram (show inp) contents of
       -- when fail, pretty print the parse errors.
-      Left (err :: ParserErrorBundle) ->
-          errorWithoutStackTrace $ PP.render $ pretty err
+      Left (ParseErrorB err) ->
+          errorWithoutStackTrace $ errorBundlePretty err
       -- otherwise,
       Right p -> do
         -- run @rename@ through the program

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -70,7 +70,8 @@ type UplcProg =
 
 class Executable p where
 
-  -- | Parse a program.
+  -- | Parse a program.  The first argument (normally the file path) describes
+  -- the input stream, the second is the program text.
   parseProgram ::
     String -> T.Text -> Either ParserErrorBundle (p PLC.SourcePos)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -5,6 +5,7 @@
 
 module PlutusCore.Parser
     ( module Export
+    , program
     , parseProgram
     , parseTerm
     , parseType
@@ -79,16 +80,14 @@ term = choice $ map try
     ]
 
 -- | Parse a PLC program. The resulting program will have fresh names. The
--- underlying monad must be capable of handling any parse errors.  The first
--- argument appears in parser errors and is supposed to describe the origin of
--- the program (typically a file path); the second argument is the program text
--- itself.
+-- underlying monad must be capable of handling any parse errors.  This passes
+-- "test" to the parser as the name of the input stream; to supply a name
+-- explicity, use `parse program <name> <input>`.
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
-    => String
-    -> Text
+    => Text
     -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
-parseProgram inputName = parse program inputName
+parseProgram = parseGen program
 
 -- | Parser for PLC programs.
 program :: Parser (Program TyName Name DefaultUni DefaultFun SourcePos)

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -78,8 +78,11 @@ term = choice $ map try
     , varTerm
     ]
 
--- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
+-- | Parse a PLC program. The resulting program will have fresh names. The
+-- underlying monad must be capable of handling any parse errors.  The first
+-- argument appears in parser errors and is supposed to describe the origin of
+-- the program (typically a file path); the second argument is the program text
+-- itself.
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
     => String

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -80,9 +80,12 @@ term = choice $ map try
 
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseProgram :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
-    Text -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
-parseProgram = parseGen program
+parseProgram ::
+    (AsParserErrorBundle e, MonadError e m, MonadQuote m)
+    => String
+    -> Text
+    -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
+parseProgram inputName = parse program inputName
 
 -- | Parser for PLC programs.
 program :: Parser (Program TyName Name DefaultUni DefaultFun SourcePos)

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -191,7 +191,7 @@ propParser = property $ do
                 (\p -> fmap (TextualProgram . void) (parseProg p))
     where
         parseProg :: T.Text -> Either ParserErrorBundle (Program TyName Name DefaultUni DefaultFun SourcePos)
-        parseProg p = runQuoteT $ parseProgram p
+        parseProg = runQuoteT . parseProgram "test"
 
 type TestFunction = T.Text -> Either DefaultError T.Text
 
@@ -215,7 +215,7 @@ parseScoped :: (AsParserErrorBundle e, AsUniqueError e SourcePos,
     T.Text
     -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram
+parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram "test"
 
 printType ::(AsParserErrorBundle e, AsUniqueError e SourcePos, AsTypeError e (Term TyName Name DefaultUni DefaultFun ()) DefaultUni DefaultFun SourcePos,
         MonadError e m)
@@ -232,7 +232,7 @@ testsType = testGroup "golden type synthesis tests" . fmap (asGolden printType)
 format
     :: (AsParserErrorBundle e, MonadError e m)
     => PrettyConfigPlc -> T.Text -> m T.Text
-format cfg = runQuoteT . fmap (displayBy cfg) . (rename <=< parseProgram)
+format cfg = runQuoteT . fmap (displayBy cfg) . (rename <=< parseProgram "test")
 
 testsGolden :: [FilePath] -> TestTree
 testsGolden

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -191,7 +191,7 @@ propParser = property $ do
                 (\p -> fmap (TextualProgram . void) (parseProg p))
     where
         parseProg :: T.Text -> Either ParserErrorBundle (Program TyName Name DefaultUni DefaultFun SourcePos)
-        parseProg = runQuoteT . parseProgram "test"
+        parseProg = runQuoteT . parseProgram
 
 type TestFunction = T.Text -> Either DefaultError T.Text
 
@@ -215,7 +215,7 @@ parseScoped :: (AsParserErrorBundle e, AsUniqueError e SourcePos,
     T.Text
     -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram "test"
+parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram
 
 printType ::(AsParserErrorBundle e, AsUniqueError e SourcePos, AsTypeError e (Term TyName Name DefaultUni DefaultFun ()) DefaultUni DefaultFun SourcePos,
         MonadError e m)
@@ -232,7 +232,7 @@ testsType = testGroup "golden type synthesis tests" . fmap (asGolden printType)
 format
     :: (AsParserErrorBundle e, MonadError e m)
     => PrettyConfigPlc -> T.Text -> m T.Text
-format cfg = runQuoteT . fmap (displayBy cfg) . (rename <=< parseProgram "test")
+format cfg = runQuoteT . fmap (displayBy cfg) . (rename <=< parseProgram)
 
 testsGolden :: [FilePath] -> TestTree
 testsGolden

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -15,7 +15,7 @@ module PlutusIR.Parser
     ) where
 
 import PlutusCore.Default qualified as PLC (DefaultFun, DefaultUni)
-import PlutusCore.Parser hiding (parseProgram)
+import PlutusCore.Parser hiding (parseProgram, program)
 import PlutusIR as PIR
 import PlutusIR.MkPir qualified as PIR
 import PlutusPrelude
@@ -130,13 +130,11 @@ program = whitespace >> do
     return prog
 
 -- | Parse a PIR program. The resulting program will have fresh names. The
--- underlying monad must be capable of handling any parse errors.  The first
--- argument appears in parser errors and is supposed to describe the origin of
--- the program (typically a file path); the second argument is the program text
--- itself.
+-- underlying monad must be capable of handling any parse errors.  This passes
+-- "test" to the parser as the name of the input stream; to supply a name
+-- explicity, use `parse program <name> <input>`.
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
-    => String
-    -> Text
+    => Text
     -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-parseProgram inputName = parse program inputName
+parseProgram = parseGen program

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -129,8 +129,11 @@ program = whitespace >> do
     notFollowedBy anySingle
     return prog
 
--- | Parse a PIR program. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
+-- | Parse a PIR program. The resulting program will have fresh names. The
+-- underlying monad must be capable of handling any parse errors.  The first
+-- argument appears in parser errors and is supposed to describe the origin of
+-- the program (typically a file path); the second argument is the program text
+-- itself.
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
     => String

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -131,6 +131,9 @@ program = whitespace >> do
 
 -- | Parse a PIR program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseProgram :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
-    Text -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-parseProgram = parseGen program
+parseProgram ::
+    (AsParserErrorBundle e, MonadError e m, MonadQuote m)
+    => String
+    -> Text
+    -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
+parseProgram inputName = parse program inputName

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -26,7 +26,7 @@ import UntypedPlutusCore.Rename (Rename (rename))
 import Data.Text (Text)
 import PlutusCore.Error (AsParserErrorBundle)
 import PlutusCore.MkPlc (mkIterApp)
-import PlutusCore.Parser hiding (parseProgram, parseTerm)
+import PlutusCore.Parser hiding (parseProgram, parseTerm, program)
 
 -- Parsers for UPLC terms
 
@@ -84,23 +84,20 @@ parseTerm :: (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m) => Text -
 parseTerm = parseGen term
 
 -- | Parse a UPLC program. The resulting program will have fresh names. The
--- underlying monad must be capable of handling any parse errors.  The first
--- argument appears in parser errors and is supposed to describe the origin of
--- the program (typically a file path); the second argument is the program text
--- itself.
+-- underlying monad must be capable of handling any parse errors.  This passes
+-- "test" to the parser as the name of the input stream; to supply a name
+-- explicity, use `parse program <name> <input>`.`
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m)
-    => String
-    -> Text
+    => Text
     -> m (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-parseProgram inputName = parse program inputName
+parseProgram = parseGen program
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped ::
     (AsParserErrorBundle e, PLC.AsUniqueError e SourcePos, MonadError e m, PLC.MonadQuote m)
-    => String
-    -> Text
+    => Text
     -> m (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped inputName = through (checkProgram (const True)) <=< rename <=< parseProgram inputName
+parseScoped = through (checkProgram (const True)) <=< rename <=< parseProgram

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -83,8 +83,11 @@ program = whitespace >> do
 parseTerm :: (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m) => Text -> m PTerm
 parseTerm = parseGen term
 
--- | Parse a UPLC program. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
+-- | Parse a UPLC program. The resulting program will have fresh names. The
+-- underlying monad must be capable of handling any parse errors.  The first
+-- argument appears in parser errors and is supposed to describe the origin of
+-- the program (typically a file path); the second argument is the program text
+-- itself.
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m)
     => String

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -85,14 +85,19 @@ parseTerm = parseGen term
 
 -- | Parse a UPLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseProgram :: (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m) => Text -> m (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-parseProgram = parseGen program
+parseProgram ::
+    (AsParserErrorBundle e, MonadError e m, PLC.MonadQuote m)
+    => String
+    -> Text
+    -> m (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
+parseProgram inputName = parse program inputName
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped ::
     (AsParserErrorBundle e, PLC.AsUniqueError e SourcePos, MonadError e m, PLC.MonadQuote m)
-    => Text
+    => String
+    -> Text
     -> m (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SourcePos)
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped = through (checkProgram (const True)) <=< rename <=< parseProgram
+parseScoped inputName = through (checkProgram (const True)) <=< rename <=< parseProgram inputName

--- a/plutus-core/untyped-plutus-core/test/Generators.hs
+++ b/plutus-core/untyped-plutus-core/test/Generators.hs
@@ -77,7 +77,7 @@ propParser = testPropertyNamed "Parser" "parser" $ property $ do
     where
         parseProg
             :: T.Text -> Either ParserErrorBundle (Program Name DefaultUni DefaultFun SourcePos)
-        parseProg p = runQuoteT $ parseProgram p
+        parseProg p = runQuoteT $ parseProgram "test" p
 
 propUnit :: TestTree
 propUnit = testCase "Unit" $ fold

--- a/plutus-core/untyped-plutus-core/test/Generators.hs
+++ b/plutus-core/untyped-plutus-core/test/Generators.hs
@@ -77,7 +77,7 @@ propParser = testPropertyNamed "Parser" "parser" $ property $ do
     where
         parseProg
             :: T.Text -> Either ParserErrorBundle (Program Name DefaultUni DefaultFun SourcePos)
-        parseProg p = runQuoteT $ parseProgram "test" p
+        parseProg = runQuoteT . parseProgram
 
 propUnit :: TestTree
 propUnit = testCase "Unit" $ fold

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -153,9 +153,9 @@ postulate
 
 {-# COMPILE GHC parse = runQuoteT . parseProgram #-}
 {-# COMPILE GHC parseU = runQuoteT . U.parseProgram #-}
-{-# COMPILE GHC parseTm = runQuoteT . parseTerm  #-}
-{-# COMPILE GHC parseTy = runQuoteT . parseType  #-}
-{-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm  #-}
+{-# COMPILE GHC parseTm = runQuoteT . parseTerm #-}
+{-# COMPILE GHC parseTy = runQuoteT . parseType #-}
+{-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm #-}
 {-# COMPILE GHC deBruijnify = \ (Program ann ver tm) -> second (void . Program ann ver) . runExcept $ deBruijnTerm tm #-}
 {-# COMPILE GHC deBruijnifyTm = second void . runExcept . deBruijnTerm #-}
 {-# COMPILE GHC deBruijnifyTy = second void . runExcept . deBruijnTy #-}

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -151,8 +151,8 @@ postulate
 {-# FOREIGN GHC import Data.Functor #-}
 {-# COMPILE GHC ParseError = type PlutusCore.Error.ParserErrorBundle #-}
 
-{-# COMPILE GHC parse = runQuoteT . parseProgram  "plutus-metatheory" #-}
-{-# COMPILE GHC parseU = runQuoteT . U.parseProgram  "plutus-metatheory" #-}
+{-# COMPILE GHC parse = runQuoteT . parseProgram #-}
+{-# COMPILE GHC parseU = runQuoteT . U.parseProgram #-}
 {-# COMPILE GHC parseTm = runQuoteT . parseTerm  #-}
 {-# COMPILE GHC parseTy = runQuoteT . parseType  #-}
 {-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm  #-}

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -151,8 +151,8 @@ postulate
 {-# FOREIGN GHC import Data.Functor #-}
 {-# COMPILE GHC ParseError = type PlutusCore.Error.ParserErrorBundle #-}
 
-{-# COMPILE GHC parse = runQuoteT . parseProgram  #-}
-{-# COMPILE GHC parseU = runQuoteT . U.parseProgram  #-}
+{-# COMPILE GHC parse = runQuoteT . parseProgram  "plutus-metatheory" #-}
+{-# COMPILE GHC parseU = runQuoteT . U.parseProgram  "plutus-metatheory" #-}
 {-# COMPILE GHC parseTm = runQuoteT . parseTerm  #-}
 {-# COMPILE GHC parseTy = runQuoteT . parseType  #-}
 {-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm  #-}


### PR DESCRIPTION
This is PLT-778.  The `uplc` parser was producing error messages like this:
```
uplc: ParseErrorB (ParseErrorBundle {bundleErrors = TrivialError 30 (Just (Tokens ('x' :| "+y)))\n"))) (fromList [Tokens ('b' :| "uiltin"),Tokens ('c' :| "on"),Tokens ('d' :| "elay"),Tokens ('e' :| "rror"),Tokens ('f' :| "orce"),Tokens ('l' :| "am")]) :| [], bundlePosState = PosState {pstateInput = "(program 1.2.3\n(lam x (lam y (x+y)))\n)", pstateOffset = 0, pstateSourcePos = SourcePos {sourceName = "test", sourceLine = Pos 1, sourceColumn = Pos 1}, pstateTabWidth = Pos 8, pstateLinePrefix = ""}})
```
That was just because of a missing call to the prettyprinter, and a one-line fix turns it into this
```
uplc: test:2:16:
  |
2 | (lam x (lam y (x+y)))
  |                ^^^^^^^
unexpected "x+y)))<newline>"
expecting "builtin", "con", "delay", "error", "force", or "lam"
```
which s a lot more readable. 

However, note that at the top it says `uplc: test:2:16:`.  That's because the parser parameter that tells it where the input's coming from was set to a default, so I also modified the code to get the file path in there.  The majority of the changes are for that and involve threading a filename (or some other identifier) through various functions.