### PR TITLE
PLT-458: Prototype of the debugger "backend"

### DIFF
--- a/plutus-core/common/Annotation.hs
+++ b/plutus-core/common/Annotation.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TypeFamilies   #-}
+-- GHC 8.10 wans about the derived MonoFoldable instance, GHC>=9.2 works fine
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+module Annotation
+    ( Ann (..)
+    , SrcSpan (..)
+    , SrcSpans (..)
+    , InlineHints (..)
+    , Inline (..)
+    , annAlwaysInline
+    , annMayInline
+    , Megaparsec.SourcePos (..)
+    , Megaparsec.Pos
+    , addSrcSpan
+    , lineInSrcSpan
+    ) where
+
+import Data.List qualified as List
+import Data.MonoTraversable
+import Data.Semigroup (Any (..))
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Flat (Flat (..))
+import GHC.Generics
+import Prettyprinter
+import Text.Megaparsec.Pos as Megaparsec
+
+newtype InlineHints name a = InlineHints { shouldInline :: a -> name -> Bool }
+    deriving (Semigroup, Monoid) via (a -> name -> Any)
+
+instance Show (InlineHints name a) where
+    show _ = "<inline hints>"
+
+-- | An annotation type used during the compilation.
+data Ann = Ann
+    { annInline   :: Inline
+    , annSrcSpans :: SrcSpans
+    }
+    deriving stock (Eq, Ord, Generic, Show)
+
+data Inline
+    = -- | When calling @PlutusIR.Compiler.Definitions.defineTerm@ to add a new term definition,
+      -- if we annotation the var on the LHS of the definition with `AlwaysInline`, the inliner will
+      -- always inline that var.
+      --
+      -- This is currently used to ensure builtin functions such as @trace@ (when the @remove-trace@
+      -- flag is on and @trace@ is rewritten to @const@) are inlined, because the inliner would
+      -- otherwise not inline them. To achieve that, we annotate the definition with `AlwaysInline`
+      -- when defining @trace@, i.e., @trace <AlwaysInline> = \_ a -> a@.
+      AlwaysInline
+    | MayInline
+    deriving stock (Eq, Ord, Generic, Show)
+
+instance Pretty Ann where
+    pretty = viaShow
+
+-- | Create an `Ann` with `AlwaysInline`.
+annAlwaysInline :: Ann
+annAlwaysInline = Ann{annInline = AlwaysInline, annSrcSpans = mempty}
+
+-- | Create an `Ann` with `MayInline`.
+annMayInline :: Ann
+annMayInline = Ann{annInline = MayInline, annSrcSpans = mempty}
+
+
+-- | The span between two source locations.
+--
+-- This corresponds roughly to the `SrcSpan` used by GHC,
+-- but we define our own version so we don't have to depend on `ghc` to use it.
+--
+-- The line and column numbers are 1-based, and the unit is Unicode code point (or `Char`).
+data SrcSpan = SrcSpan
+    { srcSpanFile  :: FilePath
+    , srcSpanSLine :: Int
+    , srcSpanSCol  :: Int
+    , srcSpanELine :: Int
+    , srcSpanECol  :: Int
+    }
+    deriving stock (Eq, Ord, Generic)
+    deriving anyclass (Flat)
+
+instance Show SrcSpan where
+    showsPrec _ s =
+        showString (srcSpanFile s)
+            . showChar ':'
+            . showsPrec 0 (srcSpanSLine s)
+            . showChar ':'
+            . showsPrec 0 (srcSpanSCol s)
+            . showChar '-'
+            . showsPrec 0 (srcSpanELine s)
+            . showChar ':'
+            . showsPrec 0 (srcSpanECol s)
+
+instance Pretty SrcSpan where
+    pretty = viaShow
+
+newtype SrcSpans = SrcSpans {unSrcSpans :: Set SrcSpan}
+    deriving newtype (Eq, Ord, Semigroup, Monoid, MonoFoldable)
+    deriving stock (Generic)
+    deriving anyclass (Flat)
+
+type instance Element SrcSpans = SrcSpan
+
+instance Show SrcSpans where
+    showsPrec _ (SrcSpans xs) =
+        showString "{ "
+            . showString
+                ( case Set.toList xs of
+                    [] -> "no-src-span"
+                    ys -> List.intercalate ", " (show <$> ys)
+                )
+            . showString " }"
+
+instance Pretty SrcSpans where
+    pretty = viaShow
+
+-- | Add an extra SrcSpan to existing 'SrcSpans' of 'Ann'
+addSrcSpan :: SrcSpan -> Ann -> Ann
+addSrcSpan s (Ann i (SrcSpans ss)) = Ann i (SrcSpans $ Set.insert s ss)
+
+-- | Tells if a line (positive integer) falls inside a SrcSpan.
+lineInSrcSpan :: Pos -> SrcSpan -> Bool
+lineInSrcSpan pos spn =
+    let i = Megaparsec.unPos pos
+    in i >= srcSpanSLine spn && i <= srcSpanELine spn

--- a/plutus-core/common/PlutusCore/InlineUtils.hs
+++ b/plutus-core/common/PlutusCore/InlineUtils.hs
@@ -1,9 +1,0 @@
-module PlutusCore.InlineUtils (InlineHints(..)) where
-
-import Data.Semigroup (Any (..))
-
-newtype InlineHints name a = InlineHints { shouldInline :: a -> name -> Bool }
-    deriving (Semigroup, Monoid) via (a -> name -> Any)
-
-instance Show (InlineHints name a) where
-    show _ = "<inline hints>"

--- a/plutus-core/executables/debugger/Event.hs
+++ b/plutus-core/executables/debugger/Event.hs
@@ -1,20 +1,44 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 -- | Handler of debugger events.
 module Event where
 
+import Annotation
 import Types
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 
 import Brick.Focus qualified as B
 import Brick.Main qualified as B
 import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
+import Control.Concurrent.MVar
 import Control.Monad.State
+import Data.MonoTraversable
 import Graphics.Vty qualified as Vty
 import Lens.Micro
 
-handleDebuggerEvent :: B.BrickEvent ResourceName e -> B.EventM ResourceName DebuggerState ()
-handleDebuggerEvent bev@(B.VtyEvent ev) = do
+type Breakpoints = [Breakpoint]
+data Breakpoint = UplcBP SourcePos
+                | TxBP SourcePos
+data DAnn = DAnn
+    { uplcAnn :: SourcePos
+    , txAnn   :: SrcSpans
+    }
+
+instance D.Breakpointable DAnn Breakpoints where
+    hasBreakpoints ann = any breakpointFired
+        where
+          breakpointFired :: Breakpoint -> Bool
+          breakpointFired = \case
+              UplcBP p -> sourceLine p == sourceLine (uplcAnn ann)
+              TxBP p   -> oany (lineInSrcSpan $ sourceLine p) $ txAnn ann
+
+handleDebuggerEvent :: MVar (D.Cmd Breakpoints)
+                    -> B.BrickEvent ResourceName e
+                    -> B.EventM ResourceName DebuggerState ()
+handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
     focusRing <- gets (^. dsFocusRing)
     let handleEditorEvent = case B.focusGetCurrent focusRing of
             Just EditorUplc ->
