### PR TITLE
PLT-1611: Fix Interval for discrete intervals

### DIFF
--- a/plutus-ledger-api/changelog.d/20230302_163021_michael.peyton-jones_fix_interval.md
+++ b/plutus-ledger-api/changelog.d/20230302_163021_michael.peyton-jones_fix_interval.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed numerous bugs in the behaviour of `Interval`s with open endpoints.

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -138,7 +138,7 @@ test-suite plutus-ledger-api-test
 
   build-depends:
     , barbies
-    , base                       >=4.9 && <5
+    , base                                                              >=4.9 && <5
     , bytestring
     , containers
     , extra
@@ -146,9 +146,9 @@ test-suite plutus-ledger-api-test
     , lens
     , mtl
     , nothunks
-    , plutus-core                ^>=1.2
-    , plutus-ledger-api          ^>=1.2
-    , plutus-ledger-api-testlib  ^>=1.2
+    , plutus-core                                                       ^>=1.2
+    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.2
+    , plutus-tx:plutus-tx-testlib                                       ^>=1.2
     , tasty
     , tasty-hedgehog
     , tasty-hunit

--- a/plutus-ledger-api/test/Spec/Interval.hs
+++ b/plutus-ledger-api/test/Spec/Interval.hs
@@ -6,14 +6,45 @@
 module Spec.Interval where
 
 import Data.List (sort)
+import Data.Maybe (fromJust)
+import Data.Set qualified as Set
 import Hedgehog (Property, forAll, property)
 import Hedgehog qualified
 import Hedgehog.Gen qualified as Gen
+import Hedgehog.Laws.Eq
+import Hedgehog.Laws.Lattice
+import Hedgehog.Laws.Ord
 import Hedgehog.Range qualified as Range
 import PlutusLedgerApi.V1.Interval qualified as Interval
+import PlutusPrelude (reoption)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Hedgehog (testPropertyNamed)
+import Test.Tasty.Hedgehog (testProperty)
 import Test.Tasty.HUnit (assertBool, testCase)
+
+-- TODO: maybe bias towards generating non-empty intervals?
+
+genExtended :: Bool -> Hedgehog.Gen a -> Hedgehog.Gen (Interval.Extended a)
+genExtended finite g =
+  if finite
+  then Interval.Finite <$> g
+  else Gen.choice [ Interval.Finite <$> g, pure Interval.NegInf, pure Interval.PosInf ]
+
+genLowerBound :: Bool -> Hedgehog.Gen a -> Hedgehog.Gen (Interval.LowerBound a)
+genLowerBound finite g = Interval.LowerBound <$> genExtended finite g <*> Gen.bool
+
+genUpperBound :: Bool -> Hedgehog.Gen a -> Hedgehog.Gen (Interval.UpperBound a)
+genUpperBound finite g = Interval.UpperBound <$> genExtended finite g <*> Gen.bool
+
+genInterval :: Bool -> Hedgehog.Gen a -> Hedgehog.Gen (Interval.Interval a)
+genInterval finite g = Interval.Interval <$> genLowerBound finite g <*> genUpperBound finite g
+
+genFiniteDiscreteInterval :: Hedgehog.Gen (Interval.Interval Integer)
+genFiniteDiscreteInterval = genInterval True (Gen.integral (toInteger <$> Range.linear @Int 0 100))
+
+genDiscreteInterval :: Hedgehog.Gen (Interval.Interval Integer)
+genDiscreteInterval = genInterval False (Gen.integral (toInteger <$> Range.linear @Int 0 100))
+
+-- Unit tests
 
 alwaysIsNotEmpty :: TestTree
 alwaysIsNotEmpty =
@@ -36,6 +67,8 @@ openOverlaps =
     let a = Interval.Interval (Interval.strictLowerBound 1) (Interval.strictUpperBound 5) :: Interval.Interval Integer
         b = Interval.Interval (Interval.strictLowerBound 4) (Interval.strictUpperBound 6) :: Interval.Interval Integer
     in assertBool "overlaps" (not $ Interval.overlaps a b)
+
+-- Property tests
 
 intvlIsEmpty :: Property
 intvlIsEmpty = property $ do
