### PR TITLE
Version 1.2.0.0

### DIFF
--- a/doc/read-the-docs-site/plutus-doc.cabal
+++ b/doc/read-the-docs-site/plutus-doc.cabal
@@ -72,9 +72,9 @@ executable doc-doctests
     , containers
     , flat               <0.5
     , lens
-    , plutus-core        ^>=1.1
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , random
     , serialise

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -62,8 +62,8 @@ library plutus-benchmark-common
     , base         >=4.9 && <5
     , criterion
     , filepath
-    , plutus-core  ^>=1.1
-    , plutus-tx    ^>=1.1
+    , plutus-core  ^>=1.2
+    , plutus-tx    ^>=1.2
 
 ---------------- nofib ----------------
 
@@ -93,9 +93,9 @@ library nofib-internal
     , base                     >=4.9 && <5
     , deepseq
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
-    , plutus-tx-plugin         ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
+    , plutus-tx-plugin         ^>=1.2
 
 executable nofib-exe
   import:         lang
@@ -114,8 +114,8 @@ executable nofib-exe
     , nofib-internal
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
     , transformers
 
 benchmark nofib
@@ -163,8 +163,8 @@ test-suite plutus-benchmark-nofib-tests
     , base                                            >=4.9 && <5
     , nofib-internal
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.2
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -196,9 +196,9 @@ library lists-internal
     , base                     >=4.9 && <5
     , mtl
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
-    , plutus-tx-plugin         ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
+    , plutus-tx-plugin         ^>=1.2
 
 executable list-sort-exe
   import:         lang
@@ -213,7 +213,7 @@ executable list-sort-exe
     , lists-internal
     , monoidal-containers
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
+    , plutus-core              ^>=1.2
 
 benchmark lists
   import:         lang
@@ -268,7 +268,7 @@ benchmark validation
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
+    , plutus-core              ^>=1.2
 
 ---------------- validation-decode ----------------
 
@@ -287,8 +287,8 @@ benchmark validation-decode
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-ledger-api        ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-ledger-api        ^>=1.2
 
 ---------------- validation-full ----------------
 
@@ -307,8 +307,8 @@ benchmark validation-full
     , flat                                                              <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core                                                       ^>=1.1
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.1
+    , plutus-core                                                       ^>=1.2
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.2
 
 ---------------- Cek cost model calibration ----------------
 
@@ -330,9 +330,9 @@ benchmark cek-calibration
     , criterion         >=1.5.9.0
     , lens
     , mtl
-    , plutus-core       ^>=1.1
-    , plutus-tx         ^>=1.1
-    , plutus-tx-plugin  ^>=1.1
+    , plutus-core       ^>=1.2
+    , plutus-tx         ^>=1.2
+    , plutus-tx-plugin  ^>=1.2
 
 ---------------- Signature verification throughput ----------------
 
@@ -354,9 +354,9 @@ executable ed25519-throughput
     , cardano-crypto-class
     , flat                  <0.5
     , hedgehog
-    , plutus-core           ^>=1.1
-    , plutus-tx             ^>=1.1
-    , plutus-tx-plugin      ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-tx             ^>=1.2
+    , plutus-tx-plugin      ^>=1.2
 
 ---------------- script contexts ----------------
 
@@ -373,9 +373,9 @@ library script-contexts-internal
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
     , base               >=4.9 && <5
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
-    , plutus-tx-plugin   ^>=1.1
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
+    , plutus-tx-plugin   ^>=1.2
 
 test-suite plutus-benchmark-script-contexts-tests
   import:         lang
@@ -390,8 +390,8 @@ test-suite plutus-benchmark-script-contexts-tests
   build-depends:
     , base                                            >=4.9 && <5
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx:plutus-tx-testlib                     ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx:plutus-tx-testlib                     ^>=1.2
     , script-contexts-internal
     , tasty
     , tasty-hunit

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -50,7 +50,7 @@ library
     , directory
     , filepath
     , lens
-    , plutus-core             ^>=1.1
+    , plutus-core             ^>=1.2
     , plutus-metatheory
     , tasty
     , tasty-expected-failure
