### PR TITLE
Deploy haddock to github pages

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,0 +1,27 @@
+name: "Build and Deploy to Github Pages"
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-haddock-site:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nixbuild/nix-quick-install-action@v21
+        with: 
+          nix_conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true 
+      - name: Build haddock site
+        run: |
+          nix build .#combined-plutus-haddock
+          mkdir dist
+          cp -RL ./result/share/doc/* ./dist/
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist

--- a/nix/cells/plutus/packages/combined-plutus-haddock.nix
+++ b/nix/cells/plutus/packages/combined-plutus-haddock.nix
@@ -24,12 +24,9 @@ cell.library.combine-haddock {
 
         * "PlutusTx": Compiling Haskell to PLC (Plutus Core; on-chain code).
         * "PlutusTx.Prelude": Haskell prelude replacement compatible with PLC.
-        * "Plutus.Contract": Writing Plutus apps (off-chain code).
-        * "Ledger.Constraints": Constructing and validating Plutus
-          transactions. Built on "PlutusTx" and "Plutus.Contract".
-        * "Ledger.Typed.Scripts": A type-safe interface for spending and
-          producing script outputs. Built on "PlutusTx".
-        * "Plutus.Trace.Emulator": Testing Plutus contracts in the emulator.
+        * "PlutusCore": Programming language in which scripts on the Cardano blockchain are written.
+        * "PlutusIR": Intermediate Representation language that compiles to Plutus Core.
+        * "UntypedPlutusCore": On-chain Plutus code.
     '';
   };
 }


### PR DESCRIPTION
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

This PR adds a Github Action to build a static site out of haddock docs. It requires a Github Environment (under Settings) named `github-pages` with `gh-pages` as the allowed branch. This currently does not use any versioning strategy and has no deploy previews. It is worth noting the artifacts created from `nix-build` are ~1GB and the retention periods are 1 day which may need more tuning.

A demo of this in practice will look like: https://sfoo-iohk.github.io/plutus/
