### PR TITLE
PLT-1139: Debugger annotation related types

### DIFF
--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -65,7 +65,7 @@ toAnonDeBruijnTerm = UPLC.termMapNames (\(UPLC.NamedDeBruijn _ ix) -> UPLC.DeBru
 
 {- | Just extract the body of a program wrapped in a 'CompiledCodeIn'.  We use this a lot. -}
 compiledCodeToTerm
-    :: Tx.CompiledCodeIn DefaultUni DefaultFun a -> Term
+    :: Tx.CompiledCodeIn DefaultUni DefaultFun () a -> Term
 compiledCodeToTerm (Tx.getPlc -> UPLC.Program _ _ body) = body
 
 {- | Lift a Haskell value to a PLC term.  The constraints get a bit out of control
@@ -94,4 +94,3 @@ type Result = EvaluationResult Term
    Properties.  -}
 cekResultMatchesHaskellValue :: Tx.Lift DefaultUni a => Term -> (Result -> Result -> b) -> a -> b
 cekResultMatchesHaskellValue term matches value = (runTermCek term) `matches` (runTermCek $ haskellValueToTerm value)
-

--- a/plutus-benchmark/ed25519-throughput/Main.hs
+++ b/plutus-benchmark/ed25519-throughput/Main.hs
@@ -67,7 +67,7 @@ type UDBProg = UPLC.Program UPLC.DeBruijn      DefaultUni DefaultFun ()
 
 
 compiledCodeToTerm
-    :: Tx.CompiledCodeIn DefaultUni DefaultFun a -> UTerm
+    :: Tx.CompiledCodeIn DefaultUni DefaultFun () a -> UTerm
 compiledCodeToTerm (Tx.getPlc -> UPLC.Program _ _ body) = body
 
 {- | Remove the textual names from a NamedDeBruijn program -}

--- a/plutus-tx-plugin/src/PlutusTx/Annotation.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Annotation.hs
@@ -1,20 +1,39 @@
+{-# LANGUAGE StrictData #-}
+
 module PlutusTx.Annotation where
+
+import PlutusTx.Code
 
 import GHC.Generics
 import Prettyprinter
 
-data Ann
+-- | An annotation type used during the compilation.
+data Ann = Ann
+    { annInline   :: Inline
+    , annSrcSpans :: SrcSpans
+    }
+    deriving stock (Eq, Ord, Generic, Show)
+
+data Inline
     = -- | When calling @PlutusIR.Compiler.Definitions.defineTerm@ to add a new term definition,
-      -- if we annotation the var on the LHS of the definition with `AnnInline`, the inliner will
+      -- if we annotation the var on the LHS of the definition with `AlwaysInline`, the inliner will
       -- always inline that var.
       --
       -- This is currently used to ensure builtin functions such as @trace@ (when the @remove-trace@
       -- flag is on and @trace@ is rewritten to @const@) are inlined, because the inliner would
-      -- otherwise not inline them. To achieve that, we annotate the definition with `AnnInline`
-      -- when defining @trace@, i.e., @trace <AnnInline> = \_ a -> a@.
-      AnnInline
-    | AnnOther
+      -- otherwise not inline them. To achieve that, we annotate the definition with `AlwaysInline`
+      -- when defining @trace@, i.e., @trace <AlwaysInline> = \_ a -> a@.
+      AlwaysInline
+    | MayInline
     deriving stock (Eq, Ord, Generic, Show)
 
 instance Pretty Ann where
     pretty = viaShow
+
+-- | Create an `Ann` with `AlwaysInline`.
+annAlwaysInline :: Ann
+annAlwaysInline = Ann{annInline = AlwaysInline, annSrcSpans = mempty}
+
+-- | Create an `Ann` with `MayInline`.
+annMayInline :: Ann
+annMayInline = Ann{annInline = MayInline, annSrcSpans = mempty}

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Binders.hs
@@ -37,7 +37,7 @@ withVarScoped ::
     m a
 withVarScoped v k = do
     let ghcName = GHC.getName v
-    var <- compileVarFresh AnnOther v
+    var <- compileVarFresh annMayInline v
     local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
 
 withVarsScoped ::
@@ -48,7 +48,7 @@ withVarsScoped ::
 withVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
-        var' <- compileVarFresh AnnOther v
+        var' <- compileVarFresh annMayInline v
         pure (name, var')
     local (\c -> c {ccScopes=pushNames vars (ccScopes c)}) (k (fmap snd vars))
 
@@ -81,7 +81,7 @@ mkLamAbsScoped ::
     GHC.Var ->
     m (PIRTerm uni fun) ->
     m (PIRTerm uni fun)
-mkLamAbsScoped v body = withVarScoped v $ \(PIR.VarDecl _ n t) -> PIR.LamAbs AnnOther n t <$> body
+mkLamAbsScoped v body = withVarScoped v $ \(PIR.VarDecl _ n t) -> PIR.LamAbs annMayInline n t <$> body
 
 mkIterLamAbsScoped :: CompilingDefault uni fun m ann => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
@@ -89,7 +89,7 @@ mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
 -- | Builds a type abstraction, binding the given variable to a name that
 -- will be in scope when running the second argument.
 mkTyAbsScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
-mkTyAbsScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyAbs AnnOther t k <$> body
+mkTyAbsScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyAbs annMayInline t k <$> body
 
 mkIterTyAbsScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRTerm uni fun) -> m (PIRTerm uni fun)
 mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
@@ -98,7 +98,7 @@ mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
 -- will be in scope when running the second argument.
 mkTyForallScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
 mkTyForallScoped v body =
-    withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyForall AnnOther t k <$> body
+    withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyForall annMayInline t k <$> body
 
 mkIterTyForallScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
 mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body vars
@@ -107,7 +107,7 @@ mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body v
 -- will be in scope when running the second argument.
 mkTyLamScoped :: Compiling uni fun m ann => GHC.Var -> m (PIRType uni) -> m (PIRType uni)
 mkTyLamScoped v body =
-    withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyLam AnnOther t k <$> body
+    withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyLam annMayInline t k <$> body
 
 mkIterTyLamScoped :: Compiling uni fun m ann => [GHC.Var] -> m (PIRType uni) -> m (PIRType uni)
 mkIterTyLamScoped vars body = foldr (\v acc -> mkTyLamScoped v acc) body vars

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -152,7 +152,7 @@ which handles these cases too.
 -}
 
 mkBuiltin :: fun -> PIR.Term tyname name uni fun Ann
-mkBuiltin = PIR.Builtin AnnOther
+mkBuiltin = PIR.Builtin annMayInline
 
 -- | The 'TH.Name's for which 'NameInfo' needs to be provided.
 builtinNames :: [TH.Name]
@@ -266,56 +266,56 @@ defineBuiltinTerms = do
 
     -- See Note [Builtin terms and values]
     -- Bool
-    defineBuiltinTerm AnnOther 'Builtins.ifThenElse $ mkBuiltin PLC.IfThenElse
-    defineBuiltinTerm AnnOther 'Builtins.true $ PIR.mkConstant AnnOther True
-    defineBuiltinTerm AnnOther 'Builtins.false $ PIR.mkConstant AnnOther False
+    defineBuiltinTerm annMayInline 'Builtins.ifThenElse $ mkBuiltin PLC.IfThenElse
+    defineBuiltinTerm annMayInline 'Builtins.true $ PIR.mkConstant annMayInline True
+    defineBuiltinTerm annMayInline 'Builtins.false $ PIR.mkConstant annMayInline False
 
-    defineBuiltinTerm AnnOther 'Builtins.unitval $ PIR.mkConstant AnnOther ()
-    defineBuiltinTerm AnnOther 'Builtins.chooseUnit $ mkBuiltin PLC.ChooseUnit
+    defineBuiltinTerm annMayInline 'Builtins.unitval $ PIR.mkConstant annMayInline ()
+    defineBuiltinTerm annMayInline 'Builtins.chooseUnit $ mkBuiltin PLC.ChooseUnit
 
     -- Bytestring builtins
-    defineBuiltinTerm AnnOther 'Builtins.appendByteString $ mkBuiltin PLC.AppendByteString
-    defineBuiltinTerm AnnOther 'Builtins.consByteString $ mkBuiltin PLC.ConsByteString
-    defineBuiltinTerm AnnOther 'Builtins.sliceByteString $ mkBuiltin PLC.SliceByteString
-    defineBuiltinTerm AnnOther 'Builtins.lengthOfByteString $ mkBuiltin PLC.LengthOfByteString
-    defineBuiltinTerm AnnOther 'Builtins.indexByteString $ mkBuiltin PLC.IndexByteString
-    defineBuiltinTerm AnnOther 'Builtins.sha2_256 $ mkBuiltin PLC.Sha2_256
-    defineBuiltinTerm AnnOther 'Builtins.sha3_256 $ mkBuiltin PLC.Sha3_256
-    defineBuiltinTerm AnnOther 'Builtins.blake2b_256 $ mkBuiltin PLC.Blake2b_256
-    defineBuiltinTerm AnnOther 'Builtins.equalsByteString $ mkBuiltin PLC.EqualsByteString
-    defineBuiltinTerm AnnOther 'Builtins.lessThanByteString $ mkBuiltin PLC.LessThanByteString
-    defineBuiltinTerm AnnOther 'Builtins.lessThanEqualsByteString $ mkBuiltin PLC.LessThanEqualsByteString
-    defineBuiltinTerm AnnOther 'Builtins.emptyByteString $ PIR.mkConstant AnnOther BS.empty
-    defineBuiltinTerm AnnOther 'Builtins.decodeUtf8 $ mkBuiltin PLC.DecodeUtf8
-    defineBuiltinTerm AnnOther 'Builtins.verifyEcdsaSecp256k1Signature $ mkBuiltin PLC.VerifyEcdsaSecp256k1Signature
-    defineBuiltinTerm AnnOther 'Builtins.verifySchnorrSecp256k1Signature $ mkBuiltin PLC.VerifySchnorrSecp256k1Signature
+    defineBuiltinTerm annMayInline 'Builtins.appendByteString $ mkBuiltin PLC.AppendByteString
+    defineBuiltinTerm annMayInline 'Builtins.consByteString $ mkBuiltin PLC.ConsByteString
+    defineBuiltinTerm annMayInline 'Builtins.sliceByteString $ mkBuiltin PLC.SliceByteString
+    defineBuiltinTerm annMayInline 'Builtins.lengthOfByteString $ mkBuiltin PLC.LengthOfByteString
+    defineBuiltinTerm annMayInline 'Builtins.indexByteString $ mkBuiltin PLC.IndexByteString
+    defineBuiltinTerm annMayInline 'Builtins.sha2_256 $ mkBuiltin PLC.Sha2_256
+    defineBuiltinTerm annMayInline 'Builtins.sha3_256 $ mkBuiltin PLC.Sha3_256
+    defineBuiltinTerm annMayInline 'Builtins.blake2b_256 $ mkBuiltin PLC.Blake2b_256
+    defineBuiltinTerm annMayInline 'Builtins.equalsByteString $ mkBuiltin PLC.EqualsByteString
+    defineBuiltinTerm annMayInline 'Builtins.lessThanByteString $ mkBuiltin PLC.LessThanByteString
+    defineBuiltinTerm annMayInline 'Builtins.lessThanEqualsByteString $ mkBuiltin PLC.LessThanEqualsByteString
+    defineBuiltinTerm annMayInline 'Builtins.emptyByteString $ PIR.mkConstant annMayInline BS.empty
+    defineBuiltinTerm annMayInline 'Builtins.decodeUtf8 $ mkBuiltin PLC.DecodeUtf8
+    defineBuiltinTerm annMayInline 'Builtins.verifyEcdsaSecp256k1Signature $ mkBuiltin PLC.VerifyEcdsaSecp256k1Signature
+    defineBuiltinTerm annMayInline 'Builtins.verifySchnorrSecp256k1Signature $ mkBuiltin PLC.VerifySchnorrSecp256k1Signature
 
     -- Crypto
-    defineBuiltinTerm AnnOther 'Builtins.verifyEd25519Signature $ mkBuiltin PLC.VerifyEd25519Signature
+    defineBuiltinTerm annMayInline 'Builtins.verifyEd25519Signature $ mkBuiltin PLC.VerifyEd25519Signature
 
     -- Integer builtins
-    defineBuiltinTerm AnnOther 'Builtins.addInteger $ mkBuiltin PLC.AddInteger
-    defineBuiltinTerm AnnOther 'Builtins.subtractInteger $ mkBuiltin PLC.SubtractInteger
-    defineBuiltinTerm AnnOther 'Builtins.multiplyInteger $ mkBuiltin PLC.MultiplyInteger
-    defineBuiltinTerm AnnOther 'Builtins.divideInteger $ mkBuiltin PLC.DivideInteger
-    defineBuiltinTerm AnnOther 'Builtins.modInteger $ mkBuiltin PLC.ModInteger
-    defineBuiltinTerm AnnOther 'Builtins.quotientInteger $ mkBuiltin PLC.QuotientInteger
-    defineBuiltinTerm AnnOther 'Builtins.remainderInteger $ mkBuiltin PLC.RemainderInteger
-    defineBuiltinTerm AnnOther 'Builtins.lessThanInteger $ mkBuiltin PLC.LessThanInteger
-    defineBuiltinTerm AnnOther 'Builtins.lessThanEqualsInteger $ mkBuiltin PLC.LessThanEqualsInteger
-    defineBuiltinTerm AnnOther 'Builtins.equalsInteger $ mkBuiltin PLC.EqualsInteger
+    defineBuiltinTerm annMayInline 'Builtins.addInteger $ mkBuiltin PLC.AddInteger
+    defineBuiltinTerm annMayInline 'Builtins.subtractInteger $ mkBuiltin PLC.SubtractInteger
+    defineBuiltinTerm annMayInline 'Builtins.multiplyInteger $ mkBuiltin PLC.MultiplyInteger
+    defineBuiltinTerm annMayInline 'Builtins.divideInteger $ mkBuiltin PLC.DivideInteger
+    defineBuiltinTerm annMayInline 'Builtins.modInteger $ mkBuiltin PLC.ModInteger
+    defineBuiltinTerm annMayInline 'Builtins.quotientInteger $ mkBuiltin PLC.QuotientInteger
+    defineBuiltinTerm annMayInline 'Builtins.remainderInteger $ mkBuiltin PLC.RemainderInteger
+    defineBuiltinTerm annMayInline 'Builtins.lessThanInteger $ mkBuiltin PLC.LessThanInteger
+    defineBuiltinTerm annMayInline 'Builtins.lessThanEqualsInteger $ mkBuiltin PLC.LessThanEqualsInteger
+    defineBuiltinTerm annMayInline 'Builtins.equalsInteger $ mkBuiltin PLC.EqualsInteger
 
     -- Error
     -- See Note [Delaying error]
     func <- delayedErrorFunc
-    -- We always want to inline `error :: forall a . () -> a`, hence `AnnInline`.
-    defineBuiltinTerm AnnInline 'Builtins.error func
+    -- We always want to inline `error :: forall a . () -> a`, hence `annAlwaysInline`.
+    defineBuiltinTerm annAlwaysInline 'Builtins.error func
 
     -- Strings and chars
-    defineBuiltinTerm AnnOther 'Builtins.appendString $ mkBuiltin PLC.AppendString
-    defineBuiltinTerm AnnOther 'Builtins.emptyString $ PIR.mkConstant AnnOther ("" :: Text)
-    defineBuiltinTerm AnnOther 'Builtins.equalsString $ mkBuiltin PLC.EqualsString
-    defineBuiltinTerm AnnOther 'Builtins.encodeUtf8 $ mkBuiltin PLC.EncodeUtf8
+    defineBuiltinTerm annMayInline 'Builtins.appendString $ mkBuiltin PLC.AppendString
+    defineBuiltinTerm annMayInline 'Builtins.emptyString $ PIR.mkConstant annMayInline ("" :: Text)
+    defineBuiltinTerm annMayInline 'Builtins.equalsString $ mkBuiltin PLC.EqualsString
+    defineBuiltinTerm annMayInline 'Builtins.encodeUtf8 $ mkBuiltin PLC.EncodeUtf8
 
     -- Tracing
     -- When `remove-trace` is specified, we define `trace` as `\_ a -> a` instead of the builtin version.
@@ -326,66 +326,66 @@ defineBuiltinTerms = do
                 t <- freshName "t"
                 a <- freshName "a"
                 pure
-                    ( PIR.tyAbs AnnOther ta (PLC.Type AnnOther) $
+                    ( PIR.tyAbs annMayInline ta (PLC.Type annMayInline) $
                         PIR.mkIterLamAbs
-                            [ PIR.VarDecl AnnOther t (PIR.mkTyBuiltin @_ @Text AnnOther)
-                            , PIR.VarDecl AnnOther a (PLC.TyVar AnnOther ta)
+                            [ PIR.VarDecl annMayInline t (PIR.mkTyBuiltin @_ @Text annMayInline)
+                            , PIR.VarDecl annMayInline a (PLC.TyVar annMayInline ta)
                             ]
-                            $ PIR.Var AnnOther a
+                            $ PIR.Var annMayInline a
                     , -- We always want to inline `\_ a -> a` (especially because the first
-                      -- element is a string), hence `AnnInline`.
-                      AnnInline
+                      -- element is a string), hence `annAlwaysInline`.
+                      annAlwaysInline
                     )
-            else pure (mkBuiltin PLC.Trace, AnnOther)
+            else pure (mkBuiltin PLC.Trace, annMayInline)
     defineBuiltinTerm ann 'Builtins.trace traceTerm
 
     -- Pairs
-    defineBuiltinTerm AnnOther 'Builtins.fst $ mkBuiltin PLC.FstPair
-    defineBuiltinTerm AnnOther 'Builtins.snd $ mkBuiltin PLC.SndPair
-    defineBuiltinTerm AnnOther 'Builtins.mkPairData $ mkBuiltin PLC.MkPairData
+    defineBuiltinTerm annMayInline 'Builtins.fst $ mkBuiltin PLC.FstPair
+    defineBuiltinTerm annMayInline 'Builtins.snd $ mkBuiltin PLC.SndPair
+    defineBuiltinTerm annMayInline 'Builtins.mkPairData $ mkBuiltin PLC.MkPairData
 
     -- List
-    defineBuiltinTerm AnnOther 'Builtins.null $ mkBuiltin PLC.NullList
-    defineBuiltinTerm AnnOther 'Builtins.head $ mkBuiltin PLC.HeadList
-    defineBuiltinTerm AnnOther 'Builtins.tail $ mkBuiltin PLC.TailList
-    defineBuiltinTerm AnnOther 'Builtins.chooseList $ mkBuiltin PLC.ChooseList
-    defineBuiltinTerm AnnOther 'Builtins.mkNilData $ mkBuiltin PLC.MkNilData
-    defineBuiltinTerm AnnOther 'Builtins.mkNilPairData $ mkBuiltin PLC.MkNilPairData
-    defineBuiltinTerm AnnOther 'Builtins.mkCons $ mkBuiltin PLC.MkCons
+    defineBuiltinTerm annMayInline 'Builtins.null $ mkBuiltin PLC.NullList
+    defineBuiltinTerm annMayInline 'Builtins.head $ mkBuiltin PLC.HeadList
+    defineBuiltinTerm annMayInline 'Builtins.tail $ mkBuiltin PLC.TailList
+    defineBuiltinTerm annMayInline 'Builtins.chooseList $ mkBuiltin PLC.ChooseList
+    defineBuiltinTerm annMayInline 'Builtins.mkNilData $ mkBuiltin PLC.MkNilData
+    defineBuiltinTerm annMayInline 'Builtins.mkNilPairData $ mkBuiltin PLC.MkNilPairData
+    defineBuiltinTerm annMayInline 'Builtins.mkCons $ mkBuiltin PLC.MkCons
 
     -- Data
-    defineBuiltinTerm AnnOther 'Builtins.chooseData $ mkBuiltin PLC.ChooseData
-    defineBuiltinTerm AnnOther 'Builtins.equalsData $ mkBuiltin PLC.EqualsData
-    defineBuiltinTerm AnnOther 'Builtins.mkConstr $ mkBuiltin PLC.ConstrData
-    defineBuiltinTerm AnnOther 'Builtins.mkMap $ mkBuiltin PLC.MapData
-    defineBuiltinTerm AnnOther 'Builtins.mkList $ mkBuiltin PLC.ListData
-    defineBuiltinTerm AnnOther 'Builtins.mkI $ mkBuiltin PLC.IData
-    defineBuiltinTerm AnnOther 'Builtins.mkB $ mkBuiltin PLC.BData
-    defineBuiltinTerm AnnOther 'Builtins.unsafeDataAsConstr $ mkBuiltin PLC.UnConstrData
-    defineBuiltinTerm AnnOther 'Builtins.unsafeDataAsMap $ mkBuiltin PLC.UnMapData
-    defineBuiltinTerm AnnOther 'Builtins.unsafeDataAsList $ mkBuiltin PLC.UnListData
-    defineBuiltinTerm AnnOther 'Builtins.unsafeDataAsB $ mkBuiltin PLC.UnBData
-    defineBuiltinTerm AnnOther 'Builtins.unsafeDataAsI $ mkBuiltin PLC.UnIData
-    defineBuiltinTerm AnnOther 'Builtins.serialiseData $ mkBuiltin PLC.SerialiseData
+    defineBuiltinTerm annMayInline 'Builtins.chooseData $ mkBuiltin PLC.ChooseData
+    defineBuiltinTerm annMayInline 'Builtins.equalsData $ mkBuiltin PLC.EqualsData
+    defineBuiltinTerm annMayInline 'Builtins.mkConstr $ mkBuiltin PLC.ConstrData
+    defineBuiltinTerm annMayInline 'Builtins.mkMap $ mkBuiltin PLC.MapData
+    defineBuiltinTerm annMayInline 'Builtins.mkList $ mkBuiltin PLC.ListData
+    defineBuiltinTerm annMayInline 'Builtins.mkI $ mkBuiltin PLC.IData
+    defineBuiltinTerm annMayInline 'Builtins.mkB $ mkBuiltin PLC.BData
+    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsConstr $ mkBuiltin PLC.UnConstrData
+    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsMap $ mkBuiltin PLC.UnMapData
+    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsList $ mkBuiltin PLC.UnListData
+    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsB $ mkBuiltin PLC.UnBData
+    defineBuiltinTerm annMayInline 'Builtins.unsafeDataAsI $ mkBuiltin PLC.UnIData
+    defineBuiltinTerm annMayInline 'Builtins.serialiseData $ mkBuiltin PLC.SerialiseData
 
 defineBuiltinTypes
     :: CompilingDefault uni fun m ann
     => m ()
 defineBuiltinTypes = do
-    defineBuiltinType ''Builtins.BuiltinByteString . ($> AnnOther) $ PLC.toTypeAst $ Proxy @BS.ByteString
-    defineBuiltinType ''Integer . ($> AnnOther) $ PLC.toTypeAst $ Proxy @Integer
-    defineBuiltinType ''Builtins.BuiltinBool . ($> AnnOther) $ PLC.toTypeAst $ Proxy @Bool
-    defineBuiltinType ''Builtins.BuiltinUnit . ($> AnnOther) $ PLC.toTypeAst $ Proxy @()
-    defineBuiltinType ''Builtins.BuiltinString . ($> AnnOther) $ PLC.toTypeAst $ Proxy @Text
-    defineBuiltinType ''Builtins.BuiltinData . ($> AnnOther) $ PLC.toTypeAst $ Proxy @PLC.Data
-    defineBuiltinType ''Builtins.BuiltinPair . ($> AnnOther) $ PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoPair)
-    defineBuiltinType ''Builtins.BuiltinList . ($> AnnOther) $ PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoList)
+    defineBuiltinType ''Builtins.BuiltinByteString . ($> annMayInline) $ PLC.toTypeAst $ Proxy @BS.ByteString
+    defineBuiltinType ''Integer . ($> annMayInline) $ PLC.toTypeAst $ Proxy @Integer
+    defineBuiltinType ''Builtins.BuiltinBool . ($> annMayInline) $ PLC.toTypeAst $ Proxy @Bool
+    defineBuiltinType ''Builtins.BuiltinUnit . ($> annMayInline) $ PLC.toTypeAst $ Proxy @()
+    defineBuiltinType ''Builtins.BuiltinString . ($> annMayInline) $ PLC.toTypeAst $ Proxy @Text
+    defineBuiltinType ''Builtins.BuiltinData . ($> annMayInline) $ PLC.toTypeAst $ Proxy @PLC.Data
+    defineBuiltinType ''Builtins.BuiltinPair . ($> annMayInline) $ PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoPair)
+    defineBuiltinType ''Builtins.BuiltinList . ($> annMayInline) $ PLC.TyBuiltin () (PLC.SomeTypeIn PLC.DefaultUniProtoList)
 
 -- | Lookup a builtin term by its TH name. These are assumed to be present, so fails if it cannot find it.
 lookupBuiltinTerm :: Compiling uni fun m ann => TH.Name -> m (PIRTerm uni fun)
 lookupBuiltinTerm name = do
     ghcName <- GHC.getName <$> getThing name
