### PR TITLE
PLT-1061: Script for updating versions and version bounds in cabal files

### DIFF
--- a/__std__/cells/plutus/library/make-plutus-shell.nix
+++ b/__std__/cells/plutus/library/make-plutus-shell.nix
@@ -72,6 +72,7 @@ inputs.std.lib.dev.mkShell {
     pkgs.yq
     pkgs.zlib
     pkgs.ghcid
+    pkgs.gnused
     pkgs.awscli2
     pkgs.bzip2
     pkgs.cacert

--- a/doc/RELEASE.adoc
+++ b/doc/RELEASE.adoc
@@ -16,12 +16,16 @@ The following packages are versioned and released:
 * The main library `plutus-tx:plutus-tx`
 - `plutus-tx-plugin`
 * The main library `plutus-tx-plugin:plutus-tx-plugin`
+- `prettyprinter-configurable`
+* The main library `prettyprinter-configurable:prettyprinter-configurable`
+- `word-array`
+* The main library `word-array:word-array`
 
 == Version Scheme
 
 All above packages are versioned and released in sync.
 That is, whenever one package releases version X, so do all other packages.
-This greatly simplifies the release process compared to versioning and releasing the packages independently.
+Since `prettyprinter-configurable` and `word-array` change infrequently, we only release version X if they have been changed since the previous release.
 
 We follow https://pvp.haskell.org/[the PVP version scheme] for the packages, where version numbers have a `major.major.minor.patch` pattern with the following semantics:
 
@@ -60,8 +64,9 @@ In all other cases, we always start a new major or minor release from master.
 
 Suppose we are releasing version `x.y.z.0`.
 
-1. Update versions and version bounds in cabal files by running `./scripts/update-versions.sh x.y.z.0`.
+1. Update versions and version bounds in cabal files by running `./scripts/update-versions.sh x.y.z.0 <additional packages>`.
 This updates the version bounds for packages in the same repo to `^>=x.y`.
+- `<additional packages>` can be empty, or `prettyprinter-configurable`, `word-array`, or both, depending on which packages we are releasing.
 2. Make sure the change log is up-to-date.
 3. Tag `x.y.z.0-rc1` on master.
 - There's no need to create a release branch at this point.
@@ -86,7 +91,7 @@ Suppose we are releasing version `x.y.z.w`.
 If so, create branch `release/x.y.z` from the `x.y.z.0` tag.
 - We create release branches lazily, because we do not expect to make many patch releases.
 2. Backport the needed fixes from master to `release/x.y.z`.
-3. Update versions in cabal files by running `./scripts/update-versions.sh x.y.z.w`.
+3. Update versions in cabal files by running `./scripts/update-versions.sh x.y.z.w <additional_packages>`.
 4. Tag `x.y.z.w-rc1` on the release branch.
 5. Run the release QA process.
 6. If no release blocking issue is found, tag version `x.y.z.w` and upload the packages to CHaP.

--- a/doc/RELEASE.adoc
+++ b/doc/RELEASE.adoc
@@ -60,8 +60,8 @@ In all other cases, we always start a new major or minor release from master.
 
 Suppose we are releasing version `x.y.z.0`.
 
-1. Update version numbers in cabal files to `x.y.z.0` (if it is not already the case).
-- Version bounds for packages in the same repo should be set to `==x.y.z.*`.
+1. Update versions and version bounds in cabal files by running `./scripts/update-versions.sh x.y.z.0`.
+This updates the version bounds for packages in the same repo to `^>=x.y`.
 2. Make sure the change log is up-to-date.
 3. Tag `x.y.z.0-rc1` on master.
 - There's no need to create a release branch at this point.
@@ -86,9 +86,10 @@ Suppose we are releasing version `x.y.z.w`.
 If so, create branch `release/x.y.z` from the `x.y.z.0` tag.
 - We create release branches lazily, because we do not expect to make many patch releases.
 2. Backport the needed fixes from master to `release/x.y.z`.
-3. Tag `x.y.z.w-rc1` on the release branch.
-4. Run the release QA process.
-5. If no release blocking issue is found, tag version `x.y.z.w` and upload the packages to CHaP.
+3. Update versions in cabal files by running `./scripts/update-versions.sh x.y.z.w`.
+4. Tag `x.y.z.w-rc1` on the release branch.
+5. Run the release QA process.
+6. If no release blocking issue is found, tag version `x.y.z.w` and upload the packages to CHaP.
 - If issues are found, fix them on master, backport the fixes to `release/x.y.z`, and go to step 3.
 
 === Release QA Process

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -9,6 +9,9 @@ versioned_packages=(
   "plutus-tx-plugin"
 )
 
+additional_packages=( "$@" )
+versioned_packages+=( "${additional_packages[@]:1}" )
+
 versioned_packages_regex=$(printf "\|%s" "${versioned_packages[@]}")
 versioned_packages_regex="\(${versioned_packages_regex:2}\)"
 

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -23,4 +23,12 @@ major_version="${components[0]}.${components[1]}"
 find . -regex ".*/$versioned_packages_regex\.cabal" -exec sed -i "s/\(^version:\s*\).*/\1$1/" {} \;
 
 # update version bounds in all cabal files
+# It looks for patterns like the following:
+#
+# - ", plutus-core"
+# - ", plutus-core:uplc"
+# - ", plutus-core ^>=1.0"
+# - ", plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.0"
+#
+# and updates the version bounds to "^>={major version}"
 find . -name "*.cabal" -exec sed -i "s/\(, ${versioned_packages_regex}[^^]*\).*/\1 ^>=$major_version/" {} \;

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+versioned_packages="\(plutus-core\|plutus-ledger-api\|plutus-tx\|plutus-tx-plugin\)"
+
+IFS='.' read -r -a components <<< "$1"
+
+major_version="${components[0]}.${components[1]}"
+
+# update package versions in cabal files for versioned packages
+find . -regex ".*/$versioned_packages\.cabal" -exec sed -i "s/\(^version:\s*\).*/\1$1/" {} \;
+
+# update version bounds in all cabal files
+find . -name "*.cabal" -exec sed -i "s/\(, ${versioned_packages}[^^]*\).*/\1 ^>=$major_version/" {} \;

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -2,14 +2,22 @@
 
 set -euo pipefail
 
-versioned_packages="\(plutus-core\|plutus-ledger-api\|plutus-tx\|plutus-tx-plugin\)"
+versioned_packages=(
+  "plutus-core"
+  "plutus-ledger-api"
+  "plutus-tx"
+  "plutus-tx-plugin"
+)
+
+versioned_packages_regex=$(printf "\|%s" "${versioned_packages[@]}")
+versioned_packages_regex="\(${versioned_packages_regex:2}\)"
 
 IFS='.' read -r -a components <<< "$1"
 
 major_version="${components[0]}.${components[1]}"
 
 # update package versions in cabal files for versioned packages
-find . -regex ".*/$versioned_packages\.cabal" -exec sed -i "s/\(^version:\s*\).*/\1$1/" {} \;
+find . -regex ".*/$versioned_packages_regex\.cabal" -exec sed -i "s/\(^version:\s*\).*/\1$1/" {} \;
 
 # update version bounds in all cabal files
-find . -name "*.cabal" -exec sed -i "s/\(, ${versioned_packages}[^^]*\).*/\1 ^>=$major_version/" {} \;
+find . -name "*.cabal" -exec sed -i "s/\(, ${versioned_packages_regex}[^^]*\).*/\1 ^>=$major_version/" {} \;

--- a/shell.nix
+++ b/shell.nix
@@ -72,6 +72,7 @@ let
     editorconfig-core-c
     editorconfig-checker
     ghcid
+    gnused
     jq
     # See https://github.com/cachix/pre-commit-hooks.nix/issues/148 for why we need this
     pre-commit


### PR DESCRIPTION
Usage: `./scripts/update-versions.sh x.y.z.w`. This updates versions in selected cabal files to `x.y.z.w`, and version bounds in all cabal files to `^>=x.y`.