### PR TITLE
Generalize CEK input-term annotations

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -124,7 +124,7 @@ nopCostModel =
                   (ModelSixArgumentsConstantCost 600)
     }
 
-nopCostParameters :: MachineParameters CekMachineCosts CekValue DefaultUni NopFun
+nopCostParameters :: MachineParameters CekMachineCosts CekValue DefaultUni NopFun ()
 nopCostParameters =
     mkMachineParameters def $
         CostModel defaultCekMachineCosts nopCostModel

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -75,7 +75,7 @@ copyData =
 
 benchWith
     :: (Ix fun, Pretty fun, Typeable fun)
-    => MachineParameters CekMachineCosts CekValue DefaultUni fun
+    => MachineParameters CekMachineCosts CekValue DefaultUni fun ()
     -> String
     -> PlainTerm DefaultUni fun
     -> Benchmark

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -74,10 +74,10 @@ defaultCekCostModel = CostModel defaultCekMachineCosts defaultBuiltinCostModel
 defaultCostModelParams :: Maybe CostModelParams
 defaultCostModelParams = extractCostModelParams defaultCekCostModel
 
-defaultCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
+defaultCekParameters :: Typeable ann => MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun ann
 defaultCekParameters = mkMachineParameters def defaultCekCostModel
 
-unitCekParameters :: MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
+unitCekParameters :: Typeable ann => MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun ann
 unitCekParameters =
     mkMachineParameters def $
         CostModel unitCekMachineCosts unitCostBuiltinCostModel

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -37,10 +37,10 @@ makeLenses ''CostModel
   cost model for builtins and their denotations.  This bundles one of those
   together with the cost model for evaluator steps.  The 'term' type will be
   CekValue when we're using this with the CEK machine. -}
-data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) =
+data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) (ann :: Type) =
     MachineParameters {
       machineCosts    :: machinecosts
-    , builtinsRuntime :: BuiltinsRuntime fun (term uni fun)
+    , builtinsRuntime :: BuiltinsRuntime fun (term uni fun ann)
     }
     deriving stock Generic
     deriving anyclass (NFData, NoThunks)
@@ -76,12 +76,12 @@ mkMachineParameters ::
     ( -- WARNING: do not discharge the equality constraint as that causes GHC to fail to inline the
       -- function at its call site, see Note [The CostingPart constraint in mkMachineParameters].
       CostingPart uni fun ~ builtincosts
-    , HasMeaningIn uni (val uni fun)
+    , HasMeaningIn uni (val uni fun ann)
     , ToBuiltinMeaning uni fun
     )
     => BuiltinVersion fun
     -> CostModel machinecosts builtincosts
-    -> MachineParameters machinecosts val uni fun
+    -> MachineParameters machinecosts val uni fun ann
 mkMachineParameters ver (CostModel mchnCosts builtinCosts) =
     MachineParameters mchnCosts (inline toBuiltinsRuntime ver builtinCosts)
 {-# INLINE mkMachineParameters #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
@@ -14,7 +14,7 @@ import UntypedPlutusCore.Evaluation.Machine.Cek
 import Control.Monad.Except
 import GHC.Exts (inline)
 
-type DefaultMachineParameters = MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun
+type DefaultMachineParameters = MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun ()
 
 {- Note [Inlining meanings of builtins]
 It's vitally important to inline the 'toBuiltinMeaning' method of a set of built-in functions as

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -93,10 +93,10 @@ A wrapper around the internal runCek to debruijn input and undebruijn output.
 -}
 runCek
     :: (Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => MachineParameters CekMachineCosts CekValue uni fun ann
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
-    -> Term Name uni fun ()
+    -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost, [Text])
 runCek params mode emitMode term =
     -- translating input
@@ -124,9 +124,9 @@ runCek params mode emitMode term =
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 runCekNoEmit
     :: (Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => MachineParameters CekMachineCosts CekValue uni fun ann
     -> ExBudgetMode cost uni fun
-    -> Term Name uni fun ()
+    -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost)
 runCekNoEmit params mode =
     -- throw away the logs
@@ -141,9 +141,9 @@ unsafeRunCekNoEmit
        , Closed uni, uni `Everywhere` PrettyConst
        , Ix fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => MachineParameters CekMachineCosts CekValue uni fun ann
     -> ExBudgetMode cost uni fun
-    -> Term Name uni fun ()
+    -> Term Name uni fun ann
     -> (EvaluationResult (Term Name uni fun ()), cost)
 unsafeRunCekNoEmit params mode =
     -- Don't use 'first': https://github.com/input-output-hk/plutus/issues/3876
@@ -154,8 +154,8 @@ unsafeRunCekNoEmit params mode =
 evaluateCek
     :: (Ix fun, PrettyUni uni fun)
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun
-    -> Term Name uni fun ()
+    -> MachineParameters CekMachineCosts CekValue uni fun ann
+    -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), [Text])
 evaluateCek emitMode params =
     -- throw away the cost
