### PR TITLE
Update comment on cost model tests

### DIFF
--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -295,7 +295,7 @@ Now a CPU usage benchmark for the function will have to be added in
 will have to be added in [`models.R`](./data/models.R) to process the results of
 the benchmark (see Step 6 below).  The benchmark should aim to cover a wide
 range of inputs in order to get a good idea of the worst-case behaviour of the
-function: some experimentation may be needed to acheive this.
+function: experimentation may be needed to achieve this.
 
 Once the benchmark is in its final form, run it using `cabal run
 plutus-core:cost-model-budgeting-bench -- --csv <file>` as described in the
@@ -333,8 +333,8 @@ sometimes more complex code may be required to obtain a good model of the
 behaviour of the function. Ideally the R model should accurate over a wide range
 of inputs so that charges for "typical" inputs are reasonable but worst-case
 inputs which require large computation times incur large charges which penalise
-excessive computation. Some experimentation may be required to achieve this, and
-it may not always be possible to satisfy both goals simultaneously. In such
+excessive computation. Developing the model may involve some experimentation,
+and it may not always be possible to satisfy both goals simultaneously. In such
 cases it may be necessary to sacrifice some accuracy in order to guarantee
 security.
 

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -115,7 +115,11 @@ details of how to add a new built-in function see the extensive notes on "How to
 add a built-in function" in
 [`PlutusCore.Default.Builtins`](../plutus-core/src/PlutusCore/Default/Builtins.hs).
 For documentation on how to add a new built-in type, see
-[`Universe.Core`](../plutus-core/src/Universe/Core.hs).
+[`Universe.Core`](../plutus-core/src/Universe/Core.hs).  Note that the procedure
+described here will only add a new built-in function to Plutus Core: to make a
+new function available from Haskell more work will be required in the
+[`plutus-tx`](https://github.com/input-output-hk/plutus/tree/master/plutus-tx)
+codebase.
 
 
 ### Adding a new function

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -309,7 +309,7 @@ used it is advisable to run some other costing benchmarks as well to check that
 the results are at least approximately consistent with the previous ones.
 
 
-#### Step 7: update the R code
+#### Step 6: update the R code
 
 We now have to extend the R code in [`models.R`](./data/models.R).  Firstly, add
 an entry for the arity of the builtin in the `arity` function:

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -379,7 +379,7 @@ object. (That's what gets read in by the code in Step 6: `paramXorByteString`
 contains the string "xorByteStringModel" and that lets the Haskell code retrieve
 the correct thing from R.)
 
-#### Step 7 add code to read the costing function from R into Haskell 
+#### Step 7: add code to read the costing function from R into Haskell 
 
 Next we have to update the code which converts benchmarking results into JSON
 models.  Go to

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -288,7 +288,7 @@ run the appropriate `param<builtin-name>` function:
                       Data.ByteString.pack $ zipWith (Data.Bits.xor) (Data.ByteString.unpack a) (Data.ByteString.unpack b)
 ```
 
-#### Step 5: add a benchmark for the new builtin
+#### Step 5: add a benchmark for the new builtin and run it
 
 Now a CPU usage benchmark for the function will have to be added in
 [`plutus-core/cost-model/budgeting-bench`](./budgeting-bench) and new R code
@@ -306,6 +306,17 @@ times incur large charges which penalise excessive computation.  Some
 experimentation may be required to achieve this, and it may not always be
 possible to satisfy both goals simultaneously.  In such cases it may be
 necessary to sacrifice some accuracy in order to guarantee security.
+
+Once the benchmark is in its final form, run it using `cabal run
+plutus-core:cost-model-budgeting-bench -- --csv <file>` as described in the
+first section of this document. Either run the full set of benchmarks and save
+the full output in a CSV file or run the new benchmark alone using `cabal run
+plutus-core:cost-model-budgeting-bench -- --csv <file> <benchmark name>` to run
+the benchmark on its own and then add the output in `<file>` results to a CSV
+file (such as `benching.csv) containing earlier benchmark results for the rest
+of the builtin functions.  If the latter method (which will be much faster) is
+used it is advisable to run some other costing benchmarks as well to check that
+the results are at least approximately consistent with previous ones.
 
 
 #### Step 6: add code to read the costing function from R into Haskell 
