### PR TITLE
Switch plutus to use CHaP

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -39,13 +39,15 @@ If you're not using `nix develop` all the time and you want to run one of these,
 The `nix develop` environment has the correct GHC with all the external Haskell dependencies of the project.
 From here you can build the project packages directly with `cabal`.
 
-NOTE: You may need to run `cabal update` so that `cabal` knows about the index state xref:update-index-state[we have pinned].
+NOTE: You may need to run `cabal update` so that `cabal` knows about the index state xref:update-haskell-deps[we have pinned].
 
 [WARNING]
 ====
 You can also use `cabal` outside the `nix develop` environment to build the project.
 _However_ there are two caveats:
 
+* We rely on forked or new versions of some system libraries.
+** You can read the https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md[Cardano node documentation] to find out how to install these.
 * You may get different versions of packages.
 ** This *shouldn't* happen, but we can't guarantee it.
 * We are not currently enabling the Nix integration for these tools, so
@@ -123,14 +125,36 @@ You need to do a few things when adding a new package, in the following order:
 . Add the package to link:cabal.project[`cabal.project`].
 . Check that you can run `nix build -f default.nix plutus.haskell.projectPackages.<package name>` successfully.
 
-[[update-haskell-pins]]
-=== How to update our pinned Haskell dependencies
+[[update-haskell-deps]]
+=== How to update our Haskell dependencies
 
-We have pinned versions of some Haskell packages specified via the usual `source-repository-package` (Cabal) mechanism.
+Our Haskell packages come from two package repositories:
+- Hackage
+- https://github.com/input-output-hk/cardano-haskell-packages[CHaP] (which is essentially another Hackage)
 
-These can be managed normally, but ensure that:
+The "index state" of each repository is pinned to a particular time in `cabal.project`.
+This tells Cabal to treat the repository "as if" it was the specified time, ensuring reproducibility.
+If you want to use a package version from repository X which was added after the pinned index state time, you need to bump the index state for X.
+This is not a big deal, since all it does is change what packages `cabal` considers to be available when doing solving, but it will change what package versions cabal picks for the plan, and so will likely result in significant recompilation, and potentially some breakage.
+That typically just means that we need to fix the breakage (and add a lower-bound on the problematic package), or add an upper-bound on the problematic package.
 
-* If it is an `source-repository-package`/`extra-dep` from Git, you update the `sha256` mapping in `nix/pkgs/haskell/haskell.nix`.
+Note that `cabal` itself keeps track of what index states it knows about, so when you bump the pinned index state you may need call `cabal update` in order for `cabal` to be happy.
+
+The Nix code which builds our packages also cares about the index state.
+This is represented by some pinned inputs in our flake (see xref:update-nix-pins[here] for more details)
+You can update these by running:
+- `nix flake lock --update-input hackage-nix` for Hackage
+- `nix flake lock --update-input CHaP` for CHaP
+
+==== Use of `source-repository-package`s
+
+We *can* use Cabal's `source-repository-package` mechanism to pull in un-released package versions.
+However, we should try and avoid this.
+In particular, we should not release our packages while we depend on a `source-repository-package`.
+
+If we are stuck in a situation where we need a long-running fork of a package, we should release it to CHaP instead (see the https://github.com/input-output-hk/cardano-haskell-packages[CHaP README] for more).
+
+If you do add a `source-repository-package`, you need to update the `sha256` mapping in `nix/pkgs/haskell/haskell.nix`.
 For the moment you have to do this by hand, using the following command to get the sha: `nix-prefetch-git --quiet <repo-url> <rev> | jq .sha256`, or by just getting it wrong and trying to build it, in which case Nix will give you the right value.
 
 [[update-nix-pins]]
@@ -145,21 +169,6 @@ and https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake-lock.ht
 
 Specifically, you will probably want to say `nix flake lock --update-input <input-name>`.
 Do *not* use `nix flake update`, as that will update all the inputs, which we typically don't want to do.
-
-[[update-index-state]]
-=== How to update the Hackage index state
-
-The Hackage index state is pinned to a particular time in `cabal.project`.
-This helps with reproducibility: alongside using the same version of `cabal`, this ensures that everyone will get the same result from the `cabal` version solver.
-If you want to use a Hackage package from after the pinned index state time, you need to bump it.
-This is not a big deal, since all it does is change what packages `cabal` considers to be available when doing solving, but it *may* result in different versions being picked, so it's not completely safe.
-
-Note that `cabal` itself keeps track of what index states it knows about, so you may need to update this with `cabal update` in order for `cabal` to be happy.
-
-The Nix code which builds our packages also cares about the index state.
-The set of index states which it knows about is controlled by `hackage.nix`, which is a Nix representation of Hackage.
-This therefore needs to be newer than the index state.
-You can update it xref:update-nix-pins[with the Nix flake commands].
 
 == Working conventions
 

--- a/__std__/cells/plutus/library/plutus-project.nix
+++ b/__std__/cells/plutus/library/plutus-project.nix
@@ -37,14 +37,9 @@ let
       withHoogle = false;
     };
 
-    # for the source repository package stanzas
-    sha256map = {
-      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-base"."cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" = "sha256-Ckbl3QkKOuMkIuTsSIWxWly6NNuhGP53q+nwYyBXzz8="; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-prelude"."533aec85c1ca05c7d171da44b89341fb736ecfe5" = "0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx"; # editorconfig-checker-disable-line
-    };
+    inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP; };
+    # No source-repository-packages right now
+    sha256map = { };
 
     # Configuration settings needed for cabal configure to work when cross compiling
     # for windows. We can't use `modules` for these as `modules` are only applied

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,21 @@
--- Bump this if you need newer packages
+-- Custom repository for cardano haskell packages, see CONTRIBUTING for more
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+-- See CONTRIBUTING for some Nix commands you will need to run if you
+-- update either of these.
+-- Bump this if you need newer packages from Hackage
 index-state: 2022-09-26T00:00:00Z