@@ -62,17 +95,6 @@ intvlIntersection = property $ do
   Hedgehog.assert $ intersec == inner
   Hedgehog.assert $ intersec2 == common
 
-intvlIntersectionWithAlwaysNever :: Property
-intvlIntersectionWithAlwaysNever = property $ do
-  (i1, i2) <- forAll $ (,) <$> Gen.integral (toInteger <$> Range.linearBounded @Int) <*> Gen.integral (toInteger <$> Range.linearBounded @Int)
-  let (from, to) = (min i1 i2, max i1 i2)
-      i = Interval.interval from to
-      e = Interval.interval to from
-
-  Hedgehog.assert $ Interval.never == i `Interval.intersection` Interval.never
-  Hedgehog.assert $ i == i `Interval.intersection` Interval.always
-  Hedgehog.assert $ e == e `Interval.intersection` i
-
 intvlOverlaps :: Property
 intvlOverlaps = property $ do
   (i1, i2) <- forAll $ (,) <$> Gen.integral (toInteger <$> Range.linearBounded @Int) <*> Gen.integral (toInteger <$> Range.linearBounded @Int)
@@ -83,16 +105,105 @@ intvlOverlaps = property $ do
   Hedgehog.assert $ Interval.always `Interval.overlaps` i
   Hedgehog.assert $ not $ Interval.never `Interval.overlaps` i
 
+{- Set model tests
+
+We can give a semantic model for a finite (inded small), discrete interval in terms of the set of
+values that are in the interval. We can easily perform many operations at the semantic level, including
+equality, intersection, etc. This allows us to check that our implementation of intervals is
+implementing the semantically correct behaviour.
+-}
+
+lowerBoundToValue :: Enum a => Interval.LowerBound a -> Maybe a
+lowerBoundToValue (Interval.LowerBound (Interval.Finite b) inclusive) = Just $ if inclusive then b else succ b
+lowerBoundToValue _                                                   = Nothing
+
+upperBoundToValue :: Enum a => Interval.UpperBound a -> Maybe a
+upperBoundToValue (Interval.UpperBound (Interval.Finite b) inclusive) = Just $ if inclusive then b else pred b
+upperBoundToValue _                                                   = Nothing
+
+intervalToSet :: (Ord a, Enum a) => Interval.Interval a -> Maybe (Set.Set a)
+intervalToSet (Interval.Interval lb ub) = Set.fromList <$> (enumFromTo <$> lowerBoundToValue lb <*> upperBoundToValue ub)
+
+setToInterval :: Set.Set a -> Interval.Interval a
+setToInterval st | Set.null st = Interval.Interval (Interval.LowerBound Interval.PosInf True) (Interval.UpperBound Interval.NegInf True)
+setToInterval st = Interval.Interval (Interval.LowerBound (Interval.Finite (Set.findMin st)) True) (Interval.UpperBound (Interval.Finite (Set.findMax st)) True)
+
+prop_intervalSetTripping :: Property
+prop_intervalSetTripping = property $ do
+  ivl <- forAll genFiniteDiscreteInterval
+  Hedgehog.tripping ivl (fromJust . intervalToSet) (Just . setToInterval)
+
+prop_intervalSetEquals :: Property
+prop_intervalSetEquals = property $ do
+  ivl1 <- forAll genFiniteDiscreteInterval
+  ivl2 <- forAll genFiniteDiscreteInterval
+  s1 <- reoption $ intervalToSet ivl1
+  s2 <- reoption $ intervalToSet ivl2
+  Hedgehog.annotateShow s1
+  Hedgehog.annotateShow s2
+  let
+    c1 = ivl1 == ivl2
+    c2 = s2 == s1
+  Hedgehog.cover 10 "True" $ c1
+  Hedgehog.cover 10 "False" $ not c1
+  c1 Hedgehog.=== c2
+
+prop_intervalSetContains :: Property
+prop_intervalSetContains = property $ do
+  ivl1 <- forAll genFiniteDiscreteInterval
+  ivl2 <- forAll genFiniteDiscreteInterval
+  s1 <- reoption $ intervalToSet ivl1
+  s2 <- reoption $ intervalToSet ivl2
+  Hedgehog.annotateShow s1
+  Hedgehog.annotateShow s2
+  let
+    c1 = ivl1 `Interval.contains` ivl2
+    c2 = s2 `Set.isSubsetOf` s1
+  Hedgehog.cover 30 "True" $ c1
+  Hedgehog.cover 30 "False" $ not c1
+  c1 Hedgehog.=== c2
+
+prop_intervalSetIntersection :: Property
+prop_intervalSetIntersection = property $ do
+  ivl1 <- forAll genFiniteDiscreteInterval
+  ivl2 <- forAll genFiniteDiscreteInterval
+  let iv3 = ivl1 `Interval.intersection` ivl2
+  s0 <- reoption $ intervalToSet iv3
+
+  s1 <- reoption $ intervalToSet ivl1
+  s2 <- reoption $ intervalToSet ivl2
+  let s3 = s1 `Set.intersection` s2
+
+  -- Just need some coverage of the interesting case
+  Hedgehog.cover 5 "Non-trivial" $ not $ Set.null s3
+
+  Hedgehog.annotateShow s0
+  Hedgehog.annotateShow s1
+  Hedgehog.annotateShow s2
+  Hedgehog.annotateShow s3
+
+  s0 Hedgehog.=== s3
+
 tests :: TestTree
 tests =
   testGroup
