### PR TITLE
Fix saturated inline heuristic

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
@@ -307,7 +307,7 @@ maybeAddSubst body ann s n rhs = do
             -- See Note [Inlining approach and 'Secrets of the GHC Inliner'] and [Inlining and
             -- purity]. This is the case where we don't know that the number of occurrences is
             -- exactly one, so there's no point checking if the term is immediately evaluated.
-            let postUnconditional = isBindingPure && acceptable rhs'
+            let postUnconditional = isBindingPure && sizeIsAcceptable rhs' && costIsAcceptable rhs'
             if postUnconditional
             then extendAndDrop (Done $ dupable rhs')
             else pure $ Just rhs'

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
@@ -263,13 +263,6 @@ effectSafe body s n purity = do
         Strict    -> purity || immediatelyEvaluated
         NonStrict -> True
 
--- | Should we inline? Should only inline things that won't duplicate work or code.
--- See Note [Inlining approach and 'Secrets of the GHC Inliner']
-acceptable ::  Term tyname name uni fun ann -> Bool
-acceptable t =
-    -- See Note [Inlining criteria]
-    costIsAcceptable t && sizeIsAcceptable t
-
 {- Note [Inlining criteria]
 What gets inlined? Our goals are simple:
 - Make the resulting program faster (or at least no slower)
@@ -287,6 +280,7 @@ There are a few things we could do to do this in a more principled way, such as 
 based on whether a function is fully applied.
 -}
 
+-- See Note [Inlining criteria]
 -- | Is the cost increase (in terms of evaluation work) of inlining a variable whose RHS is
 -- the given term acceptable?
 costIsAcceptable :: Term tyname name uni fun ann -> Bool
@@ -317,6 +311,7 @@ costIsAcceptable = \case
   TyInst{}   -> False
   Let{}      -> False
 
+-- See Note [Inlining criteria]
 -- | Is the size increase (in the AST) of inlining a variable whose RHS is
 -- the given term acceptable?
 sizeIsAcceptable :: Term tyname name uni fun ann -> Bool


### PR DESCRIPTION
I was looking at this and I realised it's subtly wrong in a way we won't
notice yet, but will be a problem once we start inlining things that are
larger.

Specifically this example:
```
let x = \y. f y in x z
```
Even if we relaxed our size limits, we would currently reject this for
saturated inlinig because we would look at the `f x` and say its cost
was potentially too high. But we were always going to pay that at each
use site anyway! The extra cost is that of evaluating the definition,
i.e. the lambda.

So we have to check the size/cost of two different things. I removed
`acceptable` entirely because I think it's kind of a footgun.

We won't notice this today because anything that we might want to inline
that has non-acceptable cost will also look too big.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
