### PR TITLE
PLT-1539: Remove Plutus Tx functions with Haskell.Monad constraint

### DIFF
--- a/plutus-benchmark/ed25519-throughput/Main.hs
+++ b/plutus-benchmark/ed25519-throughput/Main.hs
@@ -25,7 +25,7 @@ import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
 import PlutusTx.IsData (toData, unstableMakeIsData)
-import PlutusTx.Prelude as Tx hiding (sort, (*))
+import PlutusTx.Prelude as Tx hiding (sort, traverse_, (*))
 
 import Cardano.Crypto.DSIGN.Class (ContextDSIGN, DSIGNAlgorithm, Signable, deriveVerKeyDSIGN, genKeyDSIGN,
                                    rawSerialiseSigDSIGN, rawSerialiseVerKeyDSIGN, signDSIGN)
@@ -35,6 +35,7 @@ import Cardano.Crypto.Seed (mkSeedFromBytes)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Hash qualified as Hash
+import Data.Foldable (traverse_)
 import Flat qualified
 import Hedgehog.Internal.Gen qualified as G
 import Hedgehog.Internal.Range qualified as R
@@ -217,4 +218,4 @@ main = do
   testHaskell 100
   printf "    n     script size             CPU usage               Memory usage\n"
   printf "  ----------------------------------------------------------------------\n"
-  mapM_ printStatistics [0, 10..150]
+  traverse_ printStatistics [0, 10..150]

--- a/plutus-benchmark/nofib/exe/Main.hs
+++ b/plutus-benchmark/nofib/exe/Main.hs
@@ -12,6 +12,7 @@ import Control.Monad ()
 import Control.Monad.Trans.Except (runExceptT)
 import Data.ByteString qualified as BS
 import Data.Char (isSpace)
+import Data.Foldable (traverse_)
 import Flat qualified
 import Options.Applicative as Opt hiding (action)
 import System.Exit (exitFailure)
@@ -35,7 +36,7 @@ import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (..), ExMemory (..))
 import PlutusCore.Pretty (prettyPlcClassicDebug)
 import PlutusTx (getPlcNoAnn)
 import PlutusTx.Code (CompiledCode, sizePlc)
-import PlutusTx.Prelude hiding (fmap, mappend, (<$), (<$>), (<*>), (<>))
+import PlutusTx.Prelude hiding (fmap, mappend, traverse_, (<$), (<$>), (<*>), (<>))
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
@@ -296,7 +297,7 @@ printSizesAndBudgets = do
 
   putStrLn "Script                     Size     CPU budget      Memory budget"
   putStrLn "-----------------------------------------------------------------"
-  mapM_ (putStr . formatInfo) statistics
+  traverse_ (putStr . formatInfo) statistics
 
 
 main :: IO ()
@@ -314,7 +315,7 @@ main = do
           Primetest n             -> if n<0 then Hs.error "Positive number expected"
                                      else print $ Prime.runPrimalityTest n
     DumpPLC pa ->
-        Hs.mapM_ putStrLn $ unindent . prettyPlcClassicDebug . UPLC.mkDefaultProg . getTerm $ pa
+        traverse_ putStrLn $ unindent . prettyPlcClassicDebug . UPLC.mkDefaultProg . getTerm $ pa
             where unindent d = map (dropWhile isSpace) $ (Hs.lines . Hs.show $ d)
     DumpFlatNamed pa ->
         writeFlatNamed . UPLC.mkDefaultProg . getTerm $ pa

--- a/plutus-tx/changelog.d/20230307_151002_unsafeFixIO_haskell_monad.md
+++ b/plutus-tx/changelog.d/20230307_151002_unsafeFixIO_haskell_monad.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed Plutus Tx library functions with the `Haskell.Monad` constraint.

--- a/plutus-tx/changelog.d/20230307_151002_unsafeFixIO_haskell_monad.md
+++ b/plutus-tx/changelog.d/20230307_151002_unsafeFixIO_haskell_monad.md
@@ -1,3 +1,8 @@
 ### Removed
 
 - Removed Plutus Tx library functions with the `Haskell.Monad` constraint.
