### PR TITLE
Make PIR available in the result of liftCode

### DIFF
--- a/plutus-tx-plugin/test/Lift/Spec.hs
+++ b/plutus-tx-plugin/test/Lift/Spec.hs
@@ -48,20 +48,20 @@ Lift.makeLift ''SynExample
 
 tests :: TestNested
 tests = testNested "Lift" [
-    goldenUPlc "int" (Lift.liftProgramDef (1::Integer))
-    , goldenUPlc "tuple" (Lift.liftProgramDef (1::Integer, 2::Integer))
-    , goldenUPlc "mono" (Lift.liftProgramDef (Mono2 2))
-    , goldenUEval "monoInterop" [ getPlcNoAnn monoCase, Lift.liftProgramDef (Mono1 1 2) ]
-    , goldenUPlc "poly" (Lift.liftProgramDef (Poly1 (1::Integer) (2::Integer)))
-    , goldenUEval "polyInterop" [ getPlcNoAnn defaultCasePoly, Lift.liftProgramDef (Poly1 (1::Integer) (2::Integer)) ]
-    , goldenUPlc "record" (Lift.liftProgramDef (MyMonoRecord 1 2))
-    , goldenUEval "boolInterop" [ getPlcNoAnn andPlc, Lift.liftProgramDef True, Lift.liftProgramDef True ]
-    , goldenUPlc "list" (Lift.liftProgramDef ([1]::[Integer]))
-    , goldenUEval "listInterop" [ getPlcNoAnn listMatch, Lift.liftProgramDef ([1]::[Integer]) ]
-    , goldenUPlc "nested" (Lift.liftProgramDef (NestedRecord (Just (1, 2))))
-    , goldenUPlc "bytestring" (Lift.liftProgramDef (WrappedBS "hello"))
-    , goldenUPlc "newtypeInt" (Lift.liftProgramDef (NewtypeInt 1))
-    , goldenUPlc "newtypeInt2" (Lift.liftProgramDef (Newtype2 $ NewtypeInt 1))
-    , goldenUPlc "newtypeInt3" (Lift.liftProgramDef (Newtype3 $ Newtype2 $ NewtypeInt 1))
-    , goldenUPlc "syn" (Lift.liftProgramDef (SynExample $ Z $ 1))
+    goldenUPlc "int" (snd (Lift.liftProgramDef (1::Integer)))
+    , goldenUPlc "tuple" (snd (Lift.liftProgramDef (1::Integer, 2::Integer)))
+    , goldenUPlc "mono" (snd (Lift.liftProgramDef (Mono2 2)))
+    , goldenUEval "monoInterop" [ getPlcNoAnn monoCase, snd (Lift.liftProgramDef (Mono1 1 2)) ]
+    , goldenUPlc "poly" (snd (Lift.liftProgramDef (Poly1 (1::Integer) (2::Integer))))
+    , goldenUEval "polyInterop" [ getPlcNoAnn defaultCasePoly, snd (Lift.liftProgramDef (Poly1 (1::Integer) (2::Integer))) ]
+    , goldenUPlc "record" (snd (Lift.liftProgramDef (MyMonoRecord 1 2)))
+    , goldenUEval "boolInterop" [ getPlcNoAnn andPlc, snd (Lift.liftProgramDef True), snd (Lift.liftProgramDef True) ]
+    , goldenUPlc "list" (snd (Lift.liftProgramDef ([1]::[Integer])))
+    , goldenUEval "listInterop" [ getPlcNoAnn listMatch, snd (Lift.liftProgramDef ([1]::[Integer])) ]
+    , goldenUPlc "nested" (snd (Lift.liftProgramDef (NestedRecord (Just (1, 2)))))
+    , goldenUPlc "bytestring" (snd (Lift.liftProgramDef (WrappedBS "hello")))
+    , goldenUPlc "newtypeInt" (snd (Lift.liftProgramDef (NewtypeInt 1)))
+    , goldenUPlc "newtypeInt2" (snd (Lift.liftProgramDef (Newtype2 $ NewtypeInt 1)))
+    , goldenUPlc "newtypeInt3" (snd (Lift.liftProgramDef (Newtype3 $ Newtype2 $ NewtypeInt 1)))
+    , goldenUPlc "syn" (snd (Lift.liftProgramDef (SynExample $ Z $ 1)))
  ]

