### PR TITLE
Stop publishing haddock for releases

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build-haddock-site:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've been publishing Haddock for each release, but each one has a whopping 1.4GB in size and it has exceeded the 10GB limit. Removing the Haddock for releases, and only keeping the master Haddock, until we find a better solution.