### PR TITLE
Improve readable prettyprinting of PIR

### DIFF
--- a/plutus-core/changelog.d/20230228_155335_michael.peyton-jones_better_readable_pp.md
+++ b/plutus-core/changelog.d/20230228_155335_michael.peyton-jones_better_readable_pp.md
@@ -1,0 +1,4 @@
+### Changed
+
+- The PIR readable prettyprinter was improved in a number of minor ways.
+

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Pretty/Readable.hs
@@ -85,19 +85,18 @@ instance (PrettyConstraints configName tyname name uni, Pretty fun)
           compoundDocM juxtFixity $ \ prettyIn ->
             let ppArg (Left a)  = braces $ prettyIn ToTheRight botFixity a
                 ppArg (Right t) = prettyIn ToTheRight juxtFixity t
-            -- Using `align` here and gathering the arguments together helps to lay out
-            -- function applications compactly like:
+            -- Lay out function applications like:
             --
-            -- foo a b c
-            --     d e f
+            -- foo
+            --   a
+            --   b
+            --   c
             --
             -- or
             --
-            -- foo
-            --  veryLongArg
-            --  a b c
+            -- foo a b c
             --
-            in prettyIn ToTheLeft juxtFixity fun <?> align (fillSep (map ppArg args))
+            in prettyIn ToTheLeft juxtFixity fun <?> vsep (map ppArg args)
         Apply{}    -> error "The impossible happened. This should be covered by the `viewApp` case above."
         TyInst{}   -> error "The impossible happened. This should be covered by the `viewApp` case above."
         Var _ name -> prettyM name
@@ -106,19 +105,18 @@ instance (PrettyConstraints configName tyname name uni, Pretty fun)
                 let pBody = prettyBot body
                 pBinds <- mapM prettyM args
                 -- See comment below about laying out lambdas
-                encloseM binderFixity $ ("/\\" <> align (fillSep pBinds) <+> "->") <?> pBody
+                encloseM binderFixity $ ("/\\" <> align (vsep pBinds) <+> "->") <?> pBody
         TyAbs{}    -> error "The impossible happened. This should be covered by the `viewTyAbs` case above."
         (viewLam -> Just (args, body)) ->
             -- Lay out abstraction like
