### PR TITLE
[PlutusTx.Plugin] Add more plugin options and clean up existing ones - Add separate max-simplifier-iterations for pir and uplc, Provide context-level integer option

### DIFF
--- a/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
+++ b/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
@@ -36,12 +36,6 @@
      - Set log level to debug
 
 
-   * - ``debug-context``
-     - Int
-     - 1
-     - Set context level to 3, which means error messages contain full contexts.
-
-
    * - ``defer-errors``
      - Bool
      - False
@@ -77,10 +71,10 @@
      - Set the max iterations for the UPLC simplifier
 
 
-   * - ``no-context``
+   * - ``context-level``
      - Int
      - 1
-     - Set context level to 0, which means error messages contain minimum contexts.
+     - Set context level for error messages.
 
 
    * - ``optimize``

--- a/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
+++ b/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
@@ -66,10 +66,15 @@
      - Dump Untyped Plutus Core
 
 
-   * - ``max-simplifier-iterations``
+   * - ``max-simplifier-iterations-pir``
      - Int
      - 12
-     - Set the max iterations for the simplifier
+     - Set the max iterations for the PIR simplifier
+
+   * - ``max-simplifier-iterations-uplc``
+     - Int
+     - 12
+     - Set the max iterations for the UPLC simplifier
 
 
    * - ``no-context``

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -127,12 +127,9 @@ pluginOptions =
                  \the compilation error is suppressed and the original Haskell \
                  \expression is replaced with a runtime-error expression."
            in (k, PluginOption typeRep (setTrue k) posDeferErrors desc)
-        , let k = "no-context"
-              desc = "Set context level to 0, which means error messages contain minimum contexts."
-           in (k, PluginOption typeRep (flag (const 0) k) posContextLevel desc)
-        , let k = "debug-context"
-              desc = "Set context level to 3, which means error messages contain full contexts."
-           in (k, PluginOption typeRep (flag (const 3) k) posContextLevel desc)
+        , let k = "context-level"
+              desc = "Set context level for error messages."
+           in (k, PluginOption typeRep (intOption k) posContextLevel desc)
         , let k = "dump-pir"
               desc = "Dump Plutus IR"
            in (k, PluginOption typeRep (setTrue k) posDumpPir desc)

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -32,6 +32,7 @@ import PyF (fmt)
 
 import Text.Read (readMaybe)
 import Type.Reflection
