### PR TITLE
PLT-1057: update R and inline-r. Bump hackage-nix haskell-nix

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -133,8 +133,6 @@ If you use Nix, these tools are provided for you via `nix develop`, and you do *
 ====
 * We rely on forked or new versions of some system libraries.
 ** You can read the https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md[Cardano node documentation] to find out how to install these.
-* You may need an old version of R installed to build everything
-** If you don't want to do this and you don't need to build those components, you can turn off the `plutus-core` `with-inline-r` flag in your `cabal.project.local`.
 * You may get different versions of packages.
 ** This *shouldn't* happen, but we can't guarantee it.
 * We are not currently enabling the Nix integration for these tools, so

--- a/cabal.project
+++ b/cabal.project
@@ -13,9 +13,9 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
 -- Bump this if you need newer packages from Hackage
-index-state: 2022-10-31T00:00:00Z
+index-state: 2022-11-15T00:00:00Z
 -- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2022-10-24T00:00:00Z
+index-state: cardano-haskell-packages 2023-01-04T00:00:00Z
 
 packages: doc/read-the-docs-site
           plutus-benchmark
@@ -41,10 +41,8 @@ benchmarks: true
 -- 'tasty' output.
 test-show-details: direct
 
-if (impl (ghc < 9))
-  -- inline-r doesn't (yet) build on 9.2.4, so only turn it on before that
-  package plutus-core
-    flags: +with-inline-r
+package plutus-core
+  flags: +with-inline-r
 
 -- See https://github.com/input-output-hk/nothunks/issues/17
 package nothunks

--- a/doc/read-the-docs-site/plutus-doc.cabal
+++ b/doc/read-the-docs-site/plutus-doc.cabal
@@ -70,7 +70,7 @@ executable doc-doctests
     , base               >=4.9      && <5
     , bytestring
     , containers