-    "plutus-ledger-api-interval"
+    "Interval"
     [ neverIsEmpty
     , alwaysIsNotEmpty
     , openIsEmpty
     , openOverlaps
-    , testPropertyNamed "interval intersection" "intvIntersection" intvlIntersection
-    , testPropertyNamed "interval intersection with always/never" "intvlIntersectionWithAlwaysNever" intvlIntersectionWithAlwaysNever
-    , testPropertyNamed "interval isEmpty" "intvlIsEmpty" intvlIsEmpty
-    , testPropertyNamed "interval overlaps" "intvlOverlaps" intvlOverlaps
+    , eqLaws genDiscreteInterval
+    , partialOrderLaws genDiscreteInterval Interval.contains
+    , boundedLatticeLaws genDiscreteInterval
+    , testGroup "properties"
+      [ testProperty "intersection" intvlIntersection
+      , testProperty "isEmpty" intvlIsEmpty
+      , testProperty "overlaps" intvlOverlaps
+      ]
+    , testGroup "set model"
+      [ testProperty "tripping" prop_intervalSetTripping
+      , testProperty "equals" prop_intervalSetEquals
+      , testProperty "contains" prop_intervalSetContains
+      , testProperty "intersection" prop_intervalSetIntersection
+      ]
     ]

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -119,11 +119,18 @@ library plutus-tx-testlib
   import:          lang
   visibility:      public
   hs-source-dirs:  testlib
-  exposed-modules: PlutusTx.Test
+  exposed-modules:
+    Hedgehog.Laws.Common
+    Hedgehog.Laws.Eq
+    Hedgehog.Laws.Lattice
+    Hedgehog.Laws.Ord
+    PlutusTx.Test
+
   build-depends:
     , base                                                       >=4.9 && <5
     , filepath
     , flat                                                       <0.5
+    , hedgehog
     , lens
     , mtl
     , plutus-core:{plutus-core, plutus-core-testlib, plutus-ir}  ^>=1.2
@@ -131,6 +138,7 @@ library plutus-tx-testlib
     , prettyprinter
     , tagged
     , tasty
+    , tasty-hedgehog
     , text
 
 test-suite plutus-tx-test

--- a/plutus-tx/src/PlutusTx/Enum.hs
+++ b/plutus-tx/src/PlutusTx/Enum.hs
@@ -12,9 +12,15 @@ import PlutusTx.Trace
 
 -- | Class 'Enum' defines operations on sequentially ordered types.
 class Enum a where
-  -- | the successor of a value.  For numeric types, 'succ' adds 1.
+  -- | The successor of a value.  For numeric types, 'succ' adds 1.
+  --
+  -- For types that implement 'Ord', @succ x@ should be the least element
+  -- that is greater than @x@, and 'error' if there is none.
   succ :: a -> a
