### PR TITLE
PLT-1375: Highlight source code while tracing through Plutus Core

### DIFF
--- a/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
+++ b/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
@@ -1,0 +1,4 @@
+### Added
+
+- The debugger can now highlight (beside the UPLC expression), the original PlutusTX expression
+  currently being evaluated.

--- a/plutus-core/executables/debugger/Draw.hs
+++ b/plutus-core/executables/debugger/Draw.hs
@@ -43,7 +43,7 @@ drawDebugger st =
         BB.borderWithLabel (B.txt "Source program") $
             B.withFocusRing
                 focusRing
-                (BE.renderEditor (B.txt . Text.unlines))
+                 (BE.renderEditor (drawDocumentWithHighlight (st ^. dsSourceHighlight)))
                 (st ^. dsSourceEditor)
     returnValueEditor =
         BB.borderWithLabel (B.txt "UPLC value being returned") $

--- a/plutus-core/executables/debugger/Event.hs
+++ b/plutus-core/executables/debugger/Event.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TupleSections         #-}
 
 -- | Handler of debugger events.
 module Event where
@@ -10,7 +8,6 @@ module Event where
 import PlutusCore.Annotation
 import PlutusCore.Pretty qualified as PLC
 import Types
-import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal
 
@@ -20,6 +17,8 @@ import Brick.Types qualified as B
 import Brick.Widgets.Edit qualified as BE
 import Control.Concurrent.MVar
 import Control.Monad.State
+import Data.Coerce
+import Data.Set as S
 import Graphics.Vty qualified as Vty
 import Lens.Micro
 import Prettyprinter
@@ -74,11 +73,8 @@ handleDebuggerEvent driverMailbox bev@(B.VtyEvent ev) = do
             pure ()
         _ -> handleEditorEvent
 handleDebuggerEvent _driverMailbox (B.AppEvent (UpdateClientEvent cekState)) = do
-    let uplcHighlight = do
-            uplcSpan <- uplcAnn <$> case cekState of
-                Computing _ _ _ t -> Just (UPLC.termAnn t)
-                Returning _ ctx _ -> contextAnn ctx
-                _                 -> Nothing
+    let uplcHighlight :: Maybe HighlightSpan = do
+            uplcSpan <- uplcAnn <$> cekStateAnn cekState
             pure HighlightSpan
                 { _hcSLoc = B.Location (srcSpanSLine uplcSpan, srcSpanSCol uplcSpan),
                   -- The ending column of a `SrcSpan` is usually one more than the column of
@@ -86,29 +82,42 @@ handleDebuggerEvent _driverMailbox (B.AppEvent (UpdateClientEvent cekState)) = d
                   -- is the line break, hence the `- 1`.
                   _hcELoc = Just $ B.Location (srcSpanELine uplcSpan, srcSpanECol uplcSpan - 1)
                 }
-    modify' $ \st -> case cekState of
-        Computing{} ->
-            st & dsUplcHighlight .~ uplcHighlight
+    let sourceHighlight :: Maybe HighlightSpan = do
+            txSpans <- txAnn <$> cekStateAnn cekState
+            -- FIXME: use some/all spans for highlighting, not just the first one
+            firstTxSpan <- S.lookupMin $ coerce txSpans
+            -- TODO: the HS_FILE supplied from the command line gets highlighted
+            -- The highlighting will not make sense or even break if the user provides
+            -- wrong HS_FILE or if the UPLC originated from multiple HS modules.
+            pure HighlightSpan
+                { _hcSLoc = B.Location (srcSpanSLine firstTxSpan, srcSpanSCol firstTxSpan),
+                  -- GHC's SrcSpan's ending column is one larger than the last character's column.
+                  -- See: ghc/compiler/GHC/Types/SrcLoc.hs#L728
+                  _hcELoc = Just $ B.Location (srcSpanELine firstTxSpan, srcSpanECol firstTxSpan -1)
+                }
+    modify' $
+      -- update line highlighting
+      set dsUplcHighlight uplcHighlight .
+      set dsSourceHighlight sourceHighlight .
+        case cekState of
+            Computing{} ->
                -- Clear the return value editor.
-               & dsReturnValueEditor .~
+               dsReturnValueEditor .~
                 BE.editorText
                     EditorReturnValue
                     Nothing
                     mempty
-        Returning _ _ v ->
-            st & dsUplcHighlight .~ uplcHighlight
-               & dsReturnValueEditor .~
+            Returning _ _ v ->
+               dsReturnValueEditor .~
                 BE.editorText
                     EditorReturnValue
                     Nothing
                     (PLC.displayPlcDef (dischargeCekValue v))
