### PR TITLE
[PlutusIR] [Compile] Replace a lambda with 'unveilDatatype'

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -431,7 +431,7 @@ SOPs:
 @
 -}
 mkConstructor :: MonadQuote m => DatatypeCompilationOpts -> PLCRecType uni fun a -> Datatype TyName Name uni (Provenance a) -> Word64 -> m (PIRTerm uni fun a)
-mkConstructor opts dty d@(Datatype ann tv tvs _ constrs) index = do
+mkConstructor opts dty d@(Datatype ann _ tvs _ constrs) index = do
     -- This is inelegant, but it should never fail
     let thisConstr = constrs !! fromIntegral index
 
@@ -452,9 +452,8 @@ mkConstructor opts dty d@(Datatype ann tv tvs _ constrs) index = do
 
             -- The pattern functor with a hole in it
             pf <- mkPatternFunctorBody opts ann d
-            -- ... and with the hole filled in with the datatype type, by making
-            -- a type lambda and immediately applying it
-            let unrolled = TyApp ann (PIR.mkIterTyLam [tv] pf) (getType dty)
+            -- ... and with the hole filled in with the datatype type
+            let unrolled = unveilDatatype (getType dty) d pf
 
             pure $ Constr ann unrolled index (fmap (PIR.mkVar ann) argsAndTypes)
           ScottEncoding -> do

--- a/plutus-core/plutus-ir/test/datatypes/listMatch.golden
+++ b/plutus-core/plutus-ir/test/datatypes/listMatch.golden
@@ -64,23 +64,25 @@
             )
             a_i1
             (constr
-              [
-                (lam
-                  List_i0 (fun (type) (type)) (sop [] [a_i2 [ List_i1 a_i2 ]])
-                )
-                (lam
-                  a_i0
-                  (type)
-                  (ifix
-                    (lam
-                      List_i0
-                      (fun (type) (type))
-                      (lam a_i0 (type) (sop [] [a_i1 [ List_i2 a_i1 ]]))
+              (sop
+                []
+                [a_i1
+                [
+                  (lam
+                    a_i0
+                    (type)
+                    (ifix
+                      (lam
+                        List_i0
+                        (fun (type) (type))
+                        (lam a_i0 (type) (sop [] [a_i1 [ List_i2 a_i1 ]]))
+                      )
+                      a_i1
                     )
-                    a_i1
                   )
-                )
-              ]
+                  a_i1
+                ]]
+              )
               0
             )
           )
@@ -117,23 +119,25 @@
               )
               a_i3
               (constr
-                [
-                  (lam
-                    List_i0 (fun (type) (type)) (sop [] [a_i4 [ List_i1 a_i4 ]])
-                  )
-                  (lam
-                    a_i0
-                    (type)
-                    (ifix
-                      (lam
-                        List_i0
-                        (fun (type) (type))
-                        (lam a_i0 (type) (sop [] [a_i1 [ List_i2 a_i1 ]]))
+                (sop
+                  []
+                  [a_i3
+                  [
+                    (lam
+                      a_i0
+                      (type)
+                      (ifix
+                        (lam
+                          List_i0
+                          (fun (type) (type))
+                          (lam a_i0 (type) (sop [] [a_i1 [ List_i2 a_i1 ]]))
+                        )
+                        a_i1
                       )
-                      a_i1
                     )
-                  )
-                ]
+                    a_i3
+                  ]]
+                )
                 1
                 arg_0_i2
                 arg_1_i1

--- a/plutus-core/plutus-ir/test/datatypes/maybe.golden
+++ b/plutus-core/plutus-ir/test/datatypes/maybe.golden
@@ -39,33 +39,10 @@
               )
               (lam a_i0 (type) (sop [] [a_i1]))
             }
-            (abs
-              a_i0
-              (type)
-              (constr
-                [
-                  (lam Maybe_i0 (fun (type) (type)) (sop [] [a_i2]))
-                  (lam a_i0 (type) (sop [] [a_i1]))
-                ]
-                0
-              )
-            )
+            (abs a_i0 (type) (constr (sop [] [a_i1]) 0))
           ]
           (abs
-            a_i0
-            (type)
-            (lam
-              arg_0_i0
-              a_i2
-              (constr
-                [
-                  (lam Maybe_i0 (fun (type) (type)) (sop [] [a_i3]))
-                  (lam a_i0 (type) (sop [] [a_i1]))
-                ]
-                1
-                arg_0_i1
-              )
-            )
+            a_i0 (type) (lam arg_0_i0 a_i2 (constr (sop [] [a_i2]) 1 arg_0_i1))
           )
         ]
         (abs

--- a/plutus-core/plutus-ir/test/recursion/even3.golden
+++ b/plutus-core/plutus-ir/test/recursion/even3.golden
@@ -504,9 +504,9 @@
                           )
                           (lam Nat_i0 (type) (sop [] [Nat_i1]))
                           (constr
-                            [
-                              (lam Nat_i0 (type) (sop [] [Nat_i1]))
-                              (ifix
+                            (sop
+                              []
+                              [(ifix
                                 (lam
                                   rec_i0
                                   (fun (fun (type) (type)) (type))
@@ -517,8 +517,8 @@
                                   )
                                 )
                                 (lam Nat_i0 (type) (sop [] [Nat_i1]))
-                              )
-                            ]
+                              )]
+                            )
                             0
                           )
                         )
