### PR TITLE
Bump CHaP after reset

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,7 +15,7 @@ repository cardano-haskell-packages
 -- Bump this if you need newer packages from Hackage
 index-state: 2022-09-26T00:00:00Z
 -- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-10-15T00:00:00Z
+index-state: cardano-haskell-packages 2022-10-24T00:00:00Z
 
 packages: doc
           plutus-benchmark

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1665763673,
-        "narHash": "sha256-27o+YI4Fnz0odnicOt+fDf2XQYKLMsh6ZrYfJJf5lpU=",
+        "lastModified": 1666576849,
+        "narHash": "sha256-FDFmN3TzQsUjNxGlKKTFpLOUOnvsQMNI4o3MahJw9zA=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "64ef88263e8334b1b60bae3d4c81c43ccb0192c8",
+        "rev": "97aab5bc3f59108d97a6bb0c4d07ae1b79b005ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Index state 2022-10-15T00:00:00Z does not exist in CHaP anymore.
