### PR TITLE
PLT-1458: Propagate budget from debug driver to client

### DIFF
--- a/plutus-core/changelog.d/20230228_215517_bezirg_dbg_budget.md
+++ b/plutus-core/changelog.d/20230228_215517_bezirg_dbg_budget.md
@@ -1,0 +1,5 @@
+### Added
+
+- The debugger TUI updates live the currently spent CPU&MEM resources of the debugged program.
+- The debugger TUI accepts a `--budget` to limit the CPU&MEM resources of the debugged program.
+

--- a/plutus-core/executables/debugger/Draw.hs
+++ b/plutus-core/executables/debugger/Draw.hs
@@ -4,6 +4,8 @@
 -- | Renders the debugger in the terminal.
 module Draw where
 
+import PlutusPrelude (render)
+
 import Types
 
 import Brick.AttrMap qualified as B
@@ -18,6 +20,7 @@ import Data.Maybe
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Lens.Micro
+import Prettyprinter hiding (line)
 
 drawDebugger ::
     DebuggerState ->
@@ -57,12 +60,20 @@ drawDebugger st =
                 focusRing
                 (BE.renderEditor (B.txt . Text.unlines))
                 (st ^. dsLogsEditor)
+    budgetTxt = B.hBox
+        [ prettyTxt "Spent:" (st ^. dsBudgetData . budgetSpent)
+          -- do not show Remaining in absence of `--budget`
+        , maybe B.emptyWidget (prettyTxt "Remaining:") (st ^. dsBudgetData . budgetRemaining)
+        ]
+    prettyTxt title = B.txt . render . group . (title <>) . pretty
+
     ui =
         B.vBox
             [ BC.center uplcEditor B.<+> B.hLimit (st ^. dsHLimitRightEditors) sourceEditor
             , B.vLimit (st ^. dsVLimitBottomEditors) $
                 BC.center returnValueEditor B.<+>
                     B.hLimit (st ^. dsHLimitRightEditors) logsEditor
+            , budgetTxt
             , footer
             ]
 

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudget.hs
@@ -211,5 +211,4 @@ newtype ExRestrictingBudget = ExRestrictingBudget
 -- | When we want to just evaluate the program we use the 'Restricting' mode with an enormous
 -- budget, so that evaluation costs of on-chain budgeting are reflected accurately in benchmarks.
 enormousBudget :: ExRestrictingBudget
-enormousBudget = ExRestrictingBudget $ ExBudget (ExCPU maxInt) (ExMemory maxInt)
-                 where maxInt = fromIntegral (maxBound ::Int)
+enormousBudget = ExRestrictingBudget $ ExBudget maxBound maxBound

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -104,7 +104,7 @@ type CostingInteger = SatInt
 -- | Counts size in machine words.
 newtype ExMemory = ExMemory CostingInteger
   deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving newtype (Num, NFData)
+  deriving newtype (Num, NFData, Read, Bounded)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
   deriving Serialise via CostingInteger
@@ -118,7 +118,7 @@ instance PrettyBy config ExMemory where
 -- appproximately 106 days.
 newtype ExCPU = ExCPU CostingInteger
   deriving stock (Eq, Ord, Show, Generic, Lift)
-  deriving newtype (Num, NFData)
+  deriving newtype (Num, NFData, Read, Bounded)
   deriving (Semigroup, Monoid) via (Sum CostingInteger)
   deriving (FromJSON, ToJSON) via CostingInteger
   deriving Serialise via CostingInteger


### PR DESCRIPTION
This adds a "footer" text of `Spent:({cpu: i | mem: j })Remaining:({cpu: N | mem: M})`                                                                                                                                                                                                                                                                                                            
and an optional cli argument `--budget=cpu,mem` to limit resources. If limit not passed, `Remaining:` is not shown.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
