### PR TITLE
PLT-456: Combine `verbose` and `debug` compiler options into `verbosity`

### DIFF
--- a/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
+++ b/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
@@ -17,119 +17,119 @@
      - Int
      - 1
      - Set context level for error messages.
-    
+
 
    * - ``coverage-all``
      - Bool
      - False
      - Add all available coverage annotations in the trace output
-    
+
 
    * - ``coverage-boolean``
      - Bool
      - False
      - Add boolean coverage annotations in the trace output
-    
+
 
    * - ``coverage-location``
      - Bool
      - False
      - Add location coverage annotations in the trace output
-    
+
 
    * - ``defer-errors``
      - Bool
      - False
      - If a compilation error happens and this option is turned on, the compilation error is suppressed and the original Haskell expression is replaced with a runtime-error expression.
-    
+
 
    * - ``dump-pir``
      - Bool
      - False
      - Dump Plutus IR
-    
+
 
    * - ``dump-plc``
      - Bool
      - False
      - Dump Typed Plutus Core
-    
+
 
    * - ``dump-uplc``
      - Bool
      - False
      - Dump Untyped Plutus Core
-    
+
 
    * - ``max-simplifier-iterations-pir``
      - Int
      - 12
      - Set the max iterations for the PIR simplifier
-    
+
 
    * - ``max-simplifier-iterations-uplc``
      - Int
      - 12
      - Set the max iterations for the UPLC simplifier
-    
+
 
    * - ``optimize``
      - Bool
      - True
      - Run optimization passes such as simplification and floating let-bindings.
-    
+
 
    * - ``pedantic``
      - Bool
      - False
      - Run type checker after each compilation pass
-    
+
 
    * - ``profile-all``
      - ProfileOpts
      - None
      - Set profiling options to All, which adds tracing when entering and exiting a term.
-    
+
 
    * - ``remove-trace``
      - Bool
      - False
      - Eliminate calls to ``trace`` from Plutus Core
-    
+
 
    * - ``simplifier-beta``
      - Bool
      - True
      - Run a simplification pass that performs beta transformations
-    
+
 
    * - ``simplifier-inline``
      - Bool
      - True
      - Run a simplification pass that performs inlining
-    
+
 
    * - ``simplifier-remove-dead-bindings``
      - Bool
      - True
      - Run a simplification pass that removes dead bindings
-    
+
 
    * - ``simplifier-unwrap-cancel``
      - Bool
      - True
      - Run a simplification pass that cancels unwrap/wrap pairs
-    
+
 
    * - ``typecheck``
      - Bool
      - True
      - Perform type checking during compilation.
-    
+
 
    * - ``verbosity``
      - Verbosity
      - Quiet
      - Set logging verbosity level (0=Quiet, 1=Verbose, 2=Debug)
-    
+
 

--- a/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
+++ b/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
@@ -13,123 +13,123 @@
      - Description
 
 
