### PR TITLE
Fix processSingleBinding

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
@@ -237,7 +237,7 @@ processSingleBinding body = \case
             -- this binding is going to be unconditionally inlined
             Nothing -> pure Nothing
             Just processedRhs -> do
-                let (varArity, bodyToCheck) = computeArity rhs
+                let (varArity, bodyToCheck) = computeArity processedRhs
                 -- when we encounter a binding, we add it to
                 -- the global map `Utils.NonRecInScopeSet`.
                 -- The `varDef` added to the map has been unconditionally inlined.

--- a/plutus-core/plutus-ir/test/TransformSpec.hs
+++ b/plutus-core/plutus-ir/test/TransformSpec.hs
@@ -262,6 +262,7 @@ inline =
             , "letNonPure" -- multiple occurrences of a non-pure binding
             , "letNonPureMulti"
             , "letNonPureMultiStrict"
+            , "rhs-modified"
             ]
 
 -- | Check whether a term is globally unique.

--- a/plutus-core/plutus-ir/test/transform/inline/rhs-modified
+++ b/plutus-core/plutus-ir/test/transform/inline/rhs-modified
@@ -1,0 +1,23 @@
+{-
+let a = <big>
+    f = \x. a
+ in f 3 + f 4
+
+In this example, `f` should not be inlined. `f x` does have a small body, i.e., `a`,
+but that is no longer the case once `a` is unconditionally inlined.
+-}
+
+(let
+  (nonrec)
+  (termbind
+    (nonstrict)
+    (vardecl a (con integer))
+    [ [ (builtin addInteger) (con integer 1) ] (con integer 2) ]
+  )
+  (termbind
+    (strict)
+    (vardecl f (fun (con integer) (con integer)))
+    (lam x (con integer) a)
+  )
+  [ [ (builtin addInteger) [ f (con integer 3) ] ] [ f (con integer 4) ] ]
+)

--- a/plutus-core/plutus-ir/test/transform/inline/rhs-modified.golden
+++ b/plutus-core/plutus-ir/test/transform/inline/rhs-modified.golden
@@ -1,0 +1,13 @@
+(let
+  (nonrec)
+  (termbind
+    (strict)
+    (vardecl f (fun (con integer) (con integer)))
+    (lam
+      x
+      (con integer)
+      [ [ (builtin addInteger) (con integer 1) ] (con integer 2) ]
+    )
+  )
+  [ [ (builtin addInteger) [ f (con integer 3) ] ] [ f (con integer 4) ] ]
+)


### PR DESCRIPTION
Fixed a bug in `processSingleBinding`, and added a test case that would otherwise fail.