-  -- | the predecessor of a value.  For numeric types, 'pred' subtracts 1.
+  -- | The predecessor of a value.  For numeric types, 'pred' subtracts 1.
+  --
+  -- For types that implement 'Ord', @pred x@ should be the greatest element
+  -- that is less than @x@, and 'error' if there is none.
   pred :: a -> a
   -- | Convert from an 'Integer'.
   toEnum :: Integer -> a

--- a/plutus-tx/testlib/Hedgehog/Laws/Common.hs
+++ b/plutus-tx/testlib/Hedgehog/Laws/Common.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Hedgehog.Laws.Common where
+
+import Hedgehog (Property, cover, forAll, property)
+import Hedgehog qualified
+import Prelude
+
+implies :: Bool -> Bool -> Bool
+implies x y = not x || y
+
+prop_idempotent :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> a) -> Property
+prop_idempotent g op = property $ do
+  x <- forAll g
+  x `op` x Hedgehog.=== x
+
+prop_commutative :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> a) -> Property
+prop_commutative g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  cover 10 "different" $ x /= y
+  cover 5 "same" $ x == y
+  x `op` y Hedgehog.=== y `op` x
+
+prop_associative :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> a) -> Property
+prop_associative g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  z <- forAll g
+  cover 10 "different" $ x /= y && y /= z
+  cover 5 "same" $ x == y || y == z || z == x
+  (x `op` y) `op` z Hedgehog.=== x `op` (y `op` z)
+
+prop_unit :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> a) -> a -> Property
+prop_unit g op unit = property $ do
+  x <- forAll g
+  cover 10 "different" $ x /= unit
+  x `op` unit Hedgehog.=== x
+
+prop_reflexive :: (Show a) => Hedgehog.Gen a -> (a -> a -> Bool) -> Property
+prop_reflexive g op = property $ do
+  x <- forAll g
+  x `op` x Hedgehog.=== True
+
+prop_symmetric :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> Bool) -> Property
+prop_symmetric g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  cover 10 "different" $ x /= y
+  cover 5 "same" $ x == y
+  x `op` y Hedgehog.=== y `op` x
+
+prop_transitive :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> Bool) -> Property
+prop_transitive g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  z <- forAll g
+  cover 10 "different" $ x /= y && y /= z
+  cover 5 "same" $ x == y || y == z || z == x
+  Hedgehog.assert $ (x `op` y && y `op` z) `implies` (x `op` z)
+
+prop_antisymmetric :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> Bool) -> Property
+prop_antisymmetric g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  cover 10 "different" $ x /= y
+  cover 5 "same" $ x == y
+  Hedgehog.assert $ (x `op` y && y `op` x) `implies` (x == y)
+
+prop_total :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> Bool) -> Property
+prop_total g op = property $ do
+  x <- forAll g
+  y <- forAll g
+  cover 10 "different" $ x /= y
+  cover 5 "same" $ x == y
+  Hedgehog.assert $ x `op` y || y `op` x

--- a/plutus-tx/testlib/Hedgehog/Laws/Eq.hs
+++ b/plutus-tx/testlib/Hedgehog/Laws/Eq.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Hedgehog.Laws.Eq where
+
+import Hedgehog qualified
+import Hedgehog.Laws.Common
+import Prelude
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+eqLaws :: (Show a, Eq a) => Hedgehog.Gen a -> TestTree
+eqLaws g = testGroup "equivalence relation laws"
+  [ testProperty "reflexive" (prop_reflexive g (==))
+  , testProperty "symmetric" (prop_symmetric g (==))
+  , testProperty "transitive" (prop_transitive g (==))
+  ]