-
-        Terminating t ->
-            st & dsUplcHighlight .~ Nothing
-               & dsReturnValueEditor .~
+            Terminating t ->
+               dsReturnValueEditor .~
                 BE.editorText
                     EditorReturnValue
                     Nothing
                     (PLC.render $ vcat ["Evaluation Finished. Result:", line, PLC.prettyPlcDef t])
-        Starting{} -> st
+            Starting{} -> id
 handleDebuggerEvent _ _ = pure ()

--- a/plutus-core/executables/debugger/Main.hs
+++ b/plutus-core/executables/debugger/Main.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE StrictData        #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 
 {- | A Plutus Core debugger TUI application.
@@ -20,6 +19,8 @@ import PlutusCore qualified as PLC
 import PlutusCore.Error
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusCore.Evaluation.Machine.MachineParameters
+import PlutusCore.Executable.Common
+import PlutusCore.Executable.Parsers
 import PlutusCore.Pretty qualified as PLC
 import UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
@@ -38,15 +39,13 @@ import Brick.Util qualified as B
 import Brick.Widgets.Edit qualified as BE
 import Control.Concurrent
 import Control.Monad.Except
-import Control.Monad.Extra
 import Control.Monad.ST (RealWorld)
-import Data.ByteString.Lazy qualified as Lazy
+import Data.Text (Text)
 import Data.Text.IO qualified as Text
-import Flat
 import Graphics.Vty qualified as Vty
 import Lens.Micro
 import Options.Applicative qualified as OA
-import System.Directory.Extra
+import UntypedPlutusCore.Core.Zip
 
 debuggerAttrMap :: B.AttrMap
 debuggerAttrMap =
@@ -62,16 +61,16 @@ darkGreen :: Vty.Color
 darkGreen = Vty.rgbColor @Int 0 100 0
 
 data Options = Options
-    {optUplcPath :: FilePath, optHsPath :: FilePath}
+    { optUplcInput       :: Input
+    , optUplcInputFormat :: Format
+    -- MAYBE: make tx file optional? the SourceEditor should be hidden in that case then
+    , optHsPath          :: FilePath
+    }
 
 parseOptions :: OA.Parser Options
 parseOptions = do
-    optUplcPath <-
-        OA.argument OA.str $
-            mconcat
-                [ OA.metavar "UPLC_FILE"
-                , OA.help "UPLC File"
-                ]
+    optUplcInput <- input
+    optUplcInputFormat <- inputformat
     optHsPath <-
         OA.argument OA.str $
             mconcat
@@ -82,28 +81,15 @@ parseOptions = do
 
 main :: IO ()
 main = do
-    opts <-
+    Options{..} <-
         OA.execParser $
             OA.info
                 (parseOptions OA.<**> OA.helper)
                 (OA.fullDesc <> OA.header "Plutus Core Debugger")
 
-    unlessM (doesFileExist (optUplcPath opts)) . fail $
-        "Does not exist or not a file: " <> optUplcPath opts
-    uplcFlat <- Lazy.readFile (optUplcPath opts)
-    uplcDebruijn <-
-        either
-            (\e -> fail $ "UPLC deserialisation failure:" <> show e)
-            pure
-            (unflat uplcFlat)
-    uplcNoAnn <- unDeBruijnProgram uplcDebruijn
-    let uplcText = PLC.displayPlcDef uplcNoAnn
-    uplcParsed <-
-        either (error . PLC.display @_ @ParserErrorBundle) pure
-            . PLC.runQuoteT
-            $ UPLC.parseProgram uplcText
-    let uplc = fmap (\sp -> DAnn sp mempty) uplcParsed
-    hsText <- Text.readFile (optHsPath opts)
+    (uplcText, uplcDAnn) <- getProgramWithText optUplcInputFormat optUplcInput
+
+    hsText <- Text.readFile optHsPath
 
     -- The communication "channels" at debugger-driver and at brick
     driverMailbox <- newEmptyMVar @(D.Cmd Breakpoints)
@@ -136,6 +122,7 @@ main = do
                         EditorSource
                         Nothing
                         hsText
+                , _dsSourceHighlight = Nothing
                 , _dsReturnValueEditor =
                     BE.editorText
                         EditorReturnValue
@@ -155,7 +142,7 @@ main = do
 
     -- TODO: find out if the driver-thread exits when brick exits
     -- or should we wait for driver-thread?
-    _dTid <- forkIO $ driverThread driverMailbox brickMailbox uplc
+    _dTid <- forkIO $ driverThread driverMailbox brickMailbox uplcDAnn
 
     void $ B.customMain initialVty builder (Just brickMailbox) app initialState
 
@@ -190,17 +177,42 @@ driverThread driverMailbox brickMailbox prog = do
         D.StepF prevState k  -> cekMToIO (D.handleStep prevState) >>= k
         D.InputF k           -> handleInput >>= k
         D.LogF text k        -> handleLog text >> k
-        D.UpdateClientF ds k -> handleUpdate ds >> k -- TODO: implement
+        D.UpdateClientF ds k -> handleUpdate ds >> k
       where
         handleInput = takeMVar driverMailbox
         handleUpdate = B.writeBChan brickMailbox . UpdateClientEvent
         handleLog = B.writeBChan brickMailbox . LogEvent
 
-unDeBruijnProgram ::
-    UPLC.Program UPLC.NamedDeBruijn DefaultUni DefaultFun () ->
-    IO (UPLC.Program UPLC.Name DefaultUni DefaultFun ())
-unDeBruijnProgram p = do
-    either (fail . show) pure
-        . PLC.runQuote
-        . runExceptT @UPLC.FreeVariableError
-        $ traverseOf UPLC.progTerm UPLC.unDeBruijnTerm p
+-- | Read uplc code in a given format
+--
+--  Adapted from `Common.getProgram`
+getProgramWithText :: Format -> Input -> IO (Text, UplcProg DAnn)
+getProgramWithText fmt inp =
+    case fmt of
+        Textual -> do
+            -- here we use the original raw uplc text, we do not attempt any prettyfying
+            (progTextRaw, progWithUplcSpan) <- parseInput inp
+            let -- IMPORTANT: we cannot have any Tx.SourceSpans available in Textual mode
+                -- We still show the SourceEditor but TX highlighting (or breakpointing) won't work.
+                -- TODO: disable setting TX.breakpoints from inside the brick gui interface
+                addEmptyTxSpans = fmap (`DAnn` mempty)
+                progWithDAnn = addEmptyTxSpans progWithUplcSpan
+            pure (progTextRaw, progWithDAnn)
+
+        Flat flatMode -> do
+            -- here comes the dance of flat-parsing->PRETTYfying->text-parsing
+            -- so we can have artificial SourceSpans in annotations
+            progWithTxSpans <- loadASTfromFlat @UplcProg @PLC.SrcSpans flatMode inp
+            -- annotations are not pprinted by default, no need to `void`
+            let progTextPretty = PLC.displayPlcDef progWithTxSpans
+
+            -- the parsed prog with uplc.srcspan
+            progWithUplcSpan <- either (fail . show @ParserErrorBundle) pure $ runExcept $
+                                   PLC.runQuoteT $ UPLC.parseProgram progTextPretty
+
+            -- zip back the two programs into one program with their annotations' combined
+            -- the zip may fail if the AST cannot parse-pretty roundtrip (should not happen).
+            progWithDAnn <- either fail pure $ runExcept $
+                               pzipWith DAnn progWithUplcSpan progWithTxSpans
+
+            pure (progTextPretty, progWithDAnn)

--- a/plutus-core/executables/debugger/Types.hs
+++ b/plutus-core/executables/debugger/Types.hs
@@ -74,6 +74,7 @@ data DebuggerState = DebuggerState
     , _dsUplcEditor          :: BE.Editor Text ResourceName
     , _dsUplcHighlight       :: Maybe HighlightSpan
     , _dsSourceEditor        :: BE.Editor Text ResourceName
+    , _dsSourceHighlight     :: Maybe HighlightSpan
     , _dsReturnValueEditor   :: BE.Editor Text ResourceName
     , _dsCekStateEditor      :: BE.Editor Text ResourceName
     , _dsVLimitBottomEditors :: Int

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -186,6 +186,7 @@ library
     UntypedPlutusCore.Check.Uniques
     UntypedPlutusCore.Core
     UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.Core.Zip
     UntypedPlutusCore.DeBruijn
     UntypedPlutusCore.Evaluation.Machine.Cek
     UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
@@ -649,9 +650,7 @@ executable debugger
   build-depends:
     , base                  >=4.9 && <5
     , brick
-    , bytestring
-    , extra
-    , flat
+    , containers
     , megaparsec
     , microlens
     , microlens-th
@@ -659,6 +658,7 @@ executable debugger
     , mtl
     , optparse-applicative
     , plutus-core           ^>=1.1
+    , plutus-core-execlib
     , prettyprinter
     , text
     , vty

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -10,6 +10,7 @@ module PlutusCore
     , parseType
     , SourcePos
     , SrcSpan (..)
+    , SrcSpans
     -- * Builtins
     , Some (..)
     , SomeTypeIn (..)

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Zip.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Core/Zip.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module UntypedPlutusCore.Core.Zip
+    ( pzipWith
+    , pzip
+    , tzipWith
+    , tzip
+    ) where
+
+import Control.Monad.Except
+import UntypedPlutusCore.Core.Instance.Eq ()
+import UntypedPlutusCore.Core.Type
+
+-- | Zip two programs using a combinator function for annotations.
+--
+-- Throws an error if the input programs are not "equal" modulo annotations.
+-- Note that the function is "left-biased", so in case that the 2 input programs contain `Name`s,
+-- the output program will contain just the `Name`s of the first input program.
+pzipWith :: forall p name uni fun ann1 ann2 ann3 m.
+           (p ~ Program name uni fun, (Eq (Term name uni fun ())), MonadError String m)
+         => (ann1 -> ann2 -> ann3)
+         -> p ann1
+         -> p ann2
+         -> m (p ann3)
+pzipWith f (Program ann1 ver1 t1) (Program ann2 ver2 t2) = do
+    when (ver1 /= ver2) $
+       throwError "zip: Versions do not match."
+    Program (f ann1 ann2) ver1 <$> tzipWith f t1 t2
+
+-- | Zip two terms using a combinator function for annotations.
+--
+-- Throws an error if the input terms are not "equal" modulo annotations.
+-- Note that the function is "left-biased", so in case that the 2 input terms contain `Name`s,
+-- the output term will contain just the `Name`s of the first input term.
+-- TODO: this is not an optimal implementation
+tzipWith :: forall t name uni fun ann1 ann2 ann3 m.
+           (t ~ Term name uni fun, Eq (t ()), MonadError String m)
+         => (ann1 -> ann2 -> ann3)
+         -> t ann1
+         -> t ann2
+         -> m (t ann3)
+tzipWith f term1 term2 = do
+    -- Prior establishing t1==t2 avoids the need to check for Eq uni, Eq fun and alpha-equivalence.
+    -- Slower this way because we have to re-traverse the terms.
+    when (void term1 /= void term2) $
+       throwError "zip: Terms do not match."
+    go term1 term2
+ where
+   go :: t ann1 -> t ann2 -> m (t ann3)
+   -- MAYBE: some boilerplate could be removed on the following clauses if termAnn was a lens
+   go (Constant a1 s1) (Constant a2 _s2)    = pure $ Constant (f a1 a2) s1
+   go (Builtin a1 f1) (Builtin a2 _f2)      = pure $ Builtin (f a1 a2) f1
+   go (Var a1 n1) (Var a2 _n2)              = pure $ Var (f a1 a2) n1
+   go (Error a1) (Error a2)                 = pure $ Error (f a1 a2)
+   -- MAYBE: some boilerplate could be removed here if we used parallel subterm traversals/toListOf
+   go (LamAbs a1 n1 t1) (LamAbs a2 _n2 t2)  = LamAbs (f a1 a2) n1 <$> go t1 t2
+   go (Apply a1 t1a t1b) (Apply a2 t2a t2b) = Apply (f a1 a2) <$> go t1a t2a <*> go t1b t2b
+   go (Force a1 t1) (Force a2 t2)           = Force (f a1 a2) <$> go t1 t2
+   go (Delay a1 t1) (Delay a2 t2)           = Delay (f a1 a2) <$> go t1 t2
+   go _ _                                   =
+       throwError "zip: This should not happen, because we prior established term equality."
+
+-- | Zip 2 programs by pairing their annotations
+pzip :: (p ~ Program name uni fun, Eq (Term name uni fun ()), MonadError String m)
+     => p ann1
+     -> p ann2
+     -> m (p (ann1,ann2))
+pzip = pzipWith (,)
+
+-- | Zip 2 terms by pairing their annotations
+tzip :: (t ~ Term name uni fun, Eq (t ()), MonadError String m)
+     => t ann1
+     -> t ann2
+     -> m (t (ann1,ann2))
+tzip = tzipWith (,)


### PR DESCRIPTION
This allows highlighting of the source Tx file using the SourceSpans annotations.

Also it allows a bit more input choices for the debugger executable. I tried to reuse parts of the execlib where possible;
and for that i did a small change to execlib that should not break the other executables.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