@@ -165,8 +165,8 @@ evaluateCek emitMode params =
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 evaluateCekNoEmit
     :: (Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
-    -> Term Name uni fun ()
+    => MachineParameters CekMachineCosts CekValue uni fun ann
+    -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) (Term Name uni fun ())
 evaluateCekNoEmit params = fst . runCekNoEmit params restrictingEnormous
 
@@ -178,8 +178,8 @@ unsafeEvaluateCek
        , Ix fun, Pretty fun, Typeable fun
        )
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun
-    -> Term Name uni fun ()
+    -> MachineParameters CekMachineCosts CekValue uni fun ann
+    -> Term Name uni fun ann
     -> (EvaluationResult (Term Name uni fun ()), [Text])
 unsafeEvaluateCek emitTime params =
     -- Don't use 'first': https://github.com/input-output-hk/plutus/issues/3876
@@ -192,8 +192,8 @@ unsafeEvaluateCekNoEmit
        , Closed uni, uni `Everywhere` PrettyConst
        , Ix fun, Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
-    -> Term Name uni fun ()
+    => MachineParameters CekMachineCosts CekValue uni fun ann
+    -> Term Name uni fun ann
     -> EvaluationResult (Term Name uni fun ())
 unsafeEvaluateCekNoEmit params = unsafeExtractEvaluationResult . evaluateCekNoEmit params
 
@@ -203,7 +203,7 @@ readKnownCek
     :: ( ReadKnown (Term Name uni fun ()) a
        , Ix fun, PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun
-    -> Term Name uni fun ()
+    => MachineParameters CekMachineCosts CekValue uni fun ann
+    -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) a
 readKnownCek params = evaluateCekNoEmit params >=> readKnownSelf

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -182,15 +182,15 @@ but functions are not printable and hence we provide a dummy instance.
 -}
 
 -- See Note [Show instance for BuiltinRuntime].
-instance Show (BuiltinRuntime (CekValue uni fun)) where
+instance Show (BuiltinRuntime (CekValue uni fun ann)) where
     show _ = "<builtin_runtime>"
 
 -- 'Values' for the modified CEK machine.
-data CekValue uni fun =
+data CekValue uni fun ann =
     -- This bang gave us a 1-2% speed-up at the time of writing.
     VCon !(Some (ValueOf uni))
-  | VDelay !(Term NamedDeBruijn uni fun ()) !(CekValEnv uni fun)
-  | VLamAbs !NamedDeBruijn !(Term NamedDeBruijn uni fun ()) !(CekValEnv uni fun)
+  | VDelay !(Term NamedDeBruijn uni fun ann) !(CekValEnv uni fun ann)
+  | VLamAbs !NamedDeBruijn !(Term NamedDeBruijn uni fun ann) !(CekValEnv uni fun ann)
     -- | A partial builtin application, accumulating arguments for eventual full application.
     -- We don't need a 'CekValEnv' here unlike in the other constructors, because 'VBuiltin'
     -- values always store their corresponding 'Term's fully discharged, see the comments at
@@ -209,12 +209,12 @@ data CekValue uni fun =
       -- be returned in the result. The laziness is important, because the arguments are discharged
       -- values and discharging is expensive, so we don't want to do it unless we really have
       -- to. Making this field strict resulted in a 3-4.5% slowdown at the time of writing.
