### PR TITLE
Version 1.2.0.0

### DIFF
--- a/doc/read-the-docs-site/plutus-doc.cabal
+++ b/doc/read-the-docs-site/plutus-doc.cabal
@@ -72,9 +72,9 @@ executable doc-doctests
     , containers
     , flat               <0.5
     , lens
-    , plutus-core        ^>=1.1
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , random
     , serialise

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -62,8 +62,8 @@ library plutus-benchmark-common
     , base         >=4.9 && <5
     , criterion
     , filepath
-    , plutus-core  ^>=1.1
-    , plutus-tx    ^>=1.1
+    , plutus-core  ^>=1.2
+    , plutus-tx    ^>=1.2
 
 ---------------- nofib ----------------
 
@@ -93,9 +93,9 @@ library nofib-internal
     , base                     >=4.9 && <5
     , deepseq
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
-    , plutus-tx-plugin         ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
+    , plutus-tx-plugin         ^>=1.2
 
 executable nofib-exe
   import:         lang
@@ -114,8 +114,8 @@ executable nofib-exe
     , nofib-internal
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
     , transformers
 
 benchmark nofib
@@ -163,8 +163,8 @@ test-suite plutus-benchmark-nofib-tests
     , base                                            >=4.9 && <5
     , nofib-internal
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.2
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -196,9 +196,9 @@ library lists-internal
     , base                     >=4.9 && <5
     , mtl
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-tx                ^>=1.1
-    , plutus-tx-plugin         ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-tx                ^>=1.2
+    , plutus-tx-plugin         ^>=1.2
 
 executable list-sort-exe
   import:         lang
@@ -213,7 +213,7 @@ executable list-sort-exe
     , lists-internal
     , monoidal-containers
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
+    , plutus-core              ^>=1.2
 
 benchmark lists
   import:         lang
@@ -268,7 +268,7 @@ benchmark validation
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
+    , plutus-core              ^>=1.2
 
 ---------------- validation-decode ----------------
 
@@ -287,8 +287,8 @@ benchmark validation-decode
     , flat                     <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core              ^>=1.1
-    , plutus-ledger-api        ^>=1.1
+    , plutus-core              ^>=1.2
+    , plutus-ledger-api        ^>=1.2
 
 ---------------- validation-full ----------------
 
@@ -307,8 +307,8 @@ benchmark validation-full
     , flat                                                              <0.5
     , optparse-applicative
     , plutus-benchmark-common
-    , plutus-core                                                       ^>=1.1
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.1
+    , plutus-core                                                       ^>=1.2
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.2
 
 ---------------- Cek cost model calibration ----------------
 
@@ -330,9 +330,9 @@ benchmark cek-calibration
     , criterion         >=1.5.9.0
     , lens
     , mtl
-    , plutus-core       ^>=1.1
-    , plutus-tx         ^>=1.1
-    , plutus-tx-plugin  ^>=1.1
+    , plutus-core       ^>=1.2
+    , plutus-tx         ^>=1.2
+    , plutus-tx-plugin  ^>=1.2
 
 ---------------- Signature verification throughput ----------------
 
@@ -354,9 +354,9 @@ executable ed25519-throughput
     , cardano-crypto-class
     , flat                  <0.5
     , hedgehog
-    , plutus-core           ^>=1.1
-    , plutus-tx             ^>=1.1
-    , plutus-tx-plugin      ^>=1.1
+    , plutus-core           ^>=1.2
+    , plutus-tx             ^>=1.2
+    , plutus-tx-plugin      ^>=1.2
 
 ---------------- script contexts ----------------
 
@@ -373,9 +373,9 @@ library script-contexts-internal
   exposed-modules: PlutusBenchmark.ScriptContexts
   build-depends:
     , base               >=4.9 && <5
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
-    , plutus-tx-plugin   ^>=1.1
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
+    , plutus-tx-plugin   ^>=1.2
 
 test-suite plutus-benchmark-script-contexts-tests
   import:         lang
@@ -390,8 +390,8 @@ test-suite plutus-benchmark-script-contexts-tests
   build-depends:
     , base                                            >=4.9 && <5
     , plutus-benchmark-common
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx:plutus-tx-testlib                     ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx:plutus-tx-testlib                     ^>=1.2
     , script-contexts-internal
     , tasty
     , tasty-hunit

