### PR TITLE
PLT-1402: Use `SrcSpan` in PIR and TPLC parsers

### DIFF
--- a/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
+++ b/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
@@ -1,0 +1,4 @@
+### Changed
+
+- PIR, TPLC and UPLC parsers now attach `PlutusCore.Annotation.SrcSpan` instead of
+  `Text.Megaparsec.Pos.SourcePos` to the parsed programs and terms.

--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -140,7 +140,7 @@ runPrint (PrintOptions iospec _mode) = do
       Left (ParseErrorB err) ->
           errorWithoutStackTrace $ errorBundlePretty err
       -- otherwise,
-      Right (p::PirProg PLC.SourcePos) -> do
+      Right (p::PirProg PLC.SrcSpan) -> do
         -- pretty print the program. Print mode may be added later on.
         let
             printed :: String

--- a/plutus-core/executables/plc/Main.hs
+++ b/plutus-core/executables/plc/Main.hs
@@ -104,7 +104,7 @@ plutusOpts = hsubparser (
 -- | Apply one script to a list of others.
 runApply :: ApplyOptions -> IO ()
 runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
-  scripts <- mapM ((getProgram ifmt ::  Input -> IO (PlcProg PLC.SourcePos)) . FileInput) inputfiles
+  scripts <- mapM ((getProgram ifmt ::  Input -> IO (PlcProg PLC.SrcSpan)) . FileInput) inputfiles
   let appliedScript =
         case map (\case p -> () <$ p) scripts of
           []          -> errorWithoutStackTrace "No input files"
@@ -150,7 +150,7 @@ runPlcPrintExample = runPrintExample getPlcExamples
 -- | Input a program, erase the types, then output it
 runErase :: EraseOptions -> IO ()
 runErase (EraseOptions inp ifmt outp ofmt mode) = do
-  typedProg <- (getProgram ifmt inp :: IO (PlcProg PLC.SourcePos))
+  typedProg <- (getProgram ifmt inp :: IO (PlcProg PLC.SrcSpan))
   let untypedProg = () <$ PLC.eraseProgram typedProg
   case ofmt of
     Textual       -> writePrettyToFileOrStd outp mode untypedProg

--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -439,8 +439,11 @@ getProgram fmt inp =
         Textual -> parseInput inp
         Flat flatMode -> do
             prog <- loadASTfromFlat flatMode inp
-            -- No source locations in Flat, so we have to make them up.
-            return $ PLC.SrcSpan "top" 1 1 1 2 <$ prog
+            return $ topSrcSpan <$ prog
+
+-- | A made-up `SrcSpan` since there's no source locations in Flat.
+topSrcSpan :: PLC.SrcSpan
+topSrcSpan = PLC.SrcSpan "top" 1 1 1 2
 
 ---------------- Serialise a program using Flat and write it to a given output ----------------
 

--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -37,7 +37,6 @@ import System.IO (hPrint, stderr)
 import Text.Read (readMaybe)
 
 import Control.Monad.ST (RealWorld)
-import Data.Maybe
 import System.Console.Haskeline qualified as Repl
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Driver qualified as D
 import UntypedPlutusCore.Evaluation.Machine.Cek.Debug.Internal qualified as D
@@ -193,7 +192,7 @@ plutusOpts = hsubparser (
 runApply :: ApplyOptions -> IO ()
 runApply (ApplyOptions inputfiles ifmt outp ofmt mode) = do
   scripts <-
-    mapM ((getProgram ifmt ::  Input -> IO (UplcProg SourcePos)) . FileInput) inputfiles
+    mapM ((getProgram ifmt ::  Input -> IO (UplcProg SrcSpan)) . FileInput) inputfiles
   let appliedScript =
         case void <$> scripts of
           []          -> errorWithoutStackTrace "No input files"
@@ -270,11 +269,10 @@ runDbg (DbgOptions inp ifmt cekModel) = do
             D.iterTM handleDbg $ D.runDriver nterm
 
 -- only using one breakpoint at a time allowed at the moment
-type Breakpoints = SourcePos
-type DAnn = SourcePos
+type Breakpoints = SrcSpan
+type DAnn = SrcSpan
 instance D.Breakpointable DAnn Breakpoints where
-    -- ignoring columns
-    hasBreakpoints (SourcePos fp1 l1 _c1) (SourcePos fp2 l2 _c2) = fp1 == fp2 && l1 == l2
+    hasBreakpoints = error "Not implemented: Breakpointable DAnn Breakpoints"
 
 -- Peel off one layer
 handleDbg :: (Cek.PrettyUni uni fun, D.GivenCekReqs uni fun DAnn RealWorld)
@@ -288,7 +286,7 @@ handleDbg = \case
     D.LogF text k        -> handleLog text >> k
     D.UpdateClientF ds k -> handleUpdate ds >> k
   where
-    handleInput = read . fromJust <$> Repl.getInputLine "> "
+    handleInput = error "Not implemented: handleInput"
     handleUpdate _s = Repl.outputStrLn "UPDATETUI" -- TODO: implement
     handleLog = Repl.outputStrLn
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -464,6 +464,7 @@ test-suite plutus-core-test
     Names.Spec
     Normalization.Check
     Normalization.Type
+    Parser.Spec
     Pretty.Readable
     TypeSynthesis.Spec
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -517,7 +517,6 @@ test-suite plutus-ir-test
     , hashable
     , hedgehog
     , lens
-    , megaparsec
     , mtl
     , plutus-core           ^>=1.1
     , plutus-core-testlib   ^>=1.1

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -9,7 +9,6 @@ module PlutusCore
     , parseTerm
     , parseType
     , SourcePos
-    , topSourcePos
     , SrcSpan (..)
     -- * Builtins
     , Some (..)

--- a/plutus-core/plutus-core/src/PlutusCore/Annotation.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Annotation.hs
@@ -16,6 +16,7 @@ module PlutusCore.Annotation
     , lineInSrcSpan
     ) where
 
+import Control.DeepSeq
 import Data.List qualified as List
 import Data.MonoTraversable
 import Data.Semigroup (Any (..))
@@ -98,8 +99,10 @@ instance Show SrcSpan where
 instance Pretty SrcSpan where
     pretty = viaShow
 
+instance NFData SrcSpan
+
 newtype SrcSpans = SrcSpans {unSrcSpans :: Set SrcSpan}
-    deriving newtype (Eq, Ord, Semigroup, Monoid, MonoFoldable)
+    deriving newtype (Eq, Ord, Semigroup, Monoid, MonoFoldable, NFData)
     deriving stock (Generic)
     deriving anyclass (Flat)
 

--- a/plutus-core/plutus-core/src/PlutusCore/Annotation.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Annotation.hs
@@ -82,7 +82,7 @@ data SrcSpan = SrcSpan
     -- is the line break).
     }
     deriving stock (Eq, Ord, Generic)
-    deriving anyclass (Flat)
+    deriving anyclass (Flat, NFData)
 
 instance Show SrcSpan where
     showsPrec _ s =
@@ -98,8 +98,6 @@ instance Show SrcSpan where
 
 instance Pretty SrcSpan where
     pretty = viaShow
-
-instance NFData SrcSpan
 
 newtype SrcSpans = SrcSpans {unSrcSpans :: Set SrcSpan}
     deriving newtype (Eq, Ord, Semigroup, Monoid, MonoFoldable, NFData)

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -1,4 +1,3 @@
--- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Parsers for PLC terms in DefaultUni.
@@ -13,8 +12,7 @@ module PlutusCore.Parser
     , ParserError(..)
     ) where
 
-import Control.Monad.Except (MonadError)
-import Data.Text (Text)
+import PlutusCore.Annotation
 import PlutusCore.Core (Program (..), Term (..), Type)
 import PlutusCore.Default
 import PlutusCore.Error (AsParserErrorBundle, ParserError (..))
@@ -24,48 +22,53 @@ import PlutusCore.Parser.Builtin as Export
 import PlutusCore.Parser.ParserCommon as Export
 import PlutusCore.Parser.Type as Export
 import PlutusCore.Quote (MonadQuote)