-      !(BuiltinRuntime (CekValue uni fun))
+      !(BuiltinRuntime (CekValue uni fun ann))
       -- ^ The partial application and its costing function.
       -- Check the docs of 'BuiltinRuntime' for details.
     deriving stock (Show)
 
-type CekValEnv uni fun = Env.RAList (CekValue uni fun)
+type CekValEnv uni fun ann = Env.RAList (CekValue uni fun ann)
 
 -- | The CEK machine is parameterized over a @spendBudget@ function. This makes the budgeting machinery extensible
 -- and allows us to separate budgeting logic from evaluation logic and avoid branching on the union
@@ -341,7 +341,7 @@ they don't actually take the context as an argument even at the source level.
 -}
 
 -- | Implicit parameter for the builtin runtime.
-type GivenCekRuntime uni fun = (?cekRuntime :: (BuiltinsRuntime fun (CekValue uni fun)))
+type GivenCekRuntime uni fun ann = (?cekRuntime :: (BuiltinsRuntime fun (CekValue uni fun ann)))
 -- | Implicit parameter for the log emitter reference.
 type GivenCekEmitter uni fun s = (?cekEmitter :: CekEmitter uni fun s)
 -- | Implicit parameter for budget spender.
@@ -350,7 +350,7 @@ type GivenCekSlippage = (?cekSlippage :: Slippage)
 type GivenCekCosts = (?cekCosts :: CekMachineCosts)
 
 -- | Constraint requiring all of the machine's implicit parameters.
-type GivenCekReqs uni fun s = (GivenCekRuntime uni fun, GivenCekEmitter uni fun s, GivenCekSpender uni fun s, GivenCekSlippage, GivenCekCosts)
+type GivenCekReqs uni fun ann s = (GivenCekRuntime uni fun ann, GivenCekEmitter uni fun s, GivenCekSpender uni fun s, GivenCekSlippage, GivenCekCosts)
 
 data CekUserError
     -- @plutus-errors@ prevents this from being strict. Not that it matters anyway.
@@ -415,7 +415,7 @@ throwingDischarged
     :: PrettyUni uni fun
     => AReview (EvaluationError CekUserError (MachineError fun)) t
     -> t
-    -> CekValue uni fun
+    -> CekValue uni fun ann
     -> CekM uni fun s x
 throwingDischarged l t = throwingWithCause l t . Just . dischargeCekValue
 
@@ -463,7 +463,7 @@ spendBudgetCek = let (CekBudgetSpender spend) = ?cekBudgetSpender in spend
 -- see Note [Scoping].
 -- | Instantiate all the free variables of a term by looking them up in an environment.
 -- Mutually recursive with dischargeCekVal.
-dischargeCekValEnv :: forall uni fun. CekValEnv uni fun -> Term NamedDeBruijn uni fun () -> Term NamedDeBruijn uni fun ()
+dischargeCekValEnv :: forall uni fun ann. CekValEnv uni fun ann -> Term NamedDeBruijn uni fun () -> Term NamedDeBruijn uni fun ()
 dischargeCekValEnv valEnv = go 0
  where
   -- The lamCnt is just a counter that measures how many lambda-abstractions
@@ -490,28 +490,28 @@ dischargeCekValEnv valEnv = go 0
 
 -- | Convert a 'CekValue' into a 'Term' by replacing all bound variables with the terms
 -- they're bound to (which themselves have to be obtain by recursively discharging values).
-dischargeCekValue :: CekValue uni fun -> Term NamedDeBruijn uni fun ()
+dischargeCekValue :: CekValue uni fun ann -> Term NamedDeBruijn uni fun ()
 dischargeCekValue = \case
     VCon     val                         -> Constant () val
-    VDelay   body env                    -> dischargeCekValEnv env $ Delay () body
+    VDelay   body env                    -> dischargeCekValEnv env $ Delay () (void body)
     -- 'computeCek' turns @LamAbs _ name body@ into @VLamAbs name body env@ where @env@ is an
     -- argument of 'computeCek' and hence we need to start discharging outside of the reassembled
     -- lambda, otherwise @name@ could clash with the names that we have in @env@.
     VLamAbs (NamedDeBruijn n _ix) body env ->
         -- The index on the binder is meaningless, we put `0` by convention, see 'Binder'.
