### PR TITLE
Make the debugger not buildable on windows

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -624,6 +624,11 @@ executable traceToStacks
 executable debugger
   import:         lang
   main-is:        Main.hs
+
+  -- brick does not work on windows
+  if os(windows)
+    buildable: False
+
   hs-source-dirs: executables/debugger
   other-modules:
     Draw


### PR DESCRIPTION
`brick` does not build there. Otherwise CI fails because it can't
resolve dependencies for the cross build.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