--- a/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Primitives/Spec.hs
@@ -45,21 +45,21 @@ primitives = testNested "Primitives" [
   , goldenPir "ifThenElse" ifThenElse
   , goldenUEval "ifThenElseApply" [ toUPlc ifThenElse, toUPlc int, toUPlc int2 ]
   , goldenPir "emptyByteString" emptyByteString
-  , goldenUEval "emptyByteStringApply" [ getPlcNoAnn emptyByteString, liftProgramDef Builtins.emptyByteString ]
+  , goldenUEval "emptyByteStringApply" [ getPlcNoAnn emptyByteString, snd (liftProgramDef Builtins.emptyByteString) ]
   , goldenPir "bytestring" bytestring
-  , goldenUEval "bytestringApply" [ getPlcNoAnn bytestring, liftProgramDef ("hello" ::Builtins.BuiltinByteString) ]
-  , goldenUEval "sha2_256" [ getPlcNoAnn sha2, liftProgramDef ("hello" :: Builtins.BuiltinByteString)]
-  , goldenUEval "equalsByteString" [ getPlcNoAnn bsEquals, liftProgramDef ("hello" :: Builtins.BuiltinByteString), liftProgramDef ("hello" :: Builtins.BuiltinByteString)]
-  , goldenUEval "ltByteString" [ getPlcNoAnn bsLt, liftProgramDef ("hello" :: Builtins.BuiltinByteString), liftProgramDef ("world" :: Builtins.BuiltinByteString)]
-  , goldenUEval "decodeUtf8" [ getPlcNoAnn bsDecode, liftProgramDef ("hello" :: Builtins.BuiltinByteString)]
-  , goldenUEval "lengthOfByteString" [ getPlcNoAnn bsLength, liftProgramDef ("hello" :: Builtins.BuiltinByteString)]
-  , goldenUEval "indexByteString" [ getPlcNoAnn bsIndex, liftProgramDef ("hello" :: Builtins.BuiltinByteString), liftProgramDef (0 :: Integer)]
-  , goldenUEval "consByteString" [ getPlcNoAnn bsCons, liftProgramDef (104 :: Integer), liftProgramDef ("ello" :: Builtins.BuiltinByteString)]
+  , goldenUEval "bytestringApply" [ getPlcNoAnn bytestring, snd (liftProgramDef ("hello" ::Builtins.BuiltinByteString)) ]
+  , goldenUEval "sha2_256" [ getPlcNoAnn sha2, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString))]
+  , goldenUEval "equalsByteString" [ getPlcNoAnn bsEquals, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString)), snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString))]
+  , goldenUEval "ltByteString" [ getPlcNoAnn bsLt, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString)), snd (liftProgramDef ("world" :: Builtins.BuiltinByteString))]
+  , goldenUEval "decodeUtf8" [ getPlcNoAnn bsDecode, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString))]
+  , goldenUEval "lengthOfByteString" [ getPlcNoAnn bsLength, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString))]
+  , goldenUEval "indexByteString" [ getPlcNoAnn bsIndex, snd (liftProgramDef ("hello" :: Builtins.BuiltinByteString)), snd (liftProgramDef (0 :: Integer))]
+  , goldenUEval "consByteString" [ getPlcNoAnn bsCons, snd (liftProgramDef (104 :: Integer)), snd (liftProgramDef ("ello" :: Builtins.BuiltinByteString))]
   , goldenPir "verify" verify
   , goldenPir "trace" trace
   , goldenPir "traceComplex" traceComplex
   , goldenPir "stringLiteral" stringLiteral
