### PR TITLE
Fix nix to build on mac

### DIFF
--- a/nix/cells/plutus/library/make-plutus-project.nix
+++ b/nix/cells/plutus/library/make-plutus-project.nix
@@ -21,6 +21,13 @@ let
     shell = {
       # We don't currently use this.
       withHoogle = false;
+
+
+      # We would expect R to be pulled in automatically as it's a dependency of
+      # plutus-core, but it appears it is not, so we need to be explicit about
+      # the dependency on R here.  Adding it as a buildInput will ensure it's
+      # added to the pkg-config env var.
+      buildInputs = [ pkgs.R ];
     };
 
     inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP; };


### PR DESCRIPTION
Building plutus core fails on mac, because it doesn't find the R library.

```
Error: cabal: Could not resolve dependencies:
[__0] trying: plutus-core-1.1.1.0 (user goal)
[__1] rejecting: plutus-core:-with-inline-r (constraint from config file,
command line flag, or user target requires opposite flag selection)
[__1] trying: plutus-core:+with-inline-r
[__2] next goal: inline-r (dependency of plutus-core +with-inline-r)
[__2] rejecting: inline-r-1.0.0.0.0.0.0.1 (conflict: pkg-config package
libR>=3.0, not found in the pkg-config database)
[__2] rejecting: inline-r-1.0.0, inline-r-0.10.5, inline-r-0.10.4,
inline-r-0.10.3, inline-r-0.10.2, inline-r-0.10.1, inline-r-0.10,
inline-r-0.9.2, inline-r-0.9.1, inline-r-0.9.0.2, inline-r-0.9.0.1,
inline-r-0.9.0.0, inline-r-0.8.0.1, inline-r-0.8.0.0, inline-r-0.7.3.0,
inline-r-0.7.2.0, inline-r-0.7.1.2, inline-r-0.7.1.1, inline-r-0.7.1.0,
inline-r-0.7.0.0 (conflict: plutus-core +with-inline-r => inline-r>1.0.0)
[__2] fail (backjumping, conflict set: inline-r, plutus-core,
plutus-core:with-inline-r)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: plutus-core,
plutus-core:with-inline-r, inline-r
```

This fix is thanks to @angerman.
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting master unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