@@ -545,9 +545,9 @@
                           )
                           (lam Nat_i0 (type) (sop [] [Nat_i1]))
                           (constr
-                            [
-                              (lam Nat_i0 (type) (sop [] [Nat_i1]))
-                              (ifix
+                            (sop
+                              []
+                              [(ifix
                                 (lam
                                   rec_i0
                                   (fun (fun (type) (type)) (type))
@@ -558,8 +558,8 @@
                                   )
                                 )
                                 (lam Nat_i0 (type) (sop [] [Nat_i1]))
-                              )
-                            ]
+                              )]
+                            )
                             1
                             arg_0_i1
                           )
@@ -615,9 +615,9 @@
           )
           (sop [] [])
         }
-        (constr [ (lam Bool_i0 (type) (sop [] [])) (sop [] []) ] 0)
+        (constr (sop [] []) 0)
       ]
-      (constr [ (lam Bool_i0 (type) (sop [] [])) (sop [] []) ] 1)
+      (constr (sop [] []) 1)
     ]
     (lam
       x_i0

--- a/plutus-core/plutus-ir/test/recursion/stupidZero.golden
+++ b/plutus-core/plutus-ir/test/recursion/stupidZero.golden
@@ -116,17 +116,17 @@
           )
           (lam Nat_i0 (type) (sop [] [Nat_i1]))
           (constr
-            [
-              (lam Nat_i0 (type) (sop [] [Nat_i1]))
-              (ifix
+            (sop
+              []
+              [(ifix
                 (lam
                   rec_i0
                   (fun (fun (type) (type)) (type))
                   (lam f_i0 (fun (type) (type)) [ f_i1 [ rec_i2 f_i1 ] ])
                 )
                 (lam Nat_i0 (type) (sop [] [Nat_i1]))
-              )
-            ]
+              )]
+            )
             0
           )
         )
@@ -149,17 +149,17 @@
           )
           (lam Nat_i0 (type) (sop [] [Nat_i1]))
           (constr
-            [
-              (lam Nat_i0 (type) (sop [] [Nat_i1]))
-              (ifix
+            (sop
+              []
+              [(ifix
                 (lam
                   rec_i0
                   (fun (fun (type) (type)) (type))
                   (lam f_i0 (fun (type) (type)) [ f_i1 [ rec_i2 f_i1 ] ])
                 )
                 (lam Nat_i0 (type) (sop [] [Nat_i1]))
-              )
-            ]
+              )]
+            )
             1
             arg_0_i1
           )

--- a/plutus-tx-plugin/test/Plugin/Data/recursive/interListConstruct.tplc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/recursive/interListConstruct.tplc.golden
@@ -132,13 +132,9 @@
                           )
                           (sop [] [])
                         }
-                        (constr
-                          [ (lam Bool_i0 (type) (sop [] [])) (sop [] []) ] 0
-                        )
+                        (constr (sop [] []) 0)
                       ]