-    * - ``context-level``
-      - Int
-      - 1
-      - Set context level for error messages.
+   * - ``context-level``
+     - Int
+     - 1
+     - Set context level for error messages.
     
 
-    * - ``coverage-all``
-      - Bool
-      - False
-      - Add all available coverage annotations in the trace output
+   * - ``coverage-all``
+     - Bool
+     - False
+     - Add all available coverage annotations in the trace output
     
 
-    * - ``coverage-boolean``
-      - Bool
-      - False
-      - Add boolean coverage annotations in the trace output
+   * - ``coverage-boolean``
+     - Bool
+     - False
+     - Add boolean coverage annotations in the trace output
     
 
-    * - ``coverage-location``
-      - Bool
-      - False
-      - Add location coverage annotations in the trace output
+   * - ``coverage-location``
+     - Bool
+     - False
+     - Add location coverage annotations in the trace output
     
 
-    * - ``defer-errors``
-      - Bool
-      - False
-      - If a compilation error happens and this option is turned on, the compilation error is suppressed and the original Haskell expression is replaced with a runtime-error expression.
+   * - ``defer-errors``
+     - Bool
+     - False
+     - If a compilation error happens and this option is turned on, the compilation error is suppressed and the original Haskell expression is replaced with a runtime-error expression.
     
 
-    * - ``dump-pir``
-      - Bool
-      - False
-      - Dump Plutus IR
+   * - ``dump-pir``
+     - Bool
+     - False
+     - Dump Plutus IR
     
 
-    * - ``dump-plc``
-      - Bool
-      - False
-      - Dump Typed Plutus Core
+   * - ``dump-plc``
+     - Bool
+     - False
+     - Dump Typed Plutus Core
     
 
-    * - ``dump-uplc``
-      - Bool
-      - False
-      - Dump Untyped Plutus Core
+   * - ``dump-uplc``
+     - Bool
+     - False
+     - Dump Untyped Plutus Core
     
 
-    * - ``max-simplifier-iterations-pir``
-      - Int
-      - 12
-      - Set the max iterations for the PIR simplifier
+   * - ``max-simplifier-iterations-pir``
+     - Int
+     - 12
+     - Set the max iterations for the PIR simplifier
     
 
-    * - ``max-simplifier-iterations-uplc``
-      - Int
-      - 12
-      - Set the max iterations for the UPLC simplifier
+   * - ``max-simplifier-iterations-uplc``
+     - Int
+     - 12
+     - Set the max iterations for the UPLC simplifier
     
 
-    * - ``optimize``
-      - Bool
-      - True
-      - Run optimization passes such as simplification and floating let-bindings.
+   * - ``optimize``
+     - Bool
+     - True
+     - Run optimization passes such as simplification and floating let-bindings.
     
 
-    * - ``pedantic``
-      - Bool
-      - False
-      - Run type checker after each compilation pass
+   * - ``pedantic``
+     - Bool
+     - False
+     - Run type checker after each compilation pass
     
 
-    * - ``profile-all``
-      - ProfileOpts
-      - None
-      - Set profiling options to All, which adds tracing when entering and exiting a term.
+   * - ``profile-all``
+     - ProfileOpts
+     - None
+     - Set profiling options to All, which adds tracing when entering and exiting a term.
     
 
-    * - ``remove-trace``
-      - Bool
-      - False
-      - Eliminate calls to ``trace`` from Plutus Core
+   * - ``remove-trace``
+     - Bool
+     - False
+     - Eliminate calls to ``trace`` from Plutus Core
     
 
-    * - ``simplifier-beta``
-      - Bool
-      - True
-      - Run a simplification pass that performs beta transformations
+   * - ``simplifier-beta``
+     - Bool
+     - True
+     - Run a simplification pass that performs beta transformations
     
 
-    * - ``simplifier-inline``
-      - Bool
-      - True
-      - Run a simplification pass that performs inlining
+   * - ``simplifier-inline``
+     - Bool
+     - True
+     - Run a simplification pass that performs inlining
     
 
-    * - ``simplifier-remove-dead-bindings``
-      - Bool
-      - True
-      - Run a simplification pass that removes dead bindings
+   * - ``simplifier-remove-dead-bindings``
+     - Bool
+     - True
+     - Run a simplification pass that removes dead bindings
     
 
-    * - ``simplifier-unwrap-cancel``
-      - Bool
-      - True
-      - Run a simplification pass that cancels unwrap/wrap pairs
+   * - ``simplifier-unwrap-cancel``
+     - Bool
+     - True
+     - Run a simplification pass that cancels unwrap/wrap pairs
     
 
-    * - ``typecheck``
-      - Bool
-      - True
-      - Perform type checking during compilation.
+   * - ``typecheck``
+     - Bool
+     - True
+     - Perform type checking during compilation.
     
 
-    * - ``verbosity``
-      - Verbosity
-      - Quiet
-      - Set logging verbosity level (0=Quiet, 1=Verbose, 2=Debug)
+   * - ``verbosity``
+     - Verbosity
+     - Quiet
+     - Set logging verbosity level (0=Quiet, 1=Verbose, 2=Debug)
     
 

--- a/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
+++ b/doc/read-the-docs-site/reference/writing-scripts/compiler-options-table.rst
@@ -12,128 +12,124 @@
      - Default
      - Description
 
-   * - ``coverage-all``
-     - Bool
-     - False
-     - Add all available coverage annotations in the trace output
 
+    * - ``context-level``
+      - Int
+      - 1
+      - Set context level for error messages.
+    
 
-   * - ``coverage-boolean``
-     - Bool
-     - False
-     - Add boolean coverage annotations in the trace output
+    * - ``coverage-all``
+      - Bool
+      - False
+      - Add all available coverage annotations in the trace output
+    
 
+    * - ``coverage-boolean``
+      - Bool
+      - False
+      - Add boolean coverage annotations in the trace output
+    
 
-   * - ``coverage-location``
-     - Bool
-     - False
-     - Add location coverage annotations in the trace output
+    * - ``coverage-location``
+      - Bool
+      - False
+      - Add location coverage annotations in the trace output
+    
 
+    * - ``defer-errors``
+      - Bool
+      - False
+      - If a compilation error happens and this option is turned on, the compilation error is suppressed and the original Haskell expression is replaced with a runtime-error expression.
+    
 
-   * - ``debug``
-     - Bool
-     - False
-     - Set log level to debug
+    * - ``dump-pir``
+      - Bool
+      - False
+      - Dump Plutus IR
+    
 
+    * - ``dump-plc``
+      - Bool
+      - False
+      - Dump Typed Plutus Core
+    
 
-   * - ``defer-errors``
-     - Bool
-     - False
-     - If a compilation error happens and this option is turned on, the compilation error is suppressed and the original Haskell expression is replaced with a runtime-error expression.
+    * - ``dump-uplc``
+      - Bool
+      - False
+      - Dump Untyped Plutus Core
+    
 
+    * - ``max-simplifier-iterations-pir``
+      - Int
+      - 12
+      - Set the max iterations for the PIR simplifier
+    
 
-   * - ``dump-pir``
-     - Bool
-     - False
-     - Dump Plutus IR
+    * - ``max-simplifier-iterations-uplc``
+      - Int
+      - 12
+      - Set the max iterations for the UPLC simplifier
+    
 
+    * - ``optimize``
+      - Bool
+      - True
+      - Run optimization passes such as simplification and floating let-bindings.
+    
 
-   * - ``dump-plc``
-     - Bool
-     - False
-     - Dump Typed Plutus Core
+    * - ``pedantic``
+      - Bool
+      - False
+      - Run type checker after each compilation pass
+    
 
+    * - ``profile-all``
+      - ProfileOpts
+      - None
+      - Set profiling options to All, which adds tracing when entering and exiting a term.
+    
 
-   * - ``dump-uplc``
-     - Bool
-     - False
-     - Dump Untyped Plutus Core
+    * - ``remove-trace``
+      - Bool
+      - False
+      - Eliminate calls to ``trace`` from Plutus Core
+    
 
+    * - ``simplifier-beta``
+      - Bool
+      - True
+      - Run a simplification pass that performs beta transformations
+    
 
-   * - ``max-simplifier-iterations-pir``
-     - Int
-     - 12
-     - Set the max iterations for the PIR simplifier
+    * - ``simplifier-inline``
+      - Bool
+      - True
+      - Run a simplification pass that performs inlining
+    
 
-   * - ``max-simplifier-iterations-uplc``
-     - Int
-     - 12
-     - Set the max iterations for the UPLC simplifier
+    * - ``simplifier-remove-dead-bindings``
+      - Bool
+      - True
+      - Run a simplification pass that removes dead bindings
+    
 
+    * - ``simplifier-unwrap-cancel``
+      - Bool
+      - True
+      - Run a simplification pass that cancels unwrap/wrap pairs
+    
 
-   * - ``context-level``
-     - Int
-     - 1
-     - Set context level for error messages.
+    * - ``typecheck``
+      - Bool
+      - True
+      - Perform type checking during compilation.
+    
 
-
-   * - ``optimize``
-     - Bool
-     - True
-     - Run optimization passes such as simplification and floating let-bindings.
-
-
-   * - ``pedantic``
-     - Bool
-     - False
-     - Run type checker after each compilation pass
-
-
-   * - ``profile-all``
-     - ProfileOpts
-     - None
-     - Set profiling options to All, which adds tracing when entering and exiting a term.
-
-
-   * - ``remove-trace``
-     - Bool
-     - False
-     - Eliminate calls to ``trace`` from Plutus Core
-
-
-   * - ``simplifier-beta``
-     - Bool
-     - True
-     - Run a simplification pass that performs beta transformations
-
-
-   * - ``simplifier-inline``
-     - Bool
-     - True
-     - Run a simplification pass that performs inlining
-
-
-   * - ``simplifier-remove-dead-bindings``
-     - Bool
-     - True
-     - Run a simplification pass that removes dead bindings
-
-
-   * - ``simplifier-unwrap-cancel``
-     - Bool
-     - True
-     - Run a simplification pass that cancels unwrap/wrap pairs
-
-
-   * - ``typecheck``
-     - Bool
-     - True
-     - Perform type checking during compilation.
-
-
-   * - ``verbose``
-     - Bool
-     - False
-     - Set log level to verbose
-
+    * - ``verbosity``
+      - Verbosity
+      - Quiet
+      - Set logging verbosity level (0=Quiet, 1=Verbose, 2=Debug)
+    
 

--- a/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
+++ b/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
@@ -63,6 +63,6 @@ genRow k (O.PluginOption tr _ field desc) = [fmt|
      - {show tr}
      - {show (pretty defaultValue)}
      - {desc}
-    |]
+|]
     where
         defaultValue = O.defaultPluginOptions ^. field

