### PR TITLE
PLT-122 Tidy up PIR executable

### DIFF
--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -691,3 +691,11 @@ runPrint (PrintOptions iospec mode) = do
     case outputSpec iospec of
       FileOutput path -> writeFile path printed
       StdOutput       -> putStrLn printed
+
+---------------- Conversions ----------------
+
+-- | Convert between textual and FLAT representations.
+runConvert :: ConvertOptions -> IO ()
+runConvert (ConvertOptions inp ifmt outp ofmt mode) = do
+    program <- (getProgram ifmt inp :: IO (PlcProg PLC.SourcePos))
+    writeProgram outp ofmt mode program

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -39,7 +39,7 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as BSL
 import Data.Foldable (traverse_)
 import Data.HashMap.Monoidal qualified as H
-import Data.List (intercalate, nub)
+import Data.List (intercalate, nub, sortOn)
 import Data.List qualified as List
 import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
@@ -59,8 +59,27 @@ import System.Mem (performGC)
 import Text.Megaparsec (errorBundlePretty)
 import Text.Printf (printf)
 
+import Control.Lens hiding (argument, set', (<.>))
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Reader
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.Coerce
+import Data.Csv qualified as Csv
+import Data.IntMap qualified as IM
+import GHC.Generics
+import Options.Applicative
+import PlutusCore.Quote (runQuoteT)
+import PlutusIR.Analysis.RetainedSize qualified as PIR
+import PlutusIR.Compiler qualified as PIR
+import PlutusIR.Core.Plated
+import PlutusIR.Core.Type qualified as PIR
+
 ----------- Executable type class -----------
--- currently we only have PLC and UPLC. PIR will be added later on.
+
+-- | PIR program type.
+type PirProg =
+  PIR.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun
 
 -- | PLC program type.
 type PlcProg =

--- a/plutus-core/executables/Common.hs
+++ b/plutus-core/executables/Common.hs
@@ -67,178 +67,196 @@ import Text.Printf (printf)
 
 -- | PIR program type.
 type PirProg =
-  PIR.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun
+    PIR.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun
 
 -- | PLC program type.
 type PlcProg =
-  PLC.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun
+    PLC.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun
 
 -- | UPLC program type.
 type UplcProg =
-  UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun
+    UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun
+
+-- | UPLC term type.
+type UplcTerm =
+    UPLC.Term UPLC.Name PLC.DefaultUni PLC.DefaultFun
 
 class ProgramLike p where
+    -- | Parse a program.  The first argument (normally the file path) describes
+    -- the input stream, the second is the program text.
+    parseNamedProgram ::
+        String -> T.Text -> Either ParserErrorBundle (p PLC.SourcePos)
 
-  -- | Parse a program.  The first argument (normally the file path) describes
-  -- the input stream, the second is the program text.
-  parseNamedProgram ::
-    String -> T.Text -> Either ParserErrorBundle (p PLC.SourcePos)
+    -- | Check a program for unique names.
+    -- Throws a @UniqueError@ when not all names are unique.
+    checkUniques ::
+        ( Ord ann
+        , AsUniqueError e ann
+        , MonadError e m
+        ) =>
+        p ann ->
+        m ()
 
-  -- | Check a program for unique names.
-  -- Throws a @UniqueError@ when not all names are unique.
-  checkUnique ::
-     (Ord ann, AsUniqueError e ann,
-       MonadError e m)
-    => p ann
-    -> m ()
+    -- | Convert names to de Bruijn indices and then serialise
+    serialiseProgramFlat :: (Flat ann, PP.Pretty ann) => AstNameType -> p ann -> IO BSL.ByteString
 
-  -- | Convert names to de Bruijn indices and then serialise
-  serialiseProgramFlat :: (Flat ann, PP.Pretty ann) => AstNameType -> p ann -> IO BSL.ByteString
-
-  -- | Read and deserialise a Flat-encoded AST
-  loadASTfromFlat :: AstNameType -> Input -> IO (p ())
+    -- | Read and deserialise a Flat-encoded AST
+    loadASTfromFlat :: AstNameType -> Input -> IO (p ())
 
 -- For PIR and PLC
 serialiseTProgramFlat :: Flat a => AstNameType -> a -> IO BSL.ByteString
 serialiseTProgramFlat nameType p =
-      case nameType of
+    case nameType of
         Named         -> pure $ BSL.fromStrict $ flat p
         DeBruijn      -> typedDeBruijnNotSupportedError
         NamedDeBruijn -> typedDeBruijnNotSupportedError
 
 -- | Instance for PIR program.
 instance ProgramLike PirProg where
-  parseNamedProgram inputName = PLC.runQuoteT . PIR.parse PIR.program inputName
-  checkUnique _ = pure () -- decided that it's not worth implementing since it's checked in PLC.
-  serialiseProgramFlat = serialiseTProgramFlat
-  loadASTfromFlat = loadTplcASTfromFlat
+    parseNamedProgram inputName = PLC.runQuoteT . PIR.parse PIR.program inputName
+    checkUniques _ = pure () -- decided that it's not worth implementing since it's checked in PLC.
+    serialiseProgramFlat = serialiseTProgramFlat
+    loadASTfromFlat = loadTplcASTfromFlat
 
 -- | Instance for PLC program.
 instance ProgramLike PlcProg where
-  parseNamedProgram inputName = PLC.runQuoteT . UPLC.parse PLC.program inputName
-  checkUnique = PLC.checkProgram (const True)
-  serialiseProgramFlat = serialiseTProgramFlat
-  loadASTfromFlat = loadTplcASTfromFlat
+    parseNamedProgram inputName = PLC.runQuoteT . UPLC.parse PLC.program inputName
+    checkUniques = PLC.checkProgram (const True)
+    serialiseProgramFlat = serialiseTProgramFlat
+    loadASTfromFlat = loadTplcASTfromFlat
 
 -- | Instance for UPLC program.
 instance ProgramLike UplcProg where
-  parseNamedProgram inputName = PLC.runQuoteT . UPLC.parse UPLC.program inputName
-  checkUnique = UPLC.checkProgram (const True)
-  serialiseProgramFlat nameType p =
-      case nameType of
-        Named         -> pure $ BSL.fromStrict $ flat p
-        DeBruijn      -> BSL.fromStrict . flat <$> toDeBruijn p
-        NamedDeBruijn -> BSL.fromStrict . flat <$> toNamedDeBruijn p
-  loadASTfromFlat = loadUplcASTfromFlat
+    parseNamedProgram inputName = PLC.runQuoteT . UPLC.parse UPLC.program inputName
+    checkUniques = UPLC.checkProgram (const True)
+    serialiseProgramFlat nameType p =
+        case nameType of
+            Named         -> pure $ BSL.fromStrict $ flat p
+            DeBruijn      -> BSL.fromStrict . flat <$> toDeBruijn p
+            NamedDeBruijn -> BSL.fromStrict . flat <$> toNamedDeBruijn p
+    loadASTfromFlat = loadUplcASTfromFlat
 
 -- We don't support de Bruijn names for typed programs because we really only
 -- want serialisation for on-chain programs (and some of the functionality we'd
 -- need isn't available anyway).
 typedDeBruijnNotSupportedError :: IO a
 typedDeBruijnNotSupportedError =
-    errorWithoutStackTrace "De-Bruijn-named ASTs are not supported for typed Plutus Core"
+    error "De-Bruijn-named ASTs are not supported for typed Plutus Core"
 
 -- | Convert an untyped program to one where the 'name' type is de Bruijn indices.
 toDeBruijn :: UplcProg ann -> IO (UPLC.Program UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ann)
 toDeBruijn prog =
-  case runExcept @UPLC.FreeVariableError $ traverseOf UPLC.progTerm UPLC.deBruijnTerm prog of
-    Left e  -> errorWithoutStackTrace $ show e
-    Right p -> return $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) p
+    case runExcept @UPLC.FreeVariableError $ traverseOf UPLC.progTerm UPLC.deBruijnTerm prog of
+        Left e  -> error $ show e
+        Right p -> return $ UPLC.programMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBruijn ix) p
 
--- | Convert an untyped program to one where the 'name' type is
--- textual names with de Bruijn indices.
-toNamedDeBruijn :: UplcProg ann
-  -> IO (UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ann)
+{- | Convert an untyped program to one where the 'name' type is
+ textual names with de Bruijn indices.
+-}
+toNamedDeBruijn ::
+    UplcProg ann ->
+    IO (UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ann)
 toNamedDeBruijn prog =
-  case runExcept @UPLC.FreeVariableError $ traverseOf UPLC.progTerm UPLC.deBruijnTerm prog of
-    Left e  -> errorWithoutStackTrace $ show e
-    Right p -> return p
+    case runExcept @UPLC.FreeVariableError $ traverseOf UPLC.progTerm UPLC.deBruijnTerm prog of
+        Left e  -> error $ show e
+        Right p -> return p
 
 ---------------- Printing budgets and costs ----------------
 
 printBudgetStateBudget :: CekModel -> ExBudget -> IO ()
 printBudgetStateBudget model b =
     case model of
-      Unit -> pure ()
-      _ ->  let ExCPU cpu = exBudgetCPU b
+        Unit -> pure ()
+        _ ->
+            let ExCPU cpu = exBudgetCPU b
                 ExMemory mem = exBudgetMemory b
-            in do
-              putStrLn $ "CPU budget:    " ++ show cpu
-              putStrLn $ "Memory budget: " ++ show mem
+             in do
+                    putStrLn $ "CPU budget:    " ++ show cpu
+                    putStrLn $ "Memory budget: " ++ show mem
 
-printBudgetStateTally :: (Cek.Hashable fun, Show fun)
-       => UPLC.Term UPLC.Name PLC.DefaultUni PLC.DefaultFun ()
-       -> CekModel ->  Cek.CekExTally fun -> IO ()
+printBudgetStateTally ::
+    (Cek.Hashable fun, Show fun) =>
+    UplcTerm () ->
+    CekModel ->
+    Cek.CekExTally fun ->
+    IO ()
 printBudgetStateTally term model (Cek.CekExTally costs) = do
-  putStrLn $ "Const      " ++ pbudget (Cek.BStep Cek.BConst)
-  putStrLn $ "Var        " ++ pbudget (Cek.BStep Cek.BVar)
-  putStrLn $ "LamAbs     " ++ pbudget (Cek.BStep Cek.BLamAbs)
-  putStrLn $ "Apply      " ++ pbudget (Cek.BStep Cek.BApply)
-  putStrLn $ "Delay      " ++ pbudget (Cek.BStep Cek.BDelay)
-  putStrLn $ "Force      " ++ pbudget (Cek.BStep Cek.BForce)
-  putStrLn $ "Builtin    " ++ pbudget (Cek.BStep Cek.BBuiltin)
-  putStrLn ""
-  putStrLn $ "startup    " ++ pbudget Cek.BStartup
-  putStrLn $ "compute    " ++ printf "%-20s" (budgetToString totalComputeCost)
-  putStrLn $ "AST nodes  " ++ printf "%15d" (UPLC.termSize term)
-  putStrLn ""
-  putStrLn $ "BuiltinApp " ++ budgetToString builtinCosts
-  case model of
-    Default ->
-        do
-          putStrLn $
-            printf
-              "Time spent executing builtins:  %4.2f%%\n"
-              (100*(getCPU builtinCosts)/totalTime)
-          putStrLn ""
-          traverse_ (\(b,cost) ->
-            putStrLn $ printf "%-22s %s" (show b) (budgetToString cost :: String)) builtinsAndCosts
-          putStrLn ""
-          putStrLn $ "Total budget spent: " ++ printf (budgetToString totalCost)
-          putStrLn $ "Predicted execution time: " ++ formatTimePicoseconds totalTime
-    Unit -> do
-          putStrLn ""
-          traverse_ (\(b,cost) ->
-            putStrLn $ printf "%-22s %s" (show b) (budgetToString cost :: String)) builtinsAndCosts
-
+    putStrLn $ "Const      " ++ pbudget (Cek.BStep Cek.BConst)
+    putStrLn $ "Var        " ++ pbudget (Cek.BStep Cek.BVar)
+    putStrLn $ "LamAbs     " ++ pbudget (Cek.BStep Cek.BLamAbs)
+    putStrLn $ "Apply      " ++ pbudget (Cek.BStep Cek.BApply)
+    putStrLn $ "Delay      " ++ pbudget (Cek.BStep Cek.BDelay)
+    putStrLn $ "Force      " ++ pbudget (Cek.BStep Cek.BForce)
+    putStrLn $ "Builtin    " ++ pbudget (Cek.BStep Cek.BBuiltin)
+    putStrLn ""
+    putStrLn $ "startup    " ++ pbudget Cek.BStartup
+    putStrLn $ "compute    " ++ printf "%-20s" (budgetToString totalComputeCost)
+    putStrLn $ "AST nodes  " ++ printf "%15d" (UPLC.termSize term)
+    putStrLn ""
+    putStrLn $ "BuiltinApp " ++ budgetToString builtinCosts
+    case model of
+        Default ->
+            do
+                putStrLn $
+                    printf
+                        "Time spent executing builtins:  %4.2f%%\n"
+                        (100 * (getCPU builtinCosts) / totalTime)
+                putStrLn ""
+                traverse_
+                    ( \(b, cost) ->
+                        putStrLn $ printf "%-22s %s" (show b) (budgetToString cost :: String)
+                    )
+                    builtinsAndCosts
+                putStrLn ""
+                putStrLn $ "Total budget spent: " ++ printf (budgetToString totalCost)
+                putStrLn $ "Predicted execution time: " ++ formatTimePicoseconds totalTime
+        Unit -> do
+            putStrLn ""
+            traverse_
+                ( \(b, cost) ->
+                    putStrLn $ printf "%-22s %s" (show b) (budgetToString cost :: String)
+                )
+                builtinsAndCosts
   where
-        getSpent k =
-            case H.lookup k costs of
-              Just v  -> v
-              Nothing -> ExBudget 0 0
-        allNodeTags =
-          fmap
+    getSpent k =
+        case H.lookup k costs of
+            Just v  -> v
+            Nothing -> ExBudget 0 0
+    allNodeTags =
+        fmap
             Cek.BStep
             [Cek.BConst, Cek.BVar, Cek.BLamAbs, Cek.BApply, Cek.BDelay, Cek.BForce, Cek.BBuiltin]
-        totalComputeCost =
-          -- For unitCekCosts this will be the total number of compute steps
-          mconcat $ map getSpent allNodeTags
-        budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) =
-            case model of
-              -- Not %d: doesn't work when CostingInteger is SatInt.
-              Default -> printf "%15s  %15s" (show cpu) (show mem) :: String
-              -- Memory usage figures are meaningless in this case
-              Unit    -> printf "%15s" (show cpu) :: String
-        pbudget = budgetToString . getSpent
-        f l e = case e of {(Cek.BBuiltinApp b, cost)  -> (b,cost):l; _ -> l}
-        builtinsAndCosts = List.foldl f [] (H.toList costs)
-        builtinCosts = mconcat (map snd builtinsAndCosts)
-        -- ^ Total builtin evaluation time (according to the models) in picoseconds
-        -- (units depend on BuiltinCostModel.costMultiplier)
-        getCPU b = let ExCPU b' = exBudgetCPU b in fromIntegral b'::Double
-        totalCost = getSpent Cek.BStartup <> totalComputeCost <> builtinCosts
-        totalTime =
-          (getCPU $ getSpent Cek.BStartup) + getCPU totalComputeCost + getCPU builtinCosts
+    totalComputeCost =
+        -- For unitCekCosts this will be the total number of compute steps
+        foldMap getSpent allNodeTags
+    budgetToString (ExBudget (ExCPU cpu) (ExMemory mem)) =
+        case model of
+            -- Not %d: doesn't work when CostingInteger is SatInt.
+            Default -> printf "%15s  %15s" (show cpu) (show mem) :: String
+            -- Memory usage figures are meaningless in this case
+            Unit    -> printf "%15s" (show cpu) :: String
+    pbudget = budgetToString . getSpent
+    f l e = case e of (Cek.BBuiltinApp b, cost) -> (b, cost) : l; _ -> l
+    builtinsAndCosts = List.foldl f [] (H.toList costs)
+    builtinCosts = mconcat (map snd builtinsAndCosts)
+    -- \^ Total builtin evaluation time (according to the models) in picoseconds
+    -- (units depend on BuiltinCostModel.costMultiplier)
+    getCPU b = let ExCPU b' = exBudgetCPU b in fromIntegral b' :: Double
+    totalCost = getSpent Cek.BStartup <> totalComputeCost <> builtinCosts
+    totalTime =
+        (getCPU $ getSpent Cek.BStartup) + getCPU totalComputeCost + getCPU builtinCosts
 
 class PrintBudgetState cost where