@@ -68,7 +68,7 @@ executable test-utils
     , base                  >=4.9 && <5
     , optparse-applicative
     , plutus-conformance
-    , plutus-core           ^>=1.1
+    , plutus-core           ^>=1.2
     , tasty-golden
     , text
 
@@ -104,6 +104,6 @@ test-suite agda-conformance
   build-depends:
     , base                >=4.9 && <5
     , plutus-conformance
-    , plutus-core         ^>=1.1
+    , plutus-core         ^>=1.2
     , plutus-metatheory
     , transformers

--- a/plutus-core/CHANGELOG.md
+++ b/plutus-core/CHANGELOG.md
@@ -1,0 +1,36 @@
+
+<a id='changelog-1.2.0.0'></a>
+# 1.2.0.0 — 2023-02-16
+
+## Added
+
+- Added `NoThunks` instance for `Data`.
+
+- A float-in compilation pass, capable of floating term bindings inwards in PIR. See Note [Float-in] for more details.
+
+- The debugger can now highlight (beside the UPLC expression), the original PlutusTX expression
+  currently being evaluated.
+
+## Changed
+
+- PIR, TPLC and UPLC parsers now attach `PlutusCore.Annotation.SrcSpan` instead of
+  `Text.Megaparsec.Pos.SourcePos` to the parsed programs and terms.
+
+- The float-in pass can now float non-recursive type and datatype bindings.
+
+- The float-in pass now floats bindings inwards more aggressively.
+  See Note [Float-in] #5.
+
+- Plutus IR was moved to a public sub-library of `plutus-core`.
+
+- `Version` no longer has an annotation, as this was entirely unused.
+
+- Made `geq` faster in certain cases, -1% of total validation time. [#5061](https://github.com/input-output-hk/plutus/pull/5061)
+
+- Made the Haskell-Tx file input to the debugger optional.
+
+## Fixed
+
+- The `goldenPIR` function now uses the correct function to print parse errors, so they are now printed in a human-readable way.
+
+- PIR, PLC and UPLC term parsers can now parse comments.

--- a/plutus-core/changelog.d/20221130_100833_michael.peyton-jones_nothunks_data.md
+++ b/plutus-core/changelog.d/20221130_100833_michael.peyton-jones_nothunks_data.md
@@ -1,4 +1,0 @@
-### Added
-
-- Added `NoThunks` instance for `Data`.
-

--- a/plutus-core/changelog.d/20230105_135411_unsafeFixIO_floatin.md
+++ b/plutus-core/changelog.d/20230105_135411_unsafeFixIO_floatin.md
@@ -1,3 +1,0 @@
-### Added
-
-- A float-in compilation pass, capable of floating term bindings inwards in PIR. See Note [Float-in] for more details.

--- a/plutus-core/changelog.d/20230206_074313_thealmartyblog_fix_goldenPIR_parser_err_show.md
+++ b/plutus-core/changelog.d/20230206_074313_thealmartyblog_fix_goldenPIR_parser_err_show.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- The `goldenPIR` function now uses the correct function to print parse errors, so they are now printed in a human-readable way.

--- a/plutus-core/changelog.d/20230207_100654_thealmartyblog_fix_term_parser.md
+++ b/plutus-core/changelog.d/20230207_100654_thealmartyblog_fix_term_parser.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- PIR, PLC and UPLC term parsers can now parse comments.

--- a/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
+++ b/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
@@ -1,4 +1,0 @@
-### Changed
-
-- PIR, TPLC and UPLC parsers now attach `PlutusCore.Annotation.SrcSpan` instead of
-  `Text.Megaparsec.Pos.SourcePos` to the parsed programs and terms.

--- a/plutus-core/changelog.d/20230213_205047_unsafeFixIO_datatype.md
+++ b/plutus-core/changelog.d/20230213_205047_unsafeFixIO_datatype.md
@@ -1,4 +1,0 @@
-
-### Changed
-
-- The float-in pass can now float non-recursive type and datatype bindings.

--- a/plutus-core/changelog.d/20230214_171339_unsafeFixIO_relax.md
+++ b/plutus-core/changelog.d/20230214_171339_unsafeFixIO_relax.md
@@ -1,4 +1,0 @@
-### Changed
-
-- The float-in pass now floats bindings inwards more aggressively.
-  See Note [Float-in] #5.

--- a/plutus-core/changelog.d/20230215_110959_michael.peyton-jones_split_out_pir.md
+++ b/plutus-core/changelog.d/20230215_110959_michael.peyton-jones_split_out_pir.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Plutus IR was moved to a public sub-library of `plutus-core`.

--- a/plutus-core/changelog.d/20230215_132227_michael.peyton-jones_no_ann_version.md
+++ b/plutus-core/changelog.d/20230215_132227_michael.peyton-jones_no_ann_version.md
@@ -1,4 +1,0 @@
-### Changed
-
-- `Version` no longer has an annotation, as this was entirely unused.
-

--- a/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
+++ b/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
@@ -1,4 +1,0 @@
-### Added
-
-- The debugger can now highlight (beside the UPLC expression), the original PlutusTX expression
-  currently being evaluated.

--- a/plutus-core/changelog.d/20230215_190332_effectfully_inlinable_geq.md
+++ b/plutus-core/changelog.d/20230215_190332_effectfully_inlinable_geq.md
@@ -1,4 +1,0 @@
-### Changed
-
-- Made `geq` faster in certain cases, -1% of total validation time. [#5061](https://github.com/input-output-hk/plutus/pull/5061)
-

--- a/plutus-core/changelog.d/20230216_194718_bezirg_tx_optional.md
+++ b/plutus-core/changelog.d/20230216_194718_bezirg_tx_optional.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Made the Haskell-Tx file input to the debugger optional.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-core
-version:            1.1.1.0
+version:            1.2.0.0
 license:            Apache-2.0
 license-files:
   LICENSE
@@ -280,7 +280,7 @@ library
     , prettyprinter-configurable  ^>=1.1
     , primitive
     , recursion-schemes
-    , satint                      ^>=1.1
+    , satint
     , semigroups                  >=0.19.1
     , serialise
     , some
@@ -331,8 +331,8 @@ test-suite plutus-core-test
     , hex-text
     , mmorph
     , mtl
-    , plutus-core          ^>=1.1
-    , plutus-core-testlib  ^>=1.1
+    , plutus-core          ^>=1.2
+    , plutus-core-testlib  ^>=1.2
     , prettyprinter
     , serialise
     , tasty
@@ -377,8 +377,8 @@ test-suite untyped-plutus-core-test
     , index-envs
     , lens
     , mtl
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-core-testlib   ^>=1.2
     , pretty-show
     , prettyprinter
     , split
@@ -397,8 +397,8 @@ executable plc
     , deepseq
     , lens
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , text
 
 executable uplc
@@ -411,8 +411,8 @@ executable uplc
     , haskeline
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , split
     , text
 
@@ -488,7 +488,7 @@ library plutus-ir
     , mtl
     , multiset
     , parser-combinators   >=0.4.0
-    , plutus-core          >=1.1
+    , plutus-core          ^>=1.2
     , prettyprinter        >=1.1.0.1
     , semigroupoids
     , semigroups           >=0.19.1
@@ -523,9 +523,9 @@ test-suite plutus-ir-test
     , hedgehog
     , lens
     , mtl
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
-    , plutus-ir             ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-core-testlib   ^>=1.2
+    , plutus-ir             ^>=1.2
     , QuickCheck
     , serialise
     , tasty
@@ -546,9 +546,9 @@ executable pir
     , lens
     , megaparsec
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
-    , plutus-ir             ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
+    , plutus-ir             ^>=1.2
     , text
     , transformers
 
@@ -575,9 +575,9 @@ library plutus-core-execlib
     , monoidal-containers
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
-    , plutus-ir             ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-core-testlib   ^>=1.2
+    , plutus-ir             ^>=1.2
     , prettyprinter
     , text
 
@@ -634,8 +634,8 @@ library plutus-core-testlib
     , mmorph
     , mtl
     , multiset
-    , plutus-core                 ^>=1.1
-    , plutus-ir                   ^>=1.1
+    , plutus-core                 ^>=1.2
+    , plutus-ir                   ^>=1.2
     , prettyprinter               >=1.1.0.1
     , prettyprinter-configurable
     , QuickCheck
@@ -679,8 +679,8 @@ executable debugger
     , mono-traversable
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , prettyprinter
     , text
     , vty
@@ -759,7 +759,7 @@ executable cost-model-budgeting-bench
     , hedgehog
     , mtl
     , optparse-applicative
-    , plutus-core            ^>=1.1
+    , plutus-core            ^>=1.2
     , QuickCheck
     , quickcheck-instances
     , random
@@ -790,7 +790,7 @@ executable generate-cost-model
     , extra
     , inline-r              >=1.0.0.0
     , optparse-applicative
-    , plutus-core           ^>=1.1
+    , plutus-core           ^>=1.2
     , text
     , vector
 
@@ -825,7 +825,7 @@ benchmark cost-model-test
     , hedgehog
     , inline-r          >=1.0.0.0
     , mmorph
-    , plutus-core       ^>=1.1
+    , plutus-core       ^>=1.2
     , template-haskell
     , text
     , vector
@@ -869,7 +869,7 @@ test-suite satint-test
     , base                        >=4.9 && <5
     , HUnit
     , QuickCheck
-    , satint                      ^>=1.1
+    , satint
     , test-framework
     , test-framework-hunit
     , test-framework-quickcheck2

--- a/plutus-ledger-api/CHANGELOG.md
+++ b/plutus-ledger-api/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+<a id='changelog-1.2.0.0'></a>
+# 1.2.0.0 — 2023-02-16
+
+## Added
+
+- Exported `mkTermToEvaluate` from `PlutusLedgerApi/Common.hs`

--- a/plutus-ledger-api/changelog.d/20230215_170512_effectfully_expose_mkTermToEvaluate.md
+++ b/plutus-ledger-api/changelog.d/20230215_170512_effectfully_expose_mkTermToEvaluate.md
@@ -1,5 +1,0 @@
-# Added
-
-- Exported `mkTermToEvaluate` from `PlutusLedgerApi/Common.hs`
-
-

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          plutus-ledger-api
-version:       1.1.1.0
+version:       1.2.0.0
 license:       Apache-2.0
 license-files:
   LICENSE
@@ -94,8 +94,8 @@ library
     , lens
     , mtl
     , nothunks
-    , plutus-core        ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , serialise
     , tagged
@@ -115,9 +115,9 @@ library plutus-ledger-api-testlib
     , base               >=4.9      && <5
     , base64-bytestring
     , bytestring
-    , plutus-core        ^>=1.1
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , PyF                >=0.11.1.0
     , serialise
@@ -145,9 +145,9 @@ test-suite plutus-ledger-api-test
     , lens
     , mtl
     , nothunks
-    , plutus-core                ^>=1.1
-    , plutus-ledger-api          ^>=1.1
-    , plutus-ledger-api-testlib  ^>=1.1
+    , plutus-core                ^>=1.2
+    , plutus-ledger-api          ^>=1.2
+    , plutus-ledger-api-testlib  ^>=1.2
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -167,9 +167,9 @@ executable evaluation-test
     , extra
     , filepath
     , mtl
-    , plutus-core                ^>=1.1
-    , plutus-ledger-api          ^>=1.1
-    , plutus-ledger-api-testlib  ^>=1.1
+    , plutus-core                ^>=1.2
+    , plutus-ledger-api          ^>=1.2
+    , plutus-ledger-api-testlib  ^>=1.2
     , serialise
     , tasty
     , tasty-hunit

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -60,7 +60,7 @@ library
     , megaparsec
     , memory
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.2
     , process
     , text
     , transformers
@@ -454,8 +454,8 @@ executable plc-agda
 test-suite test1
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.1
-    , plutus-core:uplc  ^>=1.1
+    , plutus-core:plc   ^>=1.2
+    , plutus-core:uplc  ^>=1.2
 
   hs-source-dirs:     test
   build-depends:
@@ -470,8 +470,8 @@ test-suite test1
 test-suite test2
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.1
-    , plutus-core:uplc  ^>=1.1
+    , plutus-core:plc   ^>=1.2
+    , plutus-core:uplc  ^>=1.2
 
   hs-source-dirs:     test
   type:               detailed-0.9
@@ -495,7 +495,7 @@ test-suite test3
     , base
     , lazy-search
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
     , plutus-metatheory
     , size-based
     , Stream

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx-plugin
-version:         1.1.1.0
+version:         1.2.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -81,8 +81,8 @@ library
     , flat                                  <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.1
-    , plutus-tx                             ^>=1.1
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
+    , plutus-tx                             ^>=1.2
     , prettyprinter
     , PyF                                   >=0.11.1.0
     , template-haskell
@@ -110,7 +110,7 @@ executable gen-plugin-opts-doc
     , containers
     , lens
     , optparse-applicative
-    , plutus-tx-plugin      ^>=1.1
+    , plutus-tx-plugin      ^>=1.2
     , prettyprinter
     , PyF                   >=0.11.1.0
     , text
@@ -162,9 +162,9 @@ test-suite plutus-tx-tests
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx-plugin                                ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx-plugin                                ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.2
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -187,7 +187,7 @@ test-suite size
   hs-source-dirs: test/size
   build-depends:
     , base                                      >=4.9 && <5.0
-    , plutus-tx-plugin                          ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}  ^>=1.1
+    , plutus-tx-plugin                          ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}  ^>=1.2
     , tagged
     , tasty

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx
-version:         1.1.1.0
+version:         1.2.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -106,7 +106,7 @@ library
     , lens
     , memory
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
     , prettyprinter
     , serialise
     , template-haskell                      >=2.13.0.0
