### PR TITLE
PLT-5279 Rewrite Decidable predicates to avoid PM on many constructors.

### DIFF
--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -261,6 +261,8 @@ library
     MAlonzo.Code.Untyped.CEK
     MAlonzo.Code.Untyped.RenamingSubstitution
     MAlonzo.Code.Utils
+    MAlonzo.Code.Utils.Decidable
+    MAlonzo.Code.Utils.Reflection
     MAlonzo.RTE
 
   autogen-modules:
@@ -449,6 +451,8 @@ library
     MAlonzo.Code.Untyped.CEK
     MAlonzo.Code.Untyped.RenamingSubstitution
     MAlonzo.Code.Utils
+    MAlonzo.Code.Utils.Decidable
+    MAlonzo.Code.Utils.Reflection
     MAlonzo.RTE
 
 executable plc-agda

--- a/plutus-metatheory/src/Algorithmic/Erasure.lagda
+++ b/plutus-metatheory/src/Algorithmic/Erasure.lagda
@@ -7,6 +7,7 @@ module Algorithmic.Erasure where
 
 \begin{code}
 open import Agda.Primitive using (lzero)
+open import Data.Nat using (ℕ)
 open import Function using (_∘_;id)
 open import Data.Nat using (_+_)
 open import Data.Nat.Properties using (+-cancelˡ-≡)
@@ -29,7 +30,8 @@ open import Type.BetaNBE using (nf)
 open import Type.BetaNBE.Completeness using (completeness)
 open import Utils using (Kind;*;Maybe;nothing;just;fromList;map-cong)
 open import RawU using (TmCon;tmCon;TyTag)
-open TyTag
+open import Builtin.Signature using (_⊢♯;con) 
+open import Builtin.Constant.Type ℕ (_⊢♯)
 
 open import Type using (Ctx⋆;∅;_,⋆_;_⊢⋆_;_∋⋆_;S;Z)
 open _⊢⋆_
@@ -65,12 +67,12 @@ eraseVar (S α) = just (eraseVar α)
 eraseVar (T α) = eraseVar α
 
 eraseTC : ∀{Φ}{Γ : Ctx Φ}{A : Φ ⊢Nf⋆ *} → AC.TyTermCon A → TmCon
