### PR TITLE
[Costing] Drop 'uni' and 'ann' from 'MachineParameters

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -124,7 +124,7 @@ nopCostModel =
                   (ModelSixArgumentsConstantCost 600)
     }
 
-nopCostParameters :: MachineParameters CekMachineCosts CekValue DefaultUni NopFun ()
+nopCostParameters :: MachineParameters CekMachineCosts NopFun (CekValue DefaultUni NopFun ())
 nopCostParameters =
     mkMachineParameters def $
         CostModel defaultCekMachineCosts nopCostModel

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -74,7 +74,7 @@ copyData =
 
 benchWith
     :: (Pretty fun, Typeable fun)
-    => MachineParameters CekMachineCosts CekValue DefaultUni fun ()
+    => MachineParameters CekMachineCosts fun (CekValue DefaultUni fun ())
     -> String
     -> PlainTerm DefaultUni fun
     -> Benchmark

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -14,7 +14,6 @@ import Control.DeepSeq
 import Control.Lens
 import GHC.Exts (inline)
 import GHC.Generics
-import GHC.Types (Type)
 import NoThunks.Class
 
 {-| We need to account for the costs of evaluator steps and also built-in function
@@ -37,10 +36,10 @@ makeLenses ''CostModel
   cost model for builtins and their denotations.  This bundles one of those
   together with the cost model for evaluator steps.  The 'term' type will be
   CekValue when we're using this with the CEK machine. -}
-data MachineParameters machinecosts term (uni :: Type -> Type) (fun :: Type) (ann :: Type) =
+data MachineParameters machinecosts fun val =
     MachineParameters {
       machineCosts    :: machinecosts
-    , builtinsRuntime :: BuiltinsRuntime fun (term uni fun ann)
+    , builtinsRuntime :: BuiltinsRuntime fun val
     }
     deriving stock Generic
     deriving anyclass (NFData, NoThunks)
@@ -76,12 +75,12 @@ mkMachineParameters ::
     ( -- WARNING: do not discharge the equality constraint as that causes GHC to fail to inline the
       -- function at its call site, see Note [The CostingPart constraint in mkMachineParameters].
       CostingPart uni fun ~ builtincosts
-    , HasMeaningIn uni (val uni fun ann)
+    , HasMeaningIn uni val
     , ToBuiltinMeaning uni fun
     )
     => BuiltinVersion fun
     -> CostModel machinecosts builtincosts
-    -> MachineParameters machinecosts val uni fun ann
+    -> MachineParameters machinecosts fun val
 mkMachineParameters ver (CostModel mchnCosts builtinCosts) =
     MachineParameters mchnCosts (inline toBuiltinsRuntime ver builtinCosts)
 {-# INLINE mkMachineParameters #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
@@ -14,7 +14,8 @@ import UntypedPlutusCore.Evaluation.Machine.Cek
 import Control.Monad.Except
 import GHC.Exts (inline)
 
-type DefaultMachineParameters = MachineParameters CekMachineCosts CekValue DefaultUni DefaultFun ()
+type DefaultMachineParameters =
+    MachineParameters CekMachineCosts DefaultFun (CekValue DefaultUni DefaultFun ())
 
 {- Note [Inlining meanings of builtins]
 It's vitally important to inline the 'toBuiltinMeaning' method of a set of built-in functions as

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek.hs
@@ -92,7 +92,7 @@ A wrapper around the internal runCek to debruijn input and undebruijn output.
 -}
 runCek
     :: PrettyUni uni fun
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term Name uni fun ann
@@ -123,7 +123,7 @@ runCek params mode emitMode term =
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 runCekNoEmit
     :: PrettyUni uni fun
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), cost)
@@ -140,7 +140,7 @@ unsafeRunCekNoEmit
        , Closed uni, uni `Everywhere` PrettyConst
        , Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> Term Name uni fun ann
     -> (EvaluationResult (Term Name uni fun ()), cost)
@@ -153,7 +153,7 @@ unsafeRunCekNoEmit params mode =
 evaluateCek
     :: PrettyUni uni fun
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun ann
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> Term Name uni fun ann
     -> (Either (CekEvaluationException Name uni fun) (Term Name uni fun ()), [Text])
 evaluateCek emitMode params =
@@ -164,7 +164,7 @@ evaluateCek emitMode params =
 -- *THIS FUNCTION IS PARTIAL if the input term contains free variables*
 evaluateCekNoEmit
     :: PrettyUni uni fun
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) (Term Name uni fun ())
 evaluateCekNoEmit params = fst . runCekNoEmit params restrictingEnormous
@@ -177,7 +177,7 @@ unsafeEvaluateCek
        , Pretty fun, Typeable fun
        )
     => EmitterMode uni fun
-    -> MachineParameters CekMachineCosts CekValue uni fun ann
+    -> MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> Term Name uni fun ann
     -> (EvaluationResult (Term Name uni fun ()), [Text])
 unsafeEvaluateCek emitTime params =
@@ -191,7 +191,7 @@ unsafeEvaluateCekNoEmit
        , Closed uni, uni `Everywhere` PrettyConst
        , Pretty fun, Typeable fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> Term Name uni fun ann
     -> EvaluationResult (Term Name uni fun ())
 unsafeEvaluateCekNoEmit params = unsafeExtractEvaluationResult . evaluateCekNoEmit params
@@ -202,7 +202,7 @@ readKnownCek
     :: ( ReadKnown (Term Name uni fun ()) a
        , PrettyUni uni fun
        )
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> Term Name uni fun ann
     -> Either (CekEvaluationException Name uni fun) a
 readKnownCek params = evaluateCekNoEmit params >=> readKnownSelf

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -550,7 +550,7 @@ tryError a = (Right <$> a) `catchError` (pure . Left)
 runCekM
     :: forall a cost uni fun ann.
     (PrettyUni uni fun)
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> (forall s. GivenCekReqs uni fun ann s => CekM uni fun s a)
@@ -774,7 +774,7 @@ enterComputeCek = computeCek (toWordArray 0) where
 -- | Evaluate a term using the CEK machine and keep track of costing, logging is optional.
 runCekDeBruijn
     :: PrettyUni uni fun
-    => MachineParameters CekMachineCosts CekValue uni fun ann
+    => MachineParameters CekMachineCosts fun (CekValue uni fun ann)
     -> ExBudgetMode cost uni fun
     -> EmitterMode uni fun
     -> Term NamedDeBruijn uni fun ann

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
@@ -34,7 +34,8 @@ typecheckAnd
        , Closed uni, uni `Everywhere` ExMemoryUsage
        )
     => BuiltinVersion fun
-    -> (MachineParameters CekMachineCosts CekValue uni fun () -> UPLC.Term Name uni fun () -> a)
+    -> (MachineParameters CekMachineCosts fun (CekValue uni fun ()) ->
+            UPLC.Term Name uni fun () -> a)
     -> CostingPart uni fun -> TPLC.Term TyName Name uni fun () -> m a
 typecheckAnd ver action costingPart term = TPLC.runQuoteT $ do
     -- here we don't use `getDefTypeCheckConfig`, to cover the


### PR DESCRIPTION
Just a tiny one. Now that `CkValue` and `CekValue` take a different number of arguments, it's even more pronounced that we shouldn't insist a particular kind on the type of values. Which is something we only do in `MachineParameters` as far as I'm aware, hence this PR fixing that.