-        dischargeCekValEnv env $ LamAbs () (NamedDeBruijn n deBruijnInitIndex) body
+        dischargeCekValEnv env $ LamAbs () (NamedDeBruijn n deBruijnInitIndex) (void body)
     -- We only return a discharged builtin application when (a) it's being returned by the machine,
     -- or (b) it's needed for an error message.
     -- @term@ is fully discharged, so we can return it directly without any further discharging.
     VBuiltin _ term _                    -> term
 
 instance (Closed uni, Pretty (SomeTypeIn uni), uni `Everywhere` PrettyConst, Pretty fun) =>
-            PrettyBy PrettyConfigPlc (CekValue uni fun) where
+            PrettyBy PrettyConfigPlc (CekValue uni fun ann) where
     prettyBy cfg = prettyBy cfg . dischargeCekValue
 
-type instance UniOf (CekValue uni fun) = uni
+type instance UniOf (CekValue uni fun ann) = uni
 
-instance HasConstant (CekValue uni fun) where
+instance HasConstant (CekValue uni fun ann) where
     asConstant (VCon val) = pure val
     asConstant _          = throwNotAConstant
 
@@ -523,15 +523,15 @@ The context in which the machine operates.
 Morally, this is a stack of frames, but we use the "intrusive list" representation so that
 we can match on context and the top frame in a single, strict pattern match.
 -}
-data Context uni fun
-    = FrameApplyFun !(CekValue uni fun) !(Context uni fun)                         -- ^ @[V _]@
-    | FrameApplyArg !(CekValEnv uni fun) !(Term NamedDeBruijn uni fun ()) !(Context uni fun) -- ^ @[_ N]@
-    | FrameForce !(Context uni fun)                                               -- ^ @(force _)@
+data Context uni fun ann
+    = FrameApplyFun !(CekValue uni fun ann) !(Context uni fun ann)                         -- ^ @[V _]@
+    | FrameApplyArg !(CekValEnv uni fun ann) !(Term NamedDeBruijn uni fun ann) !(Context uni fun ann) -- ^ @[_ N]@
+    | FrameForce !(Context uni fun ann)                                               -- ^ @(force _)@
     | NoFrame
     deriving stock (Show)
 
 -- See Note [ExMemoryUsage instances for non-constants].
-instance (Closed uni, uni `Everywhere` ExMemoryUsage) => ExMemoryUsage (CekValue uni fun) where
+instance (Closed uni, uni `Everywhere` ExMemoryUsage) => ExMemoryUsage (CekValue uni fun ann) where
     memoryUsage = \case
         VCon c      -> memoryUsage c
         VDelay {}   -> 1
@@ -544,12 +544,12 @@ tryError :: MonadError e m => m a -> m (Either e a)
 tryError a = (Right <$> a) `catchError` (pure . Left)
 
 runCekM
-    :: forall a cost uni fun.
+    :: forall a cost uni fun ann.
     (PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => MachineParameters CekMachineCosts CekValue uni fun ann
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
-    -> (forall s. GivenCekReqs uni fun s => CekM uni fun s a)
+    -> (forall s. GivenCekReqs uni fun ann s => CekM uni fun s a)
     -> (Either (CekEvaluationException NamedDeBruijn uni fun) a, cost, [Text])
 runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) (EmitterMode getEmitterMode) a = runST $ do
     ExBudgetInfo{_exBudgetModeSpender, _exBudgetModeGetFinal, _exBudgetModeGetCumulative} <- getExBudgetInfo