-            --  \ (x : t) (y : t')
-            --    (z : t'') -> body
-            -- or
-            --  \ (x : t) (y : t')
-            --    (z : t'') ->
-            --    bigStartOfBody
+            --  \(x : t)
+            --   (y : t')
+            --   (z : t'') ->
+            --    body
+            --
             compoundDocM binderFixity $ \prettyIn ->
                 let prettyBot x = prettyIn ToTheRight botFixity x
-                    prettyBinds = align . fillSep . map (prettyIn ToTheLeft binderFixity) $ args
+                    prettyBinds = align . vsep . map (prettyIn ToTheLeft binderFixity) $ args
                 in ("\\" <> prettyBinds <+> "->") <?> prettyBot body
         LamAbs{}   -> error "The impossible happened. This should be covered by the `viewLam` case above."
         Unwrap _ term          ->
@@ -135,14 +133,17 @@ instance (PrettyConstraints configName tyname name uni, Pretty fun)
                 let prettyBot x = prettyIn ToTheRight botFixity x
                     prec NonRec = ""
                     prec _      = "rec"
+                    -- nest 2 including the "let": this means that we will always break after the let,
+                    -- so that the bindings can be simply indented by 2 spaces, keeping the indent low
+                    prettyLet r binds = vsep [ nest 2 ("let" <> prec r <> line <> vcatHard (prettyBot <$> binds)), "in"]
                 -- Lay out let-bindings in a layout-sensitive way
                 --
-                -- let !x : t = a
+                -- let
+                --   !x : t = a
+                --   !y : t = b
                 -- in
-                -- let !y : t = b
-                -- in foo x y
-                in align (sep [ sep ["let" <> prec r <+> align (vcatHard (prettyBot <$> binds)), "in"]
-                              | (r, binds) <- lets ]) <+> prettyBot body
+                -- foo x y
+                in vsep $ [ prettyLet r binds | (r, binds) <- lets ] ++ [ prettyBot body ]
         Let{} -> error "The impossible happened. This should be covered by the `viewLet` case above."
 
 instance (PrettyConstraints configName tyname name uni, Pretty fun)
@@ -188,10 +189,10 @@ instance PrettyReadableBy configName tyname
       showKinds <- view $ prettyConfig . pcrShowKinds
       withPrettyAt ToTheRight botFixity $ \prettyBot -> do
         case showKinds of
-          ShowKindsYes -> encloseM binderFixity (sep [prettyBot x, "::" <+> prettyBot k])
+          ShowKindsYes -> encloseM binderFixity (prettyBot x <?> ("::" <+> prettyBot k))
           ShowKindsNonType -> case k of
             Type{} -> return $ prettyBot x
-            _      -> encloseM binderFixity (sep [prettyBot x, "::" <+> prettyBot k])
+            _      -> encloseM binderFixity (prettyBot x <?> ("::" <+> prettyBot k))
           ShowKindsNo -> return $ prettyBot x
 
 instance PrettyConstraints configName tyname name uni
@@ -199,4 +200,4 @@ instance PrettyConstraints configName tyname name uni
   prettyBy = inContextM $ \case
     VarDecl _ x t -> do
       withPrettyAt ToTheRight botFixity $ \prettyBot -> do
-        encloseM binderFixity (sep [prettyBot x, ":" <+> prettyBot t])
+        encloseM binderFixity (prettyBot x <?> (":" <+> prettyBot t))

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/errorBinding.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/errorBinding.golden
@@ -1,3 +1,5 @@
-letrec !x_0 : integer = error {integer}
-       ~y_1 : integer = x_0
-in 1
+letrec
+  !x_0 : integer = error {integer}
+  ~y_1 : integer = x_0
+in
+1

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/even3.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/even3.golden
@@ -1,18 +1,20 @@
-letrec data Nat_0 | match_Nat_1 where
-         Zero_2 : Nat_0
-         Suc_3 : Nat_0 -> Nat_0
+letrec
+  data Nat_0 | match_Nat_1 where
+    Zero_2 : Nat_0
+    Suc_3 : Nat_0 -> Nat_0
 in
-let data Bool_4 | match_Bool_5 where
-      True_6 : Bool_4
-      False_7 : Bool_4
-    !three_8 : Nat_0 = Suc_3 (Suc_3 (Suc_3 Zero_2))
+let
+  data Bool_4 | match_Bool_5 where
+    True_6 : Bool_4
+    False_7 : Bool_4
+  !three_8 : Nat_0 = Suc_3 (Suc_3 (Suc_3 Zero_2))
 in
-letrec !even_9 : Nat_0 -> Bool_4
-         = \(n_10 : Nat_0) ->
-             match_Nat_1
-               n_10 {Bool_4} True_6 (\(pred_11 : Nat_0) -> odd_12 pred_11)
-       !odd_12 : Nat_0 -> Bool_4
-         = \(n_10 : Nat_0) ->
-             match_Nat_1
-               n_10 {Bool_4} False_7 (\(pred_11 : Nat_0) -> even_9 pred_11)
-in even_9 three_8
+letrec
+  !even_9 : Nat_0 -> Bool_4
+    = \(n_10 : Nat_0) ->
+        match_Nat_1 n_10 {Bool_4} True_6 (\(pred_11 : Nat_0) -> odd_12 pred_11)
+  !odd_12 : Nat_0 -> Bool_4
+    = \(n_10 : Nat_0) ->
+        match_Nat_1 n_10 {Bool_4} False_7 (\(pred_11 : Nat_0) -> even_9 pred_11)
+in
+even_9 three_8

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/idleAll.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/idleAll.golden
@@ -1,5 +1,7 @@
-let data (D1_0 :: * -> *) a_1 | match_D1_2 where
-      C1_3 : D1_0 a_1
-    data (D2_4 :: * -> *) a_1 | match_D2_5 where
-      C2_6 : all a_1. D2_4 a_1
-in /\a_1 -> \(x_7 : a_1) -> x_7
+let
+  data (D1_0 :: * -> *) a_1 | match_D1_2 where
+    C1_3 : D1_0 a_1
+  data (D2_4 :: * -> *) a_1 | match_D2_5 where
+    C2_6 : all a_1. D2_4 a_1
+in
+/\a_1 -> \(x_7 : a_1) -> x_7

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/letDep.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/letDep.golden
@@ -1,3 +1,5 @@
-let !i_0 : integer = 3
-    !j_1 : integer = i_0
-in j_1
+let
+  !i_0 : integer = 3
+  !j_1 : integer = i_0
+in
+j_1

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/letInLet.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/letInLet.golden
@@ -1,4 +1,8 @@
-let !unitval2_0 : all a_1. a_1 -> a_1
-      = let !unitval_2 : all a_1. a_1 -> a_1 = /\a_1 -> \(x_3 : a_1) -> x_3
-        in unitval_2
-in unitval2_0
+let
+  !unitval2_0 : all a_1. a_1 -> a_1
+    = let
+      !unitval_2 : all a_1. a_1 -> a_1 = /\a_1 -> \(x_3 : a_1) -> x_3
+    in
+    unitval_2
+in
+unitval2_0

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/listMatch.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/listMatch.golden
@@ -1,8 +1,13 @@
-letrec data (List_0 :: * -> *) a_1 | match_List_2 where
-         Nil_3 : List_0 a_1
-         Cons_4 : a_1 -> List_0 a_1 -> List_0 a_1
-in match_List_2
-     {all a_1. a_1 -> a_1} (Nil_3 {all a_1. a_1 -> a_1}) {all a_1. a_1 -> a_1}
-     (/\a_1 -> \(x_5 : a_1) -> x_5) (\(head_6 : all a_1. a_1 -> a_1) (tail_7
-                                      : List_0 (all a_1. a_1 -> a_1)) ->
-                                       head_6)
+letrec
+  data (List_0 :: * -> *) a_1 | match_List_2 where
+    Nil_3 : List_0 a_1
+    Cons_4 : a_1 -> List_0 a_1 -> List_0 a_1
+in
+match_List_2
+  {all a_1. a_1 -> a_1}
+  (Nil_3 {all a_1. a_1 -> a_1})
+  {all a_1. a_1 -> a_1}
+  (/\a_1 -> \(x_5 : a_1) -> x_5)
+  (\(head_6 : all a_1. a_1 -> a_1)
+    (tail_7 : List_0 (all a_1. a_1 -> a_1)) ->
+     head_6)

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/maybe.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/maybe.golden
@@ -1,4 +1,6 @@
-let data (Maybe_0 :: * -> *) a_1 | match_Maybe_2 where
-      Nothing_3 : Maybe_0 a_1
-      Just_4 : a_1 -> Maybe_0 a_1
-in Just_4 {all a_1. a_1 -> a_1} (/\a_1 -> \(x_5 : a_1) -> x_5)
+let
+  data (Maybe_0 :: * -> *) a_1 | match_Maybe_2 where
+    Nothing_3 : Maybe_0 a_1
+    Just_4 : a_1 -> Maybe_0 a_1
+in
+Just_4 {all a_1. a_1 -> a_1} (/\a_1 -> \(x_5 : a_1) -> x_5)

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/mutuallyRecursiveValues.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/mutuallyRecursiveValues.golden
@@ -1,3 +1,5 @@
-letrec !x_0 : all a_1. a_1 -> a_1 = y_2
-       !y_2 : all a_1. a_1 -> a_1 = /\a_1 -> \(z_3 : a_1) -> x_0 {a_1} z_3
-in x_0
+letrec
+  !x_0 : all a_1. a_1 -> a_1 = y_2
+  !y_2 : all a_1. a_1 -> a_1 = /\a_1 -> \(z_3 : a_1) -> x_0 {a_1} z_3
+in
+x_0

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/recursiveTypeBind.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/recursiveTypeBind.golden
@@ -1,2 +1,7 @@
-letrec unit_0 = all a_1. unit_0 -> unit_0 in
-let !lazyVal_2 : unit_0 -> integer = \(x_3 : unit_0) -> 3 in lazyVal_2
+letrec
+  unit_0 = all a_1. unit_0 -> unit_0
+in
+let
+  !lazyVal_2 : unit_0 -> integer = \(x_3 : unit_0) -> 3
+in
+lazyVal_2

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/some.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/some.golden
@@ -1,3 +1,5 @@
-let data (Some_0 :: (* -> *) -> *) (f_1 :: * -> *) | match_Some_2 where
-      MkSome_3 : all a_4. f_1 a_4 -> Some_0 f_1
-in /\a_4 -> \(x_5 : a_4) -> x_5
+let
+  data (Some_0 :: (* -> *) -> *) (f_1 :: * -> *) | match_Some_2 where
+    MkSome_3 : all a_4. f_1 a_4 -> Some_0 f_1
+in
+/\a_4 -> \(x_5 : a_4) -> x_5

--- a/plutus-core/plutus-ir/test/prettyprintingReadable/stupidZero.golden
+++ b/plutus-core/plutus-ir/test/prettyprintingReadable/stupidZero.golden
@@ -1,10 +1,18 @@
-letrec data Nat_0 | match_Nat_1 where
-         Zero_2 : Nat_0
-         Suc_3 : Nat_0 -> Nat_0
+letrec
+  data Nat_0 | match_Nat_1 where
+    Zero_2 : Nat_0
+    Suc_3 : Nat_0 -> Nat_0
 in
-let !three_4 : Nat_0 = Suc_3 (Suc_3 (Suc_3 Zero_2)) in
-letrec !stupidZero_5 : Nat_0 -> Nat_0
-         = \(n_6 : Nat_0) ->
-             match_Nat_1
-               n_6 {Nat_0} Zero_2 (\(pred_7 : Nat_0) -> stupidZero_5 pred_7)
-in stupidZero_5 three_4
+let
+  !three_4 : Nat_0 = Suc_3 (Suc_3 (Suc_3 Zero_2))
+in
+letrec
+  !stupidZero_5 : Nat_0 -> Nat_0
+    = \(n_6 : Nat_0) ->
+        match_Nat_1
+          n_6
+          {Nat_0}
+          Zero_2
+          (\(pred_7 : Nat_0) -> stupidZero_5 pred_7)
+in
+stupidZero_5 three_4

--- a/plutus-tx-plugin/test/Budget/allCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allCheap.plc.golden
@@ -1,48 +1,44 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> True)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 1 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> acc) (/\dead ->
-                                                                    False)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> True)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 1 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> acc)
+                 (/\dead -> False)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in go eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/allEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allEmptyList.plc.golden
@@ -1,25 +1,36 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> True)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 1 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> acc) (/\dead ->
-                                                                    False)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> True)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 1 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> acc)
+                 (/\dead -> False)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer = Nil {integer} in go eta
+let
+  !eta : List integer = Nil {integer}
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/allExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/allExpensive.plc.golden
@@ -1,48 +1,44 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> True)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 11 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> acc) (/\dead ->
-                                                                    False)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> True)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 11 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> acc)
+                 (/\dead -> False)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in go eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/anyCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyCheap.plc.golden
@@ -1,48 +1,44 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> False)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 10 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> True) (/\dead ->
-                                                                     acc)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> False)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 10 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> True)
+                 (/\dead -> acc)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in go eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/anyEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyEmptyList.plc.golden
@@ -1,25 +1,36 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> False)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 1 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> True) (/\dead ->
-                                                                     acc)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> False)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 1 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> True)
+                 (/\dead -> acc)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer = Nil {integer} in go eta
+let
+  !eta : List integer = Nil {integer}
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/anyExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/anyExpensive.plc.golden
@@ -1,48 +1,44 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> False)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool}
-                                                    (lessThanEqualsInteger 1 x)
-                                                    False True) {all dead. Bool}
-                                                 (/\dead -> True) (/\dead ->
-                                                                     acc)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> False)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger 1 x) False True)
+                 {all dead. Bool}
+                 (/\dead -> True)
+                 (/\dead -> acc)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in go eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/applicative.plc.golden
+++ b/plutus-tx-plugin/test/Budget/applicative.plc.golden
@@ -1,31 +1,44 @@
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    !x : Maybe integer = Just {integer} 1
-    !y : Maybe integer = Just {integer} 2
-    !ds : Maybe (integer -> integer)
-      = (let b = integer -> integer
-         in \(dFunctor
-             : (\(f :: * -> *) -> all a. all b. (a -> b) -> f a -> f b) Maybe)
-             (f : integer -> b) (fa : Maybe integer) ->
-              dFunctor {integer} {b} f fa)
-          (/\a b ->
-             \(f : a -> b) (ds : Maybe a) ->
-               Maybe_match
-                 {a} ds {all dead. Maybe b} (\(a : a) ->
-                                               /\dead -> Just {b} (f a))
-                 (/\dead -> Nothing {b}) {all dead. dead}) (\(x : integer) (y
-                                                             : integer) ->
-                                                              addInteger x y) x
-in Maybe_match
-     {integer -> integer} ds {all dead. Maybe integer}
-     (\(ipv : integer -> integer) ->
-        /\dead ->
-          Maybe_match
-            {integer} y {all dead. Maybe integer} (\(ipv : integer) ->
-                                                     /\dead ->
-                                                       Just {integer} (ipv ipv))
-            (/\dead -> Nothing {integer}) {all dead. dead}) (/\dead ->
-                                                               Nothing
-                                                                 {integer})
-     {all dead. dead}
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  !x : Maybe integer = Just {integer} 1
+  !y : Maybe integer = Just {integer} 2
+  !ds : Maybe (integer -> integer)
+    = (let
+          b = integer -> integer
+        in
+        \(dFunctor
+            : (\(f :: * -> *) -> all a. all b. (a -> b) -> f a -> f b) Maybe)
+         (f : integer -> b)
+         (fa : Maybe integer) ->
+          dFunctor {integer} {b} f fa)
+        (/\a
+           b ->
+           \(f : a -> b)
+            (ds : Maybe a) ->
+             Maybe_match
+               {a}
+               ds
+               {all dead. Maybe b}
+               (\(a : a) -> /\dead -> Just {b} (f a))
+               (/\dead -> Nothing {b})
+               {all dead. dead})
+        (\(x : integer) (y : integer) -> addInteger x y)
+        x
+in
+Maybe_match
+  {integer -> integer}
+  ds
+  {all dead. Maybe integer}
+  (\(ipv : integer -> integer) ->
+     /\dead ->
+       Maybe_match
+         {integer}
+         y
+         {all dead. Maybe integer}
+         (\(ipv : integer) -> /\dead -> Just {integer} (ipv ipv))
+         (/\dead -> Nothing {integer})
+         {all dead. dead})
+  (/\dead -> Nothing {integer})
+  {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/elem.plc.golden
+++ b/plutus-tx-plugin/test/Budget/elem.plc.golden
@@ -1,47 +1,44 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec !go : List integer -> Bool
-         = \(ds : List integer) ->
-             Nil_match
-               {integer} ds {all dead. Bool} (/\dead -> False)
-               (\(x : integer) (xs : List integer) ->
-                  /\dead ->
-                    let !acc : Bool = go xs in Bool_match
-                                                 (ifThenElse
-                                                    {Bool} (equalsInteger 0 x)
-                                                    True False) {all dead. Bool}
-                                                 (/\dead -> True) (/\dead ->
-                                                                     acc)
-                                                 {all dead. dead})
-               {all dead. dead}
+letrec
+  !go : List integer -> Bool
+    = \(ds : List integer) ->
+        Nil_match
+          {integer}
+          ds
+          {all dead. Bool}
+          (/\dead -> False)
+          (\(x : integer)
+            (xs : List integer) ->
+             /\dead ->
+               let
+                 !acc : Bool = go xs
+               in
+               Bool_match
+                 (ifThenElse {Bool} (equalsInteger 0 x) True False)
+                 {all dead. Bool}
+                 (/\dead -> True)
+                 (/\dead -> acc)
+                 {all dead. dead})
+          {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in go eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+go eta

--- a/plutus-tx-plugin/test/Budget/filter.plc.golden
+++ b/plutus-tx-plugin/test/Budget/filter.plc.golden
@@ -1,52 +1,49 @@
-let data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-letrec !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
-         = /\a b ->
-             \(f : a -> b -> b) (acc : b) (l : List a) ->
-               Nil_match
-                 {a} l {all dead. b} (/\dead -> acc) (\(x : a) (xs : List a) ->
-                                                        /\dead ->
-                                                          f
-                                                            x (foldr
-                                                                 {a} {b} f acc
-                                                                 xs))
-                 {all dead. dead}
+letrec
+  !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
+    = /\a
+        b ->
+        \(f : a -> b -> b)
+         (acc : b)
+         (l : List a) ->
+          Nil_match
+            {a}
+            l
+            {all dead. b}
+            (/\dead -> acc)
+            (\(x : a) (xs : List a) -> /\dead -> f x (foldr {a} {b} f acc xs))
+            {all dead. dead}
 in
-let !eta : List integer
-      = (let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                   c
-                                     1 (c
-                                          2 (c
-                                               3
-                                               (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-          (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-          (Nil {integer})
-in foldr
-     {integer} {List integer} (\(e : integer) (xs : List integer) ->
-                                 Bool_match
-                                   (ifThenElse
-                                      {Bool} (equalsInteger (modInteger e 2) 0)
-                                      True False) {all dead. List integer}
-                                   (/\dead -> Cons {integer} e xs) (/\dead ->
-                                                                      xs)
-                                   {all dead. dead}) (Nil {integer}) eta
+let
+  !eta : List integer
+    = (let
+          a = List integer
+        in
+        \(c : integer -> a -> a)
+         (n : a) ->
+          c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+        (Nil {integer})
+in
+foldr
+  {integer}
+  {List integer}
+  (\(e : integer)
+    (xs : List integer) ->
+     Bool_match
+       (ifThenElse {Bool} (equalsInteger (modInteger e 2) 0) True False)
+       {all dead. List integer}
+       (/\dead -> Cons {integer} e xs)
+       (/\dead -> xs)
+       {all dead. dead})
+  (Nil {integer})
+  eta

--- a/plutus-tx-plugin/test/Budget/findCheap.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findCheap.plc.golden
@@ -1,47 +1,47 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-in (let b = Maybe integer in \(f : integer -> b -> b) (z : b) ->
-                               letrec !go : List integer -> b
-                                        = \(ds : List integer) ->
-                                            Nil_match
-                                              {integer} ds {all dead. b}
-                                              (/\dead -> z) (\(x : integer) (xs
-                                                              : List integer) ->
-                                                               /\dead ->
-                                                                 f x (go xs))
-                                              {all dead. dead}
-                               in \(eta : List integer) -> go eta)
-     (\(a : integer) (acc : Maybe integer) ->
-        Bool_match
-          (ifThenElse {Bool} (lessThanEqualsInteger 10 a) False True)
-          {all dead. Maybe integer} (/\dead -> Just {integer} a) (/\dead -> acc)
-          {all dead. dead}) (Nothing {integer})
-     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                 c
-                                   1 (c
-                                        2 (c
-                                             3 (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-        (Nil {integer}))
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+(let
+    b = Maybe integer
+  in
+  \(f : integer -> b -> b)
+   (z : b) ->
+    letrec
+      !go : List integer -> b
+        = \(ds : List integer) ->
+            Nil_match
+              {integer}
+              ds
+              {all dead. b}
+              (/\dead -> z)
+              (\(x : integer) (xs : List integer) -> /\dead -> f x (go xs))
+              {all dead. dead}
+    in
+    \(eta : List integer) -> go eta)
+  (\(a : integer)
+    (acc : Maybe integer) ->
+     Bool_match
+       (ifThenElse {Bool} (lessThanEqualsInteger 10 a) False True)
+       {all dead. Maybe integer}
+       (/\dead -> Just {integer} a)
+       (/\dead -> acc)
+       {all dead. dead})
+  (Nothing {integer})
+  ((let
+       a = List integer
+     in
+     \(c : integer -> a -> a)
+      (n : a) ->
+       c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+     (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+     (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/findEmptyList.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findEmptyList.plc.golden
@@ -1,26 +1,40 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-in (let b = Maybe integer in \(f : integer -> b -> b) (z : b) ->
-                               letrec !go : List integer -> b
-                                        = \(ds : List integer) ->
-                                            Nil_match
-                                              {integer} ds {all dead. b}
-                                              (/\dead -> z) (\(x : integer) (xs
-                                                              : List integer) ->
-                                                               /\dead ->
-                                                                 f x (go xs))
-                                              {all dead. dead}
-                               in \(eta : List integer) -> go eta)
-     (\(a : integer) (acc : Maybe integer) ->
-        Bool_match
-          (ifThenElse {Bool} (lessThanEqualsInteger 1 a) False True)
-          {all dead. Maybe integer} (/\dead -> Just {integer} a) (/\dead -> acc)
-          {all dead. dead}) (Nothing {integer}) (Nil {integer})
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+(let
+    b = Maybe integer
+  in
+  \(f : integer -> b -> b)
+   (z : b) ->
+    letrec
+      !go : List integer -> b
+        = \(ds : List integer) ->
+            Nil_match
+              {integer}
+              ds
+              {all dead. b}
+              (/\dead -> z)
+              (\(x : integer) (xs : List integer) -> /\dead -> f x (go xs))
+              {all dead. dead}
+    in
+    \(eta : List integer) -> go eta)
+  (\(a : integer)
+    (acc : Maybe integer) ->
+     Bool_match
+       (ifThenElse {Bool} (lessThanEqualsInteger 1 a) False True)
+       {all dead. Maybe integer}
+       (/\dead -> Just {integer} a)
+       (/\dead -> acc)
+       {all dead. dead})
+  (Nothing {integer})
+  (Nil {integer})

--- a/plutus-tx-plugin/test/Budget/findExpensive.plc.golden
+++ b/plutus-tx-plugin/test/Budget/findExpensive.plc.golden
@@ -1,47 +1,47 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-in (let b = Maybe integer in \(f : integer -> b -> b) (z : b) ->
-                               letrec !go : List integer -> b
-                                        = \(ds : List integer) ->
-                                            Nil_match
-                                              {integer} ds {all dead. b}
-                                              (/\dead -> z) (\(x : integer) (xs
-                                                              : List integer) ->
-                                                               /\dead ->
-                                                                 f x (go xs))
-                                              {all dead. dead}
-                               in \(eta : List integer) -> go eta)
-     (\(a : integer) (acc : Maybe integer) ->
-        Bool_match
-          (ifThenElse {Bool} (lessThanEqualsInteger 1 a) False True)
-          {all dead. Maybe integer} (/\dead -> Just {integer} a) (/\dead -> acc)
-          {all dead. dead}) (Nothing {integer})
-     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                 c
-                                   1 (c
-                                        2 (c
-                                             3 (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-        (Nil {integer}))
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+(let
+    b = Maybe integer
+  in
+  \(f : integer -> b -> b)
+   (z : b) ->
+    letrec
+      !go : List integer -> b
+        = \(ds : List integer) ->
+            Nil_match
+              {integer}
+              ds
+              {all dead. b}
+              (/\dead -> z)
+              (\(x : integer) (xs : List integer) -> /\dead -> f x (go xs))
+              {all dead. dead}
+    in
+    \(eta : List integer) -> go eta)
+  (\(a : integer)
+    (acc : Maybe integer) ->
+     Bool_match
+       (ifThenElse {Bool} (lessThanEqualsInteger 1 a) False True)
+       {all dead. Maybe integer}
+       (/\dead -> Just {integer} a)
+       (/\dead -> acc)
+       {all dead. dead})
+  (Nothing {integer})
+  ((let
+       a = List integer
+     in
+     \(c : integer -> a -> a)
+      (n : a) ->
+       c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+     (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+     (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/ifThenElse1.plc.golden
+++ b/plutus-tx-plugin/test/Budget/ifThenElse1.plc.golden
@@ -1,10 +1,17 @@
-let ~a : integer = addInteger 1 2
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-in Bool_match
-     (ifThenElse {Bool} (lessThanInteger 3 4) True False) {all dead. integer}
-     (/\dead -> 5) (/\dead ->
-                      let !x : integer = a
-                          !y : integer = a
-                      in addInteger x y) {all dead. dead}
+let
+  ~a : integer = addInteger 1 2
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+Bool_match
+  (ifThenElse {Bool} (lessThanInteger 3 4) True False)
+  {all dead. integer}
+  (/\dead -> 5)
+  (/\dead ->
+     let
+       !x : integer = a
+       !y : integer = a
+     in
+     addInteger x y)
+  {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/ifThenElse2.plc.golden
+++ b/plutus-tx-plugin/test/Budget/ifThenElse2.plc.golden
@@ -1,12 +1,17 @@
-let ~a : integer = addInteger 1 2
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-in Bool_match
-     (ifThenElse {Bool} (lessThanInteger 3 4) True False) {integer -> integer}
-     (\(x : integer) -> addInteger x 5) (\(x : integer) ->
-                                           let !x : integer
-                                                 = let !y : integer = a
-                                                   in addInteger x y
-                                               !y : integer = a
-                                           in addInteger x y) (addInteger 6 7)
+let
+  ~a : integer = addInteger 1 2
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+Bool_match
+  (ifThenElse {Bool} (lessThanInteger 3 4) True False)
+  {integer -> integer}
+  (\(x : integer) -> addInteger x 5)
+  (\(x : integer) ->
+     let
+       !x : integer = let !y : integer = a in addInteger x y
+       !y : integer = a
+     in
+     addInteger x y)
+  (addInteger 6 7)

--- a/plutus-tx-plugin/test/Budget/monadicDo.plc.golden
+++ b/plutus-tx-plugin/test/Budget/monadicDo.plc.golden
@@ -1,20 +1,33 @@
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    !fMonadMaybe_c : all a. all b. Maybe a -> (a -> Maybe b) -> Maybe b
-      = /\a b ->
-          \(ds : Maybe a) (k : a -> Maybe b) ->
-            Maybe_match
-              {a} ds {all dead. Maybe b} (\(x : a) -> /\dead -> k x) (/\dead ->
-                                                                        Nothing
-                                                                          {b})
-              {all dead. dead}
-    !x : Maybe integer = Just {integer} 1
-    !y : Maybe integer = Just {integer} 2
-in fMonadMaybe_c
-     {integer} {integer} x (\(x : integer) ->
-                              fMonadMaybe_c
-                                {integer} {integer} y (\(y : integer) ->
-                                                         let !ds : integer
-                                                               = addInteger x y
-                                                         in Just {integer} ds))
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  !fMonadMaybe_c : all a. all b. Maybe a -> (a -> Maybe b) -> Maybe b
+    = /\a
+        b ->
+        \(ds : Maybe a)
+         (k : a -> Maybe b) ->
+          Maybe_match
+            {a}
+            ds
+            {all dead. Maybe b}
+            (\(x : a) -> /\dead -> k x)
+            (/\dead -> Nothing {b})
+            {all dead. dead}
+  !x : Maybe integer = Just {integer} 1
+  !y : Maybe integer = Just {integer} 2
+in
+fMonadMaybe_c
+  {integer}
+  {integer}
+  x
+  (\(x : integer) ->
+     fMonadMaybe_c
+       {integer}
+       {integer}
+       y
+       (\(y : integer) ->
+          let
+            !ds : integer = addInteger x y
+          in
+          Just {integer} ds))

--- a/plutus-tx-plugin/test/Budget/patternMatch.plc.golden
+++ b/plutus-tx-plugin/test/Budget/patternMatch.plc.golden
@@ -1,19 +1,22 @@
-let data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    !x : Maybe integer = Just {integer} 1
-    !y : Maybe integer = Just {integer} 2
-in Maybe_match
-     {integer} x {all dead. Maybe integer} (\(x : integer) ->
-                                              /\dead ->
-                                                Maybe_match
-                                                  {integer} y
-                                                  {all dead. Maybe integer}
-                                                  (\(y : integer) ->
-                                                     /\dead ->
-                                                       Just
-                                                         {integer} (addInteger
-                                                                      x y))
-                                                  (/\dead -> Nothing {integer})
-                                                  {all dead. dead})
-     (/\dead -> Nothing {integer}) {all dead. dead}
+let
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  !x : Maybe integer = Just {integer} 1
+  !y : Maybe integer = Just {integer} 2
+in
+Maybe_match
+  {integer}
+  x
+  {all dead. Maybe integer}
+  (\(x : integer) ->
+     /\dead ->
+       Maybe_match
+         {integer}
+         y
+         {all dead. Maybe integer}
+         (\(y : integer) -> /\dead -> Just {integer} (addInteger x y))
+         (/\dead -> Nothing {integer})
+         {all dead. dead})
+  (/\dead -> Nothing {integer})
+  {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/show.plc.golden
+++ b/plutus-tx-plugin/test/Budget/show.plc.golden
@@ -1,435 +1,548 @@
-let !y : integer = 10
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
+let
+  !y : integer = 10
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
 in
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-letrec !go : List integer -> integer -> List integer
-         = \(acc : List integer) (n : integer) ->
-             let ~q : integer = quotientInteger n y
-             in Bool_match
-                  (ifThenElse {Bool} (equalsInteger q 0) True False)
-                  {all dead. List integer} (/\dead ->
-                                              Cons
-                                                {integer} (remainderInteger n y)
-                                                acc) (/\dead ->
-                                                        go
-                                                          (Cons
-                                                             {integer}
-                                                             (remainderInteger
-                                                                n y) acc) q)
-                  {all dead. dead}
+letrec
+  !go : List integer -> integer -> List integer
+    = \(acc : List integer)
+       (n : integer) ->
+        let
+          ~q : integer = quotientInteger n y
+        in
+        Bool_match
+          (ifThenElse {Bool} (equalsInteger q 0) True False)
+          {all dead. List integer}
+          (/\dead -> Cons {integer} (remainderInteger n y) acc)
+          (/\dead -> go (Cons {integer} (remainderInteger n y) acc) q)
+          {all dead. dead}
 in
-letrec !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
-         = /\a b ->
-             \(f : a -> b -> b) (acc : b) (l : List a) ->
-               Nil_match
-                 {a} l {all dead. b} (/\dead -> acc) (\(x : a) (xs : List a) ->
-                                                        /\dead ->
-                                                          f
-                                                            x (foldr
-                                                                 {a} {b} f acc
-                                                                 xs))
-                 {all dead. dead}
+letrec
+  !foldr : all a. all b. (a -> b -> b) -> b -> List a -> b
+    = /\a
+        b ->
+        \(f : a -> b -> b)
+         (acc : b)
+         (l : List a) ->
+          Nil_match
+            {a}
+            l
+            {all dead. b}
+            (/\dead -> acc)
+            (\(x : a) (xs : List a) -> /\dead -> f x (foldr {a} {b} f acc xs))
+            {all dead. dead}
 in
-let !id : all a. a -> a = /\a -> \(x : a) -> x in
-letrec !wcshowsPrec
-         : integer -> List string -> List string
-         = \(w : integer) ->
-             Bool_match
-               (ifThenElse {Bool} (lessThanInteger w 0) True False)
-               {all dead. List string -> List string} (/\dead ->
-                                                         \(x : List string) ->
-                                                           Cons
-                                                             {string} "-"
-                                                             (wcshowsPrec
-                                                                (subtractInteger
-                                                                   0 w) x))
-               (/\dead ->
-                  foldr
-                    {integer} {List string -> List string}
-                    (\(digit : integer) (acc : List string -> List string) (x
-                      : List string) ->
-                       Cons
-                         {string}
-                         (Bool_match
+let
+  !id : all a. a -> a = /\a -> \(x : a) -> x
+in
+letrec
+  !wcshowsPrec
+     : integer -> List string -> List string
+    = \(w : integer) ->
+        Bool_match
+          (ifThenElse {Bool} (lessThanInteger w 0) True False)
+          {all dead. List string -> List string}
+          (/\dead ->
+             \(x : List string) ->
+               Cons {string} "-" (wcshowsPrec (subtractInteger 0 w) x))
+          (/\dead ->
+             foldr
+               {integer}
+               {List string -> List string}
+               (\(digit : integer)
+                 (acc : List string -> List string)
+                 (x : List string) ->
+                  Cons
+                    {string}
+                    (Bool_match
+                       (ifThenElse {Bool} (equalsInteger digit 0) True False)
+                       {all dead. string}
+                       (/\dead -> "0")
+                       (/\dead ->
+                          Bool_match
                             (ifThenElse
-                               {Bool} (equalsInteger digit 0) True False)
-                            {all dead. string} (/\dead -> "0")
+                               {Bool}
+                               (equalsInteger digit 1)
+                               True
+                               False)
+                            {all dead. string}
+                            (/\dead -> "1")
                             (/\dead ->
                                Bool_match
                                  (ifThenElse
-                                    {Bool} (equalsInteger digit 1) True False)
-                                 {all dead. string} (/\dead -> "1")
+                                    {Bool}
+                                    (equalsInteger digit 2)
+                                    True
+                                    False)
+                                 {all dead. string}
+                                 (/\dead -> "2")
                                  (/\dead ->
                                     Bool_match
                                       (ifThenElse
-                                         {Bool} (equalsInteger digit 2) True
-                                         False) {all dead. string} (/\dead ->
-                                                                      "2")
+                                         {Bool}
+                                         (equalsInteger digit 3)
+                                         True
+                                         False)
+                                      {all dead. string}
+                                      (/\dead -> "3")
                                       (/\dead ->
                                          Bool_match
                                            (ifThenElse
-                                              {Bool} (equalsInteger digit 3)
-                                              True False) {all dead. string}
-                                           (/\dead -> "3")
+                                              {Bool}
+                                              (equalsInteger digit 4)
+                                              True
+                                              False)
+                                           {all dead. string}
+                                           (/\dead -> "4")
                                            (/\dead ->
                                               Bool_match
                                                 (ifThenElse
-                                                   {Bool} (equalsInteger
-                                                             digit 4) True
-                                                   False) {all dead. string}
-                                                (/\dead -> "4")
+                                                   {Bool}
+                                                   (equalsInteger digit 5)
+                                                   True
+                                                   False)
+                                                {all dead. string}
+                                                (/\dead -> "5")
                                                 (/\dead ->
                                                    Bool_match
                                                      (ifThenElse
-                                                        {Bool} (equalsInteger
-                                                                  digit 5) True
+                                                        {Bool}
+                                                        (equalsInteger digit 6)
+                                                        True
                                                         False)
                                                      {all dead. string}
-                                                     (/\dead -> "5")
+                                                     (/\dead -> "6")
                                                      (/\dead ->
                                                         Bool_match
                                                           (ifThenElse
                                                              {Bool}
                                                              (equalsInteger
-                                                                digit 6) True
+                                                                digit
+                                                                7)
+                                                             True
                                                              False)
                                                           {all dead. string}
-                                                          (/\dead -> "6")
+                                                          (/\dead -> "7")
                                                           (/\dead ->
                                                              Bool_match
                                                                (ifThenElse
                                                                   {Bool}
                                                                   (equalsInteger
-                                                                     digit 7)
-                                                                  True False)
+                                                                     digit
+                                                                     8)
+                                                                  True
+                                                                  False)
                                                                {all dead. string}
-                                                               (/\dead -> "7")
+                                                               (/\dead -> "8")
                                                                (/\dead ->
                                                                   Bool_match
                                                                     (ifThenElse
                                                                        {Bool}
                                                                        (equalsInteger
                                                                           digit
-                                                                          8)
+                                                                          9)
                                                                        True
                                                                        False)
-                                                                    {all dead. string}
-                                                                    (/\dead ->
-                                                                       "8")
-                                                                    (/\dead ->
-                                                                       Bool_match
-                                                                         (ifThenElse
-                                                                            {Bool}
-                                                                            (equalsInteger
-                                                                               digit
-                                                                               9)
-                                                                            True
-                                                                            False)
-                                                                         {string}
-                                                                         "9"
-                                                                         "<invalid digit>")
-                                                                    {all dead. dead})
+                                                                    {string}
+                                                                    "9"
+                                                                    "<invalid digit>")
                                                                {all dead. dead})
                                                           {all dead. dead})
                                                      {all dead. dead})
                                                 {all dead. dead})
-                                           {all dead. dead}) {all dead. dead})
-                                 {all dead. dead}) {all dead. dead}) (acc x))
-                    (id {List string}) (go (Nil {integer}) w)) {all dead. dead}
+                                           {all dead. dead})
+                                      {all dead. dead})
+                                 {all dead. dead})
+                            {all dead. dead})
+                       {all dead. dead})
+                    (acc x))
+               (id {List string})
+               (go (Nil {integer}) w))
+          {all dead. dead}
 in
-let !toHex : integer -> List string -> List string
-      = \(x : integer) ->
-          Bool_match
-            (ifThenElse {Bool} (lessThanEqualsInteger x 9) True False)
-            {all dead. List string -> List string} (/\dead -> wcshowsPrec x)
-            (/\dead ->
-               Bool_match
-                 (ifThenElse {Bool} (equalsInteger x 10) True False)
-                 {all dead. List string -> List string} (/\dead ->
-                                                           \(ds
-                                                            : List string) ->
-                                                             Cons
-                                                               {string} "a" ds)
-                 (/\dead ->
-                    Bool_match
-                      (ifThenElse {Bool} (equalsInteger x 11) True False)
-                      {all dead. List string -> List string}
-                      (/\dead -> \(ds : List string) -> Cons {string} "b" ds)
-                      (/\dead ->
-                         Bool_match
-                           (ifThenElse {Bool} (equalsInteger x 12) True False)
-                           {all dead. List string -> List string}
-                           (/\dead ->
-                              \(ds : List string) -> Cons {string} "c" ds)
-                           (/\dead ->
-                              Bool_match
-                                (ifThenElse
-                                   {Bool} (equalsInteger x 13) True False)
-                                {all dead. List string -> List string}
-                                (/\dead ->
-                                   \(ds : List string) -> Cons {string} "d" ds)
-                                (/\dead ->
-                                   Bool_match
-                                     (ifThenElse
-                                        {Bool} (equalsInteger x 14) True False)
-                                     {all dead. List string -> List string}
-                                     (/\dead ->
-                                        \(ds : List string) ->
-                                          Cons {string} "e" ds)
-                                     (/\dead ->
-                                        Bool_match
-                                          (ifThenElse
-                                             {Bool} (equalsInteger x 15) True
-                                             False) {List string -> List string}
-                                          (\(ds : List string) ->
-                                             Cons {string} "f" ds)
-                                          (\(ds : List string) ->
-                                             Cons {string} "<invalid byte>" ds))
-                                     {all dead. dead}) {all dead. dead})
-                           {all dead. dead}) {all dead. dead}) {all dead. dead})
-            {all dead. dead}
-    !x : integer = -1234567890
-    data (Tuple2 :: * -> * -> *) a b | Tuple2_match where
-      Tuple2 : a -> b -> Tuple2 a b
-in
-letrec !go : all a. integer -> List a -> Tuple2 (List a) (List a)
-         = /\a ->
-             \(ds : integer) (ds : List a) ->
-               Nil_match
-                 {a} ds {all dead. Tuple2 (List a) (List a)} (/\dead ->
-                                                                Tuple2
-                                                                  {List a}
-                                                                  {List a}
-                                                                  (Nil {a})
-                                                                  (Nil {a}))
-                 (\(y : a) (ys : List a) ->
-                    /\dead ->
-                      Bool_match
-                        (ifThenElse {Bool} (equalsInteger ds 1) True False)
-                        {all dead. Tuple2 (List a) (List a)}
-                        (/\dead ->
-                           Tuple2
-                             {List a} {List a} ((let a = List a
-                                                 in \(c : a -> a -> a) (n
-                                                     : a) ->
-                                                      c y n)
-                                                  (\(ds : a) (ds : List a) ->
-                                                     Cons {a} ds ds) (Nil {a}))
-                             ys) (/\dead ->
-                                    Tuple2_match
-                                      {List a} {List a} (go
-                                                           {a} (subtractInteger
-                                                                  ds 1) ys)
-                                      {Tuple2 (List a) (List a)} (\(zs : List a)
-                                                                   (ws
-                                                                   : List a) ->
-                                                                    Tuple2
-                                                                      {List a}
-                                                                      {List a}
-                                                                      (Cons
-                                                                         {a} y
-                                                                         zs)
-                                                                      ws))
-                        {all dead. dead}) {all dead. dead}
-in
-letrec !fEnumBool_cenumFromTo : integer -> integer -> List integer
-         = \(x : integer) (y : integer) ->
+let
+  !toHex : integer -> List string -> List string
+    = \(x : integer) ->
+        Bool_match
+          (ifThenElse {Bool} (lessThanEqualsInteger x 9) True False)
+          {all dead. List string -> List string}
+          (/\dead -> wcshowsPrec x)
+          (/\dead ->
              Bool_match
-               (ifThenElse {Bool} (lessThanEqualsInteger x y) False True)
-               {all dead. List integer} (/\dead -> Nil {integer})
+               (ifThenElse {Bool} (equalsInteger x 10) True False)
+               {all dead. List string -> List string}
+               (/\dead -> \(ds : List string) -> Cons {string} "a" ds)
                (/\dead ->
-                  Cons {integer} x (fEnumBool_cenumFromTo (addInteger x 1) y))
-               {all dead. dead}
-in
-let !fShowInteger_cshowsPrec : integer -> integer -> List string -> List string
-      = \(w : integer) (w : integer) -> wcshowsPrec w
-in
-letrec !go : List string -> integer -> integer
-         = \(ds : List string) (eta : integer) ->
-             Nil_match
-               {string} ds {all dead. integer} (/\dead -> eta)
-               (\(x : string) (xs : List string) ->
-                  /\dead -> go xs (addInteger eta 1)) {all dead. dead}
-in
-let data (UTuple2 :: * -> * -> *) a b | UTuple2_match where
-      UTuple2 : a -> b -> UTuple2 a b
-in
-letrec !concatBuiltinStrings : List string -> string
-         = \(ds : List string) ->
-             let ~ds : Tuple2 (List string) (List string)
-                   = let !w : integer = divideInteger (go ds 0) 2
-                     in UTuple2_match
-                          {List string} {List string}
-                          (Bool_match
-                             (ifThenElse
-                                {Bool} (lessThanEqualsInteger w 0) True False)
-                             {all dead. UTuple2 (List string) (List string)}
-                             (/\dead ->
-                                UTuple2
-                                  {List string} {List string} (Nil {string}) ds)
-                             (/\dead ->
-                                Tuple2_match
-                                  {List string} {List string} (go {string} w ds)
-                                  {UTuple2 (List string) (List string)}
-                                  (\(ww : List string) (ww : List string) ->
-                                     UTuple2 {List string} {List string} ww ww))
-                             {all dead. dead})
-                          {Tuple2 (List string) (List string)}
-                          (\(ww : List string) (ww : List string) ->
-                             Tuple2 {List string} {List string} ww ww)
-             in Nil_match
-                  {string} ds {string} "" (\(x : string) (ds : List string) ->
-                                             Nil_match
-                                               {string} ds {all dead. string}
-                                               (/\dead -> x)
-                                               (\(ipv : string) (ipv
-                                                 : List string) ->
-                                                  /\dead ->
-                                                    appendString
-                                                      (Tuple2_match
-                                                         {List string}
-                                                         {List string} ds
-                                                         {string}
-                                                         (\(ys : List string)
-                                                           (zs : List string) ->
-                                                            concatBuiltinStrings
-                                                              ys))
-                                                      (Tuple2_match
-                                                         {List string}
-                                                         {List string} ds
-                                                         {string}
-                                                         (\(ys : List string)
-                                                           (zs : List string) ->
-                                                            concatBuiltinStrings
-                                                              zs)))
-                                               {all dead. dead})
-in
-let !fShowInteger_cshow : integer -> string
-      = \(x : integer) ->
-          concatBuiltinStrings (fShowInteger_cshowsPrec 0 x (Nil {string}))
-    data (Show :: * -> *) a | Show_match where
-      CConsShow
-      : (integer -> a -> List string -> List string) -> (a -> string) -> Show a
-    ~fShowInteger : Show integer
-      = CConsShow {integer} fShowInteger_cshowsPrec fShowInteger_cshow
-    data (Tuple5 :: * -> * -> * -> * -> * -> *) a b c d e | Tuple5_match where
-      Tuple5 : a -> b -> c -> d -> e -> Tuple5 a b c d e
-    !showsPrec : all a. Show a -> integer -> a -> List string -> List string
-      = /\a ->
-          \(v : Show a) ->
-            Show_match
-              {a} v {integer -> a -> List string -> List string}
-              (\(v : integer -> a -> List string -> List string) (v
-                : a -> string) ->
-                 v)
-    !a : integer = trace {integer} (fShowInteger_cshow x) x
-    !b : integer = trace {integer} "This is an example" a
-    !c : integer
-      = trace
-          {integer} (let !x : bytestring = encodeUtf8 "This is an example"
-                     in concatBuiltinStrings
-                          (foldr
-                             {integer} {List string -> List string}
-                             (\(i : integer) ->
-                                let ~x : integer = indexByteString x i
-                                in \(acc : List string -> List string) (x
-                                    : List string) ->
-                                     toHex
-                                       (divideInteger x 16) (toHex
-                                                               (modInteger x 16)
-                                                               (acc x)))
-                             (id {List string}) (fEnumBool_cenumFromTo
-                                                   0 (subtractInteger
-                                                        (lengthOfByteString x)
-                                                        1)) (Nil {string}))) b
-    !d : integer
-      = trace
-          {integer} (let !b : Bool
-                           = ifThenElse
-                               {Bool} (lessThanEqualsInteger c 0) False True
-                     in Bool_match b {string} "True" "False") c
-    !e : integer
-      = trace
-          {integer} (let !dShow : Show integer = fShowInteger
-                         !x : List integer
-                           = (let a = List integer in \(c : integer -> a -> a)
-                                                       (n : a) ->
-                                                        c a (c b (c c (c d n))))
-                               (\(ds : integer) (ds : List integer) ->
-                                  Cons {integer} ds ds) (Nil {integer})
-                     in concatBuiltinStrings
-                          (let !w : integer -> List string -> List string
-                                 = showsPrec {integer} dShow 0
-                               !w : List string = Nil {string}
-                           in UTuple2_match
-                                {string} {List string}
-                                (Nil_match
-                                   {integer} x
-                                   {all dead. UTuple2 string (List string)}
+                  Bool_match
+                    (ifThenElse {Bool} (equalsInteger x 11) True False)
+                    {all dead. List string -> List string}
+                    (/\dead -> \(ds : List string) -> Cons {string} "b" ds)
+                    (/\dead ->
+                       Bool_match
+                         (ifThenElse {Bool} (equalsInteger x 12) True False)
+                         {all dead. List string -> List string}
+                         (/\dead -> \(ds : List string) -> Cons {string} "c" ds)
+                         (/\dead ->
+                            Bool_match
+                              (ifThenElse
+                                 {Bool}
+                                 (equalsInteger x 13)
+                                 True
+                                 False)
+                              {all dead. List string -> List string}
+                              (/\dead ->
+                                 \(ds : List string) -> Cons {string} "d" ds)
+                              (/\dead ->
+                                 Bool_match
+                                   (ifThenElse
+                                      {Bool}
+                                      (equalsInteger x 14)
+                                      True
+                                      False)
+                                   {all dead. List string -> List string}
                                    (/\dead ->
-                                      UTuple2 {string} {List string} "[]" w)
-                                   (\(x : integer) (xs : List integer) ->
-                                      /\dead ->
-                                        UTuple2
-                                          {string} {List string} "["
-                                          (w
-                                             x
-                                             (foldr
-                                                {integer}
-                                                {List string -> List string}
-                                                (\(a : integer) (acc
-                                                  : List string -> List string)
-                                                  (x : List string) ->
-                                                   Cons
-                                                     {string} "," (w a (acc x)))
-                                                (id {List string}) xs
-                                                (Cons {string} "]" w))))
-                                   {all dead. dead}) {List string}
-                                (\(ww : string) (ww : List string) ->
-                                   Cons {string} ww ww))) d
-    !x : integer
-      = trace
+                                      \(ds : List string) ->
+                                        Cons {string} "e" ds)
+                                   (/\dead ->
+                                      Bool_match
+                                        (ifThenElse
+                                           {Bool}
+                                           (equalsInteger x 15)
+                                           True
+                                           False)
+                                        {List string -> List string}
+                                        (\(ds : List string) ->
+                                           Cons {string} "f" ds)
+                                        (\(ds : List string) ->
+                                           Cons {string} "<invalid byte>" ds))
+                                   {all dead. dead})
+                              {all dead. dead})
+                         {all dead. dead})
+                    {all dead. dead})
+               {all dead. dead})
+          {all dead. dead}
+  !x : integer = -1234567890
+  data (Tuple2 :: * -> * -> *) a b | Tuple2_match where
+    Tuple2 : a -> b -> Tuple2 a b
+in
+letrec
+  !go : all a. integer -> List a -> Tuple2 (List a) (List a)
+    = /\a ->
+        \(ds : integer)
+         (ds : List a) ->
+          Nil_match
+            {a}
+            ds
+            {all dead. Tuple2 (List a) (List a)}
+            (/\dead -> Tuple2 {List a} {List a} (Nil {a}) (Nil {a}))
+            (\(y : a)
+              (ys : List a) ->
+               /\dead ->
+                 Bool_match
+                   (ifThenElse {Bool} (equalsInteger ds 1) True False)
+                   {all dead. Tuple2 (List a) (List a)}
+                   (/\dead ->
+                      Tuple2
+                        {List a}
+                        {List a}
+                        ((let
+                             a = List a
+                           in
+                           \(c : a -> a -> a) (n : a) -> c y n)
+                           (\(ds : a) (ds : List a) -> Cons {a} ds ds)
+                           (Nil {a}))
+                        ys)
+                   (/\dead ->
+                      Tuple2_match
+                        {List a}
+                        {List a}
+                        (go {a} (subtractInteger ds 1) ys)
+                        {Tuple2 (List a) (List a)}
+                        (\(zs : List a)
+                          (ws : List a) ->
+                           Tuple2 {List a} {List a} (Cons {a} y zs) ws))
+                   {all dead. dead})
+            {all dead. dead}
+in
+letrec
+  !fEnumBool_cenumFromTo : integer -> integer -> List integer
+    = \(x : integer)
+       (y : integer) ->
+        Bool_match
+          (ifThenElse {Bool} (lessThanEqualsInteger x y) False True)
+          {all dead. List integer}
+          (/\dead -> Nil {integer})
+          (/\dead ->
+             Cons {integer} x (fEnumBool_cenumFromTo (addInteger x 1) y))
+          {all dead. dead}
+in
+let
+  !fShowInteger_cshowsPrec : integer -> integer -> List string -> List string
+    = \(w : integer) (w : integer) -> wcshowsPrec w
+in
+letrec
+  !go : List string -> integer -> integer
+    = \(ds : List string)
+       (eta : integer) ->
+        Nil_match
+          {string}
+          ds
+          {all dead. integer}
+          (/\dead -> eta)
+          (\(x : string)
+            (xs : List string) ->
+             /\dead -> go xs (addInteger eta 1))
+          {all dead. dead}
+in
+let
+  data (UTuple2 :: * -> * -> *) a b | UTuple2_match where
+    UTuple2 : a -> b -> UTuple2 a b
+in
+letrec
+  !concatBuiltinStrings : List string -> string
+    = \(ds : List string) ->
+        let
+          ~ds : Tuple2 (List string) (List string)
+            = let
+              !w : integer = divideInteger (go ds 0) 2
+            in
+            UTuple2_match
+              {List string}
+              {List string}
+              (Bool_match
+                 (ifThenElse {Bool} (lessThanEqualsInteger w 0) True False)
+                 {all dead. UTuple2 (List string) (List string)}
+                 (/\dead ->
+                    UTuple2 {List string} {List string} (Nil {string}) ds)
+                 (/\dead ->
+                    Tuple2_match
+                      {List string}
+                      {List string}
+                      (go {string} w ds)
+                      {UTuple2 (List string) (List string)}
+                      (\(ww : List string)
+                        (ww : List string) ->
+                         UTuple2 {List string} {List string} ww ww))
+                 {all dead. dead})
+              {Tuple2 (List string) (List string)}
+              (\(ww : List string)
+                (ww : List string) ->
+                 Tuple2 {List string} {List string} ww ww)
+        in
+        Nil_match
+          {string}
+          ds
+          {string}
+          ""
+          (\(x : string)
+            (ds : List string) ->
+             Nil_match
+               {string}
+               ds
+               {all dead. string}
+               (/\dead -> x)
+               (\(ipv : string)
+                 (ipv : List string) ->
+                  /\dead ->
+                    appendString
+                      (Tuple2_match
+                         {List string}
+                         {List string}
+                         ds
+                         {string}
+                         (\(ys : List string)
+                           (zs : List string) ->
+                            concatBuiltinStrings ys))
+                      (Tuple2_match
+                         {List string}
+                         {List string}
+                         ds
+                         {string}
+                         (\(ys : List string)
+                           (zs : List string) ->
+                            concatBuiltinStrings zs)))
+               {all dead. dead})
+in
+let
+  !fShowInteger_cshow : integer -> string
+    = \(x : integer) ->
+        concatBuiltinStrings (fShowInteger_cshowsPrec 0 x (Nil {string}))
+  data (Show :: * -> *) a | Show_match where
+    CConsShow
+      : (integer -> a -> List string -> List string) -> (a -> string) -> Show a
+  ~fShowInteger : Show integer
+    = CConsShow {integer} fShowInteger_cshowsPrec fShowInteger_cshow
+  data (Tuple5 :: * -> * -> * -> * -> * -> *) a b c d e | Tuple5_match where
+    Tuple5 : a -> b -> c -> d -> e -> Tuple5 a b c d e
+  !showsPrec : all a. Show a -> integer -> a -> List string -> List string
+    = /\a ->
+        \(v : Show a) ->
+          Show_match
+            {a}
+            v
+            {integer -> a -> List string -> List string}
+            (\(v : integer -> a -> List string -> List string)
+              (v : a -> string) ->
+               v)
+  !a : integer = trace {integer} (fShowInteger_cshow x) x
+  !b : integer = trace {integer} "This is an example" a
+  !c : integer
+    = trace
+        {integer}
+        (let
+          !x : bytestring = encodeUtf8 "This is an example"
+        in
+        concatBuiltinStrings
+          (foldr
+             {integer}
+             {List string -> List string}
+             (\(i : integer) ->
+                let
+                  ~x : integer = indexByteString x i
+                in
+                \(acc : List string -> List string)
+                 (x : List string) ->
+                  toHex (divideInteger x 16) (toHex (modInteger x 16) (acc x)))
+             (id {List string})
+             (fEnumBool_cenumFromTo
+                0
+                (subtractInteger (lengthOfByteString x) 1))
+             (Nil {string})))
+        b
+  !d : integer
+    = trace
+        {integer}
+        (let
+          !b : Bool = ifThenElse {Bool} (lessThanEqualsInteger c 0) False True
+        in
+        Bool_match b {string} "True" "False")
+        c
+  !e : integer
+    = trace
+        {integer}
+        (let
+          !dShow : Show integer = fShowInteger
+          !x : List integer
+            = (let
+                  a = List integer
+                in
+                \(c : integer -> a -> a) (n : a) -> c a (c b (c c (c d n))))
+                (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+                (Nil {integer})
+        in
+        concatBuiltinStrings
+          (let
+            !w : integer -> List string -> List string
+              = showsPrec {integer} dShow 0
+            !w : List string = Nil {string}
+          in
+          UTuple2_match
+            {string}
+            {List string}
+            (Nil_match
+               {integer}
+               x
+               {all dead. UTuple2 string (List string)}
+               (/\dead -> UTuple2 {string} {List string} "[]" w)
+               (\(x : integer)
+                 (xs : List integer) ->
+                  /\dead ->
+                    UTuple2
+                      {string}
+                      {List string}
+                      "["
+                      (w
+                         x
+                         (foldr
+                            {integer}
+                            {List string -> List string}
+                            (\(a : integer)
+                              (acc : List string -> List string)
+                              (x : List string) ->
+                               Cons {string} "," (w a (acc x)))
+                            (id {List string})
+                            xs
+                            (Cons {string} "]" w))))
+               {all dead. dead})
+            {List string}
+            (\(ww : string) (ww : List string) -> Cons {string} ww ww)))
+        d
+  !x : integer
+    = trace
+        {integer}
+        (let
+          !w : Show integer = fShowInteger
+          !w : Show integer = fShowInteger
+          !w : Show integer = fShowInteger
+          !w : Show integer = fShowInteger
+          !w : Show integer = fShowInteger
+          !w : Tuple5 integer integer integer integer integer
+            = Tuple5 {integer} {integer} {integer} {integer} {integer} a b c d e
+        in
+        Tuple5_match
           {integer}
-          (let !w : Show integer = fShowInteger
-               !w : Show integer = fShowInteger
-               !w : Show integer = fShowInteger
-               !w : Show integer = fShowInteger
-               !w : Show integer = fShowInteger
-               !w : Tuple5 integer integer integer integer integer
-                 = Tuple5
-                     {integer} {integer} {integer} {integer} {integer} a b c d e
-           in Tuple5_match
-                {integer} {integer} {integer} {integer} {integer} w {string}
-                (\(ww : integer) (ww : integer) (ww : integer) (ww : integer)
-                  (ww : integer) ->
-                   concatBuiltinStrings
-                     (let !x : List string = Nil {string}
-                      in Cons
-                           {string} "("
-                           (showsPrec
-                              {integer} w 0 ww
-                              (Cons
-                                 {string} ","
-                                 (showsPrec
-                                    {integer} w 0 ww
-                                    (Cons
-                                       {string} ","
-                                       (showsPrec
-                                          {integer} w 0 ww
-                                          (Cons
-                                             {string} ","
-                                             (showsPrec
-                                                {integer} w 0 ww
-                                                (Cons
-                                                   {string} ","
-                                                   (showsPrec
-                                                      {integer} w 0 ww
-                                                      (Cons
-                                                         {string} ")"
-                                                         x))))))))))))) e
-in multiplyInteger x 2
+          {integer}
+          {integer}
+          {integer}
+          {integer}
+          w
+          {string}
+          (\(ww : integer)
+            (ww : integer)
+            (ww : integer)
+            (ww : integer)
+            (ww : integer) ->
+             concatBuiltinStrings
+               (let
+                 !x : List string = Nil {string}
+               in
+               Cons
+                 {string}
+                 "("
+                 (showsPrec
+                    {integer}
+                    w
+                    0
+                    ww
+                    (Cons
+                       {string}
+                       ","
+                       (showsPrec
+                          {integer}
+                          w
+                          0
+                          ww
+                          (Cons
+                             {string}
+                             ","
+                             (showsPrec
+                                {integer}
+                                w
+                                0
+                                ww
+                                (Cons
+                                   {string}
+                                   ","
+                                   (showsPrec
+                                      {integer}
+                                      w
+                                      0
+                                      ww
+                                      (Cons
+                                         {string}
+                                         ","
+                                         (showsPrec
+                                            {integer}
+                                            w
+                                            0
+                                            ww
+                                            (Cons {string} ")" x)))))))))))))
+        e
+in
+multiplyInteger x 2

--- a/plutus-tx-plugin/test/Budget/sum.plc.golden
+++ b/plutus-tx-plugin/test/Budget/sum.plc.golden
@@ -1,46 +1,48 @@
-letrec data (List :: * -> *) a | Nil_match where
-         Nil : List a
-         Cons : a -> List a -> List a
+letrec
+  data (List :: * -> *) a | Nil_match where
+    Nil : List a
+    Cons : a -> List a -> List a
 in
-let data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
-      CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
-in (let !dAdditiveMonoid : AdditiveMonoid integer
-          = CConsAdditiveMonoid
-              {integer} (\(x : integer) (y : integer) -> addInteger x y) 0
-        !f : integer -> integer -> integer
-          = AdditiveMonoid_match
-              {integer} dAdditiveMonoid {(\a -> a -> a -> a) integer}
-              (\(v : (\a -> a -> a -> a) integer) (v : integer) -> v)
-        !z : integer
-          = AdditiveMonoid_match
-              {integer} dAdditiveMonoid {integer}
-              (\(v : (\a -> a -> a -> a) integer) (v : integer) -> v)
-    in
-    letrec !go : List integer -> integer
-             = \(ds : List integer) ->
-                 Nil_match
-                   {integer} ds {all dead. integer} (/\dead -> z)
-                   (\(x : integer) (xs : List integer) -> /\dead -> f x (go xs))
-                   {all dead. dead}
-    in \(eta : List integer) -> go eta)
-     ((let a = List integer in \(c : integer -> a -> a) (n : a) ->
-                                 c
-                                   1 (c
-                                        2 (c
-                                             3 (c
-                                                  4
-                                                  (c
-                                                     5
-                                                     (c
-                                                        6
-                                                        (c
-                                                           7
-                                                           (c
-                                                              8
-                                                              (c
-                                                                 9
-                                                                 (c
-                                                                    10
-                                                                    n))))))))))
-        (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
-        (Nil {integer}))
+let
+  data (AdditiveMonoid :: * -> *) a | AdditiveMonoid_match where
+    CConsAdditiveMonoid : (\a -> a -> a -> a) a -> a -> AdditiveMonoid a
+in
+(let
+    !dAdditiveMonoid : AdditiveMonoid integer
+      = CConsAdditiveMonoid
+          {integer}
+          (\(x : integer) (y : integer) -> addInteger x y)
+          0
+    !f : integer -> integer -> integer
+      = AdditiveMonoid_match
+          {integer}
+          dAdditiveMonoid
+          {(\a -> a -> a -> a) integer}
+          (\(v : (\a -> a -> a -> a) integer) (v : integer) -> v)
+    !z : integer
+      = AdditiveMonoid_match
+          {integer}
+          dAdditiveMonoid
+          {integer}
+          (\(v : (\a -> a -> a -> a) integer) (v : integer) -> v)
+  in
+  letrec
+    !go : List integer -> integer
+      = \(ds : List integer) ->
+          Nil_match
+            {integer}
+            ds
+            {all dead. integer}
+            (/\dead -> z)
+            (\(x : integer) (xs : List integer) -> /\dead -> f x (go xs))
+            {all dead. dead}
+  in
+  \(eta : List integer) -> go eta)
+  ((let
+       a = List integer
+     in
+     \(c : integer -> a -> a)
+      (n : a) ->
+       c 1 (c 2 (c 3 (c 4 (c 5 (c 6 (c 7 (c 8 (c 9 (c 10 n))))))))))
+     (\(ds : integer) (ds : List integer) -> Cons {integer} ds ds)
+     (Nil {integer}))

--- a/plutus-tx-plugin/test/Budget/toFromData.plc.golden
+++ b/plutus-tx-plugin/test/Budget/toFromData.plc.golden
@@ -1,200 +1,239 @@
-let data Unit | Unit_match where
-      Unit : Unit
-    data (Tuple3 :: * -> * -> * -> *) a b c | Tuple3_match where
-      Tuple3 : a -> b -> c -> Tuple3 a b c
-    data Bool | Bool_match where
-      True : Bool
-      False : Bool
-    data (Either :: * -> * -> *) a b | Either_match where
-      Left : a -> Either a b
-      Right : b -> Either a b
-    data (Maybe :: * -> *) a | Maybe_match where
-      Just : a -> Maybe a
-      Nothing : Maybe a
-    !reconstructCaseError : string = "PT1"
-    !unitval : unit = ()
-in (let b = Maybe (Tuple3 Bool integer Bool)
-    in \(dUnsafeFromData : (\a -> data -> a) integer) (dUnsafeFromData
-        : (\a -> data -> a) b) (d : data) ->
-         let !tup : pair integer (list data) = unConstrData d
-             !index : integer = fstPair {integer} {list data} tup
-         in ifThenElse
-              {unit -> Either integer b} (equalsInteger index 1)
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  data (Tuple3 :: * -> * -> * -> *) a b c | Tuple3_match where
+    Tuple3 : a -> b -> c -> Tuple3 a b c
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+  data (Either :: * -> * -> *) a b | Either_match where
+    Left : a -> Either a b
+    Right : b -> Either a b
+  data (Maybe :: * -> *) a | Maybe_match where
+    Just : a -> Maybe a
+    Nothing : Maybe a
+  !reconstructCaseError : string = "PT1"
+  !unitval : unit = ()
+in
+(let
+    b = Maybe (Tuple3 Bool integer Bool)
+  in
+  \(dUnsafeFromData : (\a -> data -> a) integer)
+   (dUnsafeFromData : (\a -> data -> a) b)
+   (d : data) ->
+    let
+      !tup : pair integer (list data) = unConstrData d
+      !index : integer = fstPair {integer} {list data} tup
+    in
+    ifThenElse
+      {unit -> Either integer b}
+      (equalsInteger index 1)
+      (\(ds : unit) ->
+         let
+           !arg : data = headList {data} (sndPair {integer} {list data} tup)
+         in
+         Right {integer} {b} (dUnsafeFromData arg))
+      (\(ds : unit) ->
+         ifThenElse
+           {unit -> Either integer b}
+           (equalsInteger index 0)
+           (\(ds : unit) ->
+              let
+                !arg : data
+                  = headList {data} (sndPair {integer} {list data} tup)
+              in
+              Left {integer} {b} (dUnsafeFromData arg))
+           (\(ds : unit) ->
+              let
+                !thunk : unit
+                  = let
+                    !wild : Unit = trace {Unit} reconstructCaseError Unit
+                  in
+                  unitval
+              in
+              error {Either integer b})
+           unitval)
+      unitval)
+  unIData
+  ((let
+       a = Tuple3 Bool integer Bool
+     in
+     \(dUnsafeFromData : (\a -> data -> a) a)
+      (d : data) ->
+       let
+         !tup : pair integer (list data) = unConstrData d
+         !index : integer = fstPair {integer} {list data} tup
+       in
+       ifThenElse
+         {unit -> Maybe a}
+         (equalsInteger index 0)
+         (\(ds : unit) ->
+            let
+              !arg : data = headList {data} (sndPair {integer} {list data} tup)
+            in
+            Just {a} (dUnsafeFromData arg))
+         (\(ds : unit) ->
+            ifThenElse
+              {unit -> Maybe a}
+              (equalsInteger index 1)
+              (\(ds : unit) -> Nothing {a})
               (\(ds : unit) ->
-                 let !arg : data
-                       = headList {data} (sndPair {integer} {list data} tup)
-                 in Right {integer} {b} (dUnsafeFromData arg))
-              (\(ds : unit) ->
-                 ifThenElse
-                   {unit -> Either integer b} (equalsInteger index 0)
-                   (\(ds : unit) ->
-                      let !arg : data
-                            = headList
-                                {data} (sndPair {integer} {list data} tup)
-                      in Left {integer} {b} (dUnsafeFromData arg))
-                   (\(ds : unit) ->
-                      let !thunk : unit
-                            = let !wild : Unit
-                                    = trace {Unit} reconstructCaseError Unit
-                              in unitval
-                      in error {Either integer b}) unitval) unitval)
-     unIData
-     ((let a = Tuple3 Bool integer Bool
-       in \(dUnsafeFromData : (\a -> data -> a) a) (d : data) ->
-            let !tup : pair integer (list data) = unConstrData d
-                !index : integer = fstPair {integer} {list data} tup
-            in ifThenElse
-                 {unit -> Maybe a} (equalsInteger index 0)
-                 (\(ds : unit) ->
-                    let !arg : data
-                          = headList {data} (sndPair {integer} {list data} tup)
-                    in Just {a} (dUnsafeFromData arg))
+                 let
+                   !thunk : unit
+                     = let
+                       !wild : Unit = trace {Unit} reconstructCaseError Unit
+                     in
+                     unitval
+                 in
+                 error {Maybe a})
+              unitval)
+         unitval)
+     (\(d : data) ->
+        let
+          !tup : pair integer (list data) = unConstrData d
+          ~t : list data = sndPair {integer} {list data} tup
+          ~t : list data = tailList {data} t
+          !index : integer = fstPair {integer} {list data} tup
+        in
+        ifThenElse
+          {unit -> Tuple3 Bool integer Bool}
+          (equalsInteger index 0)
+          (\(ds : unit) ->
+             let
+               !arg : data = headList {data} t
+               !arg : data = headList {data} t
+               !arg : data = headList {data} (tailList {data} t)
+             in
+             Tuple3
+               {Bool}
+               {integer}
+               {Bool}
+               (let
+                 !tup : pair integer (list data) = unConstrData arg
+                 !index : integer = fstPair {integer} {list data} tup
+               in
+               ifThenElse
+                 {unit -> Bool}
+                 (equalsInteger index 1)
+                 (\(ds : unit) -> True)
                  (\(ds : unit) ->
                     ifThenElse
-                      {unit -> Maybe a} (equalsInteger index 1) (\(ds : unit) ->
-                                                                   Nothing {a})
+                      {unit -> Bool}
+                      (equalsInteger index 0)
+                      (\(ds : unit) -> False)
                       (\(ds : unit) ->
-                         let !thunk : unit
-                               = let !wild : Unit
-                                       = trace {Unit} reconstructCaseError Unit
-                                 in unitval
-                         in error {Maybe a}) unitval) unitval)
-        (\(d : data) ->
-           let !tup : pair integer (list data) = unConstrData d
-               ~t : list data = sndPair {integer} {list data} tup
-               ~t : list data = tailList {data} t
-               !index : integer = fstPair {integer} {list data} tup
-           in ifThenElse
-                {unit -> Tuple3 Bool integer Bool} (equalsInteger index 0)
-                (\(ds : unit) ->
-                   let !arg : data = headList {data} t
-                       !arg : data = headList {data} t
-                       !arg : data = headList {data} (tailList {data} t)
-                   in Tuple3
-                        {Bool} {integer} {Bool}
-                        (let !tup : pair integer (list data) = unConstrData arg
-                             !index : integer
-                               = fstPair {integer} {list data} tup
-                         in ifThenElse
-                              {unit -> Bool} (equalsInteger index 1)
-                              (\(ds : unit) -> True)
-                              (\(ds : unit) ->
-                                 ifThenElse
-                                   {unit -> Bool} (equalsInteger index 0)
-                                   (\(ds : unit) -> False)
-                                   (\(ds : unit) ->
-                                      let !thunk : unit
-                                            = let !wild : Unit
-                                                    = trace
-                                                        {Unit}
-                                                        reconstructCaseError
-                                                        Unit
-                                              in unitval
-                                      in error {Bool}) unitval) unitval)
-                        (unIData arg)
-                        (let !tup : pair integer (list data) = unConstrData arg
-                             !index : integer
-                               = fstPair {integer} {list data} tup
-                         in ifThenElse
-                              {unit -> Bool} (equalsInteger index 1)
-                              (\(ds : unit) -> True)
-                              (\(ds : unit) ->
-                                 ifThenElse
-                                   {unit -> Bool} (equalsInteger index 0)
-                                   (\(ds : unit) -> False)
-                                   (\(ds : unit) ->
-                                      let !thunk : unit
-                                            = let !wild : Unit
-                                                    = trace
-                                                        {Unit}
-                                                        reconstructCaseError
-                                                        Unit
-                                              in unitval
-                                      in error {Bool}) unitval) unitval))
-                (\(ds : unit) ->
-                   let !thunk : unit
-                         = let !wild : Unit
+                         let
+                           !thunk : unit
+                             = let
+                               !wild : Unit
                                  = trace {Unit} reconstructCaseError Unit
-                           in unitval
-                   in error {Tuple3 Bool integer Bool}) unitval))
-     ((let b = Maybe (Tuple3 Bool integer Bool) in \(dToData
-                                                    : (\a -> a -> data) integer)
-                                                    (dToData
-                                                    : (\a -> a -> data) b) (ds
-                                                    : Either integer b) ->
-                                                     Either_match
-                                                       {integer} {b} ds {data}
-                                                       (\(arg : integer) ->
-                                                          constrData
-                                                            0 (mkCons
-                                                                 {data} (dToData
-                                                                           arg)
-                                                                 (mkNilData
-                                                                    unitval)))
-                                                       (\(arg : b) ->
-                                                          constrData
-                                                            1 (mkCons
-                                                                 {data} (dToData
-                                                                           arg)
-                                                                 (mkNilData
-                                                                    unitval))))
-        (\(i : integer) -> iData i) ((let a = Tuple3 Bool integer Bool
-                                      in \(dToData : (\a -> a -> data) a) (ds
-                                          : Maybe a) ->
-                                           Maybe_match
-                                             {a} ds {all dead. data}
-                                             (\(arg : a) ->
-                                                /\dead ->
-                                                  constrData
-                                                    0 (mkCons
-                                                         {data} (dToData arg)
-                                                         (mkNilData unitval)))
-                                             (/\dead ->
-                                                constrData
-                                                  1 (mkNilData unitval))
-                                             {all dead. dead})
-                                       (\(w : Tuple3 Bool integer Bool) ->
-                                          Tuple3_match
-                                            {Bool} {integer} {Bool} w {data}
-                                            (\(ww : Bool) (ww : integer) (ww
-                                              : Bool) ->
-                                               constrData
-                                                 0 (mkCons
-                                                      {data}
-                                                      (Bool_match
-                                                         ww {all dead. data}
-                                                         (/\dead ->
-                                                            constrData
-                                                              1 (mkNilData
-                                                                   unitval))
-                                                         (/\dead ->
-                                                            constrData
-                                                              0 (mkNilData
-                                                                   unitval))
-                                                         {all dead. dead})
-                                                      (mkCons
-                                                         {data} (iData ww)
-                                                         (mkCons
-                                                            {data}
-                                                            (Bool_match
-                                                               ww
-                                                               {all dead. data}
-                                                               (/\dead ->
-                                                                  constrData
-                                                                    1
-                                                                    (mkNilData
-                                                                       unitval))
-                                                               (/\dead ->
-                                                                  constrData
-                                                                    0
-                                                                    (mkNilData
-                                                                       unitval))
-                                                               {all dead. dead})
-                                                            (mkNilData
-                                                               unitval)))))))
-        (Right
-           {integer} {Maybe (Tuple3 Bool integer Bool)}
-           (Just
-              {Tuple3 Bool integer Bool} (Tuple3
-                                            {Bool} {integer} {Bool} True 1
-                                            False))))
+                             in
+                             unitval
+                         in
+                         error {Bool})
+                      unitval)
+                 unitval)
+               (unIData arg)
+               (let
+                 !tup : pair integer (list data) = unConstrData arg
+                 !index : integer = fstPair {integer} {list data} tup
+               in
+               ifThenElse
+                 {unit -> Bool}
+                 (equalsInteger index 1)
+                 (\(ds : unit) -> True)
+                 (\(ds : unit) ->
+                    ifThenElse
+                      {unit -> Bool}
+                      (equalsInteger index 0)
+                      (\(ds : unit) -> False)
+                      (\(ds : unit) ->
+                         let
+                           !thunk : unit
+                             = let
+                               !wild : Unit
+                                 = trace {Unit} reconstructCaseError Unit
+                             in
+                             unitval
+                         in
+                         error {Bool})
+                      unitval)
+                 unitval))
+          (\(ds : unit) ->
+             let
+               !thunk : unit
+                 = let
+                   !wild : Unit = trace {Unit} reconstructCaseError Unit
+                 in
+                 unitval
+             in
+             error {Tuple3 Bool integer Bool})
+          unitval))
+  ((let
+       b = Maybe (Tuple3 Bool integer Bool)
+     in
+     \(dToData : (\a -> a -> data) integer)
+      (dToData : (\a -> a -> data) b)
+      (ds : Either integer b) ->
+       Either_match
+         {integer}
+         {b}
+         ds
+         {data}
+         (\(arg : integer) ->
+            constrData 0 (mkCons {data} (dToData arg) (mkNilData unitval)))
+         (\(arg : b) ->
+            constrData 1 (mkCons {data} (dToData arg) (mkNilData unitval))))
+     (\(i : integer) -> iData i)
+     ((let
+          a = Tuple3 Bool integer Bool
+        in
+        \(dToData : (\a -> a -> data) a)
+         (ds : Maybe a) ->
+          Maybe_match
+            {a}
+            ds
+            {all dead. data}
+            (\(arg : a) ->
+               /\dead ->
+                 constrData 0 (mkCons {data} (dToData arg) (mkNilData unitval)))
+            (/\dead -> constrData 1 (mkNilData unitval))
+            {all dead. dead})
+        (\(w : Tuple3 Bool integer Bool) ->
+           Tuple3_match
+             {Bool}
+             {integer}
+             {Bool}
+             w
+             {data}
+             (\(ww : Bool)
+               (ww : integer)
+               (ww : Bool) ->
+                constrData
+                  0
+                  (mkCons
+                     {data}
+                     (Bool_match
+                        ww
+                        {all dead. data}
+                        (/\dead -> constrData 1 (mkNilData unitval))
+                        (/\dead -> constrData 0 (mkNilData unitval))
+                        {all dead. dead})
+                     (mkCons
+                        {data}
+                        (iData ww)
+                        (mkCons
+                           {data}
+                           (Bool_match
+                              ww
+                              {all dead. data}
+                              (/\dead -> constrData 1 (mkNilData unitval))
+                              (/\dead -> constrData 0 (mkNilData unitval))
+                              {all dead. dead})
+                           (mkNilData unitval)))))))
+     (Right
+        {integer}
+        {Maybe (Tuple3 Bool integer Bool)}
+        (Just
+           {Tuple3 Bool integer Bool}
+           (Tuple3 {Bool} {integer} {Bool} True 1 False))))


### PR DESCRIPTION
This fixes some things I didn't like about the readable PIR prettyprinting, notably:
- Bindings in lets were always indented at least as far as the `let`/`letrec`. If we break immediately we can consistently indent them at most 2 spaces.
- The body of a let was not broken vertically when the rest of the let was, which seemed inconsistent to me.
- Arguments in applications and bindings were laid out with `fillSep`, which led to weird behaviour especially when one of the later items was itself substantial and needed to break. If we just do the boring thing and use `vsep` then we get IMO simpler and more readable output.
- When we split a variable declaration, the second part went at the same indentation level, which looked odd.