-    printBudgetState :: UPLC.Term PLC.Name PLC.DefaultUni PLC.DefaultFun ()
-      -> CekModel
-      -> cost
-      -> IO ()
-    -- TODO: Tidy this up.  We're passing in the term and the CEK cost model
-    -- here, but we only need them in tallying mode (where we need the term so
-    -- we can print out the AST size and we need the model type to decide how
-    -- much information we're going to print out).
+    printBudgetState ::
+        UPLC.Term PLC.Name PLC.DefaultUni PLC.DefaultFun () ->
+        CekModel ->
+        cost ->
+        IO ()
+
+-- TODO: Tidy this up.  We're passing in the term and the CEK cost model
+-- here, but we only need them in tallying mode (where we need the term so
+-- we can print out the AST size and we need the model type to decide how
+-- much information we're going to print out).
 
 instance PrintBudgetState Cek.CountingSt where
     printBudgetState _term model (Cek.CountingSt budget) = printBudgetStateBudget model budget
@@ -253,63 +271,66 @@ instance PrintBudgetState Cek.RestrictingSt where
     printBudgetState _term model (Cek.RestrictingSt (ExRestrictingBudget budget)) =
         printBudgetStateBudget model budget
 
-
 ---------------- Types for commands and arguments ----------------
 
-data Input       = FileInput FilePath | StdInput
+data Input = FileInput FilePath | StdInput
 instance Show Input where
     show (FileInput path) = show path
     show StdInput         = "<stdin>"
 
-data Output      = FileOutput FilePath | StdOutput
-data IOSpec      = MkIOSpec
-  { inputSpec  :: Input
-  , outputSpec :: Output}
-data TimingMode  = NoTiming | Timing Integer deriving stock (Eq)  -- Report program execution time?
-data CekModel    = Default | Unit   -- Which cost model should we use for CEK machine steps?
-data PrintMode   = Classic | Debug | Readable | ReadableDebug deriving stock (Show, Read)
-data TraceMode   = None | Logs | LogsWithTimestamps | LogsWithBudgets deriving stock (Show, Read)
+data Output = FileOutput FilePath | StdOutput
+data IOSpec = MkIOSpec
+    { inputSpec  :: Input
+    , outputSpec :: Output
+    }
+data TimingMode = NoTiming | Timing Integer deriving stock (Eq) -- Report program execution time?
+data CekModel = Default | Unit -- Which cost model should we use for CEK machine steps?
+data PrintMode = Classic | Debug | Readable | ReadableDebug deriving stock (Show, Read)
+data TraceMode = None | Logs | LogsWithTimestamps | LogsWithBudgets deriving stock (Show, Read)
 type ExampleName = T.Text
 data ExampleMode = ExampleSingle ExampleName | ExampleAvailable
--- | @Name@ can be @Name@s or de Bruijn indices when we (de)serialise the ASTs.
--- PLC doesn't support de Bruijn indices when (de)serialising ASTs.
--- UPLC supports @Name@ or de Bruijn indices.
-data AstNameType =
-  Named
-  | DeBruijn
-  | NamedDeBruijn
 
-type Files       = [FilePath]
+{- | @Name@ can be @Name@s or de Bruijn indices when we (de)serialise the ASTs.
+ PLC doesn't support de Bruijn indices when (de)serialising ASTs.
+ UPLC supports @Name@ or de Bruijn indices.
+-}
+data AstNameType
+    = Named
+    | DeBruijn
+    | NamedDeBruijn
+
+type Files = [FilePath]
 
 -- | Input/output format for programs
-data Format =
-  Textual
-  | Flat AstNameType
+data Format
+    = Textual
+    | Flat AstNameType
+
 instance Show Format where
     show Textual              = "textual"
     show (Flat Named)         = "flat-named"
     show (Flat DeBruijn)      = "flat-deBruijn"
     show (Flat NamedDeBruijn) = "flat-namedDeBruijn"
 
-data ConvertOptions   = ConvertOptions Input Format Output Format PrintMode
-data PrintOptions     = PrintOptions IOSpec PrintMode
-newtype ExampleOptions   = ExampleOptions ExampleMode
-data ApplyOptions     = ApplyOptions Files Format Output Format PrintMode
+data ConvertOptions = ConvertOptions Input Format Output Format PrintMode
+data PrintOptions = PrintOptions IOSpec PrintMode
+newtype ExampleOptions = ExampleOptions ExampleMode
+data ApplyOptions = ApplyOptions Files Format Output Format PrintMode
 
 helpText ::
-  -- | Either "Untyped Plutus Core" or "Typed Plutus Core"
-  String -> String
+    -- | Either "Untyped Plutus Core" or "Typed Plutus Core"
+    String ->
+    String
 helpText lang =
-       "This program provides a number of utilities for dealing with "
-    ++ lang
-    ++ " programs, including application, evaluation, and conversion between a "
-    ++ "number of different formats.  The program also provides a number of example "
-    ++ "programs.  Some commands read or write Plutus Core abstract "
-    ++ "syntax trees serialised in Flat format: ASTs are always written with "
-    ++ "unit annotations, and any Flat-encoded AST supplied as input must also be "
-    ++ "equipped with unit annotations.  Attempting to read a serialised AST with any "
-    ++ "non-unit annotation type will cause an error."
-
+    "This program provides a number of utilities for dealing with "
+        ++ lang
+        ++ " programs, including application, evaluation, and conversion between a "
+        ++ "number of different formats.  The program also provides a number of example "
+        ++ "programs.  Some commands read or write Plutus Core abstract "
+        ++ "syntax trees serialised in Flat format: ASTs are always written with "
+        ++ "unit annotations, and any Flat-encoded AST supplied as input must also be "
+        ++ "equipped with unit annotations.  Attempting to read a serialised AST with any "
+        ++ "non-unit annotation type will cause an error."
 
 ---------------- Reading programs from files ----------------
 
@@ -320,29 +341,29 @@ getInput StdInput         = T.getContents
 
 -- | For PLC and UPLC source programs. Read and parse and check the program for @UniqueError@'s.
 parseInput ::
-  (ProgramLike p, PLC.Rename (p PLC.SourcePos) ) =>
-  -- | The source program
-  Input ->
-  -- | The output is either a UPLC or PLC program with annotation
-  IO (p PLC.SourcePos)
+    (ProgramLike p, PLC.Rename (p PLC.SourcePos)) =>
+    -- | The source program
+    Input ->
+    -- | The output is either a UPLC or PLC program with annotation
+    IO (p PLC.SourcePos)
 parseInput inp = do
     contents <- getInput inp
     -- parse the program
     case parseNamedProgram (show inp) contents of
-      -- when fail, pretty print the parse errors.
-      Left (ParseErrorB err) ->
-          errorWithoutStackTrace $ errorBundlePretty err
-      -- otherwise,
-      Right p -> do
-        -- run @rename@ through the program
-        renamed <- PLC.runQuoteT $ rename p
-        -- check the program for @UniqueError@'s
-        let checked = through Common.checkUnique renamed
-        case checked of
-          -- pretty print the error
-          Left (err :: PLC.UniqueError PLC.SourcePos) ->
-            errorWithoutStackTrace $ PP.render $ pretty err
-          Right _ -> pure p
+        -- when fail, pretty print the parse errors.
+        Left (ParseErrorB err) ->
+            error $ errorBundlePretty err
+        -- otherwise,
+        Right p -> do
+            -- run @rename@ through the program
+            renamed <- PLC.runQuoteT $ rename p
+            -- check the program for @UniqueError@'s
+            let checked = through Common.checkUniques renamed
+            case checked of
+                -- pretty print the error
+                Left (err :: PLC.UniqueError PLC.SourcePos) ->
+                    error $ PP.render $ pretty err
+                Right _ -> pure p
 
 -- Read a binary-encoded file (eg, Flat-encoded PLC)
 getBinaryInput :: Input -> IO BSL.ByteString
@@ -351,122 +372,136 @@ getBinaryInput (FileInput file) = BSL.readFile file
 
 ---------------- Name conversions ----------------
 
--- | Untyped AST with names consisting solely of De Bruijn indices. This is
--- currently only used for intermediate values during Flat
--- serialisation/deserialisation.  We may wish to add TypedProgramDeBruijn as
--- well if we modify the CEK machine to run directly on de Bruijnified ASTs, but
--- support for this is lacking elsewhere at the moment.
+{- | Untyped AST with names consisting solely of De Bruijn indices. This is
+ currently only used for intermediate values during Flat
+ serialisation/deserialisation.  We may wish to add TypedProgramDeBruijn as
+ well if we modify the CEK machine to run directly on de Bruijnified ASTs, but
+ support for this is lacking elsewhere at the moment.
+-}
 type UntypedProgramDeBruijn ann = UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ann
 
--- | Convert an untyped de-Bruijn-indexed program to one with standard names.
--- We have nothing to base the names on, so every variable is named "v" (but
--- with a Unique for disambiguation).  Again, we don't support typed programs.
+{- | Convert an untyped de-Bruijn-indexed program to one with standard names.
+ We have nothing to base the names on, so every variable is named "v" (but
+ with a Unique for disambiguation).  Again, we don't support typed programs.
+-}
 fromDeBruijn :: UntypedProgramDeBruijn ann -> IO (UplcProg ann)
 fromDeBruijn prog = do
     case PLC.runQuote $
-      runExceptT @UPLC.FreeVariableError $
-      traverseOf UPLC.progTerm UPLC.unDeBruijnTerm prog of
-      Left e  -> errorWithoutStackTrace $ show e
-      Right p -> return p
+        runExceptT @UPLC.FreeVariableError $
+            traverseOf UPLC.progTerm UPLC.unDeBruijnTerm prog of
+        Left e  -> error $ show e
+        Right p -> return p
 
 -- | Read and deserialise a Flat-encoded PIR/PLC AST
 loadTplcASTfromFlat :: Flat a => AstNameType -> Input -> IO a
 loadTplcASTfromFlat flatMode inp =
-  case flatMode of
-    Named         -> getBinaryInput inp >>= handleResult . unflat
-    DeBruijn      -> typedDeBruijnNotSupportedError
-    NamedDeBruijn -> typedDeBruijnNotSupportedError
-  where handleResult =
-              \case
-               Left e  -> errorWithoutStackTrace $ "Flat deserialisation failure: " ++ show e
-               Right r -> return r
+    case flatMode of
+        Named         -> getBinaryInput inp >>= handleResult . unflat
+        DeBruijn      -> typedDeBruijnNotSupportedError
+        NamedDeBruijn -> typedDeBruijnNotSupportedError
+  where
+    handleResult =
+        \case
+            Left e  -> error $ "Flat deserialisation failure: " ++ show e
+            Right r -> return r
 
 -- | Read and deserialise a Flat-encoded UPLC AST
 loadUplcASTfromFlat :: AstNameType -> Input -> IO (UplcProg ())
 loadUplcASTfromFlat flatMode inp = do
     input <- getBinaryInput inp
     case flatMode of
-         Named    -> handleResult $ unflat input
-         DeBruijn -> do
-             deserialised <- handleResult $ unflat input
-             let namedProgram = UPLC.programMapNames UPLC.fakeNameDeBruijn deserialised
-             fromDeBruijn namedProgram
-         NamedDeBruijn -> do
-             deserialised <- handleResult $ unflat input
-             fromDeBruijn deserialised
-    where handleResult =
-              \case
-               Left e  -> errorWithoutStackTrace $ "Flat deserialisation failure: " ++ show e
-               Right r -> return r
+        Named -> handleResult $ unflat input
+        DeBruijn -> do
+            deserialised <- handleResult $ unflat input
+            let namedProgram = UPLC.programMapNames UPLC.fakeNameDeBruijn deserialised
+            fromDeBruijn namedProgram
+        NamedDeBruijn -> do
+            deserialised <- handleResult $ unflat input
+            fromDeBruijn deserialised
+  where
+    handleResult =
+        \case
+            Left e  -> error $ "Flat deserialisation failure: " ++ show e
+            Right r -> return r
 
 -- Read either a UPLC/PLC/PIR file or a Flat file, depending on 'fmt'
 getProgram ::
-  (ProgramLike p,
-   Functor p,
-   PLC.Rename (p PLC.SourcePos)) =>
-  Format -> Input -> IO (p PLC.SourcePos)
+    ( ProgramLike p
+    , Functor p
+    , PLC.Rename (p PLC.SourcePos)
+    ) =>
+    Format ->
+    Input ->
+    IO (p PLC.SourcePos)
 getProgram fmt inp =
     case fmt of
-      Textual  -> parseInput inp
-      Flat flatMode -> do
-               prog <- loadASTfromFlat flatMode inp
-               -- No source locations in Flat, so we have to make them up.
-               return $ PLC.topSourcePos <$ prog
+        Textual -> parseInput inp
+        Flat flatMode -> do
+            prog <- loadASTfromFlat flatMode inp
+            -- No source locations in Flat, so we have to make them up.
+            return $ PLC.topSourcePos <$ prog
 
 ---------------- Serialise a program using Flat and write it to a given output ----------------
 
 writeFlat ::
-  (ProgramLike p, Functor p) => Output -> AstNameType -> p ann -> IO ()
+    (ProgramLike p, Functor p) => Output -> AstNameType -> p ann -> IO ()
 writeFlat outp flatMode prog = do
-  -- Change annotations to (): see Note [Annotation types].
-  flatProg <- serialiseProgramFlat flatMode (() <$ prog)
-  case outp of
-    FileOutput file -> BSL.writeFile file flatProg
-    StdOutput       -> BSL.putStr flatProg
+    -- Change annotations to (): see Note [Annotation types].
+    flatProg <- serialiseProgramFlat flatMode (() <$ prog)
+    case outp of
+        FileOutput file -> BSL.writeFile file flatProg
+        StdOutput       -> BSL.putStr flatProg
 
 ---------------- Write an AST as PLC source ----------------
 
 getPrintMethod ::
-  PP.PrettyPlc a => PrintMode -> (a -> Doc ann)
+    PP.PrettyPlc a => PrintMode -> (a -> Doc ann)
 getPrintMethod = \case
-      Classic       -> PP.prettyPlcClassicDef
-      Debug         -> PP.prettyPlcClassicDebug
-      Readable      -> PP.prettyPlcReadableDef
-      ReadableDebug -> PP.prettyPlcReadableDebug
+    Classic       -> PP.prettyPlcClassicDef
+    Debug         -> PP.prettyPlcClassicDebug
+    Readable      -> PP.prettyPlcReadableDef
+    ReadableDebug -> PP.prettyPlcReadableDebug
 
 writeProgram ::
-  (ProgramLike p,
-   Functor p,
-   PP.PrettyBy PP.PrettyConfigPlc (p ann)) =>
-   Output -> Format -> PrintMode -> p ann -> IO ()
+    ( ProgramLike p
+    , Functor p
+    , PP.PrettyBy PP.PrettyConfigPlc (p ann)
+    ) =>
+    Output ->
+    Format ->
+    PrintMode ->
+    p ann ->
+    IO ()
 writeProgram outp Textual mode prog      = writePrettyToFileOrStd outp mode prog
 writeProgram outp (Flat flatMode) _ prog = writeFlat outp flatMode prog
 
 writePrettyToFileOrStd ::
-  (PP.PrettyBy PP.PrettyConfigPlc (p ann)) => Output -> PrintMode -> p ann -> IO ()
+    (PP.PrettyBy PP.PrettyConfigPlc (p ann)) => Output -> PrintMode -> p ann -> IO ()
 writePrettyToFileOrStd outp mode prog = do
-  let printMethod = getPrintMethod mode
-  case outp of
+    let printMethod = getPrintMethod mode
+    case outp of
         FileOutput file -> writeFile file . Prelude.show . printMethod $ prog
         StdOutput       -> print . printMethod $ prog
 
 writeToFileOrStd ::
-  Output -> String -> IO ()
+    Output -> String -> IO ()
 writeToFileOrStd outp v = do
-  case outp of
+    case outp of
         FileOutput file -> writeFile file v
         StdOutput       -> putStrLn v
 
 ---------------- Examples ----------------
 
 data TypeExample = TypeExample (PLC.Kind ()) (PLC.Type PLC.TyName PLC.DefaultUni ())
-data TypedTermExample = TypedTermExample
-    (PLC.Type PLC.TyName PLC.DefaultUni ())
-    (PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ())
+data TypedTermExample
+    = TypedTermExample
+        (PLC.Type PLC.TyName PLC.DefaultUni ())
+        (PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ())
 data SomeTypedExample = SomeTypeExample TypeExample | SomeTypedTermExample TypedTermExample
 
-newtype UntypedTermExample = UntypedTermExample
-    (UPLC.Term PLC.Name PLC.DefaultUni PLC.DefaultFun ())
+newtype UntypedTermExample
+    = UntypedTermExample
+        (UPLC.Term PLC.Name PLC.DefaultUni PLC.DefaultFun ())
 newtype SomeUntypedExample = SomeUntypedTermExample UntypedTermExample
 
 data SomeExample = SomeTypedExample SomeTypedExample | SomeUntypedExample SomeUntypedExample
@@ -475,30 +510,31 @@ prettySignature :: ExampleName -> SomeExample -> Doc ann
 prettySignature name (SomeTypedExample (SomeTypeExample (TypeExample kind _))) =
     pretty name <+> "::" <+> PP.prettyPlcDef kind
 prettySignature name (SomeTypedExample (SomeTypedTermExample (TypedTermExample ty _))) =
-    pretty name <+> ":"  <+> PP.prettyPlcDef ty
+    pretty name <+> ":" <+> PP.prettyPlcDef ty
 prettySignature name (SomeUntypedExample _) =
     pretty name
 
 prettyExample :: SomeExample -> Doc ann
 prettyExample =
     \case
-         SomeTypedExample (SomeTypeExample (TypeExample _ ty)) -> PP.prettyPlcDef ty
-         SomeTypedExample (SomeTypedTermExample (TypedTermExample _ term))
-             -> PP.prettyPlcDef $ PLC.Program () (PLC.defaultVersion ()) term
-         SomeUntypedExample (SomeUntypedTermExample (UntypedTermExample term)) ->
-             PP.prettyPlcDef $ UPLC.Program () (PLC.defaultVersion ()) term
+        SomeTypedExample (SomeTypeExample (TypeExample _ ty)) -> PP.prettyPlcDef ty
+        SomeTypedExample (SomeTypedTermExample (TypedTermExample _ term)) ->
+            PP.prettyPlcDef $ PLC.Program () (PLC.defaultVersion ()) term
+        SomeUntypedExample (SomeUntypedTermExample (UntypedTermExample term)) ->
+            PP.prettyPlcDef $ UPLC.Program () (PLC.defaultVersion ()) term
 
 toTypedTermExample ::
-  PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun () -> TypedTermExample
-toTypedTermExample term = TypedTermExample ty term where
+    PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun () -> TypedTermExample
+toTypedTermExample term = TypedTermExample ty term
+  where
     program = PLC.Program () (PLC.defaultVersion ()) term
     errOrTy = PLC.runQuote . runExceptT $ do
         tcConfig <- PLC.getDefTypeCheckConfig ()
         PLC.inferTypeOfProgram tcConfig program
     ty = case errOrTy of
         Left (err :: PLC.Error PLC.DefaultUni PLC.DefaultFun ()) ->
-          errorWithoutStackTrace $ PP.displayPlcDef err
-        Right vTy                                                -> PLC.unNormalized vTy
+            error $ PP.displayPlcDef err
+        Right vTy -> PLC.unNormalized vTy
 
 getInteresting :: IO [(ExampleName, PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ())]
 getInteresting =
@@ -509,49 +545,50 @@ getInteresting =
 simpleExamples :: [(ExampleName, SomeTypedExample)]
 simpleExamples =
     [ ("succInteger", SomeTypedTermExample $ toTypedTermExample StdLib.succInteger)
-    , ("unit"       , SomeTypeExample      $ TypeExample (PLC.Type ()) StdLib.unit)
-    , ("unitval"    , SomeTypedTermExample $ toTypedTermExample StdLib.unitval)
-    , ("bool"       , SomeTypeExample      $ TypeExample (PLC.Type ()) StdLib.bool)
-    , ("true"       , SomeTypedTermExample $ toTypedTermExample StdLib.true)
-    , ("false"      , SomeTypedTermExample $ toTypedTermExample StdLib.false)
-    , ("churchNat"  , SomeTypeExample      $ TypeExample (PLC.Type ()) StdLib.churchNat)
-    , ("churchZero" , SomeTypedTermExample $ toTypedTermExample StdLib.churchZero)
-    , ("churchSucc" , SomeTypedTermExample $ toTypedTermExample StdLib.churchSucc)
+    , ("unit", SomeTypeExample $ TypeExample (PLC.Type ()) StdLib.unit)
+    , ("unitval", SomeTypedTermExample $ toTypedTermExample StdLib.unitval)
+    , ("bool", SomeTypeExample $ TypeExample (PLC.Type ()) StdLib.bool)
+    , ("true", SomeTypedTermExample $ toTypedTermExample StdLib.true)
+    , ("false", SomeTypedTermExample $ toTypedTermExample StdLib.false)
+    , ("churchNat", SomeTypeExample $ TypeExample (PLC.Type ()) StdLib.churchNat)
+    , ("churchZero", SomeTypedTermExample $ toTypedTermExample StdLib.churchZero)
+    , ("churchSucc", SomeTypedTermExample $ toTypedTermExample StdLib.churchSucc)
     ]
 
 getInterestingExamples ::
-  ([(ExampleName, SomeTypedExample)] -> [(ExampleName, SomeExample)]) ->
-  IO [(ExampleName, SomeExample)]
+    ([(ExampleName, SomeTypedExample)] -> [(ExampleName, SomeExample)]) ->
+    IO [(ExampleName, SomeExample)]
 getInterestingExamples res = do
     interesting <- getInteresting
     let examples =
-          simpleExamples ++
-          map (second $ SomeTypedTermExample . toTypedTermExample) interesting
+            simpleExamples
+                ++ map (second $ SomeTypedTermExample . toTypedTermExample) interesting
     pure $ res examples
 
 -- | Get available typed examples.
 getPlcExamples :: IO [(ExampleName, SomeExample)]
 getPlcExamples = getInterestingExamples $ map (fmap SomeTypedExample)
 
--- | Get available untyped examples. Currently the untyped
--- examples are obtained by erasing typed ones, but it might be useful to have
--- some untyped ones that can't be obtained by erasure.
+{- | Get available untyped examples. Currently the untyped
+ examples are obtained by erasing typed ones, but it might be useful to have
+ some untyped ones that can't be obtained by erasure.
+-}
 getUplcExamples :: IO [(ExampleName, SomeExample)]
 getUplcExamples =
-  getInterestingExamples $
-    mapMaybeSnd convert
-      where convert =
-                \case
-                  SomeTypeExample _ -> Nothing
-                  SomeTypedTermExample (TypedTermExample _ e) ->
-                      Just . SomeUntypedExample . SomeUntypedTermExample . UntypedTermExample $
-                        PLC.eraseTerm e
-            mapMaybeSnd _ []     = []
-            mapMaybeSnd f ((a,b):r) =
-                case f b of
-                  Nothing -> mapMaybeSnd f r
-                  Just b' -> (a,b') : mapMaybeSnd f r
-
+    getInterestingExamples $
+        mapMaybeSnd convert
+  where
+    convert =
+        \case
+            SomeTypeExample _ -> Nothing
+            SomeTypedTermExample (TypedTermExample _ e) ->
+                Just . SomeUntypedExample . SomeUntypedTermExample . UntypedTermExample $
+                    PLC.eraseTerm e
+    mapMaybeSnd _ [] = []
+    mapMaybeSnd f ((a, b) : r) =
+        case f b of
+            Nothing -> mapMaybeSnd f r
+            Just b' -> (a, b') : mapMaybeSnd f r
 
 -- The implementation is a little hacky: we generate interesting examples when the list of examples
 -- is requested and at each lookup of a particular example. I.e. each time we generate distinct