+-- Bump this if you need newer packages from CHaP
+index-state: cardano-haskell-packages 2022-10-10T00:00:00Z
 
 packages: doc
           plutus-benchmark
@@ -32,45 +48,3 @@ allow-newer:
 -- See the note on nix/pkgs/default.nix:agdaPackages for why this is here.
 -- (NOTE this will change to ieee754 in newer versions of nixpkgs).
 extra-packages: ieee, filemanip
-
--- https://github.com/Quid2/flat/pull/22 fixes a potential exception
--- when decoding invalid (e.g. malicious) text literals.
-source-repository-package
-  type: git
-  location: https://github.com/Quid2/flat.git
-  tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-crypto.git
-  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c
-  subdir:
-    base-deriving-via
-    binary
-    binary/test
-    cardano-crypto-class
-    cardano-crypto-praos
-    cardano-crypto-tests
-    measures
-    orphans-deriving-via
-    slotting
-    strict-containers
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
-  subdir:
-    cardano-prelude
-    cardano-prelude-test
-
--- Needed when actually building on windows (not for windows cross)
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/Win32-network
-  tag: 3825d3abf75f83f406c1f7161883c438dac7277d

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665150333,
+        "narHash": "sha256-ruLu/xAJfpOFa/aea3xnoprmsOFoxwLR23N/nU5L4X4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "d4af732a53321a1d1760023a2fa5b3f656cc3bfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -775,6 +792,7 @@
     },
     "root": {
       "inputs": {
+        "CHaP": "CHaP",
         "__old__cardano-repo-tool": "__old__cardano-repo-tool",
         "__old__gitignore-nix": "__old__gitignore-nix",
         "__old__hackage-nix": "__old__hackage-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,10 @@
       url = "github:input-output-hk/hackage.nix";
       flake = false;
     };
+    CHaP = {
+      url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
     sphinxcontrib-haddock = {
       url = "github:michaelpj/sphinxcontrib-haddock";
       flake = false;

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -35,6 +35,7 @@ let
   baseProject =
     { deferPluginErrors }:
     import ./haskell.nix {
+      inherit (sources) CHaP;
       inherit lib haskell-nix R libsodium-vrf secp256k1 rPackages z3;
       inherit agdaWithStdlib compiler-nix-name gitignore-nix;
       inherit enableHaskellProfiling;

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -3,6 +3,7 @@
 ############################################################################
 { lib
 , rPackages
+, CHaP
 , haskell-nix
 , agdaWithStdlib
 , gitignore-nix
@@ -20,6 +21,7 @@ let
   r-packages = with rPackages; [ R tidyverse dplyr stringr MASS plotly shiny shinyjs purrr ];
   project = haskell-nix.cabalProject' ({ pkgs, ... }: {
     inherit compiler-nix-name;
+
     # This is incredibly difficult to get right, almost everything goes wrong,
     # see https://github.com/input-output-hk/haskell.nix/issues/496
     src = let root = ../../../.; in
@@ -30,13 +32,9 @@ let
         # particularly bad on Hercules, see https://github.com/hercules-ci/support/issues/40
         name = "plutus";
       };
-    sha256map = {
-      "https://github.com/Quid2/flat.git"."ee59880f47ab835dbd73bea0847dab7869fc20d8" = "1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-base"."cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" = "sha256-Ckbl3QkKOuMkIuTsSIWxWly6NNuhGP53q+nwYyBXzz8="; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-crypto.git"."07397f0e50da97eaa0575d93bee7ac4b2b2576ec" = "06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/cardano-prelude"."533aec85c1ca05c7d171da44b89341fb736ecfe5" = "0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g"; # editorconfig-checker-disable-line
-      "https://github.com/input-output-hk/Win32-network"."3825d3abf75f83f406c1f7161883c438dac7277d" = "19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx"; # editorconfig-checker-disable-line
-    };
+    inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
+    # No source-repository-packages right now
+    sha256map = { };
     # Configuration settings needed for cabal configure to work when cross compiling
     # for windows. We can't use `modules` for these as `modules` are only applied
     # after cabal has been configured.

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -34,6 +34,7 @@ let
     cardano-repo-tool = tmpSources.__old__cardano-repo-tool;
     gitignore-nix = tmpSources.__old__gitignore-nix;
     hackage-nix = tmpSources.__old__hackage-nix;
+    CHaP = tmpSources.CHaP;
     iohk-nix = tmpSources.__old__iohk-nix;
     pre-commit-hooks-nix = tmpSources.__old__pre-commit-hooks-nix;
     inherit (tmpSources) haskell-language-server sphinxcontrib-haddock;

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -257,6 +257,7 @@ library
     UntypedPlutusCore.Transform.ForceDelay
     UntypedPlutusCore.Transform.Inline
 
+  -- Bound on cardano-crypto-class for the fixed SECP primitives
   build-depends:
     , aeson
     , algebraic-graphs            >=0.7
@@ -267,7 +268,7 @@ library
     , bimap
     , bytestring
     , cardano-crypto
-    , cardano-crypto-class
+    , cardano-crypto-class        ^>=2.0.0.1
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1


### PR DESCRIPTION
This switches us to getting our packages from CHaP, rather than using `source-repository-package`s, which should be much easier in the long run.

@zliu41 I didn't mention anything about releasing _to_ CHaP, which I think could just go into https://github.com/input-output-hk/plutus/pull/4885. It's pretty easy, we can just link to https://github.com/input-output-hk/cardano-haskell-packages#-from-github