### PR TITLE
Typo in the comments (ECDSA)

### DIFF
--- a/plutus-core/plutus-core/src/Crypto.hs
+++ b/plutus-core/plutus-core/src/Crypto.hs
@@ -87,7 +87,7 @@ verifyEd25519Signature_V2 pk msg sig =
 -- [dangerous](https://bitcoin.stackexchange.com/a/81116/35586). Other than
 -- length, we make no requirements of what hash gets used.
 verifyEcdsaSecp256k1Signature
-  :: BS.ByteString -- ^ Public key   (32 bytes)
+  :: BS.ByteString -- ^ Public key   (33 bytes)
   -> BS.ByteString -- ^ Message hash (32 bytes)
   -> BS.ByteString -- ^ Signature    (64 bytes)
   -> Emitter (EvaluationResult Bool)


### PR DESCRIPTION
The public key of `verifyEcdsaSecp256k1Signature` is 33 bytes rather than 32. The rest of the description is correct.