@@ -34,7 +58,12 @@ handleDebuggerEvent bev@(B.VtyEvent ev) = do
         Vty.EvKey (Vty.KChar '?') [] ->
             modify' $ set dsKeyBindingsMode KeyBindingsShown
         Vty.EvKey Vty.KEsc [] -> B.halt
-        Vty.EvKey (Vty.KChar 's') [] -> modify' $ \st ->
+        Vty.EvKey (Vty.KChar 's') [] -> do
+          _success <- liftIO $ tryPutMVar driverMailbox D.Step
+          -- MAYBE: when not success we could have a dialog show up
+          -- saying that the debugger seems to be stuck
+          -- and an option to kill its thread (cek) and reload the program?
+          modify' $ \st ->
             -- Stepping. Currently it highlights one line at a time.
             let highlightNextLine = \case
                     Nothing ->
@@ -42,6 +71,7 @@ handleDebuggerEvent bev@(B.VtyEvent ev) = do
                     Just (HighlightSpan (B.Location (r, c)) _) ->
                         Just (HighlightSpan (B.Location (r + 1, c)) Nothing)
              in st & dsUplcHighlight %~ highlightNextLine
+
         Vty.EvKey (Vty.KChar '\t') [] -> modify' $ \st ->
             st & dsFocusRing %~ B.focusNext
         Vty.EvKey Vty.KBackTab [] -> modify' $ \st ->
@@ -58,4 +88,4 @@ handleDebuggerEvent bev@(B.VtyEvent ev) = do
             -- This disables editing the text, making the editors read-only.
             pure ()
         _ -> handleEditorEvent
-handleDebuggerEvent _ = pure ()
+handleDebuggerEvent _ _ = pure ()

--- a/plutus-core/executables/debugger/Main.hs
+++ b/plutus-core/executables/debugger/Main.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ApplicativeDo     #-}
+{-# LANGUAGE ImplicitParams    #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE StrictData        #-}
@@ -13,19 +15,31 @@
 -}
 module Main (main) where
 
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
+import PlutusCore.Evaluation.Machine.MachineParameters
+import UntypedPlutusCore as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
+
 import Draw
 import Event
 import Types
 
 import Brick.AttrMap qualified as B
+import Brick.BChan qualified as B
 import Brick.Focus qualified as B
 import Brick.Main qualified as B
 import Brick.Util qualified as B
 import Brick.Widgets.Edit qualified as BE
+import Control.Concurrent
+import Control.Monad.Except
 import Control.Monad.Extra
+import Control.Monad.ST (RealWorld)
+import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Graphics.Vty qualified as Vty
 import Options.Applicative qualified as OA
+import PlutusPrelude
 import System.Directory.Extra
 
 debuggerAttrMap :: B.AttrMap
@@ -66,12 +80,17 @@ main = do
         "Does not exist or not a file: " <> optPath opts
     uplcText <- Text.readFile (optPath opts)
 
-    let app :: B.App DebuggerState e ResourceName
+    -- The communication "channels" at debugger-driver and at brick
+    driverMailbox <- newEmptyMVar @(D.Cmd Breakpoints)
+    -- chan size of 20 is used as default for builtin non-custom events (mouse,key,etc)
+    brickMailbox <- B.newBChan @CustomBrickEvent 20
+
+    let app :: B.App DebuggerState CustomBrickEvent ResourceName
         app =
             B.App
                 { B.appDraw = drawDebugger
                 , B.appChooseCursor = B.showFirstCursor
-                , B.appHandleEvent = handleDebuggerEvent
+                , B.appHandleEvent = handleDebuggerEvent driverMailbox
                 , B.appStartEvent = pure ()
                 , B.appAttrMap = const debuggerAttrMap
                 }
@@ -105,4 +124,50 @@ main = do
                 , _dsVLimitBottomEditors = 20
                 }
 
-    void $ B.defaultMain app initialState
+    let builder = Vty.mkVty Vty.defaultConfig
+    initialVty <- builder
+
+    -- TODO: find out if the driver-thread exits when brick exits
+    -- or should we wait for driver-thread?
+    _dTid <- forkIO $ driverThread driverMailbox brickMailbox uplcText
+
+    void $ B.customMain initialVty builder (Just brickMailbox) app initialState
+
+-- | The custom events that can arrive at our brick mailbox.
+data CustomBrickEvent =
+    UpdateClientEvent (D.CekState DefaultUni DefaultFun DAnn)
+    -- ^ the driver passes a new cek state to the brick client
+    -- this should mean that the brick client should update its tui
+  | LogEvent String
+    -- ^ the driver logged some text, the brick client can decide to show it in the tui
+
+
+-- | The main entrypoint of the driver thread.
+--
+-- The driver operates in IO (not in BrickM): the only way to "influence" Brick is via the mailboxes
+driverThread :: MVar (D.Cmd Breakpoints) -> B.BChan CustomBrickEvent -> Text.Text -> IO ()
+driverThread driverMailbox brickMailbox _uplcText = do
+    let term = undefined -- void $ prog ^. UPLC.progTerm
+        MachineParameters cekcosts cekruntime = PLC.defaultCekParameters
+    let ndterm = fromRight undefined $ runExcept @FreeVariableError $ deBruijnTerm term
+        emptySrcSpansNdDterm = fmap (undefined) ndterm
+    let ?cekRuntime = cekruntime
+        ?cekEmitter = const $ pure ()
+        ?cekBudgetSpender = CekBudgetSpender $ \_ _ -> pure ()
+        ?cekCosts = cekcosts
+        ?cekSlippage = defaultSlippage
+      in D.iterM handle $ D.runDriver emptySrcSpansNdDterm
+  where
+    -- | Peels off one Free monad layer
+    handle :: GivenCekReqs DefaultUni DefaultFun DAnn RealWorld
+           => D.DebugF DefaultUni DefaultFun DAnn Breakpoints (IO a)
+           -> IO a
+    handle = \case
+        D.StepF prevState k  -> cekMToIO (D.handleStep prevState) >>= k
+        D.InputF k           -> handleInput >>= k
+        D.LogF text k        -> handleLog text >> k
+        D.UpdateClientF ds k -> handleUpdate ds >> k -- TODO: implement
+      where
+        handleInput = takeMVar driverMailbox
+        handleUpdate = B.writeBChan brickMailbox . UpdateClientEvent
+        handleLog = B.writeBChan brickMailbox . LogEvent

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -64,6 +64,7 @@ common lang
 library
   import:          lang
   exposed-modules:
+    Annotation
     Crypto
     Data.ByteString.Hash
     Data.Either.Extras
@@ -187,6 +188,8 @@ library
     UntypedPlutusCore.DeBruijn
     UntypedPlutusCore.Evaluation.Machine.Cek
     UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver
+    UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
     UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     UntypedPlutusCore.MkUPlc
     UntypedPlutusCore.Parser
@@ -227,7 +230,6 @@ library
     PlutusCore.Default.Builtins
     PlutusCore.Default.Universe
     PlutusCore.Eq
-    PlutusCore.InlineUtils
     PlutusCore.Parser.Builtin
     PlutusCore.Parser.ParserCommon
     PlutusCore.Parser.Type
@@ -301,6 +303,7 @@ library
     , extra
     , filepath
     , flat                        <0.5
+    , free
     , ghc-prim
     , hashable                    >=1.4
     , hedgehog                    >=1.0
@@ -309,6 +312,7 @@ library
     , lens
     , megaparsec
     , mmorph
+    , mono-traversable
     , monoidal-containers
     , mtl
     , multiset
@@ -540,6 +544,7 @@ test-suite untyped-plutus-core-test
     Evaluation.Builtins.Definition
     Evaluation.Builtins.MakeRead
     Evaluation.Builtins.SignatureVerification
+    Evaluation.Debug
     Evaluation.FreeVars
     Evaluation.Golden
     Evaluation.Machines
@@ -587,7 +592,8 @@ executable uplc
   build-depends:
     , base                  >=4.9 && <5
     , deepseq
-    , lens
+    , haskeline
+    , mtl
     , optparse-applicative
     , plutus-core           ^>=1.1
     , plutus-core-execlib
@@ -645,8 +651,10 @@ executable debugger
     , extra
     , microlens
     , microlens-th
+    , mono-traversable
     , mtl
     , optparse-applicative
+    , plutus-core           ^>=1.1
     , text
     , vty
 

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -68,7 +68,7 @@ import GHC.Generics
 -- | A relative index used for de Bruijn identifiers.
 newtype Index = Index Word64
     deriving stock (Generic)
-    deriving newtype (Show, Num, Enum, Real, Integral, Eq, Ord, Pretty, NFData)
+    deriving newtype (Show, Num, Enum, Real, Integral, Eq, Ord, Pretty, NFData, Read)
 
 -- | The LamAbs index (for debruijn indices) and the starting level of DeBruijn monad
 deBruijnInitIndex :: Index
@@ -77,7 +77,7 @@ deBruijnInitIndex = 0
 -- The bangs gave us a speedup of 6%.
 -- | A term name as a de Bruijn index.
 data NamedDeBruijn = NamedDeBruijn { ndbnString :: !T.Text, ndbnIndex :: !Index }
-    deriving stock (Show, Generic)
+    deriving stock (Show, Generic, Read)
     deriving anyclass NFData
 
 -- | A wrapper around nameddebruijn that must hold the invariant of name=`fakeName`.

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Provenance.hs
@@ -16,7 +16,7 @@ import Prettyprinter qualified as PP
 -- | Indicates where a value comes from.
 --
 -- This is either an original annotation or a pieces of context explaining how the term
--- relates to a previous 'Provenance'. We also provide 'NoProvenance' for convenience.
+-- relates to a previous 'Provenance'. We also provide 'noProvenance' for convenience.
 --
 -- The provenance should always be just the original annotation, if we have one. It should only be another
 -- kind of provenance if we're in the process of generating some term that doesn't correspond directly to a term in

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -17,9 +17,9 @@ import Control.Monad.Reader
 
 import Control.Lens
 
+import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
-import PlutusCore.InlineUtils
 import PlutusCore.MkPlc qualified as PLC
 import PlutusCore.Pretty qualified as PLC
 import PlutusCore.Quote

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
@@ -20,9 +20,9 @@ import PlutusIR.Transform.Inline.Utils
 import PlutusIR.Transform.Rename ()
 import PlutusPrelude
 
+import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
-import PlutusCore.InlineUtils
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename (dupable, liftDupable)

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
@@ -16,8 +16,8 @@ import PlutusIR.Purity (firstEffectfulTerm, isPure)
 import PlutusIR.Transform.Rename ()
 import PlutusPrelude
 
+import Annotation
 import PlutusCore.Builtin qualified as PLC