-    maybeTerm <- PIR.lookupTerm AnnOther (LexName ghcName)
+    maybeTerm <- PIR.lookupTerm annMayInline (LexName ghcName)
     case maybeTerm of
         Just t  -> pure t
         Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
@@ -394,7 +394,7 @@ lookupBuiltinTerm name = do
 lookupBuiltinType :: Compiling uni fun m ann => TH.Name -> m (PIRType uni)
 lookupBuiltinType name = do
     ghcName <- GHC.getName <$> getThing name
-    maybeType <- PIR.lookupType AnnOther (LexName ghcName)
+    maybeType <- PIR.lookupType annMayInline (LexName ghcName)
     case maybeType of
         Just t  -> pure t
         Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
@@ -403,7 +403,7 @@ lookupBuiltinType name = do
 errorFunc :: Compiling uni fun m ann => m (PIRTerm uni fun)
 errorFunc = do
     n <- safeFreshTyName "e"
-    pure $ PIR.TyAbs AnnOther n (PIR.Type AnnOther) (PIR.Error AnnOther (PIR.TyVar AnnOther n))
+    pure $ PIR.TyAbs annMayInline n (PIR.Type annMayInline) (PIR.Error annMayInline (PIR.TyVar annMayInline n))
 
 -- | The delayed error function 'error :: forall a . () -> a'.
 delayedErrorFunc :: CompilingDefault uni fun m ann => m (PIRTerm uni fun)
