### PR TITLE
Add Eq for CostModelApplyError

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/CostModelInterface.hs
@@ -168,7 +168,7 @@ data CostModelApplyError =
       -- ^ internal error when we are transforming the applied params from json with given jsonstring error (should not happen)
     | CMTooFewParamsError { cmTooFewExpected :: !Int, cmTooFewActual :: !Int }
       -- ^ See Note [Cost model parameters from the ledger's point of view]
-    deriving stock Show
+    deriving stock (Eq, Show)
     deriving anyclass Exception
 
 -- | A non-fatal warning when trying to create a cost given some plain costmodel parameters.


### PR DESCRIPTION
<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested

This is a prerequisite for https://github.com/input-output-hk/cardano-node/pull/5197 , where infectious `Eq` got in the way.