-import Text.Megaparsec (MonadParsec (notFollowedBy), SourcePos, anySingle, choice, getSourcePos, many, some, try)
+
+import Control.Monad.Except (MonadError)
+import Data.Text (Text)
+import Text.Megaparsec (MonadParsec (notFollowedBy), anySingle, choice, many, some, try)
 
 -- | A parsable PLC term.
-type PTerm = Term TyName Name DefaultUni DefaultFun SourcePos
+type PTerm = Term TyName Name DefaultUni DefaultFun SrcSpan
 
 varTerm :: Parser PTerm
-varTerm = Var <$> getSourcePos <*> name
+varTerm = withSpan $ \sp ->
+    Var sp <$> name'
 
 tyAbsTerm :: Parser PTerm
-tyAbsTerm = inParens $ TyAbs <$> wordPos "abs" <*> tyName  <*> kind <*> term
+tyAbsTerm = withSpan $ \sp ->
+    inParens $ TyAbs sp <$> (symbol "abs" *> tyName)  <*> kind <*> term
 
 lamTerm :: Parser PTerm
-lamTerm = inParens $ LamAbs <$> wordPos "lam" <*> name <*> pType <*> term
+lamTerm = withSpan $ \sp ->
+    inParens $ LamAbs sp <$> (symbol "lam" *> name) <*> pType <*> term
 
 appTerm :: Parser PTerm
-appTerm = do
-    pos <- getSourcePos
-    inBrackets $ mkIterApp <$> pure pos <*> term <*> some term
+appTerm = withSpan $ \sp ->
+    inBrackets $ mkIterApp sp <$> term <*> some term
 
 conTerm :: Parser PTerm
-conTerm = inParens $ Constant <$> wordPos "con" <*> constant
+conTerm = withSpan $ \sp ->
+    inParens $ Constant sp <$> (symbol "con" *> constant)
 
 builtinTerm :: Parser PTerm
-builtinTerm = inParens $ Builtin <$> wordPos "builtin" <*> builtinFunction
+builtinTerm = withSpan $ \sp ->
+    inParens $ Builtin sp <$> (symbol "builtin" *> builtinFunction)
 
 tyInstTerm :: Parser PTerm
-tyInstTerm = do
-    pos <- getSourcePos
-    inBraces $ do
-        tm <- term
-        tys <- many pType
-        pure $ mkIterInst pos tm tys
+tyInstTerm = withSpan $ \sp ->
+    inBraces $ mkIterInst sp <$> term <*> many pType
 
 unwrapTerm :: Parser PTerm
-unwrapTerm = inParens $ Unwrap <$> wordPos "unwrap" <*> term
+unwrapTerm = withSpan $ \sp ->
+    inParens $ Unwrap sp <$> (symbol "unwrap" *> term)
 
 iwrapTerm :: Parser PTerm
-iwrapTerm = inParens $ IWrap <$> wordPos "iwrap" <*> pType <*> pType <*> term
+iwrapTerm = withSpan $ \sp ->
+    inParens $ IWrap sp <$> (symbol "iwrap" *> pType) <*> pType <*> term
 
-errorTerm
-    :: Parser PTerm
-errorTerm = inParens $ Error <$> wordPos "error" <*> pType
+errorTerm :: Parser PTerm
+errorTerm = withSpan $ \sp ->
+    inParens $ Error sp <$> (symbol "error" *> pType)
 
 -- | Parser for all PLC terms.
 term :: Parser PTerm
@@ -91,24 +94,26 @@ term = do
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
     => Text
-    -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
+    -> m (Program TyName Name DefaultUni DefaultFun SrcSpan)
 parseProgram = parseGen program
 
 -- | Parser for PLC programs.
-program :: Parser (Program TyName Name DefaultUni DefaultFun SourcePos)
-program = whitespace >> do
-    prog <- inParens $ Program <$> wordPos "program" <*> version <*> term
+program :: Parser (Program TyName Name DefaultUni DefaultFun SrcSpan)
+program = do
+    whitespace
+    prog <- withSpan $ \sp ->
+        inParens $ Program sp <$> (symbol "program" *> version) <*> term
     notFollowedBy anySingle
-    return prog
+    pure prog
 
--- | Parse a PLC term. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
+-- | Parse a PLC term. The resulting program will have fresh names. The underlying monad
+-- must be capable of handling any parse errors.
 parseTerm :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
-    Text -> m (Term TyName Name DefaultUni DefaultFun SourcePos)
+    Text -> m (Term TyName Name DefaultUni DefaultFun SrcSpan)
 parseTerm = parseGen term
 
--- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
+-- | Parse a PLC type. The resulting program will have fresh names. The underlying monad
+-- must be capable of handling any parse errors.
 parseType :: (AsParserErrorBundle e, MonadError e m, MonadQuote m) =>
-    Text -> m (Type TyName DefaultUni SourcePos)
+    Text -> m (Type TyName DefaultUni SrcSpan)
 parseType = parseGen pType

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -32,15 +32,15 @@ type PTerm = Term TyName Name DefaultUni DefaultFun SrcSpan
 
 varTerm :: Parser PTerm
 varTerm = withSpan $ \sp ->
-    Var sp <$> name'
+    Var sp <$> name
 
 tyAbsTerm :: Parser PTerm
 tyAbsTerm = withSpan $ \sp ->
-    inParens $ TyAbs sp <$> (symbol "abs" *> tyName)  <*> kind <*> term
+    inParens $ TyAbs sp <$> (symbol "abs" *> trailingWhitespace tyName)  <*> kind <*> term
 
 lamTerm :: Parser PTerm
 lamTerm = withSpan $ \sp ->
-    inParens $ LamAbs sp <$> (symbol "lam" *> name) <*> pType <*> term
+    inParens $ LamAbs sp <$> (symbol "lam" *> trailingWhitespace name) <*> pType <*> term
 
 appTerm :: Parser PTerm
 appTerm = withSpan $ \sp ->

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -72,20 +72,21 @@ errorTerm = withSpan $ \sp ->
 
 -- | Parser for all PLC terms.
 term :: Parser PTerm
-term = do
-    whitespace
-    choice $ map try
-        [ tyAbsTerm
-        , lamTerm
-        , appTerm
-        , conTerm
-        , builtinTerm
-        , tyInstTerm
-        , unwrapTerm
-        , iwrapTerm
-        , errorTerm
-        , varTerm
-        ]
+term = leadingWhitespace go
+  where
+    go =
+        choice $ map try
+            [ tyAbsTerm
+            , lamTerm
+            , appTerm
+            , conTerm
+            , builtinTerm
+            , tyInstTerm
+            , unwrapTerm
+            , iwrapTerm
+            , errorTerm
+            , varTerm
+            ]
 
 -- | Parse a PLC program. The resulting program will have fresh names. The
 -- underlying monad must be capable of handling any parse errors.  This passes
@@ -99,12 +100,13 @@ parseProgram = parseGen program
 
 -- | Parser for PLC programs.
 program :: Parser (Program TyName Name DefaultUni DefaultFun SrcSpan)
-program = do
-    whitespace
-    prog <- withSpan $ \sp ->
-        inParens $ Program sp <$> (symbol "program" *> version) <*> term
-    notFollowedBy anySingle
-    pure prog
+program = leadingWhitespace go
+  where
+    go = do
+        prog <- withSpan $ \sp ->
+            inParens $ Program sp <$> (symbol "program" *> version) <*> term
+        notFollowedBy anySingle
+        pure prog
 
 -- | Parse a PLC term. The resulting program will have fresh names. The underlying monad
 -- must be capable of handling any parse errors.

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -74,7 +74,7 @@ conList uniA = inBrackets $ constantOf uniA `sepBy` symbol ","
 
 -- | Parser for pairs.
 conPair :: DefaultUni (Esc a) -> DefaultUni (Esc b) -> Parser (a, b)