@@ -411,5 +411,5 @@ delayedErrorFunc = do
     n <- safeFreshTyName "a"
     t <- liftQuote (freshName "thunk")
     let ty = PLC.toTypeAst $ Proxy @()
-    pure $ PIR.TyAbs AnnOther n (PIR.Type AnnOther) $
-        PIR.LamAbs AnnOther t (ty $> AnnOther) $ PIR.Error AnnOther (PIR.TyVar AnnOther n)
+    pure $ PIR.TyAbs annMayInline n (PIR.Type annMayInline) $
+        PIR.LamAbs annMayInline t (ty $> annMayInline) $ PIR.Error annMayInline (PIR.TyVar annMayInline n)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Laziness.hs
@@ -26,10 +26,10 @@ a simplifier pass. Also, PLC isn't lazy, so combinators work less well.
 -}
 
 delay :: Compiling uni fun m ann => PIRTerm uni fun -> m (PIRTerm uni fun)
-delay body = PIR.TyAbs AnnOther <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type AnnOther) <*> pure body
+delay body = PIR.TyAbs annMayInline <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type annMayInline) <*> pure body
 
 delayType :: Compiling uni fun m ann => PIRType uni -> m (PIRType uni)
-delayType orig = PIR.TyForall AnnOther <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type AnnOther) <*> pure orig
+delayType orig = PIR.TyForall annMayInline <$> liftQuote (freshTyName "dead") <*> pure (PIR.Type annMayInline) <*> pure orig
 
 delayVar :: Compiling uni fun m ann => PIRVar uni -> m (PIRVar uni)
 delayVar (PIR.VarDecl ann n ty) = do
