### PR TITLE
GitHub action to add "status: needs triage" label to new issues

### DIFF
--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,0 +1,21 @@
+name: Add triage label
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  add_triage_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["status: needs triage"]
+            })


### PR DESCRIPTION
This does what it says.  The YAML code is based on the example [here](https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues).