### PR TITLE
PLT-828: integrate debug CEK machine with brick

### DIFF
--- a/plutus-core/executables/debugger/Draw.hs
+++ b/plutus-core/executables/debugger/Draw.hs
@@ -52,16 +52,17 @@ drawDebugger st =
                 (BE.renderEditor (B.txt . Text.unlines))
                 (st ^. dsReturnValueEditor)
     cekStateEditor =
-        BB.borderWithLabel (B.txt "CEK machine state") $
+        BB.borderWithLabel (B.txt "Placeholder") $
             B.withFocusRing
                 focusRing
                 (BE.renderEditor (B.txt . Text.unlines))
                 (st ^. dsCekStateEditor)
     ui =
         B.vBox
-            [ BC.center uplcEditor B.<+> BC.center sourceEditor
+            [ BC.center uplcEditor B.<+> B.hLimit (st ^. dsHLimitRightEditors) sourceEditor
             , B.vLimit (st ^. dsVLimitBottomEditors) $
-                BC.center returnValueEditor B.<+> BC.center cekStateEditor
+                BC.center returnValueEditor B.<+>
+                    B.hLimit (st ^. dsHLimitRightEditors) cekStateEditor
             , footer
             ]
 
@@ -142,7 +143,7 @@ debuggerKeyBindings =
             [ B.txt "Step            (s)"
             , B.txt "Move cursor     (Arrow)"
             , B.txt "Switch window   (Tab)"
-            , B.txt "Resize windows  (^Up/^Down)"
+            , B.txt "Resize windows  (^Up/^Down/^Left/^Right)"
             , B.txt "Quit            (Esc)"
             ]
         , B.txt "Press any key to exit"

--- a/plutus-core/executables/debugger/Event.hs
+++ b/plutus-core/executables/debugger/Event.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 -- | Handler of debugger events.
 module Event where
 
 import Annotation
+import PlutusCore qualified as PLC
+import PlutusCore.Pretty qualified as PLC
 import Types
+import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
 
 import Brick.Focus qualified as B
 import Brick.Main qualified as B
@@ -15,28 +20,13 @@ import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
 import Control.Concurrent.MVar
 import Control.Monad.State
-import Data.MonoTraversable
+import Data.Text qualified as Text
 import Graphics.Vty qualified as Vty
 import Lens.Micro
-
-type Breakpoints = [Breakpoint]
-data Breakpoint = UplcBP SourcePos
-                | TxBP SourcePos
-data DAnn = DAnn
-    { uplcAnn :: SourcePos
-    , txAnn   :: SrcSpans
-    }
-
-instance D.Breakpointable DAnn Breakpoints where
-    hasBreakpoints ann = any breakpointFired
-        where
-          breakpointFired :: Breakpoint -> Bool
-          breakpointFired = \case
-              UplcBP p -> sourceLine p == sourceLine (uplcAnn ann)
-              TxBP p   -> oany (lineInSrcSpan $ sourceLine p) $ txAnn ann
+import Text.Megaparsec
 
 handleDebuggerEvent :: MVar (D.Cmd Breakpoints)
-                    -> B.BrickEvent ResourceName e
+                    -> B.BrickEvent ResourceName CustomBrickEvent
                     -> B.EventM ResourceName DebuggerState ()
 handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
     focusRing <- gets (^. dsFocusRing)
@@ -59,19 +49,11 @@ handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
             modify' $ set dsKeyBindingsMode KeyBindingsShown
         Vty.EvKey Vty.KEsc [] -> B.halt
         Vty.EvKey (Vty.KChar 's') [] -> do
-          _success <- liftIO $ tryPutMVar driverMailbox D.Step
           -- MAYBE: when not success we could have a dialog show up
           -- saying that the debugger seems to be stuck
           -- and an option to kill its thread (cek) and reload the program?
-          modify' $ \st ->
-            -- Stepping. Currently it highlights one line at a time.
-            let highlightNextLine = \case
-                    Nothing ->
-                        Just (HighlightSpan (B.Location (1, 1)) Nothing)
-                    Just (HighlightSpan (B.Location (r, c)) _) ->
-                        Just (HighlightSpan (B.Location (r + 1, c)) Nothing)
-             in st & dsUplcHighlight %~ highlightNextLine
-
+          _success <- liftIO $ tryPutMVar driverMailbox D.Step
+          pure ()
         Vty.EvKey (Vty.KChar '\t') [] -> modify' $ \st ->
             st & dsFocusRing %~ B.focusNext
         Vty.EvKey Vty.KBackTab [] -> modify' $ \st ->
@@ -80,6 +62,10 @@ handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
             st & dsVLimitBottomEditors %~ (+ 1)
         Vty.EvKey Vty.KDown [Vty.MCtrl] -> modify' $ \st ->
             st & dsVLimitBottomEditors %~ (\x -> x - 1)
+        Vty.EvKey Vty.KLeft [Vty.MCtrl] -> modify' $ \st ->
+            st & dsHLimitRightEditors %~ (+ 1)
+        Vty.EvKey Vty.KRight [Vty.MCtrl] -> modify' $ \st ->
+            st & dsHLimitRightEditors %~ (\x -> x - 1)
         Vty.EvKey Vty.KUp [] -> handleEditorEvent
         Vty.EvKey Vty.KDown [] -> handleEditorEvent
         Vty.EvKey Vty.KLeft [] -> handleEditorEvent
@@ -88,4 +74,73 @@ handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
             -- This disables editing the text, making the editors read-only.
             pure ()
         _ -> handleEditorEvent
+handleDebuggerEvent _driverMailbox (B.AppEvent (UpdateClientEvent cekState)) = do
+    let mHighlightedTerm = case cekState of
+            Computing _ _ _ t -> Just $ t
+            Returning _ ctx v -> do
+                ann <- contextAnn ctx
+                pure $ const ann <$> dischargeCekValue v
+            _ -> Nothing
+        uplcHighlight = do
+            highlightedTerm <- mHighlightedTerm
+            let uplcPos = uplcAnn $ UPLC.termAnn highlightedTerm
+            pure $ mkUplcSpan uplcPos highlightedTerm
+    modify' $ \st -> case cekState of
+        Computing{} ->
+            st & dsUplcHighlight .~ uplcHighlight
+               & dsReturnValueEditor .~
+                BE.editorText
+                    EditorReturnValue
+                    Nothing
+                    ""
+        Returning _ _ v ->
+            let vtag = case v of
+                    VCon{}     -> "VCon"
+                    VDelay{}   -> "VDelay"
+                    VLamAbs{}  -> "VLamAbs"
+                    VBuiltin{} -> "VBuiltin"
+            in st & dsUplcHighlight .~ uplcHighlight
+                  & dsReturnValueEditor .~
+                BE.editorText
+                    EditorReturnValue
+                    Nothing
+                    (vtag <> ": " <> PLC.displayPlcDef (dischargeCekValue v))
+
+        Terminating t ->
+            st & dsUplcHighlight .~ Nothing
+               & dsReturnValueEditor .~
+                BE.editorText
+                    EditorReturnValue
+                    Nothing
+                    ("Evaluation Finished. Result: \n\n" <> PLC.displayPlcDef t)
+        Starting{} -> st
 handleDebuggerEvent _ _ = pure ()
+
+-- | Attempt to highlight the first token of a Term. This is a temporary workaround.
+--
+-- Ideally we want to highlight the entire Term, but currently the UPLC parser only attaches
+-- a @SourcePos@ to each Term, while we'd need it to attach a @SrcSpan@.
+mkUplcSpan
+    :: PLC.SourcePos ->
+    D.DTerm UPLC.DefaultUni UPLC.DefaultFun DAnn ->
+    HighlightSpan
+mkUplcSpan pos term = HighlightSpan sloc eloc
+    where
+        sline = unPos $ sourceLine pos
+        scol = unPos $ sourceColumn pos
+        sloc = B.Location (sline, scol)
+        eloc = case delta of
+            Nothing -> Nothing
+            Just d ->
+                let eline = sline
+                    ecol = scol + d - 1
+                 in Just $ B.Location (eline, ecol)
+        delta = length <$> case term of
+            UPLC.Var _ name -> Just . Text.unpack $ UPLC.ndbnString name
+            UPLC.LamAbs{}   -> Just "lam"
+            UPLC.Apply{}    -> Just "["
+            UPLC.Force{}    -> Just "force"
+            UPLC.Delay{}    -> Just "delay"
+            UPLC.Constant{} -> Just "con"
+            UPLC.Builtin{}  -> Just "builtin"
+            UPLC.Error{}    -> Just "error"

--- a/plutus-core/executables/debugger/Types.hs
+++ b/plutus-core/executables/debugger/Types.hs
@@ -19,8 +19,12 @@ import Data.Text (Text)
 import Lens.Micro.TH
 
 type Breakpoints = [Breakpoint]
+
 data Breakpoint = UplcBP SourcePos
                 | TxBP SourcePos
+
+-- | Annotation used in the debugger. Contains source locations for the UPLC program
+-- and the source program.
 data DAnn = DAnn
     { uplcAnn :: SourcePos
     , txAnn   :: SrcSpans

--- a/plutus-core/executables/debugger/Types.hs
+++ b/plutus-core/executables/debugger/Types.hs
@@ -1,13 +1,48 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell       #-}
 
 -- | Debugger TUI Types.
 module Types where
 
+import Annotation
+import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
+import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal (CekState)
+
 import Brick.Focus qualified as B
 import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
+import Data.MonoTraversable
 import Data.Text (Text)
 import Lens.Micro.TH
+
+type Breakpoints = [Breakpoint]
+data Breakpoint = UplcBP SourcePos
+                | TxBP SourcePos
+data DAnn = DAnn
+    { uplcAnn :: SourcePos
+    , txAnn   :: SrcSpans
+    }
+
+instance D.Breakpointable DAnn Breakpoints where
+    hasBreakpoints ann = any breakpointFired
+        where
+          breakpointFired :: Breakpoint -> Bool
+          breakpointFired = \case
+              UplcBP p -> sourceLine p == sourceLine (uplcAnn ann)
+              TxBP p   -> oany (lineInSrcSpan $ sourceLine p) $ txAnn ann
+
+-- | The custom events that can arrive at our brick mailbox.
+data CustomBrickEvent =
+    UpdateClientEvent (CekState UPLC.DefaultUni UPLC.DefaultFun DAnn)
+    -- ^ the driver passes a new cek state to the brick client
+    -- this should mean that the brick client should update its tui
+  | LogEvent String
+    -- ^ the driver logged some text, the brick client can decide to show it in the tui
+
+
 
 data KeyBindingsMode = KeyBindingsShown | KeyBindingsHidden
     deriving stock (Eq, Ord, Show)
@@ -38,6 +73,8 @@ data DebuggerState = DebuggerState
     , _dsCekStateEditor      :: BE.Editor Text ResourceName
     , _dsVLimitBottomEditors :: Int
     -- ^ Controls the height limit of the bottom windows.
+    , _dsHLimitRightEditors  :: Int
+    -- ^ Controls the width limit of the right windows.
     }
 
 makeLenses ''DebuggerState

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -657,6 +657,7 @@ executable debugger
     , mtl
     , optparse-applicative
     , plutus-core           ^>=1.1
+    , prettyprinter
     , text
     , vty
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -647,7 +647,10 @@ executable debugger
   build-depends:
     , base                  >=4.9 && <5
     , brick
+    , bytestring
     , extra
+    , flat
+    , megaparsec
     , microlens
     , microlens-th
     , mono-traversable

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Debug/Internal.hs
@@ -21,6 +21,7 @@
 module UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
     ( CekState (..)
     , Context (..)
+    , contextAnn
     , ioToCekM
     , cekMToIO
     , lenContext
@@ -288,10 +289,10 @@ cekStateAnn = \case
 
 contextAnn :: Context uni fun ann -> Maybe ann
 contextAnn = \case
-  FrameApplyFun ann _ _   -> pure ann
-  FrameApplyArg ann _ _ _ -> pure ann
-  FrameForce ann _        -> pure ann
-  NoFrame                 -> empty
+    FrameApplyFun ann _ _   -> pure ann
+    FrameApplyArg ann _ _ _ -> pure ann
+    FrameForce ann _        -> pure ann
+    NoFrame                 -> empty
 
 lenContext :: Context uni fun ann -> Word
 lenContext = go 0
@@ -417,4 +418,3 @@ stepAndMaybeSpend !kind !unbudgetedSteps = do
     if unbudgetedStepsTotal >= ?cekSlippage
     then spendAccumulatedBudget unbudgetedSteps' >> pure (toWordArray 0)
     else pure unbudgetedSteps'
-


### PR DESCRIPTION
This is the integration. Now one can launch the debugger with a UPLC program (in a `flat` file) and a source program, and press 's' to step through the program. Currently UPLC has highlighting, source doesn't.

e.g.
```
cabal run plutus-core:debugger -- ~/demo/DebuggerDemo.flat ~/demo/DebuggerDemo.hs
```