@@ -41,8 +41,8 @@ force
     => PIRTerm uni fun -> m (PIRTerm uni fun)
 force thunk = do
     a <- liftQuote (freshTyName "dead")
-    let fakeTy = PIR.TyForall AnnOther a (PIR.Type AnnOther) (PIR.TyVar AnnOther a)
-    pure $ PIR.TyInst AnnOther thunk fakeTy
+    let fakeTy = PIR.TyForall annMayInline a (PIR.Type annMayInline) (PIR.TyVar annMayInline a)
+    pure $ PIR.TyInst annMayInline thunk fakeTy
 
 maybeDelay :: Compiling uni fun m ann => Bool -> PIRTerm uni fun -> m (PIRTerm uni fun)
 maybeDelay yes t = if yes then delay t else pure t

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Names.hs
@@ -69,13 +69,13 @@ compileTyVarFresh :: Compiling uni fun m ann => GHC.TyVar -> m PLCTyVar
 compileTyVarFresh v = do
     k' <- compileKind $ GHC.tyVarKind v
     t' <- compileTyNameFresh $ GHC.getName v
-    pure $ PLC.TyVarDecl AnnOther t' (k' $> AnnOther)
+    pure $ PLC.TyVarDecl annMayInline t' (k' $> annMayInline)
 
 compileTcTyVarFresh :: Compiling uni fun m ann => GHC.TyCon -> m PLCTyVar
 compileTcTyVarFresh tc = do
     k' <- compileKind $ GHC.tyConKind tc
     t' <- compileTyNameFresh $ GHC.getName tc
