### PR TITLE
[Builtins] Make builtin application look lazy

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -45,7 +45,7 @@ import Data.DList (DList)
 import Data.Either.Extras
 import Data.String
 import Data.Text (Text)
-import GHC.Exts (inline, oneShot)
+import GHC.Exts (inline)
 import GHC.TypeLits
 import Universe
 
@@ -345,7 +345,7 @@ liftReadKnownM (Right x)  = MakeKnownSuccess x
 -- | Convert a constant embedded into a PLC term to the corresponding Haskell value.
 readKnownConstant :: forall val a. KnownBuiltinType val a => val -> ReadKnownM a
 -- Note [Performance of ReadKnownIn and MakeKnownIn instances]
-readKnownConstant val = asConstant val >>= oneShot \case
+readKnownConstant val = asConstant val >>= \case
     Some (ValueOf uniAct x) -> do
         let uniExp = knownUni @_ @(UniOf val) @a
         -- 'geq' matches on its first argument first, so we make the type tag that will be known

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -45,7 +45,7 @@ import Data.DList (DList)
 import Data.Either.Extras
 import Data.String
 import Data.Text (Text)
-import GHC.Exts (inline)
+import GHC.Exts (inline, lazy)
 import GHC.TypeLits
 import Universe
 
@@ -371,7 +371,7 @@ class uni ~ UniOf val => MakeKnownIn uni val a where
     --
     -- Note that the value is only forced to WHNF, so care must be taken to ensure that every value
     -- of a type from the universe gets forced to NF whenever it's forced to WHNF.
-    makeKnown x = pure . fromValue $! x
+    makeKnown x = lazy (pure . fromValue $! x)
     {-# INLINE makeKnown #-}
 
 type MakeKnown val = MakeKnownIn (UniOf val) val

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -49,7 +49,7 @@ import Data.IntCast (intCastEq)
 import Data.Proxy
 import Data.Text qualified as Text
 import Data.Word
-import GHC.Exts (inline, oneShot)
+import GHC.Exts (inline)
 import Text.Pretty
 import Text.PrettyBy
 import Text.PrettyBy.Fixity
@@ -331,7 +331,7 @@ instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Int64 wher
         -- See Note [Performance of KnownTypeIn instances].
         -- Funnily, we don't need 'inline' here, unlike in the default implementation of 'readKnown'
         -- (go figure why).
-        inline readKnownConstant term >>= oneShot \(i :: Integer) ->
+        inline readKnownConstant term >>= \(i :: Integer) ->
             -- We don't make use here of `toIntegralSized` because of performance considerations,
             -- see: https://gitlab.haskell.org/ghc/ghc/-/issues/19641
             -- OPTIMIZE: benchmark an alternative `integerToIntMaybe`, modified from 'ghc-bignum'
@@ -364,7 +364,7 @@ instance HasConstantIn DefaultUni term => MakeKnownIn DefaultUni term Word8 wher
 
 instance HasConstantIn DefaultUni term => ReadKnownIn DefaultUni term Word8 where
     readKnown term =
-        inline readKnownConstant term >>= oneShot \(i :: Integer) ->
+        inline readKnownConstant term >>= \(i :: Integer) ->
            case toIntegralSized i of
                Just w8 -> pure w8
                _       -> throwing_ _EvaluationFailure


### PR DESCRIPTION
Those `oneShot`s should no longer be needed, because we now have them elsewhere. Making the result appear lazy helps sharing at least in case of builtins returning booleans. Needs benchmarking, don't look here yet. 