### PR TITLE
Hashable extends Eq starting from hashable 1.4

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -285,7 +285,7 @@ library
     , filepath
     , flat
     , ghc-prim
-    , hashable
+    , hashable                    >=1.4
     , hedgehog                    >=1.0
     , index-envs
     , int-cast


### PR DESCRIPTION
This change rules out cabal build plans that pick up `hashable < 1.4` (which won't compile anyway).

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

Closes #4855