### PR TITLE
Use unique-less readable PIR for Budget.Spec

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
@@ -12,6 +12,7 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module PlutusIR.Core.Instance.Pretty.Readable
   ( prettyPirReadable
+  , prettyPirReadableNoUnique
   , PrettyPir
   ) where
 
@@ -25,11 +26,18 @@ import Prettyprinter.Custom
 
 type PrettyPir = PrettyBy (PrettyConfigReadable PrettyConfigName)
 
--- | Pretty-print something with the Pir prettyprinter settings.
+-- | Pretty-print something with the @PrettyConfigReadable@ config.
 prettyPirReadable :: PrettyPir a => a -> Doc ann
 prettyPirReadable = prettyBy prettyConfigReadable
   -- Using 'debugPrettyConfigName', because it's actually helpful unlike 'defPrettyConfigName'.
-  where prettyConfigReadable = botPrettyConfigReadable debugPrettyConfigName def
+  where
+    prettyConfigReadable = botPrettyConfigReadable debugPrettyConfigName def
+
+-- | Like `prettyPirReadable`, but does not print uniques.
+prettyPirReadableNoUnique :: PrettyPir a => a -> Doc ann
+prettyPirReadableNoUnique = prettyBy prettyConfigReadable
+  where
+    prettyConfigReadable = botPrettyConfigReadable defPrettyConfigName def
 
 -- | Split an application into its (possible) head and arguments (either types or term)
 viewApp :: Term tyname name uni fun ann

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -19,65 +19,65 @@ import PlutusTx.Code
 import PlutusTx.IsData qualified as PlutusTx
 import PlutusTx.Prelude qualified as PlutusTx
 import PlutusTx.Show qualified as PlutusTx
-import PlutusTx.Test (goldenBudget, goldenPir)
+import PlutusTx.Test (goldenBudget, goldenPirReadable)
 import PlutusTx.TH (compile)
 
 tests :: TestNested
 tests = testNested "Budget" [
     goldenBudget "sum" compiledSum
-  , goldenPir "sum" compiledSum
+  , goldenPirReadable "sum" compiledSum
 
   , goldenBudget "anyCheap" compiledAnyCheap
-  , goldenPir "anyCheap" compiledAnyCheap
+  , goldenPirReadable "anyCheap" compiledAnyCheap
 
   , goldenBudget "anyExpensive" compiledAnyExpensive
-  , goldenPir "anyExpensive" compiledAnyExpensive
+  , goldenPirReadable "anyExpensive" compiledAnyExpensive
 
   , goldenBudget "anyEmptyList" compiledAnyEmptyList
-  , goldenPir "anyEmptyList" compiledAnyEmptyList
+  , goldenPirReadable "anyEmptyList" compiledAnyEmptyList
 
   , goldenBudget "allCheap" compiledAllCheap
-  , goldenPir "allCheap" compiledAllCheap
+  , goldenPirReadable "allCheap" compiledAllCheap
 
   , goldenBudget "allExpensive" compiledAllExpensive
-  , goldenPir "allExpensive" compiledAllExpensive
+  , goldenPirReadable "allExpensive" compiledAllExpensive
 
   , goldenBudget "allEmptyList" compiledAllEmptyList
-  , goldenPir "allEmptyList" compiledAllEmptyList
+  , goldenPirReadable "allEmptyList" compiledAllEmptyList
 
   , goldenBudget "findCheap" compiledFindCheap
-  , goldenPir "findCheap" compiledFindCheap
+  , goldenPirReadable "findCheap" compiledFindCheap
 
   , goldenBudget "findExpensive" compiledFindExpensive
-  , goldenPir "findExpensive" compiledFindExpensive
+  , goldenPirReadable "findExpensive" compiledFindExpensive
 
   , goldenBudget "findEmptyList" compiledFindEmptyList
-  , goldenPir "findEmptyList" compiledFindEmptyList
+  , goldenPirReadable "findEmptyList" compiledFindEmptyList
 
   , goldenBudget "filter" compiledFilter
-  , goldenPir "filter" compiledFilter
+  , goldenPirReadable "filter" compiledFilter
 
   , goldenBudget "elem" compiledElem
-  , goldenPir "elem" compiledElem
+  , goldenPirReadable "elem" compiledElem
 
   , goldenBudget "toFromData" compiledToFromData
-  , goldenPir "toFromData" compiledToFromData
+  , goldenPirReadable "toFromData" compiledToFromData
 
   , goldenBudget "monadicDo" monadicDo
-  , goldenPir "monadicDo" monadicDo
+  , goldenPirReadable "monadicDo" monadicDo
   -- These should be a little cheaper than the previous one,
   -- less overhead from going via monadic functions
   , goldenBudget "applicative" applicative
-  , goldenPir "applicative" applicative
+  , goldenPirReadable "applicative" applicative
   , goldenBudget "patternMatch" patternMatch
-  , goldenPir "patternMatch" patternMatch
+  , goldenPirReadable "patternMatch" patternMatch
   , goldenBudget "show" compiledShow
-  , goldenPir "show" compiledShow
+  , goldenPirReadable "show" compiledShow
   -- These test cases are for testing the float-in pass.
   , goldenBudget "ifThenElse1" compiledIfThenElse1
-  , goldenPir "ifThenElse1" compiledIfThenElse1
+  , goldenPirReadable "ifThenElse1" compiledIfThenElse1
   , goldenBudget "ifThenElse2" compiledIfThenElse2
-  , goldenPir "ifThenElse2" compiledIfThenElse2
+  , goldenPirReadable "ifThenElse2" compiledIfThenElse2
   ]
 
 compiledSum :: CompiledCode Integer

--- a/plutus-tx-plugin/test/Budget/allCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allCheap.plc.golden
@@ -1,293 +1,80 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl MultiplicativeMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              MultiplicativeMonoid_match
-              (vardecl
-                CConsMultiplicativeMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ MultiplicativeMonoid a ])
-                )
-              )
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ MultiplicativeMonoid Bool ])
-                    [
-                      [
-                        { CConsMultiplicativeMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) r)
-                                ]
-                                (abs dead (type) False)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      True
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { MultiplicativeMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { MultiplicativeMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 1) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    data (MultiplicativeMonoid :: * -> *) a | MultiplicativeMonoid_match where
+      CConsMultiplicativeMonoid
+      : (\a -> a -> a -> a) a -> a -> MultiplicativeMonoid a
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : MultiplicativeMonoid Bool
+                                       = CConsMultiplicativeMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> r) (/\dead ->
+                                                                        False)
+                                                       {all dead. dead}) True
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         MultiplicativeMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (MultiplicativeMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         1 v) False True)
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/allEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allEmptyList.plc.golden
@@ -1,240 +1,60 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl MultiplicativeMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              MultiplicativeMonoid_match
-              (vardecl
-                CConsMultiplicativeMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ MultiplicativeMonoid a ])
-                )
-              )
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ MultiplicativeMonoid Bool ])
-                    [
-                      [
-                        { CConsMultiplicativeMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) r)
-                                ]
-                                (abs dead (type) False)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      True
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { MultiplicativeMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { MultiplicativeMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 1) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            { Nil (con integer) }
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    data (MultiplicativeMonoid :: * -> *) a | MultiplicativeMonoid_match where
+      CConsMultiplicativeMonoid
+      : (\a -> a -> a -> a) a -> a -> MultiplicativeMonoid a
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : MultiplicativeMonoid Bool
+                                       = CConsMultiplicativeMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> r) (/\dead ->
+                                                                        False)
+                                                       {all dead. dead}) True
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         MultiplicativeMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (MultiplicativeMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         1 v) False True)
+     (Nil {integer})

--- a/plutus-tx-plugin/test/Budget/allExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allExpensive.plc.golden
@@ -1,293 +1,80 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl MultiplicativeMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              MultiplicativeMonoid_match
-              (vardecl
-                CConsMultiplicativeMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ MultiplicativeMonoid a ])
-                )
-              )
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ MultiplicativeMonoid Bool ])
-                    [
-                      [
-                        { CConsMultiplicativeMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) r)
-                                ]
-                                (abs dead (type) False)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      True
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { MultiplicativeMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { MultiplicativeMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 11) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    data (MultiplicativeMonoid :: * -> *) a | MultiplicativeMonoid_match where
+      CConsMultiplicativeMonoid
+      : (\a -> a -> a -> a) a -> a -> MultiplicativeMonoid a
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : MultiplicativeMonoid Bool
+                                       = CConsMultiplicativeMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> r) (/\dead ->
+                                                                        False)
+                                                       {all dead. dead}) True
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         MultiplicativeMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (MultiplicativeMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         11 v) False True)
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/anyCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyCheap.plc.golden
@@ -1,293 +1,79 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl AdditiveMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              AdditiveMonoid_match
-              (vardecl
-                CConsAdditiveMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ AdditiveMonoid a ])
-                )
-              )
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ AdditiveMonoid Bool ])
-                    [
-                      [
-                        { CConsAdditiveMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) True)
-                                ]
-                                (abs dead (type) r)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      False
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { AdditiveMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { AdditiveMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 10) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : AdditiveMonoid Bool
+                                       = CConsAdditiveMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> True)
+                                                       (/\dead -> r)
+                                                       {all dead. dead}) False
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         AdditiveMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (AdditiveMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         10 v) False True)
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/anyEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyEmptyList.plc.golden
@@ -1,240 +1,59 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl AdditiveMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              AdditiveMonoid_match
-              (vardecl
-                CConsAdditiveMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ AdditiveMonoid a ])
-                )
-              )
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ AdditiveMonoid Bool ])
-                    [
-                      [
-                        { CConsAdditiveMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) True)
-                                ]
-                                (abs dead (type) r)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      False
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { AdditiveMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { AdditiveMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 1) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            { Nil (con integer) }
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : AdditiveMonoid Bool
+                                       = CConsAdditiveMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> True)
+                                                       (/\dead -> r)
+                                                       {all dead. dead}) False
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         AdditiveMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (AdditiveMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         1 v) False True)
+     (Nil {integer})