@@ -423,12 +434,11 @@ plutus-core:cost-model-test`.
 ### Step 9: update the cost model JSON file
 
 Once the previous steps have been carried out, proceed as described in the first
-section: run `cost-model-budgeting-bench` on the reference machine and then feed
-the results to `generate-cost-model` to produce a new JSON cost model file
-(which will contain sensible coefficients for the costing functions for the new
-builtin in place of the arbitray ones we added in Step 3), and check it in along
-with a CSV file containing a full set of benchmark results which can be used to
-reproduce it.
+section: feed the results of the costing benchmarks to `generate-cost-model` to
+produce a new JSON cost model file (which will contain sensible coefficients for
+the costing functions for the new builtin in place of the arbitray ones we added
+in Step 3), and check it in along with a CSV file containing a full set of
+benchmark results which can be used to reproduce it.
 
 If you're confident that the evaluator hasn't changed too much since
 the cost model was last fully updated it may be possible to save time

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -293,19 +293,9 @@ run the appropriate `param<builtin-name>` function:
 Now a CPU usage benchmark for the function will have to be added in
 [`plutus-core/cost-model/budgeting-bench`](./budgeting-bench) and new R code
 will have to be added in [`models.R`](./data/models.R) to process the results of
-the benchmark.  The benchmark should aim to cover a wide range of inputs in
-order to get a good idea of the worst-case behaviour of the function.  The exact
-form of the R code will depend on the behaviour of the function being added and
-will probably be based on the expected time complexity of the function, backed
-up by examination of the initial benchmark results.  In simpler cases it may be
-possible to re-use existing R code, but sometimes more complex code may be
-required to obtain a good model of the behaviour of the function.  Ideally the R
-model should accurate over a wide range of inputs so that charges for "typical"
-inputs are reasonable but worst-case inputs which require large computation
-times incur large charges which penalise excessive computation.  Some
-experimentation may be required to achieve this, and it may not always be
-possible to satisfy both goals simultaneously.  In such cases it may be
-necessary to sacrifice some accuracy in order to guarantee security.
+the benchmark (see Step 6 below).  The benchmark should aim to cover a wide
+range of inputs in order to get a good idea of the worst-case behaviour of the
+function: some experimentation may be needed to acheive this.
 
 Once the benchmark is in its final form, run it using `cabal run
 plutus-core:cost-model-budgeting-bench -- --csv <file>` as described in the
@@ -319,7 +309,77 @@ used it is advisable to run some other costing benchmarks as well to check that
 the results are at least approximately consistent with the previous ones.
 
 
-#### Step 6: add code to read the costing function from R into Haskell 
+#### Step 7: update the R code
+
+We now have to extend the R code in [`models.R`](./data/models.R).  Firstly, add
+an entry for the arity of the builtin in the `arity` function:
+
+```
+   arity <- function(name) {
+       switch (name,
+           "AddInteger" = 2,
+           ...
+           "XorByteString" = 2,
+           ...
+           )
+```
+
+Now add a function to infer coefficients for the CPU costing function from
+benchmarking data. The exact form of the R code will depend on the behaviour of
+the function being added and will probably be based on the expected time
+complexity of the function, backed up by examination of the initial benchmark
+results. In simpler cases it may be possible to re-use existing R code, but
+sometimes more complex code may be required to obtain a good model of the
+behaviour of the function. Ideally the R model should accurate over a wide range
+of inputs so that charges for "typical" inputs are reasonable but worst-case
+inputs which require large computation times incur large charges which penalise
+excessive computation. Some experimentation may be required to achieve this, and
+it may not always be possible to satisfy both goals simultaneously. In such
+cases it may be necessary to sacrifice some accuracy in order to guarantee
+security.
+
+
+In the case of `xorByteString` we assume that the time taken will be linear in
+the minimum of the sizes of the arguments (ie, the arguments of the new
+builtin).  It is often worthwhile to plot the benchmark data and experiment with
+it in order to check that it has the form expected when the basic shape of the
+costing function was selected (Steps 1, 3 and 6).  For example, we have assumed
+that the execution time of `xorByteString` is linear in the _minimum_ of the
+argument sizes since the function stops when it gets to the end of the smaller
+argument, but note that we call `unpack` on both arguments and that this takes
+linear time. Examination of benchmark results might reveal that if one input is
+very large then the unpacking step will dominate the execution time, and if this
+is the case it might be more sensible to use a model linear in the _maximum_ of
+the input sizes.  In general, think carefully about the structure of the model
+and issues such as whether the raw data might need to have outliers discarded or
+whether only some subset of the data should be used to arrive at an accurate
+worst-case model.
+
+```
+    xorByteStringModel <- {
+        fname <- "XorByteString"
+        filtered <- data %>%
+            filter.and.check.nonempty(fname) %>%
+            discard.overhead ()
+        m <- lm(t ~ pmin(x_mem, y_mem), filtered)
+        adjustModel(m,fname)
+    }
+```
+
+Finally, add an entry to the list which is returned by `modelFun` (at the very
+end of the file):
+
+```
+        xorByteStringModel = xorByteStringModel,
+```
+
+From the point of view of Haskell this effectively creates a record field called
+`xorByteStringModel` which contains a Haskell representation of the R model
+object. (That's what gets read in by the code in Step 6: `paramXorByteString`
+contains the string "xorByteStringModel" and that lets the Haskell code retrieve
+the correct thing from R.)
+
+#### Step 7 add code to read the costing function from R into Haskell 
 
 Next we have to update the code which converts benchmarking results into JSON
 models.  Go to
@@ -361,62 +421,7 @@ sizes `m` and `n` then the result will have size `min(m,n)` so we define the mem
 costing function to be `(m,n) -> 0 + 1*min(m,n)`.
 
 
-#### Step 7: update the R code
-
-We now have to extend the R code in [`models.R`](./data/models.R).  Firstly, add
-an entry for the arity of the builtin in the `arity` function:
-
-```
-   arity <- function(name) {
-       switch (name,
-           "AddInteger" = 2,
-           ...
-           "XorByteString" = 2,
-           ...
-           )
-```
-
-Now add a function to infer coefficients for the CPU costing function from
-benchmarking data.  In the case of `xorByteString` we assume that the time taken
-will be linear in the minimum of the sizes of the arguments (ie, the arguments
-of the new builtin).  It is often worthwhile to plot the benchmark data and
-experiment with it in order to check that it has the form expected when the
-basic shape of the costing function was selected (Steps 1, 3 and 6).  For
-example, we have assumed that the execution time of `xorByteString` is linear in
-the _minimum_ of the argument sizes since the function stops when it gets to the
-end of the smaller argument, but note that we call `unpack` on both arguments
-and that this takes linear time. Examination of benchmark results might reveal
-that if one input is very large then the unpacking step will dominate the
-execution time, and if this is the case it might be more sensible to use a model
-linear in the _maximum_ of the input sizes.  In general, think carefully about
-the structure of the model and issues such as whether the raw data might need to
-have outliers discarded or whether only some subset of the data should be used
-to arrive at an accurate worst-case model.
-
-```
-    xorByteStringModel <- {
-        fname <- "XorByteString"
-        filtered <- data %>%
-            filter.and.check.nonempty(fname) %>%
-            discard.overhead ()
-        m <- lm(t ~ pmin(x_mem, y_mem), filtered)
-        adjustModel(m,fname)
-    }
-```
-
-Finally, add an entry to the list which is returned by `modelFun` (at the very end of the file):
-
-```
-        xorByteStringModel = xorByteStringModel,
-```
-
-From the point of view of Haskell this effectively creates a record field called
-`xorByteStringModel` which contains a Haskell representation of the R model
-object. (That's what gets read in by the code in Step 6: `paramXorByteString`
-contains the string "xorByteStringModel" and that lets the Haskell code retrieve
-the correct thing from R.)
-
-### Step 8: test the Haskell versions of the costing functions
+#### Step 8: test the Haskell versions of the costing functions
 
 The code in [`CreateCostModel`](./create-cost-model/CreateBuiltinCostModel.hs)
 converts the cost modelling functions fitted by R into Haskell functions.  As
@@ -431,7 +436,7 @@ how to do this) and then run the tests with `cabal bench
 plutus-core:cost-model-test`.
 
 
-### Step 9: update the cost model JSON file
+#### Step 9: update the cost model JSON file
 
 Once the previous steps have been carried out, proceed as described in the first
 section: feed the results of the costing benchmarks to `generate-cost-model` to
@@ -454,7 +459,3 @@ can run benchmarks on their own machine and have the results re-scaled
 to be compatible with our reference machine, thereby removing (or at
 least lessening) the necessity for Cardano developers to do the
 benchmarking).
-
-
-
-

--- a/plutus-core/cost-model/CostModelGeneration.md
+++ b/plutus-core/cost-model/CostModelGeneration.md
@@ -313,10 +313,10 @@ first section of this document. Either run the full set of benchmarks and save
 the full output in a CSV file or run the new benchmark alone using `cabal run
 plutus-core:cost-model-budgeting-bench -- --csv <file> <benchmark name>` to run
 the benchmark on its own and then add the output in `<file>` results to a CSV
-file (such as `benching.csv) containing earlier benchmark results for the rest
+file (such as `benching.csv`) containing earlier benchmark results for the rest
 of the builtin functions.  If the latter method (which will be much faster) is
 used it is advisable to run some other costing benchmarks as well to check that
-the results are at least approximately consistent with previous ones.
+the results are at least approximately consistent with the previous ones.
 
 
 #### Step 6: add code to read the costing function from R into Haskell 

--- a/plutus-core/cost-model/test/TestCostModels.hs
+++ b/plutus-core/cost-model/test/TestCostModels.hs
@@ -60,8 +60,12 @@ import Hedgehog.Range qualified as Range
    be any problem because the functions should be the same as the ones we
    construct from R here (they're essentially the contents of 'costModelsR'
    converted to JSON), but it wouldn't do any harm to include any possible loss
-   of accuracy due to serialisation/deserialisation in the tests as well.
-
+   of accuracy due to serialisation/deserialisation in the tests as well.  Doing
+   the tests the way they're done here is arguably better because it may reveal
+   problems in the costing interface before the cost model file is updated, and
+   we want to be sure that we don’t include an incorrect costing function in the
+   JSON. Maybe it would be sensible to have some separate tests that check that
+   converting to JSON and then back is the identity.
 -}
 
 -- How many tests to run for each costing function


