### PR TITLE
fix: make legacy ci code pure

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -15,7 +15,8 @@ let
   # currently that is linux and darwin.
   systems = filterSystems supportedSystems;
   crossSystems =
-    let pkgs = (import ./default.nix { }).pkgs;
+    # System doesn't matter as long as we only use lib
+    let pkgs = (import ./default.nix { system = "x86_64-linux"; }).pkgs;
     in { inherit (pkgs.lib.systems.examples) mingwW64; };
 
   # Collects haskell derivations and builds an attrset:

--- a/nix/lib/ci.nix
+++ b/nix/lib/ci.nix
@@ -1,7 +1,11 @@
 let
-  # Generic nixpkgs, use *only* for lib functions that are stable across versions
-  pkgs = import (import ../sources.nix { system = builtins.currentSystem; }).nixpkgs { };
-  lib = pkgs.lib;
+  # System doesn't matter as long as we only use lib
+  lib = (import (import ../sources.nix {
+    system = "x86_64-linux";
+  }).nixpkgs
+    {
+      system = "x86_64-linux";
+    }).lib;
 in
 rec {
   # Borrowed from https://github.com/cachix/ghcide-nix/pull/4/files#diff-70bfff902f4dec33e545cac10ee5844d # editorconfig-checker-disable-line
@@ -132,7 +136,7 @@ rec {
               v = builtins.getAttr n attrs;
               newNameSections = nameSections ++ [ n ];
             in
-            if pkgs.lib.isDerivation v
+            if lib.isDerivation v
             then [ (builtins.concatStringsSep "." newNameSections) ]
             else if builtins.isAttrs v
             then go newNameSections v
@@ -143,7 +147,7 @@ rec {
     go [ ];
 
   # Creates an aggregate job with the given name from every derivation in the attribute set.
-  derivationAggregate = name: attrs: pkgs.releaseTools.aggregate {
+  derivationAggregate = pkgs: name: attrs: pkgs.releaseTools.aggregate {
     inherit name;
     constituents = derivationPaths attrs;
   };

--- a/release.nix
+++ b/release.nix
@@ -4,6 +4,8 @@
 , rootsOnly ? false
 }:
 let
+  pkgs = import (import ../sources.nix { system = builtins.currentSystem; }).nixpkgs { };
+
   traceNames = prefix: builtins.mapAttrs (n: v:
     if builtins.isAttrs v
     then if v ? type && v.type == "derivation"
@@ -20,4 +22,5 @@ let
   # Don't filter anyting out of required for now
   requiredJobsets = ciJobsets;
 in
-traceNames "" (ciJobsets // { required = derivationAggregate "required-plutus" requiredJobsets; })
+traceNames ""
+  (ciJobsets // { required = derivationAggregate pkgs "required-plutus" requiredJobsets; })


### PR DESCRIPTION
Since plutus-apps likely isn't going to be standardized by the time hydra goes down, I need to add tullia exports to that repo with the legacy ci code. That code relies on the ci.nix in this repo, so this is a fix to make it pure here.