@@ -562,55 +599,60 @@ getUplcExamples =
 -- Convert a time in picoseconds into a readable format with appropriate units
 formatTimePicoseconds :: Double -> String
 formatTimePicoseconds t
-    | t >= 1e12 = printf "%.3f s"  (t/1e12)
-    | t >= 1e9  = printf "%.3f ms" (t/1e9)
-    | t >= 1e6  = printf "%.3f μs" (t/1e6)
-    | t >= 1e3  = printf "%.3f ns" (t/1e3)
-    | otherwise = printf "%f ps"   t
+    | t >= 1e12 = printf "%.3f s" (t / 1e12)
+    | t >= 1e9 = printf "%.3f ms" (t / 1e9)
+    | t >= 1e6 = printf "%.3f μs" (t / 1e6)
+    | t >= 1e3 = printf "%.3f ns" (t / 1e3)
+    | otherwise = printf "%f ps" t
 
-{-| Apply an evaluator to a program a number of times and report the mean execution
+{- | Apply an evaluator to a program a number of times and report the mean execution
 time.  The first measurement is often significantly larger than the rest
 (perhaps due to warm-up effects), and this can distort the mean.  To avoid this
-we measure the evaluation time (n+1) times and discard the first result. -}
+we measure the evaluation time (n+1) times and discard the first result.
+-}
 timeEval :: NFData a => Integer -> (t -> a) -> t -> IO [a]
 timeEval n evaluate prog