+import UntypedPlutusCore qualified as UPLC
 
 data PluginOptions = PluginOptions
     { _posDoTypecheck                    :: Bool
@@ -44,7 +45,8 @@ data PluginOptions = PluginOptions
     , _posPedantic                       :: Bool
     , _posVerbose                        :: Bool
     , _posDebug                          :: Bool
-    , _posMaxSimplifierIterations        :: Int
+    , _posMaxSimplifierIterationsPir     :: Int
+    , _posMaxSimplifierIterationsUPlc    :: Int
     , _posDoSimplifierUnwrapCancel       :: Bool
     , _posDoSimplifierBeta               :: Bool
     , _posDoSimplifierInline             :: Bool
@@ -152,9 +154,12 @@ pluginOptions =
         , let k = "debug"
               desc = "Set log level to debug"
            in (k, PluginOption typeRep (setTrue k) posDebug desc)
-        , let k = "max-simplifier-iterations"
-              desc = "Set the max iterations for the simplifier"
-           in (k, PluginOption typeRep (intOption k) posMaxSimplifierIterations desc)
+        , let k = "max-simplifier-iterations-pir"
+              desc = "Set the max iterations for the PIR simplifier"
+           in (k, PluginOption typeRep (intOption k) posMaxSimplifierIterationsPir desc)
+        , let k = "max-simplifier-iterations-uplc"
+              desc = "Set the max iterations for the UPLC simplifier"
+           in (k, PluginOption typeRep (intOption k) posMaxSimplifierIterationsUPlc desc)
         , let k = "simplifier-unwrap-cancel"
               desc = "Run a simplification pass that cancels unwrap/wrap pairs"
            in (k, PluginOption typeRep (setTrue k) posDoSimplifierUnwrapCancel desc)
@@ -210,7 +215,8 @@ defaultPluginOptions =
         , _posPedantic = False
         , _posVerbose = False
         , _posDebug = False
-        , _posMaxSimplifierIterations = view PIR.coMaxSimplifierIterations PIR.defaultCompilationOpts
+        , _posMaxSimplifierIterationsPir = view PIR.coMaxSimplifierIterations PIR.defaultCompilationOpts
+        , _posMaxSimplifierIterationsUPlc = view UPLC.soMaxSimplifierIterations UPLC.defaultSimplifyOpts
         , _posDoSimplifierUnwrapCancel = True
         , _posDoSimplifierBeta = True
         , _posDoSimplifierInline = True

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -399,7 +399,7 @@ runCompiler moduleName opts expr = do
                  & set (PIR.ccOpts . PIR.coPedantic) (_posPedantic opts)
                  & set (PIR.ccOpts . PIR.coVerbose) (_posVerbose opts)
                  & set (PIR.ccOpts . PIR.coDebug) (_posDebug opts)
-                 & set (PIR.ccOpts . PIR.coMaxSimplifierIterations) (_posMaxSimplifierIterations opts)
+                 & set (PIR.ccOpts . PIR.coMaxSimplifierIterations) (_posMaxSimplifierIterationsPir opts)
                  & set PIR.ccTypeCheckConfig pirTcConfig
                  -- Simplifier options
                  & set (PIR.ccOpts . PIR.coDoSimplifierUnwrapCancel)       (_posDoSimplifierUnwrapCancel opts)
@@ -407,7 +407,7 @@ runCompiler moduleName opts expr = do
                  & set (PIR.ccOpts . PIR.coDoSimplifierInline)             (_posDoSimplifierInline opts)
                  & set (PIR.ccOpts . PIR.coInlineHints)                    hints
         plcOpts = PLC.defaultCompilationOpts
-            & set (PLC.coSimplifyOpts . UPLC.soMaxSimplifierIterations) (_posMaxSimplifierIterations opts)
+            & set (PLC.coSimplifyOpts . UPLC.soMaxSimplifierIterations) (_posMaxSimplifierIterationsUPlc opts)
             & set (PLC.coSimplifyOpts . UPLC.soInlineHints) hints
 
     -- GHC.Core -> Pir translation.

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 
 module Budget.Spec where

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -9,7 +9,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 
 module IsData.Spec where

--- a/plutus-tx-plugin/test/IsData/Spec.hs
+++ b/plutus-tx-plugin/test/IsData/Spec.hs
@@ -11,7 +11,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module IsData.Spec where
 

--- a/plutus-tx-plugin/test/Optimization/Spec.hs
+++ b/plutus-tx-plugin/test/Optimization/Spec.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module Optimization.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 
 module Plugin.Basic.Spec where

--- a/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Basic/Spec.hs
@@ -8,7 +8,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module Plugin.Basic.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin -fplugin-opt PlutusTx.Plugin:coverage-all #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 
 module Plugin.Coverage.Spec (coverage) where
 

--- a/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Coverage/Spec.hs
@@ -53,11 +53,11 @@ boolQualifiedDisappears = plc (Proxy @"boolQualifiedDisappears") (\ () -> Haskel
 coverage :: TestNested
 coverage = testNested "Coverage"
   [ pure $ testGroup "Application heads and line coverage"
-         [ mkTests "noBool" noBool Set.empty [29]
-         , mkTests "boolTrueFalse" boolTrueFalse (Set.singleton "&&") [32]
-         , mkTests "boolOtherFunction" boolOtherFunction (Set.fromList ["&&", "=="]) [35, 39, 40, 41]
-         , mkTests "boolOtherFunctionSimplifiesAway" boolOtherFunctionSimplifiesAway (Set.fromList ["&&", "=="]) [47]
-         , mkTests "boolQualifiedDisappears" boolQualifiedDisappears Set.empty [50]
+         [ mkTests "noBool" noBool Set.empty [30]
+         , mkTests "boolTrueFalse" boolTrueFalse (Set.singleton "&&") [33]
+         , mkTests "boolOtherFunction" boolOtherFunction (Set.fromList ["&&", "=="]) [36, 40, 41, 42]
+         , mkTests "boolOtherFunctionSimplifiesAway" boolOtherFunctionSimplifiesAway (Set.fromList ["&&", "=="]) [48]
+         , mkTests "boolQualifiedDisappears" boolQualifiedDisappears Set.empty [51]
          ]
  , goldenPir "coverageCode" boolOtherFunction ]
 

--- a/plutus-tx-plugin/test/Plugin/Coverage/coverageCode.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Coverage/coverageCode.plc.golden
@@ -30,7 +30,7 @@
                 { (builtin trace) (all dead (type) (all a (type) [ Maybe a ])) }
                 (con
                   string
-                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 26, _covLocEndCol = 33})"
+                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 42, _covLocEndLine = 42, _covLocStartCol = 26, _covLocEndCol = 33})"
                 )
               ]
               (abs dead (type) Nothing)
