### PR TITLE
Update `getSourceSpan`

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -874,13 +874,14 @@ getSourceSpan _ GHC.ProfNote{GHC.profNoteCC=cc} =
     GHC.NormalCC _ _ _ (GHC.RealSrcSpan sp _) -> Just sp
     GHC.AllCafsCC _ (GHC.RealSrcSpan sp _)    -> Just sp
     _                                         -> Nothing
-getSourceSpan mmb GHC.HpcTick{GHC.tickId=tid} = do
+getSourceSpan mmb GHC.Breakpoint{GHC.breakpointId=bid} = do
   mb <- mmb
   let arr = GHC.modBreaks_locs mb
       range = Array.bounds arr
-  GHC.RealSrcSpan sp _ <- if Array.inRange range tid  then Just $ arr Array.! tid else Nothing
+  GHC.RealSrcSpan sp _ <- if Array.inRange range bid  then Just $ arr Array.! bid else Nothing
   return sp
-getSourceSpan _ _ = Nothing
+-- The `HpcTick` case requires reading mix files via `Trace.Hpc.Mix.readMix`.
+getSourceSpan _ GHC.HpcTick{} = Nothing
 
 -- | Obviously this function computes a GHC.RealSrcSpan from a CovLoc
 toCovLoc :: GHC.RealSrcSpan -> CovLoc


### PR DESCRIPTION
It should look at `ModBreaks` in the `Breakpoint` case, not the `HpcTick` case.