@@ -126,8 +126,8 @@ library plutus-tx-testlib
     , flat                                            <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx                                       ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx                                       ^>=1.2
     , prettyprinter
     , tagged
     , tasty
@@ -166,8 +166,8 @@ test-suite plutus-tx-test
     , filepath
     , hedgehog
     , hedgehog-fn
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx                                       ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx                                       ^>=1.2
     , pretty-show
     , serialise
     , tasty

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -13,7 +13,9 @@ fi
 PACKAGE=$1
 VERSION=$2
 
-echo "Assembling changelog for $PACKAGE-$VERSION"
-pushd $PACKAGE > /dev/null
-scriv collect --version "$VERSION"
-popd > /dev/null
+if [ -d "$PACKAGE" ]; then
+  echo "Assembling changelog for $PACKAGE-$VERSION"
+  pushd $PACKAGE > /dev/null
+  scriv collect --version "$VERSION"
+  popd > /dev/null
+fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -19,6 +19,7 @@ shift
 
 default_packages=(
   "plutus-core"
+  "plutus-ir"
   "plutus-ledger-api"
   "plutus-tx"
   "plutus-tx-plugin"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -22,7 +22,9 @@ major_version="${components[0]}.${components[1]}"
 
 echo "Updating version of $PACKAGE to $VERSION"
 # update package version in cabal file for package
-sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
+if [ -f "./$PACKAGE/$PACKAGE.cabal" ]; then
+  sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
+fi
 
 # update version bounds in all cabal files
 # It looks for patterns like the following:
@@ -33,5 +35,5 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # - ", plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.0"
 #
 # and updates the version bounds to "^>={major version}"
-echo "Updating version bounds on $PACKAGE to '>=$major_version'"
+echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
 find . -name "*.cabal" -exec sed -i "s/\(, $PACKAGE[^^]*\).*/\1 ^>=$major_version/" {} \;

--- a/scriv.ini
+++ b/scriv.ini
@@ -1,3 +1,3 @@
 [scriv]
 format = md
-version = 1.0.0.0
+version = 1.2.0.0


### PR DESCRIPTION
We haven't made a release for a while. We've split PIR into a separate library, updated parser, among other things, and started enforcing changelogs. So it is time for a release.

Since there's no major change to the API, I'm bumping the second component of the major version.

The release does not include `word-array` or `prettyprinter-configurable` since they have not been modified.