### PR TITLE
Add --silent option to plc/pir/uplc commands

### DIFF
--- a/plutus-core/executables/pir/Main.hs
+++ b/plutus-core/executables/pir/Main.hs
@@ -254,7 +254,9 @@ loadPirAndAnalyse (AnalyseOptions inp ifmt outp) = do
         case outp of
             FileOutput path -> BSL.writeFile path
             StdOutput       -> BSL.putStr
-
+            -- NoOutput supresses the output of programs/terms, but that's not
+            -- what we've got here.
+            NoOutput        -> BSL.putStr
 
 ---------------- Parse and print a PIR source file ----------------
 -- This option for PIR source file does NOT check for @UniqueError@'s.
@@ -276,7 +278,7 @@ runPrint (PrintOptions inp outp mode) = do
         case outp of
             FileOutput path -> writeFile path printed
             StdOutput       -> putStrLn printed
-
+            NoOutput        -> pure ()
 
 ---------------- Main ----------------
 

--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -328,6 +328,7 @@ writeFlat outp flatMode prog = do
     case outp of
         FileOutput file -> BSL.writeFile file flatProg
         StdOutput       -> BSL.putStr flatProg
+        NoOutput        -> pure ()
 
 ---------------- Write an AST as PLC source ----------------
 
@@ -359,6 +360,7 @@ writePrettyToFileOrStd outp mode prog = do
     case outp of
         FileOutput file -> writeFile file . Prelude.show . printMethod $ prog
         StdOutput       -> print . printMethod $ prog
+        NoOutput        -> pure ()
 
 writeToFileOrStd ::
     Output -> String -> IO ()
@@ -366,6 +368,7 @@ writeToFileOrStd outp v = do
     case outp of
         FileOutput file -> writeFile file v
         StdOutput       -> putStrLn v
+        NoOutput        -> pure ()
 
 ---------------- Examples ----------------
 
@@ -619,6 +622,7 @@ runPrint (PrintOptions inp outp mode) = do
     case outp of
         FileOutput path -> writeFile path printed
         StdOutput       -> putStrLn printed
+        NoOutput        -> pure ()
 
 ---------------- Conversions ----------------
 

--- a/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
@@ -28,7 +28,7 @@ stdInput = flag' StdInput
 -- | Parser for an output stream. If none is specified,
 -- default to stdout for ease of use in pipeline.
 output :: Parser Output
-output = fileOutput <|> stdOutput <|> pure StdOutput
+output = fileOutput <|> stdOutput <|> noOutput <|> pure StdOutput
 
 fileOutput :: Parser Output
 fileOutput = FileOutput <$> strOption
@@ -41,6 +41,12 @@ stdOutput :: Parser Output
 stdOutput = flag' StdOutput
   (  long "stdout"
   <> help "Write to stdout (default)" )
+
+noOutput :: Parser Output
+noOutput = flag' NoOutput
+  (  long "silent"
+  <> short 's'
+  <> help "Don't output the evaluation result" )
 
 formatHelp :: String
 formatHelp =

--- a/plutus-core/executables/src/PlutusCore/Executable/Types.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Types.hs
@@ -50,7 +50,7 @@ instance Show Input where
     show (FileInput path) = show path
     show StdInput         = "<stdin>"
 
-data Output = FileOutput FilePath | StdOutput
+data Output = FileOutput FilePath | StdOutput | NoOutput
 data TimingMode = NoTiming | Timing Integer deriving stock (Eq) -- Report program execution time?
 data CekModel = Default | Unit -- Which cost model should we use for CEK machine steps?
 data PrintMode = Classic | Debug | Readable | ReadableDebug deriving stock (Show, Read)


### PR DESCRIPTION
The plc excutables usually print the output of a program after execution has finished, but that can take a long time or be distracting if you just want to see the execution costs, for example.  This (very small)  PR adds a `-s`/`--silent` option that stops the executables from outputting the result.  That may not make a lot of sense in some cases (eg for `convert`) but to deal with that properly would require adding new option types and option parsers.  Let's just trust the user not to be silly.