-    pure $ PLC.TyVarDecl AnnOther t' (k' $> AnnOther)
+    pure $ PLC.TyVarDecl annMayInline t' (k' $> annMayInline)
 
 pushName :: GHC.Name -> PLCVar uni-> ScopeStack uni -> ScopeStack uni
 pushName ghcName n stack = let Scope ns tyns = NE.head stack in Scope (Map.insert ghcName n ns) tyns NE.<| stack

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -8,8 +8,10 @@
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}
 
-module PlutusTx.Compiler.Types (module PlutusTx.Compiler.Types,
-  Ann (..)) where
+module PlutusTx.Compiler.Types (
+    module PlutusTx.Compiler.Types,
+    module PlutusTx.Annotation
+    ) where
 
 import PlutusTx.Compiler.Error
 import PlutusTx.Coverage

--- a/plutus-tx-plugin/test/Lib.hs
+++ b/plutus-tx-plugin/test/Lib.hs
@@ -31,14 +31,14 @@ import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
 
 instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun) =>
-            ToUPlc (CompiledCodeIn uni fun a) uni fun where
+            ToUPlc (CompiledCodeIn uni fun () a) uni fun where
     toUPlc v = do
         v' <- catchAll $ getPlc v
         toUPlc v'
 
 goldenPir
