### PR TITLE
Make cross-compilation work again.

### DIFF
--- a/__std__/nix/plutus/library/plutus-project.nix
+++ b/__std__/nix/plutus/library/plutus-project.nix
@@ -22,6 +22,8 @@ let
 
     compiler-nix-name = library.ghc-compiler-nix-name;
 
+    evalPackages = library.pkgs;
+
     # This is incredibly difficult to get right, almost everything goes wrong,
     # see https://github.com/input-output-hk/haskell.nix/issues/496
     src = library.haskell-nix.haskellLib.cleanSourceWith {
@@ -149,7 +151,7 @@ let
             platforms = lib.platforms.linux;
           };
 
-          # Werror everything. 
+          # Werror everything.
           # This is a pain, see https://github.com/input-output-hk/haskell.nix/issues/519
           plutus-core.ghcOptions = [ "-Werror" ];
 
@@ -191,4 +193,4 @@ let
 
 in
 
-project 
+project

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -20,6 +20,7 @@ let
   r-packages = with rPackages; [ R tidyverse dplyr stringr MASS plotly shiny shinyjs purrr ];
   project = haskell-nix.cabalProject' ({ pkgs, ... }: {
     inherit compiler-nix-name;
+    evalPackages = pkgs.buildPackages.buildPackages;
     # This is incredibly difficult to get right, almost everything goes wrong,
     # see https://github.com/input-output-hk/haskell.nix/issues/496
     src = let root = ../../../.; in


### PR DESCRIPTION
 To correctly eval the haskell.nix project we need the pkgs for the current
 system, not the cross system one.

 cf. https://github.com/input-output-hk/haskell.nix/issues/1666