-  , goldenUEval "equalsString" [ getPlcNoAnn stringEquals, liftProgramDef ("hello" :: Builtins.BuiltinString), liftProgramDef ("hello" :: Builtins.BuiltinString)]
+  , goldenUEval "equalsString" [ getPlcNoAnn stringEquals, snd (liftProgramDef ("hello" :: Builtins.BuiltinString)), snd (liftProgramDef ("hello" :: Builtins.BuiltinString))]
   , goldenPir "encodeUtf8" stringEncode
   , goldenPir "serialiseData" dataEncode
   , goldenUEval "serialiseDataApply" [ toUPlc dataEncode, toUPlc constructData1 ]

--- a/plutus-tx-plugin/test/StdLib/Spec.hs
+++ b/plutus-tx-plugin/test/StdLib/Spec.hs
@@ -47,7 +47,7 @@ roundPlc = plc (Proxy @"roundPlc") Ratio.round
 tests :: TestNested
 tests =
   testNested "StdLib"
-    [ goldenUEval "ratioInterop" [ getPlcNoAnn roundPlc, Lift.liftProgramDef (Ratio.fromGHC 3.75) ]
+    [ goldenUEval "ratioInterop" [ getPlcNoAnn roundPlc, snd (Lift.liftProgramDef (Ratio.fromGHC 3.75)) ]
     , testRatioProperty "round" Ratio.round round
     , testRatioProperty "truncate" Ratio.truncate truncate
     , testRatioProperty "abs" (fmap Ratio.toGHC Ratio.abs) abs

--- a/plutus-tx/changelog.d/20230504_121943_unsafeFixIO_lift_pir.md
+++ b/plutus-tx/changelog.d/20230504_121943_unsafeFixIO_lift_pir.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `liftCode` and some other functions in `PlutusTx.Lift` now return PIR in addition to UPLC.

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -24,7 +24,6 @@ import PlutusTx.Lift.Class qualified as Lift
 import PlutusTx.Lift.Instances ()
 import PlutusTx.Lift.TH (LiftError (..), makeLift, makeTypeable)
 
-import Data.Bifunctor
 import PlutusIR
 import PlutusIR qualified as PIR
 import PlutusIR.Compiler
@@ -42,11 +41,12 @@ import PlutusCore.Version qualified as PLC
 
 import UntypedPlutusCore qualified as UPLC
 
+import Control.Arrow ((***))
 import Control.Exception
 import Control.Lens hiding (lifted)
 import Control.Monad.Except hiding (lift)
 import Control.Monad.Reader hiding (lift)
-
+import Data.Bifunctor
 import Data.Default.Class
 import Data.Proxy
 import Data.Typeable qualified as GHC
@@ -73,9 +73,9 @@ safeLift
        , PrettyPrintable uni fun
        , Default (PLC.CostingPart uni fun)
        )
-    => PLC.Version -> a -> m (UPLC.Term UPLC.NamedDeBruijn uni fun ())
+    => PLC.Version -> a -> m (PIR.Term PLC.TyName PLC.Name uni fun (), UPLC.Term UPLC.NamedDeBruijn uni fun ())
 safeLift v x = do
-    lifted <- liftQuote $ runDefT () $ Lift.lift x
+    pir <- liftQuote $ runDefT () $ Lift.lift x
     tcConfig <- PLC.getDefTypeCheckConfig $ Original ()
     -- NOTE:  Disabling simplifier, as it takes a lot of time during runtime
     let ccConfig = toDefaultCompilationCtx tcConfig
@@ -85,10 +85,10 @@ safeLift v x = do
           -- that takes all the compilation options and everything.
           & set (ccOpts . coDatatypes . dcoStyle) (if v >= PLC.plcVersion110 then SumsOfProducts else ScottEncoding)
         ucOpts = PLC.defaultCompilationOpts & PLC.coSimplifyOpts . UPLC.soMaxSimplifierIterations .~ 0
-    plc <- flip runReaderT ccConfig $ compileProgram (Program () v lifted)
+    plc <- flip runReaderT ccConfig $ compileProgram (Program () v pir)
     uplc <- flip runReaderT ucOpts $ PLC.compileProgram plc
     (UPLC.Program _ _ db) <- traverseOf UPLC.progTerm UPLC.deBruijnTerm uplc
-    pure $ void db
+    pure $ (void pir, void db)
 
 -- | Get a Plutus Core program corresponding to the given value.
 safeLiftProgram
@@ -101,8 +101,8 @@ safeLiftProgram
        , PrettyPrintable uni fun
        , Default (PLC.CostingPart uni fun)
        )