-    :: (PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Flat, Pretty (PLC.SomeTypeIn uni), Pretty fun, Flat fun)
-    => String -> CompiledCodeIn uni fun a -> TestNested
+    :: (PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Flat, Pretty (PLC.SomeTypeIn uni), Pretty fun, Pretty ann, Flat fun, Flat ann)
+    => String -> CompiledCodeIn uni fun ann a -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ pretty $ getPir value
 
 runPlcCek :: ToUPlc a PLC.DefaultUni PLC.DefaultFun => [a] -> ExceptT SomeException IO (UPLC.Term PLC.Name PLC.DefaultUni PLC.DefaultFun ())

--- a/plutus-tx/src/PlutusTx/Code.hs
+++ b/plutus-tx/src/PlutusTx/Code.hs
@@ -26,7 +26,9 @@ import Flat.Decoder (DecodeException)
 
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
+import Data.Set (Set)
 import ErrorCode
+import GHC.Generics
 -- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
 
@@ -35,7 +37,7 @@ import Prelude as Haskell
 -- this 'CompiledCodeIn'. It could be okay to give it a representational role, since
 -- we compile newtypes the same as their underlying types, but people probably just
 -- shouldn't coerce the final parameter regardless, so we play it safe with a nominal role.
-type role CompiledCodeIn representational representational nominal
+type role CompiledCodeIn representational representational representational nominal
 -- NOTE: any changes to this type must be paralleled by changes
 -- in the plugin code that generates values of this type. That is
 -- done by code generation so it's not typechecked normally.
