### PR TITLE
Fix typo (?) in README

### DIFF
--- a/plutus-conformance/README.md
+++ b/plutus-conformance/README.md
@@ -69,7 +69,7 @@ The expected output may contain:
 
 The input files are expected to have the concrete syntax. The expected output will show "parse error" when the parser fails to parse the input file.
 
-#### "evaluation error"
+#### "evaluation failure"
 
 If evaluation fails with an error, the expected output will show "evaluation error".
 

--- a/plutus-conformance/README.md
+++ b/plutus-conformance/README.md
@@ -71,7 +71,7 @@ The input files are expected to have the concrete syntax. The expected output wi
 
 #### "evaluation failure"
 
-If evaluation fails with an error, the expected output will show "evaluation error".
+If evaluation fails with an error, the expected output will show "evaluation failure".
 
 #### An untyped plutus core program
 


### PR DESCRIPTION
In all files the actual term is "evaluation failure" and not error. It is unclear which part is incorrect but its at least not consistent in the current state.
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