--- a/plutus-tx/testlib/Hedgehog/Laws/Lattice.hs
+++ b/plutus-tx/testlib/Hedgehog/Laws/Lattice.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Hedgehog.Laws.Lattice where
+
+import Hedgehog (Property, cover, forAll, property)
+import Hedgehog qualified
+import Hedgehog.Laws.Common
+import PlutusTx.Lattice
+import Prelude
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+joinLatticeLaws :: (Show a, Eq a, JoinSemiLattice a) => Hedgehog.Gen a -> TestTree
+joinLatticeLaws g = testGroup "join semilattice laws"
+  [ testProperty "idempotent" (prop_idempotent g (\/))
+  , testProperty "commutative" (prop_commutative g (\/))
+  , testProperty "associative" (prop_associative g (\/))
+  ]
+
+boundedJoinLatticeLaws :: (Show a, Eq a, BoundedJoinSemiLattice a) => Hedgehog.Gen a -> TestTree
+boundedJoinLatticeLaws g = testGroup "bounded join semilattice laws"
+  [ joinLatticeLaws g
+  , testProperty "unit" (prop_unit g (\/) bottom)
+  ]
+
+meetLatticeLaws :: (Show a, Eq a, MeetSemiLattice a) => Hedgehog.Gen a -> TestTree
+meetLatticeLaws g = testGroup "meet semilattice laws"
+  [ testProperty "idempotent" (prop_idempotent g (/\))
+  , testProperty "commutative" (prop_commutative g (/\))
+  , testProperty "associative" (prop_associative g (/\))
+  ]
+
+boundedMeetLatticeLaws :: (Show a, Eq a, BoundedMeetSemiLattice a) => Hedgehog.Gen a -> TestTree
+boundedMeetLatticeLaws g = testGroup "bounded meet semilattice laws"
+  [ meetLatticeLaws g
+  , testProperty "unit" (prop_unit g (/\) top)
+  ]
+
+prop_latticeAbsorb :: (Show a, Eq a, Lattice a) => Hedgehog.Gen a -> Property
+prop_latticeAbsorb g = property $ do
+  x <- forAll g
+  y <- forAll g
+  cover 10 "different" $ x /= y
+  x \/ (x /\ y) Hedgehog.=== x
+  x /\ (x \/ y) Hedgehog.=== x
+
+latticeLaws :: (Show a, Eq a, Lattice a) => Hedgehog.Gen a -> TestTree
+latticeLaws g = testGroup "lattice laws"
+  [ joinLatticeLaws g
+  , meetLatticeLaws g
+  , testProperty "absorption" (prop_latticeAbsorb g)
+  ]
+
+boundedLatticeLaws :: (Show a, Eq a, BoundedLattice a) => Hedgehog.Gen a -> TestTree
+boundedLatticeLaws g = testGroup "bounded lattice laws"
+  [ boundedJoinLatticeLaws g
+  , boundedMeetLatticeLaws g
+  , testProperty "absorption" (prop_latticeAbsorb g)
+  ]

--- a/plutus-tx/testlib/Hedgehog/Laws/Ord.hs
+++ b/plutus-tx/testlib/Hedgehog/Laws/Ord.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Hedgehog.Laws.Ord where
+
+import Hedgehog qualified
+import Hedgehog.Laws.Common
+import Prelude
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+-- There is no typeclass for this, sadly
+partialOrderLaws :: (Show a, Eq a) => Hedgehog.Gen a -> (a -> a -> Bool) -> TestTree
+partialOrderLaws g op = testGroup "partial ordering laws"
+  [ testProperty "reflexive" (prop_reflexive g op)
+  , testProperty "transitive" (prop_transitive g op)
+  , testProperty "antisymmetric" (prop_antisymmetric g op)
+  ]
+
+ordLaws :: (Show a, Ord a) => Hedgehog.Gen a -> TestTree
+ordLaws g = testGroup "total ordering laws"
+  [ partialOrderLaws g (<=)
+  , testProperty "total" (prop_total g (<=))
+  ]
+


### PR DESCRIPTION
`Interval` was not in a good place. It violated a bunch of laws. The first thing this PR does is add a bunch more tests:
- Generic tests for the typeclasses that `Interval` has instances of.
- Some specific tests that test that finite intervals behave the same as sets of consecutive numbers.

The latter gives us a "semantic" test that lets us check whether our operations on intervals are doing the right thing with respect to a model - in this case the model is the set of values that fall into the inteval.

Then we need to actually fix `Interval`. The most straightforward solution I could see is just to restrict most of its operations to intervals on enumerable types. That lets us turn non-inclusive bounds into inclusive bounds, which simplifies things a lot. Without that information, we can't easily even tell if e.g. an interval is empty or not.

Arguably we should just have never had non-inclusive bounds in the first place and it's unnecessary generality. However, I think changing that now would be more disruptive than it is worth.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