--- a/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
+++ b/plutus-tx-plugin/app/GeneratePluginOptionsDoc.hs
@@ -59,10 +59,10 @@ optionsTable = [fmt|
 
 genRow :: O.OptionKey -> O.PluginOption -> Text
 genRow k (O.PluginOption tr _ field desc) = [fmt|
-    * - ``{k}``
-      - {show tr}
-      - {show (pretty defaultValue)}
-      - {desc}
+   * - ``{k}``
+     - {show tr}
+     - {show (pretty defaultValue)}
+     - {desc}
     |]
     where
         defaultValue = O.defaultPluginOptions ^. field

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -59,6 +59,16 @@ data CompileContext uni fun = CompileContext {
     ccBuiltinVer  :: PLC.BuiltinVersion fun
     }
 
+-- | Verbosity level of the Plutus Tx compiler.
+data Verbosity =
+    Quiet
+    | Verbose
+    | Debug
+    deriving stock (Eq, Show)
+
+instance Pretty Verbosity where
+    pretty = viaShow
+
 -- | Profiling options. @All@ profiles everything. @None@ is the default.
 data ProfileOpts =
     All -- set this with -fplugin-opt PlutusTx.Plugin:profile-all

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -43,8 +43,7 @@ data PluginOptions = PluginOptions
     , _posDumpUPlc                       :: Bool
     , _posOptimize                       :: Bool
     , _posPedantic                       :: Bool
-    , _posVerbose                        :: Bool
-    , _posDebug                          :: Bool
+    , _posVerbosity                      :: Verbosity
     , _posMaxSimplifierIterationsPir     :: Int
     , _posMaxSimplifierIterationsUPlc    :: Int
     , _posDoSimplifierUnwrapCancel       :: Bool
@@ -145,12 +144,13 @@ pluginOptions =
         , let k = "pedantic"
               desc = "Run type checker after each compilation pass"
            in (k, PluginOption typeRep (setTrue k) posPedantic desc)
-        , let k = "verbose"
-              desc = "Set log level to verbose"
-           in (k, PluginOption typeRep (setTrue k) posVerbose desc)
-        , let k = "debug"
-              desc = "Set log level to debug"
-           in (k, PluginOption typeRep (setTrue k) posDebug desc)
+        , let k = "verbosity"
+              desc = "Set logging verbosity level (0=Quiet, 1=Verbose, 2=Debug)"
+              toVerbosity v
+                  | v <= 0 = Quiet
+                  | v == 1 = Verbose
+                  | otherwise = Debug
+           in (k, PluginOption typeRep (fromIntOption k (Success. toVerbosity)) posVerbosity desc)
         , let k = "max-simplifier-iterations-pir"
               desc = "Set the max iterations for the PIR simplifier"
            in (k, PluginOption typeRep (intOption k) posMaxSimplifierIterationsPir desc)
@@ -199,6 +199,18 @@ intOption k = \case
         | otherwise -> Failure $ CannotParseValue k v (someTypeRep (Proxy @Int))
     Nothing -> Failure $ MissingValue k
 
+-- | Obtain an option value of type @a@ from an `Int`.
+fromIntOption ::
+    OptionKey ->
+    (Int -> Validation ParseError a) ->
+    Maybe OptionValue ->
+    Validation ParseError (a -> a)
+fromIntOption k f = \case
+    Just v
+        | Just i <- readMaybe (Text.unpack v) -> const <$> f i
+        | otherwise -> Failure $ CannotParseValue k v (someTypeRep (Proxy @Int))
+    Nothing -> Failure $ MissingValue k
+
 defaultPluginOptions :: PluginOptions
 defaultPluginOptions =
     PluginOptions
@@ -210,8 +222,7 @@ defaultPluginOptions =
         , _posDumpUPlc = False
         , _posOptimize = True
         , _posPedantic = False
-        , _posVerbose = False
-        , _posDebug = False
+        , _posVerbosity = Quiet
         , _posMaxSimplifierIterationsPir = view PIR.coMaxSimplifierIterations PIR.defaultCompilationOpts
         , _posMaxSimplifierIterationsUPlc = view UPLC.soMaxSimplifierIterations UPLC.defaultSimplifyOpts
         , _posDoSimplifierUnwrapCancel = True

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -397,8 +397,8 @@ runCompiler moduleName opts expr = do
         pirCtx = PIR.toDefaultCompilationCtx plcTcConfig
                  & set (PIR.ccOpts . PIR.coOptimize) (_posOptimize opts)
                  & set (PIR.ccOpts . PIR.coPedantic) (_posPedantic opts)
-                 & set (PIR.ccOpts . PIR.coVerbose) (_posVerbose opts)
-                 & set (PIR.ccOpts . PIR.coDebug) (_posDebug opts)
+                 & set (PIR.ccOpts . PIR.coVerbose) (_posVerbosity opts == Verbose)
+                 & set (PIR.ccOpts . PIR.coDebug) (_posVerbosity opts == Debug)
                  & set (PIR.ccOpts . PIR.coMaxSimplifierIterations) (_posMaxSimplifierIterationsPir opts)
                  & set PIR.ccTypeCheckConfig pirTcConfig
                  -- Simplifier options


### PR DESCRIPTION
Once we have the debugger, the `debug` option will be confusing - it could be thought of as the option for producing Plutus Core with SrcSpan annotations.