--- a/plutus-tx-plugin/test/Budget/anyExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyExpensive.plc.golden
@@ -1,293 +1,79 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl AdditiveMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              AdditiveMonoid_match
-              (vardecl
-                CConsAdditiveMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ AdditiveMonoid a ])
-                )
-              )
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ AdditiveMonoid Bool ])
-                    [
-                      [
-                        { CConsAdditiveMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) True)
-                                ]
-                                (abs dead (type) r)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      False
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { AdditiveMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { AdditiveMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                v
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin lessThanEqualsInteger) (con integer 1) ] v ]
-                    ]
-                    False
-                  ]
-                  True
-                ]
-              )
-            ]
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : AdditiveMonoid Bool
+                                       = CConsAdditiveMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> True)
+                                                       (/\dead -> r)
+                                                       {all dead. dead}) False
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         AdditiveMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (AdditiveMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(v : integer) ->
+                                                    ifThenElse
+                                                      {Bool}
+                                                      (lessThanEqualsInteger
+                                                         1 v) False True)
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/applicative.plc.golden
+++ b/plutus-tx-plugin/test/Budget/applicative.plc.golden
@@ -1,133 +1,31 @@
-(program
-  (let
-    (nonrec)
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl x [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 1) ]
-    )
-    (termbind
-      (strict)
-      (vardecl y [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 2) ]
-    )
-    (termbind
-      (strict)
-      (vardecl ds [ Maybe (fun (con integer) (con integer)) ])
-      [
-        [
-          [
-            (let
-              (nonrec)
-              (typebind (tyvardecl b (type)) (fun (con integer) (con integer)))
-              (lam
-                dFunctor
-                [
-                  (lam
-                    f
-                    (fun (type) (type))
-                    (all
-                      a
-                      (type)
-                      (all b (type) (fun (fun a b) (fun [ f a ] [ f b ])))
-                    )
-                  )
-                  Maybe
-                ]
-                (lam
-                  f
-                  (fun (con integer) b)
-                  (lam
-                    fa
-                    [ Maybe (con integer) ]
-                    [ [ { { dFunctor (con integer) } b } f ] fa ]
-                  )
-                )
-              )
-            )
-            (abs
-              a
-              (type)
-              (abs
-                b
-                (type)
-                (lam
-                  f
-                  (fun a b)
-                  (lam
-                    ds
-                    [ Maybe a ]
-                    {
-                      [
-                        [
-                          {
-                            [ { Maybe_match a } ds ]
-                            (all dead (type) [ Maybe b ])
-                          }
-                          (lam a a (abs dead (type) [ { Just b } [ f a ] ]))
-                        ]
-                        (abs dead (type) { Nothing b })
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          ]
-          (lam
-            x
-            (con integer)
-            (lam y (con integer) [ [ (builtin addInteger) x ] y ])
-          )
-        ]
-        x
-      ]
-    )
-    {
-      [
-        [
-          {
-            [ { Maybe_match (fun (con integer) (con integer)) } ds ]
-            (all dead (type) [ Maybe (con integer) ])
-          }
-          (lam
-            ipv
-            (fun (con integer) (con integer))
-            (abs
-              dead
-              (type)
-              {
-                [
-                  [
-                    {
-                      [ { Maybe_match (con integer) } y ]
-                      (all dead (type) [ Maybe (con integer) ])
-                    }
-                    (lam
-                      ipv
-                      (con integer)
-                      (abs dead (type) [ { Just (con integer) } [ ipv ipv ] ])
-                    )
-                  ]
-                  (abs dead (type) { Nothing (con integer) })
-                ]
-                (all dead (type) dead)
-              }
-            )
-          )
-        ]
-        (abs dead (type) { Nothing (con integer) })
-      ]
-      (all dead (type) dead)
-    }
-  )
-)
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    !x : Maybe integer = Just {integer} 1
+    !y : Maybe integer = Just {integer} 2
+    !ds : Maybe (integer -> integer)
+      = (let b = integer -> integer
+         in \(dFunctor
+             : (\(f :: * -> *) -> all a. all b. (a -> b) -> f a -> f b) Maybe)
+             (f : integer -> b) (fa : Maybe integer) ->
+              dFunctor {integer} {b} f fa)
+          (/\a b ->
+             \(f : a -> b) (ds : Maybe a) ->
+               Maybe_match
+                 {a} ds {all dead. Maybe b} (\(a : a) ->
+                                               /\dead -> Just {b} (f a))
+                 (/\dead -> Nothing {b}) {all dead. dead}) (\(x : integer) (y
+                                                             : integer) ->
+                                                              addInteger x y) x
+in Maybe_match
+     {integer -> integer} ds {all dead. Maybe integer}
+     (\(ipv : integer -> integer) ->
+        /\dead ->
+          Maybe_match
+            {integer} y {all dead. Maybe integer} (\(ipv : integer) ->
+                                                     /\dead ->
+                                                       Just {integer} (ipv ipv))
+            (/\dead -> Nothing {integer}) {all dead. dead}) (/\dead ->
+                                                               Nothing
+                                                                 {integer})
+     {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/elem.plc.golden
+++ b/plutus-tx-plugin/test/Budget/elem.plc.golden
@@ -1,293 +1,78 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl AdditiveMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              AdditiveMonoid_match
-              (vardecl
-                CConsAdditiveMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ AdditiveMonoid a ])
-                )
-              )
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          [
-            [
-              [
-                {
-                  { fFoldableNil_cfoldMap [ (lam a (type) a) Bool ] }
-                  (con integer)
-                }
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl v [ AdditiveMonoid Bool ])
-                    [
-                      [
-                        { CConsAdditiveMonoid Bool }
-                        (lam
-                          l
-                          Bool
-                          (lam
-                            r
-                            Bool
-                            {
-                              [
-                                [
-                                  { [ Bool_match l ] (all dead (type) Bool) }
-                                  (abs dead (type) True)
-                                ]
-                                (abs dead (type) r)
-                              ]
-                              (all dead (type) dead)
-                            }
-                          )
-                        )
-                      ]
-                      False
-                    ]
-                  )
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) Bool ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) Bool ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) Bool ]
-                          [
-                            [
-                              [
-                                {
-                                  [ { AdditiveMonoid_match Bool } v ]
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                }
-                                (lam
-                                  v
-                                  [ (lam a (type) (fun a (fun a a))) Bool ]
-                                  (lam v Bool v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      { [ { AdditiveMonoid_match Bool } v ] Bool }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) Bool ]
-                        (lam v Bool v)
-                      )
-                    ]
-                  ]
-                )
-              ]
-              (lam
-                y
-                (con integer)
-                [
-                  [
-                    [
-                      { (builtin ifThenElse) Bool }
-                      [ [ (builtin equalsInteger) (con integer 0) ] y ]
-                    ]
-                    True
-                  ]
-                  False
-                ]
-              )
-            ]
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in fFoldableNil_cfoldMap
+     {(\a -> a) Bool} {integer} (let !v : AdditiveMonoid Bool
+                                       = CConsAdditiveMonoid
+                                           {Bool} (\(l : Bool) (r : Bool) ->
+                                                     Bool_match
+                                                       l {all dead. Bool}
+                                                       (/\dead -> True)
+                                                       (/\dead -> r)
+                                                       {all dead. dead}) False
+                                 in CConsMonoid
+                                      {(\a -> a) Bool}
+                                      (\(eta : (\a -> a) Bool) (eta
+                                        : (\a -> a) Bool) ->
+                                         AdditiveMonoid_match
+                                           {Bool} v {(\a -> a -> a -> a) Bool}
+                                           (\(v : (\a -> a -> a -> a) Bool) (v
+                                             : Bool) ->
+                                              v) eta eta)
+                                      (AdditiveMonoid_match
+                                         {Bool} v {Bool}
+                                         (\(v : (\a -> a -> a -> a) Bool) (v
+                                           : Bool) ->
+                                            v))) (\(y : integer) ->
+                                                    ifThenElse
+                                                      {Bool} (equalsInteger 0 y)
+                                                      True False)
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/filter.plc.golden
+++ b/plutus-tx-plugin/test/Budget/filter.plc.golden
@@ -1,193 +1,52 @@
-(program
-  (let
-    (nonrec)
-    (datatypebind
-      (datatype
-        (tyvardecl Bool (type))
-
-        Bool_match
-        (vardecl True Bool) (vardecl False Bool)
-      )
-    )
-    (let
-      (rec)
-      (datatypebind
-        (datatype
-          (tyvardecl List (fun (type) (type)))
-          (tyvardecl a (type))
-          Nil_match
-          (vardecl Nil [ List a ])
-          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            foldr
-            (all
-              a
-              (type)
-              (all b (type) (fun (fun a (fun b b)) (fun b (fun [ List a ] b))))
-            )
-          )
-          (abs
-            a
-            (type)
-            (abs
-              b
-              (type)
-              (lam
-                f
-                (fun a (fun b b))
-                (lam
-                  acc
-                  b
-                  (lam
-                    l
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } l ] (all dead (type) b) }
-                          (abs dead (type) acc)
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [ [ f x ] [ [ [ { { foldr a } b } f ] acc ] xs ] ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (termbind
-            (strict)
-            (vardecl eta [ List (con integer) ])
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          )
-          [
-            [
-              [
-                { { foldr (con integer) } [ List (con integer) ] }
-                (lam
-                  e
-                  (con integer)
-                  (lam
-                    xs
-                    [ List (con integer) ]
-                    {
-                      [
-                        [
-                          {
-                            [
-                              Bool_match
-                              [
-                                [
-                                  [
-                                    { (builtin ifThenElse) Bool }
-                                    [
-                                      [
-                                        (builtin equalsInteger)
-                                        [
-                                          [ (builtin modInteger) e ]
-                                          (con integer 2)
-                                        ]
-                                      ]
-                                      (con integer 0)
-                                    ]
-                                  ]
-                                  True
-                                ]
-                                False
-                              ]
-                            ]
-                            (all dead (type) [ List (con integer) ])
-                          }
-                          (abs dead (type) [ [ { Cons (con integer) } e ] xs ])
-                        ]
-                        (abs dead (type) xs)
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-            eta
-          ]
-        )
-      )
-    )
-  )
-)
+let data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+letrec !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
+         = /\a b ->
+             \(f : a -> b -> b) (acc : b) (l : List a) ->
+               Nil_match
+                 {a} l {all dead. b} (/\dead -> acc) (\(x : a) (xs : List a) ->
+                                                        /\dead ->
+                                                          f
+                                                            x (foldr
+                                                                 {a} {b} f acc
+                                                                 xs))
+                 {all dead. dead}
+in
+let !eta : List integer
+      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                   c
+                                     1 (c
+                                          2 (c
+                                               3
+                                               (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+          (Nil {integer})
+in foldr
+     {integer} {List integer} (\(e : integer) (xs : List integer) ->
+                                 Bool_match
+                                   (ifThenElse
+                                      {Bool} (equalsInteger (modInteger e 2) 0)
+                                      True False) {all dead. List integer}
+                                   (/\dead -> Cons {integer} e xs) (/\dead ->
+                                                                      xs)
+                                   {all dead. dead}) (Nil {integer}) eta

--- a/plutus-tx-plugin/test/Budget/findCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findCheap.plc.golden
@@ -1,278 +1,74 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Maybe (fun (type) (type)))
-              (tyvardecl a (type))
-              Maybe_match
-              (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (termbind
-            (strict)
-            (vardecl x [ List (con integer) ])
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          )
-          [
-            [
-              [
-                {
-                  {
-                    fFoldableNil_cfoldMap
-                    [ (lam a (type) [ Maybe a ]) (con integer) ]
-                  }
-                  (con integer)
-                }
-                [
-                  [
-                    { CConsMonoid [ (lam a (type) [ Maybe a ]) (con integer) ] }
-                    (lam
-                      ds
-                      [ (lam a (type) [ Maybe a ]) (con integer) ]
-                      (lam
-                        b
-                        [ (lam a (type) [ Maybe a ]) (con integer) ]
-                        {
-                          [
-                            [
-                              {
-                                [ { Maybe_match (con integer) } ds ]
-                                (all
-                                  dead
-                                  (type)
-                                  [ (lam a (type) [ Maybe a ]) (con integer) ]
-                                )
-                              }
-                              (lam ipv (con integer) (abs dead (type) ds))
-                            ]
-                            (abs dead (type) b)
-                          ]
-                          (all dead (type) dead)
-                        }
-                      )
-                    )
-                  ]
-                  { Nothing (con integer) }
-                ]
-              ]
-              (lam
-                x
-                (con integer)
-                {
-                  [
-                    [
-                      {
-                        [
-                          Bool_match
-                          [
-                            [
-                              [
-                                { (builtin ifThenElse) Bool }
-                                [
-                                  [
-                                    (builtin lessThanEqualsInteger)
-                                    (con integer 10)
-                                  ]
-                                  x
-                                ]
-                              ]
-                              False
-                            ]
-                            True
-                          ]
-                        ]
-                        (all dead (type) [ Maybe (con integer) ])
-                      }
-                      (abs dead (type) [ { Just (con integer) } x ])
-                    ]
-                    (abs dead (type) { Nothing (con integer) })
-                  ]
-                  (all dead (type) dead)
-                }
-              )
-            ]
-            x
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    !x : List integer
+      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                   c
+                                     1 (c
+                                          2 (c
+                                               3
+                                               (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+          (Nil {integer})
+in fFoldableNil_cfoldMap
+     {(\a -> Maybe a) integer} {integer}
+     (CConsMonoid
+        {(\a -> Maybe a) integer} (\(ds : (\a -> Maybe a) integer) (b
+                                    : (\a -> Maybe a) integer) ->
+                                     Maybe_match
+                                       {integer} ds
+                                       {all dead. (\a -> Maybe a) integer}
+                                       (\(ipv : integer) -> /\dead -> ds)
+                                       (/\dead -> b) {all dead. dead})
+        (Nothing {integer})) (\(x : integer) ->
+                                Bool_match
+                                  (ifThenElse
+                                     {Bool} (lessThanEqualsInteger 10 x) False
+                                     True) {all dead. Maybe integer}
+                                  (/\dead -> Just {integer} x) (/\dead ->
+                                                                  Nothing
+                                                                    {integer})
+                                  {all dead. dead}) x

--- a/plutus-tx-plugin/test/Budget/findEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findEmptyList.plc.golden
@@ -1,223 +1,52 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Maybe (fun (type) (type)))
-              (tyvardecl a (type))
-              Maybe_match
-              (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (termbind
-            (strict) (vardecl x [ List (con integer) ]) { Nil (con integer) }
-          )
-          [
-            [
-              [
-                {
-                  {
-                    fFoldableNil_cfoldMap
-                    [ (lam a (type) [ Maybe a ]) (con integer) ]
-                  }
-                  (con integer)
-                }
-                [
-                  [
-                    { CConsMonoid [ (lam a (type) [ Maybe a ]) (con integer) ] }
-                    (lam
-                      ds
-                      [ (lam a (type) [ Maybe a ]) (con integer) ]
-                      (lam
-                        b
-                        [ (lam a (type) [ Maybe a ]) (con integer) ]
-                        {
-                          [
-                            [
-                              {
-                                [ { Maybe_match (con integer) } ds ]
-                                (all
-                                  dead
-                                  (type)
-                                  [ (lam a (type) [ Maybe a ]) (con integer) ]
-                                )
-                              }
-                              (lam ipv (con integer) (abs dead (type) ds))
-                            ]
-                            (abs dead (type) b)
-                          ]
-                          (all dead (type) dead)
-                        }
-                      )
-                    )
-                  ]
-                  { Nothing (con integer) }
-                ]
-              ]
-              (lam
-                x
-                (con integer)
-                {
-                  [
-                    [
-                      {
-                        [
-                          Bool_match
-                          [
-                            [
-                              [
-                                { (builtin ifThenElse) Bool }
-                                [
-                                  [
-                                    (builtin lessThanEqualsInteger)
-                                    (con integer 1)
-                                  ]
-                                  x
-                                ]
-                              ]
-                              False
-                            ]
-                            True
-                          ]
-                        ]
-                        (all dead (type) [ Maybe (con integer) ])
-                      }
-                      (abs dead (type) [ { Just (con integer) } x ])
-                    ]
-                    (abs dead (type) { Nothing (con integer) })
-                  ]
-                  (all dead (type) dead)
-                }
-              )
-            ]
-            x
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    !x : List integer = Nil {integer}
+in fFoldableNil_cfoldMap
+     {(\a -> Maybe a) integer} {integer}
+     (CConsMonoid
+        {(\a -> Maybe a) integer} (\(ds : (\a -> Maybe a) integer) (b
+                                    : (\a -> Maybe a) integer) ->
+                                     Maybe_match
+                                       {integer} ds
+                                       {all dead. (\a -> Maybe a) integer}
+                                       (\(ipv : integer) -> /\dead -> ds)
+                                       (/\dead -> b) {all dead. dead})
+        (Nothing {integer})) (\(x : integer) ->
+                                Bool_match
+                                  (ifThenElse
+                                     {Bool} (lessThanEqualsInteger 1 x) False
+                                     True) {all dead. Maybe integer}
+                                  (/\dead -> Just {integer} x) (/\dead ->
+                                                                  Nothing
+                                                                    {integer})
+                                  {all dead. dead}) x

--- a/plutus-tx-plugin/test/Budget/findExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findExpensive.plc.golden
@@ -1,278 +1,74 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl Maybe (fun (type) (type)))
-              (tyvardecl a (type))
-              Maybe_match
-              (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-            )
-          )
-          (datatypebind
-            (datatype
-              (tyvardecl Bool (type))
-
-              Bool_match
-              (vardecl True Bool) (vardecl False Bool)
-            )
-          )
-          (termbind
-            (strict)
-            (vardecl x [ List (con integer) ])
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          )
-          [
-            [
-              [
-                {
-                  {
-                    fFoldableNil_cfoldMap
-                    [ (lam a (type) [ Maybe a ]) (con integer) ]
-                  }
-                  (con integer)
-                }
-                [
-                  [
-                    { CConsMonoid [ (lam a (type) [ Maybe a ]) (con integer) ] }
-                    (lam
-                      ds
-                      [ (lam a (type) [ Maybe a ]) (con integer) ]
-                      (lam
-                        b
-                        [ (lam a (type) [ Maybe a ]) (con integer) ]
-                        {
-                          [
-                            [
-                              {
-                                [ { Maybe_match (con integer) } ds ]
-                                (all
-                                  dead
-                                  (type)
-                                  [ (lam a (type) [ Maybe a ]) (con integer) ]
-                                )
-                              }
-                              (lam ipv (con integer) (abs dead (type) ds))
-                            ]
-                            (abs dead (type) b)
-                          ]
-                          (all dead (type) dead)
-                        }
-                      )
-                    )
-                  ]
-                  { Nothing (con integer) }
-                ]
-              ]
-              (lam
-                x
-                (con integer)
-                {
-                  [
-                    [
-                      {
-                        [
-                          Bool_match
-                          [
-                            [
-                              [
-                                { (builtin ifThenElse) Bool }
-                                [
-                                  [
-                                    (builtin lessThanEqualsInteger)
-                                    (con integer 1)
-                                  ]
-                                  x
-                                ]
-                              ]
-                              False
-                            ]
-                            True
-                          ]
-                        ]
-                        (all dead (type) [ Maybe (con integer) ])
-                      }
-                      (abs dead (type) [ { Just (con integer) } x ])
-                    ]
-                    (abs dead (type) { Nothing (con integer) })
-                  ]
-                  (all dead (type) dead)
-                }
-              )
-            ]
-            x
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    !x : List integer
+      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                   c
+                                     1 (c
+                                          2 (c
+                                               3
+                                               (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+          (Nil {integer})
+in fFoldableNil_cfoldMap
+     {(\a -> Maybe a) integer} {integer}
+     (CConsMonoid
+        {(\a -> Maybe a) integer} (\(ds : (\a -> Maybe a) integer) (b
+                                    : (\a -> Maybe a) integer) ->
+                                     Maybe_match
+                                       {integer} ds
+                                       {all dead. (\a -> Maybe a) integer}
+                                       (\(ipv : integer) -> /\dead -> ds)
+                                       (/\dead -> b) {all dead. dead})
+        (Nothing {integer})) (\(x : integer) ->
+                                Bool_match
+                                  (ifThenElse
+                                     {Bool} (lessThanEqualsInteger 1 x) False
+                                     True) {all dead. Maybe integer}
+                                  (/\dead -> Just {integer} x) (/\dead ->
+                                                                  Nothing
+                                                                    {integer})
+                                  {all dead. dead}) x

--- a/plutus-tx-plugin/test/Budget/ifThenElse1.plc.golden
+++ b/plutus-tx-plugin/test/Budget/ifThenElse1.plc.golden
@@ -1,78 +1,12 @@
-(program
-  (let
-    (nonrec)
-    (termbind
-      (nonstrict)
-      (vardecl
-        fAdditiveSemigroupInteger
-        [ (lam a (type) (fun a (fun a a))) (con integer) ]
-      )
-      (lam
-        x (con integer) (lam y (con integer) [ [ (builtin addInteger) x ] y ])
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        bad_name
-        (all
-          a
-          (type)
-          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a (fun a a)))
-        )
-      )
-      (abs a (type) (lam v [ (lam a (type) (fun a (fun a a))) a ] v))
-    )
-    (termbind
-      (nonstrict)
-      (vardecl a (con integer))
-      [
-        [
-          [ { bad_name (con integer) } fAdditiveSemigroupInteger ]
-          (con integer 1)
-        ]
-        (con integer 2)
-      ]
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Bool (type))
-
-        Bool_match
-        (vardecl True Bool) (vardecl False Bool)
-      )
-    )
-    {
-      [
-        [
-          {
-            [
-              Bool_match
-              [
-                [
-                  [
-                    { (builtin ifThenElse) Bool }
-                    [
-                      [ (builtin lessThanInteger) (con integer 3) ]
-                      (con integer 4)
-                    ]
-                  ]
-                  True
-                ]
-                False
-              ]
-            ]
-            (all dead (type) (con integer))
-          }
-          (abs dead (type) (con integer 5))
-        ]
-        (abs
-          dead
-          (type)
-          [ [ [ { bad_name (con integer) } fAdditiveSemigroupInteger ] a ] a ]
-        )
-      ]
-      (all dead (type) dead)
-    }
-  )
-)
+let ~fAdditiveSemigroupInteger : (\a -> a -> a -> a) integer
+      = \(x : integer) (y : integer) -> addInteger x y
+    !bad_name : all a. (\a -> a -> a -> a) a -> a -> a -> a
+      = /\a -> \(v : (\a -> a -> a -> a) a) -> v
+    ~a : integer = bad_name {integer} fAdditiveSemigroupInteger 1 2
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in Bool_match
+     (ifThenElse {Bool} (lessThanInteger 3 4) True False) {all dead. integer}
+     (/\dead -> 5) (/\dead -> bad_name {integer} fAdditiveSemigroupInteger a a)
+     {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/ifThenElse2.plc.golden
+++ b/plutus-tx-plugin/test/Budget/ifThenElse2.plc.golden
@@ -1,99 +1,17 @@
-(program
-  (let
-    (nonrec)
-    (termbind
-      (nonstrict)
-      (vardecl
-        fAdditiveSemigroupInteger
-        [ (lam a (type) (fun a (fun a a))) (con integer) ]
-      )
-      (lam
-        x (con integer) (lam y (con integer) [ [ (builtin addInteger) x ] y ])
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
+let ~fAdditiveSemigroupInteger : (\a -> a -> a -> a) integer
+      = \(x : integer) (y : integer) -> addInteger x y
+    !bad_name : all a. (\a -> a -> a -> a) a -> a -> a -> a
+      = /\a -> \(v : (\a -> a -> a -> a) a) -> v
+    ~a : integer = bad_name {integer} fAdditiveSemigroupInteger 1 2
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in Bool_match
+     (ifThenElse {Bool} (lessThanInteger 3 4) True False) {integer -> integer}
+     (\(x : integer) -> bad_name {integer} fAdditiveSemigroupInteger x 5)
+     (\(x : integer) ->
         bad_name
-        (all
-          a
-          (type)
-          (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a (fun a a)))
-        )
-      )
-      (abs a (type) (lam v [ (lam a (type) (fun a (fun a a))) a ] v))
-    )
-    (termbind
-      (nonstrict)
-      (vardecl a (con integer))
-      [
-        [
-          [ { bad_name (con integer) } fAdditiveSemigroupInteger ]
-          (con integer 1)
-        ]
-        (con integer 2)
-      ]
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Bool (type))
-
-        Bool_match
-        (vardecl True Bool) (vardecl False Bool)
-      )
-    )
-    [
-      [
-        [
-          {
-            [
-              Bool_match
-              [
-                [
-                  [
-                    { (builtin ifThenElse) Bool }
-                    [
-                      [ (builtin lessThanInteger) (con integer 3) ]
-                      (con integer 4)
-                    ]
-                  ]
-                  True
-                ]
-                False
-              ]
-            ]
-            (fun (con integer) (con integer))
-          }
-          (lam
-            x
-            (con integer)
-            [
-              [ [ { bad_name (con integer) } fAdditiveSemigroupInteger ] x ]
-              (con integer 5)
-            ]
-          )
-        ]
-        (lam
-          x
-          (con integer)
-          [
-            [
-              [ { bad_name (con integer) } fAdditiveSemigroupInteger ]
-              [
-                [ [ { bad_name (con integer) } fAdditiveSemigroupInteger ] x ] a
-              ]
-            ]
-            a
-          ]
-        )
-      ]
-      [
-        [
-          [ { bad_name (con integer) } fAdditiveSemigroupInteger ]
-          (con integer 6)
-        ]
-        (con integer 7)
-      ]
-    ]
-  )
-)
+          {integer} fAdditiveSemigroupInteger (bad_name
+                                                 {integer}
+                                                 fAdditiveSemigroupInteger x a)
+          a) (bad_name {integer} fAdditiveSemigroupInteger 6 7)

--- a/plutus-tx-plugin/test/Budget/monadicDo.plc.golden
+++ b/plutus-tx-plugin/test/Budget/monadicDo.plc.golden
@@ -1,83 +1,20 @@
-(program
-  (let
-    (nonrec)
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        fMonadMaybe_c
-        (all
-          a
-          (type)
-          (all b (type) (fun [ Maybe a ] (fun (fun a [ Maybe b ]) [ Maybe b ])))
-        )
-      )
-      (abs
-        a
-        (type)
-        (abs
-          b
-          (type)
-          (lam
-            ds
-            [ Maybe a ]
-            (lam
-              k
-              (fun a [ Maybe b ])
-              {
-                [
-                  [
-                    { [ { Maybe_match a } ds ] (all dead (type) [ Maybe b ]) }
-                    (lam x a (abs dead (type) [ k x ]))
-                  ]
-                  (abs dead (type) { Nothing b })
-                ]
-                (all dead (type) dead)
-              }
-            )
-          )
-        )
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl x [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 1) ]
-    )
-    (termbind
-      (strict)
-      (vardecl y [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 2) ]
-    )
-    [
-      [ { { fMonadMaybe_c (con integer) } (con integer) } x ]
-      (lam
-        x
-        (con integer)
-        [
-          [ { { fMonadMaybe_c (con integer) } (con integer) } y ]
-          (lam
-            y
-            (con integer)
-            (let
-              (nonrec)
-              (termbind
-                (strict)
-                (vardecl ds (con integer))
-                [ [ (builtin addInteger) x ] y ]
-              )
-              [ { Just (con integer) } ds ]
-            )
-          )
-        ]
-      )
-    ]
-  )
-)
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    !fMonadMaybe_c : all a. all b. Maybe a -> (a -> Maybe b) -> Maybe b
+      = /\a b ->
+          \(ds : Maybe a) (k : a -> Maybe b) ->
+            Maybe_match
+              {a} ds {all dead. Maybe b} (\(x : a) -> /\dead -> k x) (/\dead ->
+                                                                        Nothing
+                                                                          {b})
+              {all dead. dead}
+    !x : Maybe integer = Just {integer} 1
+    !y : Maybe integer = Just {integer} 2
+in fMonadMaybe_c
+     {integer} {integer} x (\(x : integer) ->
+                              fMonadMaybe_c
+                                {integer} {integer} y (\(y : integer) ->
+                                                         let !ds : integer
+                                                               = addInteger x y
+                                                         in Just {integer} ds))

--- a/plutus-tx-plugin/test/Budget/patternMatch.plc.golden
+++ b/plutus-tx-plugin/test/Budget/patternMatch.plc.golden
@@ -1,67 +1,19 @@
-(program
-  (let
-    (nonrec)
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    (termbind
-      (strict)
-      (vardecl x [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 1) ]
-    )
-    (termbind
-      (strict)
-      (vardecl y [ Maybe (con integer) ])
-      [ { Just (con integer) } (con integer 2) ]
-    )
-    {
-      [
-        [
-          {
-            [ { Maybe_match (con integer) } x ]
-            (all dead (type) [ Maybe (con integer) ])
-          }
-          (lam
-            x
-            (con integer)
-            (abs
-              dead
-              (type)
-              {
-                [
-                  [
-                    {
-                      [ { Maybe_match (con integer) } y ]
-                      (all dead (type) [ Maybe (con integer) ])
-                    }
-                    (lam
-                      y
-                      (con integer)
-                      (abs
-                        dead
-                        (type)
-                        [
-                          { Just (con integer) }
-                          [ [ (builtin addInteger) x ] y ]
-                        ]
-                      )
-                    )
-                  ]
-                  (abs dead (type) { Nothing (con integer) })
-                ]
-                (all dead (type) dead)
-              }
-            )
-          )
-        ]
-        (abs dead (type) { Nothing (con integer) })
-      ]
-      (all dead (type) dead)
-    }
-  )
-)
+let data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+    !x : Maybe integer = Just {integer} 1
+    !y : Maybe integer = Just {integer} 2
+in Maybe_match
+     {integer} x {all dead. Maybe integer} (\(x : integer) ->
+                                              /\dead ->
+                                                Maybe_match
+                                                  {integer} y
+                                                  {all dead. Maybe integer}
+                                                  (\(y : integer) ->
+                                                     /\dead ->
+                                                       Just
+                                                         {integer} (addInteger
+                                                                      x y))
+                                                  (/\dead -> Nothing {integer})
+                                                  {all dead. dead})
+     (/\dead -> Nothing {integer}) {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/show.plc.golden
+++ b/plutus-tx-plugin/test/Budget/show.plc.golden
@@ -1,3146 +1,471 @@
-(program
-  (let
-    (nonrec)
-    (termbind (strict) (vardecl y (con integer)) (con integer 10))
-    (datatypebind
-      (datatype
-        (tyvardecl Bool (type))
-
-        Bool_match
-        (vardecl True Bool) (vardecl False Bool)
-      )
-    )
-    (let
-      (rec)
-      (datatypebind
-        (datatype
-          (tyvardecl List (fun (type) (type)))
-          (tyvardecl a (type))
-          Nil_match
-          (vardecl Nil [ List a ])
-          (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            go
-            (fun
-              [ List (con integer) ] (fun (con integer) [ List (con integer) ])
-            )
-          )
-          (lam
-            acc
-            [ List (con integer) ]
-            (lam
-              n
-              (con integer)
-              (let
-                (nonrec)
-                (termbind
-                  (nonstrict)
-                  (vardecl q (con integer))
-                  [ [ (builtin quotientInteger) n ] y ]
-                )
-                {
-                  [
-                    [
-                      {
-                        [
-                          Bool_match
-                          [
-                            [
-                              [
-                                { (builtin ifThenElse) Bool }
-                                [
-                                  [ (builtin equalsInteger) q ] (con integer 0)
-                                ]
-                              ]
-                              True
-                            ]
-                            False
-                          ]
-                        ]
-                        (all dead (type) [ List (con integer) ])
-                      }
-                      (abs
-                        dead
-                        (type)
-                        [
-                          [
-                            { Cons (con integer) }
-                            [ [ (builtin remainderInteger) n ] y ]
-                          ]
-                          acc
-                        ]
-                      )
-                    ]
-                    (abs
-                      dead
-                      (type)
-                      [
-                        [
-                          go
-                          [
-                            [
-                              { Cons (con integer) }
-                              [ [ (builtin remainderInteger) n ] y ]
-                            ]
-                            acc
-                          ]
-                        ]
-                        q
-                      ]
-                    )
-                  ]
-                  (all dead (type) dead)
-                }
-              )
-            )
-          )
-        )
-        (let
-          (rec)
-          (termbind
-            (strict)
-            (vardecl
-              foldr
-              (all
-                a
-                (type)
-                (all
-                  b (type) (fun (fun a (fun b b)) (fun b (fun [ List a ] b)))
-                )
-              )
-            )
-            (abs
-              a
-              (type)
-              (abs
-                b
-                (type)
-                (lam
-                  f
-                  (fun a (fun b b))
-                  (lam
-                    acc
-                    b
-                    (lam
-                      l
-                      [ List a ]
-                      {
-                        [
-                          [
-                            { [ { Nil_match a } l ] (all dead (type) b) }
-                            (abs dead (type) acc)
-                          ]
-                          (lam
-                            x
-                            a
-                            (lam
-                              xs
-                              [ List a ]
-                              (abs
-                                dead
-                                (type)
-                                [
-                                  [ f x ] [ [ [ { { foldr a } b } f ] acc ] xs ]
-                                ]
-                              )
-                            )
-                          )
-                        ]
-                        (all dead (type) dead)
-                      }
-                    )
-                  )
-                )
-              )
-            )
-          )
-          (let
-            (nonrec)
-            (termbind
-              (strict)
-              (vardecl id (all a (type) (fun a a)))
-              (abs a (type) (lam x a x))
-            )
-            (let
-              (rec)
-              (termbind
-                (strict)
-                (vardecl
-                  wcshowsPrec
-                  (fun
-                    (con integer)
-                    (fun [ List (con string) ] [ List (con string) ])
-                  )
-                )
-                (lam
-                  w
-                  (con integer)
-                  {
-                    [
-                      [
-                        {
-                          [
-                            Bool_match
-                            [
-                              [
-                                [
-                                  { (builtin ifThenElse) Bool }
-                                  [
-                                    [ (builtin lessThanInteger) w ]
-                                    (con integer 0)
-                                  ]
-                                ]
-                                True
-                              ]
-                              False
-                            ]
-                          ]
-                          (all
-                            dead
-                            (type)
-                            (fun [ List (con string) ] [ List (con string) ])
-                          )
-                        }
-                        (abs
-                          dead
-                          (type)
-                          (lam
-                            x
-                            [ List (con string) ]
-                            [
-                              [ { Cons (con string) } (con string "-") ]
-                              [
-                                [
-                                  wcshowsPrec
-                                  [
-                                    [
-                                      (builtin subtractInteger) (con integer 0)
-                                    ]
-                                    w
-                                  ]
-                                ]
-                                x
-                              ]
-                            ]
-                          )
-                        )
-                      ]
-                      (abs
-                        dead
-                        (type)
-                        [
-                          [
-                            [
-                              {
-                                { foldr (con integer) }
-                                (fun
-                                  [ List (con string) ] [ List (con string) ]
-                                )
-                              }
-                              (lam
-                                digit
-                                (con integer)
-                                (lam
-                                  acc
-                                  (fun
-                                    [ List (con string) ] [ List (con string) ]
-                                  )
-                                  (lam
-                                    x
-                                    [ List (con string) ]
-                                    [
-                                      [
-                                        { Cons (con string) }
-                                        {
-                                          [
-                                            [
-                                              {
-                                                [
-                                                  Bool_match
-                                                  [
-                                                    [
-                                                      [
-                                                        {
-                                                          (builtin ifThenElse)
-                                                          Bool
-                                                        }
-                                                        [
-                                                          [
-                                                            (builtin
-                                                              equalsInteger
-                                                            )
-                                                            digit
-                                                          ]
-                                                          (con integer 0)
-                                                        ]
-                                                      ]
-                                                      True
-                                                    ]
-                                                    False
-                                                  ]
-                                                ]
-                                                (all dead (type) (con string))
-                                              }
-                                              (abs dead (type) (con string "0"))
-                                            ]
-                                            (abs
-                                              dead
-                                              (type)
-                                              {
-                                                [
-                                                  [
-                                                    {
-                                                      [
-                                                        Bool_match
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                (builtin
-                                                                  ifThenElse
-                                                                )
-                                                                Bool
-                                                              }
-                                                              [
-                                                                [
-                                                                  (builtin
-                                                                    equalsInteger
-                                                                  )
-                                                                  digit
-                                                                ]
-                                                                (con integer 1)
-                                                              ]
-                                                            ]
-                                                            True
-                                                          ]
-                                                          False
-                                                        ]
-                                                      ]
-                                                      (all
-                                                        dead (type) (con string)
-                                                      )
-                                                    }
-                                                    (abs
-                                                      dead
-                                                      (type)
-                                                      (con string "1")
-                                                    )
-                                                  ]
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    {
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              Bool_match
-                                                              [
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      (builtin
-                                                                        ifThenElse
-                                                                      )
-                                                                      Bool
-                                                                    }
-                                                                    [
-                                                                      [
-                                                                        (builtin
-                                                                          equalsInteger
-                                                                        )
-                                                                        digit
-                                                                      ]
-                                                                      (con
-                                                                        integer
-                                                                        2
-                                                                      )
-                                                                    ]
-                                                                  ]
-                                                                  True
-                                                                ]
-                                                                False
-                                                              ]
-                                                            ]
-                                                            (all
-                                                              dead
-                                                              (type)
-                                                              (con string)
-                                                            )
-                                                          }
-                                                          (abs
-                                                            dead
-                                                            (type)
-                                                            (con string "2")
-                                                          )
-                                                        ]
-                                                        (abs
-                                                          dead
-                                                          (type)
-                                                          {
-                                                            [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    Bool_match
-                                                                    [
-                                                                      [
-                                                                        [
-                                                                          {
-                                                                            (builtin
-                                                                              ifThenElse
-                                                                            )
-                                                                            Bool
-                                                                          }
-                                                                          [
-                                                                            [
-                                                                              (builtin
-                                                                                equalsInteger
-                                                                              )
-                                                                              digit
-                                                                            ]
-                                                                            (con
-                                                                              integer
-                                                                              3
-                                                                            )
-                                                                          ]
-                                                                        ]
-                                                                        True
-                                                                      ]
-                                                                      False
-                                                                    ]
-                                                                  ]
-                                                                  (all
-                                                                    dead
-                                                                    (type)
-                                                                    (con string)
-                                                                  )
-                                                                }
-                                                                (abs
-                                                                  dead
-                                                                  (type)
-                                                                  (con
-                                                                    string "3"
-                                                                  )
-                                                                )
-                                                              ]
-                                                              (abs
-                                                                dead
-                                                                (type)
-                                                                {
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        [
-                                                                          Bool_match
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  (builtin
-                                                                                    ifThenElse
-                                                                                  )
-                                                                                  Bool
-                                                                                }
-                                                                                [
-                                                                                  [
-                                                                                    (builtin
-                                                                                      equalsInteger
-                                                                                    )
-                                                                                    digit
-                                                                                  ]
-                                                                                  (con
-                                                                                    integer
-                                                                                    4
-                                                                                  )
-                                                                                ]
-                                                                              ]
-                                                                              True
-                                                                            ]
-                                                                            False
-                                                                          ]
-                                                                        ]
-                                                                        (all
-                                                                          dead
-                                                                          (type)
-                                                                          (con
-                                                                            string
-                                                                          )
-                                                                        )
-                                                                      }
-                                                                      (abs
-                                                                        dead
-                                                                        (type)
-                                                                        (con
-                                                                          string
-                                                                          "4"
-                                                                        )
-                                                                      )
-                                                                    ]
-                                                                    (abs
-                                                                      dead
-                                                                      (type)
-                                                                      {
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              [
-                                                                                Bool_match
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      {
-                                                                                        (builtin
-                                                                                          ifThenElse
-                                                                                        )
-                                                                                        Bool
-                                                                                      }
-                                                                                      [
-                                                                                        [
-                                                                                          (builtin
-                                                                                            equalsInteger
-                                                                                          )
-                                                                                          digit
-                                                                                        ]
-                                                                                        (con
-                                                                                          integer
-                                                                                          5
-                                                                                        )
-                                                                                      ]
-                                                                                    ]
-                                                                                    True
-                                                                                  ]
-                                                                                  False
-                                                                                ]
-                                                                              ]
-                                                                              (all
-                                                                                dead
-                                                                                (type)
-                                                                                (con
-                                                                                  string
-                                                                                )
-                                                                              )
-                                                                            }
-                                                                            (abs
-                                                                              dead
-                                                                              (type)
-                                                                              (con
-                                                                                string
-                                                                                "5"
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (abs
-                                                                            dead
-                                                                            (type)
-                                                                            {
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            {
-                                                                                              (builtin
-                                                                                                ifThenElse
-                                                                                              )
-                                                                                              Bool
-                                                                                            }
-                                                                                            [
-                                                                                              [
-                                                                                                (builtin
-                                                                                                  equalsInteger
-                                                                                                )
-                                                                                                digit
-                                                                                              ]
-                                                                                              (con
-                                                                                                integer
-                                                                                                6
-                                                                                              )
-                                                                                            ]
-                                                                                          ]
-                                                                                          True
-                                                                                        ]
-                                                                                        False
-                                                                                      ]
-                                                                                    ]
-                                                                                    (all
-                                                                                      dead
-                                                                                      (type)
-                                                                                      (con
-                                                                                        string
-                                                                                      )
-                                                                                    )
-                                                                                  }
-                                                                                  (abs
-                                                                                    dead
-                                                                                    (type)
-                                                                                    (con
-                                                                                      string
-                                                                                      "6"
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                (abs
-                                                                                  dead
-                                                                                  (type)
-                                                                                  {
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    (builtin
-                                                                                                      ifThenElse
-                                                                                                    )
-                                                                                                    Bool
-                                                                                                  }
-                                                                                                  [
-                                                                                                    [
-                                                                                                      (builtin
-                                                                                                        equalsInteger
-                                                                                                      )
-                                                                                                      digit
-                                                                                                    ]
-                                                                                                    (con
-                                                                                                      integer
-                                                                                                      7
-                                                                                                    )
-                                                                                                  ]
-                                                                                                ]
-                                                                                                True
-                                                                                              ]
-                                                                                              False
-                                                                                            ]
-                                                                                          ]
-                                                                                          (all
-                                                                                            dead
-                                                                                            (type)
-                                                                                            (con
-                                                                                              string
-                                                                                            )
-                                                                                          )
-                                                                                        }
-                                                                                        (abs
-                                                                                          dead
-                                                                                          (type)
-                                                                                          (con
-                                                                                            string
-                                                                                            "7"
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (abs
-                                                                                        dead
-                                                                                        (type)
-                                                                                        {
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          (builtin
-                                                                                                            ifThenElse
-                                                                                                          )
-                                                                                                          Bool
-                                                                                                        }
-                                                                                                        [
-                                                                                                          [
-                                                                                                            (builtin
-                                                                                                              equalsInteger
-                                                                                                            )
-                                                                                                            digit
-                                                                                                          ]
-                                                                                                          (con
-                                                                                                            integer
-                                                                                                            8
-                                                                                                          )
-                                                                                                        ]
-                                                                                                      ]
-                                                                                                      True
-                                                                                                    ]
-                                                                                                    False
-                                                                                                  ]
-                                                                                                ]
-                                                                                                (all
-                                                                                                  dead
-                                                                                                  (type)
-                                                                                                  (con
-                                                                                                    string
-                                                                                                  )
-                                                                                                )
-                                                                                              }
-                                                                                              (abs
-                                                                                                dead
-                                                                                                (type)
-                                                                                                (con
-                                                                                                  string
-                                                                                                  "8"
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (abs
-                                                                                              dead
-                                                                                              (type)
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              (builtin
-                                                                                                                ifThenElse
-                                                                                                              )
-                                                                                                              Bool
-                                                                                                            }
-                                                                                                            [
-                                                                                                              [
-                                                                                                                (builtin
-                                                                                                                  equalsInteger
-                                                                                                                )
-                                                                                                                digit
-                                                                                                              ]
-                                                                                                              (con
-                                                                                                                integer
-                                                                                                                9
-                                                                                                              )
-                                                                                                            ]
-                                                                                                          ]
-                                                                                                          True
-                                                                                                        ]
-                                                                                                        False
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (con
-                                                                                                      string
-                                                                                                    )
-                                                                                                  }
-                                                                                                  (con
-                                                                                                    string
-                                                                                                    "9"
-                                                                                                  )
-                                                                                                ]
-                                                                                                (con
-                                                                                                  string
-                                                                                                  "<invalid digit>"
-                                                                                                )
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
-                                                                                          (all
-                                                                                            dead
-                                                                                            (type)
-                                                                                            dead
-                                                                                          )
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (all
-                                                                                      dead
-                                                                                      (type)
-                                                                                      dead
-                                                                                    )
-                                                                                  }
-                                                                                )
-                                                                              ]
-                                                                              (all
-                                                                                dead
-                                                                                (type)
-                                                                                dead
-                                                                              )
-                                                                            }
-                                                                          )
-                                                                        ]
-                                                                        (all
-                                                                          dead
-                                                                          (type)
-                                                                          dead
-                                                                        )
-                                                                      }
-                                                                    )
-                                                                  ]
-                                                                  (all
-                                                                    dead
-                                                                    (type)
-                                                                    dead
-                                                                  )
-                                                                }
-                                                              )
-                                                            ]
-                                                            (all
-                                                              dead (type) dead
-                                                            )
-                                                          }
-                                                        )
-                                                      ]
-                                                      (all dead (type) dead)
-                                                    }
-                                                  )
-                                                ]
-                                                (all dead (type) dead)
-                                              }
-                                            )
-                                          ]
-                                          (all dead (type) dead)
-                                        }
-                                      ]
-                                      [ acc x ]
-                                    ]
-                                  )
-                                )
-                              )
-                            ]
-                            { id [ List (con string) ] }
-                          ]
-                          [ [ go { Nil (con integer) } ] w ]
-                        ]
-                      )
-                    ]
-                    (all dead (type) dead)
-                  }
-                )
-              )
-              (let
-                (nonrec)
-                (termbind
-                  (strict)
-                  (vardecl
-                    toHex
-                    (fun
-                      (con integer)
-                      (fun [ List (con string) ] [ List (con string) ])
-                    )
-                  )
-                  (lam
-                    x
-                    (con integer)
-                    {
-                      [
-                        [
-                          {
-                            [
-                              Bool_match
-                              [
-                                [
-                                  [
-                                    { (builtin ifThenElse) Bool }
-                                    [
-                                      [ (builtin lessThanEqualsInteger) x ]
-                                      (con integer 9)
-                                    ]
-                                  ]
-                                  True
-                                ]
-                                False
-                              ]
-                            ]
-                            (all
-                              dead
-                              (type)
-                              (fun [ List (con string) ] [ List (con string) ])
-                            )
-                          }
-                          (abs dead (type) [ wcshowsPrec x ])
-                        ]
-                        (abs
-                          dead
-                          (type)
-                          {
-                            [
-                              [
-                                {
-                                  [
+let !y : integer = 10
+    data Bool | Bool_match where
+      True : Bool
+      False : Bool
+in
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+letrec !go : List integer -> integer -> List integer
+         = \(acc : List integer) (n : integer) ->
+             let ~q : integer = quotientInteger n y
+             in Bool_match
+                  (ifThenElse {Bool} (equalsInteger q 0) True False)
+                  {all dead. List integer} (/\dead ->
+                                              Cons
+                                                {integer} (remainderInteger n y)
+                                                acc) (/\dead ->
+                                                        go
+                                                          (Cons
+                                                             {integer}
+                                                             (remainderInteger
+                                                                n y) acc) q)
+                  {all dead. dead}
+in
+letrec !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
+         = /\a b ->
+             \(f : a -> b -> b) (acc : b) (l : List a) ->
+               Nil_match
+                 {a} l {all dead. b} (/\dead -> acc) (\(x : a) (xs : List a) ->
+                                                        /\dead ->
+                                                          f
+                                                            x (foldr
+                                                                 {a} {b} f acc
+                                                                 xs))
+                 {all dead. dead}
+in
+let !id : all a. a -> a = /\a -> \(x : a) -> x in
+letrec !wcshowsPrec
+         : integer -> List string -> List string
+         = \(w : integer) ->
+             Bool_match
+               (ifThenElse {Bool} (lessThanInteger w 0) True False)
+               {all dead. List string -> List string} (/\dead ->
+                                                         \(x : List string) ->
+                                                           Cons
+                                                             {string} "-"
+                                                             (wcshowsPrec
+                                                                (subtractInteger
+                                                                   0 w) x))
+               (/\dead ->
+                  foldr
+                    {integer} {List string -> List string}
+                    (\(digit : integer) (acc : List string -> List string) (x
+                      : List string) ->
+                       Cons
+                         {string}
+                         (Bool_match
+                            (ifThenElse
+                               {Bool} (equalsInteger digit 0) True False)
+                            {all dead. string} (/\dead -> "0")
+                            (/\dead ->
+                               Bool_match
+                                 (ifThenElse
+                                    {Bool} (equalsInteger digit 1) True False)
+                                 {all dead. string} (/\dead -> "1")
+                                 (/\dead ->
                                     Bool_match
-                                    [
-                                      [
-                                        [
-                                          { (builtin ifThenElse) Bool }
-                                          [
-                                            [ (builtin equalsInteger) x ]
-                                            (con integer 10)
-                                          ]
-                                        ]
-                                        True
-                                      ]
-                                      False
-                                    ]
-                                  ]
-                                  (all
-                                    dead
-                                    (type)
-                                    (fun
-                                      [ List (con string) ]
-                                      [ List (con string) ]
-                                    )
-                                  )
-                                }
-                                (abs
-                                  dead
-                                  (type)
-                                  (lam
-                                    ds
-                                    [ List (con string) ]
-                                    [
-                                      [ { Cons (con string) } (con string "a") ]
-                                      ds
-                                    ]
-                                  )
-                                )
-                              ]
-                              (abs
-                                dead
-                                (type)
-                                {
-                                  [
-                                    [
-                                      {
-                                        [
-                                          Bool_match
-                                          [
-                                            [
-                                              [
-                                                { (builtin ifThenElse) Bool }
-                                                [
-                                                  [ (builtin equalsInteger) x ]
-                                                  (con integer 11)
-                                                ]
-                                              ]
-                                              True
-                                            ]
-                                            False
-                                          ]
-                                        ]
-                                        (all
-                                          dead
-                                          (type)
-                                          (fun
-                                            [ List (con string) ]
-                                            [ List (con string) ]
-                                          )
-                                        )
-                                      }
-                                      (abs
-                                        dead
-                                        (type)
-                                        (lam
-                                          ds
-                                          [ List (con string) ]
-                                          [
-                                            [
-                                              { Cons (con string) }
-                                              (con string "b")
-                                            ]
-                                            ds
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                    (abs
-                                      dead
-                                      (type)
-                                      {
-                                        [
-                                          [
-                                            {
-                                              [
-                                                Bool_match
-                                                [
-                                                  [
-                                                    [
-                                                      {
-                                                        (builtin ifThenElse)
-                                                        Bool
-                                                      }
-                                                      [
-                                                        [
-                                                          (builtin
-                                                            equalsInteger
-                                                          )
-                                                          x
-                                                        ]
-                                                        (con integer 12)
-                                                      ]
-                                                    ]
-                                                    True
-                                                  ]
-                                                  False
-                                                ]
-                                              ]
-                                              (all
-                                                dead
-                                                (type)
-                                                (fun
-                                                  [ List (con string) ]
-                                                  [ List (con string) ]
-                                                )
-                                              )
-                                            }
-                                            (abs
-                                              dead
-                                              (type)
-                                              (lam
-                                                ds
-                                                [ List (con string) ]
-                                                [
-                                                  [
-                                                    { Cons (con string) }
-                                                    (con string "c")
-                                                  ]
-                                                  ds
-                                                ]
-                                              )
-                                            )
-                                          ]
-                                          (abs
-                                            dead
-                                            (type)
-                                            {
-                                              [
-                                                [
-                                                  {
-                                                    [
-                                                      Bool_match
-                                                      [
-                                                        [
-                                                          [
-                                                            {
-                                                              (builtin
-                                                                ifThenElse
-                                                              )
-                                                              Bool
-                                                            }
-                                                            [
-                                                              [
-                                                                (builtin
-                                                                  equalsInteger
-                                                                )
-                                                                x
-                                                              ]
-                                                              (con integer 13)
-                                                            ]
-                                                          ]
-                                                          True
-                                                        ]
-                                                        False
-                                                      ]
-                                                    ]
-                                                    (all
-                                                      dead
-                                                      (type)
-                                                      (fun
-                                                        [ List (con string) ]
-                                                        [ List (con string) ]
-                                                      )
-                                                    )
-                                                  }
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    (lam
-                                                      ds
-                                                      [ List (con string) ]
-                                                      [
-                                                        [
-                                                          { Cons (con string) }
-                                                          (con string "d")
-                                                        ]
-                                                        ds
-                                                      ]
-                                                    )
-                                                  )
-                                                ]
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  {
-                                                    [
-                                                      [
-                                                        {
-                                                          [
-                                                            Bool_match
-                                                            [
-                                                              [
-                                                                [
-                                                                  {
-                                                                    (builtin
-                                                                      ifThenElse
-                                                                    )
-                                                                    Bool
-                                                                  }
-                                                                  [
-                                                                    [
-                                                                      (builtin
-                                                                        equalsInteger
-                                                                      )
-                                                                      x
-                                                                    ]
-                                                                    (con
-                                                                      integer 14
-                                                                    )
-                                                                  ]
-                                                                ]
-                                                                True
-                                                              ]
-                                                              False
-                                                            ]
-                                                          ]
-                                                          (all
-                                                            dead
-                                                            (type)
-                                                            (fun
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                            )
-                                                          )
-                                                        }
-                                                        (abs
-                                                          dead
-                                                          (type)
-                                                          (lam
-                                                            ds
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                            [
-                                                              [
-                                                                {
-                                                                  Cons
-                                                                  (con string)
-                                                                }
-                                                                (con string "e")
-                                                              ]
-                                                              ds
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                      (abs
-                                                        dead
-                                                        (type)
-                                                        [
-                                                          [
-                                                            {
-                                                              [
-                                                                Bool_match
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        (builtin
-                                                                          ifThenElse
-                                                                        )
-                                                                        Bool
-                                                                      }
-                                                                      [
-                                                                        [
-                                                                          (builtin
-                                                                            equalsInteger
-                                                                          )
-                                                                          x
-                                                                        ]
-                                                                        (con
-                                                                          integer
-                                                                          15
-                                                                        )
-                                                                      ]
-                                                                    ]
-                                                                    True
-                                                                  ]
-                                                                  False
-                                                                ]
-                                                              ]
-                                                              (fun
-                                                                [
-                                                                  List
-                                                                  (con string)
-                                                                ]
-                                                                [
-                                                                  List
-                                                                  (con string)
-                                                                ]
-                                                              )
-                                                            }
-                                                            (lam
-                                                              ds
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                              [
-                                                                [
-                                                                  {
-                                                                    Cons
-                                                                    (con string)
-                                                                  }
-                                                                  (con
-                                                                    string "f"
-                                                                  )
-                                                                ]
-                                                                ds
-                                                              ]
-                                                            )
-                                                          ]
-                                                          (lam
-                                                            ds
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                            [
-                                                              [
-                                                                {
-                                                                  Cons
-                                                                  (con string)
-                                                                }
-                                                                (con
-                                                                  string
-                                                                  "<invalid byte>"
-                                                                )
-                                                              ]
-                                                              ds
-                                                            ]
-                                                          )
-                                                        ]
-                                                      )
-                                                    ]
-                                                    (all dead (type) dead)
-                                                  }
-                                                )
-                                              ]
-                                              (all dead (type) dead)
-                                            }
-                                          )
-                                        ]
-                                        (all dead (type) dead)
-                                      }
-                                    )
-                                  ]
-                                  (all dead (type) dead)
-                                }
-                              )
-                            ]
-                            (all dead (type) dead)
-                          }
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-                (termbind
-                  (strict) (vardecl x (con integer)) (con integer -1234567890)
-                )
-                (termbind
-                  (strict)
-                  (vardecl
-                    build
-                    (all
-                      a
-                      (type)
-                      (fun
-                        (all b (type) (fun (fun a (fun b b)) (fun b b)))
-                        [ List a ]
-                      )
-                    )
-                  )
-                  (abs
-                    a
-                    (type)
-                    (lam
-                      g
-                      (all b (type) (fun (fun a (fun b b)) (fun b b)))
-                      [
-                        [
-                          { g [ List a ] }
-                          (lam
-                            ds a (lam ds [ List a ] [ [ { Cons a } ds ] ds ])
-                          )
-                        ]
-                        { Nil a }
-                      ]
-                    )
-                  )
-                )
-                (datatypebind
-                  (datatype
-                    (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
-                    (tyvardecl a (type)) (tyvardecl b (type))
-                    Tuple2_match
-                    (vardecl Tuple2 (fun a (fun b [ [ Tuple2 a ] b ])))
-                  )
-                )
-                (let
-                  (rec)
-                  (termbind
-                    (strict)
-                    (vardecl
-                      go
-                      (all
-                        a
-                        (type)
-                        (fun
-                          (con integer)
-                          (fun [ List a ] [ [ Tuple2 [ List a ] ] [ List a ] ])
-                        )
-                      )
-                    )
-                    (abs
-                      a
-                      (type)
-                      (lam
-                        ds
-                        (con integer)
-                        (lam
-                          ds
-                          [ List a ]
-                          {
-                            [
-                              [
-                                {
-                                  [ { Nil_match a } ds ]
-                                  (all
-                                    dead
-                                    (type)
-                                    [ [ Tuple2 [ List a ] ] [ List a ] ]
-                                  )
-                                }
-                                (abs
-                                  dead
-                                  (type)
-                                  [
-                                    [
-                                      { { Tuple2 [ List a ] } [ List a ] }
-                                      { Nil a }
-                                    ]
-                                    { Nil a }
-                                  ]
-                                )
-                              ]
-                              (lam
-                                y
-                                a
-                                (lam
-                                  ys
-                                  [ List a ]
-                                  (abs
-                                    dead
-                                    (type)
-                                    {
-                                      [
-                                        [
-                                          {
-                                            [
+                                      (ifThenElse
+                                         {Bool} (equalsInteger digit 2) True
+                                         False) {all dead. string} (/\dead ->
+                                                                      "2")
+                                      (/\dead ->
+                                         Bool_match
+                                           (ifThenElse
+                                              {Bool} (equalsInteger digit 3)
+                                              True False) {all dead. string}
+                                           (/\dead -> "3")
+                                           (/\dead ->
                                               Bool_match
-                                              [
-                                                [
-                                                  [
-                                                    {
-                                                      (builtin ifThenElse) Bool
-                                                    }
-                                                    [
-                                                      [
-                                                        (builtin equalsInteger)
-                                                        ds
-                                                      ]
-                                                      (con integer 1)
-                                                    ]
-                                                  ]
-                                                  True
-                                                ]
-                                                False
-                                              ]
-                                            ]
-                                            (all
-                                              dead
-                                              (type)
-                                              [
-                                                [ Tuple2 [ List a ] ] [ List a ]
-                                              ]
-                                            )
-                                          }
-                                          (abs
-                                            dead
-                                            (type)
-                                            [
-                                              [
-                                                {
-                                                  { Tuple2 [ List a ] }
-                                                  [ List a ]
-                                                }
-                                                [
-                                                  { build a }
-                                                  (abs
-                                                    a
-                                                    (type)
-                                                    (lam
-                                                      c
-                                                      (fun a (fun a a))
-                                                      (lam n a [ [ c y ] n ])
-                                                    )
-                                                  )
-                                                ]
-                                              ]
-                                              ys
-                                            ]
-                                          )
-                                        ]
-                                        (abs
-                                          dead
-                                          (type)
-                                          [
-                                            {
-                                              [
-                                                {
-                                                  { Tuple2_match [ List a ] }
-                                                  [ List a ]
-                                                }
-                                                [
-                                                  [
-                                                    { go a }
-                                                    [
-                                                      [
-                                                        (builtin
-                                                          subtractInteger
-                                                        )
-                                                        ds
-                                                      ]
-                                                      (con integer 1)
-                                                    ]
-                                                  ]
-                                                  ys
-                                                ]
-                                              ]
-                                              [
-                                                [ Tuple2 [ List a ] ] [ List a ]
-                                              ]
-                                            }
-                                            (lam
-                                              zs
-                                              [ List a ]
-                                              (lam
-                                                ws
-                                                [ List a ]
-                                                [
-                                                  [
-                                                    {
-                                                      { Tuple2 [ List a ] }
-                                                      [ List a ]
-                                                    }
-                                                    [ [ { Cons a } y ] zs ]
-                                                  ]
-                                                  ws
-                                                ]
-                                              )
-                                            )
-                                          ]
-                                        )
-                                      ]
-                                      (all dead (type) dead)
-                                    }
-                                  )
-                                )
-                              )
-                            ]
-                            (all dead (type) dead)
-                          }
-                        )
-                      )
-                    )
-                  )
-                  (let
-                    (rec)
-                    (termbind
-                      (strict)
-                      (vardecl
-                        fEnumBool_cenumFromTo
-                        (fun
-                          (con integer)
-                          (fun (con integer) [ List (con integer) ])
-                        )
-                      )
-                      (lam
-                        x
-                        (con integer)
-                        (lam
-                          y
-                          (con integer)
-                          {
-                            [
-                              [
-                                {
-                                  [
-                                    Bool_match
-                                    [
-                                      [
-                                        [
-                                          { (builtin ifThenElse) Bool }
-                                          [
-                                            [
-                                              (builtin lessThanEqualsInteger) x
-                                            ]
-                                            y
-                                          ]
-                                        ]
-                                        False
-                                      ]
-                                      True
-                                    ]
-                                  ]
-                                  (all dead (type) [ List (con integer) ])
-                                }
-                                (abs dead (type) { Nil (con integer) })
-                              ]
-                              (abs
-                                dead
-                                (type)
-                                [
-                                  [ { Cons (con integer) } x ]
-                                  [
-                                    [
-                                      fEnumBool_cenumFromTo
-                                      [
-                                        [ (builtin addInteger) x ]
-                                        (con integer 1)
-                                      ]
-                                    ]
-                                    y
-                                  ]
-                                ]
-                              )
-                            ]
-                            (all dead (type) dead)
-                          }
-                        )
-                      )
-                    )
-                    (let
-                      (nonrec)
-                      (termbind
-                        (strict)
-                        (vardecl
-                          fShowInteger_cshowsPrec
-                          (fun
-                            (con integer)
-                            (fun
-                              (con integer)
-                              (fun [ List (con string) ] [ List (con string) ])
-                            )
-                          )
-                        )
-                        (lam
-                          w
-                          (con integer)
-                          (lam w (con integer) [ wcshowsPrec w ])
-                        )
-                      )
-                      (datatypebind
-                        (datatype
-                          (tyvardecl Monoid (fun (type) (type)))
-                          (tyvardecl a (type))
-                          Monoid_match
-                          (vardecl
-                            CConsMonoid
-                            (fun
-                              [ (lam a (type) (fun a (fun a a))) a ]
-                              (fun a [ Monoid a ])
-                            )
-                          )
-                        )
-                      )
-                      (termbind
-                        (strict)
-                        (vardecl
-                          p1Monoid
-                          (all
-                            a
-                            (type)
-                            (fun
-                              [ Monoid a ]
-                              [ (lam a (type) (fun a (fun a a))) a ]
-                            )
-                          )
-                        )
-                        (abs
-                          a
-                          (type)
-                          (lam
-                            v
-                            [ Monoid a ]
-                            [
-                              {
-                                [ { Monoid_match a } v ]
-                                [ (lam a (type) (fun a (fun a a))) a ]
-                              }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) a ]
-                                (lam v a v)
-                              )
-                            ]
-                          )
-                        )
-                      )
-                      (termbind
-                        (strict)
-                        (vardecl mempty (all a (type) (fun [ Monoid a ] a)))
-                        (abs
-                          a
-                          (type)
-                          (lam
-                            v
-                            [ Monoid a ]
-                            [
-                              { [ { Monoid_match a } v ] a }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) a ]
-                                (lam v a v)
-                              )
-                            ]
-                          )
-                        )
-                      )
-                      (let
-                        (rec)
-                        (termbind
-                          (strict)
-                          (vardecl
-                            fFoldableNil_cfoldMap
-                            (all
-                              m
-                              (type)
-                              (all
-                                a
-                                (type)
-                                (fun
-                                  [ Monoid m ]
-                                  (fun (fun a m) (fun [ List a ] m))
-                                )
-                              )
-                            )
-                          )
-                          (abs
-                            m
-                            (type)
-                            (abs
-                              a
-                              (type)
-                              (lam
-                                dMonoid
-                                [ Monoid m ]
-                                (lam
-                                  eta
-                                  (fun a m)
-                                  (lam
-                                    eta
-                                    [ List a ]
-                                    {
-                                      [
-                                        [
-                                          {
-                                            [ { Nil_match a } eta ]
-                                            (all dead (type) m)
-                                          }
-                                          (abs
-                                            dead (type) [ { mempty m } dMonoid ]
-                                          )
-                                        ]
-                                        (lam
-                                          x
-                                          a
-                                          (lam
-                                            xs
-                                            [ List a ]
-                                            (abs
-                                              dead
-                                              (type)
-                                              [
-                                                [
-                                                  [ { p1Monoid m } dMonoid ]
-                                                  [ eta x ]
-                                                ]
-                                                [
-                                                  [
-                                                    [
-                                                      {
-                                                        {
-                                                          fFoldableNil_cfoldMap
-                                                          m
-                                                        }
-                                                        a
-                                                      }
-                                                      dMonoid
-                                                    ]
-                                                    eta
-                                                  ]
-                                                  xs
-                                                ]
-                                              ]
-                                            )
-                                          )
-                                        )
-                                      ]
-                                      (all dead (type) dead)
-                                    }
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                        (let
-                          (nonrec)
-                          (datatypebind
-                            (datatype
-                              (tyvardecl
-                                UTuple2 (fun (type) (fun (type) (type)))
-                              )
-                              (tyvardecl a (type)) (tyvardecl b (type))
-                              UTuple2_match
-                              (vardecl
-                                UTuple2 (fun a (fun b [ [ UTuple2 a ] b ]))
-                              )
-                            )
-                          )
-                          (let
-                            (rec)
-                            (termbind
-                              (strict)
-                              (vardecl
-                                concatBuiltinStrings
-                                (fun [ List (con string) ] (con string))
-                              )
-                              (lam
-                                ds
-                                [ List (con string) ]
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (nonstrict)
-                                    (vardecl
-                                      ds
-                                      [
-                                        [ Tuple2 [ List (con string) ] ]
-                                        [ List (con string) ]
-                                      ]
-                                    )
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl w (con integer))
-                                        [
-                                          [
-                                            (builtin divideInteger)
-                                            [
-                                              [
-                                                [
-                                                  [
-                                                    {
-                                                      {
-                                                        fFoldableNil_cfoldMap
-                                                        [
-                                                          (lam a (type) a)
-                                                          [
-                                                            (lam
-                                                              a (type) (fun a a)
-                                                            )
-                                                            (con integer)
-                                                          ]
-                                                        ]
-                                                      }
-                                                      (con string)
-                                                    }
-                                                    [
-                                                      (let
-                                                        (nonrec)
-                                                        (typebind
-                                                          (tyvardecl a (type))
-                                                          [
-                                                            (lam
-                                                              a (type) (fun a a)
-                                                            )
-                                                            (con integer)
-                                                          ]
-                                                        )
-                                                        (lam
-                                                          v
-                                                          [ Monoid a ]
-                                                          [
-                                                            [
-                                                              {
-                                                                CConsMonoid
-                                                                [
-                                                                  (lam
-                                                                    a (type) a
-                                                                  )
-                                                                  a
-                                                                ]
-                                                              }
-                                                              (lam
-                                                                eta
-                                                                [
-                                                                  (lam
-                                                                    a (type) a
-                                                                  )
-                                                                  a
-                                                                ]
-                                                                (lam
-                                                                  eta
-                                                                  [
-                                                                    (lam
-                                                                      a (type) a
-                                                                    )
-                                                                    a
-                                                                  ]
-                                                                  [
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          p1Monoid
-                                                                          a
-                                                                        }
-                                                                        v
-                                                                      ]
-                                                                      eta
-                                                                    ]
-                                                                    eta
-                                                                  ]
-                                                                )
-                                                              )
-                                                            ]
-                                                            [ { mempty a } v ]
-                                                          ]
-                                                        )
-                                                      )
-                                                      [
-                                                        [
-                                                          {
-                                                            CConsMonoid
-                                                            [
-                                                              (lam
-                                                                a
-                                                                (type)
-                                                                (fun a a)
-                                                              )
-                                                              (con integer)
-                                                            ]
-                                                          }
-                                                          (lam
-                                                            ds
-                                                            [
-                                                              (lam
-                                                                a
-                                                                (type)
-                                                                (fun a a)
-                                                              )
-                                                              (con integer)
-                                                            ]
-                                                            (lam
-                                                              ds
-                                                              [
-                                                                (lam
-                                                                  a
-                                                                  (type)
-                                                                  (fun a a)
-                                                                )
-                                                                (con integer)
-                                                              ]
-                                                              (lam
-                                                                x
-                                                                (con integer)
-                                                                [ ds [ ds x ] ]
-                                                              )
-                                                            )
-                                                          )
-                                                        ]
-                                                        { id (con integer) }
-                                                      ]
-                                                    ]
-                                                  ]
-                                                  (lam
-                                                    x
-                                                    (con string)
-                                                    (lam
-                                                      y
-                                                      (con integer)
-                                                      [
-                                                        [
-                                                          (builtin addInteger) y
-                                                        ]
-                                                        (con integer 1)
-                                                      ]
-                                                    )
-                                                  )
-                                                ]
-                                                ds
-                                              ]
-                                              (con integer 0)
-                                            ]
-                                          ]
-                                          (con integer 2)
-                                        ]
-                                      )
-                                      [
-                                        {
-                                          [
-                                            {
-                                              {
-                                                UTuple2_match
-                                                [ List (con string) ]
-                                              }
-                                              [ List (con string) ]
-                                            }
-                                            {
-                                              [
-                                                [
-                                                  {
-                                                    [
-                                                      Bool_match
-                                                      [
-                                                        [
-                                                          [
-                                                            {
-                                                              (builtin
-                                                                ifThenElse
-                                                              )
-                                                              Bool
-                                                            }
-                                                            [
-                                                              [
-                                                                (builtin
-                                                                  lessThanEqualsInteger
-                                                                )
-                                                                w
-                                                              ]
-                                                              (con integer 0)
-                                                            ]
-                                                          ]
-                                                          True
-                                                        ]
-                                                        False
-                                                      ]
-                                                    ]
-                                                    (all
-                                                      dead
-                                                      (type)
-                                                      [
-                                                        [
-                                                          UTuple2
-                                                          [ List (con string) ]
-                                                        ]
-                                                        [ List (con string) ]
-                                                      ]
-                                                    )
-                                                  }
-                                                  (abs
-                                                    dead
-                                                    (type)
-                                                    [
-                                                      [
-                                                        {
-                                                          {
-                                                            UTuple2
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                          }
-                                                          [ List (con string) ]
-                                                        }
-                                                        { Nil (con string) }
-                                                      ]
-                                                      ds
-                                                    ]
-                                                  )
-                                                ]
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  [
-                                                    {
-                                                      [
-                                                        {
-                                                          {
-                                                            Tuple2_match
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                          }
-                                                          [ List (con string) ]
-                                                        }
-                                                        [
-                                                          [
-                                                            { go (con string) }
-                                                            w
-                                                          ]
-                                                          ds
-                                                        ]
-                                                      ]
-                                                      [
-                                                        [
-                                                          UTuple2
-                                                          [ List (con string) ]
-                                                        ]
-                                                        [ List (con string) ]
-                                                      ]
-                                                    }
-                                                    (lam
-                                                      ww
-                                                      [ List (con string) ]
-                                                      (lam
-                                                        ww
-                                                        [ List (con string) ]
-                                                        [
-                                                          [
-                                                            {
-                                                              {
-                                                                UTuple2
-                                                                [
-                                                                  List
-                                                                  (con string)
-                                                                ]
-                                                              }
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                            }
-                                                            ww
-                                                          ]
-                                                          ww
-                                                        ]
-                                                      )
-                                                    )
-                                                  ]
-                                                )
-                                              ]
-                                              (all dead (type) dead)
-                                            }
-                                          ]
-                                          [
-                                            [ Tuple2 [ List (con string) ] ]
-                                            [ List (con string) ]
-                                          ]
-                                        }
-                                        (lam
-                                          ww
-                                          [ List (con string) ]
-                                          (lam
-                                            ww
-                                            [ List (con string) ]
-                                            [
-                                              [
-                                                {
-                                                  {
-                                                    Tuple2 [ List (con string) ]
-                                                  }
-                                                  [ List (con string) ]
-                                                }
-                                                ww
-                                              ]
-                                              ww
-                                            ]
-                                          )
-                                        )
-                                      ]
-                                    )
-                                  )
-                                  [
-                                    [
-                                      {
-                                        [ { Nil_match (con string) } ds ]
-                                        (con string)
-                                      }
-                                      (con string "")
-                                    ]
-                                    (lam
-                                      x
-                                      (con string)
-                                      (lam
-                                        ds
-                                        [ List (con string) ]
-                                        {
-                                          [
-                                            [
-                                              {
-                                                [
-                                                  { Nil_match (con string) } ds
-                                                ]
-                                                (all dead (type) (con string))
-                                              }
-                                              (abs dead (type) x)
-                                            ]
-                                            (lam
-                                              ipv
-                                              (con string)
-                                              (lam
-                                                ipv
-                                                [ List (con string) ]
-                                                (abs
-                                                  dead
-                                                  (type)
-                                                  [
-                                                    [
-                                                      (builtin appendString)
-                                                      [
-                                                        {
-                                                          [
-                                                            {
-                                                              {
-                                                                Tuple2_match
-                                                                [
-                                                                  List
-                                                                  (con string)
-                                                                ]
-                                                              }
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                            }
-                                                            ds
-                                                          ]
-                                                          (con string)
-                                                        }
-                                                        (lam
-                                                          ys
-                                                          [ List (con string) ]
-                                                          (lam
-                                                            zs
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                            [
-                                                              concatBuiltinStrings
-                                                              ys
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                    ]
-                                                    [
-                                                      {
-                                                        [
-                                                          {
-                                                            {
-                                                              Tuple2_match
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                            }
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                          }
-                                                          ds
-                                                        ]
-                                                        (con string)
-                                                      }
-                                                      (lam
-                                                        ys
-                                                        [ List (con string) ]
-                                                        (lam
-                                                          zs
-                                                          [ List (con string) ]
-                                                          [
+                                                (ifThenElse
+                                                   {Bool} (equalsInteger
+                                                             digit 4) True
+                                                   False) {all dead. string}
+                                                (/\dead -> "4")
+                                                (/\dead ->
+                                                   Bool_match
+                                                     (ifThenElse
+                                                        {Bool} (equalsInteger
+                                                                  digit 5) True
+                                                        False)
+                                                     {all dead. string}
+                                                     (/\dead -> "5")
+                                                     (/\dead ->
+                                                        Bool_match
+                                                          (ifThenElse
+                                                             {Bool}
+                                                             (equalsInteger
+                                                                digit 6) True
+                                                             False)
+                                                          {all dead. string}
+                                                          (/\dead -> "6")
+                                                          (/\dead ->
+                                                             Bool_match
+                                                               (ifThenElse
+                                                                  {Bool}
+                                                                  (equalsInteger
+                                                                     digit 7)
+                                                                  True False)
+                                                               {all dead. string}
+                                                               (/\dead -> "7")
+                                                               (/\dead ->
+                                                                  Bool_match
+                                                                    (ifThenElse
+                                                                       {Bool}
+                                                                       (equalsInteger
+                                                                          digit
+                                                                          8)
+                                                                       True
+                                                                       False)
+                                                                    {all dead. string}
+                                                                    (/\dead ->
+                                                                       "8")
+                                                                    (/\dead ->
+                                                                       Bool_match
+                                                                         (ifThenElse
+                                                                            {Bool}
+                                                                            (equalsInteger
+                                                                               digit
+                                                                               9)
+                                                                            True
+                                                                            False)
+                                                                         {string}
+                                                                         "9"
+                                                                         "<invalid digit>")
+                                                                    {all dead. dead})
+                                                               {all dead. dead})
+                                                          {all dead. dead})
+                                                     {all dead. dead})
+                                                {all dead. dead})
+                                           {all dead. dead}) {all dead. dead})
+                                 {all dead. dead}) {all dead. dead}) (acc x))
+                    (id {List string}) (go (Nil {integer}) w)) {all dead. dead}
+in
+let !toHex : integer -> List string -> List string
+      = \(x : integer) ->
+          Bool_match
+            (ifThenElse {Bool} (lessThanEqualsInteger x 9) True False)
+            {all dead. List string -> List string} (/\dead -> wcshowsPrec x)
+            (/\dead ->
+               Bool_match
+                 (ifThenElse {Bool} (equalsInteger x 10) True False)
+                 {all dead. List string -> List string} (/\dead ->
+                                                           \(ds
+                                                            : List string) ->
+                                                             Cons
+                                                               {string} "a" ds)
+                 (/\dead ->
+                    Bool_match
+                      (ifThenElse {Bool} (equalsInteger x 11) True False)
+                      {all dead. List string -> List string}
+                      (/\dead -> \(ds : List string) -> Cons {string} "b" ds)
+                      (/\dead ->
+                         Bool_match
+                           (ifThenElse {Bool} (equalsInteger x 12) True False)
+                           {all dead. List string -> List string}
+                           (/\dead ->
+                              \(ds : List string) -> Cons {string} "c" ds)
+                           (/\dead ->
+                              Bool_match
+                                (ifThenElse
+                                   {Bool} (equalsInteger x 13) True False)
+                                {all dead. List string -> List string}
+                                (/\dead ->
+                                   \(ds : List string) -> Cons {string} "d" ds)
+                                (/\dead ->
+                                   Bool_match
+                                     (ifThenElse
+                                        {Bool} (equalsInteger x 14) True False)
+                                     {all dead. List string -> List string}
+                                     (/\dead ->
+                                        \(ds : List string) ->
+                                          Cons {string} "e" ds)
+                                     (/\dead ->
+                                        Bool_match
+                                          (ifThenElse
+                                             {Bool} (equalsInteger x 15) True
+                                             False) {List string -> List string}
+                                          (\(ds : List string) ->
+                                             Cons {string} "f" ds)
+                                          (\(ds : List string) ->
+                                             Cons {string} "<invalid byte>" ds))
+                                     {all dead. dead}) {all dead. dead})
+                           {all dead. dead}) {all dead. dead}) {all dead. dead})
+            {all dead. dead}
+    !x : integer = -1234567890
+    !build : all a. (all b. (a -> b -> b) -> b -> b) -> List a
+      = /\a ->
+          \(g : all b. (a -> b -> b) -> b -> b) ->
+            g {List a} (\(ds : a) (ds : List a) -> Cons {a} ds ds) (Nil {a})
+    data (Tuple2 :: * -> * -> *) a b | Tuple2_match where
+      Tuple2 : a -> b -> Tuple2 a b
+in
+letrec !go : all a. integer -> List a -> Tuple2 (List a) (List a)
+         = /\a ->
+             \(ds : integer) (ds : List a) ->
+               Nil_match
+                 {a} ds {all dead. Tuple2 (List a) (List a)} (/\dead ->
+                                                                Tuple2
+                                                                  {List a}
+                                                                  {List a}
+                                                                  (Nil {a})
+                                                                  (Nil {a}))
+                 (\(y : a) (ys : List a) ->
+                    /\dead ->
+                      Bool_match
+                        (ifThenElse {Bool} (equalsInteger ds 1) True False)
+                        {all dead. Tuple2 (List a) (List a)}
+                        (/\dead ->
+                           Tuple2
+                             {List a} {List a} (build
+                                                  {a} (/\a ->
+                                                         \(c : a -> a -> a) (n
+                                                          : a) ->
+                                                           c y n)) ys)
+                        (/\dead ->
+                           Tuple2_match
+                             {List a} {List a} (go
+                                                  {a} (subtractInteger ds 1) ys)
+                             {Tuple2 (List a) (List a)} (\(zs : List a) (ws
+                                                          : List a) ->
+                                                           Tuple2
+                                                             {List a} {List a}
+                                                             (Cons {a} y zs)
+                                                             ws))
+                        {all dead. dead}) {all dead. dead}
+in
+letrec !fEnumBool_cenumFromTo : integer -> integer -> List integer
+         = \(x : integer) (y : integer) ->
+             Bool_match
+               (ifThenElse {Bool} (lessThanEqualsInteger x y) False True)
+               {all dead. List integer} (/\dead -> Nil {integer})
+               (/\dead ->
+                  Cons {integer} x (fEnumBool_cenumFromTo (addInteger x 1) y))
+               {all dead. dead}
+in
+let !fShowInteger_cshowsPrec : integer -> integer -> List string -> List string
+      = \(w : integer) (w : integer) -> wcshowsPrec w
+    data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+    !p1Monoid : all a. Monoid a -> (\a -> a -> a -> a) a
+      = /\a ->
+          \(v : Monoid a) ->
+            Monoid_match
+              {a} v {(\a -> a -> a -> a) a} (\(v : (\a -> a -> a -> a) a) (v
+                                              : a) ->
+                                               v)
+    !mempty : all a. Monoid a -> a
+      = /\a ->
+          \(v : Monoid a) ->
+            Monoid_match {a} v {a} (\(v : (\a -> a -> a -> a) a) (v : a) -> v)
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead -> mempty {m} dMonoid)
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      p1Monoid
+                        {m} dMonoid (eta x) (fFoldableNil_cfoldMap
+                                               {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (UTuple2 :: * -> * -> *) a b | UTuple2_match where
+      UTuple2 : a -> b -> UTuple2 a b
+in
+letrec !concatBuiltinStrings : List string -> string
+         = \(ds : List string) ->
+             let ~ds : Tuple2 (List string) (List string)
+                   = let !w : integer
+                           = divideInteger
+                               (fFoldableNil_cfoldMap
+                                  {(\a -> a) ((\a -> a -> a) integer)} {string}
+                                  ((let a = (\a -> a -> a) integer
+                                    in \(v : Monoid a) ->
+                                         CConsMonoid
+                                           {(\a -> a) a} (\(eta : (\a -> a) a)
+                                                           (eta
+                                                           : (\a -> a) a) ->
+                                                            p1Monoid
+                                                              {a} v eta eta)
+                                           (mempty {a} v))
+                                     (CConsMonoid
+                                        {(\a -> a -> a) integer}
+                                        (\(ds : (\a -> a -> a) integer) (ds
+                                          : (\a -> a -> a) integer) (x
+                                          : integer) ->
+                                           ds (ds x)) (id {integer})))
+                                  (\(x : string) (y : integer) ->
+                                     addInteger y 1) ds 0) 2
+                     in UTuple2_match
+                          {List string} {List string}
+                          (Bool_match
+                             (ifThenElse
+                                {Bool} (lessThanEqualsInteger w 0) True False)
+                             {all dead. UTuple2 (List string) (List string)}
+                             (/\dead ->
+                                UTuple2
+                                  {List string} {List string} (Nil {string}) ds)
+                             (/\dead ->
+                                Tuple2_match
+                                  {List string} {List string} (go {string} w ds)
+                                  {UTuple2 (List string) (List string)}
+                                  (\(ww : List string) (ww : List string) ->
+                                     UTuple2 {List string} {List string} ww ww))
+                             {all dead. dead})
+                          {Tuple2 (List string) (List string)}
+                          (\(ww : List string) (ww : List string) ->
+                             Tuple2 {List string} {List string} ww ww)
+             in Nil_match
+                  {string} ds {string} "" (\(x : string) (ds : List string) ->
+                                             Nil_match
+                                               {string} ds {all dead. string}
+                                               (/\dead -> x)
+                                               (\(ipv : string) (ipv
+                                                 : List string) ->
+                                                  /\dead ->
+                                                    appendString
+                                                      (Tuple2_match
+                                                         {List string}
+                                                         {List string} ds
+                                                         {string}
+                                                         (\(ys : List string)
+                                                           (zs : List string) ->
                                                             concatBuiltinStrings
-                                                            zs
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                  ]
-                                                )
-                                              )
-                                            )
-                                          ]
-                                          (all dead (type) dead)
-                                        }
-                                      )
-                                    )
-                                  ]
-                                )
-                              )
-                            )
-                            (let
-                              (nonrec)
-                              (termbind
-                                (strict)
-                                (vardecl
-                                  fShowInteger_cshow
-                                  (fun (con integer) (con string))
-                                )
-                                (lam
-                                  x
-                                  (con integer)
-                                  [
-                                    concatBuiltinStrings
-                                    [
-                                      [
-                                        [
-                                          fShowInteger_cshowsPrec
-                                          (con integer 0)
-                                        ]
-                                        x
-                                      ]
-                                      { Nil (con string) }
-                                    ]
-                                  ]
-                                )
-                              )
-                              (datatypebind
-                                (datatype
-                                  (tyvardecl Show (fun (type) (type)))
-                                  (tyvardecl a (type))
-                                  Show_match
-                                  (vardecl
-                                    CConsShow
-                                    (fun
-                                      (fun
-                                        (con integer)
-                                        (fun
-                                          a
-                                          (fun
-                                            [ List (con string) ]
-                                            [ List (con string) ]
-                                          )
-                                        )
-                                      )
-                                      (fun (fun a (con string)) [ Show a ])
-                                    )
-                                  )
-                                )
-                              )
-                              (termbind
-                                (nonstrict)
-                                (vardecl fShowInteger [ Show (con integer) ])
-                                [
-                                  [
-                                    { CConsShow (con integer) }
-                                    fShowInteger_cshowsPrec
-                                  ]
-                                  fShowInteger_cshow
-                                ]
-                              )
-                              (datatypebind
-                                (datatype
-                                  (tyvardecl
-                                    Tuple5
-                                    (fun
-                                      (type)
-                                      (fun
-                                        (type)
-                                        (fun
-                                          (type)
-                                          (fun (type) (fun (type) (type)))
-                                        )
-                                      )
-                                    )
-                                  )
-                                  (tyvardecl a (type))
-                                  (tyvardecl b (type))
-                                  (tyvardecl c (type))
-                                  (tyvardecl d (type))
-                                  (tyvardecl e (type))
-                                  Tuple5_match
-                                  (vardecl
-                                    Tuple5
-                                    (fun
-                                      a
-                                      (fun
-                                        b
-                                        (fun
-                                          c
-                                          (fun
-                                            d
-                                            (fun
-                                              e
-                                              [
-                                                [ [ [ [ Tuple5 a ] b ] c ] d ] e
-                                              ]
-                                            )
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl
-                                  showsPrec
-                                  (all
-                                    a
-                                    (type)
-                                    (fun
-                                      [ Show a ]
-                                      (fun
-                                        (con integer)
-                                        (fun
-                                          a
-                                          (fun
-                                            [ List (con string) ]
-                                            [ List (con string) ]
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                                (abs
-                                  a
-                                  (type)
-                                  (lam
-                                    v
-                                    [ Show a ]
-                                    [
-                                      {
-                                        [ { Show_match a } v ]
-                                        (fun
-                                          (con integer)
-                                          (fun
-                                            a
-                                            (fun
-                                              [ List (con string) ]
-                                              [ List (con string) ]
-                                            )
-                                          )
-                                        )
-                                      }
-                                      (lam
-                                        v
-                                        (fun
-                                          (con integer)
-                                          (fun
-                                            a
-                                            (fun
-                                              [ List (con string) ]
-                                              [ List (con string) ]
-                                            )
-                                          )
-                                        )
-                                        (lam v (fun a (con string)) v)
-                                      )
-                                    ]
-                                  )
-                                )
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl a (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    [ fShowInteger_cshow x ]
-                                  ]
-                                  x
-                                ]
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl b (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    (con string "This is an example")
-                                  ]
-                                  a
-                                ]
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl c (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl x (con bytestring))
-                                        [
-                                          (builtin encodeUtf8)
-                                          (con string "This is an example")
-                                        ]
-                                      )
-                                      [
-                                        concatBuiltinStrings
-                                        [
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  { foldr (con integer) }
-                                                  (fun
-                                                    [ List (con string) ]
-                                                    [ List (con string) ]
-                                                  )
-                                                }
-                                                (lam
-                                                  i
-                                                  (con integer)
-                                                  (let
-                                                    (nonrec)
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl x (con integer))
-                                                      [
-                                                        [
-                                                          (builtin
-                                                            indexByteString
-                                                          )
-                                                          x
-                                                        ]
-                                                        i
-                                                      ]
-                                                    )
-                                                    (lam
-                                                      acc
-                                                      (fun
-                                                        [ List (con string) ]
-                                                        [ List (con string) ]
-                                                      )
-                                                      (lam
-                                                        x
-                                                        [ List (con string) ]
-                                                        [
-                                                          [
-                                                            toHex
-                                                            [
-                                                              [
-                                                                (builtin
-                                                                  divideInteger
-                                                                )
-                                                                x
-                                                              ]
-                                                              (con integer 16)
-                                                            ]
-                                                          ]
-                                                          [
-                                                            [
-                                                              toHex
-                                                              [
-                                                                [
-                                                                  (builtin
-                                                                    modInteger
-                                                                  )
-                                                                  x
-                                                                ]
-                                                                (con integer 16)
-                                                              ]
-                                                            ]
-                                                            [ acc x ]
-                                                          ]
-                                                        ]
-                                                      )
-                                                    )
-                                                  )
-                                                )
-                                              ]
-                                              { id [ List (con string) ] }
-                                            ]
-                                            [
-                                              [
-                                                fEnumBool_cenumFromTo
-                                                (con integer 0)
-                                              ]
-                                              [
-                                                [
-                                                  (builtin subtractInteger)
-                                                  [
-                                                    (builtin lengthOfByteString)
-                                                    x
-                                                  ]
-                                                ]
-                                                (con integer 1)
-                                              ]
-                                            ]
-                                          ]
-                                          { Nil (con string) }
-                                        ]
-                                      ]
-                                    )
-                                  ]
-                                  b
-                                ]
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl d (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl b Bool)
-                                        [
-                                          [
-                                            [
-                                              { (builtin ifThenElse) Bool }
-                                              [
-                                                [
-                                                  (builtin
-                                                    lessThanEqualsInteger
-                                                  )
-                                                  c
-                                                ]
-                                                (con integer 0)
-                                              ]
-                                            ]
-                                            False
-                                          ]
-                                          True
-                                        ]
-                                      )
-                                      [
-                                        [
-                                          { [ Bool_match b ] (con string) }
-                                          (con string "True")
-                                        ]
-                                        (con string "False")
-                                      ]
-                                    )
-                                  ]
-                                  c
-                                ]
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl e (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl dShow [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl x [ List (con integer) ])
-                                        [
-                                          { build (con integer) }
-                                          (abs
-                                            a
-                                            (type)
-                                            (lam
-                                              c
-                                              (fun (con integer) (fun a a))
-                                              (lam
-                                                n
-                                                a
-                                                [
-                                                  [ c a ]
-                                                  [
-                                                    [ c b ]
-                                                    [ [ c c ] [ [ c d ] n ] ]
-                                                  ]
-                                                ]
-                                              )
-                                            )
-                                          )
-                                        ]
-                                      )
-                                      [
-                                        concatBuiltinStrings
-                                        (let
-                                          (nonrec)
-                                          (termbind
-                                            (strict)
-                                            (vardecl
-                                              w
-                                              (fun
-                                                (con integer)
-                                                (fun
-                                                  [ List (con string) ]
-                                                  [ List (con string) ]
-                                                )
-                                              )
-                                            )
-                                            [
-                                              [
-                                                { showsPrec (con integer) }
-                                                dShow
-                                              ]
-                                              (con integer 0)
-                                            ]
-                                          )
-                                          (termbind
-                                            (strict)
-                                            (vardecl w [ List (con string) ])
-                                            { Nil (con string) }
-                                          )
-                                          [
-                                            {
-                                              [
-                                                {
-                                                  { UTuple2_match (con string) }
-                                                  [ List (con string) ]
-                                                }
-                                                {
-                                                  [
-                                                    [
-                                                      {
-                                                        [
-                                                          {
-                                                            Nil_match
-                                                            (con integer)
-                                                          }
-                                                          x
-                                                        ]
-                                                        (all
-                                                          dead
-                                                          (type)
-                                                          [
-                                                            [
-                                                              UTuple2
-                                                              (con string)
-                                                            ]
-                                                            [
-                                                              List (con string)
-                                                            ]
-                                                          ]
-                                                        )
-                                                      }
-                                                      (abs
-                                                        dead
-                                                        (type)
-                                                        [
-                                                          [
-                                                            {
-                                                              {
-                                                                UTuple2
-                                                                (con string)
-                                                              }
-                                                              [
-                                                                List
-                                                                (con string)
-                                                              ]
-                                                            }
-                                                            (con string "[]")
-                                                          ]
-                                                          w
-                                                        ]
-                                                      )
-                                                    ]
-                                                    (lam
-                                                      x
-                                                      (con integer)
-                                                      (lam
-                                                        xs
-                                                        [ List (con integer) ]
-                                                        (abs
-                                                          dead
-                                                          (type)
-                                                          [
-                                                            [
-                                                              {
-                                                                {
-                                                                  UTuple2
-                                                                  (con string)
-                                                                }
-                                                                [
-                                                                  List
-                                                                  (con string)
-                                                                ]
-                                                              }
-                                                              (con string "[")
-                                                            ]
-                                                            [
-                                                              [ w x ]
-                                                              [
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        {
-                                                                          foldr
-                                                                          (con
-                                                                            integer
-                                                                          )
-                                                                        }
-                                                                        (fun
-                                                                          [
-                                                                            List
-                                                                            (con
-                                                                              string
-                                                                            )
-                                                                          ]
-                                                                          [
-                                                                            List
-                                                                            (con
-                                                                              string
-                                                                            )
-                                                                          ]
-                                                                        )
-                                                                      }
-                                                                      (lam
-                                                                        a
-                                                                        (con
-                                                                          integer
-                                                                        )
-                                                                        (lam
-                                                                          acc
-                                                                          (fun
-                                                                            [
-                                                                              List
-                                                                              (con
-                                                                                string
-                                                                              )
-                                                                            ]
-                                                                            [
-                                                                              List
-                                                                              (con
-                                                                                string
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                          (lam
-                                                                            x
-                                                                            [
-                                                                              List
-                                                                              (con
-                                                                                string
-                                                                              )
-                                                                            ]
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  Cons
-                                                                                  (con
-                                                                                    string
-                                                                                  )
-                                                                                }
-                                                                                (con
-                                                                                  string
-                                                                                  ","
-                                                                                )
-                                                                              ]
-                                                                              [
-                                                                                [
-                                                                                  w
-                                                                                  a
-                                                                                ]
-                                                                                [
-                                                                                  acc
-                                                                                  x
-                                                                                ]
-                                                                              ]
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      )
-                                                                    ]
-                                                                    {
-                                                                      id
-                                                                      [
-                                                                        List
-                                                                        (con
-                                                                          string
-                                                                        )
-                                                                      ]
-                                                                    }
-                                                                  ]
-                                                                  xs
-                                                                ]
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      Cons
-                                                                      (con
-                                                                        string
-                                                                      )
-                                                                    }
-                                                                    (con
-                                                                      string "]"
-                                                                    )
-                                                                  ]
-                                                                  w
-                                                                ]
-                                                              ]
-                                                            ]
-                                                          ]
-                                                        )
-                                                      )
-                                                    )
-                                                  ]
-                                                  (all dead (type) dead)
-                                                }
-                                              ]
-                                              [ List (con string) ]
-                                            }
-                                            (lam
-                                              ww
-                                              (con string)
-                                              (lam
-                                                ww
-                                                [ List (con string) ]
-                                                [
-                                                  [ { Cons (con string) } ww ]
-                                                  ww
-                                                ]
-                                              )
-                                            )
-                                          ]
-                                        )
-                                      ]
-                                    )
-                                  ]
-                                  d
-                                ]
-                              )
-                              (termbind
-                                (strict)
-                                (vardecl x (con integer))
-                                [
-                                  [
-                                    { (builtin trace) (con integer) }
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl w [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl w [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl w [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl w [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl w [ Show (con integer) ])
-                                        fShowInteger
-                                      )
-                                      (termbind
-                                        (strict)
-                                        (vardecl
-                                          w
-                                          [
-                                            [
-                                              [
-                                                [
-                                                  [ Tuple5 (con integer) ]
-                                                  (con integer)
-                                                ]
-                                                (con integer)
-                                              ]
-                                              (con integer)
-                                            ]
-                                            (con integer)
-                                          ]
-                                        )
-                                        [
-                                          [
-                                            [
-                                              [
-                                                [
-                                                  {
-                                                    {
-                                                      {
-                                                        {
-                                                          {
-                                                            Tuple5 (con integer)
-                                                          }
-                                                          (con integer)
-                                                        }
-                                                        (con integer)
-                                                      }
-                                                      (con integer)
-                                                    }
-                                                    (con integer)
-                                                  }
-                                                  a
-                                                ]
-                                                b
-                                              ]
-                                              c
-                                            ]
-                                            d
-                                          ]
-                                          e
-                                        ]
-                                      )
-                                      [
-                                        {
-                                          [
-                                            {
-                                              {
-                                                {
-                                                  {
-                                                    {
-                                                      Tuple5_match (con integer)
-                                                    }
-                                                    (con integer)
-                                                  }
-                                                  (con integer)
-                                                }
-                                                (con integer)
-                                              }
-                                              (con integer)
-                                            }
-                                            w
-                                          ]
-                                          (con string)
-                                        }
-                                        (lam
-                                          ww
-                                          (con integer)
-                                          (lam
-                                            ww
-                                            (con integer)
-                                            (lam
-                                              ww
-                                              (con integer)
-                                              (lam
-                                                ww
-                                                (con integer)
-                                                (lam
-                                                  ww
-                                                  (con integer)
-                                                  [
-                                                    concatBuiltinStrings
-                                                    (let
-                                                      (nonrec)
-                                                      (termbind
-                                                        (strict)
-                                                        (vardecl
-                                                          x
-                                                          [ List (con string) ]
-                                                        )
-                                                        { Nil (con string) }
-                                                      )
-                                                      [
-                                                        [
-                                                          { Cons (con string) }
-                                                          (con string "(")
-                                                        ]
-                                                        [
-                                                          [
-                                                            [
-                                                              [
-                                                                {
-                                                                  showsPrec
-                                                                  (con integer)
-                                                                }
-                                                                w
-                                                              ]
-                                                              (con integer 0)
-                                                            ]
-                                                            ww
-                                                          ]
-                                                          [
-                                                            [
-                                                              {
-                                                                Cons
-                                                                (con string)
-                                                              }
-                                                              (con string ",")
-                                                            ]
-                                                            [
-                                                              [
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      showsPrec
-                                                                      (con
-                                                                        integer
-                                                                      )
-                                                                    }
-                                                                    w
-                                                                  ]
-                                                                  (con
-                                                                    integer 0
-                                                                  )
-                                                                ]
-                                                                ww
-                                                              ]
-                                                              [
-                                                                [
-                                                                  {
-                                                                    Cons
-                                                                    (con string)
-                                                                  }
-                                                                  (con
-                                                                    string ","
-                                                                  )
-                                                                ]
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          showsPrec
-                                                                          (con
-                                                                            integer
-                                                                          )
-                                                                        }
-                                                                        w
-                                                                      ]
-                                                                      (con
-                                                                        integer
-                                                                        0
-                                                                      )
-                                                                    ]
-                                                                    ww
-                                                                  ]
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        Cons
-                                                                        (con
-                                                                          string
-                                                                        )
-                                                                      }
-                                                                      (con
-                                                                        string
-                                                                        ","
-                                                                      )
-                                                                    ]
-                                                                    [
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              showsPrec
-                                                                              (con
-                                                                                integer
-                                                                              )
-                                                                            }
-                                                                            w
-                                                                          ]
-                                                                          (con
-                                                                            integer
-                                                                            0
-                                                                          )
-                                                                        ]
-                                                                        ww
-                                                                      ]
-                                                                      [
-                                                                        [
-                                                                          {
-                                                                            Cons
-                                                                            (con
-                                                                              string
-                                                                            )
-                                                                          }
-                                                                          (con
-                                                                            string
-                                                                            ","
-                                                                          )
-                                                                        ]
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  showsPrec
-                                                                                  (con
-                                                                                    integer
-                                                                                  )
-                                                                                }
-                                                                                w
-                                                                              ]
-                                                                              (con
-                                                                                integer
-                                                                                0
-                                                                              )
-                                                                            ]
-                                                                            ww
-                                                                          ]
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                Cons
-                                                                                (con
-                                                                                  string
-                                                                                )
-                                                                              }
-                                                                              (con
-                                                                                string
-                                                                                ")"
-                                                                              )
-                                                                            ]
-                                                                            x
-                                                                          ]
-                                                                        ]
-                                                                      ]
-                                                                    ]
-                                                                  ]
-                                                                ]
-                                                              ]
-                                                            ]
-                                                          ]
-                                                        ]
-                                                      ]
-                                                    )
-                                                  ]
-                                                )
-                                              )
-                                            )
-                                          )
-                                        )
-                                      ]
-                                    )
-                                  ]
-                                  e
-                                ]
-                              )
-                              [
-                                [ (builtin multiplyInteger) x ] (con integer 2)
-                              ]
-                            )
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-  )
-)
+                                                              ys))
+                                                      (Tuple2_match
+                                                         {List string}
+                                                         {List string} ds
+                                                         {string}
+                                                         (\(ys : List string)
+                                                           (zs : List string) ->
+                                                            concatBuiltinStrings
+                                                              zs)))
+                                               {all dead. dead})
+in
+let !fShowInteger_cshow : integer -> string
+      = \(x : integer) ->
+          concatBuiltinStrings (fShowInteger_cshowsPrec 0 x (Nil {string}))
+    data (Show :: * -> *) a | Show_match where
+      CConsShow
+      : (integer -> a -> List string -> List string) -> (a -> string) -> Show a
+    ~fShowInteger : Show integer
+      = CConsShow {integer} fShowInteger_cshowsPrec fShowInteger_cshow
+    data (Tuple5 :: * -> * -> * -> * -> * -> *) a b c d e | Tuple5_match where
+      Tuple5 : a -> b -> c -> d -> e -> Tuple5 a b c d e
+    !showsPrec : all a. Show a -> integer -> a -> List string -> List string
+      = /\a ->
+          \(v : Show a) ->
+            Show_match
+              {a} v {integer -> a -> List string -> List string}
+              (\(v : integer -> a -> List string -> List string) (v
+                : a -> string) ->
+                 v)
+    !a : integer = trace {integer} (fShowInteger_cshow x) x
+    !b : integer = trace {integer} "This is an example" a
+    !c : integer
+      = trace
+          {integer} (let !x : bytestring = encodeUtf8 "This is an example"
+                     in concatBuiltinStrings
+                          (foldr
+                             {integer} {List string -> List string}
+                             (\(i : integer) ->
+                                let ~x : integer = indexByteString x i
+                                in \(acc : List string -> List string) (x
+                                    : List string) ->
+                                     toHex
+                                       (divideInteger x 16) (toHex
+                                                               (modInteger x 16)
+                                                               (acc x)))
+                             (id {List string}) (fEnumBool_cenumFromTo
+                                                   0 (subtractInteger
+                                                        (lengthOfByteString x)
+                                                        1)) (Nil {string}))) b
+    !d : integer
+      = trace
+          {integer} (let !b : Bool
+                           = ifThenElse
+                               {Bool} (lessThanEqualsInteger c 0) False True
+                     in Bool_match b {string} "True" "False") c
+    !e : integer
+      = trace
+          {integer} (let !dShow : Show integer = fShowInteger
+                         !x : List integer
+                           = build
+                               {integer} (/\a ->
+                                            \(c : integer -> a -> a) (n : a) ->
+                                              c a (c b (c c (c d n))))
+                     in concatBuiltinStrings
+                          (let !w : integer -> List string -> List string
+                                 = showsPrec {integer} dShow 0
+                               !w : List string = Nil {string}
+                           in UTuple2_match
+                                {string} {List string}
+                                (Nil_match
+                                   {integer} x
+                                   {all dead. UTuple2 string (List string)}
+                                   (/\dead ->
+                                      UTuple2 {string} {List string} "[]" w)
+                                   (\(x : integer) (xs : List integer) ->
+                                      /\dead ->
+                                        UTuple2
+                                          {string} {List string} "["
+                                          (w
+                                             x
+                                             (foldr
+                                                {integer}
+                                                {List string -> List string}
+                                                (\(a : integer) (acc
+                                                  : List string -> List string)
+                                                  (x : List string) ->
+                                                   Cons
+                                                     {string} "," (w a (acc x)))
+                                                (id {List string}) xs
+                                                (Cons {string} "]" w))))
+                                   {all dead. dead}) {List string}
+                                (\(ww : string) (ww : List string) ->
+                                   Cons {string} ww ww))) d
+    !x : integer
+      = trace
+          {integer}
+          (let !w : Show integer = fShowInteger
+               !w : Show integer = fShowInteger
+               !w : Show integer = fShowInteger
+               !w : Show integer = fShowInteger
+               !w : Show integer = fShowInteger
+               !w : Tuple5 integer integer integer integer integer
+                 = Tuple5
+                     {integer} {integer} {integer} {integer} {integer} a b c d e
+           in Tuple5_match
+                {integer} {integer} {integer} {integer} {integer} w {string}
+                (\(ww : integer) (ww : integer) (ww : integer) (ww : integer)
+                  (ww : integer) ->
+                   concatBuiltinStrings
+                     (let !x : List string = Nil {string}
+                      in Cons
+                           {string} "("
+                           (showsPrec
+                              {integer} w 0 ww
+                              (Cons
+                                 {string} ","
+                                 (showsPrec
+                                    {integer} w 0 ww
+                                    (Cons
+                                       {string} ","
+                                       (showsPrec
+                                          {integer} w 0 ww
+                                          (Cons
+                                             {string} ","
+                                             (showsPrec
+                                                {integer} w 0 ww
+                                                (Cons
+                                                   {string} ","
+                                                   (showsPrec
+                                                      {integer} w 0 ww
+                                                      (Cons
+                                                         {string} ")"
+                                                         x))))))))))))) e
+in multiplyInteger x 2