+  Functions requiring `Functor` and `Applicative` are using `PlutusTx.Functor` and
+  `PlutusTx.Applicative`, but those requiring `Monad` were using Haskell's `Monad`, which
+  is inconsistent and confusing. We should either add a `PlutusTx.Monad` class, or switch
+  to Haskell's `Functor` and `Applicative`. Some of these functions like `sequence_` and
+  `mapM_` are also not useful, and one should prefer `sequenceA_` and `traverse_`, respectively.

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -3,18 +3,11 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module PlutusTx.Foldable (
   Foldable(..),
-  -- * Special biased folds
-  foldrM,
-  foldlM,
-  -- * Folding actions
-  -- ** Applicative actions
+  -- * Applicative actions
   traverse_,
   for_,
   sequenceA_,
-  sequence_,
   asum,
-  -- ** Monadic actions
-  mapM_,
   -- * Specialized folds
   concat,
   concatMap,
@@ -137,28 +130,10 @@ sum = foldr (+) zero
 product :: (Foldable t, MultiplicativeMonoid a) => t a -> a
 product = foldr (*) one
 
--- | Plutus Tx version of 'Data.Foldable.foldrM'.
-foldrM :: (Foldable t, Haskell.Monad m) => (a -> b -> m b) -> b -> t a -> m b
-foldrM f z0 xs = foldl c Haskell.return xs z0
-  where c k x z = f x z Haskell.>>= k
-        {-# INLINE c #-}
-
--- | Plutus Tx version of 'Data.Foldable.foldlM'.
-foldlM :: (Foldable t, Haskell.Monad m) => (b -> a -> m b) -> b -> t a -> m b
-foldlM f z0 xs = foldr c Haskell.return xs z0
-  where c x k z = f z x Haskell.>>= k
-        {-# INLINE c #-}
-
 -- | Plutus Tx version of 'Data.Foldable.traverse_'.
 traverse_ :: (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
 traverse_ f = foldr c (pure ())
   where c x k = f x *> k
-        {-# INLINE c #-}
-
--- | Plutus Tx version of 'Data.Foldable.sequence_'.
-sequence_ :: (Foldable t, Haskell.Monad m) => t (m a) -> m ()
-sequence_ = foldr c (Haskell.return ())
-  where c m k = m Haskell.>> k
         {-# INLINE c #-}
 
 -- | Plutus Tx version of 'Data.Foldable.for_'.
@@ -222,10 +197,3 @@ find :: Foldable t => (a -> Bool) -> t a -> Maybe a
 find p = foldr f Nothing
   where
     f a acc = if p a then Just a else acc
-
--- | Plutus Tx version of 'Data.Foldable.mapM_'.
-{-# INLINABLE mapM_ #-}
-mapM_ :: (Foldable t, Haskell.Monad m) => (a -> m b) -> t a -> m ()
-mapM_ f = foldr c (Haskell.return ())
-  where c x k = f x Haskell.>> k
-        {-# INLINE c #-}

--- a/plutus-tx/src/PlutusTx/Foldable.hs
+++ b/plutus-tx/src/PlutusTx/Foldable.hs
@@ -44,8 +44,6 @@ import PlutusTx.Monoid (Monoid (..))
 import PlutusTx.Numeric
 import PlutusTx.Semigroup ((<>))
 
-import Prelude qualified as Haskell (Monad, return, (>>), (>>=))
-
 -- | Plutus Tx version of 'Data.Foldable.Foldable'.
 class Foldable t where
     -- | Plutus Tx version of 'Data.Foldable.foldr'.


### PR DESCRIPTION
I'm fine with removing these to make things look less weird (especially `sequence_` and `mapM_`, which shouldn't be used anyway).

However, I still don't think we need our own `Monad` class. Rather, I'm in favor of removing our `Applicative` and `Functor` classes (and perhaps more) and use the Haskell ones, because.. why not? We don't have any instance of those classes whose definitions differ from the respective Haskell instances.

Some other classes, like `PlutusTx.AdditiveSemigroup`, exist for a good reason (for now): `Integer`'s `PlutusTx.+` differ from its `GHC.Num.+`, and the latter cannot be used ("for now" because they can be made to work in the future). I don't think this applies to `Monad`, `Applicative` and `Functor`.