-                      (constr
-                        [ (lam Bool_i0 (type) (sop [] [])) (sop [] []) ] 1
-                      )
+                      (constr (sop [] []) 1)
                     ]
                     (lam
                       x_i0
@@ -359,78 +355,90 @@
                       [ [ dat_i1 a_i6 ] b_i5 ]
                     )
                     (constr
-                      [
-                        (lam
-                          InterList_i0
-                          (fun (type) (fun (type) (type)))
-                          (sop [a_i6 b_i5 [ [ InterList_i1 b_i5 ] a_i6 ]] [])
-                        )
-                        (lam
-                          a_i0
-                          (type)
-                          (lam
-                            b_i0
-                            (type)
-                            (ifix
+                      (sop
+                        [a_i5
+                        b_i4
+                        [
+                          [
+                            (lam
+                              a_i0
+                              (type)
                               (lam
-                                rec_i0
-                                (fun
-                                  (fun (fun (type) (fun (type) (type))) (type))
-                                  (type)
-                                )
-                                (lam
-                                  spine_i0
-                                  (fun (fun (type) (fun (type) (type))) (type))
-                                  [
-                                    spine_i1
-                                    [
-                                      (lam
-                                        InterList_i0
-                                        (fun (type) (fun (type) (type)))
-                                        (lam
-                                          a_i0
-                                          (type)
+                                b_i0
+                                (type)
+                                (ifix
+                                  (lam
+                                    rec_i0
+                                    (fun
+                                      (fun
+                                        (fun (type) (fun (type) (type))) (type)
+                                      )
+                                      (type)
+                                    )
+                                    (lam
+                                      spine_i0
+                                      (fun
+                                        (fun (type) (fun (type) (type))) (type)
+                                      )
+                                      [
+                                        spine_i1
+                                        [
                                           (lam
-                                            b_i0
-                                            (type)
-                                            (sop
-                                              [a_i2
-                                              b_i1
-                                              [ [ InterList_i3 b_i1 ] a_i2 ]]
-                                              []
+                                            InterList_i0
+                                            (fun (type) (fun (type) (type)))
+                                            (lam
+                                              a_i0
+                                              (type)
+                                              (lam
+                                                b_i0
+                                                (type)
+                                                (sop
+                                                  [a_i2
+                                                  b_i1
+                                                  [
+                                                    [ InterList_i3 b_i1 ] a_i2
+                                                  ]]
+                                                  []
+                                                )
+                                              )
                                             )
                                           )
-                                        )
-                                      )
-                                      (lam
-                                        a_i0
-                                        (type)
-                                        (lam
-                                          b_i0
-                                          (type)
-                                          [
-                                            rec_i4
+                                          (lam
+                                            a_i0
+                                            (type)
                                             (lam
-                                              dat_i0
-                                              (fun (type) (fun (type) (type)))
-                                              [ [ dat_i1 a_i3 ] b_i2 ]
+                                              b_i0
+                                              (type)
+                                              [
+                                                rec_i4
+                                                (lam
+                                                  dat_i0
+                                                  (fun
+                                                    (type) (fun (type) (type))
+                                                  )
+                                                  [ [ dat_i1 a_i3 ] b_i2 ]
+                                                )
+                                              ]
                                             )
-                                          ]
-                                        )
-                                      )
-                                    ]
-                                  ]
+                                          )
+                                        ]
+                                      ]
+                                    )
+                                  )
+                                  (lam
+                                    dat_i0
+                                    (fun (type) (fun (type) (type)))
+                                    [ [ dat_i1 a_i3 ] b_i2 ]
+                                  )
                                 )
                               )
-                              (lam
-                                dat_i0
-                                (fun (type) (fun (type) (type)))
-                                [ [ dat_i1 a_i3 ] b_i2 ]
-                              )
                             )
-                          )
-                        )
-                      ]
+                            b_i4
+                          ]
+                          a_i5
+                        ]]
+                        []
+                      )
                       0
                       arg_0_i3
                       arg_1_i2
@@ -496,75 +504,82 @@
               dat_i0 (fun (type) (fun (type) (type))) [ [ dat_i1 a_i3 ] b_i2 ]
             )
             (constr
-              [
-                (lam
-                  InterList_i0
-                  (fun (type) (fun (type) (type)))
-                  (sop [a_i3 b_i2 [ [ InterList_i1 b_i2 ] a_i3 ]] [])
-                )
-                (lam
-                  a_i0
-                  (type)
-                  (lam
-                    b_i0
-                    (type)
-                    (ifix
+              (sop
+                [a_i2
+                b_i1
+                [
+                  [
+                    (lam
+                      a_i0
+                      (type)
                       (lam
-                        rec_i0
-                        (fun
-                          (fun (fun (type) (fun (type) (type))) (type)) (type)
-                        )
-                        (lam
-                          spine_i0
-                          (fun (fun (type) (fun (type) (type))) (type))
-                          [
-                            spine_i1
-                            [
-                              (lam
-                                InterList_i0
-                                (fun (type) (fun (type) (type)))
-                                (lam
-                                  a_i0
-                                  (type)
+                        b_i0
+                        (type)
+                        (ifix
+                          (lam
+                            rec_i0
+                            (fun
+                              (fun (fun (type) (fun (type) (type))) (type))
+                              (type)
+                            )
+                            (lam
+                              spine_i0
+                              (fun (fun (type) (fun (type) (type))) (type))
+                              [
+                                spine_i1
+                                [
                                   (lam
-                                    b_i0
-                                    (type)
-                                    (sop
-                                      [a_i2 b_i1 [ [ InterList_i3 b_i1 ] a_i2 ]]
-                                      []
+                                    InterList_i0
+                                    (fun (type) (fun (type) (type)))
+                                    (lam
+                                      a_i0
+                                      (type)
+                                      (lam
+                                        b_i0
+                                        (type)
+                                        (sop
+                                          [a_i2
+                                          b_i1
+                                          [ [ InterList_i3 b_i1 ] a_i2 ]]
+                                          []
+                                        )
+                                      )
                                     )
                                   )
-                                )
-                              )
-                              (lam
-                                a_i0
-                                (type)
-                                (lam
-                                  b_i0
-                                  (type)
-                                  [
-                                    rec_i4
+                                  (lam
+                                    a_i0
+                                    (type)
                                     (lam
-                                      dat_i0
-                                      (fun (type) (fun (type) (type)))
-                                      [ [ dat_i1 a_i3 ] b_i2 ]
+                                      b_i0
+                                      (type)
+                                      [
+                                        rec_i4
+                                        (lam
+                                          dat_i0
+                                          (fun (type) (fun (type) (type)))
+                                          [ [ dat_i1 a_i3 ] b_i2 ]
+                                        )
+                                      ]
                                     )
-                                  ]
-                                )
-                              )
-                            ]
-                          ]
+                                  )
+                                ]
+                              ]
+                            )
+                          )
+                          (lam
+                            dat_i0
+                            (fun (type) (fun (type) (type)))
+                            [ [ dat_i1 a_i3 ] b_i2 ]
+                          )
                         )
                       )
-                      (lam
-                        dat_i0
-                        (fun (type) (fun (type) (type)))
-                        [ [ dat_i1 a_i3 ] b_i2 ]
-                      )
                     )
-                  )
-                )
-              ]
+                    b_i1
+                  ]
+                  a_i2
+                ]]
+                []
+              )
               1
             )
           )


### PR DESCRIPTION
This should probably alleviate at least some of the confusion. @michaelpj what you were doing there with creating a lambda and immediately applying it is in fact a pretty common thing in the Plutus IR compiler. So common we've named a paper after it! It's just unveiling. You can even see how the same thing is done for Scott-encoding as well, albeit for a slightly different reason (with Scott-encoding we need unveiling for the types of arguments, with SOPs we need it for the type of the result).

Here's a comparison of compilation output for the `InterList` example:

```
                      SOP    Unveil SOP    Scott
lines of S-exps       749    764           817
occurrences of ifix   6      6             5

```

With unveiling we get slightly larger output, but we're also being consistent and making the dreaded line less dreaded.

Questions still remain though:

1. should the data type compilation machinery in Plutus Core adopt some of this logic?
2. should we try to reduce the amount of duplication? I'm rather skeptical that we're being optimal there
3. would compilation of mutually recursive affect things in a non-trivial way? I remember that incorporating mutually recursive data types wasn't an easy thing even without trying not to produce so many duplicated types
4. do we even care that much about type duplication, given that it all gets erased anyway? I'd argue that yes, because they make it harder to analyze compilation output, hiding optimization opportunities for us and making us reluctant to look into compilation output in the first place (just like the S-expression abomination)