### PR TITLE
Imperator is outdated, replace with Hebi and OpShin

### DIFF
--- a/doc/read-the-docs-site/simple-example.rst
+++ b/doc/read-the-docs-site/simple-example.rst
@@ -291,8 +291,9 @@ There are languages other than Plutus Tx that can be compiled into Plutus Core.
 We list some of them here for reference. However, we are not endorsing them; we are not representing their qualities nor their state of development regarding their production-readiness. 
 
 * `Aiken <https://github.com/txpipe/aiken/>`_
+* `Hebi <https://github.com/OpShin/hebi>`_
 * `Helios <https://github.com/hyperion-bt/helios>`_
-* `Imperator <https://github.com/ImperatorLang/imperator>`_
+* `OpShin <https://github.com/OpShin/opshin>`_
 * `plu-ts <https://github.com/HarmonicLabs/plu-ts>`_
 * `Plutarch <https://github.com/Plutonomicon/plutarch-core>`_
 * `Pluto <https://github.com/Plutonomicon/pluto>`_


### PR DESCRIPTION
The ImperatorLang framework was recently renamed OpShin. The language "imperator" itself was deprecated and replaced by the imperative language OpShin and the functional language Hebi. This changes adds both to the list and removes the deprecated language.