### PR TITLE
Allow newer `cardano-crypto-class`. Bump up `plutus-core-1.1.1.1`

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-core
-version:            1.1.1.0
+version:            1.1.1.1
 license:            Apache-2.0
 license-files:
   LICENSE
@@ -245,7 +245,7 @@ library
     , bimap
     , bytestring
     , cardano-crypto
-    , cardano-crypto-class        ^>=2.0.0.1
+    , cardano-crypto-class        >=2.0.0.1 && <2.2
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1


### PR DESCRIPTION
Not much has changed in `cardano-crypto-class` since the last release. A fix in a function name required a major bump, but it does not affect plutus-core.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
