### PR TITLE
PLT-956: Fix cost model tests

### DIFF
--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -37,7 +37,7 @@ import Hedgehog.Main qualified as HH (defaultMain)
 import Hedgehog.Range qualified as Range
 
 {- | This module is supposed to test that the R cost models for built-in functions
-   defined in models.R (using the CSV output from 'cost-model-budgeting-bench;))
+   defined in models.R (using the CSV output from 'cost-model-budgeting-bench'))
    produce the same results as the Haskell versions. However there are a couple
    of subtleties.  (A) The R models use floating point numbers and the Haskell
    versions use CostingIntegers, and there will be some difference in precision
@@ -51,15 +51,16 @@ import Hedgehog.Range qualified as Range
 
 {-
    The tests here use Haskell costing functions (in 'costModelsR' from
-   'CreateBuiltinCostModel.hs') which are loaded directly from R.  The costing
-   functions we use in practice are read from 'builtinCostModel.json', which
-   contains JSON-serialised versions of the Haskell costing functions.  Perhaps
-   the tests should be reading the Haskell costing functions from the JSON file
-   as well; there shouldn't really be any problem because the functions should
-   be the same as the ones we construct from R here (they're essentially the
-   contents of 'costModelsR' converted to JSON), but it wouldn't do any harm to
-   include any possible loss of accuracy due to serialisation/deserialisation in
-   the tests as well.
+   'CreateBuiltinCostModel.hs') which are loaded directly from R, based purely
+   on the contents of benching.csv, which must be present in
+   plutus-core/cost-model/data.  The costing functions we use in practice are
+   read from 'builtinCostModel.json', which contains JSON-serialised versions of
+   the Haskell costing functions.  Perhaps the tests should be reading the
+   Haskell costing functions from the JSON file as well; there shouldn't really
+   be any problem because the functions should be the same as the ones we
+   construct from R here (they're essentially the contents of 'costModelsR'
+   converted to JSON), but it wouldn't do any harm to include any possible loss
+   of accuracy due to serialisation/deserialisation in the tests as well.
 
 -}
 

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -14,7 +14,7 @@
 
 import PlutusCore.DataFilePaths qualified as DFP
 import PlutusCore.Evaluation.Machine.BuiltinCostModel
-import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (..))
 import PlutusCore.Evaluation.Machine.ExMemory
 
 import CreateBuiltinCostModel

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -186,7 +186,7 @@ instance (ExMemoryUsage a, ExMemoryUsage b) => ExMemoryUsage (a, b) where
 instance ExMemoryUsage SatInt where
     memoryUsage n = memoryUsage (fromIntegral @SatInt @Int n)
     {-# INLINE memoryUsage #-}
-deriving newtype instance ExMemoryUsage ExMemory
+
 deriving newtype instance ExMemoryUsage Unique
 
 -- See https://github.com/input-output-hk/plutus/issues/1861

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -18,7 +18,6 @@ module PlutusCore.Evaluation.Machine.ExMemory
 ) where
 
 import PlutusCore.Data
-import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusPrelude
 
@@ -183,11 +182,6 @@ class ExMemoryUsage a where
 instance (ExMemoryUsage a, ExMemoryUsage b) => ExMemoryUsage (a, b) where
     memoryUsage (a, b) = 1 <> memoryUsage a <> memoryUsage b
     {-# INLINE memoryUsage #-}
-instance ExMemoryUsage SatInt where
-    memoryUsage n = memoryUsage (fromIntegral @SatInt @Int n)
-    {-# INLINE memoryUsage #-}
-
-deriving newtype instance ExMemoryUsage Unique
 
 -- See https://github.com/input-output-hk/plutus/issues/1861
 instance ExMemoryUsage (SomeTypeIn uni) where


### PR DESCRIPTION
Looking at PLT-953 (moving the cost model code into a separate Cabal component/package), I noticed that the cost model tests (which aren’t run in CI because of sporadic failures) were failing most of the time.  These tests run the Haskell costing functions for builtins and compare the results with predictions obtained directly from the R models, checking that they agree to within a small margin of error.  

The reason that they were failing is because #4778 changed the costing code to take objects as arguments where they’d previously taken sizes: the new version calculates the sizes itself.  Unfortunately there was an existing `ExMemoryUsage` instance for `ExMemory` which meant that the testing code continued to compile, but the Haskell costing functions were being fed the sizes of sizes, not the sizes themselves.  The result of this was that the Haskell costing functions were generally being given arguments which were all 1, but the R functions were getting genuine size arguments and so the results of the two versions differed.  This is fixed by using a wrapper type with a special `ExMemoryUsage` instance which allows us to pass size arguments to the Haskell costing functions: the tests all pass now. 