-    | n <= 0 = errorWithoutStackTrace "Error: the number of repetitions should be at least 1"
+    | n <= 0 = error "Error: the number of repetitions should be at least 1"
     | otherwise = do
-  (results, times) <-
-    unzip . tail <$> for (replicate (fromIntegral (n+1)) prog) (timeOnce evaluate)
-  let mean = fromIntegral (sum times) / fromIntegral n :: Double
-      runs :: String = if n==1 then "run" else "runs"
-  printf "Mean evaluation time (%d %s): %s\n" n runs (formatTimePicoseconds mean)
-  pure results
-    where timeOnce eval prg = do
-            start <- performGC >> getCPUTime
-            let result = eval prg
-                !_ = rnf result
-            end <- getCPUTime
-            pure (result, end - start)
-
+        (results, times) <-
+            unzip . tail <$> for (replicate (fromIntegral (n + 1)) prog) (timeOnce evaluate)
+        let mean = fromIntegral (sum times) / fromIntegral n :: Double
+            runs :: String = if n == 1 then "run" else "runs"
+        printf "Mean evaluation time (%d %s): %s\n" n runs (formatTimePicoseconds mean)
+        pure results
+  where
+    timeOnce eval prg = do
+        start <- performGC >> getCPUTime
+        let result = eval prg
+            !_ = rnf result
+        end <- getCPUTime
+        pure (result, end - start)
 
 ------------ Aux functions for @runEval@ ------------------
 
-handleEResult :: (PP.PrettyBy PP.PrettyConfigPlc a1, Show a2) =>
-  PrintMode -> Either a2 a1 -> IO b
+handleEResult ::
+    (PP.PrettyBy PP.PrettyConfigPlc a1, Show a2) =>
+    PrintMode ->
+    Either a2 a1 ->
+    IO b
 handleEResult printMode result =
-  case result of
-    Right v  -> print (getPrintMethod printMode v) >> exitSuccess
-    Left err -> print err *> exitFailure
+    case result of
+        Right v  -> print (getPrintMethod printMode v) >> exitSuccess
+        Left err -> print err *> exitFailure
 handleTimingResults :: (Eq a1, Eq b, Show a1) => p -> [Either a1 b] -> IO a2
 handleTimingResults _ results =
     case nub results of
-      [Right _]  -> exitSuccess -- We don't want to see the result here
-      [Left err] -> print err >> exitFailure
-      -- Should never happen
-      _          -> error "Timing evaluations returned inconsistent results"
+        [Right _]  -> exitSuccess -- We don't want to see the result here
+        [Left err] -> print err >> exitFailure
+        -- Should never happen
+        _          -> error "Timing evaluations returned inconsistent results"
 
 ----------------- Print examples -----------------------
 
 runPrintExample ::
     IO [(ExampleName, SomeExample)] ->
-    ExampleOptions -> IO ()
+    ExampleOptions ->
+    IO ()
 runPrintExample getFn (ExampleOptions ExampleAvailable) = do
     examples <- getFn
     traverse_ (T.putStrLn . PP.render . uncurry prettySignature) examples
@@ -620,7 +662,6 @@ runPrintExample getFn (ExampleOptions (ExampleSingle name)) = do
         Nothing -> "Unknown name: " <> name
         Just ex -> PP.render $ prettyExample ex
 
-
 ---------------- Print the cost model parameters ----------------
 
 runDumpModel :: IO ()
@@ -628,83 +669,86 @@ runDumpModel = do
     let params = fromJust PLC.defaultCostModelParams
     BSL.putStr $ Aeson.encode params
 
-
 ---------------- Print the type signatures of the default builtins ----------------
 
 -- Some types to represent signatures of built-in functions
 type PlcTerm = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ()
 type PlcType = PLC.Type PLC.TyName PLC.DefaultUni ()
-data QVarOrType = QVar String | Type PlcType  -- Quantified type variable or actual type
+data QVarOrType = QVar String | Type PlcType -- Quantified type variable or actual type
 
-data Signature = Signature [QVarOrType] PlcType  -- Argument types, return type
+data Signature = Signature [QVarOrType] PlcType -- Argument types, return type
 instance Show Signature where
     show (Signature args res) =
         "[ " ++ (intercalate ", " $ map showQT args) ++ " ] -> " ++ showTy (normTy res)