@@ -45,27 +47,43 @@ type role CompiledCodeIn representational representational nominal
 --
 -- Note: the compiled PLC program does *not* have normalized types,
 -- if you want to put it on the chain you must normalize the types first.
-data CompiledCodeIn uni fun a =
+data CompiledCodeIn uni fun ann a =
     -- | Serialized UPLC code and possibly serialized PIR code with metadata used for program coverage.
     SerializedCode BS.ByteString (Maybe BS.ByteString) CoverageIndex
     -- | Deserialized UPLC program, and possibly deserialized PIR program with metadata used for program coverage.
-    | DeserializedCode (UPLC.Program UPLC.NamedDeBruijn uni fun ()) (Maybe (PIR.Program PLC.TyName PLC.Name uni fun ())) CoverageIndex
+    | DeserializedCode (UPLC.Program UPLC.NamedDeBruijn uni fun ann) (Maybe (PIR.Program PLC.TyName PLC.Name uni fun ann)) CoverageIndex
 
--- | 'CompiledCodeIn' instantiated with default built-in types and functions.
-type CompiledCode = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun
+-- | 'CompiledCodeIn' instantiated with default built-in types and functions, and empty annotation.
+type CompiledCode = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun ()
+
+-- | The span between two source locations.
+data SrcSpan = SrcSpan
+    { srcSpanFile  :: FilePath
+    , srcSpanSLine :: Int
+    , srcSpanSCol  :: Int
+    , srcSpanELine :: Int
+    , srcSpanECol  :: Int
+    }
+    deriving stock (Eq, Ord, Generic, Show)
+
+type SrcSpans = Set SrcSpan
+
+-- | 'CompiledCodeIn' instantiated with default built-in types and functions, and
+-- a set of `SrcSpan`s as annotation.
+type CompiledCodeDebug = CompiledCodeIn PLC.DefaultUni PLC.DefaultFun SrcSpans
 
 -- | Apply a compiled function to a compiled argument.
 applyCode
     :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun)
-    => CompiledCodeIn uni fun (a -> b) -> CompiledCodeIn uni fun a -> CompiledCodeIn uni fun b
+    => CompiledCodeIn uni fun () (a -> b) -> CompiledCodeIn uni fun () a -> CompiledCodeIn uni fun () b
 applyCode fun arg = DeserializedCode (UPLC.applyProgram (getPlc fun) (getPlc arg)) (PIR.applyProgram <$> getPir fun <*> getPir arg) (getCovIdx fun <> getCovIdx arg)
 
 -- | The size of a 'CompiledCodeIn', in AST nodes.
-sizePlc :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun) => CompiledCodeIn uni fun a -> Integer
+sizePlc :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun, Flat ann) => CompiledCodeIn uni fun ann a -> Integer
 sizePlc = UPLC.programSize . getPlc
 
-instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun)
-    => Flat (CompiledCodeIn uni fun a) where
+instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun, Flat ann)
+    => Flat (CompiledCodeIn uni fun ann a) where
     encode c = encode (getPlc c)
 
     decode = do
@@ -89,8 +107,8 @@ instance HasErrorCode ImpossibleDeserialisationFailure where
 
 -- | Get the actual Plutus Core program out of a 'CompiledCodeIn'.
 getPlc
-    :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun)
-    => CompiledCodeIn uni fun a -> UPLC.Program UPLC.NamedDeBruijn uni fun ()
+    :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun, Flat ann)
+    => CompiledCodeIn uni fun ann a -> UPLC.Program UPLC.NamedDeBruijn uni fun ann
 getPlc wrapper = case wrapper of
     SerializedCode plc _ _ -> case unflat (BSL.fromStrict plc) of
         Left e  -> throw $ ImpossibleDeserialisationFailure e
@@ -99,8 +117,8 @@ getPlc wrapper = case wrapper of
 
 -- | Get the Plutus IR program, if there is one, out of a 'CompiledCodeIn'.
 getPir
-    :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun)
-    => CompiledCodeIn uni fun a -> Maybe (PIR.Program PIR.TyName PIR.Name uni fun ())
+    :: (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun, Flat ann)
+    => CompiledCodeIn uni fun ann a -> Maybe (PIR.Program PIR.TyName PIR.Name uni fun ann)
 getPir wrapper = case wrapper of
     SerializedCode _ pir _ -> case pir of
         Just bs -> case unflat (BSL.fromStrict bs) of
@@ -109,7 +127,7 @@ getPir wrapper = case wrapper of
         Nothing -> Nothing
     DeserializedCode _ pir _ -> pir
 
-getCovIdx :: CompiledCodeIn uni fun a -> CoverageIndex
+getCovIdx :: CompiledCodeIn uni fun ann a -> CoverageIndex
 getCovIdx wrapper = case wrapper of
   SerializedCode _ _ idx   -> idx
   DeserializedCode _ _ idx -> idx

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -102,7 +102,7 @@ safeLiftCode
        , PLC.Typecheckable uni fun
        , PrettyPrintable uni fun
        )
-    => a -> m (CompiledCodeIn uni fun a)
+    => a -> m (CompiledCodeIn uni fun () a)
 safeLiftCode x = DeserializedCode <$> safeLiftProgram x <*> pure Nothing <*> pure mempty
 
 unsafely
@@ -135,7 +135,7 @@ liftProgramDef = liftProgram
 -- | Get a Plutus Core program corresponding to the given value as a 'CompiledCodeIn', throwing any errors that occur as exceptions and ignoring fresh names.
 liftCode
     :: (Lift.Lift uni a, Throwable uni fun, PLC.Typecheckable uni fun)
-    => a -> CompiledCodeIn uni fun a
+    => a -> CompiledCodeIn uni fun () a
 liftCode x = unsafely $ safeLiftCode x
 
 {- Note [Checking the type of a term with Typeable]
@@ -205,7 +205,7 @@ typeCode
        )
     => Proxy a
     -> PLC.Program PLC.TyName PLC.Name uni fun ()
-    -> m (CompiledCodeIn uni fun a)
+    -> m (CompiledCodeIn uni fun () a)
 typeCode p prog@(PLC.Program _ _ term) = do
     _ <- typeCheckAgainst p term
     compiled <- flip runReaderT PLC.defaultCompilationOpts $ PLC.compileProgram prog

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -129,8 +129,8 @@ measureBudget compiledCode =
 -- Compilation testing
 
 goldenPir
-    :: (PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Flat, Pretty (PLC.SomeTypeIn uni), Pretty fun, Flat fun)
-    => String -> CompiledCodeIn uni fun a -> TestNested
+    :: (PLC.Closed uni, uni `PLC.Everywhere` PrettyConst, uni `PLC.Everywhere` Flat, Pretty (PLC.SomeTypeIn uni), Pretty fun, Pretty ann, Flat fun, Flat ann)
+    => String -> CompiledCodeIn uni fun ann a -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ pretty $ getPir value
 
 -- Evaluation testing
@@ -145,7 +145,7 @@ goldenEvalCekLog name values = nestedGoldenVsDocM name $ pretty . view _1 <$> (r
 -- Helpers
 
 instance (PLC.Closed uni, uni `PLC.Everywhere` Flat, Flat fun) =>
-            ToUPlc (CompiledCodeIn uni fun a) uni fun where
+            ToUPlc (CompiledCodeIn uni fun () a) uni fun where
     toUPlc v = do
         v' <- catchAll $ getPlc v
         toUPlc v'
@@ -167,4 +167,3 @@ runPlcCekTrace values = do
      let (result,  UPLC.TallyingSt tally _, logOut) = UPLC.runCek PLC.defaultCekParameters UPLC.tallying UPLC.logEmitter (p^.UPLC.progTerm)
      res <- fromRightM (throwError . SomeException) result
      pure (logOut, tally, res)
-


### PR DESCRIPTION
- The `Ann` type now contains a set of `SrcSpan`s.
- Added a type parameter to `CompiledCodeIn` for annotation, so that there's a `CompiledCode` and a `CompiledCodeDebug`.