--- a/plutus-tx-plugin/test/Budget/sum.plc.golden
+++ b/plutus-tx-plugin/test/Budget/sum.plc.golden
@@ -1,273 +1,69 @@
-(program
-  (let
-    (rec)
-    (datatypebind
-      (datatype
-        (tyvardecl List (fun (type) (type)))
-        (tyvardecl a (type))
-        Nil_match
-        (vardecl Nil [ List a ])
-        (vardecl Cons (fun a (fun [ List a ] [ List a ])))
-      )
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Monoid (fun (type) (type)))
-          (tyvardecl a (type))
-          Monoid_match
-          (vardecl
-            CConsMonoid
-            (fun [ (lam a (type) (fun a (fun a a))) a ] (fun a [ Monoid a ]))
-          )
-        )
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl
-            fFoldableNil_cfoldMap
-            (all
-              m
-              (type)
-              (all
-                a (type) (fun [ Monoid m ] (fun (fun a m) (fun [ List a ] m)))
-              )
-            )
-          )
-          (abs
-            m
-            (type)
-            (abs
-              a
-              (type)
-              (lam
-                dMonoid
-                [ Monoid m ]
-                (lam
-                  eta
-                  (fun a m)
-                  (lam
-                    eta
-                    [ List a ]
-                    {
-                      [
-                        [
-                          { [ { Nil_match a } eta ] (all dead (type) m) }
-                          (abs
-                            dead
-                            (type)
-                            [
-                              { [ { Monoid_match m } dMonoid ] m }
-                              (lam
-                                v
-                                [ (lam a (type) (fun a (fun a a))) m ]
-                                (lam v m v)
-                              )
-                            ]
-                          )
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [ List a ]
-                            (abs
-                              dead
-                              (type)
-                              [
-                                [
-                                  [
-                                    {
-                                      [ { Monoid_match m } dMonoid ]
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                    }
-                                    (lam
-                                      v
-                                      [ (lam a (type) (fun a (fun a a))) m ]
-                                      (lam v m v)
-                                    )
-                                  ]
-                                  [ eta x ]
-                                ]
-                                [
-                                  [
-                                    [
-                                      { { fFoldableNil_cfoldMap m } a } dMonoid
-                                    ]
-                                    eta
-                                  ]
-                                  xs
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      (all dead (type) dead)
-                    }
-                  )
-                )
-              )
-            )
-          )
-        )
-        (let
-          (nonrec)
-          (datatypebind
-            (datatype
-              (tyvardecl AdditiveMonoid (fun (type) (type)))
-              (tyvardecl a (type))
-              AdditiveMonoid_match
-              (vardecl
-                CConsAdditiveMonoid
-                (fun
-                  [ (lam a (type) (fun a (fun a a))) a ]
-                  (fun a [ AdditiveMonoid a ])
-                )
-              )
-            )
-          )
-          [
-            (let
-              (nonrec)
-              (termbind
-                (strict)
-                (vardecl dAdditiveMonoid [ AdditiveMonoid (con integer) ])
-                [
-                  [
-                    { CConsAdditiveMonoid (con integer) }
-                    (lam
-                      x
-                      (con integer)
-                      (lam y (con integer) [ [ (builtin addInteger) x ] y ])
-                    )
-                  ]
-                  (con integer 0)
-                ]
-              )
-              [
-                [
-                  {
-                    { fFoldableNil_cfoldMap [ (lam a (type) a) (con integer) ] }
-                    (con integer)
-                  }
-                  [
-                    [
-                      { CConsMonoid [ (lam a (type) a) (con integer) ] }
-                      (lam
-                        eta
-                        [ (lam a (type) a) (con integer) ]
-                        (lam
-                          eta
-                          [ (lam a (type) a) (con integer) ]
-                          [
-                            [
-                              [
-                                {
-                                  [
-                                    { AdditiveMonoid_match (con integer) }
-                                    dAdditiveMonoid
-                                  ]
-                                  [
-                                    (lam a (type) (fun a (fun a a)))
-                                    (con integer)
-                                  ]
-                                }
-                                (lam
-                                  v
-                                  [
-                                    (lam a (type) (fun a (fun a a)))
-                                    (con integer)
-                                  ]
-                                  (lam v (con integer) v)
-                                )
-                              ]
-                              eta
-                            ]
-                            eta
-                          ]
-                        )
-                      )
-                    ]
-                    [
-                      {
-                        [
-                          { AdditiveMonoid_match (con integer) } dAdditiveMonoid
-                        ]
-                        (con integer)
-                      }
-                      (lam
-                        v
-                        [ (lam a (type) (fun a (fun a a))) (con integer) ]
-                        (lam v (con integer) v)
-                      )
-                    ]
-                  ]
-                ]
-                (lam ds (con integer) ds)
-              ]
-            )
-            [
-              [
-                (let
-                  (nonrec)
-                  (typebind (tyvardecl a (type)) [ List (con integer) ])
-                  (lam
-                    c
-                    (fun (con integer) (fun a a))
-                    (lam
-                      n
-                      a
-                      [
-                        [ c (con integer 1) ]
-                        [
-                          [ c (con integer 2) ]
-                          [
-                            [ c (con integer 3) ]
-                            [
-                              [ c (con integer 4) ]
-                              [
-                                [ c (con integer 5) ]
-                                [
-                                  [ c (con integer 6) ]
-                                  [
-                                    [ c (con integer 7) ]
-                                    [
-                                      [ c (con integer 8) ]
-                                      [
-                                        [ c (con integer 9) ]
-                                        [ [ c (con integer 10) ] n ]
-                                      ]
-                                    ]
-                                  ]
-                                ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      ]
-                    )
-                  )
-                )
-                (lam
-                  ds
-                  (con integer)
-                  (lam
-                    ds
-                    [ List (con integer) ]
-                    [ [ { Cons (con integer) } ds ] ds ]
-                  )
-                )
-              ]
-              { Nil (con integer) }
-            ]
-          ]
-        )
-      )
-    )
-  )
-)
+letrec data (List :: * -> *) a | Nil_match where
+         Nil : List a
+         Cons : a -> List a -> List a
+in
+let data (Monoid :: * -> *) a | Monoid_match where
+      CConsMonoid : (\a -> a -> a -> a) a -> a -> Monoid a
+in
+letrec !fFoldableNil_cfoldMap
+         : all m. all a. Monoid m -> (a -> m) -> List a -> m
+         = /\m a ->
+             \(dMonoid : Monoid m) (eta : a -> m) (eta : List a) ->
+               Nil_match
+                 {a} eta {all dead. m} (/\dead ->
+                                          Monoid_match
+                                            {m} dMonoid {m}
+                                            (\(v : (\a -> a -> a -> a) m) (v
+                                              : m) ->
+                                               v))
+                 (\(x : a) (xs : List a) ->
+                    /\dead ->
+                      Monoid_match
+                        {m} dMonoid {(\a -> a -> a -> a) m}
+                        (\(v : (\a -> a -> a -> a) m) (v : m) -> v) (eta x)
+                        (fFoldableNil_cfoldMap {m} {a} dMonoid eta xs))
+                 {all dead. dead}
+in
+let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+in (let !dAdditiveMonoid : AdditiveMonoid integer
+          = CConsAdditiveMonoid
+              {integer} (\(x : integer) (y : integer) -> addInteger x y) 0
+    in fFoldableNil_cfoldMap
+         {(\a -> a) integer} {integer} (CConsMonoid
+                                          {(\a -> a) integer}
+                                          (\(eta : (\a -> a) integer) (eta
+                                            : (\a -> a) integer) ->
+                                             AdditiveMonoid_match
+                                               {integer} dAdditiveMonoid
+                                               {(\a -> a -> a -> a) integer}
+                                               (\(v
+                                                 : (\a -> a -> a -> a) integer)
+                                                 (v : integer) ->
+                                                  v) eta eta)
+                                          (AdditiveMonoid_match
+                                             {integer} dAdditiveMonoid {integer}
+                                             (\(v : (\a -> a -> a -> a) integer)
+                                               (v : integer) ->
+                                                v))) (\(ds : integer) -> ds))
+     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
+                                 c
+                                   1 (c
+                                        2 (c
+                                             3 (c
+                                                  4
+                                                  (c
+                                                     5
+                                                     (c
+                                                        6
+                                                        (c
+                                                           7
+                                                           (c
+                                                              8
+                                                              (c
+                                                                 9
+                                                                 (c
+                                                                    10
+                                                                    n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/toFromData.plc.golden
+++ b/plutus-tx-plugin/test/Budget/toFromData.plc.golden
@@ -1,765 +1,168 @@
-(program
-  (let
-    (nonrec)
-    (datatypebind
-      (datatype
-        (tyvardecl Bool (type))
-
-        Bool_match
-        (vardecl True Bool) (vardecl False Bool)
-      )
-    )
-    (termbind (strict) (vardecl unitval (con unit)) (con unit ()))
-    (termbind
-      (nonstrict)
-      (vardecl fToDataBool [ (lam a (type) (fun a (con data))) Bool ])
-      (lam
-        ds
-        Bool
-        {
-          [
-            [
-              { [ Bool_match ds ] (all dead (type) (con data)) }
-              (abs
-                dead
-                (type)
-                [
-                  [ (builtin constrData) (con integer 1) ]
-                  [ (builtin mkNilData) unitval ]
-                ]
-              )
-            ]
-            (abs
-              dead
-              (type)
-              [
-                [ (builtin constrData) (con integer 0) ]
-                [ (builtin mkNilData) unitval ]
-              ]
-            )
-          ]
-          (all dead (type) dead)
-        }
-      )
-    )
-    (termbind
-      (nonstrict)
-      (vardecl
-        fToDataInteger [ (lam a (type) (fun a (con data))) (con integer) ]
-      )
-      (lam i (con integer) [ (builtin iData) i ])
-    )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (termbind
-      (strict) (vardecl reconstructCaseError (con string)) (con string "PT1")
-    )
-    (termbind
-      (nonstrict)
-      (vardecl fUnsafeFromDataBool [ (lam a (type) (fun (con data) a)) Bool ])
-      (lam
-        d
-        (con data)
-        (let
-          (nonrec)
-          (termbind
-            (strict)
-            (vardecl
-              tup [ [ (con pair) (con integer) ] [ (con list) (con data) ] ]
-            )
-            [ (builtin unConstrData) d ]
-          )
-          (termbind
-            (strict)
-            (vardecl index (con integer))
-            [
-              { { (builtin fstPair) (con integer) } [ (con list) (con data) ] }
-              tup
-            ]
-          )
-          [
-            [
-              [
-                [
-                  { (builtin ifThenElse) (fun (con unit) Bool) }
-                  [ [ (builtin equalsInteger) index ] (con integer 1) ]
-                ]
-                (lam ds (con unit) True)
-              ]
-              (lam
-                ds
-                (con unit)
-                [
-                  [
-                    [
-                      [
-                        { (builtin ifThenElse) (fun (con unit) Bool) }
-                        [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                      ]
-                      (lam ds (con unit) False)
-                    ]
-                    (lam
-                      ds
-                      (con unit)
-                      (let
-                        (nonrec)
-                        (termbind
-                          (strict)
-                          (vardecl thunk (con unit))
-                          (let
-                            (nonrec)
-                            (termbind
-                              (strict)
-                              (vardecl wild Unit)
-                              [
-                                [
-                                  { (builtin trace) Unit } reconstructCaseError
-                                ]
-                                Unit
-                              ]
-                            )
-                            unitval
-                          )
-                        )
-                        (error Bool)
-                      )
-                    )
-                  ]
-                  unitval
-                ]
-              )
-            ]
-            unitval
-          ]
-        )
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Tuple3 (fun (type) (fun (type) (fun (type) (type)))))
-        (tyvardecl a (type)) (tyvardecl b (type)) (tyvardecl c (type))
-        Tuple3_match
-        (vardecl Tuple3 (fun a (fun b (fun c [ [ [ Tuple3 a ] b ] c ]))))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Either (fun (type) (fun (type) (type))))
-        (tyvardecl a (type)) (tyvardecl b (type))
-        Either_match
-        (vardecl Left (fun a [ [ Either a ] b ]))
-        (vardecl Right (fun b [ [ Either a ] b ]))
-      )
-    )
-    (datatypebind
-      (datatype
-        (tyvardecl Maybe (fun (type) (type)))
-        (tyvardecl a (type))
-        Maybe_match
-        (vardecl Just (fun a [ Maybe a ])) (vardecl Nothing [ Maybe a ])
-      )
-    )
-    [
-      [
-        [
-          (let
-            (nonrec)
-            (typebind
-              (tyvardecl b (type))
-              [ Maybe [ [ [ Tuple3 Bool ] (con integer) ] Bool ] ]
-            )
-            (lam
-              dUnsafeFromData
-              [ (lam a (type) (fun (con data) a)) (con integer) ]
-              (lam
-                dUnsafeFromData
-                [ (lam a (type) (fun (con data) a)) b ]
-                (lam
-                  d
-                  (con data)
-                  (let
-                    (nonrec)
-                    (termbind
-                      (strict)
-                      (vardecl
-                        tup
-                        [
-                          [ (con pair) (con integer) ] [ (con list) (con data) ]
-                        ]
-                      )
-                      [ (builtin unConstrData) d ]
-                    )
-                    (termbind
-                      (strict)
-                      (vardecl index (con integer))
-                      [
-                        {
-                          { (builtin fstPair) (con integer) }
-                          [ (con list) (con data) ]
-                        }
-                        tup
-                      ]
-                    )
-                    [
-                      [
-                        [
-                          [
-                            {
-                              (builtin ifThenElse)
-                              (fun (con unit) [ [ Either (con integer) ] b ])
-                            }
-                            [
-                              [ (builtin equalsInteger) index ] (con integer 1)
-                            ]
-                          ]
-                          (lam
-                            ds
-                            (con unit)
-                            (let
-                              (nonrec)
-                              (termbind
-                                (strict)
-                                (vardecl arg (con data))
-                                [
-                                  { (builtin headList) (con data) }
-                                  [
-                                    {
-                                      { (builtin sndPair) (con integer) }
-                                      [ (con list) (con data) ]
-                                    }
-                                    tup
-                                  ]
-                                ]
-                              )
-                              [
-                                { { Right (con integer) } b }
-                                [ dUnsafeFromData arg ]
-                              ]
-                            )
-                          )
-                        ]
-                        (lam
-                          ds
-                          (con unit)
-                          [
-                            [
-                              [
-                                [
-                                  {
-                                    (builtin ifThenElse)
-                                    (fun
-                                      (con unit) [ [ Either (con integer) ] b ]
-                                    )
-                                  }
-                                  [
-                                    [ (builtin equalsInteger) index ]
-                                    (con integer 0)
-                                  ]
-                                ]
-                                (lam
-                                  ds
-                                  (con unit)
-                                  (let
-                                    (nonrec)
-                                    (termbind
-                                      (strict)
-                                      (vardecl arg (con data))
-                                      [
-                                        { (builtin headList) (con data) }
-                                        [
-                                          {
-                                            { (builtin sndPair) (con integer) }
-                                            [ (con list) (con data) ]
-                                          }
-                                          tup
-                                        ]
-                                      ]
-                                    )
-                                    [
-                                      { { Left (con integer) } b }
-                                      [ dUnsafeFromData arg ]
-                                    ]
-                                  )
-                                )
-                              ]
-                              (lam
-                                ds
-                                (con unit)
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (strict)
-                                    (vardecl thunk (con unit))
-                                    (let
-                                      (nonrec)
-                                      (termbind
-                                        (strict)
-                                        (vardecl wild Unit)
-                                        [
-                                          [
-                                            { (builtin trace) Unit }
-                                            reconstructCaseError
-                                          ]
-                                          Unit
-                                        ]
-                                      )
-                                      unitval
-                                    )
-                                  )
-                                  (error [ [ Either (con integer) ] b ])
-                                )
-                              )
-                            ]
-                            unitval
-                          ]
-                        )
-                      ]
-                      unitval
-                    ]
-                  )
-                )
-              )
-            )
-          )
-          (builtin unIData)
-        ]
-        [
-          (let
-            (nonrec)
-            (typebind
-              (tyvardecl a (type)) [ [ [ Tuple3 Bool ] (con integer) ] Bool ]
-            )
-            (lam
-              dUnsafeFromData
-              [ (lam a (type) (fun (con data) a)) a ]
-              (lam
-                d
-                (con data)
-                (let
-                  (nonrec)
-                  (termbind
-                    (strict)
-                    (vardecl
-                      tup
-                      [ [ (con pair) (con integer) ] [ (con list) (con data) ] ]
-                    )
-                    [ (builtin unConstrData) d ]
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl index (con integer))
-                    [
-                      {
-                        { (builtin fstPair) (con integer) }
-                        [ (con list) (con data) ]
-                      }
-                      tup
-                    ]
-                  )
-                  [
-                    [
-                      [
-                        [
-                          { (builtin ifThenElse) (fun (con unit) [ Maybe a ]) }
-                          [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                        ]
-                        (lam
-                          ds
-                          (con unit)
-                          (let
-                            (nonrec)
-                            (termbind
-                              (strict)
-                              (vardecl arg (con data))
-                              [
-                                { (builtin headList) (con data) }
-                                [
-                                  {
-                                    { (builtin sndPair) (con integer) }
-                                    [ (con list) (con data) ]
-                                  }
-                                  tup
-                                ]
-                              ]
-                            )
-                            [ { Just a } [ dUnsafeFromData arg ] ]
-                          )
-                        )
-                      ]
-                      (lam
-                        ds
-                        (con unit)
-                        [
-                          [
-                            [
-                              [
-                                {
-                                  (builtin ifThenElse)
-                                  (fun (con unit) [ Maybe a ])
-                                }
-                                [
-                                  [ (builtin equalsInteger) index ]
-                                  (con integer 1)
-                                ]
-                              ]
-                              (lam ds (con unit) { Nothing a })
-                            ]
-                            (lam
-                              ds
-                              (con unit)
-                              (let
-                                (nonrec)
-                                (termbind
-                                  (strict)
-                                  (vardecl thunk (con unit))
-                                  (let
-                                    (nonrec)
-                                    (termbind
-                                      (strict)
-                                      (vardecl wild Unit)
-                                      [
-                                        [
-                                          { (builtin trace) Unit }
-                                          reconstructCaseError
-                                        ]
-                                        Unit
-                                      ]
-                                    )
-                                    unitval
-                                  )
-                                )
-                                (error [ Maybe a ])
-                              )
-                            )
-                          ]
-                          unitval
-                        ]
-                      )
-                    ]
-                    unitval
-                  ]
-                )
-              )
-            )
-          )
-          (let
-            (nonrec)
-            (termbind
-              (strict)
-              (vardecl
-                dUnsafeFromData [ (lam a (type) (fun (con data) a)) Bool ]
-              )
-              fUnsafeFromDataBool
-            )
-            (termbind
-              (strict)
-              (vardecl
-                dUnsafeFromData [ (lam a (type) (fun (con data) a)) Bool ]
-              )
-              fUnsafeFromDataBool
-            )
-            (lam
-              d
-              (con data)
-              (let
-                (nonrec)
-                (termbind
-                  (strict)
-                  (vardecl
-                    tup
-                    [ [ (con pair) (con integer) ] [ (con list) (con data) ] ]
-                  )
-                  [ (builtin unConstrData) d ]
-                )
-                (termbind
-                  (nonstrict)
-                  (vardecl t [ (con list) (con data) ])
-                  [
-                    {
-                      { (builtin sndPair) (con integer) }
-                      [ (con list) (con data) ]
-                    }
-                    tup
-                  ]
-                )
-                (termbind
-                  (nonstrict)
-                  (vardecl t [ (con list) (con data) ])
-                  [ { (builtin tailList) (con data) } t ]
-                )
-                (termbind
-                  (strict)
-                  (vardecl index (con integer))
-                  [
-                    {
-                      { (builtin fstPair) (con integer) }
-                      [ (con list) (con data) ]
-                    }
-                    tup
-                  ]
-                )
-                [
-                  [
-                    [
-                      [
-                        {
-                          (builtin ifThenElse)
-                          (fun
-                            (con unit)
-                            [ [ [ Tuple3 Bool ] (con integer) ] Bool ]
-                          )
-                        }
-                        [ [ (builtin equalsInteger) index ] (con integer 0) ]
-                      ]
-                      (lam
-                        ds
-                        (con unit)
-                        (let
-                          (nonrec)
-                          (termbind
-                            (strict)
-                            (vardecl arg (con data))
-                            [ { (builtin headList) (con data) } t ]
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl arg (con data))
-                            [ { (builtin headList) (con data) } t ]
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl arg (con data))
-                            [
-                              { (builtin headList) (con data) }
-                              [ { (builtin tailList) (con data) } t ]
-                            ]
-                          )
-                          [
-                            [
-                              [
-                                { { { Tuple3 Bool } (con integer) } Bool }
-                                [ dUnsafeFromData arg ]
-                              ]
-                              [ (builtin unIData) arg ]
-                            ]
-                            [ dUnsafeFromData arg ]
-                          ]
-                        )
-                      )
-                    ]
-                    (lam
-                      ds
-                      (con unit)
-                      (let
-                        (nonrec)
-                        (termbind
-                          (strict)
-                          (vardecl thunk (con unit))
-                          (let
-                            (nonrec)
-                            (termbind
-                              (strict)
-                              (vardecl wild Unit)
-                              [
-                                [
-                                  { (builtin trace) Unit } reconstructCaseError
-                                ]
-                                Unit
-                              ]
-                            )
-                            unitval
-                          )
-                        )
-                        (error [ [ [ Tuple3 Bool ] (con integer) ] Bool ])
-                      )
-                    )
-                  ]
-                  unitval
-                ]
-              )
-            )
-          )
-        ]
-      ]
-      [
-        [
-          [
-            (let
-              (nonrec)
-              (typebind
-                (tyvardecl b (type))
-                [ Maybe [ [ [ Tuple3 Bool ] (con integer) ] Bool ] ]
-              )
-              (lam
-                dToData
-                [ (lam a (type) (fun a (con data))) (con integer) ]
-                (lam
-                  dToData
-                  [ (lam a (type) (fun a (con data))) b ]
-                  (lam
-                    ds
-                    [ [ Either (con integer) ] b ]
-                    [
-                      [
-                        {
-                          [ { { Either_match (con integer) } b } ds ] (con data)
-                        }
-                        (lam
-                          arg
-                          (con integer)
-                          [
-                            [ (builtin constrData) (con integer 0) ]
-                            [
-                              [
-                                { (builtin mkCons) (con data) } [ dToData arg ]
-                              ]
-                              [ (builtin mkNilData) unitval ]
-                            ]
-                          ]
-                        )
-                      ]
-                      (lam
-                        arg
-                        b
-                        [
-                          [ (builtin constrData) (con integer 1) ]
-                          [
-                            [ { (builtin mkCons) (con data) } [ dToData arg ] ]
-                            [ (builtin mkNilData) unitval ]
-                          ]
-                        ]
-                      )
-                    ]
-                  )
-                )
-              )
-            )
-            fToDataInteger
-          ]
-          [
-            (let
-              (nonrec)
-              (typebind
-                (tyvardecl a (type)) [ [ [ Tuple3 Bool ] (con integer) ] Bool ]
-              )
-              (lam
-                dToData
-                [ (lam a (type) (fun a (con data))) a ]
-                (lam
-                  ds
-                  [ Maybe a ]
-                  {
-                    [
-                      [
-                        {
-                          [ { Maybe_match a } ds ] (all dead (type) (con data))
-                        }
-                        (lam
-                          arg
-                          a
-                          (abs
-                            dead
-                            (type)
-                            [
-                              [ (builtin constrData) (con integer 0) ]
-                              [
-                                [
-                                  { (builtin mkCons) (con data) }
-                                  [ dToData arg ]
-                                ]
-                                [ (builtin mkNilData) unitval ]
-                              ]
-                            ]
-                          )
-                        )
-                      ]
-                      (abs
-                        dead
-                        (type)
-                        [
-                          [ (builtin constrData) (con integer 1) ]
-                          [ (builtin mkNilData) unitval ]
-                        ]
-                      )
-                    ]
-                    (all dead (type) dead)
-                  }
-                )
-              )
-            )
-            (let
-              (nonrec)
-              (termbind
-                (strict)
-                (vardecl w [ (lam a (type) (fun a (con data))) Bool ])
-                fToDataBool
-              )
-              (termbind
-                (strict)
-                (vardecl w [ (lam a (type) (fun a (con data))) (con integer) ])
-                fToDataInteger
-              )
-              (termbind
-                (strict)
-                (vardecl w [ (lam a (type) (fun a (con data))) Bool ])
-                fToDataBool
-              )
-              (lam
-                w
-                [ [ [ Tuple3 Bool ] (con integer) ] Bool ]
-                [
-                  {
-                    [ { { { Tuple3_match Bool } (con integer) } Bool } w ]
-                    (con data)
-                  }
-                  (lam
-                    ww
-                    Bool
-                    (lam
-                      ww
-                      (con integer)
-                      (lam
-                        ww
-                        Bool
-                        [
-                          [ (builtin constrData) (con integer 0) ]
-                          [
-                            [ { (builtin mkCons) (con data) } [ w ww ] ]
-                            [
-                              [ { (builtin mkCons) (con data) } [ w ww ] ]
-                              [
-                                [ { (builtin mkCons) (con data) } [ w ww ] ]
-                                [ (builtin mkNilData) unitval ]
-                              ]
-                            ]
-                          ]
-                        ]
-                      )
-                    )
-                  )
-                ]
-              )
-            )
-          ]
-        ]
-        [
-          {
-            { Right (con integer) }
-            [ Maybe [ [ [ Tuple3 Bool ] (con integer) ] Bool ] ]
-          }
-          [
-            { Just [ [ [ Tuple3 Bool ] (con integer) ] Bool ] }
-            [
-              [
-                [ { { { Tuple3 Bool } (con integer) } Bool } True ]
-                (con integer 1)
-              ]
-              False
-            ]
-          ]
-        ]
-      ]
-    ]
-  )
-)
+let data Bool | Bool_match where
+      True : Bool
+      False : Bool
+    !unitval : unit = ()
+    ~fToDataBool : (\a -> a -> data) Bool
+      = \(ds : Bool) ->
+          Bool_match
+            ds {all dead. data} (/\dead -> constrData 1 (mkNilData unitval))
+            (/\dead -> constrData 0 (mkNilData unitval)) {all dead. dead}
+    ~fToDataInteger : (\a -> a -> data) integer = \(i : integer) -> iData i
+    data Unit | Unit_match where
+      Unit : Unit
+    !reconstructCaseError : string = "PT1"
+    ~fUnsafeFromDataBool : (\a -> data -> a) Bool
+      = \(d : data) ->
+          let !tup : pair integer (list data) = unConstrData d
+              !index : integer = fstPair {integer} {list data} tup
+          in ifThenElse
+               {unit -> Bool} (equalsInteger index 1) (\(ds : unit) -> True)
+               (\(ds : unit) ->
+                  ifThenElse
+                    {unit -> Bool} (equalsInteger index 0) (\(ds : unit) ->
+                                                              False)
+                    (\(ds : unit) ->
+                       let !thunk : unit
+                             = let !wild : Unit
+                                     = trace {Unit} reconstructCaseError Unit
+                               in unitval
+                       in error {Bool}) unitval) unitval
+    data (Tuple3 :: * -> * -> * -> *) a b c | Tuple3_match where
+      Tuple3 : a -> b -> c -> Tuple3 a b c
+    data (Either :: * -> * -> *) a b | Either_match where
+      Left : a -> Either a b
+      Right : b -> Either a b
+    data (Maybe :: * -> *) a | Maybe_match where
+      Just : a -> Maybe a
+      Nothing : Maybe a
+in (let b = Maybe (Tuple3 Bool integer Bool)
+    in \(dUnsafeFromData : (\a -> data -> a) integer) (dUnsafeFromData
+        : (\a -> data -> a) b) (d : data) ->
+         let !tup : pair integer (list data) = unConstrData d
+             !index : integer = fstPair {integer} {list data} tup
+         in ifThenElse
+              {unit -> Either integer b} (equalsInteger index 1)
+              (\(ds : unit) ->
+                 let !arg : data
+                       = headList {data} (sndPair {integer} {list data} tup)
+                 in Right {integer} {b} (dUnsafeFromData arg))
+              (\(ds : unit) ->
+                 ifThenElse
+                   {unit -> Either integer b} (equalsInteger index 0)
+                   (\(ds : unit) ->
+                      let !arg : data
+                            = headList
+                                {data} (sndPair {integer} {list data} tup)
+                      in Left {integer} {b} (dUnsafeFromData arg))
+                   (\(ds : unit) ->
+                      let !thunk : unit
+                            = let !wild : Unit
+                                    = trace {Unit} reconstructCaseError Unit
+                              in unitval
+                      in error {Either integer b}) unitval) unitval)
+     unIData ((let a = Tuple3 Bool integer Bool
+               in \(dUnsafeFromData : (\a -> data -> a) a) (d : data) ->
+                    let !tup : pair integer (list data) = unConstrData d
+                        !index : integer = fstPair {integer} {list data} tup
+                    in ifThenElse
+                         {unit -> Maybe a} (equalsInteger index 0)
+                         (\(ds : unit) ->
+                            let !arg : data
+                                  = headList
+                                      {data} (sndPair {integer} {list data} tup)
+                            in Just {a} (dUnsafeFromData arg))
+                         (\(ds : unit) ->
+                            ifThenElse
+                              {unit -> Maybe a} (equalsInteger index 1)
+                              (\(ds : unit) -> Nothing {a})
+                              (\(ds : unit) ->
+                                 let !thunk : unit
+                                       = let !wild : Unit
+                                               = trace
+                                                   {Unit} reconstructCaseError
+                                                   Unit
+                                         in unitval
+                                 in error {Maybe a}) unitval) unitval)
+                (let !dUnsafeFromData : (\a -> data -> a) Bool
+                       = fUnsafeFromDataBool
+                     !dUnsafeFromData : (\a -> data -> a) Bool
+                       = fUnsafeFromDataBool
+                 in \(d : data) ->
+                      let !tup : pair integer (list data) = unConstrData d
+                          ~t : list data = sndPair {integer} {list data} tup
+                          ~t : list data = tailList {data} t
+                          !index : integer = fstPair {integer} {list data} tup
+                      in ifThenElse
+                           {unit -> Tuple3 Bool integer Bool} (equalsInteger
+                                                                 index 0)
+                           (\(ds : unit) ->
+                              let !arg : data = headList {data} t
+                                  !arg : data = headList {data} t
+                                  !arg : data
+                                    = headList {data} (tailList {data} t)
+                              in Tuple3
+                                   {Bool} {integer} {Bool} (dUnsafeFromData arg)
+                                   (unIData arg) (dUnsafeFromData arg))
+                           (\(ds : unit) ->
+                              let !thunk : unit
+                                    = let !wild : Unit
+                                            = trace
+                                                {Unit} reconstructCaseError Unit
+                                      in unitval
+                              in error {Tuple3 Bool integer Bool}) unitval))
+     ((let b = Maybe (Tuple3 Bool integer Bool) in \(dToData
+                                                    : (\a -> a -> data) integer)
+                                                    (dToData
+                                                    : (\a -> a -> data) b) (ds
+                                                    : Either integer b) ->
+                                                     Either_match
+                                                       {integer} {b} ds {data}
+                                                       (\(arg : integer) ->
+                                                          constrData
+                                                            0 (mkCons
+                                                                 {data} (dToData
+                                                                           arg)
+                                                                 (mkNilData
+                                                                    unitval)))
+                                                       (\(arg : b) ->
+                                                          constrData
+                                                            1 (mkCons
+                                                                 {data} (dToData
+                                                                           arg)
+                                                                 (mkNilData
+                                                                    unitval))))
+        fToDataInteger ((let a = Tuple3 Bool integer Bool
+                         in \(dToData : (\a -> a -> data) a) (ds : Maybe a) ->
+                              Maybe_match
+                                {a} ds {all dead. data} (\(arg : a) ->
+                                                           /\dead ->
+                                                             constrData
+                                                               0
+                                                               (mkCons
+                                                                  {data}
+                                                                  (dToData arg)
+                                                                  (mkNilData
+                                                                     unitval)))
+                                (/\dead -> constrData 1 (mkNilData unitval))
+                                {all dead. dead})
+                          (let !w : (\a -> a -> data) Bool = fToDataBool
+                               !w : (\a -> a -> data) integer = fToDataInteger
+                               !w : (\a -> a -> data) Bool = fToDataBool
+                           in \(w : Tuple3 Bool integer Bool) ->
+                                Tuple3_match
+                                  {Bool} {integer} {Bool} w {data}
+                                  (\(ww : Bool) (ww : integer) (ww : Bool) ->
+                                     constrData
+                                       0 (mkCons
+                                            {data} (w ww)
+                                            (mkCons
+                                               {data} (w ww)
+                                               (mkCons
+                                                  {data} (w ww)
+                                                  (mkNilData unitval)))))))
+        (Right
+           {integer} {Maybe (Tuple3 Bool integer Bool)}
+           (Just
+              {Tuple3 Bool integer Bool} (Tuple3
+                                            {Bool} {integer} {Bool} True 1
+                                            False))))

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -121,13 +121,13 @@ library plutus-tx-testlib
   hs-source-dirs:  testlib
   exposed-modules: PlutusTx.Test
   build-depends:
-    , base                                            >=4.9 && <5
+    , base                                                       >=4.9 && <5
     , filepath
-    , flat                                            <0.5
+    , flat                                                       <0.5
     , lens
     , mtl
-    , plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.2
-    , plutus-tx                                       ^>=1.2
+    , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.2
+    , plutus-tx                                                  ^>=1.2
     , prettyprinter
     , tagged
     , tasty


### PR DESCRIPTION
The golden PIR files for `Budget.Spec` often need to be inspected to understand why a change to the compiler leads to different costs. Using the readable version makes this much easier.

Adding the uniques would be helpful for disambiguation (although it can also be distracting), but it makes it harder to diff two PIRs since the uniques can be totally different. So it doesn't print the uniques.