@@ -565,7 +565,7 @@ runCekM (MachineParameters costs runtime) (ExBudgetMode getExBudgetInfo) (Emitte
     pure (errOrRes, st, logs)
 
 -- | Look up a variable name in the environment.
-lookupVarName :: forall uni fun s . (PrettyUni uni fun) => NamedDeBruijn -> CekValEnv uni fun -> CekM uni fun s (CekValue uni fun)
+lookupVarName :: forall uni fun ann s . (PrettyUni uni fun) => NamedDeBruijn -> CekValEnv uni fun ann -> CekM uni fun s (CekValue uni fun ann)
 lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
     case varEnv `Env.indexOne` coerce varIx of
         Nothing  -> throwingWithCause _MachineError OpenTermEvaluatedMachineError $ Just var where
@@ -576,11 +576,11 @@ lookupVarName varName@(NamedDeBruijn _ varIx) varEnv =
 -- 'makeKnown' or a partial builtin application depending on whether the built-in function is
 -- fully saturated or not.
 evalBuiltinApp
-    :: (GivenCekReqs uni fun s, PrettyUni uni fun)
+    :: (GivenCekReqs uni fun ann s, PrettyUni uni fun)
     => fun
     -> Term NamedDeBruijn uni fun ()
-    -> BuiltinRuntime (CekValue uni fun)
-    -> CekM uni fun s (CekValue uni fun)
+    -> BuiltinRuntime (CekValue uni fun ann)
+    -> CekM uni fun s (CekValue uni fun ann)
 evalBuiltinApp fun term runtime = case runtime of
     BuiltinResult cost getX -> do
         spendBudgetCek (BBuiltinApp fun) cost
@@ -596,11 +596,11 @@ evalBuiltinApp fun term runtime = case runtime of
 -- See Note [Compilation peculiarities].
 -- | The entering point to the CEK machine's engine.
 enterComputeCek
-    :: forall uni fun s
-    . (Ix fun, PrettyUni uni fun, GivenCekReqs uni fun s)
-    => Context uni fun
-    -> CekValEnv uni fun
-    -> Term NamedDeBruijn uni fun ()
+    :: forall uni fun ann s
+    . (Ix fun, PrettyUni uni fun, GivenCekReqs uni fun ann s)
+    => Context uni fun ann
+    -> CekValEnv uni fun ann
+    -> Term NamedDeBruijn uni fun ann
     -> CekM uni fun s (Term NamedDeBruijn uni fun ())
 enterComputeCek = computeCek (toWordArray 0) where
     -- | The computing part of the CEK machine.
@@ -611,9 +611,9 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- 4. looks up a variable in the environment and calls 'returnCek' ('Var')
     computeCek
         :: WordArray
-        -> Context uni fun
-        -> CekValEnv uni fun
-        -> Term NamedDeBruijn uni fun ()
+        -> Context uni fun ann
+        -> CekValEnv uni fun ann
+        -> Term NamedDeBruijn uni fun ann
         -> CekM uni fun s (Term NamedDeBruijn uni fun ())
     -- s ; ρ ▻ {L A}  ↦ s , {_ A} ; ρ ▻ L
     computeCek !unbudgetedSteps !ctx !env (Var _ varName) = do
@@ -640,11 +640,11 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- s ; ρ ▻ abs α L  ↦  s ◅ abs α (L , ρ)
     -- s ; ρ ▻ con c  ↦  s ◅ con c
     -- s ; ρ ▻ builtin bn  ↦  s ◅ builtin bn arity arity [] [] ρ
-    computeCek !unbudgetedSteps !ctx !_ term@(Builtin _ bn) = do
+    computeCek !unbudgetedSteps !ctx !_ (Builtin _ bn) = do
         !unbudgetedSteps' <- stepAndMaybeSpend BBuiltin unbudgetedSteps
         meaning <- lookupBuiltin bn ?cekRuntime
-        -- The @term@ is a 'Builtin', so it's fully discharged.
-        returnCek unbudgetedSteps' ctx (VBuiltin bn term meaning)
+        -- The term is a 'Builtin', so it's fully discharged.
+        returnCek unbudgetedSteps' ctx (VBuiltin bn (Builtin () bn) meaning)
     -- s ; ρ ▻ error A  ↦  <> A
     computeCek !_ !_ !_ (Error _) =
         throwing_ _EvaluationFailure
@@ -660,8 +660,8 @@ enterComputeCek = computeCek (toWordArray 0) where
     -}
     returnCek
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun
+        -> Context uni fun ann
+        -> CekValue uni fun ann
         -> CekM uni fun s (Term NamedDeBruijn uni fun ())
     --- Instantiate all the free variable of the resulting term in case there are any.
     -- . ◅ V           ↦  [] V
