### PR TITLE
Use `SrcSpan` instead of `SourcePos` for UPLC in debugger

### DIFF
--- a/plutus-core/executables/debugger/Types.hs
+++ b/plutus-core/executables/debugger/Types.hs
@@ -17,6 +17,7 @@ import Brick.Widgets.Edit qualified as BE
 import Data.MonoTraversable
 import Data.Text (Text)
 import Lens.Micro.TH
+import Text.Megaparsec
 
 type Breakpoints = [Breakpoint]
 
@@ -26,7 +27,7 @@ data Breakpoint = UplcBP SourcePos
 -- | Annotation used in the debugger. Contains source locations for the UPLC program
 -- and the source program.
 data DAnn = DAnn
-    { uplcAnn :: SourcePos
+    { uplcAnn :: SrcSpan
     , txAnn   :: SrcSpans
     }
 
@@ -35,7 +36,7 @@ instance D.Breakpointable DAnn Breakpoints where
         where
           breakpointFired :: Breakpoint -> Bool
           breakpointFired = \case
-              UplcBP p -> sourceLine p == sourceLine (uplcAnn ann)
+              UplcBP p -> unPos (sourceLine p) == srcSpanSLine (uplcAnn ann)
               TxBP p   -> oany (lineInSrcSpan $ sourceLine p) $ txAnn ann
 
 -- | The custom events that can arrive at our brick mailbox.


### PR DESCRIPTION
Previously `mkUplcSpan` wasn't doing the right thing in the `Returning` case. It used the returned value to determine the length of the highlight. If, for example, the return value is a `lam`, and the original term that evaluated to that value is a `force`, it'd only highlight the first 3 letters of `force` (because `length "lam" == 3`).

This PR fixes it by using `SrcSpan` instead of `SourcePos` in `DAnn`. This is what we need to do anyway, once we make the UPLC parser return `SrcSpan`-annotated terms instead of `SourcePos`-annotated ones.