### PR TITLE
Fix index-state syntax

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,14 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING for some Nix commands you will need to run if you
 -- update either of these.
--- Bump this if you need newer packages from Hackage
+
+-- repeating hackage index-state to work around haskell.nix parsing limitation
 index-state: 2022-11-15T00:00:00Z
--- Bump this if you need newer packages from CHaP
-index-state: cardano-haskell-packages 2023-01-04T00:00:00Z
+index-state:
+  -- Bump this if you need newer packages from Hackage
+  , hackage.haskell.org 2022-11-15T00:00:00Z
+  -- Bump this if you need newer packages from CHaP
+  , cardano-haskell-packages 2023-01-04T00:00:00Z
 
 packages: doc/read-the-docs-site
           plutus-benchmark


### PR DESCRIPTION
The second index-state stanza completely ovverides the first, resetting hackage index state to HEAD. See haskell/cabal#8568

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