-import PlutusCore.InlineUtils
 import PlutusCore.Name
 import PlutusCore.Quote
 import PlutusCore.Rename

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Driver.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Driver.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE LambdaCase             #-}
+module UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver
+    ( Breakpointable (..)
+    , CekState
+    , Cmd (..)
+    , DTerm
+    , runDriver
+    , DebugF (..)
+    -- | Reexport some functions for convenience
+    , handleStep
+    , F.MonadFree
+    , F.iterM
+    , F.iterTM
+    , F.partialIterT
+    , F.cutoff
+    , FreeT
+    ) where
+
+import UntypedPlutusCore
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
+
+import Control.Lens hiding (Context)
+import Control.Monad.Reader
+import Control.Monad.Trans.Free as F
+import Data.Function
+
+{- Note [Stepping the driver]
+
+The client instructs the driver to do a single step of the Cek (`Step` Cmd) or multiple steps until
+a condition is met (`Continue`,`Next`,`Finish`). The driver upon receiving a Command (via `inputF`)
+fires a series of `stepF` actions to fulfill the command. A `stepF` action is supposed to move the
+underlying CEK machine a *single* step forward. Since the driver is written as a free monad, the
+interpretation of the `stepF` action is left open.
+
+When the driver calls `stepF state`, it yields its coroutine with the current driver/cek state
+(before the stepping interpretation). The interpreter of `stepF` receives the currentState and
+calculates a newstate from it (e.g. **actually stepping the cek machine**). The interpreter then
+resumes the driver coroutine with the new state.
+
+The sensible interpretation to this is the CEK's state transition function (`handleStep oldState
+===> newState`), but other exotic options may be: logging the before/after states, or even
+"mutating" the running program's variables in the environment before/after the state transition
+(similar to C debuggers). The interpreter can even supply a different state transition function
+(e.g. `id`), but we see little benefit in it at the moment. Currently all interpreters
+(brick,repl,testing) just call`handleStep`.
+-}
+
+
+-- | Leave abstract the types of annotation and breakpoints.
+-- The only thing the driver requires is an inclusion relation of breakpoints into the Annotation
+class Breakpointable ann bps | ann -> bps where
+    -- MAYBE: we cannot know which breakpoint fired, return instead `Maybe Breakpoint`?
+    hasBreakpoints :: ann -> bps -> Bool
+
+-- | The `Term`s that makes sense to debug
+type DTerm uni fun ann = Term NamedDeBruijn uni fun ann
+
+-- | The commands that the driver may receive from the client (tui,cli,test,etc)
+data Cmd bps
+  = Step -- ^ Instruct the driver to a *SINGLE* step.
+         -- Note: No need to pass breakpoints here because the stepping granularity is *minimal*.
+  | Continue bps -- ^ Instruct to multi-step until end-of-program or until breakpoint reached
+  | Next bps -- ^ Instruct to multi-step over the function call at point or until breakpoint reached
+  | Finish bps -- ^ Instruct to multi-step to end of current function or until breakpoint reached
+  deriving stock (Show, Read)
+
+-- | The drivers's suspension functor
+data DebugF uni fun ann bps a
+   -- | Await for the client (e.g. TUI) to tell what to do next (Cmd).
+  = InputF (Cmd bps -> a)
+    -- | A generator of logging messages of the driver
+  | LogF String a
+    -- | An enumeratee of Driver State (generator+iteratee):
+    -- Yield a state before doing a step, then await for a state to resume after the step.
+    -- See Note [Stepping the driver].
+  | StepF
+      (CekState uni fun ann) -- ^ yield with the current driver's state before running a step
+      (CekState uni fun ann -> a) -- ^ resume back with a state after the step interpretation
+    -- | A generator of CekState to yield to client (e.g. TUI)
+  | UpdateClientF (CekState uni fun ann) a
+  deriving stock Functor
+
+-- | The monad that the driver operates in
+type Driving m uni fun ann bps =
+    ( MonadReader (CekState uni fun ann) m -- ^ the state of the debugger
+    , MonadFree (DebugF uni fun ann bps) m -- ^ the effects of the driver
+    , Breakpointable ann bps
+    )
+
+-- | Entrypoint of the driver
+runDriver :: forall uni fun ann bps m.
+            (Breakpointable ann bps, MonadFree (DebugF uni fun ann bps) m)
+          => DTerm uni fun ann -> m ()
+runDriver = void . runReaderT driver . initState
+    where
+      initState :: DTerm uni fun ann -> CekState uni fun ann
+      initState = Starting
+
+-- | The driver action. The driver repeatedly:
+---
+-- 1) waits for a `Cmd`
+-- 2) runs one or more CEK steps
+-- 3) informs the client for CEK updates&logs
+---
+-- The driver computation exits when it reaches a CEK `Terminating` state.
+driver :: Driving m uni fun ann bps => m ()
+driver = inputF >>= \case
+    -- Condition immediately satisfied
+    Step -> multiStepUntil $ const True
+
+    Continue bs -> multiStepUntil $ maybe False (`hasBreakpoints` bs) . cekStateAnn
+
+    Next bs -> do
+        startState <- ask
+        multiStepUntil $ \curState ->
+            maybe False (`hasBreakpoints` bs) (cekStateAnn curState)  ||
+            -- has activation record length been restored?
+            let leCtx = onCtxLen (<)
+            in curState `leCtx` startState
+
+    Finish bs -> do
+        startState <- ask
+        multiStepUntil $ \curState ->
+            maybe False (`hasBreakpoints` bs) (cekStateAnn curState) ||
+            -- has activation record length become smaller?
+            let ltCtx = onCtxLen (<=)
+            in curState `ltCtx` startState
+  where
+    -- | Comparison on states' contexts
+    onCtxLen :: (state ~ CekState uni fun ann
+               , ctxLen ~ Maybe Word -- `Maybe` because ctx can be missing if terminating
+               )
+             => (ctxLen -> ctxLen -> a)
+             -> state -> state -> a
+    onCtxLen = (`on` preview (cekStateContext . to lenContext))
+
+-- | Do one or more cek steps until Terminating state is reached or condition on 'CekState' is met.
+multiStepUntil :: Driving m uni fun ann bp
+               => (CekState uni fun ann -> Bool) -> m ()
+multiStepUntil cond = do
+    logF "Driver is going to do a single step"
+    newState <- stepF =<< ask
+    case newState of
+        Terminating{} ->
+            -- don't recurse to driver, but EXIT the driver
+            updateClientF newState
+        _ -> -- update state
+            local (const newState) $
+                if cond newState
+                then do
+                    updateClientF newState
+                    driver -- tail recurse
+                else
+                    multiStepUntil cond -- tail recurse
+
+-- * boilerplate "suspension actions"
+-- Being in 'Driving' monad here is too constraining, but it does not matter.
+inputF :: Driving m uni fun ann bps => m (Cmd bps)
+inputF = liftF $ InputF id
+logF :: Driving m uni fun ann bps => String -> m ()
+logF text = liftF $ LogF text ()
+updateClientF :: Driving m uni fun ann bps => CekState uni fun ann -> m ()
+updateClientF dState = liftF $ UpdateClientF dState ()
+stepF :: Driving m uni fun ann bps => CekState uni fun ann -> m (CekState uni fun ann)
+stepF yieldState = liftF $ StepF yieldState id

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
@@ -1,0 +1,420 @@
+-- editorconfig-checker-disable-file
+-- | The CEK machine.
+-- The CEK machine relies on variables having non-equal 'Unique's whenever they have non-equal
+-- string names. I.e. 'Unique's are used instead of string names. This is for efficiency reasons.
+-- The CEK machines handles name capture by design.
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE ImplicitParams        #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NPlusKPatterns        #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
+    ( CekState (..)
+    , Context (..)
+    , ioToCekM
+    , cekMToIO
+    , lenContext
+    , cekStateContext
+    , cekStateAnn
+    , runCekDeBruijn
+    , computeCek
+    , returnCek
+    , handleStep
+    , defaultSlippage
+    , module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    )
+where
+
+import PlutusCore.Builtin
+import PlutusCore.DeBruijn
+import PlutusCore.Evaluation.Machine.ExBudget
+import PlutusCore.Evaluation.Machine.Exception
+import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.Evaluation.Result
+import PlutusPrelude
+import UntypedPlutusCore.Core
+import UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts (CekMachineCosts (..))
+
+import Control.Lens hiding (Context, ix)
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.ST
+import Data.RandomAccessList.Class qualified as Env
+import Data.Semigroup (stimes)
+import Data.Text (Text)
+import Data.Word64Array.Word8 hiding (Index)
+import GHC.IO (ioToST)
+
+{- Note [Debuggable vs Original versions of CEK]
+
+The debuggable version of CEK was created from copying over the original CEK/Internal.hs module
+and modifying the `computeCek`, `returnCek` functions.
+These functions were modified so as to execute a single step (Compute or Return resp.) and immediately
+return with the CEK's machine new state (`CekState`), whereas previously these two functions would iteratively run to completion.
+
+The interface otherwise remains the same. Moreover, the `Original.runCekDeBruijn` and `Debug.runCekDeBruijn` must behave equivalently.
+-}
+import UntypedPlutusCore.Evaluation.Machine.Cek.Internal hiding (Context (..), runCekDeBruijn)
+
+data CekState uni fun ann =
+    -- loaded a term but not fired the cek yet
+    Starting (Term NamedDeBruijn uni fun ann)
+    -- the next state is computing
+    | Computing WordArray (Context uni fun ann) (CekValEnv uni fun ann) (Term NamedDeBruijn uni fun ann)
+    -- the next state is returning
+    | Returning WordArray (Context uni fun ann) (CekValue uni fun ann)
+    -- evaluation finished
+    | Terminating (Term NamedDeBruijn uni fun ())
+
+instance Pretty (CekState uni fun ann) where
+    pretty = \case
+        Starting{}    -> "Starting"
+        Computing{}   -> "Computing"
+        Returning{}   -> "Returning"
+        Terminating{} -> "Terminating"
+
+data Context uni fun ann
+    = FrameApplyFun ann !(CekValue uni fun ann) !(Context uni fun ann)                         -- ^ @[V _]@
+    | FrameApplyArg ann !(CekValEnv uni fun ann) !(Term NamedDeBruijn uni fun ann) !(Context uni fun ann) -- ^ @[_ N]@
+    | FrameForce ann !(Context uni fun ann)                                               -- ^ @(force _)@
+    | NoFrame
+    deriving stock (Show)
+
+computeCek
+    :: forall uni fun ann s
+    . (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => WordArray
+    -> Context uni fun ann
+    -> CekValEnv uni fun ann
+    -> Term NamedDeBruijn uni fun ann
+    -> CekM uni fun s (CekState uni fun ann)
+-- s ; ρ ▻ {L A}  ↦ s , {_ A} ; ρ ▻ L
+computeCek !unbudgetedSteps !ctx !env (Var _ varName) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BVar unbudgetedSteps
+    val <- lookupVarName varName env
+    pure $ Returning unbudgetedSteps' ctx val
+computeCek !unbudgetedSteps !ctx !_ (Constant _ val) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BConst unbudgetedSteps
+    pure $ Returning unbudgetedSteps' ctx (VCon val)
+computeCek !unbudgetedSteps !ctx !env (LamAbs _ name body) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BLamAbs unbudgetedSteps
+    pure $ Returning unbudgetedSteps' ctx (VLamAbs name body env)
+computeCek !unbudgetedSteps !ctx !env (Delay _ body) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BDelay unbudgetedSteps
+    pure $ Returning unbudgetedSteps' ctx (VDelay body env)
+-- s ; ρ ▻ lam x L  ↦  s ◅ lam x (L , ρ)
+computeCek !unbudgetedSteps !ctx !env (Force _ body) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BForce unbudgetedSteps
+    pure $ Computing unbudgetedSteps' (FrameForce (termAnn body) ctx) env body
+-- s ; ρ ▻ [L M]  ↦  s , [_ (M,ρ)]  ; ρ ▻ L
+computeCek !unbudgetedSteps !ctx !env (Apply _ fun arg) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BApply unbudgetedSteps
+    pure $ Computing unbudgetedSteps' (FrameApplyArg (termAnn fun) env arg ctx) env fun
+-- s ; ρ ▻ abs α L  ↦  s ◅ abs α (L , ρ)
+-- s ; ρ ▻ con c  ↦  s ◅ con c
+-- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] [] ρ
+computeCek !unbudgetedSteps !ctx !_ (Builtin _ bn) = do
+    !unbudgetedSteps' <- stepAndMaybeSpend BBuiltin unbudgetedSteps
+    let meaning = lookupBuiltin bn ?cekRuntime
+    -- 'Builtin' is fully discharged.
+    pure $ Returning unbudgetedSteps' ctx (VBuiltin bn (Builtin () bn) meaning)
+-- s ; ρ ▻ error A  ↦  <> A
+computeCek !_ !_ !_ (Error _) =
+    throwing_ _EvaluationFailure
+
+returnCek
+    :: forall uni fun ann s
+    . (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => WordArray
+    -> Context uni fun ann
+    -> CekValue uni fun ann
+    -> CekM uni fun s (CekState uni fun ann)
+--- Instantiate all the free variable of the resulting term in case there are any.
+-- . ◅ V           ↦  [] V
+returnCek !unbudgetedSteps NoFrame val = do
+    spendAccumulatedBudget unbudgetedSteps
+    pure $ Terminating (dischargeCekValue val)
+-- s , {_ A} ◅ abs α M  ↦  s ; ρ ▻ M [ α / A ]*
+returnCek !unbudgetedSteps (FrameForce _ ctx) fun = forceEvaluate unbudgetedSteps ctx fun
+-- s , [_ (M,ρ)] ◅ V  ↦  s , [V _] ; ρ ▻ M
+returnCek !unbudgetedSteps (FrameApplyArg _funAnn argVarEnv arg ctx) fun =
+    -- MAYBE: perhaps it is worth here to merge the _funAnn with argAnn
+    pure $ Computing unbudgetedSteps (FrameApplyFun (termAnn arg) fun ctx) argVarEnv arg
+-- s , [(lam x (M,ρ)) _] ◅ V  ↦  s ; ρ [ x  ↦  V ] ▻ M
+-- FIXME: add rule for VBuiltin once it's in the specification.
+returnCek !unbudgetedSteps (FrameApplyFun _ fun ctx) arg =
+    applyEvaluate unbudgetedSteps ctx fun arg
+
+-- | @force@ a term and proceed.
+-- If v is a delay then compute the body of v;
+-- if v is a builtin application then check that it's expecting a type argument,
+-- and either calculate the builtin application or stick a 'Force' on top of its 'Term'
+-- representation depending on whether the application is saturated or not,
+-- if v is anything else, fail.
+forceEvaluate
+    :: forall uni fun ann s
+    . (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => WordArray
+    -> Context uni fun ann
+    -> CekValue uni fun ann
+    -> CekM uni fun s (CekState uni fun ann)
+forceEvaluate !unbudgetedSteps !ctx (VDelay body env) =
+    pure $ Computing unbudgetedSteps ctx env body
+forceEvaluate !unbudgetedSteps !ctx (VBuiltin fun term runtime) = do
+    -- @term@ is fully discharged, and so @term'@ is, hence we can put it in a 'VBuiltin'.
+    let term' = Force (termAnn term) term
+    case runtime of
+        -- It's only possible to force a builtin application if the builtin expects a type
+        -- argument next.
+        BuiltinExpectForce runtime' -> do
+            -- We allow a type argument to appear last in the type of a built-in function,
+            -- otherwise we could just assemble a 'VBuiltin' without trying to evaluate the
+            -- application.
+            res <- evalBuiltinApp fun term' runtime'
+            pure $ Returning unbudgetedSteps ctx res
+        _ ->
+            throwingWithCause _MachineError BuiltinTermArgumentExpectedMachineError (Just term')
+forceEvaluate !_ !_ val =
+    throwingDischarged _MachineError NonPolymorphicInstantiationMachineError val
+
+-- | Apply a function to an argument and proceed.
+-- If the function is a lambda 'lam x ty body' then extend the environment with a binding of @v@
+-- to x@ and call 'computeCek' on the body.
+-- If the function is a builtin application then check that it's expecting a term argument,
+-- and either calculate the builtin application or stick a 'Apply' on top of its 'Term'
+-- representation depending on whether the application is saturated or not.
+-- If v is anything else, fail.
+applyEvaluate
+    :: forall uni fun ann s
+    . (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => WordArray
+    -> Context uni fun ann
+    -> CekValue uni fun ann   -- lhs of application
+    -> CekValue uni fun ann   -- rhs of application
+    -> CekM uni fun s (CekState uni fun ann)
+applyEvaluate !unbudgetedSteps !ctx (VLamAbs _ body env) arg =
+    pure $ Computing unbudgetedSteps ctx (Env.cons arg env) body
+-- Annotating @f@ and @exF@ with bangs gave us some speed-up, but only until we added a bang to
+-- 'VCon'. After that the bangs here were making things a tiny bit slower and so we removed them.
+applyEvaluate !unbudgetedSteps !ctx (VBuiltin fun term runtime) arg = do
+    let argTerm = dischargeCekValue arg
+        -- @term@ and @argTerm@ are fully discharged, and so @term'@ is, hence we can put it
+        -- in a 'VBuiltin'.
+        term' = Apply (termAnn term) term argTerm
+    case runtime of
+        -- It's only possible to apply a builtin application if the builtin expects a term
+        -- argument next.
+        BuiltinExpectArgument f -> do
+            res <- evalBuiltinApp fun term' $ f arg
+            pure $ Returning unbudgetedSteps ctx res
+        _ ->
+            throwingWithCause _MachineError UnexpectedBuiltinTermArgumentMachineError (Just term')
+applyEvaluate !_ !_ val _ =
+    throwingDischarged _MachineError NonFunctionalApplicationMachineError val
+
+-- MAYBE: runCekDeBruijn can be shared between original&debug ceks by passing a `enterComputeCek` func.
+runCekDeBruijn
+    :: (PrettyUni uni fun)
+    => MachineParameters CekMachineCosts CekValue uni fun ann
+    -> ExBudgetMode cost uni fun
+    -> EmitterMode uni fun
+    -> Term NamedDeBruijn uni fun ann
+    -> (Either (CekEvaluationException NamedDeBruijn uni fun) (Term NamedDeBruijn uni fun ()), cost, [Text])
+runCekDeBruijn params mode emitMode term =
+    runCekM params mode emitMode $ do
+        spendBudgetCek BStartup (cekStartupCost ?cekCosts)
+        enterComputeCek NoFrame Env.empty term
+
+-- See Note [Compilation peculiarities].
+-- | The entering point to the CEK machine's engine.
+enterComputeCek
+    :: forall uni fun ann s
+    . (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => Context uni fun ann
+    -> CekValEnv uni fun ann
+    -> Term NamedDeBruijn uni fun ann
+    -> CekM uni fun s (Term NamedDeBruijn uni fun ())
+enterComputeCek ctx env term = iterToFinalState $ Computing (toWordArray 0) ctx env term
+ where
+   iterToFinalState :: CekState uni fun ann -> CekM uni fun s (Term NamedDeBruijn uni fun ())
+   iterToFinalState = handleStep
+                      >=>
+                      \case
+                          Terminating t -> pure t
+                          x             -> iterToFinalState x
+
+-- | The state transition function of the machine.
+handleStep :: forall uni fun ann s.
+             (PrettyUni uni fun, GivenCekReqs uni fun ann s)
+           => CekState uni fun ann
+           -> CekM uni fun s (CekState uni fun ann)
+handleStep = \case
+    Starting term                           ->  pure $ Computing (toWordArray 0) NoFrame Env.empty term
+    Computing !unbudgetedSteps ctx env term -> computeCek unbudgetedSteps ctx env term
+    Returning !unbudgetedSteps ctx val      -> returnCek unbudgetedSteps ctx val
+    self@(Terminating _)                    -> pure self -- FINAL STATE, idempotent
+
+-- * Helpers
+------------
+
+ioToCekM :: IO a -> CekM uni fun RealWorld a
+ioToCekM = CekM . ioToST
+
+cekMToIO :: CekM uni fun RealWorld a -> IO a
+cekMToIO = stToIO . unCekM
+
+cekStateContext :: Traversal' (CekState uni fun ann) (Context uni fun ann)
+cekStateContext f = \case
+    Computing w k e t -> (\k' -> Computing w k' e t) <$> f k
+    Returning w k v   -> Returning w `flip` v <$> f k
+    x                 -> pure x
+
+cekStateAnn :: CekState uni fun ann -> Maybe ann
+cekStateAnn = \case
+    Computing _ _ _ t -> pure $ termAnn t
+    Returning _ ctx _ -> contextAnn ctx
+    Terminating{}     -> empty
+    Starting t        -> pure $ termAnn t -- TODO: not sure if we want the annotation here
+
+contextAnn :: Context uni fun ann -> Maybe ann
+contextAnn = \case
+  FrameApplyFun ann _ _   -> pure ann
+  FrameApplyArg ann _ _ _ -> pure ann
+  FrameForce ann _        -> pure ann
+  NoFrame                 -> empty
+
+lenContext :: Context uni fun ann -> Word
+lenContext = go 0
+    where
+      go :: Word -> Context uni fun ann -> Word
+      go !n = \case
+              FrameApplyFun _ _ k   -> go (n+1) k
+              FrameApplyArg _ _ _ k -> go (n+1) k
+              FrameForce _ k        -> go (n+1) k
+              NoFrame               -> 0
+
+
+-- * Duplicated functions from Cek.Internal module
+-- FIXME: share these functions with Cek.Internal
+-- preliminary testing shows that sharing slows down original cek
+
+-- | A 'MonadError' version of 'try'.
+tryError :: MonadError e m => m a -> m (Either e a)
+tryError a = (Right <$> a) `catchError` (pure . Left)
+
+cekStepCost :: CekMachineCosts -> StepKind -> ExBudget
+cekStepCost costs = \case
+    BConst   -> cekConstCost costs
+    BVar     -> cekVarCost costs
+    BLamAbs  -> cekLamCost costs
+    BApply   -> cekApplyCost costs
+    BDelay   -> cekDelayCost costs
+    BForce   -> cekForceCost costs
+    BBuiltin -> cekBuiltinCost costs
+
+-- | Call 'dischargeCekValue' over the received 'CekVal' and feed the resulting 'Term' to
+-- 'throwingWithCause' as the cause of the failure.
+throwingDischarged
+    :: PrettyUni uni fun
+    => AReview (EvaluationError CekUserError (MachineError fun)) t
+    -> t
+    -> CekValue uni fun ann
+    -> CekM uni fun s x
+throwingDischarged l t = throwingWithCause l t . Just . dischargeCekValue
+
+-- See Note [Cost slippage]
+-- | The default number of slippage (in machine steps) to allow.
+defaultSlippage :: Slippage
+defaultSlippage = 200
+
+runCekM
+    :: forall a cost uni fun ann.
+    (PrettyUni uni fun)
+    => MachineParameters CekMachineCosts CekValue uni fun ann
+    -> ExBudgetMode cost uni fun
+    -> EmitterMode uni fun
+    -> (forall s. GivenCekReqs uni fun ann s => CekM uni fun s a)
+    -> (Either (CekEvaluationException NamedDeBruijn uni fun) a, cost, [Text])
+runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) (EmitterMode getEmitterMode) a = runST $ do
+    ExBudgetInfo{_exBudgetModeSpender, _exBudgetModeGetFinal, _exBudgetModeGetCumulative} <- getExBudgetInfo
+    CekEmitterInfo{_cekEmitterInfoEmit, _cekEmitterInfoGetFinal} <- getEmitterMode _exBudgetModeGetCumulative
+    let ?cekRuntime = runtime
+        ?cekEmitter = _cekEmitterInfoEmit
+        ?cekBudgetSpender = _exBudgetModeSpender
+        ?cekCosts = costs
+        ?cekSlippage = defaultSlippage
+    errOrRes <- unCekM $ tryError a
+    st <- _exBudgetModeGetFinal
+    logs <- _cekEmitterInfoGetFinal
+    pure (errOrRes, st, logs)
+
+-- | Look up a variable name in the environment.
+lookupVarName :: forall uni fun ann s . (PrettyUni uni fun) => NamedDeBruijn -> CekValEnv uni fun ann -> CekM uni fun s (CekValue uni fun ann)
+lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
+    case varEnv `Env.indexOne` coerce varIx of
+        Nothing  -> throwingWithCause _MachineError OpenTermEvaluatedMachineError $ Just var where
+            var = Var () varName
+        Just val -> pure val
+
+-- | Take pieces of a possibly partial builtin application and either create a 'CekValue' using
+-- 'makeKnown' or a partial builtin application depending on whether the built-in function is
+-- fully saturated or not.
+evalBuiltinApp
+    :: (GivenCekReqs uni fun ann s, PrettyUni uni fun)
+    => fun
+    -> Term NamedDeBruijn uni fun ()
+    -> BuiltinRuntime (CekValue uni fun ann)
+    -> CekM uni fun s (CekValue uni fun ann)
+evalBuiltinApp fun term runtime = case runtime of
+    BuiltinResult cost getX -> do
+        spendBudgetCek (BBuiltinApp fun) cost
+        case getX of
+            MakeKnownFailure logs err       -> do
+                ?cekEmitter logs
+                throwKnownTypeErrorWithCause term err
+            MakeKnownSuccess x              -> pure x
+            MakeKnownSuccessWithLogs logs x -> ?cekEmitter logs $> x
+    _ -> pure $ VBuiltin fun term runtime
+{-# INLINE evalBuiltinApp #-}
+
+spendBudgetCek :: GivenCekSpender uni fun s => ExBudgetCategory fun -> ExBudget -> CekM uni fun s ()
+spendBudgetCek = let (CekBudgetSpender spend) = ?cekBudgetSpender in spend
+
+-- | Spend the budget that has been accumulated for a number of machine steps.
+--
+spendAccumulatedBudget :: (GivenCekReqs uni fun ann s) => WordArray -> CekM uni fun s ()
+spendAccumulatedBudget !unbudgetedSteps = iforWordArray unbudgetedSteps spend
+  where
+    -- Making this a definition of its own causes it to inline better than actually writing it inline, for
+    -- some reason.
+    -- Skip index 7, that's the total counter!
+    -- See Note [Structure of the step counter]
+    {-# INLINE spend #-}
+    spend !i !w = unless (i == 7) $ let kind = toEnum i in spendBudgetCek (BStep kind) (stimes w (cekStepCost ?cekCosts kind))
+
+-- | Accumulate a step, and maybe spend the budget that has accumulated for a number of machine steps, but only if we've exceeded our slippage.
+--
+stepAndMaybeSpend :: (GivenCekReqs uni fun ann s) => StepKind -> WordArray -> CekM uni fun s WordArray
+stepAndMaybeSpend !kind !unbudgetedSteps = do
+    -- See Note [Structure of the step counter]
+    -- This generates let-expressions in GHC Core, however all of them bind unboxed things and
+    -- so they don't survive further compilation, see https://stackoverflow.com/a/14090277
+    let !ix = fromIntegral $ fromEnum kind
+        !unbudgetedSteps' = overIndex 7 (+1) $ overIndex ix (+1) unbudgetedSteps
+        !unbudgetedStepsTotal = readArray unbudgetedSteps' 7
+    -- There's no risk of overflow here, since we only ever increment the total
+    -- steps by 1 and then check this condition.
+    if unbudgetedStepsTotal >= ?cekSlippage
+    then spendAccumulatedBudget unbudgetedSteps' >> pure (toWordArray 0)
+    else pure unbudgetedSteps'
+

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -30,9 +30,9 @@ import UntypedPlutusCore.Core.Type
 import UntypedPlutusCore.MkUPlc
 import UntypedPlutusCore.Rename ()
 
+import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
-import PlutusCore.InlineUtils
 import PlutusCore.Name
 import PlutusCore.Quote
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE ImplicitParams        #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists       #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+
+module Evaluation.Debug
+    ( test_debug
+    ) where
+
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+import PlutusCore.Evaluation.Machine.MachineParameters
+import UntypedPlutusCore
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
+
+import Control.Monad.RWS
+import Control.Monad.ST (RealWorld)
+import Data.ByteString.Lazy.Char8 qualified as BS
+import Data.Void
+import Prettyprinter
+import Test.Tasty
+import Test.Tasty.Golden
+
+test_debug :: TestTree
+test_debug = testGroup "debug" $
+    fmap goldenVsDebug examples
+
+-- i am not testing breakpoint functionality at the moment
+type Breakpoints = Void
+newtype EmptyAnn = EmptyAnn ()
+    deriving newtype (Semigroup, Monoid)
+instance Breakpointable EmptyAnn Breakpoints where
+    hasBreakpoints _ = absurd
+
+examples :: [(String, [Cmd Breakpoints], DTerm DefaultUni DefaultFun EmptyAnn)]
+examples = [
+             ("ex1", repeat Step, Delay mempty $ Error mempty)
+           , ("ex2", replicate 4 Step, Force mempty $ Delay mempty $ Error mempty)
+           -- TODO: these break because they throw IO exception
+           -- , ("ex4", replicate 5 Step, Force mempty $ Delay mempty $ Error mempty)
+           -- , ("ex1", repeat Step, Error mempty)
+           ]
+
+goldenVsDebug :: (TestName, [Cmd Breakpoints], DTerm DefaultUni DefaultFun EmptyAnn) -> TestTree
+goldenVsDebug (name, cmds, term) =
+    goldenVsString name
+    ("untyped-plutus-core/test/Evaluation/Debug/" ++ name ++ ".golden")
+    (BS.pack . unlines <$> mock cmds term)
+
+-- A Mocking interpreter
+
+mock :: [Cmd Breakpoints] -- ^ commands to feed
+     -> DTerm DefaultUni DefaultFun EmptyAnn -- ^ term to debug
+     -> IO [String] -- ^ mocking output
+mock cmds = cekMToIO . runMocking . runDriver
+    where
+      MachineParameters cekCosts cekRuntime = defaultCekParameters
+
+      runMocking :: (m ~ CekM DefaultUni DefaultFun RealWorld)
+                 => FreeT (DebugF DefaultUni DefaultFun EmptyAnn Breakpoints) m ()
+                 -> m [String]
+      runMocking driver =
+          let ?cekRuntime = cekRuntime
+              ?cekEmitter = const $ pure ()
+              ?cekBudgetSpender = CekBudgetSpender $ \_ _ -> pure ()
+              ?cekCosts = cekCosts
+              ?cekSlippage = defaultSlippage
+          in
+              -- MAYBE: use cutoff or partialIterT to prevent runaway
+              fmap snd $ execRWST (iterTM handle driver) cmds ()
+
+-- Interpretation of the mocker
+-------------------------------
+
+type Mocking uni fun t m = ( PrettyUni uni fun, GivenCekReqs uni fun EmptyAnn RealWorld
+                           , MonadTrans t
+                           -- | the mock client feeds commands
+                           , MonadReader [Cmd Breakpoints] (t m)
+                           -- | and logs to some string output
+                           , MonadWriter [String] (t m)
+                           )
+
+handle :: ( Mocking uni fun t m
+         , m ~ CekM uni fun RealWorld
+         )
+       => DebugF uni fun EmptyAnn Breakpoints (t m ()) -> t m ()
+handle = \case
+    StepF prevState k -> do
+        newState <- lift (handleStep prevState)
+        tell [show $ "OldState:" <+> pretty prevState <+> "NewState:" <+> pretty newState]
+        k newState
+    InputF k          -> handleInput k
+    LogF text k       -> handleLog text >> k
+    UpdateClientF _ k -> k -- ignore
+  where
+
+    -- more general as :: (MonadReader [Cmd] m, MonadWriter [String] m) => (Cmd -> m ()) -> m ()
+    handleInput :: Mocking uni fun t m => (Cmd Breakpoints -> t m ()) -> t m ()
+    handleInput k = do
+        cmds <- ask
+        case cmds of
+            [] ->
+                tell ["Early run out of commands"]
+            (cmd:cmds') ->
+                local (const cmds') $
+                    -- continue by feeding the next command to continuation
+                    k cmd
+
+    -- more general as handleLog :: (MonadWriter [String] m) => String -> m ()
+    handleLog :: Mocking uni fun t m => String -> t m ()
+    handleLog = tell . pure

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex1.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex1.golden
@@ -1,0 +1,6 @@
+Driver is going to do a single step
+OldState: Starting NewState: Computing
+Driver is going to do a single step
+OldState: Computing NewState: Returning
+Driver is going to do a single step
+OldState: Returning NewState: Terminating

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex2.golden
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Debug/ex2.golden
@@ -1,0 +1,9 @@
+Driver is going to do a single step
+OldState: Starting NewState: Computing
+Driver is going to do a single step
+OldState: Computing NewState: Computing
+Driver is going to do a single step
+OldState: Computing NewState: Returning
+Driver is going to do a single step
+OldState: Returning NewState: Computing
+Early run out of commands

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -7,6 +7,7 @@ import GHC.IO.Encoding (setLocaleEncoding, utf8)
 
 import DeBruijn.Spec (test_debruijn)
 import Evaluation.Builtins (test_builtins)
+import Evaluation.Debug (test_debug)
 import Evaluation.FreeVars (test_freevars)
 import Evaluation.Golden (test_golden)
 import Evaluation.Machines
@@ -29,6 +30,7 @@ main = do
     , test_debruijn
     , test_freevars
     , test_parsing
+    , test_debug
     , schnorrVerifyRegressions
     ]
 

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -59,7 +59,6 @@ library
     PlutusTx.Plugin
 
   other-modules:
-    PlutusTx.Annotation
     PlutusTx.Compiler.Binders
     PlutusTx.Compiler.Builtins
     PlutusTx.Compiler.Expr

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -26,7 +26,6 @@ import GHC.Types.Id.Make qualified as GHC
 import GHC.Types.Tickish qualified as GHC
 import GHC.Types.TyThing qualified as GHC
 import PlutusTx.Builtins qualified as Builtins
-import PlutusTx.Code
 import PlutusTx.Compiler.Binders
 import PlutusTx.Compiler.Builtins
 import PlutusTx.Compiler.Error

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -3,14 +3,13 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types        #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module PlutusTx.Compiler.Types (
     module PlutusTx.Compiler.Types,
-    module PlutusTx.Annotation
+    module Annotation
     ) where
 
 import PlutusTx.Compiler.Error
@@ -19,10 +18,10 @@ import PlutusTx.PLCTypes
 
 import PlutusIR.Compiler.Definitions
 
+import Annotation
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Default qualified as PLC
 import PlutusCore.Quote
-import PlutusTx.Annotation
 
 import GHC qualified
 import GHC.Core.FamInstEnv qualified as GHC

--- a/plutus-tx-plugin/src/PlutusTx/PIRTypes.hs
+++ b/plutus-tx-plugin/src/PlutusTx/PIRTypes.hs
@@ -1,8 +1,7 @@
 module PlutusTx.PIRTypes where
 
+import Annotation
 import PlutusIR qualified as PIR
-import PlutusTx.Annotation
-import PlutusTx.Code
 
 type PIRKind = PIR.Kind Ann
 type PIRType uni = PIR.Type PIR.TyName uni Ann

--- a/plutus-tx-plugin/src/PlutusTx/PLCTypes.hs
+++ b/plutus-tx-plugin/src/PlutusTx/PLCTypes.hs
@@ -1,9 +1,8 @@
 module PlutusTx.PLCTypes where
 
+import Annotation
 import PlutusCore qualified as PLC
 import PlutusCore.MkPlc qualified as PLC
-import PlutusTx.Annotation
-import PlutusTx.Code
 import UntypedPlutusCore qualified as UPLC
 
 type PLCKind = PLC.Kind Ann

--- a/plutus-tx/src/PlutusTx/Code.hs
+++ b/plutus-tx/src/PlutusTx/Code.hs
@@ -18,68 +18,16 @@ import PlutusTx.Coverage
 import PlutusTx.Lift.Instances ()
 import UntypedPlutusCore qualified as UPLC
 
+import Annotation
 import Control.Exception
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Functor (void)
-import Data.List qualified as List
-import Data.Set (Set)
-import Data.Set qualified as Set
 import ErrorCode
 import Flat (Flat (..), unflat)
 import Flat.Decoder (DecodeException)
-import GHC.Generics
 -- We do not use qualified import because the whole module contains off-chain code
 import Prelude as Haskell
-import Prettyprinter
-
--- | The span between two source locations.
---
--- This corresponds roughly to the `SrcSpan` used by GHC, but we define our own version so we don't have to depend on `ghc` to use it.
---
--- The line and column numbers are 1-based, and the unit is Unicode code point (or `Char`).
-data SrcSpan = SrcSpan
-    { srcSpanFile  :: FilePath
-    , srcSpanSLine :: Int
-    , srcSpanSCol  :: Int
-    , srcSpanELine :: Int
-    , srcSpanECol  :: Int
-    }
-    deriving stock (Eq, Ord, Generic)
-    deriving anyclass (Flat)
-
-instance Show SrcSpan where
-    showsPrec _ s =
-        showString (srcSpanFile s)
-            . showChar ':'
-            . showsPrec 0 (srcSpanSLine s)
-            . showChar ':'
-            . showsPrec 0 (srcSpanSCol s)
-            . showChar '-'
-            . showsPrec 0 (srcSpanELine s)
-            . showChar ':'
-            . showsPrec 0 (srcSpanECol s)
-
-instance Pretty SrcSpan where
-    pretty = viaShow
-
-newtype SrcSpans = SrcSpans {unSrcSpans :: Set SrcSpan}
-    deriving newtype (Eq, Ord, Semigroup, Monoid)
-    deriving stock (Generic)
-    deriving anyclass (Flat)
-
-instance Show SrcSpans where
-    showsPrec _ (SrcSpans xs) =
-        showString "{ "
-            . showString
-                ( case Set.toList xs of
-                    [] -> "no-src-span"
-                    ys -> List.intercalate ", " (show <$> ys)
-                )
-            . showString " }"
-
-instance Pretty SrcSpans where
-    pretty = viaShow
 
 -- The final type parameter is inferred to be phantom, but we give it a nominal
 -- role, since it corresponds to the Haskell type of the program that was compiled into


### PR DESCRIPTION
Prototype of the debugger backend. 

1) the `CEK.Internal` is duplicated  to `Cek.Debug.Internal` and the recursive step functions are modified to immediately stop and return a `CekState`.
2) An adapter/driver (written as free-monad) wraps the `Cek.Debug.Internal` : the adapter receives `Command`s from the debug-client and steps the CEK forward (one or more times).
3) A client feeds commands to the adapter and interprets the adapter's free monad actions.

Three different debug-clients are written:  MOCK for testing,  CLI connected to uplc executable, and BRICK for curses style debugging.

The input terms of the `Cek.Internal` and `Cek.Debug.Internal` remain agnostic of the input's `ann`otations.
The adapter that sits on top of `Cek.Debug.Internal` constrains this `ann` by `Breakpointable ann breakpoints =>` to leave abstract the location of breakpoints.

E.g. Mock client does not use breakpoints at all `type Breakpoints = Void` , the CLI uses breakpoints of `UPLC.SourcePos`, and the Brick client can use both a `UPLC.SourcePos` and a `Tx.SourcePos` as a breakpoint.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