### PR DESCRIPTION
PLT-603 is an issue to check that the order of [steps 8 and 9 ](https://github.com/input-output-hk/plutus/blob/master/plutus-core/cost-model/CostModelGeneration.md#step-8-test-the-haskell-versions-of-the-costing-functions) in `CostModelGeneration.md` is correct.  I think that this issue was prompted by a question (some time ago) from @zliu41.

I believe that the order is correct (run the tests _before_ updating the cost model file), but I got a bit confused myself so I've expanded a comment a bit to clarify what's going on, and I'm also appending a detailed comment from PLT-603 below.  I've also added a new issue at PLT-1250 to add  test that cost model serialisation/deserialisation is correct, which would fill in the gap in the testing mentioned below.  

> As explained [here](https://github.com/input-output-hk/plutus/blob/cfc26a48f9151bb0940c9e4bf04638161cfc3c3f/plutus-core/cost-model/test/TestCostModels.hs#L52), the tests in `plutus-core:cost-model-test` run the R modelling code which reads the benchmark results and fits costing functions to them; they then read the costing functions from the R process, convert them into the Haskell objects which represent costing functions, and compare the result of  evaluating those functions (on random inputs) with the result of feeding the same inputs (converted from costing integers to real numbers) to the predictions of the models in the R process. 
> 
> When the cost model is updated, it runs the R code, reads the modelling functions from the R process into Haskell objects (as above) and then serialises those objects into JSON in `builtinCostModel.json`.  Subsequently the evaluator reads that file (or receives some equivalent data from the node) and reconstructs the objects representing the costing functions.  We don’t check that those costing functions are the same as the ones we get by reading the R models directly; we’re trusting that serialising to JSON and then deserialising again gives us back exactly the same thing, which could in principle fail because of, for example, loss of precision during the serialisation/deserialisation process.  Maybe we should check this as well: the comment linked to above already mentions this.  Doing the tests this way is arguably better because it may reveal problems in the costing interface before the cost model file is updated, and we want to be sure that we don’t include an incorrect costing function in the JSON.



<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