-    => PLC.Version -> a -> m (UPLC.Program UPLC.NamedDeBruijn uni fun ())
-safeLiftProgram v x = UPLC.Program () v <$> safeLift v x
+    => PLC.Version -> a -> m (PIR.Program PLC.TyName PLC.Name uni fun (), UPLC.Program UPLC.NamedDeBruijn uni fun ())
+safeLiftProgram v x = (PIR.Program () v *** UPLC.Program () v) <$> safeLift v x
 
 safeLiftCode
     :: (Lift.Lift uni a
@@ -115,11 +115,12 @@ safeLiftCode
        , Default (PLC.CostingPart uni fun)
        )
     => PLC.Version -> a -> m (CompiledCodeIn uni fun a)
-safeLiftCode v x =
-    DeserializedCode
-        <$> ((const mempty <$>) <$> safeLiftProgram v x)
-        <*> pure Nothing
-        <*> pure mempty
+safeLiftCode v =
+    fmap
+        ( \(pir, uplc) ->
+            DeserializedCode (mempty <$ uplc) (Just (mempty <$ pir)) mempty
+        )
+        . safeLiftProgram v
 
 unsafely
     :: Throwable uni fun
@@ -133,19 +134,19 @@ unsafely ma = runQuote $ do
 -- | Get a Plutus Core term corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
 lift
     :: (Lift.Lift uni a, Throwable uni fun, PLC.Typecheckable uni fun, Default (PLC.CostingPart uni fun))
-    => PLC.Version -> a -> UPLC.Term UPLC.NamedDeBruijn uni fun ()
+    => PLC.Version -> a -> (PIR.Term PLC.TyName PLC.Name uni fun (), UPLC.Term UPLC.NamedDeBruijn uni fun ())
 lift v a = unsafely $ safeLift v a
 
 -- | Get a Plutus Core program corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
 liftProgram
     :: (Lift.Lift uni a, Throwable uni fun, PLC.Typecheckable uni fun, Default (PLC.CostingPart uni fun))
-    => PLC.Version -> a -> UPLC.Program UPLC.NamedDeBruijn uni fun ()
-liftProgram v x = UPLC.Program () v $ lift v x
+    => PLC.Version -> a -> (PIR.Program PLC.TyName PLC.Name uni fun (), UPLC.Program UPLC.NamedDeBruijn uni fun ())
+liftProgram v x = unsafely $ safeLiftProgram v x
 
 -- | Get a Plutus Core program in the default universe with the default version, corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
 liftProgramDef
     :: Lift.Lift PLC.DefaultUni a
-    => a -> UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
+    => a -> (PIR.Program PLC.TyName PLC.Name PLC.DefaultUni PLC.DefaultFun (), UPLC.Program UPLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ())
 liftProgramDef = liftProgram PLC.latestVersion
 
 -- | Get a Plutus Core program corresponding to the given value as a 'CompiledCodeIn', throwing any errors that occur as exceptions and ignoring fresh names.

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -41,7 +41,6 @@ import PlutusCore.Version qualified as PLC
 
 import UntypedPlutusCore qualified as UPLC
 
-import Control.Arrow ((***))
 import Control.Exception
 import Control.Lens hiding (lifted)
 import Control.Monad.Except hiding (lift)
@@ -102,7 +101,7 @@ safeLiftProgram
        , Default (PLC.CostingPart uni fun)
        )
     => PLC.Version -> a -> m (PIR.Program PLC.TyName PLC.Name uni fun (), UPLC.Program UPLC.NamedDeBruijn uni fun ())
-safeLiftProgram v x = (PIR.Program () v *** UPLC.Program () v) <$> safeLift v x
+safeLiftProgram v x = bimap (PIR.Program () v) (UPLC.Program () v) <$> safeLift v x
 
 safeLiftCode
     :: (Lift.Lift uni a


### PR DESCRIPTION
This enables us to see the PIR of many test cases, which is useful for debugging.