### PR TITLE
deleted cross-reference to technical report that doesn't yet contain …

### DIFF
--- a/doc/read-the-docs-site/reference/cardano/cost-model-parameters.rst
+++ b/doc/read-the-docs-site/reference/cardano/cost-model-parameters.rst
@@ -7,8 +7,6 @@ The cost model for Plutus Core scripts has a number of parameters.
 These are listed and briefly described below.
 All of these parameters are listed in the Cardano protocol parameters and can be individually adjusted.
 
-For more details on the meaning of the parameters, consult :cite:t:`plutus-report`.
-
 .. csv-table:: Machine parameters
    :file: ./machine-parameters.csv
    :widths: 20, 30, 40


### PR DESCRIPTION
…cost model information

I've verified the accuracy of this page with Plutus Core team members. The only change is to remove a cross-reference from the top part of the page that points to the technical report that does not yet contain any information about the cost model. 

