### PR TITLE
PLT-1319 Fix TestSimple to actually work

### DIFF
--- a/plutus-metatheory/src/Algorithmic/Evaluation.lagda
+++ b/plutus-metatheory/src/Algorithmic/Evaluation.lagda
@@ -83,6 +83,6 @@ stepper : {A : ∅ ⊢Nf⋆ *} → ∅ ⊢ A → ℕ → Either RuntimeError (�
 stepper {A} t n with eval (gas n) t
 ... | steps x (done t' v) = return t'
 ... | steps x out-of-gas  = inj₁ gasError
-... | steps x (error _)   = inj₁ userError
+... | steps x (error _)   = return (error A)
 
 \end{code}

--- a/plutus-metatheory/src/Algorithmic/Evaluation.lagda
+++ b/plutus-metatheory/src/Algorithmic/Evaluation.lagda
@@ -83,6 +83,6 @@ stepper : {A : ∅ ⊢Nf⋆ *} → ∅ ⊢ A → ℕ → Either RuntimeError (�
 stepper {A} t n with eval (gas n) t
 ... | steps x (done t' v) = return t'
 ... | steps x out-of-gas  = inj₁ gasError
-... | steps x (error _)   = return (error A)
+... | steps x (error _)   = inj₁ userError
 
 \end{code}

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -261,6 +261,11 @@ reportError (runtimeError gasError)         = "gasError"
 reportError (runtimeError userError)        = "userError"
 reportError (runtimeError runtimeTypeError) = "runtimeTypeError"
 
+
+{- check if the term is an error term, and in that case 
+  return an ERROR. 
+  This is used when evaluation of the reduction semantics has ended
+-}
 checkError : ∀{A} → ∅ ⊢ A → Either ERROR (∅ ⊢ A )
 checkError (error _) = inj₁ (runtimeError userError)
 checkError t         = return t

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -11,6 +11,7 @@ import System.Process
 
 import MAlonzo.Code.Main qualified as M
 
+-- |List of tests that are expected to succeed
 succeedingEvalTests = ["succInteger"
         ,"unitval"
         ,"true"
@@ -27,21 +28,23 @@ succeedingEvalTests = ["succInteger"
         ,"ApplyAdd2"
         ]
 
+-- |List of tests that are expected to fail
 failingEvalTests = ["DivideByZero"]
 
 type Mode = String
 data Command = Evaluate Mode | Typecheck deriving Show
 
--- For each Command construct arguments to pass to plc-agda
+-- |For each Command construct arguments to pass to plc-agda
 mkArgs :: String -> Command -> [String]
 mkArgs file (Evaluate mode) = ["evaluate","--input",file,"--mode",mode]
 mkArgs file Typecheck       = ["typecheck","--input",file]
 
--- For each Command determine which executable should generate examples
+-- |For each Command determine which executable should generate examples
 exampleGenerator :: Command -> String
 exampleGenerator (Evaluate "U") = "uplc"
 exampleGenerator _              = "plc"
 
+-- |@runTest cmd tst@ generates a @tst@ example and run it with the given @cmd@.
 runTest :: Command -> String -> IO ()
 runTest command test = withTempFile $ \tmp -> do
   example <- readProcess (exampleGenerator command) ["example", "-s",test] []
@@ -49,6 +52,7 @@ runTest command test = withTempFile $ \tmp -> do
   putStrLn $ "test: " ++ test ++ " [" ++ show command ++ "]"
   withArgs (mkArgs tmp command) M.main
 
+-- |Run a list of tests with a given command expecting them to succeed.
 runSucceedingTests :: Command -> [String] -> IO ()
 runSucceedingTests command [] = return ()
 runSucceedingTests command (test:tests) = catch
@@ -57,6 +61,7 @@ runSucceedingTests command (test:tests) = catch
     ExitFailure _ -> exitFailure
     ExitSuccess   -> runSucceedingTests command tests)
 
+-- |Run a list of tests with a given command expecting them to fail.
 runFailingTests :: Command -> [String] -> IO ()
 runFailingTests command [] = return ()
 runFailingTests command (test:tests) = catch
@@ -66,23 +71,29 @@ runFailingTests command (test:tests) = catch
     ExitSuccess   -> exitFailure)
 
 main = do
-  -- Evaluation tests
+  -- Run evaluation tests for each mode
   putStrLn "running succ TCK"
   runSucceedingTests (Evaluate "TCK") succeedingEvalTests
   putStrLn "running fail TCK"
   runFailingTests (Evaluate "TCK") failingEvalTests
+
   putStrLn "running succ TCEK"
   runSucceedingTests (Evaluate "TCEK") succeedingEvalTests
   putStrLn "running fail TCEK"
   runFailingTests (Evaluate "TCEK") failingEvalTests
+
   putStrLn "running succ U..."
   runSucceedingTests (Evaluate "U") succeedingEvalTests
   putStrLn "running fail U..."
   runFailingTests (Evaluate "U") failingEvalTests
+
   putStrLn "running succ TL"
   runSucceedingTests (Evaluate "TL") succeedingEvalTests
   putStrLn "running fail TL"
   runFailingTests (Evaluate "TL") failingEvalTests
 
+  -- Typechecking tests
+  -- NOTE: Evaluation tests beginning with T eun the typechecker.
+  --       The following is more of a test that the typechecking command works.
   putStrLn "Typechecking succ"
   runSucceedingTests Typecheck succeedingEvalTests

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -29,22 +29,6 @@ succeedingEvalTests = ["succInteger"
 
 failingEvalTests = ["DivideByZero"]
 
-succeedingTCTests = ["succInteger"
-        ,"unitval"
-        ,"true"
-        ,"false"
-        ,"churchZero"
-        ,"churchSucc"
-        ,"overapplication"
-        ,"factorial"
-        ,"fibonacci"
-        ,"NatRoundTrip"
-        ,"ScottListSum"
-        ,"IfIntegers"
-        ,"ApplyAdd1"
-        ,"ApplyAdd2"
-        ]
-
 -- For each mode determine which executable should generate examples
 modeExampleGenerator :: String -> String
 modeExampleGenerator "U" = "uplc"
@@ -87,6 +71,8 @@ main = do
   putStrLn "running fail U..."
   runFailingTests "evaluate" "U" failingEvalTests
   putStrLn "running succ TL"
-  runSucceedingTests "evaluate" "TL" succeedingTCTests
+  runSucceedingTests "evaluate" "TL" succeedingEvalTests
   putStrLn "running fail TL"
   runFailingTests "evaluate" "TL" failingEvalTests
+
+-- TODO: Testing of typecheck command

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -44,7 +44,7 @@ exampleGenerator :: Command -> String
 exampleGenerator (Evaluate "U") = "uplc"
 exampleGenerator _              = "plc"
 
--- |@runTest cmd tst@ generates a @tst@ example and run it with the given @cmd@.
+-- |@runTest cmd tst@ generates a @tst@ example and runs it with the given @cmd@.
 runTest :: Command -> String -> IO ()
 runTest command test = withTempFile $ \tmp -> do
   example <- readProcess (exampleGenerator command) ["example", "-s",test] []
@@ -93,7 +93,7 @@ main = do
   runFailingTests (Evaluate "TL") failingEvalTests
 
   -- Typechecking tests
-  -- NOTE: Evaluation tests beginning with T eun the typechecker.
+  -- NOTE: Evaluation tests beginning with T already run the typechecker.
   --       The following is more of a test that the typechecking command works.
   putStrLn "Typechecking succ"
   runSucceedingTests Typecheck succeedingEvalTests

--- a/plutus-metatheory/test/TestSimple.hs
+++ b/plutus-metatheory/test/TestSimple.hs
@@ -86,4 +86,3 @@ main = do
 
   putStrLn "Typechecking succ"
   runSucceedingTests Typecheck succeedingEvalTests
--- TODO: Testing of typecheck command


### PR DESCRIPTION
The `TestSimple.hs` file should test succeeding  and non-succeeding examples.
The current tests fails to do that:
 The first failing test should have failed, because `plc-agda` terminated successfully, but succeeded and finished test execution.

This PR:
  * Fixes the agda code to actually fail.
  * Corrects the tests to actually tests all the evaluation modes.
   * Typechecking tests now working.  

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Changelog fragments have been written (if appropriate)
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting master unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
