### PR TITLE
PLT-579 Fix some tests that are failing on `agda-conformance`

### DIFF
--- a/plutus-conformance/agda/Spec.hs
+++ b/plutus-conformance/agda/Spec.hs
@@ -42,12 +42,6 @@ failingTests = [
     "test-cases/uplc/evaluation/builtin/mkNilPairData"
     , "test-cases/uplc/evaluation/builtin/chooseUnit"
     , "test-cases/uplc/evaluation/builtin/mkNilData"
-    , "test-cases/uplc/evaluation/example/churchZero"
-    , "test-cases/uplc/evaluation/example/force-lam"
-    , "test-cases/uplc/evaluation/example/succInteger"
-    , "test-cases/uplc/evaluation/example/churchSucc"
-    , "test-cases/uplc/evaluation/term/lam"
-    , "test-cases/uplc/evaluation/term/delay-lam"
     -- this is because agda has the BuiltinVersion=V1; haskell defaults to latest BuilinVersion
     , "test-cases/uplc/evaluation/builtin/consByteString"
     ]

--- a/plutus-metatheory/src/Untyped.hs
+++ b/plutus-metatheory/src/Untyped.hs
@@ -45,7 +45,8 @@ uconv ::  Int -> UTerm -> Term NamedDeBruijn DefaultUni DefaultFun ()
 uconv i (UVar x)     = Var
   ()
   (NamedDeBruijn (T.pack [tmnames !! (i - 1 - fromInteger x)])
-                 (Index (fromInteger x)))
+                -- PLC's debruijn starts counting from 1, while in the metatheory it starts from 0.
+                 (Index (fromInteger x + 1)))
 uconv i (ULambda t)  = LamAbs
   ()
   (NamedDeBruijn (T.pack [tmnames !! i]) deBruijnInitIndex)


### PR DESCRIPTION
Fixed all the failing tests relating to Debruijn indices. There's a separate ticket for the other failing tests - they are failing with the evaluator throwing an error, so that requires another fix.

Added some comments and removed some seemingly dead code.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
