### PR TITLE
Add pkg-config to the shell

### DIFF
--- a/__std__/cells/plutus/devshells/plutus-shell.nix
+++ b/__std__/cells/plutus/devshells/plutus-shell.nix
@@ -49,6 +49,7 @@ inputs.std.lib.dev.mkShell {
     pkgs.awscli2
     pkgs.bzip2
     pkgs.cacert
+    pkgs.pkg-config # TODO(std) Keep an eye on https://github.com/input-output-hk/plutus/pull/4906
 
     pkgs.rPackages.plotly
     pkgs.R


### PR DESCRIPTION
After integrating CHaP, `nix develop` stopped working on Darwin. 
That is, running `cabal build all` would yield:
```
Error: cabal: Could not resolve dependencies:
[__0] trying: plutus-core-1.0.0.0 (user goal)
[__1] next goal: inline-r (dependency of plutus-core)
[__1] rejecting: inline-r-0.10.5, inline-r-0.10.4, inline-r-0.10.3,
inline-r-0.10.2, inline-r-0.10.1, inline-r-0.10, inline-r-0.9.2,
inline-r-0.9.1, inline-r-0.9.0.2, inline-r-0.9.0.1, inline-r-0.9.0.0,
inline-r-0.8.0.1, inline-r-0.8.0.0, inline-r-0.7.3.0, inline-r-0.7.2.0,
inline-r-0.7.1.2, inline-r-0.7.1.1, inline-r-0.7.1.0, inline-r-0.7.0.0
(conflict: pkg-config package libR>=3.0, not found in the pkg-config database)
[__1] fail (backjumping, conflict set: inline-r, plutus-core)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: inline-r, plutus-core
```
Turns out that when `cabal.project` contains no `source-repository-package` stanzas then haskell.nix does not include `pkg-config` in its devshell's `buildInputs`.