@@ -686,8 +686,8 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- if v is anything else, fail.
     forceEvaluate
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun
+        -> Context uni fun ann
+        -> CekValue uni fun ann
         -> CekM uni fun s (Term NamedDeBruijn uni fun ())
     forceEvaluate !unbudgetedSteps !ctx (VDelay body env) = computeCek unbudgetedSteps ctx env body
     forceEvaluate !unbudgetedSteps !ctx (VBuiltin fun term runtime) = do
@@ -716,9 +716,9 @@ enterComputeCek = computeCek (toWordArray 0) where
     -- If v is anything else, fail.
     applyEvaluate
         :: WordArray
-        -> Context uni fun
-        -> CekValue uni fun   -- lhs of application
-        -> CekValue uni fun   -- rhs of application
+        -> Context uni fun ann
+        -> CekValue uni fun ann   -- lhs of application
+        -> CekValue uni fun ann   -- rhs of application
         -> CekM uni fun s (Term NamedDeBruijn uni fun ())
     applyEvaluate !unbudgetedSteps !ctx (VLamAbs _ body env) arg =
         computeCek unbudgetedSteps ctx (Env.cons arg env) body
@@ -770,10 +770,10 @@ enterComputeCek = computeCek (toWordArray 0) where
 -- | Evaluate a term using the CEK machine and keep track of costing, logging is optional.
 runCekDeBruijn
     :: (Ix fun, PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun
+    => MachineParameters CekMachineCosts CekValue uni fun ann
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
-    -> Term NamedDeBruijn uni fun ()
+    -> Term NamedDeBruijn uni fun ann
     -> (Either (CekEvaluationException NamedDeBruijn uni fun) (Term NamedDeBruijn uni fun ()), cost, [Text])
 runCekDeBruijn params mode emitMode term =
     runCekM params mode emitMode $ do

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -46,6 +46,11 @@ module UntypedPlutusCore.Evaluation.Machine.Cek.Internal
     , extractEvaluationResult
     , runCekDeBruijn
     , dischargeCekValue
+    , Context (..)
+    , CekValEnv
+    , GivenCekReqs
+    , GivenCekSpender
+    , Slippage
     )
 where
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
@@ -34,7 +34,7 @@ typecheckAnd
        , Closed uni, uni `Everywhere` ExMemoryUsage
        )
     => BuiltinVersion fun
-    -> (MachineParameters CekMachineCosts CekValue uni fun -> UPLC.Term Name uni fun () -> a)
+    -> (MachineParameters CekMachineCosts CekValue uni fun () -> UPLC.Term Name uni fun () -> a)
     -> CostingPart uni fun -> TPLC.Term TyName Name uni fun () -> m a
 typecheckAnd ver action costingPart term = TPLC.runQuoteT $ do
     -- here we don't use `getDefTypeCheckConfig`, to cover the

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -62,7 +62,7 @@ test_machines =
 
 testBudget
     :: (Ix fun, Show fun, Hashable fun, PrettyUni DefaultUni fun)
-    => BuiltinsRuntime fun (CekValue DefaultUni fun)
+    => BuiltinsRuntime fun (CekValue DefaultUni fun ())
     -> TestName
     -> Term Name DefaultUni fun ()
     -> TestNested


### PR DESCRIPTION
I would like to have `ann` available in CEK's Term, because then I can share more between the canonical cek and the debuggable-steppable cek.

Originally, I put `ann` everywhere both in the `Term`s that come in the CEK and the `Term`s that come out of the CEK.
@effectfully pointed to me that the out-Terms should remain as-is, i.e. with `ann`==`()` . This implies that the dischargeCekValue/Env functions have to be constrained to `()` and that had me put some `void`s over there. I don't like these `void`s there but discharge should suppose to be lazy anyway.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