@@ -145,12 +145,12 @@
               traceBool
               (con
                 string
-                "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 1, _covLocEndCol = 32}) True"
+                "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 1, _covLocEndCol = 32}) True"
               )
             ]
             (con
               string
-              "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 1, _covLocEndCol = 32}) False"
+              "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 1, _covLocEndCol = 32}) False"
             )
           ]
           {
@@ -159,7 +159,7 @@
                 { (builtin trace) (all dead (type) Bool) }
                 (con
                   string
-                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 1, _covLocEndCol = 32})"
+                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 1, _covLocEndCol = 32})"
                 )
               ]
               (abs
@@ -174,12 +174,12 @@
                           traceBool
                           (con
                             string
-                            "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 14, _covLocEndCol = 24}) True"
+                            "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 14, _covLocEndCol = 24}) True"
                           )
                         ]
                         (con
                           string
-                          "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 14, _covLocEndCol = 24}) False"
+                          "CoverBool (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 14, _covLocEndCol = 24}) False"
                         )
                       ]
                       {
@@ -188,7 +188,7 @@
                             { (builtin trace) (all dead (type) Bool) }
                             (con
                               string
-                              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 14, _covLocEndCol = 24})"
+                              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 14, _covLocEndCol = 24})"
                             )
                           ]
                           (abs
@@ -206,7 +206,7 @@
                                       }
                                       (con
                                         string
-                                        "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 15, _covLocEndCol = 16})"
+                                        "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 15, _covLocEndCol = 16})"
                                       )
                                     ]
                                     (abs dead (type) x)
@@ -223,7 +223,7 @@
                                     }
                                     (con
                                       string
-                                      "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 22, _covLocEndCol = 23})"
+                                      "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 22, _covLocEndCol = 23})"
                                     )
                                   ]
                                   (abs dead (type) (con integer 5))
@@ -243,7 +243,7 @@
                         { (builtin trace) (all dead (type) Bool) }
                         (con
                           string
-                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 44, _covLocEndLine = 44, _covLocStartCol = 28, _covLocEndCol = 32})"
+                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 45, _covLocEndLine = 45, _covLocStartCol = 28, _covLocEndCol = 32})"
                         )
                       ]
                       (abs dead (type) True)
@@ -267,7 +267,7 @@
             { (builtin trace) (all dead (type) [ Maybe Bool ]) }
             (con
               string
-              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 35, _covLocEndLine = 35, _covLocStartCol = 54, _covLocEndCol = 57})"
+              "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 36, _covLocEndLine = 36, _covLocStartCol = 54, _covLocEndCol = 57})"
             )
           ]
           (abs
@@ -279,7 +279,7 @@
                   { (builtin trace) (all dead (type) [ Maybe Bool ]) }
                   (con
                     string
-                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 39, _covLocEndLine = 41, _covLocStartCol = 1, _covLocEndCol = 33})"
+                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 42, _covLocStartCol = 1, _covLocEndCol = 33})"
                   )
                 ]
                 (abs
@@ -307,7 +307,7 @@
                                   }
                                   (con
                                     string
-                                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 40, _covLocStartCol = 12, _covLocEndCol = 22})"
+                                    "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 12, _covLocEndCol = 22})"
                                   )
                                 ]
                                 (abs
@@ -334,7 +334,7 @@
                                                     }
                                                     (con
                                                       string
-                                                      "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 40, _covLocStartCol = 21, _covLocEndCol = 22})"
+                                                      "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 21, _covLocEndCol = 22})"
                                                     )
                                                   ]
                                                   (abs dead (type) y)