-conPair uniA uniB = inParens $ do
+conPair uniA uniB = inParensSpc $ do
     a <- constantOf uniA
     _ <- symbol ","
     b <- constantOf uniB

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -74,7 +74,7 @@ conList uniA = inBrackets $ constantOf uniA `sepBy` symbol ","
 
 -- | Parser for pairs.
 conPair :: DefaultUni (Esc a) -> DefaultUni (Esc b) -> Parser (a, b)
-conPair uniA uniB = inParensSpc $ do
+conPair uniA uniB = trailingWhitespace . inParens $ do
     a <- constantOf uniA
     _ <- symbol ","
     b <- constantOf uniB

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/ParserCommon.hs
@@ -28,9 +28,6 @@ sure to enclose every 'Parser' that doesn't consume trailing whitespce (e.g. 'ta
 'manyTill', 'Lex.decimal' etc) in a call to 'lexeme'.
 -}
 
-topSourcePos :: SourcePos
-topSourcePos = initialPos "top"
-
 newtype ParserState = ParserState { identifiers :: M.Map T.Text Unique }
     deriving stock (Show)
 
@@ -102,37 +99,24 @@ symbol :: T.Text -> Parser T.Text
 symbol = Lex.symbol whitespace
 
 inParens :: Parser a -> Parser a
-inParens = between (symbol "(") (symbol ")")
+inParens = between (symbol "(") (char ')')
 
--- | Like `inParens` but does not consume trailing whitespaces.
--- The other ticked functions below are similar.
---
--- TODO: these ticked functions should replace the original ones once PIR and TPLC parsers
--- are migrated to `SrcSpan`.
-inParens' :: Parser a -> Parser a
-inParens' = between (symbol "(") (char ')')
+-- | Like `inParens` but also consumes trailing whitespaces.
+inParensSpc :: Parser a -> Parser a
+inParensSpc = (<* whitespace) . inParens
 
 inBrackets :: Parser a -> Parser a
-inBrackets = between (symbol "[") (symbol "]")
+inBrackets = between (symbol "[") (char ']')
 
-inBrackets' :: Parser a -> Parser a
-inBrackets' = between (symbol "[") (char ']')
+-- | Like `inBrackets` but also consumes trailing whitespaces.
+inBracketsSpc :: Parser a -> Parser a
+inBracketsSpc = (<* whitespace) . inBrackets
 
 inBraces :: Parser a -> Parser a
-inBraces = between (symbol "{") (symbol "}")
-
-inBraces' :: Parser a -> Parser a
-inBraces' = between (symbol "{") (char '}')
+inBraces = between (symbol "{") (char '}')
 
 isIdentifierChar :: Char -> Bool
 isIdentifierChar c = isAlphaNum c || c == '_' || c == '\''
-
--- | Create a parser that matches the input word and returns its source position.
--- This is for attaching source positions to parsed terms/programs.
-wordPos ::
-    -- | The word to match
-    T.Text -> Parser SourcePos
-wordPos w = lexeme $ try $ getSourcePos <* symbol w
 
 toSrcSpan :: SourcePos -> SourcePos -> SrcSpan
 toSrcSpan start end =
@@ -144,17 +128,8 @@ toSrcSpan start end =
         , srcSpanECol = unPos (sourceColumn end)
         }
 
-version :: Parser (Version SourcePos)
-version = lexeme $ do
-    p <- getSourcePos
-    x <- Lex.decimal
-    void $ char '.'
-    y <- Lex.decimal
-    void $ char '.'
-    Version p x y <$> Lex.decimal
-
-version' :: Parser (Version SrcSpan)
-version' = withSpan $ \sp -> do
+version :: Parser (Version SrcSpan)
+version = withSpan $ \sp -> do
     x <- Lex.decimal
     void $ char '.'
     y <- Lex.decimal
@@ -162,7 +137,11 @@ version' = withSpan $ \sp -> do
     Version sp x y <$> Lex.decimal
 
 name :: Parser Name
-name = lexeme $ try $ do
+name = lexeme name'
+
+-- | Like `name` but does not consume trailing whitespaces.
+name' :: Parser Name
+name' = try $ do
     void $ lookAhead letterChar
     str <- takeWhileP (Just "identifier") isIdentifierChar
     Name str <$> intern str

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
@@ -34,11 +34,11 @@ funType = withSpan $ \sp ->
 
 allType :: Parser PType
 allType = withSpan $ \sp ->
-    inParens $ TyForall sp <$> (symbol "all" *> tyName) <*> kind <*> pType
+    inParens $ TyForall sp <$> (symbol "all" *> trailingWhitespace tyName) <*> kind <*> pType
 
 lamType :: Parser PType
 lamType = withSpan $ \sp ->
-    inParens $ TyLam sp <$> (symbol "lam" *> tyName) <*> kind <*> pType
+    inParens $ TyLam sp <$> (symbol "lam" *> trailingWhitespace tyName) <*> kind <*> pType
 
 ifixType :: Parser PType
 ifixType = withSpan $ \sp ->
@@ -118,7 +118,7 @@ defaultUniApplication = do
 -- doing it.
 defaultUni :: Parser (SomeTypeIn (Kinded DefaultUni))
 defaultUni = choice $ map try
