### PR TITLE
[Test] [Builtins] Use 'BuiltinsRuntime' in no-exceptions tests

### DIFF
--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -50,13 +50,14 @@ test_builtinsDon'tThrow =
     testGroup "Builtins don't throw" $
         enumerate @(BuiltinVersion DefaultFun) <&> \ver ->
             testGroup (fromString . render $ "Version: " <> pretty ver) $
-                enumerate @DefaultFun <&> \fun ->
+                let runtimes = toBuiltinsRuntime ver defaultBuiltinCostModel
+                in enumerate @DefaultFun <&> \fun ->
                     -- Perhaps using @maxBound@ (with @Enum@, @Bounded@) is indeed better than
                     -- @Default@ for BuiltinVersions
                     testPropertyNamed
                         (display fun)
                         (fromString $ display fun)
-                        (prop_builtinEvaluation ver fun defaultBuiltinCostModel gen f)
+                        (prop_builtinEvaluation runtimes fun gen f)
   where
     gen bn = Gen.choice [genArgsWellTyped def bn, genArgsArbitrary def bn]
     f bn args = \case
@@ -96,10 +97,11 @@ test_alwaysThrows =
     testGroup
         "Builtins throwing exceptions should cause tests to fail"
         [ testPropertyNamed (display AlwaysThrows) (fromString . display $ AlwaysThrows) $
-            prop_builtinEvaluation @_ @AlwaysThrows ver AlwaysThrows () (genArgsWellTyped ver) f
+            prop_builtinEvaluation @_ @AlwaysThrows runtimes AlwaysThrows (genArgsWellTyped ver) f
         ]
   where
     ver = AlwaysThrowsV1
+    runtimes = toBuiltinsRuntime ver ()
     f bn args = \case
         Left _ -> success
         Right _ -> do
@@ -110,17 +112,16 @@ test_alwaysThrows =
 
 prop_builtinEvaluation ::
     forall uni fun.
-    (ToBuiltinMeaning uni fun, PrettyUni uni, Pretty fun) =>
-    PLC.BuiltinVersion fun ->
+    (PrettyUni uni, Pretty fun) =>
+    BuiltinsRuntime fun (Term uni fun) ->
     fun ->
-    CostingPart uni fun ->
     -- | A function making a generator for @fun@'s arguments.
     (fun -> Gen [Term uni fun]) ->
     -- | A function that takes a builtin function, a list of arguments, and the evaluation
     -- outcome, and decides whether to pass or fail the property.
     (fun -> [Term uni fun] -> Either SomeException (MakeKnownM (Term uni fun)) -> PropertyT IO ()) ->
     Property
-prop_builtinEvaluation ver bn costModel mkGen f = property $ do
+prop_builtinEvaluation runtimes bn mkGen f = property $ do
     args0 <- forAllNoShow $ mkGen bn
     let
         eval :: [Term uni fun] -> BuiltinRuntime (Term uni fun) -> MakeKnownM (Term uni fun)
@@ -134,8 +135,7 @@ prop_builtinEvaluation ver bn costModel mkGen f = property $ do
             -- TODO: can we make this function run in @GenT MakeKnownM@ and generate arguments
             -- on the fly to avoid this error case?
             error $ "Wrong number of args for builtin " <> display bn <> ": " <> display args0
-        BuiltinMeaning _ _ denot = toBuiltinMeaning ver bn
-        runtime0 = denot costModel
+        runtime0 = lookupBuiltin bn runtimes
     f bn args0 =<< liftIO (try @SomeException . evaluate $ eval args0 runtime0)
 
 genArgsWellTyped ::


### PR DESCRIPTION
I was trying to test that `BuiltinRuntime`s are always in WHNF at runtime and needed these changes to make progress. The testing endeavor failed miserably, but I thought it was worth keeping some changes anyway, because I think they make the code slightly cleaner and you're-holding-it-righter. 