--- a/plutus-conformance/plutus-conformance.cabal
+++ b/plutus-conformance/plutus-conformance.cabal
@@ -50,7 +50,7 @@ library
     , directory
     , filepath
     , lens
-    , plutus-core             ^>=1.1
+    , plutus-core             ^>=1.2
     , plutus-metatheory
     , tasty
     , tasty-expected-failure
@@ -68,7 +68,7 @@ executable test-utils
     , base                  >=4.9 && <5
     , optparse-applicative
     , plutus-conformance
-    , plutus-core           ^>=1.1
+    , plutus-core           ^>=1.2
     , tasty-golden
     , text
 
@@ -104,6 +104,6 @@ test-suite agda-conformance
   build-depends:
     , base                >=4.9 && <5
     , plutus-conformance
-    , plutus-core         ^>=1.1
+    , plutus-core         ^>=1.2
     , plutus-metatheory
     , transformers

--- a/plutus-core/CHANGELOG.md
+++ b/plutus-core/CHANGELOG.md
@@ -1,0 +1,43 @@
+
+<a id='changelog-1.2.0.0'></a>
+# 1.2.0.0 — 2023-02-24
+
+## Added
+
+- Added `NoThunks` instance for `Data`.
+
+- A float-in compilation pass, capable of floating term bindings inwards in PIR. See Note [Float-in] for more details.
+
+- Tests targeting testing of (1) unconditional inlining of functions (2) call site inlining of fully applied functions (for the upcoming implementation).
+
+- The debugger can now highlight (beside the UPLC expression), the original PlutusTX expression
+  currently being evaluated.
+
+- The debugger driver will now capture any error during the stepping of a PLC program and
+  display it inside the debugging clients (tui,cli,etc).
+
+- function to track the type and term lambda abstraction order of a term in the PIR inliner.
+
+## Changed
+
+- PIR, TPLC and UPLC parsers now attach `PlutusCore.Annotation.SrcSpan` instead of
+  `Text.Megaparsec.Pos.SourcePos` to the parsed programs and terms.
+
+- The float-in pass can now float non-recursive type and datatype bindings.
+
+- The float-in pass now floats bindings inwards more aggressively.
+  See Note [Float-in] #5.
+
+- Plutus IR was moved to a public sub-library of `plutus-core`.
+
+- `Version` no longer has an annotation, as this was entirely unused.
+
+- Made `geq` faster in certain cases, -1% of total validation time. [#5061](https://github.com/input-output-hk/plutus/pull/5061)
+
+- Made the Haskell-Tx file input to the debugger optional.
+
+## Fixed
+
+- The `goldenPIR` function now uses the correct function to print parse errors, so they are now printed in a human-readable way.
+
+- PIR, PLC and UPLC term parsers can now parse comments.

--- a/plutus-core/changelog.d/20221130_100833_michael.peyton-jones_nothunks_data.md
+++ b/plutus-core/changelog.d/20221130_100833_michael.peyton-jones_nothunks_data.md
@@ -1,4 +1,0 @@
-### Added
-
-- Added `NoThunks` instance for `Data`.
-

--- a/plutus-core/changelog.d/20230105_135411_unsafeFixIO_floatin.md
+++ b/plutus-core/changelog.d/20230105_135411_unsafeFixIO_floatin.md
@@ -1,3 +1,0 @@
-### Added
-
-- A float-in compilation pass, capable of floating term bindings inwards in PIR. See Note [Float-in] for more details.

--- a/plutus-core/changelog.d/20230206_074313_thealmartyblog_fix_goldenPIR_parser_err_show.md
+++ b/plutus-core/changelog.d/20230206_074313_thealmartyblog_fix_goldenPIR_parser_err_show.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- The `goldenPIR` function now uses the correct function to print parse errors, so they are now printed in a human-readable way.

--- a/plutus-core/changelog.d/20230207_100654_thealmartyblog_fix_term_parser.md
+++ b/plutus-core/changelog.d/20230207_100654_thealmartyblog_fix_term_parser.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- PIR, PLC and UPLC term parsers can now parse comments.

--- a/plutus-core/changelog.d/20230213_073414_thealmartyblog_plt_1445_add_inliner_tests.md
+++ b/plutus-core/changelog.d/20230213_073414_thealmartyblog_plt_1445_add_inliner_tests.md
@@ -1,3 +1,0 @@
-### Added
-
-- Tests targeting testing of (1) unconditional inlining of functions (2) call site inlining of fully applied functions (for the upcoming implementation).

--- a/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
+++ b/plutus-core/changelog.d/20230213_133329_unsafeFixIO_parser.md
@@ -1,4 +1,0 @@
-### Changed
-
-- PIR, TPLC and UPLC parsers now attach `PlutusCore.Annotation.SrcSpan` instead of
-  `Text.Megaparsec.Pos.SourcePos` to the parsed programs and terms.

--- a/plutus-core/changelog.d/20230213_205047_unsafeFixIO_datatype.md
+++ b/plutus-core/changelog.d/20230213_205047_unsafeFixIO_datatype.md
@@ -1,4 +1,0 @@
-
-### Changed
-
-- The float-in pass can now float non-recursive type and datatype bindings.

--- a/plutus-core/changelog.d/20230214_171339_unsafeFixIO_relax.md
+++ b/plutus-core/changelog.d/20230214_171339_unsafeFixIO_relax.md
@@ -1,4 +1,0 @@
-### Changed
-
-- The float-in pass now floats bindings inwards more aggressively.
-  See Note [Float-in] #5.

--- a/plutus-core/changelog.d/20230215_110959_michael.peyton-jones_split_out_pir.md
+++ b/plutus-core/changelog.d/20230215_110959_michael.peyton-jones_split_out_pir.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Plutus IR was moved to a public sub-library of `plutus-core`.

--- a/plutus-core/changelog.d/20230215_132227_michael.peyton-jones_no_ann_version.md
+++ b/plutus-core/changelog.d/20230215_132227_michael.peyton-jones_no_ann_version.md
@@ -1,4 +1,0 @@
-### Changed
-
-- `Version` no longer has an annotation, as this was entirely unused.
-

--- a/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
+++ b/plutus-core/changelog.d/20230215_151615_bezirg_tx_highlight.md
@@ -1,4 +1,0 @@
-### Added
-
-- The debugger can now highlight (beside the UPLC expression), the original PlutusTX expression
-  currently being evaluated.

--- a/plutus-core/changelog.d/20230215_190332_effectfully_inlinable_geq.md
+++ b/plutus-core/changelog.d/20230215_190332_effectfully_inlinable_geq.md
@@ -1,4 +1,0 @@
-### Changed
-
-- Made `geq` faster in certain cases, -1% of total validation time. [#5061](https://github.com/input-output-hk/plutus/pull/5061)
-

--- a/plutus-core/changelog.d/20230216_194718_bezirg_tx_optional.md
+++ b/plutus-core/changelog.d/20230216_194718_bezirg_tx_optional.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Made the Haskell-Tx file input to the debugger optional.

--- a/plutus-core/changelog.d/20230220_195818_bezirg_dbgr_errors.md
+++ b/plutus-core/changelog.d/20230220_195818_bezirg_dbgr_errors.md
@@ -1,4 +1,0 @@
-### Added
-
-- The debugger driver will now capture any error during the stepping of a PLC program and
-  display it inside the debugging clients (tui,cli,etc).

--- a/plutus-core/changelog.d/20230222_090552_thealmartyblog_plt_1446_add_lam_tracking.md
+++ b/plutus-core/changelog.d/20230222_090552_thealmartyblog_plt_1446_add_lam_tracking.md
@@ -1,3 +1,0 @@
-### Added
-
-- function to track the type and term lambda abstraction order of a term in the PIR inliner.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-core
-version:            1.1.1.0
+version:            1.2.0.0
 license:            Apache-2.0
 license-files:
   LICENSE
@@ -12,7 +12,10 @@ synopsis:           Language library for Plutus Core
 description:        Pretty-printer, parser, and typechecker for Plutus Core.
 category:           Language, Plutus
 build-type:         Simple
-extra-doc-files:    README.md
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
 extra-source-files:
   cost-model/data/*.R
   cost-model/data/benching.csv
@@ -280,7 +283,7 @@ library
     , prettyprinter-configurable  ^>=1.1
     , primitive
     , recursion-schemes
-    , satint                      ^>=1.1
+    , satint
     , semigroups                  >=0.19.1
     , serialise
     , some
@@ -321,18 +324,17 @@ test-suite plutus-core-test
   default-language: Haskell2010
   build-depends:
     , aeson
-    , base                 >=4.9 && <5
+    , base                                            >=4.9 && <5
     , bytestring
     , containers
     , data-default-class
     , filepath
-    , flat                 <0.5
+    , flat                                            <0.5
     , hedgehog
     , hex-text
     , mmorph
     , mtl
-    , plutus-core          ^>=1.1
-    , plutus-core-testlib  ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
     , prettyprinter
     , serialise
     , tasty
@@ -369,16 +371,15 @@ test-suite untyped-plutus-core-test
     Transform.Simplify
 
   build-depends:
-    , base                  >=4.9 && <5
+    , base                                            >=4.9 && <5
     , bytestring
     , cardano-crypto-class
-    , flat                  <0.5
+    , flat                                            <0.5
     , hedgehog
     , index-envs
     , lens
     , mtl
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
     , pretty-show
     , prettyprinter
     , split
@@ -397,8 +398,8 @@ executable plc
     , deepseq
     , lens
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , text
 
 executable uplc
@@ -411,8 +412,8 @@ executable uplc
     , haskeline
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , prettyprinter
     , split
     , text
@@ -489,7 +490,7 @@ library plutus-ir
     , mtl
     , multiset
     , parser-combinators   >=0.4.0
-    , plutus-core          >=1.1
+    , plutus-core          ^>=1.2
     , prettyprinter        >=1.1.0.1
     , semigroupoids
     , semigroups           >=0.19.1
@@ -517,16 +518,15 @@ test-suite plutus-ir-test
     TypeSpec
 
   build-depends:
-    , base                  >=4.9 && <5
+    , base                                  >=4.9 && <5
     , containers
-    , flat                  <0.5
+    , flat                                  <0.5
     , hashable
     , hedgehog
     , lens
     , mtl
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
-    , plutus-ir             ^>=1.1
+    , plutus-core-testlib                   ^>=1.2
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
     , QuickCheck
     , serialise
     , tasty
@@ -540,16 +540,15 @@ executable pir
   main-is:        pir/Main.hs
   hs-source-dirs: executables
   build-depends:
-    , base                  >=4.9 && <5
+    , base                                  >=4.9 && <5
     , bytestring
     , cassava
     , containers
     , lens
     , megaparsec
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
-    , plutus-ir             ^>=1.1
+    , plutus-core-execlib                   ^>=1.2
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
     , text
     , transformers
 
@@ -567,18 +566,16 @@ library plutus-core-execlib
 
   build-depends:
     , aeson
-    , base                  >=4.9 && <5
+    , base                                                       >=4.9 && <5
     , bytestring
     , deepseq
-    , flat                  <0.5
+    , flat                                                       <0.5
     , lens
     , megaparsec
     , monoidal-containers
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-testlib   ^>=1.1
-    , plutus-ir             ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.2
     , prettyprinter
     , text
 
@@ -622,22 +619,21 @@ library plutus-core-testlib
     Test.Tasty.Extras
 
   build-depends:
-    , base                        >=4.9     && <5
+    , base                                  >=4.9     && <5
     , bifunctors
     , bytestring
     , containers
     , data-default-class
-    , dependent-map               >=0.4.0.0
+    , dependent-map                         >=0.4.0.0
     , filepath
-    , hedgehog                    >=1.0
+    , hedgehog                              >=1.0
     , lazy-search
     , lens
     , mmorph
     , mtl
     , multiset
-    , plutus-core                 ^>=1.1
-    , plutus-ir                   ^>=1.1
-    , prettyprinter               >=1.1.0.1
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
+    , prettyprinter                         >=1.1.0.1
     , prettyprinter-configurable
     , QuickCheck
     , quickcheck-instances
@@ -680,8 +676,8 @@ executable debugger
     , mono-traversable
     , mtl
     , optparse-applicative
-    , plutus-core           ^>=1.1
-    , plutus-core-execlib
+    , plutus-core           ^>=1.2
+    , plutus-core-execlib   ^>=1.2
     , prettyprinter
     , text
     , text-zipper
@@ -761,7 +757,7 @@ executable cost-model-budgeting-bench
     , hedgehog
     , mtl
     , optparse-applicative
-    , plutus-core            ^>=1.1
+    , plutus-core            ^>=1.2
     , QuickCheck
     , quickcheck-instances
     , random
@@ -792,7 +788,7 @@ executable generate-cost-model
     , extra
     , inline-r              >=1.0.0.0
     , optparse-applicative
-    , plutus-core           ^>=1.1
+    , plutus-core           ^>=1.2
     , text
     , vector
 
@@ -827,7 +823,7 @@ benchmark cost-model-test
     , hedgehog
     , inline-r          >=1.0.0.0
     , mmorph
-    , plutus-core       ^>=1.1
+    , plutus-core       ^>=1.2
     , template-haskell
     , text
     , vector
@@ -871,7 +867,7 @@ test-suite satint-test
     , base                        >=4.9 && <5
     , HUnit
     , QuickCheck
-    , satint                      ^>=1.1
+    , satint
     , test-framework
     , test-framework-hunit
     , test-framework-quickcheck2

--- a/plutus-ledger-api/CHANGELOG.md
+++ b/plutus-ledger-api/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+<a id='changelog-1.2.0.0'></a>
+# 1.2.0.0 — 2023-02-24
+
+## Added
+
+- Exported `mkTermToEvaluate` from `PlutusLedgerApi/Common.hs`

--- a/plutus-ledger-api/changelog.d/20230215_170512_effectfully_expose_mkTermToEvaluate.md
+++ b/plutus-ledger-api/changelog.d/20230215_170512_effectfully_expose_mkTermToEvaluate.md
@@ -1,5 +1,0 @@
-# Added
-
-- Exported `mkTermToEvaluate` from `PlutusLedgerApi/Common.hs`
-
-

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,19 +1,20 @@
-cabal-version: 3.0
-name:          plutus-ledger-api
-version:       1.1.1.0
-license:       Apache-2.0
+cabal-version:   3.0
+name:            plutus-ledger-api
+version:         1.2.0.0
+license:         Apache-2.0
 license-files:
   LICENSE
   NOTICE
 
-maintainer:    michael.peyton-jones@iohk.io
-author:        Michael Peyton Jones, Jann Mueller
-synopsis:      Interface to the Plutus ledger for the Cardano ledger.
+maintainer:      michael.peyton-jones@iohk.io
+author:          Michael Peyton Jones, Jann Mueller
+synopsis:        Interface to the Plutus ledger for the Cardano ledger.
 description:
   Interface to the Plutus scripting support for the Cardano ledger.
 
-category:      Language
-build-type:    Simple
+category:        Language
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
 
 source-repository head
   type:     git
@@ -94,8 +95,8 @@ library
     , lens
     , mtl
     , nothunks
-    , plutus-core        ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , serialise
     , tagged
@@ -115,9 +116,9 @@ library plutus-ledger-api-testlib
     , base               >=4.9      && <5
     , base64-bytestring
     , bytestring
-    , plutus-core        ^>=1.1
-    , plutus-ledger-api  ^>=1.1
-    , plutus-tx          ^>=1.1
+    , plutus-core        ^>=1.2
+    , plutus-ledger-api  ^>=1.2
+    , plutus-tx          ^>=1.2
     , prettyprinter
     , PyF                >=0.11.1.0
     , serialise
@@ -145,9 +146,9 @@ test-suite plutus-ledger-api-test
     , lens
     , mtl
     , nothunks
-    , plutus-core                ^>=1.1
-    , plutus-ledger-api          ^>=1.1
-    , plutus-ledger-api-testlib  ^>=1.1
+    , plutus-core                ^>=1.2
+    , plutus-ledger-api          ^>=1.2
+    , plutus-ledger-api-testlib  ^>=1.2
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -167,9 +168,9 @@ executable evaluation-test
     , extra
     , filepath
     , mtl
-    , plutus-core                ^>=1.1
-    , plutus-ledger-api          ^>=1.1
-    , plutus-ledger-api-testlib  ^>=1.1
+    , plutus-core                ^>=1.2
+    , plutus-ledger-api          ^>=1.2
+    , plutus-ledger-api-testlib  ^>=1.2
     , serialise
     , tasty
     , tasty-hunit

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -60,7 +60,7 @@ library
     , megaparsec
     , memory
     , optparse-applicative
-    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-execlib}  ^>=1.2
     , process
     , text
     , transformers
@@ -456,8 +456,8 @@ executable plc-agda
 test-suite test1
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.1
-    , plutus-core:uplc  ^>=1.1
+    , plutus-core:plc   ^>=1.2
+    , plutus-core:uplc  ^>=1.2
 
   hs-source-dirs:     test
   build-depends:
@@ -472,8 +472,8 @@ test-suite test1
 test-suite test2
   import:             lang
   build-tool-depends:
-    , plutus-core:plc   ^>=1.1
-    , plutus-core:uplc  ^>=1.1
+    , plutus-core:plc   ^>=1.2
+    , plutus-core:uplc  ^>=1.2
 
   hs-source-dirs:     test
   type:               detailed-0.9
@@ -497,7 +497,7 @@ test-suite test3
     , base
     , lazy-search
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
     , plutus-metatheory
     , size-based
     , Stream

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx-plugin
-version:         1.1.1.0
+version:         1.2.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -81,8 +81,8 @@ library
     , flat                                  <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.1
-    , plutus-tx                             ^>=1.1
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
+    , plutus-tx                             ^>=1.2
     , prettyprinter
     , PyF                                   >=0.11.1.0
     , template-haskell
@@ -110,7 +110,7 @@ executable gen-plugin-opts-doc
     , containers
     , lens
     , optparse-applicative
-    , plutus-tx-plugin      ^>=1.1
+    , plutus-tx-plugin      ^>=1.2
     , prettyprinter
     , PyF                   >=0.11.1.0
     , text
@@ -162,9 +162,9 @@ test-suite plutus-tx-tests
     , hedgehog
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx-plugin                                ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx-plugin                                ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}        ^>=1.2
     , tasty
     , tasty-hedgehog
     , tasty-hunit
@@ -187,7 +187,7 @@ test-suite size
   hs-source-dirs: test/size
   build-depends:
     , base                                      >=4.9 && <5.0
-    , plutus-tx-plugin                          ^>=1.1
-    , plutus-tx:{plutus-tx, plutus-tx-testlib}  ^>=1.1
+    , plutus-tx-plugin                          ^>=1.2
+    , plutus-tx:{plutus-tx, plutus-tx-testlib}  ^>=1.2
     , tagged
     , tasty

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx
-version:         1.1.1.0
+version:         1.2.0.0
 license:         Apache-2.0
 license-files:
   LICENSE
@@ -106,7 +106,7 @@ library
     , lens
     , memory
     , mtl
-    , plutus-core:{plutus-core, plutus-ir}  ^>=1.1
+    , plutus-core:{plutus-core, plutus-ir}  ^>=1.2
     , prettyprinter
     , serialise
     , template-haskell                      >=2.13.0.0
@@ -126,8 +126,8 @@ library plutus-tx-testlib
     , flat                                            <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx                                       ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx                                       ^>=1.2
     , prettyprinter
     , tagged
     , tasty
@@ -166,8 +166,8 @@ test-suite plutus-tx-test
     , filepath
     , hedgehog
     , hedgehog-fn
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.1
-    , plutus-tx                                       ^>=1.1
+    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
+    , plutus-tx                                       ^>=1.2
     , pretty-show
     , serialise
     , tasty

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -33,5 +33,5 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # - ", plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.0"
 #
 # and updates the version bounds to "^>={major version}"
-echo "Updating version bounds on $PACKAGE to '>=$major_version'"
+echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
 find . -name "*.cabal" -exec sed -i "s/\(, $PACKAGE[^^]*\).*/\1 ^>=$major_version/" {} \;


### PR DESCRIPTION
I considered tagging 1.2.0.0 from the commit where we started enforcing changelogs.
However, it would be inconvenient because I'd have to add a few commits on top of that, and backport them to master.
Also, by then we had already had a few changelog entries anyway.

So I'm tagging 1.2.0.0 from master. The changelog won't be exhaustive for this release, but will be for future releases.