-    , flat
+    , flat               <0.5
     , lens
     , plutus-core        ^>=1.1
     , plutus-ledger-api  ^>=1.1

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1666576849,
-        "narHash": "sha256-FDFmN3TzQsUjNxGlKKTFpLOUOnvsQMNI4o3MahJw9zA=",
+        "lastModified": 1672829743,
+        "narHash": "sha256-lM3s0UQDxfipHbEFhmW2d5QcmKIPVsLT2ai6RnHAP84=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "97aab5bc3f59108d97a6bb0c4d07ae1b79b005ca",
+        "rev": "551630b2c90ed9107079ab402534ed3b56db6f04",
         "type": "github"
       },
       "original": {

--- a/nix/cells/plutus/library/r-overlay.nix
+++ b/nix/cells/plutus/library/r-overlay.nix
@@ -2,6 +2,7 @@
 
 self: super: {
 
+  # TODO: not sure if this patch is still needed
   rPackages = super.rPackages.override {
     overrides = ({
       hexbin = super.rPackages.hexbin.overrideDerivation (attrs: {
@@ -10,27 +11,5 @@ self: super: {
       });
     });
   };
-
-  # haskell inline-r package fails to compile with more recent version of R:
-  # https://github.com/tweag/HaskellR/issues/374
-  R = super.R.overrideAttrs (oldAttrs: rec {
-    version = "4.1.3";
-    src = self.fetchurl {
-      url = "https://cran.r-project.org/src/base/R-4/R-${version}.tar.gz";
-      sha256 = "sha256-Ff9bMzxhCUBgsqUunB2OxVzELdAp45yiKr2qkJUm/tY=";
-    };
-    # TODO(std) see if this is still needed
-    # Backport https://github.com/NixOS/nixpkgs/pull/99570
-    prePatch = super.lib.optionalString super.stdenv.isDarwin ''
-      substituteInPlace configure --replace \
-        "-install_name libRblas.dylib" "-install_name $out/lib/R/lib/libRblas.dylib"
-      substituteInPlace configure --replace \
-        "-install_name libRlapack.dylib" "-install_name $out/lib/R/lib/libRlapack.dylib"
-      substituteInPlace configure --replace \
-        "-install_name libR.dylib" "-install_name $out/lib/R/lib/libR.dylib"
-    '';
-    # Only need the first patch for 4.1.3:
-    patches = [ (builtins.head oldAttrs.patches) ];
-  });
 
 }

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -109,7 +109,7 @@ executable nofib-exe
     , ansi-wl-pprint
     , base                     >=4.9 && <5
     , bytestring
-    , flat
+    , flat                     <0.5
     , lens
     , nofib-internal
     , optparse-applicative
@@ -265,7 +265,7 @@ benchmark validation
     , deepseq
     , directory
     , filepath
-    , flat
+    , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
     , plutus-core              ^>=1.1
@@ -284,7 +284,7 @@ benchmark validation-decode
     , criterion                >=1.5.9.0
     , directory
     , filepath
-    , flat
+    , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
     , plutus-core              ^>=1.1
@@ -304,7 +304,7 @@ benchmark validation-full
     , criterion                                                         >=1.5.9.0
     , directory
     , filepath
-    , flat
+    , flat                                                              <0.5
     , optparse-applicative
     , plutus-benchmark-common
     , plutus-core                                                       ^>=1.1
@@ -352,7 +352,7 @@ executable ed25519-throughput
     , base                  >=4.9 && <5
     , bytestring
     , cardano-crypto-class
-    , flat
+    , flat                  <0.5
     , hedgehog
     , plutus-core           ^>=1.1
     , plutus-tx             ^>=1.1

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -298,7 +298,7 @@ library
     , exceptions
     , extra
     , filepath
-    , flat
+    , flat                        <0.5
     , ghc-prim
     , hashable                    >=1.4
     , hedgehog                    >=1.0
@@ -348,7 +348,7 @@ library plutus-core-execlib
     , base                  >=4.9 && <5
     , bytestring
     , deepseq
-    , flat
+    , flat                  <0.5
     , lens
     , megaparsec
     , monoidal-containers
@@ -469,7 +469,7 @@ test-suite plutus-core-test
     , containers
     , data-default-class
     , filepath
-    , flat
+    , flat                 <0.5
     , hedgehog
     , hex-text
     , mmorph
@@ -506,7 +506,7 @@ test-suite plutus-ir-test
   build-depends:
     , base                  >=4.9 && <5
     , containers
-    , flat
+    , flat                  <0.5
     , hashable
     , hedgehog
     , lens
@@ -549,7 +549,7 @@ test-suite untyped-plutus-core-test
     , base                  >=4.9 && <5
     , bytestring
     , cardano-crypto-class
-    , flat
+    , flat                  <0.5
     , hedgehog
     , index-envs
     , lens
@@ -724,13 +724,13 @@ executable generate-cost-model
   build-depends:
     , aeson-pretty
     , barbies
-    , base                  >=4.9 && <5
+    , base                  >=4.9   && <5
     , bytestring
     , cassava
     , directory
     , exceptions
     , extra
-    , inline-r
+    , inline-r              >1.0.0
     , optparse-applicative
     , plutus-core           ^>=1.1
     , text
@@ -759,13 +759,13 @@ benchmark cost-model-test
 
   build-depends:
     , barbies
-    , base              >=4.9 && <5
+    , base              >=4.9   && <5
     , bytestring
     , cassava
     , exceptions
     , extra
     , hedgehog
-    , inline-r
+    , inline-r          >1.0.0
     , mmorph
     , plutus-core       ^>=1.1
     , template-haskell

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -90,7 +90,7 @@ library
     , containers
     , deepseq
     , extra
-    , flat
+    , flat               <0.5
     , lens
     , mtl
     , nothunks

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -79,7 +79,7 @@ library
     , containers
     , either
     , extra
-    , flat
+    , flat              <0.5
     , lens
     , mtl
     , plutus-core       ^>=1.1
@@ -158,7 +158,7 @@ test-suite plutus-tx-tests
     , base                                            >=4.9 && <5
     , containers
     , deepseq
-    , flat
+    , flat                                            <0.5
     , hedgehog
     , lens
     , mtl

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -100,7 +100,7 @@ library
     , deepseq
     , deriving-compat
     , extra
-    , flat
+    , flat              <0.5
     , ghc-prim
     , hashable
     , lens
@@ -123,7 +123,7 @@ library plutus-tx-testlib
   build-depends:
     , base                                            >=4.9 && <5
     , filepath
-    , flat
+    , flat                                            <0.5
     , lens
     , mtl
     , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1


### PR DESCRIPTION
Tested with&without nix, with ghc9.2 & ghc 8.10 and R 4.2, R 4.1.

I did not test on Mac and Win. Perhaps it does not work in Win.

Bumping hackage-nix was not required, but I left it there.


<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