-            where showQT =
-                      \case
-                       QVar tv -> "forall " ++ tv
-                       Type ty -> showTy (normTy ty)
-                  normTy :: PlcType -> PlcType
-                  normTy ty = PLC.runQuote $ PLC.unNormalized <$> normalizeType ty
-                  showTy ty =
-                      case ty of
-                        PLC.TyBuiltin _ t -> show $ PP.pretty t
-                        PLC.TyApp {}      -> showMultiTyApp $ unwrapTyApp ty
-                        _                 -> show $ PP.pretty ty
-                  unwrapTyApp ty =
-                      case ty of
-                        PLC.TyApp _ t1 t2 -> unwrapTyApp t1 ++ [t2]
-                        -- Assumes iterated built-in type applications all associate to the left;
-                        -- if not, we'll just get some odd formatting.
-                        _                 -> [ty]
-                  showMultiTyApp =
-                      \case
-                        []     -> "<empty type application>"   -- Should never happen
-                        op:tys -> showTy op ++ "(" ++ intercalate ", " (map showTy tys) ++ ")"
+      where
+        showQT =
+            \case
+                QVar tv -> "forall " ++ tv
+                Type ty -> showTy (normTy ty)
+        normTy :: PlcType -> PlcType
+        normTy ty = PLC.runQuote $ PLC.unNormalized <$> normalizeType ty
+        showTy ty =
+            case ty of
+                PLC.TyBuiltin _ t -> show $ PP.pretty t
+                PLC.TyApp{}       -> showMultiTyApp $ unwrapTyApp ty
+                _                 -> show $ PP.pretty ty
+        unwrapTyApp ty =
+            case ty of
+                PLC.TyApp _ t1 t2 -> unwrapTyApp t1 ++ [t2]
+                -- Assumes iterated built-in type applications all associate to the left;
+                -- if not, we'll just get some odd formatting.
+                _                 -> [ty]
+        showMultiTyApp =
+            \case
+                []       -> "<empty type application>" -- Should never happen
+                op : tys -> showTy op ++ "(" ++ intercalate ", " (map showTy tys) ++ ")"
 
 typeSchemeToSignature :: PLC.TypeScheme PlcTerm args res -> Signature
 typeSchemeToSignature = toSig []
-    where toSig :: [QVarOrType] -> PLC.TypeScheme PlcTerm args res -> Signature
-          toSig acc =
-              \case
-               pR@PLC.TypeSchemeResult -> Signature acc (PLC.toTypeAst pR)
-               arr@(PLC.TypeSchemeArrow schB) ->
-                   toSig (acc ++ [Type $ PLC.toTypeAst $ PLC.argProxy arr]) schB
-               PLC.TypeSchemeAll proxy schK ->
-                   case proxy of
-                     (_ :: Proxy '(text, uniq, kind)) ->
-                         toSig (acc ++ [QVar $ symbolVal @text Proxy]) schK
+  where
+    toSig :: [QVarOrType] -> PLC.TypeScheme PlcTerm args res -> Signature
+    toSig acc =
+        \case
+            pR@PLC.TypeSchemeResult -> Signature acc (PLC.toTypeAst pR)
+            arr@(PLC.TypeSchemeArrow schB) ->
+                toSig (acc ++ [Type $ PLC.toTypeAst $ PLC.argProxy arr]) schB
+            PLC.TypeSchemeAll proxy schK ->
+                case proxy of
+                    (_ :: Proxy '(text, uniq, kind)) ->
+                        toSig (acc ++ [QVar $ symbolVal @text Proxy]) schK
 
 runPrintBuiltinSignatures :: IO ()
 runPrintBuiltinSignatures = do
-  let builtins = enumerate @UPLC.DefaultFun
-  mapM_ (\x -> putStr (printf "%-25s: %s\n" (show $ PP.pretty x) (show $ getSignature x))) builtins
-      where
-        getSignature (PLC.toBuiltinMeaning @_ @_ @PlcTerm def -> PLC.BuiltinMeaning sch _ _) =
-          typeSchemeToSignature sch
-
+    let builtins = enumerate @UPLC.DefaultFun
+    mapM_
+      (\x -> putStr (printf "%-25s: %s\n" (show $ PP.pretty x) (show $ getSignature x)))
+      builtins
+  where
+    getSignature (PLC.toBuiltinMeaning @_ @_ @PlcTerm def -> PLC.BuiltinMeaning sch _ _) =
+        typeSchemeToSignature sch
 
 ---------------- Parse and print a PLC/UPLC source file ----------------
 
 runPrint :: PrintOptions -> IO ()
 runPrint (PrintOptions iospec mode) = do
-    parsed <- (parseInput (inputSpec iospec) :: IO (PlcProg PLC.SourcePos) )
+    parsed <- (parseInput (inputSpec iospec) :: IO (PlcProg PLC.SourcePos))
     let printed = show $ getPrintMethod mode parsed
     case outputSpec iospec of
-      FileOutput path -> writeFile path printed
-      StdOutput       -> putStrLn printed
+        FileOutput path -> writeFile path printed
+        StdOutput       -> putStrLn printed
 
 ---------------- Conversions ----------------
 
 -- | Convert between textual and FLAT representations.
 runConvert ::
-  forall (p :: * -> *) .
-  (ProgramLike p,
-   Functor p,
-   PLC.Rename (p PLC.SourcePos),
-   PP.PrettyBy PP.PrettyConfigPlc (p PLC.SourcePos))
-  => ConvertOptions
-  -> IO ()
+    forall (p :: * -> *).
+    ( ProgramLike p
+    , Functor p
+    , PLC.Rename (p PLC.SourcePos)
+    , PP.PrettyBy PP.PrettyConfigPlc (p PLC.SourcePos)
+    ) =>
+    ConvertOptions ->
+    IO ()
 runConvert (ConvertOptions inp ifmt outp ofmt mode) = do
     program :: p PLC.SourcePos <- getProgram ifmt inp
     writeProgram outp ofmt mode program

--- a/plutus-core/executables/Parsers.hs
+++ b/plutus-core/executables/Parsers.hs
@@ -1,4 +1,3 @@
--- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase #-}
 
 -- | Common option parsers for executables
@@ -9,7 +8,8 @@ import Common
 
 import Options.Applicative
 
--- | Parser for an input stream. If none is specified, default to stdin: this makes use in pipelines easier
+-- | Parser for an input stream. If none is specified,
+-- default to stdin for ease of use in pipeline.
 input :: Parser Input
 input = fileInput <|> stdInput <|> pure StdInput
 
@@ -25,7 +25,8 @@ stdInput = flag' StdInput
   (  long "stdin"
   <> help "Read from stdin (default)" )
 
--- | Parser for an output stream. If none is specified, default to stdout: this makes use in pipelines easier
+-- | Parser for an output stream. If none is specified,
+-- default to stdout for ease of use in pipeline.
 output :: Parser Output
 output = fileOutput <|> stdOutput <|> pure StdOutput
 
@@ -40,6 +41,9 @@ stdOutput :: Parser Output
 stdOutput = flag' StdOutput
   (  long "stdout"
   <> help "Write to stdout (default)" )
+
+ioSpec :: Parser IOSpec
+ioSpec = MkIOSpec <$> input <*> output
 
 formatHelp :: String
 formatHelp =
@@ -118,7 +122,7 @@ printmode = option auto
         ++ "Readable -> prettyPlcReadableDef, ReadableDebug -> prettyPlcReadableDebug" ))
 
 printOpts :: Parser PrintOptions
-printOpts = PrintOptions <$> input <*> printmode
+printOpts = PrintOptions <$> ioSpec <*> printmode
 
 convertOpts :: Parser ConvertOptions
 convertOpts = ConvertOptions <$> input <*> inputformat <*> output <*> outputformat <*> printmode

--- a/plutus-core/executables/Parsers.hs
+++ b/plutus-core/executables/Parsers.hs
@@ -47,7 +47,8 @@ ioSpec = MkIOSpec <$> input <*> output
 
 formatHelp :: String
 formatHelp =
-  "textual, flat-named (names), flat (de Bruijn indices), or flat-namedDeBruijn (names and de Bruijn indices)"
+  "textual, flat-named (names), flat (de Bruijn indices), "
+  <> "or flat-namedDeBruijn (names and de Bruijn indices)"
 
 formatReader :: String -> Maybe Format
 formatReader =
@@ -90,7 +91,8 @@ timing2 = Timing <$> option auto
   (  long "time-execution"
   <> short 'X'
   <> metavar "N"
-  <> help "Report mean execution time of program over N repetitions. Use a large value of N if possible to get accurate results."
+  <> help ("Report mean execution time of program over N repetitions. "
+  <> " Use a large value of N if possible to get accurate results.")
   )
 
 -- We really do need two separate parsers here.
@@ -104,7 +106,7 @@ tracemode = option auto
   <> metavar "MODE"
   <> value None
   <> showDefault
-  <> help "Mode for trace ouptupt.")
+  <> help "Mode for trace output.")
 
 files :: Parser Files
 files = some (argument str (metavar "[FILES...]"))
@@ -118,8 +120,10 @@ printmode = option auto
   <> metavar "MODE"
   <> value Debug
   <> showDefault
-  <> help ("Print mode for textual output (ignored elsewhere): Classic -> plcPrettyClassicDef, Debug -> plcPrettyClassicDebug, "
-        ++ "Readable -> prettyPlcReadableDef, ReadableDebug -> prettyPlcReadableDebug" ))
+  <> help
+    ("Print mode for textual output (ignored elsewhere): Classic -> plcPrettyClassicDef, "
+     <> "Debug -> plcPrettyClassicDebug, "
+     <> "Readable -> prettyPlcReadableDef, ReadableDebug -> prettyPlcReadableDebug" ))
 
 printOpts :: Parser PrintOptions
 printOpts = PrintOptions <$> ioSpec <*> printmode

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -33,6 +33,7 @@ type PIRCompilationCtx a = PIR.CompilationCtx PLC.DefaultUni PLC.DefaultFun a
 data Command = Analyse IOSpec
              | Compile COpts
              | Print PrintOptions
