### PR TITLE
Publish Haddock for each release

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build-haddock-site:
     runs-on: ubuntu-latest
@@ -13,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: nixbuild/nix-quick-install-action@v21
-        with: 
+        with:
           nix_conf: |
             experimental-features = nix-command flakes
-            accept-flake-config = true 
+            accept-flake-config = true
       - name: Build haddock site
         run: |
           nix build .#combined-plutus-haddock
@@ -25,3 +27,4 @@ jobs:
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist
+          target-folder: ${{ github.ref_name }}


### PR DESCRIPTION
Currently the haddock is published at https://input-output-hk.github.io/plutus/

Once this PR is merged, the haddock for master will be at https://input-output-hk.github.io/plutus/master, and the haddock for the releases will be at `https://input-output-hk.github.io/plutus/<version>`, e.g., https://input-output-hk.github.io/plutus/1.2.0.0.

This is done by triggering the GH action on tags of the form `a.b.c.d`, and specifying the `target-folder`.

I've tested this on a fork.