-    [ inParensSpc defaultUniApplication
+    [ trailingWhitespace (inParens defaultUniApplication)
     , someType @_ @Integer <$ symbol "integer"
     , someType @_ @ByteString <$ symbol "bytestring"
     , someType @_ @Text <$ symbol "string"

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
@@ -7,6 +7,7 @@ module PlutusCore.Parser.Type where
 
 import PlutusPrelude
 
+import PlutusCore.Annotation
 import PlutusCore.Core.Type
 import PlutusCore.Data
 import PlutusCore.Default
@@ -21,41 +22,44 @@ import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 
 -- | A PLC @Type@ to be parsed. ATM the parser only works
 -- for types in the @DefaultUni@ with @DefaultFun@.
-type PType = Type TyName DefaultUni SourcePos
+type PType = Type TyName DefaultUni SrcSpan
 
 varType :: Parser PType
-varType = TyVar <$> getSourcePos <*> tyName
+varType = withSpan $ \sp ->
+    TyVar sp <$> tyName
 
 funType :: Parser PType
-funType = inParens $ TyFun <$> wordPos "fun" <*> pType <*> pType
+funType = withSpan $ \sp ->
+    inParens $ TyFun sp <$> (symbol "fun" *> pType) <*> pType
 
 allType :: Parser PType
-allType = inParens $ TyForall <$> wordPos "all" <*> tyName <*> kind <*> pType
+allType = withSpan $ \sp ->
+    inParens $ TyForall sp <$> (symbol "all" *> tyName) <*> kind <*> pType
 
 lamType :: Parser PType
-lamType = inParens $ TyLam <$> wordPos "lam" <*> tyName <*> kind <*> pType
+lamType = withSpan $ \sp ->
+    inParens $ TyLam sp <$> (symbol "lam" *> tyName) <*> kind <*> pType
 
 ifixType :: Parser PType
-ifixType = inParens $ TyIFix <$> wordPos "ifix" <*> pType <*> pType
+ifixType = withSpan $ \sp ->
+    inParens $ TyIFix sp <$> (symbol "ifix" *> pType) <*> pType
 
 builtinType :: Parser PType
-builtinType = inParens $ do
-    ann <- wordPos "con"
-    SomeTypeIn (Kinded uni) <- defaultUni
-    pure . TyBuiltin ann $ SomeTypeIn uni
+builtinType = withSpan $ \sp -> inParens $ do
+    SomeTypeIn (Kinded uni) <- (symbol "con" *> defaultUni)
+    pure $ TyBuiltin sp (SomeTypeIn uni)
 
 appType :: Parser PType
-appType = inBrackets $ do
-    pos  <- getSourcePos
+appType = withSpan $ \sp -> inBrackets $ do
     fn   <- pType
     args <- some pType
-    pure $ mkIterTyApp pos fn args
+    pure $ mkIterTyApp sp fn args
 
-kind :: Parser (Kind SourcePos)
-kind = inParens (typeKind <|> funKind)
-    where
-        typeKind = Type <$> wordPos "type"
-        funKind  = KindArrow <$> wordPos "fun" <*> kind <*> kind
+kind :: Parser (Kind SrcSpan)
+kind = withSpan $ \sp ->
+    let typeKind = Type sp <$ symbol "type"
+        funKind = KindArrow sp <$> (symbol "fun" *> kind) <*> kind
+     in inParens (typeKind <|> funKind)
 
 -- | Parser for @PType@.
 pType :: Parser PType
@@ -114,7 +118,7 @@ defaultUniApplication = do
 -- doing it.
 defaultUni :: Parser (SomeTypeIn (Kinded DefaultUni))
 defaultUni = choice $ map try
-    [ inParens defaultUniApplication
+    [ inParensSpc defaultUniApplication
     , someType @_ @Integer <$ symbol "integer"
     , someType @_ @ByteString <$ symbol "bytestring"
     , someType @_ @Text <$ symbol "string"

--- a/plutus-core/plutus-core/test/Parser/Spec.hs
+++ b/plutus-core/plutus-core/test/Parser/Spec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+-- | Tests for TPLC parser.
+module Parser.Spec (tests) where
+
+import PlutusCore
+import PlutusCore.Error (ParserErrorBundle)
+import PlutusCore.Generators.Hedgehog.AST
+import PlutusPrelude
+
+import Data.Text qualified as T
+import Hedgehog hiding (Var)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+-- | The `SrcSpan` of a parsed `Term` should not including trailing whitespaces.
+propTermSrcSpan :: Property
+propTermSrcSpan = property $ do
+    term <- forAllWith display (runAstGen genTerm)
+    let code = display (term :: Term TyName Name DefaultUni DefaultFun ())
+    let (endingLine, endingCol) = length &&& T.length . last $ T.lines code
+    trailingSpaces <- forAll $ Gen.text (Range.linear 0 10) (Gen.element [' ', '\n'])
+    case runQuoteT . parseTerm @ParserErrorBundle $ code <> trailingSpaces of
+        Right parsed ->
+            let sp = termAnn parsed
+             in (srcSpanELine sp, srcSpanECol sp) === (endingLine, endingCol + 1)
+        Left err -> annotate (display err) >> failure
+
+tests :: TestTree
+tests =
+    testGroup
+        "parsing"
+        [ testPropertyNamed
+            "parser captures ending positions correctly"
+            "propTermSrcSpan"
+            propTermSrcSpan
+        ]

--- a/plutus-core/plutus-core/test/Spec.hs
+++ b/plutus-core/plutus-core/test/Spec.hs
@@ -19,6 +19,7 @@ import Evaluation.Spec (test_evaluation)
 import Names.Spec
 import Normalization.Check
 import Normalization.Type
+import Parser.Spec qualified as Parser
 import Pretty.Readable
 import TypeSynthesis.Spec (test_typecheck)
 
@@ -31,6 +32,7 @@ import PlutusCore.Generators.Hedgehog.AST as AST
 import PlutusCore.Generators.NEAT.Spec qualified as NEAT
 import PlutusCore.MkPlc
 import PlutusCore.Pretty
+import PlutusCore.Test
 
 import Control.Monad.Except
 import Data.ByteString.Lazy qualified as BSL
@@ -134,7 +136,7 @@ natWordSerializationProp = Hedgehog.withTests 10000 $ property $ do
   and programs.  We have unit tests for the unit and boolean types, and property
   tests for the full set of types in the default universe. -}
 
-type DefaultError = Error DefaultUni DefaultFun SourcePos
+type DefaultError = Error DefaultUni DefaultFun SrcSpan
 
 {-| Test that the parser can successfully consume the output from the
    prettyprinter for the unit and boolean types.  We use a unit test here
@@ -142,9 +144,9 @@ type DefaultError = Error DefaultUni DefaultFun SourcePos
 testLexConstant :: Assertion
 testLexConstant =
     for_ smallConsts $ \t -> do
-            let res :: Either ParserErrorBundle (Term TyName Name DefaultUni DefaultFun SourcePos)
+            let res :: Either ParserErrorBundle (Term TyName Name DefaultUni DefaultFun SrcSpan)
                 res = runQuoteT $ parseTerm $ displayPlcDef t
-            -- using `void` here to get rid of `SourcePos`
+            -- using `void` here to get rid of `SrcSpan`
             fmap void res @?= Right t
         where
           smallConsts :: [Term TyName Name DefaultUni DefaultFun ()]
@@ -187,20 +189,25 @@ propLexConstant = withTests (1000 :: Hedgehog.TestLimit) . property $ do
     term <- forAllPretty $ Constant () <$> runAstGen genConstantForTest
     Hedgehog.tripping term displayPlcDef (fmap void . parseTm)
     where
-        parseTm :: T.Text -> Either ParserErrorBundle (Term TyName Name DefaultUni DefaultFun SourcePos)
+        parseTm :: T.Text -> Either ParserErrorBundle (Term TyName Name DefaultUni DefaultFun SrcSpan)
         parseTm tm = runQuoteT $ parseTerm tm
-
 
 -- | Generate a random 'Program', pretty-print it, and parse the pretty-printed
 -- text, hopefully returning the same thing.
 propParser :: Property
 propParser = property $ do
     prog <- TextualProgram <$> forAllPretty (runAstGen genProgram)
-    Hedgehog.tripping prog (displayPlcDef . unTextualProgram)
-                (\p -> fmap (TextualProgram . void) (parseProg p))
-    where
-        parseProg :: T.Text -> Either ParserErrorBundle (Program TyName Name DefaultUni DefaultFun SourcePos)
-        parseProg = runQuoteT . parseProgram
+    Hedgehog.tripping
+        prog
+        (displayPlcDef . unTextualProgram)
+        (\p -> fmap (TextualProgram . void) (parseProg p))
+  where
+    parseProg ::
+        T.Text ->
+        Either
+            ParserErrorBundle
+            (Program TyName Name DefaultUni DefaultFun SrcSpan)
+    parseProg = runQuoteT . parseProgram
 
 type TestFunction = T.Text -> Either DefaultError T.Text
 
@@ -219,21 +226,31 @@ asGolden f file = goldenVsString file (file ++ ".golden") (asIO f file)
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped :: (AsParserErrorBundle e, AsUniqueError e SourcePos,
-        MonadError e m, MonadQuote m) =>
-    T.Text
-    -> m (Program TyName Name DefaultUni DefaultFun SourcePos)
+parseScoped ::
+    ( AsParserErrorBundle e
+    , AsUniqueError e SrcSpan
+    , MonadError e m
+    , MonadQuote m
+    ) =>
+    T.Text ->
+    m (Program TyName Name DefaultUni DefaultFun SrcSpan)
 -- don't require there to be no free variables at this point, we might be parsing an open term
 parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram
 
-printType ::(AsParserErrorBundle e, AsUniqueError e SourcePos, AsTypeError e (Term TyName Name DefaultUni DefaultFun ()) DefaultUni DefaultFun SourcePos,
-        MonadError e m)
-    => T.Text
-    -> m T.Text
-printType txt = runQuoteT $ T.pack . show . pretty <$> do
-    scoped <- parseScoped txt
-    config <- getDefTypeCheckConfig topSourcePos
-    inferTypeOfProgram config scoped
+printType ::
+    ( AsParserErrorBundle e
+    , AsUniqueError e SrcSpan
+    , AsTypeError e (Term TyName Name DefaultUni DefaultFun ()) DefaultUni DefaultFun SrcSpan
+    , MonadError e m
+    ) =>
+    T.Text ->
+    m T.Text
+printType txt =
+    runQuoteT $
+        T.pack . show . pretty <$> do
+            scoped <- parseScoped txt
+            config <- getDefTypeCheckConfig topSrcSpan
+            inferTypeOfProgram config scoped
 
 testsType :: [FilePath] -> TestTree
 testsType = testGroup "golden type synthesis tests" . fmap (asGolden printType)
@@ -286,4 +303,5 @@ allTests plcFiles rwFiles typeFiles typeErrorFiles =
     , CBOR.DataStability.tests
     , Check.tests
     , NEAT.tests
+    , Parser.tests
     ]

--- a/plutus-core/plutus-core/test/type-errors/applyType.plc.golden
+++ b/plutus-core/plutus-core/test/type-errors/applyType.plc.golden
@@ -1,4 +1,4 @@
-Type mismatch at test:2:3 in term
+Type mismatch at test:2:3-2:37 in term
   '(con integer 0)'.
 Expected type
   '(fun * *)',

--- a/plutus-core/plutus-core/test/type-errors/errorKind.plc.golden
+++ b/plutus-core/plutus-core/test/type-errors/errorKind.plc.golden
@@ -1,3 +1,3 @@
-Kind mismatch at test:2:4 in type '(lam
+Kind mismatch at test:2:3-2:26 in type '(lam
   a (type) a
 )'. Expected kind '(type)' , found kind '(fun (type) (type))'

--- a/plutus-core/plutus-core/test/type-errors/instType.plc.golden
+++ b/plutus-core/plutus-core/test/type-errors/instType.plc.golden
@@ -1,4 +1,4 @@
-Type mismatch at test:2:3 in term
+Type mismatch at test:2:3-2:35 in term
   '(con integer 0)'.
 Expected type
   '(all * (type) *)',

--- a/plutus-core/plutus-core/test/type-errors/unwrapType.plc.golden
+++ b/plutus-core/plutus-core/test/type-errors/unwrapType.plc.golden
@@ -1,4 +1,4 @@
-Type mismatch at test:2:4 in term
+Type mismatch at test:2:3-2:26 in term
   '(con integer 0)'.
 Expected type
   '(ifix * *)',

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -1,4 +1,3 @@
--- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Parsers for PIR terms in DefaultUni.
@@ -11,9 +10,9 @@ module PlutusIR.Parser
     , parseProgram
     , Parser
     , SourcePos
-    , topSourcePos
     ) where
 
+import PlutusCore.Annotation
 import PlutusCore.Default qualified as PLC (DefaultFun, DefaultUni)
 import PlutusCore.Parser hiding (parseProgram, program)
 import PlutusIR as PIR
@@ -29,109 +28,113 @@ import PlutusCore.Error (AsParserErrorBundle)
 import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 
 -- | A parsable PIR pTerm.
-type PTerm = PIR.Term TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos
+type PTerm = PIR.Term TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan
 
 recursivity :: Parser Recursivity
-recursivity = inParens $ (wordPos "rec" >> return Rec) <|> (wordPos "nonrec" >> return NonRec)
+recursivity = inParensSpc $ (symbol "rec" $> Rec) <|> (symbol "nonrec" $> NonRec)
 
 strictness :: Parser Strictness
-strictness = inParens $ (wordPos "strict" >> return Strict) <|> (wordPos "nonstrict" >> return NonStrict)
+strictness = inParensSpc $ (symbol "strict" $> Strict) <|> (symbol "nonstrict" $> NonStrict)
 
-varDecl :: Parser (VarDecl TyName Name PLC.DefaultUni SourcePos)
-varDecl = inParens $ VarDecl <$> wordPos "vardecl" <*> name <*> pType
+varDecl :: Parser (VarDecl TyName Name PLC.DefaultUni SrcSpan)
+varDecl = withSpan $ \sp ->
+    inParens $ VarDecl sp <$> (symbol "vardecl" *> name) <*> pType
 
-tyVarDecl :: Parser (TyVarDecl TyName SourcePos)
-tyVarDecl = inParens $ TyVarDecl <$> wordPos "tyvardecl" <*> tyName <*> kind
+tyVarDecl :: Parser (TyVarDecl TyName SrcSpan)
+tyVarDecl = withSpan $ \sp ->
+    inParens $ TyVarDecl sp <$> (symbol "tyvardecl" *> tyName) <*> kind
 
-datatype :: Parser (Datatype TyName Name PLC.DefaultUni SourcePos)
-datatype = inParens $ Datatype <$> wordPos "datatype"
-    <*> tyVarDecl
-    <*> many tyVarDecl
-    <*> name
-    <*> many varDecl
+datatype :: Parser (Datatype TyName Name PLC.DefaultUni SrcSpan)
+datatype = withSpan $ \sp ->
+    inParens $
+        Datatype sp
+            <$> (symbol "datatype" *> tyVarDecl)
+            <*> many tyVarDecl
+            <*> name
+            <*> many varDecl
 
-binding
-    :: Parser (Binding TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-binding = inParens $ choice $ map try
-    [ wordPos "termbind" >> TermBind <$> getSourcePos <*> strictness <*> varDecl <*> pTerm
-    , wordPos "typebind" >> TypeBind <$> getSourcePos <*> tyVarDecl <*> pType
-    , wordPos "datatypebind" >> DatatypeBind <$> getSourcePos <*> datatype
+binding :: Parser (Binding TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
+binding = withSpan $ \sp ->
+    inParens . choice $ try <$>
+    [ TermBind sp <$> (symbol "termbind" *> strictness) <*> varDecl <*> pTerm
+    , TypeBind sp <$> (symbol "typebind" *> tyVarDecl) <*> pType
+    , DatatypeBind sp <$> (symbol "datatypebind" *> datatype)
     ]
 
 varTerm :: Parser PTerm
-varTerm = do
-    n <- name
-    ann <- getSourcePos
-    pure $ PIR.Var ann n
+varTerm = withSpan $ \sp ->
+    PIR.Var sp <$> name'
 
 -- A small type wrapper for parsers that are parametric in the type of term they parse
 type Parametric
     = Parser PTerm -> Parser PTerm
 
 absTerm :: Parametric
-absTerm tm = inParens $ PIR.tyAbs <$> wordPos "abs" <*> tyName <*> kind <*> tm
+absTerm tm = withSpan $ \sp ->
+    inParens $ PIR.tyAbs sp <$> (symbol "abs" *> tyName) <*> kind <*> tm
 
 lamTerm :: Parametric
-lamTerm tm = inParens $ PIR.lamAbs <$> wordPos "lam" <*> name <*> pType <*> tm
+lamTerm tm = withSpan $ \sp ->
+    inParens $ PIR.lamAbs sp <$> (symbol "lam" *> name) <*> pType <*> tm
 
 conTerm :: Parametric
-conTerm _tm = inParens $ PIR.constant <$> wordPos "con" <*> constant
+conTerm _tm = withSpan $ \sp ->
+    inParens $ PIR.constant sp <$> (symbol "con" *> constant)
 
 iwrapTerm :: Parametric
-iwrapTerm tm = inParens $ PIR.iWrap <$> wordPos "iwrap" <*> pType <*> pType <*> tm
+iwrapTerm tm = withSpan $ \sp ->
+    inParens $ PIR.iWrap sp <$> (symbol "iwrap" *> pType) <*> pType <*> tm
 
 builtinTerm :: Parametric
-builtinTerm _tm = inParens $ PIR.builtin <$> wordPos "builtin" <*> builtinFunction
+builtinTerm _tm = withSpan $ \sp ->
+    inParens $ PIR.builtin sp <$> (symbol "builtin" *> builtinFunction)
 
 unwrapTerm :: Parametric
-unwrapTerm tm = inParens $ PIR.unwrap <$> wordPos "unwrap" <*> tm
+unwrapTerm tm = withSpan $ \sp ->
+    inParens $ PIR.unwrap sp <$> (symbol "unwrap" *> tm)
 
 errorTerm :: Parametric
-errorTerm _tm = inParens $ PIR.error <$> wordPos "error" <*> pType
+errorTerm _tm = withSpan $ \sp ->
+    inParens $ PIR.error sp <$> (symbol "error" *> pType)
 
-letTerm
-    :: Parser PTerm
-letTerm = Let <$> wordPos "let" <*> recursivity <*> NE.some (try binding) <*> pTerm
+letTerm :: Parser PTerm
+letTerm = withSpan $ \sp ->
+    inParens $ Let sp <$> (symbol "let" *> recursivity) <*> NE.some (try binding) <*> pTerm
 
 appTerm :: Parametric
-appTerm tm = do
-    pos <- getSourcePos
-    inBrackets $ PIR.mkIterApp <$> pure pos <*> tm <*> some tm
+appTerm tm = withSpan $ \sp ->
+    inBrackets $ PIR.mkIterApp sp <$> tm <*> some tm
 
 tyInstTerm :: Parametric
-tyInstTerm tm = do
-    pos <- getSourcePos
-    inBraces $ PIR.mkIterInst <$> pure pos <*> tm <*> some pType
-
-term' :: Parametric
-term' other = choice $ map try [
-    varTerm
-    , absTerm self
-    , lamTerm self
-    , conTerm self
-    , iwrapTerm self
-    , builtinTerm self
-    , unwrapTerm self
-    , errorTerm self
-    , inParens other
-    , tyInstTerm self
-    , appTerm self
-    ]
-    where self = term' other
+tyInstTerm tm = withSpan $ \sp ->
+    inBraces $ PIR.mkIterInst sp <$> tm <*> some pType
 
 pTerm :: Parser PTerm
-pTerm = whitespace >> term' letTerm
+pTerm = whitespace >> go
+  where
+    go = choice $ try <$>
+        [ varTerm
+        , letTerm
+        , absTerm go
+        , lamTerm go
+        , conTerm go
+        , iwrapTerm go
+        , builtinTerm go
+        , unwrapTerm go
+        , errorTerm go
+        , tyInstTerm go
+        , appTerm go
+        ]
 
 -- Note that PIR programs do not actually carry a version number
 -- we (optionally) parse it all the same so we can parse all PLC code
-program :: Parser (Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
-program = whitespace >> do
-    prog <- inParens $ do
-        p <- wordPos "program"
-        option () $ void version
-        Program p <$> pTerm
+program :: Parser (Program TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
+program = do
+    whitespace
+    prog <- withSpan $ \sp ->
+        inParens $ Program sp <$> (symbol "program" *> option () (void version) *> pTerm)
     notFollowedBy anySingle
-    return prog
+    pure prog
 
 -- | Parse a PIR program. The resulting program will have fresh names. The
 -- underlying monad must be capable of handling any parse errors.  This passes
@@ -140,5 +143,5 @@ program = whitespace >> do
 parseProgram ::
     (AsParserErrorBundle e, MonadError e m, MonadQuote m)
     => Text
-    -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SourcePos)
+    -> m (Program TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
 parseProgram = parseGen program

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -31,18 +31,20 @@ import Text.Megaparsec hiding (ParseError, State, many, parse, some)
 type PTerm = PIR.Term TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan
 
 recursivity :: Parser Recursivity
-recursivity = inParensSpc $ (symbol "rec" $> Rec) <|> (symbol "nonrec" $> NonRec)
+recursivity = trailingWhitespace . inParens $
+    (symbol "rec" $> Rec) <|> (symbol "nonrec" $> NonRec)
 
 strictness :: Parser Strictness
-strictness = inParensSpc $ (symbol "strict" $> Strict) <|> (symbol "nonstrict" $> NonStrict)
+strictness = trailingWhitespace . inParens $
+    (symbol "strict" $> Strict) <|> (symbol "nonstrict" $> NonStrict)
 
 varDecl :: Parser (VarDecl TyName Name PLC.DefaultUni SrcSpan)
 varDecl = withSpan $ \sp ->
-    inParens $ VarDecl sp <$> (symbol "vardecl" *> name) <*> pType
+    inParens $ VarDecl sp <$> (symbol "vardecl" *> trailingWhitespace name) <*> pType
 
 tyVarDecl :: Parser (TyVarDecl TyName SrcSpan)
 tyVarDecl = withSpan $ \sp ->
-    inParens $ TyVarDecl sp <$> (symbol "tyvardecl" *> tyName) <*> kind
+    inParens $ TyVarDecl sp <$> (symbol "tyvardecl" *> trailingWhitespace tyName) <*> kind
 
 datatype :: Parser (Datatype TyName Name PLC.DefaultUni SrcSpan)
 datatype = withSpan $ \sp ->
@@ -50,7 +52,7 @@ datatype = withSpan $ \sp ->
         Datatype sp
             <$> (symbol "datatype" *> tyVarDecl)
             <*> many tyVarDecl
-            <*> name
+            <*> trailingWhitespace name
             <*> many varDecl
 
 binding :: Parser (Binding TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
@@ -63,7 +65,7 @@ binding = withSpan $ \sp ->
 
 varTerm :: Parser PTerm
 varTerm = withSpan $ \sp ->
-    PIR.Var sp <$> name'
+    PIR.Var sp <$> name
 
 -- A small type wrapper for parsers that are parametric in the type of term they parse
 type Parametric
@@ -71,11 +73,11 @@ type Parametric
 
 absTerm :: Parametric
 absTerm tm = withSpan $ \sp ->
-    inParens $ PIR.tyAbs sp <$> (symbol "abs" *> tyName) <*> kind <*> tm
+    inParens $ PIR.tyAbs sp <$> (symbol "abs" *> trailingWhitespace tyName) <*> kind <*> tm
 
 lamTerm :: Parametric
 lamTerm tm = withSpan $ \sp ->
-    inParens $ PIR.lamAbs sp <$> (symbol "lam" *> name) <*> pType <*> tm
+    inParens $ PIR.lamAbs sp <$> (symbol "lam" *> trailingWhitespace name) <*> pType <*> tm
 
 conTerm :: Parametric
 conTerm _tm = withSpan $ \sp ->

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -112,7 +112,7 @@ tyInstTerm tm = withSpan $ \sp ->
     inBraces $ PIR.mkIterInst sp <$> tm <*> some pType
 
 pTerm :: Parser PTerm
-pTerm = whitespace >> go
+pTerm = leadingWhitespace go
   where
     go = choice $ try <$>
         [ varTerm
@@ -131,12 +131,13 @@ pTerm = whitespace >> go
 -- Note that PIR programs do not actually carry a version number
 -- we (optionally) parse it all the same so we can parse all PLC code
 program :: Parser (Program TyName Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
-program = do
-    whitespace
-    prog <- withSpan $ \sp ->
-        inParens $ Program sp <$> (symbol "program" *> option () (void version) *> pTerm)
-    notFollowedBy anySingle
-    pure prog
+program = leadingWhitespace go
+  where
+    go = do
+        prog <- withSpan $ \sp ->
+            inParens $ Program sp <$> (symbol "program" *> option () (void version) *> pTerm)
+        notFollowedBy anySingle
+        pure prog
 
 -- | Parse a PIR program. The resulting program will have fresh names. The
 -- underlying monad must be capable of handling any parse errors.  This passes

--- a/plutus-core/plutus-ir/test/Spec.hs
+++ b/plutus-core/plutus-ir/test/Spec.hs
@@ -15,12 +15,11 @@ import ParserSpec
 import TransformSpec
 import TypeSpec
 
+import PlutusCore qualified as PLC
 import PlutusIR
 import PlutusIR.Core.Instance.Pretty.Readable
 import PlutusIR.Parser (pTerm)
 import PlutusIR.Test
-
-import PlutusCore qualified as PLC
 
 import Test.Tasty
 import Test.Tasty.Extras
@@ -86,7 +85,7 @@ datatypes = testNested "datatypes"
     , goldenPlcFromPirCatch pTerm "idleAll"
     , goldenPlcFromPirCatch pTerm "some"
     , goldenEvalPir pTerm "listMatchEval"
-    , goldenTypeFromPir PLC.topSourcePos pTerm "dataEscape"
+    , goldenTypeFromPir topSrcSpan pTerm "dataEscape"
     ]
 
 recursion :: TestNested

--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -11,7 +11,6 @@ import PlutusCore.Quote
 
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty qualified as PLC
-import PlutusCore.Test
 import PlutusPrelude
 
 import PlutusIR.Analysis.RetainedSize qualified as RetainedSize
@@ -30,8 +29,6 @@ import PlutusIR.Transform.Rename ()
 import PlutusIR.Transform.ThunkRecursions qualified as ThunkRec
 import PlutusIR.Transform.Unwrap qualified as Unwrap
 import PlutusIR.TypeCheck as TC
-
-import Text.Megaparsec.Pos
 
 transform :: TestNested
 transform = testNested "transform" [
@@ -145,11 +142,11 @@ recSplit =
   ]
 
 
-instance Semigroup SourcePos where
-  p1 <> _ = p1
+instance Semigroup PLC.SrcSpan where
+  sp1 <> _ = sp1
 
-instance Monoid SourcePos where
-  mempty = initialPos ""
+instance Monoid PLC.SrcSpan where
+  mempty = initialSrcSpan ""
 
 inline :: TestNested
 inline =

--- a/plutus-core/plutus-ir/test/TypeSpec.hs
+++ b/plutus-core/plutus-ir/test/TypeSpec.hs
@@ -8,7 +8,7 @@ import PlutusIR.Transform.Rename ()
 
 types :: TestNested
 types = testNested "types"
-    $ map (goldenTypeFromPir topSourcePos pTerm)
+    $ map (goldenTypeFromPir topSrcSpan pTerm)
   [ "letInLet"
   ,"listMatch"
   ,"maybe"
@@ -44,7 +44,7 @@ types = testNested "types"
 
 typeErrors :: TestNested
 typeErrors = testNested "type-errors"
-    $ map (goldenTypeFromPirCatch topSourcePos pTerm)
+    $ map (goldenTypeFromPirCatch topSrcSpan pTerm)
     [ "wrongDataConstrReturnType"
     , "nonSelfRecursive"
     , "typeLet"

--- a/plutus-core/plutus-ir/test/datatypes/idleAll.golden
+++ b/plutus-core/plutus-ir/test/datatypes/idleAll.golden
@@ -1,3 +1,3 @@
 Error during PIR typechecking:
-The result-type of a dataconstructor is malformed at location idleAll:12:6
+The result-type of a dataconstructor is malformed at location idleAll:12:5-17:5
 The expected result-type is: [ D2 a ]

--- a/plutus-core/plutus-ir/test/datatypes/some.golden
+++ b/plutus-core/plutus-ir/test/datatypes/some.golden
@@ -1,3 +1,3 @@
 Error during PIR typechecking:
-The result-type of a dataconstructor is malformed at location some:4:6
+The result-type of a dataconstructor is malformed at location some:4:5-9:5
 The expected result-type is: [ Some f ]

--- a/plutus-core/plutus-ir/test/errors/mutuallyRecursiveTypes.golden
+++ b/plutus-core/plutus-ir/test/errors/mutuallyRecursiveTypes.golden
@@ -1,1 +1,1 @@
-Unsupported construct: Mutually recursive datatypes ((recursive) let binding; from mutuallyRecursiveTypes:4:2)
+Unsupported construct: Mutually recursive datatypes ((recursive) let binding; from mutuallyRecursiveTypes:4:1-24:1)

--- a/plutus-core/plutus-ir/test/errors/recursiveTypeBind.golden
+++ b/plutus-core/plutus-ir/test/errors/recursiveTypeBind.golden
@@ -1,1 +1,1 @@
-Error during compilation: Type bindings cannot appear in recursive let, use datatypebind instead((recursive) let binding; from recursiveTypeBind:1:2)
+Error during compilation: Type bindings cannot appear in recursive let, use datatypebind instead((recursive) let binding; from recursiveTypeBind:1:1-11:1)

--- a/plutus-core/plutus-ir/test/type-errors/nonSelfRecursive.golden
+++ b/plutus-core/plutus-ir/test/type-errors/nonSelfRecursive.golden
@@ -1,2 +1,2 @@
 Error during PIR typechecking:
-Free type variable at  nonSelfRecursive:8:57 :  List
+Free type variable at  nonSelfRecursive:8:57-8:61 :  List

--- a/plutus-core/plutus-ir/test/type-errors/nonSelfRecursive.golden
+++ b/plutus-core/plutus-ir/test/type-errors/nonSelfRecursive.golden
@@ -1,2 +1,2 @@
 Error during PIR typechecking:
-Free type variable at  nonSelfRecursive:8:57-8:61 :  List
+Free type variable at  nonSelfRecursive:8:57-8:60 :  List

--- a/plutus-core/plutus-ir/test/type-errors/typeLet.golden
+++ b/plutus-core/plutus-ir/test/type-errors/typeLet.golden
@@ -1,5 +1,5 @@
 Error during PIR typechecking:
-Type mismatch at typeLet:4:3 in term
+Type mismatch at typeLet:4:3-4:33 in term
   '(con integer 1)'.
 Expected type
   'a',

--- a/plutus-core/plutus-ir/test/type-errors/wrongDataConstrReturnType.golden
+++ b/plutus-core/plutus-ir/test/type-errors/wrongDataConstrReturnType.golden
@@ -1,3 +1,3 @@
 Error during PIR typechecking:
-The result-type of a dataconstructor is malformed at location wrongDataConstrReturnType:4:6
+The result-type of a dataconstructor is malformed at location wrongDataConstrReturnType:4:5-10:5
 The expected result-type is: [ Maybe a ]

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -24,6 +24,8 @@ module PlutusCore.Test
     , goldenTEvalCatch
     , goldenUEvalCatch
     , goldenUEvalProfile
+    , initialSrcSpan
+    , topSrcSpan
     , NoMarkRenameT(..)
     , noMarkRename
     , NoRenameT(..)
@@ -48,6 +50,7 @@ import PlutusCore.Generators.Hedgehog.AST
 import PlutusCore.Generators.Hedgehog.Utils
 
 import PlutusCore qualified as TPLC
+import PlutusCore.Annotation
 import PlutusCore.Check.Scoping
 import PlutusCore.DeBruijn
 import PlutusCore.Evaluation.Machine.Ck qualified as TPLC
@@ -250,6 +253,12 @@ goldenUEvalProfile
     :: ToUPlc a TPLC.DefaultUni TPLC.DefaultFun
     => String -> [a] -> TestNested
 goldenUEvalProfile name values = nestedGoldenVsDocM name $ pretty . view _2 <$> (rethrow $ runUPlcProfile values)
+
+initialSrcSpan :: FilePath -> SrcSpan
+initialSrcSpan fp = SrcSpan fp 1 1 1 2
+
+topSrcSpan :: SrcSpan
+topSrcSpan = initialSrcSpan "top"
 
 -- See Note [Marking].
 -- | A version of 'RenameT' that fails to take free variables into account.

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -254,6 +254,7 @@ goldenUEvalProfile
     => String -> [a] -> TestNested
 goldenUEvalProfile name values = nestedGoldenVsDocM name $ pretty . view _2 <$> (rethrow $ runUPlcProfile values)
 
+-- | A made-up `SrcSpan` for testing.
 initialSrcSpan :: FilePath -> SrcSpan
 initialSrcSpan fp = SrcSpan fp 1 1 1 2
 

--- a/plutus-core/testlib/PlutusIR/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Test.hs
@@ -7,7 +7,12 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module PlutusIR.Test where
+module PlutusIR.Test (
+    module PlutusIR.Test,
+    initialSrcSpan,
+    topSrcSpan,
+    rethrow,
+) where
 
 import PlutusPrelude
 import Test.Tasty.Extras

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -68,27 +68,29 @@ errorTerm = withSpan $ \sp ->
 
 -- | Parser for all UPLC terms.
 term :: Parser PTerm
-term = do
-    whitespace
-    choice $ map try [
-        conTerm
-        , builtinTerm
-        , varTerm
-        , lamTerm
-        , appTerm
-        , delayTerm
-        , forceTerm
-        , errorTerm
-        ]
+term = leadingWhitespace go
+  where
+    go =
+        choice $ map try [
+            conTerm
+            , builtinTerm
+            , varTerm
+            , lamTerm
+            , appTerm
+            , delayTerm
+            , forceTerm
+            , errorTerm
+            ]
 
 -- | Parser for UPLC programs.
 program :: Parser (UPLC.Program PLC.Name PLC.DefaultUni PLC.DefaultFun SrcSpan)
-program = do
-    whitespace
-    prog <- withSpan $ \sp ->
-        inParens $ UPLC.Program sp <$> (symbol "program" *> version) <*> term
-    notFollowedBy anySingle
-    pure prog
+program = leadingWhitespace go
+  where
+    go = do
+        prog <- withSpan $ \sp ->
+            inParens $ UPLC.Program sp <$> (symbol "program" *> version) <*> term
+        notFollowedBy anySingle
+        pure prog
 
 -- | Parse a UPLC term. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -44,11 +44,11 @@ builtinTerm = withSpan $ \sp ->
 
 varTerm :: Parser PTerm
 varTerm = withSpan $ \sp ->
-    UPLC.Var sp <$> name'
+    UPLC.Var sp <$> name
 
 lamTerm :: Parser PTerm
 lamTerm = withSpan $ \sp ->
-    inParens $ UPLC.LamAbs sp <$> (symbol "lam" *> name) <*> term
+    inParens $ UPLC.LamAbs sp <$> (symbol "lam" *> trailingWhitespace name) <*> term
 
 appTerm :: Parser PTerm
 appTerm = withSpan $ \sp ->

--- a/plutus-core/untyped-plutus-core/test/Generators.hs
+++ b/plutus-core/untyped-plutus-core/test/Generators.hs
@@ -6,7 +6,7 @@
 -- | UPLC property tests (pretty-printing\/parsing and binary encoding\/decoding).
 module Generators where
 
-import PlutusPrelude (display, fold, on, void)
+import PlutusPrelude (display, fold, on, void, (&&&))
 
 import PlutusCore (Name, _nameText)
 import PlutusCore.Annotation
@@ -20,13 +20,17 @@ import PlutusCore.Parser (defaultUni, parseGen)
 import PlutusCore.Pretty (displayPlcDef)
 import PlutusCore.Quote (QuoteT, runQuoteT)
 import UntypedPlutusCore.Core.Type (Program (Program),
-                                    Term (Apply, Builtin, Constant, Delay, Error, Force, LamAbs, Var))
+                                    Term (Apply, Builtin, Constant, Delay, Error, Force, LamAbs, Var), progTerm,
+                                    termAnn)
 import UntypedPlutusCore.Parser (parseProgram, parseTerm)
 
+import Control.Lens (view)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Hedgehog (property, tripping)
+import Hedgehog (annotate, failure, property, tripping, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 import Test.Tasty.HUnit (testCase, (@?=))
@@ -80,6 +84,25 @@ propParser = testPropertyNamed "Parser" "parser" $ property $ do
             :: T.Text -> Either ParserErrorBundle (Program Name DefaultUni DefaultFun SrcSpan)
         parseProg = runQuoteT . parseProgram
 
+-- | The `SrcSpan` of a parsed `Term` should not including trailing whitespaces.
+propTermSrcSpan :: TestTree
+propTermSrcSpan = testPropertyNamed
+    "parser captures ending positions correctly"
+    "propTermSrcSpan"
+    . property
+    $ do
+        code <-
+            display
+                <$> forAllPretty
+                    (view progTerm <$> runAstGen (Generators.genProgram @DefaultFun))
+        let (endingLine, endingCol) = length &&& T.length . last $ T.lines code
+        trailingSpaces <- forAllPretty $ Gen.text (Range.linear 0 10) (Gen.element [' ', '\n'])
+        case runQuoteT . parseTerm @ParserErrorBundle $ code <> trailingSpaces of
+            Right parsed ->
+                let sp = termAnn parsed
+                 in (srcSpanELine sp, srcSpanECol sp) === (endingLine, endingCol + 1)
+            Left err -> annotate (display err) >> failure
+
 propUnit :: TestTree
 propUnit = testCase "Unit" $ fold
     [ pTerm "(con bool True)"
@@ -123,6 +146,7 @@ test_parsing :: TestTree
 test_parsing = testGroup "Parsing"
                [ propFlat
                , propParser
+               , propTermSrcSpan
                , propUnit
                , propDefaultUni
                ]

--- a/plutus-core/untyped-plutus-core/test/Spec.hs
+++ b/plutus-core/untyped-plutus-core/test/Spec.hs
@@ -33,4 +33,3 @@ main = do
     , test_debug
     , schnorrVerifyRegressions
     ]
-

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -164,22 +164,22 @@ postulate
 {-# COMPILE GHC parseU = getProgram #-}
 {-# COMPILE GHC parseTm = runQuoteT . parseTerm #-}
 {-# COMPILE GHC parseTy = runQuoteT . parseType #-}
-{-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm' #-}
+{-# COMPILE GHC parseTmU = runQuoteT . U.parseTerm #-}
 {-# COMPILE GHC deBruijnify = \ (Program ann ver tm) -> second (void . Program ann ver) . runExcept $ deBruijnTerm tm #-}
 {-# COMPILE GHC deBruijnifyTm = second void . runExcept . deBruijnTerm #-}
 {-# COMPILE GHC deBruijnifyTy = second void . runExcept . deBruijnTy #-}
 {-# FOREIGN GHC import PlutusCore #-}
-{-# COMPILE GHC ProgramN = type PlutusCore.Program TyName Name DefaultUni DefaultFun PlutusCore.SourcePos #-}
+{-# COMPILE GHC ProgramN = type PlutusCore.Program TyName Name DefaultUni DefaultFun PlutusCore.SrcSpan #-}
 {-# COMPILE GHC Program = type PlutusCore.Program NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun () #-}
-{-# COMPILE GHC TermN = type PlutusCore.Term TyName Name DefaultUni DefaultFun PlutusCore.SourcePos #-}
+{-# COMPILE GHC TermN = type PlutusCore.Term TyName Name DefaultUni DefaultFun PlutusCore.SrcSpan #-}
 {-# COMPILE GHC Term = type PlutusCore.Term NamedTyDeBruijn NamedDeBruijn DefaultUni DefaultFun () #-}
-{-# COMPILE GHC TypeN = type PlutusCore.Type TyName DefaultUni PlutusCore.SourcePos #-}
+{-# COMPILE GHC TypeN = type PlutusCore.Type TyName DefaultUni PlutusCore.SrcSpan #-}
 {-# COMPILE GHC Type = type PlutusCore.Type NamedTyDeBruijn DefaultUni () #-}
 {-# COMPILE GHC showTerm = T.pack . show #-}
 
-{-# COMPILE GHC ProgramNU = type U.Program Name DefaultUni DefaultFun PlutusCore.SourcePos #-}
+{-# COMPILE GHC ProgramNU = type U.Program Name DefaultUni DefaultFun PlutusCore.SrcSpan #-}
 {-# COMPILE GHC ProgramU = type U.Program NamedDeBruijn DefaultUni DefaultFun () #-}
-{-# COMPILE GHC TermNU = type U.Term Name DefaultUni DefaultFun PlutusCore.SourcePos #-}
+{-# COMPILE GHC TermNU = type U.Term Name DefaultUni DefaultFun PlutusCore.SrcSpan #-}
 {-# COMPILE GHC TermU = type U.Term NamedDeBruijn DefaultUni DefaultFun () #-}
 {-# COMPILE GHC deBruijnifyU = \ (U.Program ann ver tm) -> second (void . U.Program ann ver) . runExcept $ U.deBruijnTerm tm #-}
 {-# COMPILE GHC deBruijnifyTmU = second void . runExcept . U.deBruijnTerm #-}


### PR DESCRIPTION
Now all 3 parsers use `SrcSpan`.