### PR TITLE
updated Tutorial 'Writing basic minting policies' to include link to …

### DIFF
--- a/doc/tutorials/basic-minting-policies.rst
+++ b/doc/tutorials/basic-minting-policies.rst
@@ -19,15 +19,18 @@ The minting policy is a function which receives these two inputs as *arguments*.
 The validating node is responsible for passing them in and running the minting policy.
 As with validator scripts, the arguments are passed encoded as :hsobj:`PlutusCore.Data.Data`.
 
-Using the script context
-------------------------
+Plutus V1 and V2 script context
+------------------------------------
 
 Minting policies have access to the :term:`script context` as their second argument.
-This will always be a value of type :hsobj:``PlutusLedgerApi.V1.Contexts.ScriptContext`` encoded as ``Data``.
+Plutus V1 and V2 minting policy scripts are differentiated only by their ``ScriptContext``. 
+
+   See this example of `two minting policies defined and compiled as both Plutus V1 and V2 <https://github.com/james-iohk/plutus-scripts/blob/master/src/TokenNamePolicy.hs>`_. 
+
 Minting policies tend to be particularly interested in the ``mint`` field, since the point of a minting policy is to control which tokens are minted.
 
 It is also important for a minting policy to look at the tokens in the ``mint`` field that are part of its own asset group.
-This requires the policy to refer to its own hash -- fortunately this is provided for us in the script context of a minting policy.
+This requires the policy to refer to its own hash --- fortunately this is provided for us in the script context of a minting policy.
 
 Writing minting policies
 ------------------------

--- a/doc/tutorials/basic-minting-policies.rst
+++ b/doc/tutorials/basic-minting-policies.rst
@@ -19,11 +19,11 @@ The minting policy is a function which receives these two inputs as *arguments*.
 The validating node is responsible for passing them in and running the minting policy.
 As with validator scripts, the arguments are passed encoded as :hsobj:`PlutusCore.Data.Data`.
 
-Plutus V1 and V2 script context
+Plutus script context versions
 ------------------------------------
 
 Minting policies have access to the :term:`script context` as their second argument.
-Plutus V1 and V2 minting policy scripts are differentiated only by their ``ScriptContext``. 
+Each version of Plutus minting policy scripts are differentiated only by their ``ScriptContext`` argument. 
 
    See this example from the file ``MustSpendScriptOutput.hs`` (lines 340 to 422) showing code addressing `Versioned Policies for both Plutus V1 and Plutus V2 <https://github.com/input-output-hk/plutus-apps/blob/05e394fb6188abbbe827ff8a51a24541a6386422/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs#L340-L422>`_. 
 

--- a/doc/tutorials/basic-minting-policies.rst
+++ b/doc/tutorials/basic-minting-policies.rst
@@ -25,7 +25,7 @@ Plutus V1 and V2 script context
 Minting policies have access to the :term:`script context` as their second argument.
 Plutus V1 and V2 minting policy scripts are differentiated only by their ``ScriptContext``. 
 
-   See this example of `two minting policies defined and compiled as both Plutus V1 and V2 <https://github.com/james-iohk/plutus-scripts/blob/master/src/TokenNamePolicy.hs>`_. 
+   See this example from the file ``MustSpendScriptOutput.hs`` (lines 340 to 422) showing code addressing `Versioned Policies for both Plutus V1 and Plutus V2 <https://github.com/input-output-hk/plutus-apps/blob/05e394fb6188abbbe827ff8a51a24541a6386422/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs#L340-L422>`_. 
 
 Minting policies tend to be particularly interested in the ``mint`` field, since the point of a minting policy is to control which tokens are minted.
 

--- a/doc/tutorials/basic-validators.rst
+++ b/doc/tutorials/basic-validators.rst
@@ -84,11 +84,13 @@ Here's an example that uses our date types to check whether the date which was p
    :start-after: BLOCK3
    :end-before: BLOCK4
 
-Using the script context
-------------------------
+Plutus V1 and V2 script context
+------------------------------------
 
 Validators have access to the :term:`script context` as their third argument.
-This will always be a value of type :hsobj:`PlutusLedgerApi.V1.Contexts.ScriptContext` encoded as ``Data``.
+Plutus V1 and V2 Validators are differentiated only by their ``ScriptContext``. 
+
+   See this example from the file ``MustSpendScriptOutput.hs`` (lines 340 to 422) showing code addressing `Versioned Policies for both Plutus V1 and Plutus V2 <https://github.com/input-output-hk/plutus-apps/blob/05e394fb6188abbbe827ff8a51a24541a6386422/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs#L340-L422>`_. 
 
 The script context gives validators a great deal of power, because it allows them to inspect other inputs and outputs of the current transaction.
 For example, here is a validator that will only accept the transaction if a particular payment is made as part of it.

--- a/doc/tutorials/basic-validators.rst
+++ b/doc/tutorials/basic-validators.rst
@@ -84,11 +84,11 @@ Here's an example that uses our date types to check whether the date which was p
    :start-after: BLOCK3
    :end-before: BLOCK4
 
-Plutus V1 and V2 script context
+Plutus script context versions
 ------------------------------------
 
 Validators have access to the :term:`script context` as their third argument.
-Plutus V1 and V2 Validators are differentiated only by their ``ScriptContext``. 
+Each version of Plutus validators are differentiated only by their ``ScriptContext`` argument. 
 
    See this example from the file ``MustSpendScriptOutput.hs`` (lines 340 to 422) showing code addressing `Versioned Policies for both Plutus V1 and Plutus V2 <https://github.com/input-output-hk/plutus-apps/blob/05e394fb6188abbbe827ff8a51a24541a6386422/plutus-contract/test/Spec/TxConstraints/MustSpendScriptOutput.hs#L340-L422>`_. 
 


### PR DESCRIPTION
Updated Tutorial "Writing basic minting policies" to mention that Plutus V1 and V2 minting policy scripts are differentiated only by their ScriptContext. Added a link to an example provided by @james-iohk of two minting policies defined and compiled as both Plutus V1 and V2: 

https://github.com/james-iohk/plutus-scripts/blob/master/src/TokenNamePolicy.hs

To review the updated page as an html page, use this link: 
https://plutus--4874.org.readthedocs.build/en/4874/
and navigate to Tutorials > Writing basic minting policies. 