-eraseTC (AC.tmInteger i)    = tmCon integer i
-eraseTC (AC.tmBytestring b) = tmCon bytestring b
-eraseTC (AC.tmString s)     = tmCon string s
-eraseTC (AC.tmBool b)       = tmCon bool b
-eraseTC AC.tmUnit           = tmCon unit tt
-eraseTC (AC.tmData d)       = tmCon pdata d
+eraseTC (AC.tmInteger i)    = tmCon (con integer)  i
+eraseTC (AC.tmBytestring b) = tmCon (con bytestring) b
+eraseTC (AC.tmString s)     = tmCon (con string) s
+eraseTC (AC.tmBool b)       = tmCon (con bool) b
+eraseTC AC.tmUnit           = tmCon (con unit) tt
+eraseTC (AC.tmData d)       = tmCon (con pdata) d
 
 erase : ∀{Φ Γ}{A : Φ ⊢Nf⋆ *} → Γ ⊢ A → len Γ ⊢
 erase (` α)                = ` (eraseVar α)

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -17,6 +17,7 @@ open import Data.Nat using (ℕ;suc)
 open import Data.Fin using (Fin) renaming (zero to Z; suc to S)
 open import Data.List.NonEmpty using (List⁺;_∷⁺_;[_];reverse)
 open import Data.Product using (Σ;proj₁)
+open import Relation.Binary using (DecidableEquality)
 
 open import Data.Bool using (Bool)
 open import Agda.Builtin.Int using (Int)
@@ -25,6 +26,8 @@ open import Utils using (ByteString;Maybe;DATA)
 import Utils as U
 open import Builtin.Signature using (Sig;sig;_⊢♯;con;`;Args) 
 import Builtin.Constant.Type ℕ (_⊢♯) as T
+
+open import Utils.Reflection using (defDec)
 ```
 
 ## Built-in functions
@@ -394,32 +397,12 @@ postulate
 -- no binding needed for traceStr
 ```
 
-The following function is used for testing.
-For now it only works for some of the builtins, but it will be
-completed when it is replaced by one defined using reflection.
+Equaility of Builtins is decidable.
+The following function is used for testing, when
+comparing expected with actual results.
 
 ```
-decBuiltin : (b b' : Builtin) → Bool
-decBuiltin addInteger addInteger = true
-decBuiltin subtractInteger subtractInteger = true
-decBuiltin multiplyInteger multiplyInteger = true
-decBuiltin divideInteger divideInteger = true
-decBuiltin quotientInteger quotientInteger = true
-decBuiltin remainderInteger remainderInteger = true
-decBuiltin modInteger modInteger = true
-decBuiltin lessThanInteger lessThanInteger = true
-decBuiltin lessThanEqualsInteger lessThanEqualsInteger = true
-decBuiltin equalsInteger equalsInteger = true
-decBuiltin appendByteString appendByteString = true
-decBuiltin sha2-256 sha2-256 = true
-decBuiltin sha3-256 sha3-256 = true
-decBuiltin verifyEd25519Signature verifyEd25519Signature = true
-decBuiltin verifyEcdsaSecp256k1Signature verifyEcdsaSecp256k1Signature = true
-decBuiltin verifySchnorrSecp256k1Signature verifySchnorrSecp256k1Signature = true
-decBuiltin equalsByteString equalsByteString = true
-decBuiltin appendString appendString = true
-decBuiltin trace trace = true
-decBuiltin _ _ = false
-
+decBuiltin : DecidableEquality Builtin
+unquoteDef decBuiltin = defDec (quote Builtin) decBuiltin
 ```
  

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -397,7 +397,7 @@ postulate
 -- no binding needed for traceStr
 ```
 
-Equaility of Builtins is decidable.
+Equality of Builtins is decidable.
 The following function is used for testing, when
 comparing expected with actual results.
 

--- a/plutus-metatheory/src/Builtin/Constant/AtomicType.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/AtomicType.lagda.md
@@ -7,8 +7,7 @@ module Builtin.Constant.AtomicType where
 
 ```
 open import Relation.Binary using (DecidableEquality)
-open import Relation.Nullary using (yes;no;¬_)
-open import Relation.Binary.PropositionalEquality using (refl)
+open import Utils.Reflection using (defDec)
 ```
 
 # Atomic Type constants
@@ -33,40 +32,5 @@ data AtomicTyCon : Set where
 
 ```
 decAtomicTyCon : DecidableEquality AtomicTyCon
-decAtomicTyCon aInteger aInteger = yes refl
-decAtomicTyCon aInteger aBytestring = no λ()
-decAtomicTyCon aInteger aString = no λ()
-decAtomicTyCon aInteger aUnit = no λ()
-decAtomicTyCon aInteger aBool = no λ()
-decAtomicTyCon aInteger aData = no λ()
-decAtomicTyCon aBytestring aInteger = no λ()
-decAtomicTyCon aBytestring aBytestring = yes refl
-decAtomicTyCon aBytestring aString = no λ()
-decAtomicTyCon aBytestring aUnit = no λ()
-decAtomicTyCon aBytestring aBool = no λ()
-decAtomicTyCon aBytestring aData = no λ()
-decAtomicTyCon aString aInteger = no λ()
-decAtomicTyCon aString aBytestring = no λ()
-decAtomicTyCon aString aString = yes refl
-decAtomicTyCon aString aUnit = no λ()
-decAtomicTyCon aString aBool = no λ()
-decAtomicTyCon aString aData = no λ()
-decAtomicTyCon aUnit aInteger = no λ()
-decAtomicTyCon aUnit aBytestring = no λ()
-decAtomicTyCon aUnit aString = no λ()
-decAtomicTyCon aUnit aUnit = yes refl
-decAtomicTyCon aUnit aBool = no λ()
-decAtomicTyCon aUnit aData = no λ()
-decAtomicTyCon aBool aInteger = no λ()
-decAtomicTyCon aBool aBytestring = no λ()
-decAtomicTyCon aBool aString = no λ()
-decAtomicTyCon aBool aUnit = no λ()
-decAtomicTyCon aBool aBool = yes refl
-decAtomicTyCon aBool aData = no λ()
-decAtomicTyCon aData aInteger = no λ()
-decAtomicTyCon aData aBytestring = no λ()
-decAtomicTyCon aData aString = no λ()
-decAtomicTyCon aData aUnit = no λ()
-decAtomicTyCon aData aBool = no λ()
-decAtomicTyCon aData aData = yes refl
+unquoteDef decAtomicTyCon = defDec (quote AtomicTyCon) decAtomicTyCon
 ```

--- a/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
+++ b/plutus-metatheory/src/Builtin/Constant/Type.lagda.md
@@ -36,4 +36,3 @@ pattern bool = atomic aBool
 pattern pdata = atomic aData
 ```
 
-

--- a/plutus-metatheory/src/Declarative/Erasure.lagda.md
+++ b/plutus-metatheory/src/Declarative/Erasure.lagda.md
@@ -10,6 +10,7 @@ module Declarative.Erasure where
 ## Imports
 
 ```
+open import Data.Nat using (ℕ)
 open import Data.Empty using (⊥)
 open import Data.List using (map)
 open import Data.Unit using (tt)
@@ -27,7 +28,9 @@ open _⊢
 import Untyped.RenamingSubstitution as U
 open import Utils using (Kind;*;Maybe;nothing;just;fromList)
 open import RawU using (TmCon;tmCon;TyTag)
-open TyTag
+open import Builtin.Signature using (_⊢♯;con) 
+open import Builtin.Constant.Type ℕ (_⊢♯)
+
 open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con
   using () renaming (TermCon to TyTermCon)
 open TyTermCon
@@ -54,12 +57,12 @@ eraseVar (S α) = just (eraseVar α)
 eraseVar (T α) = eraseVar α
 
 eraseTC : ∀{Φ}{Γ : Ctx Φ}{A : Φ ⊢⋆ *} → TyTermCon A → TmCon
-eraseTC (tmInteger i)      = tmCon integer i
-eraseTC (tmBytestring b)   = tmCon bytestring b
-eraseTC (tmString s)       = tmCon string s
-eraseTC (tmBool b)         = tmCon bool b 
-eraseTC tmUnit             = tmCon unit tt
-eraseTC (tmData d)         = tmCon pdata d
+eraseTC (tmInteger i)      = tmCon (con integer) i
+eraseTC (tmBytestring b)   = tmCon (con bytestring) b
+eraseTC (tmString s)       = tmCon (con string) s
+eraseTC (tmBool b)         = tmCon (con bool) b 
+eraseTC tmUnit             = tmCon (con unit) tt
+eraseTC (tmData d)         = tmCon (con pdata) d
 
 erase : ∀{Φ Γ}{A : Φ ⊢⋆ *} → Γ ⊢ A → len Γ ⊢
 

--- a/plutus-metatheory/src/Raw.lagda
+++ b/plutus-metatheory/src/Raw.lagda
@@ -21,6 +21,8 @@ open AtomicTyCon
 open import Utils using (Kind;*;_⇒_)
 open import RawU using (TagCon;tagCon;Tag;decTagCon)
 open Tag
+
+open import Utils.Reflection using (defEq)
 \end{code}
 
 The raw un-scope-checked and un-type-checked syntax
@@ -196,9 +198,9 @@ decRTm (error A) (error A') with decRTy A A'
 ... | true = true
 ... | false = false
 decRTm (builtin b) (builtin b') = decBuiltin b b'
-decRTm (wrap pat arg t) (wrap pat' arg' t') with decRTy pat pat'
+decRTm (wrap pat ar t) (wrap pat' ar' t') with decRTy pat pat'
 ... | false = false
-... | true with decRTy arg arg'
+... | true with decRTy ar ar'
 ... | false = false
 ... | true with decRTm t t'
 ... | false = false
@@ -229,7 +231,7 @@ rawPrinter (t · u) = "(" ++ rawPrinter t ++ "·" ++ rawPrinter u ++ ")"
 rawPrinter (con c) = "(con)"
 rawPrinter (error A) = "(error" ++ rawTyPrinter A ++ ")"
 rawPrinter (builtin b) = "(builtin)"
-rawPrinter (wrap pat arg t) = "(wrap" ++ ")"
+rawPrinter (wrap pat ar t) = "(wrap" ++ ")"
 rawPrinter (unwrap t) = "(unwrap" ++ rawPrinter t ++ ")"
 \end{code}
  

--- a/plutus-metatheory/src/Scoped.lagda
+++ b/plutus-metatheory/src/Scoped.lagda
@@ -15,6 +15,9 @@ open import Data.String using (String;_++_)
 
 open import Builtin using (Builtin)
 open Builtin.Builtin
+
+open import Builtin.Signature using (_⊢♯;con) 
+open import Builtin.Constant.Type ℕ (_⊢♯)
 open import Builtin.Constant.AtomicType using (aBool)
 
 open import Raw using (RawTy;RawTm;RawTyCon)
@@ -26,7 +29,6 @@ open import Utils using (Kind;Maybe;nothing;just;maybe;Monad;Either;inj₁;inj�
 open Monad{{...}}
 
 open import RawU using (TyTag;TmCon;tmCon;tagCon2TmCon;tmCon2TagCon)
-open TyTag
 \end{code}
 
 \begin{code}
@@ -331,8 +333,8 @@ uglyWeirdFin (T x) = "(T " ++ uglyWeirdFin x ++ ")"
 uglyWeirdFin (S x) = "(S " ++ uglyWeirdFin x ++ ")"
 
 uglyTmCon : TmCon → String
-uglyTmCon (tmCon integer x) = "(integer " ++ ishow x ++ ")"
-uglyTmCon (tmCon bytestring x) = "bytestring"
+uglyTmCon (tmCon (con integer) x) = "(integer " ++ ishow x ++ ")"
+uglyTmCon (tmCon (con bytestring) x) = "bytestring"
 uglyTmCon size = "size"
 
 postulate showNat : ℕ → String

--- a/plutus-metatheory/src/Scoped/Extrication.lagda
+++ b/plutus-metatheory/src/Scoped/Extrication.lagda
@@ -14,7 +14,9 @@ open import Relation.Binary.PropositionalEquality as Eq using (refl)
 open import Utils using (Kind;*)
 
 open import RawU using (TmCon;tmCon;TyTag)
-open TyTag
+open import Builtin.Signature using (_⊢♯;con) 
+open import Builtin.Constant.Type ℕ (_⊢♯)
+
 open import Type using (Ctx⋆;∅;_,⋆_;_∋⋆_;Z;S)
 open import Type.BetaNormal using (_⊢Nf⋆_;_⊢Ne⋆_)
 open _⊢Nf⋆_
@@ -83,16 +85,12 @@ extricateVar (S x) = S (extricateVar x)
 extricateVar (T x) = T (extricateVar x)
 
 extricateC : ∀{Γ}{A : Γ ⊢Nf⋆ *} → B.TermCon A → RawU.TmCon
-extricateC (tmInteger i)    = tmCon integer i
-extricateC (tmBytestring b) = tmCon bytestring b
-extricateC (tmString s)     = tmCon string s
-extricateC (tmBool b)       = tmCon bool b
-extricateC tmUnit           = tmCon unit tt
-extricateC (tmData d)       = tmCon pdata d
---extricateC (pairDATA x y) = pairDATA x y
---extricateC (pairID i ds)  = pairID i ds
---extricateC (listData xs)  = listData xs
---extricateC (listPair xs)  = listPair xs
+extricateC (tmInteger i)    = tmCon (con integer) i
+extricateC (tmBytestring b) = tmCon (con bytestring) b
+extricateC (tmString s)     = tmCon (con string) s
+extricateC (tmBool b)       = tmCon (con bool) b
+extricateC tmUnit           = tmCon (con unit) tt
+extricateC (tmData d)       = tmCon (con pdata) d
 
 extricateSub : ∀ {Γ Δ} → (∀ {J} → Δ ∋⋆ J → Γ ⊢Nf⋆ J)
   → Scoped.Tel⋆ (len⋆ Γ) (len⋆ Δ)

--- a/plutus-metatheory/src/Untyped.lagda.md
+++ b/plutus-metatheory/src/Untyped.lagda.md
@@ -21,13 +21,14 @@ open import Agda.Builtin.String using (primStringFromList; primStringAppend; pri
 open import Data.Nat using (ℕ;suc;zero)
 open import Data.Bool using (Bool;true;false;_∧_)
 open import Data.Integer using (_<?_;_+_;_-_;∣_∣;_≤?_;_≟_;ℤ) renaming (_*_ to _**_)
-open import Relation.Nullary using (yes;no)
+open import Relation.Nullary using (does;yes;no)
 open import Data.Integer.Show using (show)
 open import Data.String using (String;_++_)
 open import Data.Empty using (⊥)
 open import Utils using (_×_;_,_)
 open import RawU using (TagCon;Tag;decTagCon;TmCon;TyTag;Untyped;tmCon;tmCon2TagCon;tagCon2TmCon)
-open TyTag
+open import Builtin.Signature using (_⊢♯;con) 
+open import Builtin.Constant.Type ℕ (_⊢♯)
 open Untyped
 ```
 
@@ -57,15 +58,15 @@ uglyDATA : DATA → String
 uglyDATA d = "(DATA)"
 
 uglyTmCon : TmCon → String
-uglyTmCon (tmCon integer x) = "(integer " ++ show x ++ ")"
-uglyTmCon (tmCon bytestring x) = "bytestring"
-uglyTmCon (tmCon unit _)  = "()"
-uglyTmCon (tmCon string s) = "(string " ++ s ++ ")"
-uglyTmCon (tmCon bool false) = "(bool " ++ "false" ++ ")"
-uglyTmCon (tmCon bool true) = "(bool " ++ "true" ++ ")"
-uglyTmCon (tmCon pdata d) = uglyDATA d
-uglyTmCon (tmCon (pair t u) (x , y)) = "(pair " ++ uglyTmCon (tmCon t x) ++ " " ++ uglyTmCon (tmCon u y) ++ ")"
-uglyTmCon (tmCon (list t) xs) = "(list [ something ])"
+uglyTmCon (tmCon (con integer) x) = "(integer " ++ show x ++ ")"
+uglyTmCon (tmCon (con bytestring) x) = "bytestring"
+uglyTmCon (tmCon (con unit) _)  = "()"
+uglyTmCon (tmCon (con string) s) = "(string " ++ s ++ ")"
+uglyTmCon (tmCon (con bool) false) = "(bool " ++ "false" ++ ")"
+uglyTmCon (tmCon (con bool) true) = "(bool " ++ "true" ++ ")"
+uglyTmCon (tmCon (con pdata) d) = uglyDATA d
+uglyTmCon (tmCon (con (pair t u)) (x , y)) = "(pair " ++ uglyTmCon (tmCon t x) ++ " " ++ uglyTmCon (tmCon u y) ++ ")"
+uglyTmCon (tmCon (con (list t)) xs) = "(list [ something ])"
 
 
 
@@ -139,14 +140,12 @@ Used to compare outputs in testing
 
 ```
 decUTm : (t t' : Untyped) → Bool
-decUTm (UVar x) (UVar x') with x Data.Nat.≟ x
-... | yes p = true
-... | no ¬p = false
+decUTm (UVar x) (UVar x') = does (x Data.Nat.≟ x)
 decUTm (ULambda t) (ULambda t') = decUTm t t'
 decUTm (UApp t u) (UApp t' u') = decUTm t t' ∧ decUTm u u'
 decUTm (UCon c) (UCon c') = decTagCon c c'
 decUTm UError UError = true
-decUTm (UBuiltin b) (UBuiltin b') = decBuiltin b b'
+decUTm (UBuiltin b) (UBuiltin b') = does (decBuiltin b b')
 decUTm (UDelay t) (UDelay t') = decUTm t t'
 decUTm (UForce t) (UForce t') = decUTm t t'
 decUTm _ _ = false

--- a/plutus-metatheory/src/Untyped/CEK.lagda.md
+++ b/plutus-metatheory/src/Untyped/CEK.lagda.md
@@ -26,10 +26,10 @@ open _⊢
 open import Untyped.RenamingSubstitution using (Sub;sub;lifts)
 open import Utils 
 open import Builtin
-open import Builtin.Signature using (Sig;sig;Args;_⊢♯;nat2Ctx⋆;fin2∈⋆;args♯)
+open import Builtin.Signature using (Sig;sig;Args;_⊢♯;con;nat2Ctx⋆;fin2∈⋆;args♯)
 open Sig
 open import RawU using (TmCon;tmCon;TyTag;decTag;⟦_⟧tag)
-open TyTag
+open import Builtin.Constant.Type ℕ (_⊢♯)
 ```
 
 ```
@@ -131,262 +131,262 @@ This WARNING will be removed once the tests are done.
 
 BUILTIN : ∀ b → BApp b (alldone (fv♯ (signature b))) (alldone (args♯ (signature b))) → Either RuntimeError Value
 BUILTIN addInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> inj₂ (V-con integer (i + i'))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> inj₂ (V-con (con integer) (i + i'))
   ; _ -> inj₁ userError
   }
 BUILTIN subtractInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> inj₂ (V-con integer (i - i'))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> inj₂ (V-con (con integer) (i - i'))
   ; _ -> inj₁ userError
   }
 BUILTIN multiplyInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> inj₂ (V-con integer (i ** i'))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> inj₂ (V-con (con integer) (i ** i'))
   ; _ -> inj₁ userError
   }
 BUILTIN divideInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf
       (i' ≟ ℤ.pos 0)
       (inj₁ userError)
-      (inj₂ (V-con integer (div i i')))
+      (inj₂ (V-con (con integer) (div i i')))
   ; _ -> inj₁ userError
   }
 BUILTIN quotientInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf
       (i' ≟ ℤ.pos 0)
       (inj₁ userError)
-      (inj₂ (V-con integer (quot i i')))
+      (inj₂ (V-con (con integer) (quot i i')))
   ; _ -> inj₁ userError
   }
 BUILTIN remainderInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf
       (i' ≟ ℤ.pos 0)
       (inj₁ userError)
-      (inj₂ (V-con integer (rem i i')))
+      (inj₂ (V-con (con integer) (rem i i')))
   ; _ -> inj₁ userError
   }
 BUILTIN modInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf
       (i' ≟ ℤ.pos 0)
       (inj₁ userError)
-      (inj₂ (V-con integer (mod i i')))
+      (inj₂ (V-con (con integer) (mod i i')))
   ; _ -> inj₁ userError
   }
 BUILTIN lessThanInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf (i <? i') (inj₂ (V-con bool true)) (inj₂ (V-con bool false))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf (i <? i') (inj₂ (V-con (con bool) true)) (inj₂ (V-con (con bool) false))
   ; _ -> inj₁ userError
   }
 BUILTIN lessThanEqualsInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf (i ≤? i') (inj₂ (V-con bool true)) (inj₂ (V-con bool false))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf (i ≤? i') (inj₂ (V-con (con bool) true)) (inj₂ (V-con (con bool) false))
   ; _ -> inj₁ userError
   }
 BUILTIN equalsInteger = λ
-  { (app (app base (V-con integer i)) (V-con integer i')) -> decIf (i ≟ i') (inj₂ (V-con bool true)) (inj₂ (V-con bool false))
+  { (app (app base (V-con (con integer) i)) (V-con (con integer) i')) -> decIf (i ≟ i') (inj₂ (V-con (con bool) true)) (inj₂ (V-con (con bool) false))
   ; _ -> inj₁ userError
   }
 BUILTIN appendByteString = λ
-  { (app (app base (V-con bytestring b)) (V-con bytestring b')) -> inj₂ (V-con bytestring (concat b b'))
+  { (app (app base (V-con (con bytestring) b)) (V-con (con bytestring) b')) -> inj₂ (V-con (con bytestring) (concat b b'))
   ; _ -> inj₁ userError
   }
 BUILTIN lessThanByteString = λ
-  { (app (app base (V-con bytestring b)) (V-con bytestring b')) -> inj₂ (V-con bool (B< b b'))
+  { (app (app base (V-con (con bytestring) b)) (V-con (con bytestring) b')) -> inj₂ (V-con (con bool) (B< b b'))
   ; _ -> inj₁ userError
   }
 BUILTIN lessThanEqualsByteString = λ
-  { (app (app base (V-con bytestring b)) (V-con bytestring b')) -> inj₂ (V-con bool (B<= b b'))
+  { (app (app base (V-con (con bytestring) b)) (V-con (con bytestring) b')) -> inj₂ (V-con (con bool) (B<= b b'))
   ; _ -> inj₁ userError
   }
 BUILTIN sha2-256 = λ
-  { (app base (V-con bytestring b)) -> inj₂ (V-con bytestring (SHA2-256 b))
+  { (app base (V-con (con bytestring) b)) -> inj₂ (V-con (con bytestring) (SHA2-256 b))
   ; _ -> inj₁ userError
   }
 BUILTIN sha3-256 = λ
-  { (app base (V-con bytestring b)) -> inj₂ (V-con bytestring (SHA3-256 b))
+  { (app base (V-con (con bytestring) b)) -> inj₂ (V-con (con bytestring) (SHA3-256 b))
   ; _ -> inj₁ userError
   }
 BUILTIN blake2b-256 = λ
-  { (app base (V-con bytestring b)) -> inj₂ (V-con bytestring (BLAKE2B-256 b))
+  { (app base (V-con (con bytestring) b)) -> inj₂ (V-con (con bytestring) (BLAKE2B-256 b))
   ; _ -> inj₁ userError
   }
 BUILTIN verifyEd25519Signature = λ
-  { (app (app (app base (V-con bytestring k)) (V-con bytestring d)) (V-con bytestring c)) -> case verifyEd25519Sig k d c of λ
-      { (just b) -> inj₂ (V-con bool b)
+  { (app (app (app base (V-con (con bytestring) k)) (V-con (con bytestring) d)) (V-con (con bytestring) c)) -> case verifyEd25519Sig k d c of λ
+      { (just b) -> inj₂ (V-con (con bool) b)
       ; nothing -> inj₁ userError
       }
   ; _ -> inj₁ userError
   }
 BUILTIN verifyEcdsaSecp256k1Signature = λ
-  { (app (app (app base (V-con bytestring k)) (V-con bytestring d)) (V-con bytestring c)) -> case verifyEcdsaSecp256k1Sig k d c of λ
-      { (just b) -> inj₂ (V-con bool b)
+  { (app (app (app base (V-con (con bytestring) k)) (V-con (con bytestring) d)) (V-con (con bytestring) c)) -> case verifyEcdsaSecp256k1Sig k d c of λ
+      { (just b) -> inj₂ (V-con (con bool) b)
       ; nothing -> inj₁ userError
       }
   ; _ -> inj₁ userError
   }
 BUILTIN verifySchnorrSecp256k1Signature = λ
-  { (app (app (app base (V-con bytestring k)) (V-con bytestring d)) (V-con bytestring c)) -> case verifySchnorrSecp256k1Sig k d c of λ
-      { (just b) -> inj₂ (V-con bool b)
+  { (app (app (app base (V-con (con bytestring) k)) (V-con (con bytestring) d)) (V-con (con bytestring) c)) -> case verifySchnorrSecp256k1Sig k d c of λ
+      { (just b) -> inj₂ (V-con (con bool) b)
       ; nothing -> inj₁ userError
       }
   ; _ -> inj₁ userError
   }
 BUILTIN encodeUtf8 = λ
-  { (app base (V-con string s)) ->
-      inj₂ (V-con bytestring (ENCODEUTF8 s))
+  { (app base (V-con (con string) s)) ->
+      inj₂ (V-con (con bytestring) (ENCODEUTF8 s))
   ; _ -> inj₁ userError
   }
 BUILTIN decodeUtf8 = λ
-  { (app base (V-con bytestring b)) ->
+  { (app base (V-con (con bytestring) b)) ->
       case DECODEUTF8 b of λ
-        { (just s) -> inj₂ (V-con string s)
+        { (just s) -> inj₂ (V-con (con string) s)
         ; nothing -> inj₁ userError
         }
   ; _ -> inj₁ userError
   }
 BUILTIN equalsByteString = λ
-  { (app (app base (V-con bytestring b)) (V-con bytestring b')) -> inj₂ (V-con bool (equals b b'))
+  { (app (app base (V-con (con bytestring) b)) (V-con (con bytestring) b')) -> inj₂ (V-con (con bool) (equals b b'))
   ; _ -> inj₁ userError
   }
 BUILTIN ifThenElse = λ
-  { (app (app (app (app⋆ base) (V-con bool b)) vt) vf) -> inj₂ $ if b then vt else vf
+  { (app (app (app (app⋆ base) (V-con (con bool) b)) vt) vf) -> inj₂ $ if b then vt else vf
   ; _ -> inj₁ userError
   }
 BUILTIN appendString = λ
-  { (app (app base (V-con string s)) (V-con string s')) -> inj₂ (V-con string (primStringAppend s s'))
+  { (app (app base (V-con (con string) s)) (V-con (con string) s')) -> inj₂ (V-con (con string) (primStringAppend s s'))
   ; _ -> inj₁ userError
   }
 BUILTIN trace = λ
-  { (app (app (app⋆ base) (V-con string s)) v) -> inj₂ (TRACE s v)
+  { (app (app (app⋆ base) (V-con (con string) s)) v) -> inj₂ (TRACE s v)
   ; _ -> inj₁ userError
   }
 BUILTIN iData = λ
-  { (app base (V-con integer i)) -> inj₂ (V-con pdata (iDATA i))
+  { (app base (V-con (con integer) i)) -> inj₂ (V-con (con pdata) (iDATA i))
   ; _ -> inj₁ userError
   }
 BUILTIN bData = λ
-  { (app base (V-con bytestring b)) -> inj₂ (V-con pdata (bDATA b))
+  { (app base (V-con (con bytestring) b)) -> inj₂ (V-con (con pdata) (bDATA b))
   ; _ -> inj₁ userError
   }
-BUILTIN consByteString (app (app base (V-con integer i)) (V-con bytestring b))  with cons i b 
-... | just b' = inj₂ (V-con bytestring b')
+BUILTIN consByteString (app (app base (V-con (con integer) i)) (V-con (con bytestring) b))  with cons i b 
+... | just b' = inj₂ (V-con (con bytestring) b')
 ... | nothing = inj₁ userError
 BUILTIN consByteString _ = inj₁ userError  
 BUILTIN sliceByteString = λ
-  { (app (app (app base (V-con integer st)) (V-con integer n)) (V-con bytestring b)) -> inj₂ (V-con bytestring (slice st n b))
+  { (app (app (app base (V-con (con integer) st)) (V-con (con integer) n)) (V-con (con bytestring) b)) -> inj₂ (V-con (con bytestring) (slice st n b))
   ; _ -> inj₁ userError
   }
 BUILTIN lengthOfByteString = λ
-  { (app base (V-con bytestring b)) -> inj₂ (V-con integer (length b))
+  { (app base (V-con (con bytestring) b)) -> inj₂ (V-con (con integer) (length b))
   ; _ -> inj₁ userError
   }
 BUILTIN indexByteString = λ
-  { (app (app base (V-con bytestring b)) (V-con integer i)) ->
+  { (app (app base (V-con (con bytestring) b)) (V-con (con integer) i)) ->
       case Data.Integer.ℤ.pos 0 ≤? i of λ
         { (no  _) -> inj₁ userError
         ; (yes _) -> case i <? length b of λ
           { (no _)  -> inj₁ userError
-          ; (yes _) -> inj₂ (V-con integer (index b i))
+          ; (yes _) -> inj₂ (V-con (con integer) (index b i))
           }
         }
   ; _ -> inj₁ userError
   }
 BUILTIN equalsString = λ
-  { (app (app base (V-con string s)) (V-con string s')) -> inj₂ (V-con bool (primStringEquality s s'))
+  { (app (app base (V-con (con string) s)) (V-con (con string) s')) -> inj₂ (V-con (con bool) (primStringEquality s s'))
   ; _ -> inj₁ userError
   }
 BUILTIN unIData = λ
-  { (app base (V-con pdata (iDATA i))) -> inj₂ (V-con integer i)
+  { (app base (V-con (con pdata) (iDATA i))) -> inj₂ (V-con (con integer) i)
   ; _ -> inj₁ userError
   }
 BUILTIN unBData = λ
-  { (app base (V-con pdata (bDATA b))) -> inj₂ (V-con bytestring b)
+  { (app base (V-con (con pdata) (bDATA b))) -> inj₂ (V-con (con bytestring) b)
   ; _ -> inj₁ userError
   }
 BUILTIN serialiseData = λ
-  { (app base (V-con pdata d)) -> inj₂ (V-con bytestring (serialiseDATA d))
+  { (app base (V-con (con pdata) d)) -> inj₂ (V-con (con bytestring) (serialiseDATA d))
   ; _ -> inj₁ userError
   }
 BUILTIN chooseUnit = λ
-  { (app (app (app⋆ base) (V-con unit tt)) v) -> inj₂ v
+  { (app (app (app⋆ base) (V-con (con unit) tt)) v) -> inj₂ v
   ; _ -> inj₁ userError
   }
 BUILTIN fstPair = λ
-  { (app (app⋆ (app⋆ base)) (V-con (pair t _) (x , _))) -> inj₂ (V-con t x)
+  { (app (app⋆ (app⋆ base)) (V-con (con (pair t _)) (x , _))) -> inj₂ (V-con t x)
   ; _ -> inj₁ userError
   }
 BUILTIN sndPair = λ
-  { (app (app⋆ (app⋆ base)) (V-con (pair _ t) (_ , y))) → inj₂ (V-con t y)
+  { (app (app⋆ (app⋆ base)) (V-con (con (pair _ t)) (_ , y))) → inj₂ (V-con t y)
   ; _ -> inj₁ userError
   }
 BUILTIN chooseList = λ
-  { (app (app (app (app⋆ (app⋆ base)) (V-con (list _) [])) (V-con t n)) (V-con _ c)) → inj₂ (V-con t n)
-  ; (app (app (app (app⋆ (app⋆ base)) (V-con (list _) (_ ∷ _))) (V-con _ n)) (V-con t c)) → inj₂ (V-con t c)
+  { (app (app (app (app⋆ (app⋆ base)) (V-con (con (list _)) [])) (V-con t n)) (V-con _ c)) → inj₂ (V-con t n)
+  ; (app (app (app (app⋆ (app⋆ base)) (V-con (con (list _)) (_ ∷ _))) (V-con _ n)) (V-con t c)) → inj₂ (V-con t c)
   ; _ -> inj₁ userError
   }
-BUILTIN mkCons (app (app (app⋆ base) (V-con t x)) (V-con (list ts) xs)) with decTag t ts 
-... | yes refl = inj₂ (V-con (list ts) (x ∷ xs)) 
+BUILTIN mkCons (app (app (app⋆ base) (V-con t x)) (V-con (con (list ts)) xs)) with decTag t ts 
+... | yes refl = inj₂ (V-con (con (list ts)) (x ∷ xs)) 
 ... | no _     = inj₁ userError
 BUILTIN mkCons _ = inj₁ userError
 BUILTIN headList = λ
-  { (app (app⋆ base) (V-con (list t) (x ∷ _))) → inj₂ (V-con t x)
+  { (app (app⋆ base) (V-con (con (list t)) (x ∷ _))) → inj₂ (V-con t x)
   ; _ -> inj₁ userError
   }
 BUILTIN tailList = λ
-  { (app (app⋆ base) (V-con (list t) (_ ∷ xs))) → inj₂ (V-con (list t) xs)
+  { (app (app⋆ base) (V-con (con (list t)) (_ ∷ xs))) → inj₂ (V-con (con (list t)) xs)
   ; _ -> inj₁ userError
   }
 BUILTIN nullList = λ
-  { (app (app⋆ base) (V-con (list _) [])) → inj₂ (V-con bool true)
-  ; (app (app⋆ base) (V-con (list _) (_ ∷ _))) → inj₂ (V-con bool false)
+  { (app (app⋆ base) (V-con (con (list _)) [])) → inj₂ (V-con (con bool) true)
+  ; (app (app⋆ base) (V-con (con (list _)) (_ ∷ _))) → inj₂ (V-con (con bool) false)
   ; _ -> inj₁ userError
   }
 BUILTIN chooseData = λ
-  { (app (app (app (app (app (app (app⋆ base) (V-con pdata (ConstrDATA x₁ x₂))) (V-con t v)) (V-con _ w)) (V-con _ x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t v)
-  ; (app (app (app (app (app (app (app⋆ base) (V-con pdata (MapDATA x₁))) (V-con _ v)) (V-con t w)) (V-con _ x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t w)
-  ; (app (app (app (app (app (app (app⋆ base) (V-con pdata (ListDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con t x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t x)
-  ; (app (app (app (app (app (app (app⋆ base) (V-con pdata (iDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con _ x)) (V-con t y)) (V-con _ z)) → inj₂ (V-con t y)
-  ; (app (app (app (app (app (app (app⋆ base) (V-con pdata (bDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con _ x)) (V-con _ y)) (V-con t z)) → inj₂ (V-con t z)
+  { (app (app (app (app (app (app (app⋆ base) (V-con (con pdata) (ConstrDATA x₁ x₂))) (V-con t v)) (V-con _ w)) (V-con _ x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t v)
+  ; (app (app (app (app (app (app (app⋆ base) (V-con (con pdata) (MapDATA x₁))) (V-con _ v)) (V-con t w)) (V-con _ x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t w)
+  ; (app (app (app (app (app (app (app⋆ base) (V-con (con pdata) (ListDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con t x)) (V-con _ y)) (V-con _ z)) → inj₂ (V-con t x)
+  ; (app (app (app (app (app (app (app⋆ base) (V-con (con pdata) (iDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con _ x)) (V-con t y)) (V-con _ z)) → inj₂ (V-con t y)
+  ; (app (app (app (app (app (app (app⋆ base) (V-con (con pdata) (bDATA x₁))) (V-con _ v)) (V-con _ w)) (V-con _ x)) (V-con _ y)) (V-con t z)) → inj₂ (V-con t z)
   ; _ -> inj₁ userError
   }
 BUILTIN constrData = λ
-  { (app (app base (V-con integer i)) (V-con (list pdata) xs)) → do
-     return (V-con pdata (ConstrDATA i xs))
+  { (app (app base (V-con (con integer) i)) (V-con (con (list (con pdata))) xs)) → do
+     return (V-con (con pdata) (ConstrDATA i xs))
   ; _ -> inj₁ userError
   }
 BUILTIN mapData = λ
-  { (app base (V-con (list (pair pdata pdata)) xs)) → do 
-     return (V-con pdata (MapDATA xs))
+  { (app base (V-con (con (list (con (pair (con pdata) (con pdata))))) xs)) → do 
+     return (V-con (con pdata) (MapDATA xs))
   ; _ -> inj₁ userError
   }
 BUILTIN listData = λ
-  { (app base (V-con (list pdata) xs)) → do 
-     return (V-con pdata (ListDATA xs))
+  { (app base (V-con (con (list (con pdata))) xs)) → do 
+     return (V-con (con pdata) (ListDATA xs))
   ; _ -> inj₁ userError
   }
 BUILTIN unConstrData = λ
-  { (app base (V-con pdata (ConstrDATA i xs))) → inj₂ (V-con (pair integer (list pdata)) (i , xs))
+  { (app base (V-con (con pdata) (ConstrDATA i xs))) → inj₂ (V-con (con (pair (con integer) (con (list (con pdata))))) (i , xs))
   ; _ -> inj₁ userError
   }
 BUILTIN unMapData = λ
-  { (app base (V-con pdata (MapDATA xs))) → inj₂ (V-con (list (pair pdata pdata)) xs)
+  { (app base (V-con (con pdata) (MapDATA xs))) → inj₂ (V-con (con (list (con (pair (con pdata) (con pdata))))) xs)
   ; _ -> inj₁ userError
   }
 BUILTIN unListData = λ
-  { (app base (V-con pdata (ListDATA xs))) → inj₂ (V-con (list pdata) xs)
+  { (app base (V-con (con pdata) (ListDATA xs))) → inj₂ (V-con (con (list (con pdata))) xs)
   ; _ -> inj₁ userError
   }
 BUILTIN equalsData = λ
   {  
-    (app (app base (V-con pdata x)) (V-con pdata y)) → inj₂ (V-con bool (eqDATA x y))
+    (app (app base (V-con (con pdata) x)) (V-con (con pdata) y)) → inj₂ (V-con (con bool) (eqDATA x y))
   ;  _ -> inj₁ userError
   }
 BUILTIN mkPairData = λ
-  { (app (app base (V-con pdata x)) (V-con pdata y)) → inj₂ (V-con (pair pdata pdata) (x , y))
+  { (app (app base (V-con (con pdata) x)) (V-con (con pdata) y)) → inj₂ (V-con (con (pair (con pdata) (con pdata))) (x , y))
   ; _ -> inj₁ userError
   }
 BUILTIN mkNilData = λ
-  { (app base (V-con unit tt)) → inj₂ (V-con (list pdata) [])
+  { (app base (V-con (con unit) tt)) → inj₂ (V-con (con (list (con pdata))) [])
   ; _ -> inj₁ userError
   }
 BUILTIN mkNilPairData = λ
-  { (app base (V-con unit tt)) -> inj₂ (V-con (list (pair pdata pdata)) [])
+  { (app base (V-con (con unit) tt)) -> inj₂ (V-con (con (list (con (pair (con pdata) (con pdata))))) [])
   ; _ -> inj₁ userError
   }
 

--- a/plutus-metatheory/src/Utils/Decidable.lagda.md
+++ b/plutus-metatheory/src/Utils/Decidable.lagda.md
@@ -1,0 +1,49 @@
+
+```
+module Utils.Decidable where
+
+open import Data.Bool using (false;true)
+open import Function using (const;_∘_)
+open import Relation.Binary using (DecidableEquality)
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;cong₂;subst)
+open import Relation.Nullary using (Dec;yes;no;¬_)
+open import Data.Product using (Σ;_×_;proj₁;proj₂) renaming (_,_ to _,,_)
+
+dmap : ∀ {α β} {A : Set α} {B : Set β} → (A → B) → (¬ A → ¬ B) → Dec A → Dec B
+dmap f g (no ¬p) = no (g ¬p)
+dmap f g (yes p) = yes (f p)
+
+dcong : ∀ {α β} {A : Set α} {B : Set β} {x y}
+      → (f : A → B) → (f x ≡ f y → x ≡ y) → Dec (x ≡ y) → Dec (f x ≡ f y)
+dcong f inj = dmap (cong f) (_∘ inj)
+
+dcong₂ : ∀ {α β γ} {A : Set α} {B : Set β} {C : Set γ} {x₁ x₂ y₁ y₂}
+       → (f : A → B → C)
+       → (f x₁ y₁ ≡ f x₂ y₂ → x₁ ≡ x₂ × y₁ ≡ y₂)
+       → Dec (x₁ ≡ x₂)
+       → Dec (y₁ ≡ y₂)
+       → Dec (f x₁ y₁ ≡ f x₂ y₂)
+dcong₂ f inj (yes refl) (yes refl) = yes refl
+dcong₂ f inj (yes _) (no ¬q) = no (λ x → ¬q (proj₂ (inj x))) 
+dcong₂ f inj (no ¬p) _ = no (λ x → ¬p (proj₁ (inj x)))
+
+dhcong : ∀ {α β γ} {A : Set α} {B : A → Set β} {C : Set γ} {x₁ x₂ y₁ y₂}
+        → (f : ∀ x → B x → C)
+        → (f x₁ y₁ ≡ f x₂ y₂ → Σ (x₁ ≡ x₂) (λ p → subst B p y₁ ≡ y₂))
+        → Dec (x₁ ≡ x₂)
+        → (∀ y₂ → Dec (y₁ ≡ y₂))
+        → Dec (f x₁ y₁ ≡ f x₂ y₂)
+dhcong f inj (yes refl) q = dcong (f _) ((λ { (refl ,, yy) → yy }) ∘ inj) (q _)
+dhcong f inj (no  c)    q = no λ {p → c (proj₁ (inj p))}
+
+dhcong₂ : ∀ {α β γ} {A : Set α} {B B' : A → Set β} {C : Set γ} {x₁ x₂ y₁ y₂ z₁ z₂}
+        → (f : ∀ x → B x → B' x → C)
+        → (f x₁ y₁ z₁ ≡ f x₂ y₂ z₂ → Σ (x₁ ≡ x₂) (λ p → subst B p y₁ ≡ y₂ × subst B' p z₁ ≡ z₂ ))
+        → Dec (x₁ ≡ x₂)
+        → (∀ y₂ → Dec (y₁ ≡ y₂))
+        → (∀ z₂ → Dec (z₁ ≡ z₂))
+        → Dec (f x₁ y₁ z₁ ≡ f x₂ y₂ z₂)
+dhcong₂ f inj (yes refl) qy qz = dcong₂ (f _) ((λ { (refl ,, yy) → yy }) ∘ inj) (qy _) (qz _)
+dhcong₂ f inj (no  c)    _  _  = no λ {p → c (proj₁ (inj p))}
+
+```

--- a/plutus-metatheory/src/Utils/Decidable.lagda.md
+++ b/plutus-metatheory/src/Utils/Decidable.lagda.md
@@ -1,14 +1,23 @@
 
 ```
 module Utils.Decidable where
+```
 
+## Imports
+
+```
 open import Data.Bool using (false;true)
 open import Function using (const;_∘_)
 open import Relation.Binary using (DecidableEquality)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;sym;cong;cong₂;subst)
 open import Relation.Nullary using (Dec;yes;no;¬_)
 open import Data.Product using (Σ;_×_;proj₁;proj₂) renaming (_,_ to _,,_)
+```
 
+Some functions to help define `DecidableEquality` predicates, inspired by effectfully's Generic Library.
+
+
+```
 dmap : ∀ {α β} {A : Set α} {B : Set β} → (A → B) → (¬ A → ¬ B) → Dec A → Dec B
 dmap f g (no ¬p) = no (g ¬p)
 dmap f g (yes p) = yes (f p)
@@ -45,5 +54,4 @@ dhcong₂ : ∀ {α β γ} {A : Set α} {B B' : A → Set β} {C : Set γ} {x₁
         → Dec (f x₁ y₁ z₁ ≡ f x₂ y₂ z₂)
 dhcong₂ f inj (yes refl) qy qz = dcong₂ (f _) ((λ { (refl ,, yy) → yy }) ∘ inj) (qy _) (qz _)
 dhcong₂ f inj (no  c)    _  _  = no λ {p → c (proj₁ (inj p))}
-
 ```

--- a/plutus-metatheory/src/Utils/Reflection.lagda.md
+++ b/plutus-metatheory/src/Utils/Reflection.lagda.md
@@ -1,0 +1,39 @@
+
+
+```
+module Utils.Reflection where
+```
+
+## Imports
+
+```
+open import Data.List using (List;[];_∷_;_++_;map)
+open import Data.Unit using (⊤)
+open import Data.Bool using (Bool;true;false)
+open import Agda.Builtin.Reflection
+open import Reflection
+
+-- Reflection machinery
+
+constructors : Definition → List Name
+constructors (data-type pars cs) = cs
+constructors _ = []
+
+vra : {A : Set} → A → Arg A
+vra = arg (arg-info visible (modality relevant quantity-0))
+
+mk-cls : Name → Clause
+mk-cls q = clause [] (vra (con q []) ∷ vra (con q []) ∷ []) (con (quote true)  [])
+
+wildcard : Arg Pattern
+wildcard = vra (dot unknown)
+
+default-cls : Clause
+default-cls = clause [] (wildcard ∷ (wildcard ∷ [])) (con (quote false) [])
+
+defEq : Name → Name → TC ⊤
+defEq T defName = do
+       d ← getDefinition T
+       let trueClauses = map mk-cls (constructors d)
+       defineFun defName (trueClauses ++ (default-cls ∷ []))
+

--- a/plutus-metatheory/src/Utils/Reflection.lagda.md
+++ b/plutus-metatheory/src/Utils/Reflection.lagda.md
@@ -15,9 +15,11 @@ open import Agda.Builtin.Reflection
 open import Reflection
 open import Relation.Binary.PropositionalEquality using (refl)
 open import Relation.Nullary using (_because_;Reflects;ofʸ;ofⁿ)
+```
 
--- Reflection machinery
+ Some definitions to help define functions by reflection
 
+```
 constructors : Definition → List Name
 constructors (data-type pars cs) = cs
 constructors _ = []
@@ -52,17 +54,25 @@ mk-DecCls q1 q2 with primQNameEquality q1 q2
 ... | false = clause [] (vra (con q1 []) ∷ vra (con q2 []) ∷ []) 
                         (con (quote _because_)  
                         (vra (con (quote false) []) ∷ vra (con (quote ofⁿ) [ vra absurd-lam ]) ∷ []))
+```
 
+The function `defEq` helps to define an equality function for datatypes which are simple enumerations.
+
+```
 defEq : Name → Name → TC ⊤
 defEq T defName = do
        d ← getDefinition T
        let trueClauses = map mk-cls (constructors d)
        defineFun defName (trueClauses ++ (default-cls ∷ []))
+```
 
+The function `defDec` helps to define a `DecidableEquality` for datatypes which are simple enumerations.
+
+```
 defDec : Name → Name → TC ⊤
 defDec T defName = do
        d ← getDefinition T
        let cls = map2 mk-DecCls (constructors d)
        defineFun defName cls
-
+```
  

--- a/plutus-metatheory/src/Utils/Reflection.lagda.md
+++ b/plutus-metatheory/src/Utils/Reflection.lagda.md
@@ -7,11 +7,14 @@ module Utils.Reflection where
 ## Imports
 
 ```
-open import Data.List using (List;[];_∷_;_++_;map)
+open import Data.List using (List;[];_∷_;_++_;map;[_])
 open import Data.Unit using (⊤)
 open import Data.Bool using (Bool;true;false)
+open import Data.Product using (_,_)
 open import Agda.Builtin.Reflection
 open import Reflection
+open import Relation.Binary.PropositionalEquality using (refl)
+open import Relation.Nullary using (_because_;Reflects;ofʸ;ofⁿ)
 
 -- Reflection machinery
 
@@ -28,8 +31,27 @@ mk-cls q = clause [] (vra (con q []) ∷ vra (con q []) ∷ []) (con (quote true
 wildcard : Arg Pattern
 wildcard = vra (dot unknown)
 
+absurd-lam : Term
+absurd-lam = pat-lam (absurd-clause (("()" , vra unknown) ∷ []) (vra (absurd 0) ∷ []) ∷ []) []
+
 default-cls : Clause
 default-cls = clause [] (wildcard ∷ (wildcard ∷ [])) (con (quote false) [])
+
+map2 : ∀ {a b} {A : Set a} {B : Set b} → (A → A → B) → List A → List B
+map2 {A = A} {B = B} f l = map2' f l l
+  where
+  map2' : (A → A → B) → List A → List A → List B
+  map2' f [] _ = []
+  map2' f (x ∷ xs) l = map (f x) l ++ map2' f xs l 
+
+mk-DecCls : Name → Name → Clause
+mk-DecCls q1 q2 with primQNameEquality q1 q2
+... | true  = clause [] (vra (con q1 []) ∷ vra (con q2 []) ∷ []) 
+                        (con (quote _because_)  
+                             (vra (con (quote true) []) ∷ vra (con (quote ofʸ) [ vra (con (quote refl) []) ]) ∷ []))
+... | false = clause [] (vra (con q1 []) ∷ vra (con q2 []) ∷ []) 
+                        (con (quote _because_)  
+                        (vra (con (quote false) []) ∷ vra (con (quote ofⁿ) [ vra absurd-lam ]) ∷ []))
 
 defEq : Name → Name → TC ⊤
 defEq T defName = do
@@ -37,3 +59,10 @@ defEq T defName = do
        let trueClauses = map mk-cls (constructors d)
        defineFun defName (trueClauses ++ (default-cls ∷ []))
 
+defDec : Name → Name → TC ⊤
+defDec T defName = do
+       d ← getDefinition T
+       let cls = map2 mk-DecCls (constructors d)
+       defineFun defName cls
+
+ 


### PR DESCRIPTION
Rewrote some decidability predicate to avoid pattern-matching on too many constructors.
In order to do this I defined some helpers that work via reflection, and some helpers specific to `Dec` predicates (inspired by @effectfully 's Generic library).

In order to avoid defining separate decidability predicates for `TyTag`s and for `TyCon`s one was defined in terms of the other.

There is more work to do to automate definitions of decidability predicates, but the changes in this PR solve the more annoying definitions.  