@@ -359,7 +359,7 @@
                                                 }
                                                 (con
                                                   string
-                                                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 40, _covLocStartCol = 26, _covLocEndCol = 36})"
+                                                  "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 26, _covLocEndCol = 36})"
                                                 )
                                               ]
                                               (abs
@@ -376,7 +376,7 @@
                                                         }
                                                         (con
                                                           string
-                                                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 40, _covLocEndLine = 40, _covLocStartCol = 31, _covLocEndCol = 36})"
+                                                          "CoverLocation (CovLoc {_covLocFile = \"test/Plugin/Coverage/Spec.hs\", _covLocStartLine = 41, _covLocEndLine = 41, _covLocStartCol = 31, _covLocEndCol = 36})"
                                                         )
                                                       ]
                                                       (abs dead (type) False)

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -8,7 +8,8 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}

--- a/plutus-tx-plugin/test/Plugin/Data/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Data/Spec.hs
@@ -10,7 +10,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -7,7 +7,8 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 

--- a/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Errors/Spec.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Plugin.Errors.Spec where

--- a/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
@@ -8,7 +8,8 @@
 {-# LANGUAGE UnboxedTuples       #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 

--- a/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Functions/Spec.hs
@@ -10,7 +10,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Plugin.Functions.Spec where

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -7,7 +7,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module Plugin.Laziness.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Laziness/Spec.hs
@@ -5,7 +5,8 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 
 module Plugin.Laziness.Spec where

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -6,7 +6,8 @@
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 
 module Plugin.Primitives.Spec where
 

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:profile-all #-}

--- a/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Profiling/Spec.hs
@@ -7,7 +7,8 @@
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:profile-all #-}
 
 -- | Tests for the profiling machinery.

--- a/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Strict/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module Plugin.Strict.Spec (strict) where
 

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -5,7 +5,8 @@
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-typecheck #-}
 

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/Spec.hs
@@ -7,7 +7,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-typecheck #-}
 
 module Plugin.Typeclasses.Spec where

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
 
 module StdLib.Spec where

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -6,7 +6,7 @@
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 
 module StdLib.Spec where
 

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -11,7 +11,8 @@
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module TH.Spec (tests) where

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-uplc=0 #-}

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module PlutusTx.Ratio(
     -- * Type

--- a/plutus-tx/src/PlutusTx/Sqrt.hs
+++ b/plutus-tx/src/PlutusTx/Sqrt.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:debug-context #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module PlutusTx.Sqrt(
     Sqrt (..)


### PR DESCRIPTION
This PR proposes the following changes to make the PlutusTx plugin more configurable and consistent so the plugin users can have the option to control plugin behavior according to their needs and is easier to know about options.

#### Provide maximum simplifier iterations for both PIR and UPLC separately:
- Updated _posMaxSimplifierIterations option to separate options for PIR and UPLC instead of relying on the same option (_posMaxSimplifierIterations) for both. As Currently, _posMaxSimplifierIterations (corresponding to plugin option max-simplifier-iterations) is used for both PIR simplifier and UPLC simplifier. So having separate options makes the plugin more configurable according to the uses.

- The new options proposed are 
    - `max-simplifier-iterations-pir` for PIR
    - `max-simplifier-iterations-uplc` for UPLC

#### Provide context-level that can be set to integer value instead of no-context for 0 level and debug-context for 3 level
- Currently, there is no way to set context levels 1, 2  using -fplugin-opt and further debug-context and no-context is being currently used to set context level to 0 and 3 respectively.  So to simplify this PR proposes merging of these options into one namely `context-level`.

- The new option context-level is used as:
  - `context-level` = < Integer >
  - `no-context` is changed to `context-level`=0
  - `debug-context` is changed to `context-level`=3

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