+             | Convert ConvertOptions
 
 data COpts = COpts
   { cIn       :: Input
@@ -153,6 +154,7 @@ main = do
         Analyse opts -> loadPirAndAnalyse opts
         Compile opts -> loadPirAndCompile opts
         Print opts   -> runPrint opts
+        Convert opts -> runConvert opts
   where
     infoOpts =
       info (pPirOpts <**> helper)

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -1,4 +1,3 @@
--- editorconfig-checker-disable-file
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
@@ -89,10 +88,12 @@ compile opts (PIR.Program _ pirT) = do
     let pirCtx = defaultCompilationCtx plcTcConfig
     runExcept $ flip runReaderT pirCtx $ runQuoteT $ PIR.compileTerm pirT
   where
-    set' :: Lens' (PIR.CompilationOpts a) b -> (COpts -> b) -> PIRCompilationCtx a -> PIRCompilationCtx a
+    set' :: Lens' (PIR.CompilationOpts a) b
+      -> (COpts -> b) -> PIRCompilationCtx a -> PIRCompilationCtx a
     set' pirOpt opt = set (PIR.ccOpts . pirOpt) (opt opts)
 
-    defaultCompilationCtx :: PLC.TypeCheckConfig PLC.DefaultUni PLC.DefaultFun -> PIRCompilationCtx a
+    defaultCompilationCtx :: PLC.TypeCheckConfig PLC.DefaultUni PLC.DefaultFun
+      -> PIRCompilationCtx a
     defaultCompilationCtx plcTcConfig =
       PIR.toDefaultCompilationCtx plcTcConfig
       & set' PIR.coOptimize                     cOptimize
@@ -125,7 +126,8 @@ loadPirAndAnalyse aopts = do
 
         -- change uniques to texts and use csv-outputtable records
         sortedRecords :: [RetentionRecord]
-        sortedRecords = (\(i,s) -> RetentionRecord (IM.findWithDefault "???" i nameTable) i s) <$> sortedRetained
+        sortedRecords =
+          (\(i,s) -> RetentionRecord (IM.findWithDefault "???" i nameTable) i s) <$> sortedRetained
 
     -- encode to csv and output it
     Csv.encodeDefaultOrderedByName sortedRecords &
@@ -137,7 +139,7 @@ loadPirAndAnalyse aopts = do
 -- This option for PIR source file does NOT check for @UniqueError@'s.
 -- Only the print option for PLC or UPLC files check for them.
 runPrint :: PrintOptions -> IO ()
-runPrint (PrintOptions inp mode) = do
+runPrint (PrintOptions inp _mode) = do
     contents <- getInput inp
     -- parse the program
     case parseNamedProgram (show inp) contents of
@@ -146,18 +148,8 @@ runPrint (PrintOptions inp mode) = do
           errorWithoutStackTrace $ errorBundlePretty err
       -- otherwise,
       Right (p::PirProg PLC.SourcePos) ->
-        -- should I add instances for (getPrintMethod mode p)?
+        -- pretty print the program. Print mode may be added later on.
         print $ pretty p
-
--- loadPirAndPrint :: POpts -> IO ()
--- loadPirAndPrint popts = do
---     pirT <- loadPir $ pIn popts
---     let
---         printed :: String
---         printed = show $ pretty pirT
---     case pOut popts of
---         FileOutput path -> writeFile path printed
---         StdOutput       -> putStrLn printed
 
 main :: IO ()
 main = do

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -19,16 +19,21 @@ import GHC.Generics
 import Options.Applicative
 import Parsers
 import PlutusCore qualified as PLC
+import PlutusCore.Error (ParserErrorBundle (..))
 import PlutusCore.Quote (runQuoteT)
 import PlutusIR as PIR
 import PlutusIR.Analysis.RetainedSize qualified as PIR
 import PlutusIR.Compiler qualified as PIR
 import PlutusIR.Core.Plated
 import PlutusPrelude
+import Text.Megaparsec (errorBundlePretty)
 
+type PLCTerm  = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
+type PIRError = PIR.Error PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
+type PIRCompilationCtx a = PIR.CompilationCtx PLC.DefaultUni PLC.DefaultFun a
 data Command = Analyse AOpts
              | Compile COpts
-             | Print POpts
+             | Print PrintOptions
 
 data AOpts = AOpts
   {
@@ -39,12 +44,6 @@ data AOpts = AOpts
 data COpts = COpts
   { cIn       :: Input
   , cOptimize :: Bool
-  }
-
-data POpts = POpts
-  {
-    pIn  :: Input
-  , pOut :: Output
   }
 
 pAOpts :: Parser AOpts
@@ -62,36 +61,30 @@ pCOpts = COpts
     switch' :: Mod FlagFields Bool -> Parser Bool
     switch' = fmap not . switch
 
-pPOpts :: Parser POpts
-pPOpts = POpts
-    <$> input
-    <*> output
-
 pPirOpts :: Parser Command
 pPirOpts = hsubparser $
     command "analyse"
         (info (Analyse <$> pAOpts) $
-            progDesc "Given a PIR program in flat format, deserialise and analyse the program looking for variables with the largest retained size.")
+            progDesc $
+              "Given a PIR program in flat format, deserialise and analyse the program, " <>
+              "looking for variables with the largest retained size.")
   <> command "compile"
         (info (Compile <$> pCOpts) $
-            progDesc "Given a PIR program in flat format, deserialise it and test if it can be successfully compiled to PLC.")
+            progDesc $
+              "Given a PIR program in flat format, deserialise it, " <>
+              "and test if it can be successfully compiled to PLC.")
   <> command "print"
-        (info (Print <$> pPOpts) $
-            progDesc "Given a PIR program in flat format, deserialise it and print it out textually.")
-
-
-type PIRTerm  = PIR.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun ()
-type PLCTerm  = PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
-type PIRError = PIR.Error PLC.DefaultUni PLC.DefaultFun (PIR.Provenance ())
-type PIRCompilationCtx a = PIR.CompilationCtx PLC.DefaultUni PLC.DefaultFun a
-
+        (info (Print <$> printOpts) $
+            progDesc $
+              "Given a PIR program in flat format, " <>
+              "deserialise it and print it out textually.")
 
 -- | Load flat pir and deserialize it
 loadPir :: Input -> IO (PirProg ())
 loadPir = loadASTfromFlat Named
 
-compile :: COpts -> PIRTerm -> Either PIRError PLCTerm
-compile opts pirT = do
+compile :: COpts -> PirProg () -> Either PIRError PLCTerm
+compile opts (PIR.Program _ pirT) = do
     plcTcConfig <- PLC.getDefTypeCheckConfig PIR.noProvenance
     let pirCtx = defaultCompilationCtx plcTcConfig
     runExcept $ flip runReaderT pirCtx $ runQuoteT $ PIR.compileTerm pirT
@@ -106,9 +99,9 @@ compile opts pirT = do
 
 loadPirAndCompile :: COpts -> IO ()
 loadPirAndCompile copts = do
-    (PIR.Program _ pirT) <- loadPir $ cIn copts
+    pirProg <- loadPir $ cIn copts
     putStrLn "!!! Compiling"
-    case compile copts pirT of
+    case compile copts pirProg of
         Left pirError -> error $ show pirError
         Right _       -> putStrLn "!!! Compilation successful"
 
@@ -140,15 +133,31 @@ loadPirAndAnalyse aopts = do
             FileOutput path -> BSL.writeFile path
             StdOutput       -> BSL.putStr
 
-loadPirAndPrint :: POpts -> IO ()
-loadPirAndPrint popts = do
-    pirT <- loadPir $ pIn popts
-    let
-        printed :: String
-        printed = show $ pretty pirT
-    case pOut popts of
-        FileOutput path -> writeFile path printed
-        StdOutput       -> putStrLn printed
+---------------- Parse and print a PIR source file ----------------
+-- This option for PIR source file does NOT check for @UniqueError@'s.
+-- Only the print option for PLC or UPLC files check for them.
+runPrint :: PrintOptions -> IO ()
+runPrint (PrintOptions inp mode) = do
+    contents <- getInput inp
+    -- parse the program
+    case parseNamedProgram (show inp) contents of
+      -- when fail, pretty print the parse errors.
+      Left (ParseErrorB err) ->
+          errorWithoutStackTrace $ errorBundlePretty err
+      -- otherwise,
+      Right (p::PirProg PLC.SourcePos) ->
+        -- should I add instances for (getPrintMethod mode p)?
+        print $ pretty p
+
+-- loadPirAndPrint :: POpts -> IO ()
+-- loadPirAndPrint popts = do
+--     pirT <- loadPir $ pIn popts
+--     let
+--         printed :: String
+--         printed = show $ pretty pirT
+--     case pOut popts of
+--         FileOutput path -> writeFile path printed
+--         StdOutput       -> putStrLn printed
 
 main :: IO ()
 main = do
@@ -156,7 +165,7 @@ main = do
     case comm of
         Analyse opts -> loadPirAndAnalyse opts
         Compile opts -> loadPirAndCompile opts
-        Print opts   -> loadPirAndPrint opts
+        Print opts   -> runPrint opts
   where
     infoOpts =
       info (pPirOpts <**> helper)

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# LANGUAGE TypeApplications  #-}
 module Main where
 
 import Common hiding (runPrint)
