### PR TITLE
Remove redundant type beta reduction in inliner.

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
@@ -1,4 +1,3 @@
--- editorconfig-checker-disable-file
 {-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE ViewPatterns #-}
 {-|
@@ -20,7 +19,8 @@ Consider two examples where applying beta should be helpful.
 2: [[(\x . (\y . t)) a] b]
 
 (1) is the typical "let-binding" pattern: each binding corresponds to an immediately-applied lambda.
-(2) is the typical "function application" pattern: a multi-argument function applied to multiple arguments.
+(2) is the typical "function application" pattern: a multi-argument function applied to multiple
+arguments.
 
 In both cases we would like to produce something like
 
@@ -45,14 +45,18 @@ to look for immediately-applied lambda abstractions then we will get the followi
   [(let x = a in (\y . t)) b]
 
 Now, if we later lift the let out, then we will be able to see that we can transform (2) further.
-But that means that a) we'd have to do the expensive let-floating pass in every iteration of the simplifier, and
+But that means that
+a) we'd have to do the expensive let-floating pass in every iteration of the
+simplifier, and
 b) we can only inline one function argument per iteration of the  simplifier, so for a function of
 arity N we *must* do at least N passes.
 
-This isn't great, so the solution is to recognize case (2) properly and handle all the arguments in one go.
-That will also match cases like (1) just fine, since it's just made up of unary function applications.
+This isn't great, so the solution is to recognize case (2) properly and handle all the arguments in
+one go. That will also match cases like (1) just fine, since it's just made up of unary function
+applications.
 
-That does mean that we need to do a manual traversal rather than doing standard bottom-up processing.
+That does mean that we need to do a manual traversal rather than doing standard bottom-up
+processing.
 
 Note that multi-beta cannot be used on TypeBinds. For instance, it is unsound to turn
 
@@ -76,12 +80,15 @@ Some examples will help:
 
 [[(\x . t) a] b] -> Nothing
 -}
-extractBindings :: Term tyname name uni fun a -> Maybe (NE.NonEmpty (Binding tyname name uni fun a), Term tyname name uni fun a)
+extractBindings ::
+  Term tyname name uni fun a
+  -> Maybe (NE.NonEmpty (Binding tyname name uni fun a), Term tyname name uni fun a)
 extractBindings = collectArgs []
   where
       collectArgs argStack (Apply _ f arg) = collectArgs (arg:argStack) f
       collectArgs argStack t               = matchArgs argStack [] t
-      matchArgs (arg:rest) acc (LamAbs a n ty body) = matchArgs rest (TermBind a Strict (VarDecl a n ty) arg:acc) body
+      matchArgs (arg:rest) acc (LamAbs a n ty body) =
+        matchArgs rest (TermBind a Strict (VarDecl a n ty) arg:acc) body
       matchArgs []         acc t                    =
           case NE.nonEmpty (reverse acc) of
               Nothing   -> Nothing

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
@@ -175,14 +175,6 @@ processTerm = handleTerm <=< traverseOf termSubtypes applyTypeSubstitution where
             -- Use 'mkLet': we're using lists of bindings rather than NonEmpty since we might
             -- actually have got rid of all of them!
             pure $ mkLet a NonRec bs' t'
-        -- We cannot currently soundly do beta for types (see SCP-2570), so we just recognize
-        -- immediately instantiated type abstractions here directly.
-        (TyInst a (TyAbs a' tn k t) rhs) -> do
-            b' <- maybeAddTySubst tn rhs
-            t' <- processTerm t
-            case b' of
-                Just rhs' -> pure $ TyInst a (TyAbs a' tn k t') rhs'
-                Nothing   -> pure t'
         -- This includes recursive let terms, we don't even consider inlining them at the moment
         t -> forMOf termSubterms t processTerm
     applyTypeSubstitution :: Type tyname uni a -> InlineM tyname name uni fun a (Type tyname uni a)


### PR DESCRIPTION
The comments that are removed mentioned SCP-2570, which became [PLT-126](https://input-output.atlassian.net/browse/PLT-126) and it was done in PR #4592.

Because of that work, it is no longer necessary to do a pattern match for `TyInst` in the inliner, because it would have turned into a type let binding and be caught in the earlier pattern for let bindings.

I also re-organize the comments a bit because there were some mis-placements. I also fixed the line lengths of `Beta.hs` in a separate commit.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested


[PLT-126]: https://input-output.atlassian.net/browse/PLT-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