### PR TITLE
fix(ci/benchmark): export script config

### DIFF
--- a/nix/cells/automation/library/plutus-benchmark-runner.nix
+++ b/nix/cells/automation/library/plutus-benchmark-runner.nix
@@ -18,9 +18,9 @@ pkgs.writeShellApplication {
     pkgs.coreutils
   ];
   text = ''
-    PR_NUMBER=${PR_NUMBER} \
-    BENCHMARK_NAME=${BENCHMARK_NAME} \
-    GITHUB_TOKEN=${GITHUB_TOKEN} \
+    export PR_NUMBER="${PR_NUMBER}"
+    export BENCHMARK_NAME="${BENCHMARK_NAME}"
+    export GITHUB_TOKEN="${GITHUB_TOKEN}"
     ${./plutus-benchmark-runner.sh}
   '';
 }

--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -67,7 +67,10 @@ in
       # Script gets current commit from HEAD in git repo it's ran in
       runner = cell.library.plutus-benchmark-runner {
         PR_NUMBER = prNumber;
-        BENCHMARK_NAME = lib.removePrefix "/benchmark " fact.comment.body;
+        # Remove newlines and carriage returns from comment
+        BENCHMARK_NAME = builtins.head (builtins.match
+          "/benchmark ([[:lower:]:]+)[[:space:]]+"
+          fact.comment.body);
         GITHUB_TOKEN = "/secrets/cicero/github/token";
       };
     in


### PR DESCRIPTION
Some invocations have been failing because of the benchmark name having newlines ex: https://cicero.ci.iog.io/invocation/c8c2aaba-83f6-4e7b-ac0b-215c08bef970

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