@@ -34,7 +33,6 @@ type PIRCompilationCtx a = PIR.CompilationCtx PLC.DefaultUni PLC.DefaultFun a
 data Command = Analyse IOSpec
              | Compile COpts
              | Print PrintOptions
-             | Convert ConvertOptions
 
 data COpts = COpts
   { cIn       :: Input
@@ -158,15 +156,13 @@ main = do
         Analyse opts -> loadPirAndAnalyse opts
         Compile opts -> loadPirAndCompile opts
         Print opts   -> runPrint opts
-        Convert opts -> runConvert @PirProg opts
   where
     infoOpts =
       info (pPirOpts <**> helper)
            ( fullDesc
            <> header "PIR tool"
            <> progDesc ("This program provides a number of utilities for dealing with "
-           <> "PIR programs, including print, analysis, compilation to PLC, "
-           <> "and conversion between a number of different formats. "))
+           <> "PIR programs, including print, analysis, and compilation to PLC."))
 
 -- | a csv-outputtable record row of {name,unique,size}
 data RetentionRecord = RetentionRecord { name :: T.Text, unique :: Int, size :: PIR.Size}

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -100,7 +100,7 @@ loadPirAndCompile copts = do
 loadPirAndAnalyse :: IOSpec -> IO ()
 loadPirAndAnalyse ioSpecs = do
     -- load pir and make sure that it is globally unique (required for retained size)
-    (PIR.Program _ pirT) <- PLC.runQuote . PLC.rename <$> loadPir (inputSpec ioSpecs)
+    PIR.Program _ pirT <- PLC.runQuote . PLC.rename <$> loadPir (inputSpec ioSpecs)
     putStrLn "!!! Analysing for retention"
     let
         -- all the variable names (tynames coerced to names)
@@ -118,8 +118,8 @@ loadPirAndAnalyse ioSpecs = do
         -- change uniques to texts and use csv-outputtable records
         sortedRecords :: [RetentionRecord]
         sortedRecords =
-          flip fmap sortedRetained $ \(i, s) ->
-            RetentionRecord (IM.findWithDefault "???" i nameTable) i s
+          sortedRetained <&> \(i, s) ->
+            RetentionRecord (IM.findWithDefault "given key is not in map" i nameTable) i s
 
     -- encode to csv and output it
     Csv.encodeDefaultOrderedByName sortedRecords &

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -159,8 +159,11 @@ main = do
     infoOpts =
       info (pPirOpts <**> helper)
            ( fullDesc
-           <> progDesc "Load a flat pir term from file and run the compiler on it"
-           <> header "pir - a small tool for loading pir from flat representation for analysis or compilation to PLC")
+          --  <> progDesc "Load a flat pir term from file and run the compiler on it"
+           <> header "PIR tool"
+           <> progDesc ("This program provides a number of utilities for dealing with "
+           <> "PIR programs, including print, analysis, compilation to PLC, "
+           <> "and conversion between a number of different formats. "))
 
 -- | a csv-outputtable record row of {name,unique,size}
 data RetentionRecord = RetentionRecord { name :: T.Text, unique :: Int, size :: PIR.Size}

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -16,7 +16,7 @@ import Data.Functor (void)
 import Data.Text.IO qualified as T
 
 import Control.DeepSeq (rnf)
-import Control.Lens
+import Control.Lens ((&), (^.))
 import Options.Applicative
 import System.Exit (exitSuccess)
 

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -155,14 +155,6 @@ runErase (EraseOptions inp ifmt outp ofmt mode) = do
     Textual       -> writePrettyToFileOrStd outp mode untypedProg
     Flat flatMode -> writeFlat outp flatMode untypedProg
 
----------------- Conversions ----------------
-
--- | Convert between textual and FLAT representations.
-runConvert :: ConvertOptions -> IO ()
-runConvert (ConvertOptions inp ifmt outp ofmt mode) = do
-    program <- (getProgram ifmt inp :: IO (PlcProg PLC.SourcePos))
-    writeProgram outp ofmt mode program
-
 ---------------- Driver ----------------
 
 main :: IO ()

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -155,12 +155,6 @@ runErase (EraseOptions inp ifmt outp ofmt mode) = do
     Textual       -> writePrettyToFileOrStd outp mode untypedProg
     Flat flatMode -> writeFlat outp flatMode untypedProg
 
----------------- Parse and print a PLC source file ----------------
-
-runPrint :: PrintOptions -> IO ()
-runPrint (PrintOptions inp mode) =
-    (parseInput inp :: IO (PlcProg PLC.SourcePos) ) >>= print . getPrintMethod mode
-
 ---------------- Conversions ----------------
 
 -- | Convert between textual and FLAT representations.

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -1,6 +1,7 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Main (main) where
 
@@ -167,6 +168,6 @@ main = do
         Example   opts         -> runPlcPrintExample opts
         Erase     opts         -> runErase        opts
         Print     opts         -> runPrint        opts
-        Convert   opts         -> runConvert      opts
+        Convert   opts         -> runConvert @PlcProg opts
         DumpModel              -> runDumpModel
         PrintBuiltinSignatures -> runPrintBuiltinSignatures

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -222,12 +222,6 @@ runUplcPrintExample ::
     ExampleOptions -> IO ()
 runUplcPrintExample = runPrintExample getUplcExamples
 
----------------- Parse and print a UPLC source file ----------------
-
-runPrint :: PrintOptions -> IO ()
-runPrint (PrintOptions inp mode) =
-    (parseInput inp :: IO (UplcProg PLC.SourcePos)) >>= print . getPrintMethod mode
-
 ---------------- Conversions ----------------
 
 -- | Convert between textual and FLAT representations.

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -222,14 +222,6 @@ runUplcPrintExample ::
     ExampleOptions -> IO ()
 runUplcPrintExample = runPrintExample getUplcExamples
 
----------------- Conversions ----------------
-
--- | Convert between textual and FLAT representations.
-runConvert :: ConvertOptions -> IO ()
-runConvert (ConvertOptions inp ifmt outp ofmt mode) = do
-    program <- (getProgram ifmt inp :: IO (UplcProg PLC.SourcePos))
-    writeProgram outp ofmt mode program
-
 ---------------- Driver ----------------
 
 main :: IO ()

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE TypeApplications          #-}
 
 module Main (main) where
 
@@ -232,6 +233,6 @@ main = do
         Eval      opts         -> runEval         opts
         Example   opts         -> runUplcPrintExample opts
         Print     opts         -> runPrint        opts
-        Convert   opts         -> runConvert      opts
+        Convert   opts         -> runConvert @UplcProg     opts
         DumpModel              -> runDumpModel
         PrintBuiltinSignatures -> runPrintBuiltinSignatures

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Type.hs
@@ -161,7 +161,7 @@ data Program tyname name uni fun ann = Program
     { _progAnn  :: ann
     , _progTerm :: Term tyname name uni fun ann
     }
-    deriving stock Generic
+    deriving stock (Show, Functor, Generic)
 makeLenses ''Program
 
 type instance PLC.HasUniques (Term tyname name uni fun ann) = (PLC.HasUnique tyname PLC.TypeUnique, PLC.HasUnique name PLC.TermUnique)

--- a/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/TypeCheck/Internal.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE TypeOperators      #-}
 module PlutusIR.TypeCheck.Internal
     ( BuiltinTypes (..)
     , TypeCheckConfig (..)
@@ -51,8 +50,8 @@ import Universe
 For PIR kind-checking, we reuse `checkKindM`, `inferKindM` directly from the PLC typechecker.
 For PIR type-checking, we port the `checkTypeM` and `inferTypeM` from PLC typechecker.
 The port is a direct copy, except for the modifications of `Term` to `PIR.Term`
-and error type signatures and `throwError` to accomodate for the new pir type-errors.
-These modifications are currently necesessary since PIR.Term ADT /= PLC.Term ADT.
+and error type signatures and `throwError` to accommodate for the new pir type-errors.
+These modifications are currently necessary since PIR.Term ADT /= PLC.Term ADT.
 We then extend this ported `PIR.inferTypeM` with cases for inferring type of LetRec and LetNonRec.
 
 See Note [Notation] of PlutusCore.TypeCheck.Internal for the notation of inference rules, which appear in the comments.


### PR DESCRIPTION
- fix line lengths of the files I touched. I apologize that it's making the diff harder to read. I will separate out these commits to another PR next time.
- tidy PIR executable:
  - add a type that specifies the input and output paths and and use it in the print function and other places. The print function now lets you specify the output path also in all three executables (PLC, UPLC, and PIR).
  - add a `PirProg` instance to the `Executable` typeclass.
  - use the `Common` functions in PIR.
  - add convert option to PIR executable.
  - the `DumpModel` function can be easily added in one line but I'm not sure if we want that function in PIR.
  - update the program description.
- rename `Executable` typeclass to `PlutusProgram` because these don't need to just apply to the executables. We can decide if we want to move it to Prelude etc if we deem it helpful.
- move more functions to `Common` and remove duplication in PLC and UPLC.

I was not sure about whether we should `checkProgram` (check for unique errors) when we parse the input in PIR. It's currently done in PLC and UPLC. Since it's being checked in PLC I think maybe it's not worth implementing the whole thing again for PIR. I've made a comment about this. 

Further tidying may include taking `checkProgram` out of parsing and adding a separate function `checkProgram` that includes typechecking for PLC and whatever checks we deem appropriate. I've started doing so but I feel the PR is large enough as is so I'm opening this and we can think about this further.  
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
