### PR TITLE
PLT-4256: Expand UPLC inliner comments slightly

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/UnconditionalInline.hs
@@ -109,6 +109,10 @@ So it seems that we're stuck. We can't inline destructors in PIR.
 But we *can* do it in UPLC! No types, so no problem. The type abstraction/instantiation will
 turn into a delay/force pair and get simplified away, and then we have something that we can
 inline. This is essentially the reason for the existence of the UPLC inlining pass.
+
+Note that much the same reasoning applies to constructors also. The main difference
+is that they might not be applied saturated, so it's not _always_ clear that we want to
+inline them. But at least in UPLC we _can_ inline them.
 -}
 
 {- Note [Inlining and global uniqueness]

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -18,7 +18,7 @@ things in sync, these are explicitly listed in Note [Differences from PIR inline
 If you add another difference, please note it there! Obviously fewer differences is
 better.
 
-See Note [The problem of inlining destructors].
+See Note [The problem of inlining destructors] for why this pass exists.
 -}
 module UntypedPlutusCore.Transform.Inline (inline, InlineHints (..)) where
 
@@ -44,6 +44,7 @@ import Data.Semigroup.Generic (GenericSemigroupMonoid (..))
 import Witherable (wither)
 
 {- Note [Differences from PIR inliner]
+See the module comment for explanation for why this exists and is similar to the PIR inliner.
 
 1. No types (obviously).
 2. No strictness information (we only have lambda arguments, which are always strict).


### PR DESCRIPTION
The explanation was already there in fact. The module comment links to a
note that explains why we can only inline destructors in UPLC. I just
added a bit more signposting.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
