### PR TITLE
Update `mkIterApp`, `mkIterInst` and `mkIterTyApp`

### DIFF
--- a/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
+++ b/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
@@ -1,8 +1,10 @@
 ### Added
 
-- Added `PlutusCore.MkPlc.mkIterAppNoAnn` and `PlutusCore.MkPlc.mkIterInstNoAnn`.
+- Added `PlutusCore.MkPlc.mkIterAppNoAnn`, `PlutusCore.MkPlc.mkIterInstNoAnn` and
+  `PlutusCore.MkPlc.mkIterTyAppNoAnn`.
 
 ### Changed
 
-- Changed `PlutusCore.MkPlc.mkIterApp` and `PlutusCore.MkPlc.mkIterInst` to require an annotation
-  to be provided for each argument.
+- Changed `PlutusCore.MkPlc.mkIterApp`, `PlutusCore.MkPlc.mkIterInst` and
+  `PlutusCore.MkPlc.mkIterTyApp `to require an annotation to be provided
+  for each argument.

--- a/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
+++ b/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
@@ -6,5 +6,5 @@
 ### Changed
 
 - Changed `PlutusCore.MkPlc.mkIterApp`, `PlutusCore.MkPlc.mkIterInst` and
-  `PlutusCore.MkPlc.mkIterTyApp `to require an annotation to be provided
+  `PlutusCore.MkPlc.mkIterTyApp` to require an annotation to be provided
   for each argument.

--- a/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
+++ b/plutus-core/changelog.d/20230523_105725_unsafeFixIO_mkplc.md
@@ -1,0 +1,8 @@
+### Added
+
+- Added `PlutusCore.MkPlc.mkIterAppNoAnn` and `PlutusCore.MkPlc.mkIterInstNoAnn`.
+
+### Changed
+
+- Changed `PlutusCore.MkPlc.mkIterApp` and `PlutusCore.MkPlc.mkIterInst` to require an annotation
+  to be provided for each argument.

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -108,8 +108,8 @@ mkUnit = eraseTerm $  mkConstant () ()
 -- Create a term instantiating a builtin and applying it to one argument
 mkApp1 :: (uni `Includes` a, NFData a) => fun -> [Type tyname uni ()] -> a -> PlainTerm uni fun
 mkApp1 !name !tys (force -> !x) =
-    eraseTerm $ mkIterApp () instantiated [mkConstant () x]
-    where instantiated = mkIterInst () (builtin () name) tys
+    eraseTerm $ mkIterAppNoAnn instantiated [mkConstant () x]
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 -- Create a term instantiating a builtin and applying it to two arguments
@@ -117,8 +117,8 @@ mkApp2
     :: (uni `Includes` a, uni `Includes` b, NFData a, NFData b)
     =>  fun -> [Type tyname uni ()]-> a -> b -> PlainTerm uni fun
 mkApp2 !name !tys (force -> !x) (force -> !y) =
-    eraseTerm $ mkIterApp () instantiated [mkConstant () x,  mkConstant () y]
-    where instantiated = mkIterInst () (builtin () name) tys
+    eraseTerm $ mkIterAppNoAnn instantiated [mkConstant () x,  mkConstant () y]
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 -- Create a term instantiating a builtin and applying it to three arguments
@@ -126,8 +126,8 @@ mkApp3
     :: (uni `Includes` a, uni `Includes` b, uni `Includes` c, NFData a, NFData b, NFData c)
     => fun -> [Type tyname uni ()] -> a -> b -> c -> PlainTerm uni fun
 mkApp3 !name !tys (force -> !x) (force -> !y) (force -> !z) =
-    eraseTerm $ mkIterApp () instantiated [mkConstant () x, mkConstant () y, mkConstant () z]
-    where instantiated = mkIterInst () (builtin () name) tys
+    eraseTerm $ mkIterAppNoAnn instantiated [mkConstant () x, mkConstant () y, mkConstant () z]
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 -- Create a term instantiating a builtin and applying it to four arguments
@@ -137,9 +137,9 @@ mkApp4
         NFData a, NFData b, NFData c, NFData d)
     => fun -> [Type tyname uni ()] -> a -> b -> c -> d -> PlainTerm uni fun
 mkApp4 !name !tys (force -> !x) (force -> !y) (force -> !z) (force -> !t) =
-    eraseTerm $ mkIterApp () instantiated [ mkConstant () x, mkConstant () y
+    eraseTerm $ mkIterAppNoAnn instantiated [ mkConstant () x, mkConstant () y
                                       , mkConstant () z, mkConstant () t ]
-    where instantiated = mkIterInst () (builtin () name) tys
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 -- Create a term instantiating a builtin and applying it to five arguments
@@ -149,9 +149,9 @@ mkApp5
         NFData a, NFData b, NFData c, NFData d, NFData e)
     => fun -> [Type tyname uni ()] -> a -> b -> c -> d -> e -> PlainTerm uni fun
 mkApp5 !name !tys (force -> !x) (force -> !y) (force -> !z) (force -> !t) (force -> !u) =
-    eraseTerm $ mkIterApp () instantiated [ mkConstant () x, mkConstant () y, mkConstant () z
+    eraseTerm $ mkIterAppNoAnn instantiated [ mkConstant () x, mkConstant () y, mkConstant () z
                                       , mkConstant () t, mkConstant () u ]
-    where instantiated = mkIterInst () (builtin () name) tys
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 -- Create a term instantiating a builtin and applying it to six arguments
@@ -161,9 +161,9 @@ mkApp6
         NFData a, NFData b, NFData c, NFData d, NFData e, NFData f)
     => fun -> [Type tyname uni ()] -> a -> b -> c -> d -> e -> f-> PlainTerm uni fun
 mkApp6 name tys (force -> !x) (force -> !y) (force -> !z) (force -> !t) (force -> !u) (force -> !v)=
-    eraseTerm $ mkIterApp () instantiated [mkConstant () x, mkConstant () y, mkConstant () z,
+    eraseTerm $ mkIterAppNoAnn instantiated [mkConstant () x, mkConstant () y, mkConstant () z,
                                        mkConstant () t, mkConstant () u, mkConstant () v]
-    where instantiated = mkIterInst () (builtin () name) tys
+    where instantiated = mkIterInstNoAnn (builtin () name) tys
 
 
 ---------------- Creating benchmarks ----------------

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
@@ -73,25 +73,25 @@ ofoldrData = runQuote $ do
         . lamAbs () fList (TyFun () listR r)
         . lamAbs () fI (TyFun () integer r)
         . lamAbs () fB (TyFun () (mkTyBuiltin @_ @ByteString ()) r)
-        . apply () (mkIterInst () fix [dataTy, r])
+        . apply () (mkIterInstNoAnn fix [dataTy, r])
         . lamAbs () rec (TyFun () dataTy r)
         . lamAbs () d dataTy
-        $ mkIterApp () (tyInst () (unwrap' () (var () d)) r)
+        $ mkIterAppNoAnn (tyInst () (unwrap' () (var () d)) r)
             [   lamAbs () i integer
               . lamAbs () ds listData
-              $ mkIterApp () (var () fConstr)
+              $ mkIterAppNoAnn (var () fConstr)
                   [ var () i
-                  , mkIterApp () (tyInst () omapList dataTy) [var () rec, var () ds]
+                  , mkIterAppNoAnn (tyInst () omapList dataTy) [var () rec, var () ds]
                   ]
             ,   lamAbs () es (TyApp () list $ opair dataTy)
               . apply () (var () fMap)
-              $ mkIterApp () (tyInst () omapList $ opair dataTy)
+              $ mkIterAppNoAnn (tyInst () omapList $ opair dataTy)
                   [ apply () (tyInst () obothPair dataTy) $ var () rec
                   , var () es
                   ]
             ,   lamAbs () ds listData
               . apply () (var () fList)
-              $ mkIterApp () (tyInst () omapList dataTy)
+              $ mkIterAppNoAnn (tyInst () omapList dataTy)
                   [ var () rec
                   , var () ds
                   ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
@@ -65,7 +65,7 @@ ofoldrData = runQuote $ do
     es      <- freshName "es"
     let listData = mkTyBuiltin @_ @[Data] ()
         listR = TyApp () list r
-        opair a = mkIterTyApp () pair [a, a]
+        opair a = mkIterTyAppNoAnn pair [a, a]
         unwrap' ann = apply ann $ mapFun Left caseData
     return
         . lamAbs () fConstr (TyFun () integer $ TyFun () listR r)

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -47,7 +47,7 @@ interListData = runQuote $ do
     b         <- freshTyName "b"
     interlist <- freshTyName "interlist"
     r         <- freshTyName "r"
-    let interlistBA = mkIterTyApp () (TyVar () interlist) [TyVar () b, TyVar () a]
+    let interlistBA = mkIterTyAppNoAnn (TyVar () interlist) [TyVar () b, TyVar () a]
     makeRecursiveType () interlist [TyVarDecl () a $ Type (), TyVarDecl () b $ Type ()]
         . TyForall () r (Type ())
         . TyFun () (TyVar () r)
@@ -62,7 +62,7 @@ interNil = runQuote $ do
     r <- freshTyName "r"
     z <- freshName "z"
     f <- freshName "f"
-    let interlistBA = mkIterTyApp () interlist [TyVar () b, TyVar () a]
+    let interlistBA = mkIterTyAppNoAnn interlist [TyVar () b, TyVar () a]
     return
         . TyAbs () a (Type ())
         . TyAbs () b (Type ())
@@ -83,7 +83,7 @@ interCons = runQuote $ do
     r  <- freshTyName "r"
     z  <- freshName "z"
     f  <- freshName "f"
-    let interlistBA = mkIterTyApp () interlist [TyVar () b, TyVar () a]
+    let interlistBA = mkIterTyAppNoAnn interlist [TyVar () b, TyVar () a]
     return
         . TyAbs () a (Type ())
         . TyAbs () b (Type ())
@@ -119,7 +119,7 @@ foldrInterList = runQuote $ do
     xs' <- freshName "xs'"
     x'  <- freshName "x'"
     y'  <- freshName "y'"
-    let interlistOf a' b' = mkIterTyApp () interlist [TyVar () a', TyVar () b']
+    let interlistOf a' b' = mkIterTyAppNoAnn interlist [TyVar () a', TyVar () b']
         fTy a' b' = mkIterTyFun () [TyVar () a', TyVar () b', TyVar () r] $ TyVar () r
         fixTyArg2
             = TyForall () a (Type ())

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -94,7 +94,7 @@ interCons = runQuote $ do
         . TyAbs () r (Type ())
         . LamAbs () z (TyVar () r)
         . LamAbs () f (mkIterTyFun () [TyVar () a, TyVar () b, interlistBA] $ TyVar () r)
-        $ mkIterApp () (Var () f)
+        $ mkIterAppNoAnn (Var () f)
           [ Var () x
           , Var () y
           , Var () xs
@@ -127,35 +127,35 @@ foldrInterList = runQuote $ do
             . TyFun () (fTy a b)
             . TyFun () (interlistOf a b)
             $ TyVar () r
-        instedFix = mkIterInst () fix [unit, fixTyArg2]
+        instedFix = mkIterInstNoAnn fix [unit, fixTyArg2]
         unwrappedXs = TyInst () (Unwrap () (Var () xs)) $ TyVar () r
-        instedRec = mkIterInst () (Apply () (Var () rec) unitval) [TyVar () b, TyVar () a]
+        instedRec = mkIterInstNoAnn (Apply () (Var () rec) unitval) [TyVar () b, TyVar () a]
     return
         . TyAbs () a0 (Type ())
         . TyAbs () b0 (Type ())
         . TyAbs () r (Type ())
         . LamAbs () f (fTy a0 b0)
         . LamAbs () z (TyVar () r)
-        $ mkIterInst ()
-            ( mkIterApp () instedFix
+        $ mkIterInstNoAnn
+            ( mkIterAppNoAnn instedFix
                 [   LamAbs () rec (TyFun () unit fixTyArg2)
                   . LamAbs () u unit
                   . TyAbs () a (Type ())
                   . TyAbs () b (Type ())
                   . LamAbs () f' (fTy a b)
                   . LamAbs () xs (interlistOf a b)
-                  $ mkIterApp () unwrappedXs
+                  $ mkIterAppNoAnn unwrappedXs
                       [ Var () z
                       ,    LamAbs () x (TyVar () a)
                          . LamAbs () y (TyVar () b)
                          . LamAbs () xs' (interlistOf b a)
-                         $ mkIterApp () (Var () f')
+                         $ mkIterAppNoAnn (Var () f')
                              [ Var () x
                              , Var () y
-                             , mkIterApp () instedRec
+                             , mkIterAppNoAnn instedRec
                                  [    LamAbs () y' (TyVar () b)
                                     . LamAbs () x' (TyVar () a)
-                                    $ mkIterApp () (Var () f')
+                                    $ mkIterAppNoAnn (Var () f')
                                         [ Var () x'
                                         , Var () y'
                                         ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/List.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/List.hs
@@ -33,13 +33,13 @@ omapList = runQuote $ do
     return
         . tyAbs () a (Type ())
         . lamAbs () f (TyFun () (TyVar () a) $ TyVar () a)
-        . apply () (mkIterInst () fix [listA, listA])
+        . apply () (mkIterInstNoAnn fix [listA, listA])
         . lamAbs () rec (TyFun () listA listA)
         . lamAbs () xs listA
         . apply () (apply () (tyInst () (unwrap' () (var () xs)) listA) $ var () xs)
         . lamAbs () x (TyVar () a)
         . lamAbs () xs' listA
-        $ mkIterApp () (tyInst () (builtin () $ Left MkCons) $ TyVar () a)
+        $ mkIterAppNoAnn (tyInst () (builtin () $ Left MkCons) $ TyVar () a)
             [ apply () (var () f) $ var () x
             , apply () (var () rec) $ var () xs'
             ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
@@ -27,7 +27,7 @@ obothPair = runQuote $ do
     return
         . tyAbs () a (Type ())
         . lamAbs () f (TyFun () (TyVar () a) $ TyVar () a)
-        . lamAbs () p (mkIterTyApp () pair [TyVar () a, TyVar () a])
+        . lamAbs () p (mkIterTyAppNoAnn pair [TyVar () a, TyVar () a])
         $ mkIterAppNoAnn (atAA $ Right Comma)
             [ apply () (var () f) . apply () (atAA $ Left FstPair) $ var () p
             , apply () (var () f) . apply () (atAA $ Left SndPair) $ var () p

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Pair.hs
@@ -23,12 +23,12 @@ obothPair = runQuote $ do
     a <- freshTyName "a"
     f <- freshName "f"
     p <- freshName "p"
-    let atAA fun = mkIterInst () (builtin () fun) [TyVar () a, TyVar () a]
+    let atAA fun = mkIterInstNoAnn (builtin () fun) [TyVar () a, TyVar () a]
     return
         . tyAbs () a (Type ())
         . lamAbs () f (TyFun () (TyVar () a) $ TyVar () a)
         . lamAbs () p (mkIterTyApp () pair [TyVar () a, TyVar () a])
-        $ mkIterApp () (atAA $ Right Comma)
+        $ mkIterAppNoAnn (atAA $ Right Comma)
             [ apply () (var () f) . apply () (atAA $ Left FstPair) $ var () p
             , apply () (var () f) . apply () (atAA $ Left SndPair) $ var () p
             ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
@@ -116,7 +116,7 @@ asTree = runQuote $ do
     return
         . TyLam () d (star ~~> (star ~~> star ~~> star) ~~> star)
         . TyLam () a star
-        $ mkIterTyApp () (TyVar () d)
+        $ mkIterTyAppNoAnn (TyVar () d)
             [ TyVar () a
             , treeTag
             ]
@@ -128,7 +128,7 @@ asForest = runQuote $ do
     return
         . TyLam () d (star ~~> (star ~~> star ~~> star) ~~> star)
         . TyLam () a star
-        $ mkIterTyApp () (TyVar () d)
+        $ mkIterTyAppNoAnn (TyVar () d)
             [ TyVar () a
             , forestTag
             ]
@@ -142,11 +142,11 @@ treeForestData = runQuote $ do
     let vA = TyVar () a
         vR = TyVar () r
         recSpine = [TyVar () treeForest, vA]
-    let tree   = mkIterTyApp () asTree   recSpine
-        forest = mkIterTyApp () asForest recSpine
+    let tree   = mkIterTyAppNoAnn asTree   recSpine
+        forest = mkIterTyAppNoAnn asForest recSpine
         body
             = TyForall () r (Type ())
-            $ mkIterTyApp () (TyVar () tag)
+            $ mkIterTyAppNoAnn (TyVar () tag)
                 [ (vA ~~> forest ~~> vR) ~~> vR
                 , vR ~~> (tree ~~> forest ~~> vR) ~~> vR
                 ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/TreeForest.hs
@@ -189,7 +189,7 @@ treeNode = runQuote $ normalizeTypesIn =<< do
         . wrapTree [vA]
         . TyAbs () r (Type ())
         . LamAbs () f (mkIterTyFun () [vA, forestA] vR)
-        $ mkIterApp () (Var () f)
+        $ mkIterAppNoAnn (Var () f)
             [ Var () x
             , Var () fr
             ]
@@ -244,7 +244,7 @@ forestCons = runQuote $ normalizeTypesIn =<< do
         . TyAbs () r (Type ())
         . LamAbs () z vR
         . LamAbs () f (mkIterTyFun () [treeA, forestA] vR)
-        $ mkIterApp () (Var () f)
+        $ mkIterAppNoAnn (Var () f)
             [ Var () tr
             , Var () fr
             ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
@@ -174,9 +174,9 @@ churchCons = runQuote $ do
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
         . LamAbs () z (TyApp () (TyVar () r) zeroT)
-        $ mkIterApp () (TyInst () (Var () f) $ TyVar () n)
+        $ mkIterAppNoAnn (TyInst () (Var () f) $ TyVar () n)
             [ Var () x
-            , mkIterApp () (TyInst () (Var () xs) $ TyVar () r)
+            , mkIterAppNoAnn (TyInst () (Var () xs) $ TyVar () r)
                 [ Var () f
                 , Var () z
                 ]
@@ -214,9 +214,9 @@ churchConcat = runQuote $ do
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
         . LamAbs () z (TyApp () (TyVar () r) zeroT)
-        $ mkIterApp () (TyInst () (Var () xs) . TyLam () p natK $ TyApp () (TyVar () r) plusTPM)
+        $ mkIterAppNoAnn (TyInst () (Var () xs) . TyLam () p natK $ TyApp () (TyVar () r) plusTPM)
             [ TyAbs () p natK $ TyInst () (Var () f) plusTPM
-            , mkIterApp () (TyInst () (Var () ys) $ TyVar () r)
+            , mkIterAppNoAnn (TyInst () (Var () ys) $ TyVar () r)
                 [ Var () f
                 , Var () z
                 ]
@@ -307,7 +307,7 @@ scottCons = runQuote $ do
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
         . LamAbs () z (TyApp () (TyVar () r) zeroT)
-        $ mkIterApp () (TyInst () (Var () f) $ TyVar () n)
+        $ mkIterAppNoAnn (TyInst () (Var () f) $ TyVar () n)
             [ Var () x
             , Var () xs
             ]
@@ -334,7 +334,7 @@ scottHead = runQuote $ do
         . TyAbs () a (Type ())
         . TyAbs () n natK
         . LamAbs () xs (mkIterTyApp () scottVec [TyVar () a, TyApp () succT $ TyVar () n])
-        $ mkIterApp ()
+        $ mkIterAppNoAnn
             (   TyInst () (Unwrap () $ Var () xs)
               . TyLam () p natK
                 $ mkIterTyApp () (TyVar () p)
@@ -376,7 +376,7 @@ scottSumHeadsOr0 = runQuote $ do
         . TyAbs () n natK
         . LamAbs () xs (vecInteger $ TyVar () n)
         . LamAbs () ys (vecInteger $ TyVar () n)
-        $ mkIterApp ()
+        $ mkIterAppNoAnn
             (   TyInst () (Unwrap () $ Var () xs)
               . TyLam () p natK
               . TyFun () (TyFun () (vecInteger $ TyVar () n) $ vecInteger (TyVar () p))
@@ -387,9 +387,9 @@ scottSumHeadsOr0 = runQuote $ do
               . LamAbs () xs' (vecInteger $ TyVar () p)
               . LamAbs () coe
                   (TyFun () (vecInteger $ TyVar () n) $ vecInteger (TyApp () succT $ TyVar () p))
-              $ mkIterApp () (builtin () AddInteger)
+              $ mkIterAppNoAnn (builtin () AddInteger)
                   [ Var () x
-                  ,   Apply () (mkIterInst () scottHead [integer, TyVar () p])
+                  ,   Apply () (mkIterInstNoAnn scottHead [integer, TyVar () p])
                     . Apply () (Var () coe)
                     $ Var () ys
                   ]

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
@@ -39,7 +39,7 @@ getEta n = do
     return
         . TyLam () f (KindArrow () (Type ()) $ Type ())
         . TyLam () z (Type ())
-        $ mkIterTyApp () n
+        $ mkIterTyAppNoAnn n
             [ TyVar () f
             , TyVar () z
             ]
@@ -69,7 +69,7 @@ succT = runQuote $ do
         . TyLam () f (KindArrow () (Type ()) $ Type ())
         . TyLam () z (Type ())
         . TyApp () (TyVar () f)
-        $ mkIterTyApp () (TyVar () n)
+        $ mkIterTyAppNoAnn (TyVar () n)
             [ TyVar () f
             , TyVar () z
             ]
@@ -88,9 +88,9 @@ plusT = runQuote $ do
         . TyLam () m natK
         . TyLam () f (KindArrow () (Type ()) $ Type ())
         . TyLam () z (Type ())
-        $ mkIterTyApp () (TyVar () n)
+        $ mkIterTyAppNoAnn (TyVar () n)
             [ TyVar () f
-            , mkIterTyApp () (TyVar () m)
+            , mkIterTyAppNoAnn (TyVar () m)
                 [ TyVar () f
                 , TyVar () z
                 ]
@@ -170,7 +170,7 @@ churchCons = runQuote $ do
         . TyAbs () a (Type ())
         . TyAbs () n natK
         . LamAbs () x (TyVar () a)
-        . LamAbs () xs (mkIterTyApp () churchVec [TyVar () a, TyVar () n])
+        . LamAbs () xs (mkIterTyAppNoAnn churchVec [TyVar () a, TyVar () n])
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
         . LamAbs () z (TyApp () (TyVar () r) zeroT)
@@ -204,13 +204,13 @@ churchConcat = runQuote $ do
     p <- freshTyName "p"
     stepFun <- getStepFun a (TyVar () r) r
     mEta <- getEta $ TyVar () m
-    let plusTPM = mkIterTyApp () plusT [TyVar () p, TyVar () m]
+    let plusTPM = mkIterTyAppNoAnn plusT [TyVar () p, TyVar () m]
     return
         . TyAbs () a (Type ())
         . TyAbs () n natK
         . TyAbs () m natK
-        . LamAbs () xs (mkIterTyApp () churchVec [TyVar () a, TyVar () n])
-        . LamAbs () ys (mkIterTyApp () churchVec [TyVar () a, mEta])
+        . LamAbs () xs (mkIterTyAppNoAnn churchVec [TyVar () a, TyVar () n])
+        . LamAbs () ys (mkIterTyAppNoAnn churchVec [TyVar () a, mEta])
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
         . LamAbs () z (TyApp () (TyVar () r) zeroT)
@@ -302,7 +302,7 @@ scottCons = runQuote $ do
         . TyAbs () a (Type ())
         . TyAbs () n natK
         . LamAbs () x (TyVar () a)
-        . LamAbs () xs (mkIterTyApp () scottVec [TyVar () a, TyVar () n])
+        . LamAbs () xs (mkIterTyAppNoAnn scottVec [TyVar () a, TyVar () n])
         . IWrap () (TyApp () scottVecF $ TyVar () a) (TyApp () succT $ TyVar () n)
         . TyAbs () r (KindArrow () natK $ Type ())
         . LamAbs () f stepFun
@@ -333,17 +333,17 @@ scottHead = runQuote $ do
     return
         . TyAbs () a (Type ())
         . TyAbs () n natK
-        . LamAbs () xs (mkIterTyApp () scottVec [TyVar () a, TyApp () succT $ TyVar () n])
+        . LamAbs () xs (mkIterTyAppNoAnn scottVec [TyVar () a, TyApp () succT $ TyVar () n])
         $ mkIterAppNoAnn
             (   TyInst () (Unwrap () $ Var () xs)
               . TyLam () p natK
-                $ mkIterTyApp () (TyVar () p)
+                $ mkIterTyAppNoAnn (TyVar () p)
                     [ TyLam () z (Type ()) $ TyVar () a
                     , unit
                     ])
             [   TyAbs () p natK
               . LamAbs () x (TyVar () a)
-              . LamAbs () xs' (mkIterTyApp () scottVec [TyVar () a, TyVar () p])
+              . LamAbs () xs' (mkIterTyAppNoAnn scottVec [TyVar () a, TyVar () p])
               $ Var () x
             , unitval
             ]
@@ -371,7 +371,7 @@ scottSumHeadsOr0 = runQuote $ do
     ys <- freshName "ys"
     xs' <- freshName "xs'"
     coe <- freshName "coe"
-    let vecInteger l = mkIterTyApp () scottVec [integer, l]
+    let vecInteger l = mkIterTyAppNoAnn scottVec [integer, l]
     return
         . TyAbs () n natK
         . LamAbs () xs (vecInteger $ TyVar () n)

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase             #-}
 {-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE TupleSections          #-}
 {-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
@@ -38,9 +39,11 @@ module PlutusCore.MkPlc
     , mkIterTyForall
     , mkIterTyLam
     , mkIterApp
+    , mkIterAppNoAnn
     , mkIterTyFun
     , mkIterLamAbs
     , mkIterInst
+    , mkIterInstNoAnn
     , mkIterTyAbs
     , mkIterTyApp
     , mkIterKindArrow
@@ -210,23 +213,39 @@ mkImmediateTyAbs
 mkImmediateTyAbs ann1 (Def (TyVarDecl ann2 name k) bind) body =
     tyInst ann1 (tyAbs ann2 name k body) bind
 
--- | Make an iterated application.
+-- | Make an iterated application. Each `apply` node uses the annotation associated with
+-- the corresponding argument.
 mkIterApp
     :: TermLike term tyname name uni fun
-    => ann
-    -> term ann -- ^ @f@
-    -> [term ann] -- ^@[ x0 ... xn ]@
-    -> term ann -- ^ @[f x0 ... xn ]@
-mkIterApp ann = foldl' (apply ann)
+    => term ann
+    -> [(ann, term ann)]
+    -> term ann
+mkIterApp = foldl' (uncurry . flip apply)
 
--- | Make an iterated instantiation.
+-- | Make an iterated application with no annotation.
+mkIterAppNoAnn
+    :: TermLike term tyname name uni fun
+    => term () -- ^ @f@
+    -> [term ()] -- ^@[ x0 ... xn ]@
+    -> term () -- ^ @[f x0 ... xn ]@
+mkIterAppNoAnn term = mkIterApp term . fmap ((),)
+
+-- | Make an iterated instantiation. Each `tyInst` node uses the annotation associated with
+-- the corresponding argument.
 mkIterInst
     :: TermLike term tyname name uni fun
-    => ann
-    -> term ann -- ^ @a@
-    -> [Type tyname uni ann] -- ^ @ [ x0 ... xn ] @
+    => term ann -- ^ @a@
+    -> [(ann, Type tyname uni ann)] -- ^ @ [ x0 ... xn ] @
     -> term ann -- ^ @{ a x0 ... xn }@
-mkIterInst ann = foldl' (tyInst ann)
+mkIterInst = foldl' (uncurry . flip tyInst)
+
+-- | Make an iterated instantiation with no annotation.
+mkIterInstNoAnn
+    :: TermLike term tyname name uni fun
+    => term () -- ^ @a@
+    -> [Type tyname uni ()] -- ^ @ [ x0 ... xn ] @
+    -> term () -- ^ @{ a x0 ... xn }@
+mkIterInstNoAnn term = mkIterInst term . fmap ((),)
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs

--- a/plutus-core/plutus-core/src/PlutusCore/Parser.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 -- | Parsers for PLC terms in DefaultUni.
 
@@ -46,7 +47,8 @@ lamTerm = withSpan $ \sp ->
 
 appTerm :: Parser PTerm
 appTerm = withSpan $ \sp ->
-    inBrackets $ mkIterApp sp <$> term <*> some term
+    -- TODO: should not use the same `sp` for all arguments.
+    inBrackets $ mkIterApp <$> term <*> (fmap (sp,) <$> some term)
 
 conTerm :: Parser PTerm
 conTerm = withSpan $ \sp ->
@@ -58,7 +60,8 @@ builtinTerm = withSpan $ \sp ->
 
 tyInstTerm :: Parser PTerm
 tyInstTerm = withSpan $ \sp ->
-    inBraces $ mkIterInst sp <$> term <*> many pType
+    -- TODO: should not use the same `sp` for all arguments.
+    inBraces $ mkIterInst <$> term <*> (fmap (sp,) <$> many pType)
 
 unwrapTerm :: Parser PTerm
 unwrapTerm = withSpan $ \sp ->

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Type.hs
@@ -1,6 +1,7 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module PlutusCore.Parser.Type where
@@ -59,7 +60,8 @@ appType :: Parser PType
 appType = withSpan $ \sp -> inBrackets $ do
     fn   <- pType
     args <- some pType
-    pure $ mkIterTyApp sp fn args
+    -- TODO: should not use the same `sp` for all arguments.
+    pure $ mkIterTyApp fn ((sp,) <$> args)
 
 kind :: Parser (Kind SrcSpan)
 kind = withSpan $ \sp ->

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck/Internal.hs
@@ -422,7 +422,7 @@ unfoldIFixOf pat arg k = do
     -- But breaking global uniqueness is a bad idea regardless.
     vPat' <- rename vPat
     normalizeTypeM $
-        mkIterTyApp () vPat'
+        mkIterTyAppNoAnn vPat'
             [ TyLam () a k . TyIFix () vPat $ TyVar () a
             , vArg
             ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
@@ -54,6 +54,6 @@ ifThenElse = runQuote $ do
           VarDecl () x unitFunA,
           VarDecl () y unitFunA
           ]
-      $ mkIterApp ()
+      $ mkIterAppNoAnn
           (tyInst () (builtin () IfThenElse) unitFunA)
           [var () b, var () x, var () y, unitval]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ChurchNat.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ChurchNat.hs
@@ -54,7 +54,7 @@ churchSucc = runQuote $ do
         . lamAbs () z (TyVar () r)
         . lamAbs () f (TyFun () (TyVar () r) $ TyVar () r)
         . apply  () (var () f)
-        $ mkIterApp () (tyInst () (var () n) $ TyVar () r)
+        $ mkIterAppNoAnn (tyInst () (var () n) $ TyVar () r)
           [ var () z
           , var () f
           ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
@@ -65,9 +65,9 @@ caseData = runQuote $ do
         . lamAbs () fList (TyFun () listData $ TyVar () r)
         . lamAbs () fI (TyFun () integer $ TyVar () r)
         . lamAbs () fB (TyFun () (mkTyBuiltin @_ @ByteString ()) $ TyVar () r)
-        $ mkIterApp () (tyInst () (builtin () ChooseData) . TyFun () unit $ TyVar () r)
+        $ mkIterAppNoAnn (tyInst () (builtin () ChooseData) . TyFun () unit $ TyVar () r)
             [ var () d
-            , lamAbs () u unit $ mkIterApp () (mkIterInst () uncurry [integer, listData, TyVar () r])
+            , lamAbs () u unit $ mkIterAppNoAnn (mkIterInstNoAnn uncurry [integer, listData, TyVar () r])
                 [ var () fConstr
                 , apply () (builtin () UnConstrData) $ var () d
                 ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
@@ -28,7 +28,7 @@ succInteger = runQuote $ do
     i  <- freshName "i"
     return
         . lamAbs () i integer
-        . mkIterApp () (builtin () AddInteger)
+        . mkIterAppNoAnn (builtin () AddInteger)
         $ [ var () i
           , mkConstant @Integer () 1
           ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
@@ -57,14 +57,14 @@ caseList = runQuote $ do
         . tyAbs () r (Type ())
         . lamAbs () z (TyVar () r)
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () listA $ TyVar () r)
-        $ mkIterApp ()
-                (mkIterInst () (builtin () ChooseList)
+        $ mkIterAppNoAnn
+                (mkIterInstNoAnn (builtin () ChooseList)
                     [ TyVar () a
                     , TyFun () unit $ TyVar () r
                     ])
             [ var () xs
             , lamAbs () u unit $ var () z
-            , lamAbs () u unit $ mkIterApp () (var () f) [funAtXs HeadList, funAtXs TailList]
+            , lamAbs () u unit $ mkIterAppNoAnn (var () f) [funAtXs HeadList, funAtXs TailList]
             , unitval
             ]
 
@@ -91,13 +91,13 @@ foldrList = runQuote $ do
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () (TyVar () r) $ TyVar () r)
         . lamAbs () z (TyVar () r)
-        . apply () (mkIterInst () fix [listA, TyVar () r])
+        . apply () (mkIterInstNoAnn fix [listA, TyVar () r])
         . lamAbs () rec (TyFun () listA $ TyVar () r)
         . lamAbs () xs listA
         . apply () (apply () (tyInst () (unwrap' () (var () xs)) $ TyVar () r) $ var () z)
         . lamAbs () x (TyVar () a)
         . lamAbs () xs' listA
-        $ mkIterApp () (var () f)
+        $ mkIterAppNoAnn (var () f)
             [ var () x
             , apply () (var () rec) $ var () xs'
             ]
@@ -123,15 +123,15 @@ foldList = runQuote $ do
         . tyAbs () a (Type ())
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
-        . apply () (mkIterInst () fix [TyVar () r, TyFun () listA $ TyVar () r])
+        . apply () (mkIterInstNoAnn fix [TyVar () r, TyFun () listA $ TyVar () r])
         . lamAbs () rec (TyFun () (TyVar () r) . TyFun () listA $ TyVar () r)
         . lamAbs () z (TyVar () r)
         . lamAbs () xs listA
         . apply () (apply () (tyInst () (unwrap' () (var () xs)) $ TyVar () r) $ var () z)
         . lamAbs () x (TyVar () a)
         . lamAbs () xs' listA
-        . mkIterApp () (var () rec)
-        $ [ mkIterApp () (var () f) [var () z, var () x]
+        . mkIterAppNoAnn (var () rec)
+        $ [ mkIterAppNoAnn (var () f) [var () z, var () x]
           , var () xs'
           ]
 -- > foldList {integer} {integer} addInteger 0
@@ -140,7 +140,7 @@ sum = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
     return
-        . mkIterApp () (mkIterInst () foldList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldList [int, int])
         $ [ add , mkConstant @Integer () 0]
 
 -- > foldrList {integer} {integer} 0 addInteger
@@ -149,7 +149,7 @@ sumr = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
     return
-        . mkIterApp () (mkIterInst () foldrList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldrList [int, int])
         $ [ add, mkConstant @Integer () 0 ]
 
 -- |  'product' as a PLC term.
@@ -160,5 +160,5 @@ product = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         mul = builtin () MultiplyInteger
     return
-        . mkIterApp () (mkIterInst () foldList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldList [int, int])
         $ [ mul , mkConstant @Integer () 1]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
@@ -96,7 +96,7 @@ foldrNat = runQuote $ do
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () r) (TyVar () r))
         . lamAbs () z (TyVar () r)
-        . apply () (mkIterInst () fix [nat, TyVar () r])
+        . apply () (mkIterInstNoAnn fix [nat, TyVar () r])
         . lamAbs () rec (TyFun () nat $ TyVar () r)
         . lamAbs () n nat
         . apply () (apply () (tyInst () (unwrap () (var () n)) $ TyVar () r) $ var () z)
@@ -122,13 +122,13 @@ foldNat = runQuote $ do
     return
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () r) (TyVar () r))
-        . apply () (mkIterInst () fix [TyVar () r, TyFun () nat $ TyVar () r])
+        . apply () (mkIterInstNoAnn fix [TyVar () r, TyFun () nat $ TyVar () r])
         . lamAbs () rec (TyFun () (TyVar () r) . TyFun () nat $ TyVar () r)
         . lamAbs () z (TyVar () r)
         . lamAbs () n nat
         . apply () (apply () (tyInst () (unwrap () (var () n)) $ TyVar () r) $ var () z)
         . lamAbs () n' nat
-        . mkIterApp () (var () rec)
+        . mkIterAppNoAnn (var () rec)
         $ [ apply () (var () f) $ var () z
           , var () n'
           ]
@@ -139,7 +139,7 @@ foldNat = runQuote $ do
 natToInteger :: (TermLike term TyName Name uni DefaultFun, uni `Includes` Integer) => term ()
 natToInteger = runQuote $ do
     return $
-        mkIterApp () (tyInst () foldNat $ mkTyBuiltin @_ @Integer ())
+        mkIterAppNoAnn (tyInst () foldNat $ mkTyBuiltin @_ @Integer ())
           [ apply () (builtin () AddInteger) (mkConstant @Integer () 1)
           , mkConstant @Integer () 0
           ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
@@ -51,7 +51,7 @@ uncurry = runQuote $ do
         . tyAbs () b (Type ())
         . tyAbs () c (Type ())
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () (TyVar () b) $ TyVar () c)
-        . lamAbs () p (mkIterTyApp () pair [TyVar () a, TyVar () b])
+        . lamAbs () p (mkIterTyAppNoAnn pair [TyVar () a, TyVar () b])
         $ mkIterAppNoAnn (var () f)
             [ apply () (mkIterInstNoAnn fstPair [TyVar () a, TyVar () b]) $ var () p
             , apply () (mkIterInstNoAnn sndPair [TyVar () a, TyVar () b]) $ var () p

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
@@ -52,7 +52,7 @@ uncurry = runQuote $ do
         . tyAbs () c (Type ())
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () (TyVar () b) $ TyVar () c)
         . lamAbs () p (mkIterTyApp () pair [TyVar () a, TyVar () b])
-        $ mkIterApp () (var () f)
-            [ apply () (mkIterInst () fstPair [TyVar () a, TyVar () b]) $ var () p
-            , apply () (mkIterInst () sndPair [TyVar () a, TyVar () b]) $ var () p
+        $ mkIterAppNoAnn (var () f)
+            [ apply () (mkIterInstNoAnn fstPair [TyVar () a, TyVar () b]) $ var () p
+            , apply () (mkIterInstNoAnn sndPair [TyVar () a, TyVar () b]) $ var () p
             ]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
@@ -94,7 +94,7 @@ cons = runQuote $ do
         . tyAbs () r (Type ())
         . lamAbs () z (TyVar () r)
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () listA $ TyVar () r)
-        $ mkIterApp () (var () f)
+        $ mkIterAppNoAnn (var () f)
           [ var () x
           , var () xs
           ]
@@ -120,13 +120,13 @@ foldrList = runQuote $ do
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () a) . TyFun () (TyVar () r) $ TyVar () r)
         . lamAbs () z (TyVar () r)
-        . apply () (mkIterInst () fix [listA, TyVar () r])
+        . apply () (mkIterInstNoAnn fix [listA, TyVar () r])
         . lamAbs () rec (TyFun () listA $ TyVar () r)
         . lamAbs () xs listA
         . apply () (apply () (tyInst () (unwrap () (var () xs)) $ TyVar () r) $ var () z)
         . lamAbs () x (TyVar () a)
         . lamAbs () xs' listA
-        $ mkIterApp () (var () f)
+        $ mkIterAppNoAnn (var () f)
           [ var () x
           , apply () (var () rec) $ var () xs'
           ]
@@ -145,7 +145,7 @@ map = runQuote $ do
         . tyAbs () a (Type ())
         . tyAbs () b (Type ())
         . lamAbs () f (TyFun () (TyVar () a) $ TyVar () b)
-        . mkIterApp () (mkIterInst () foldrList [TyVar () a, TyApp () listTy $ TyVar () b])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldrList [TyVar () a, TyApp () listTy $ TyVar () b])
         $ [   lamAbs () x (TyVar () a)
             . apply () (tyInst () cons (TyVar () b))
             . apply () (var () f)
@@ -173,15 +173,15 @@ foldList = runQuote $ do
         . tyAbs () a (Type ())
         . tyAbs () r (Type ())
         . lamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
-        . apply () (mkIterInst () fix [TyVar () r, TyFun () listA $ TyVar () r])
+        . apply () (mkIterInstNoAnn fix [TyVar () r, TyFun () listA $ TyVar () r])
         . lamAbs () rec (TyFun () (TyVar () r) . TyFun () listA $ TyVar () r)
         . lamAbs () z (TyVar () r)
         . lamAbs () xs listA
         . apply () (apply () (tyInst () (unwrap () (var () xs)) $ TyVar () r) $ var () z)
         . lamAbs () x (TyVar () a)
         . lamAbs () xs' listA
-        . mkIterApp () (var () rec)
-        $ [ mkIterApp () (var () f) [var () z, var () x]
+        . mkIterAppNoAnn (var () rec)
+        $ [ mkIterAppNoAnn (var () f) [var () z, var () x]
           , var () xs'
           ]
 
@@ -200,9 +200,9 @@ reverse = runQuote $ do
     return
         . tyAbs () a (Type ())
         . lamAbs () xs listA
-        $ mkIterApp () (mkIterInst () foldList [vA, listA])
+        $ mkIterAppNoAnn (mkIterInstNoAnn foldList [vA, listA])
             [ lamAbs () r listA . lamAbs () x vA $
-                mkIterApp () (tyInst () cons vA) [var () x, var () r]
+                mkIterAppNoAnn (tyInst () cons vA) [var () x, var () r]
             , tyInst () nil vA
             , var () xs
             ]
@@ -234,12 +234,12 @@ enumFromTo = runQuote $ do
     return
         . lamAbs () n int
         . lamAbs () m int
-        . mkIterApp () (mkIterInst () fix [int, listInt])
+        . mkIterAppNoAnn (mkIterInstNoAnn fix [int, listInt])
         $ [   lamAbs () rec (TyFun () int listInt)
             . lamAbs () n' int
-            . mkIterApp () (tyInst () ifThenElse listInt)
-            $ [ mkIterApp () leqInteger [ var () n' , var () m]
-              , lamAbs () u unit $ mkIterApp () (tyInst () cons int)
+            . mkIterAppNoAnn (tyInst () ifThenElse listInt)
+            $ [ mkIterAppNoAnn leqInteger [ var () n' , var () m]
+              , lamAbs () u unit $ mkIterAppNoAnn (tyInst () cons int)
                     [ var () n'
                     ,    apply () (var () rec)
                        . apply () succInteger
@@ -258,7 +258,7 @@ sum = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
     return
-        . mkIterApp () (mkIterInst () foldList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldList [int, int])
         $ [ add , mkConstant @Integer () 0]
 
 -- > foldrList {integer} {integer} 0 addInteger
@@ -267,7 +267,7 @@ sumr = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
     return
-        . mkIterApp () (mkIterInst () foldrList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldrList [int, int])
         $ [ add, mkConstant @Integer () 0 ]
 
 -- |  'product' as a PLC term.
@@ -278,5 +278,5 @@ product = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         mul = builtin () MultiplyInteger
     return
-        . mkIterApp () (mkIterInst () foldList [int, int])
+        . mkIterAppNoAnn (mkIterInstNoAnn foldList [int, int])
         $ [ mul , mkConstant @Integer () 1]

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta.hs
@@ -31,13 +31,13 @@ metaEitherToSum
     -> Type TyName uni ()
     -> Either (term ()) (term ())
     -> term ()
-metaEitherToSum a b (Left  x) = apply () (mkIterInst () left  [a, b]) x
-metaEitherToSum a b (Right y) = apply () (mkIterInst () right [a, b]) y
+metaEitherToSum a b (Left  x) = apply () (mkIterInstNoAnn left  [a, b]) x
+metaEitherToSum a b (Right y) = apply () (mkIterInstNoAnn right [a, b]) y
 
 -- | Convert a Haskell list of 'Term's to a PLC @list@.
 metaListToScottList
     :: TermLike term TyName Name uni fun => Type TyName uni () -> [term ()] -> term ()
 metaListToScottList ty =
     foldr
-        (\x xs -> mkIterApp () (tyInst () cons ty) [x, xs])
+        (\x xs -> mkIterAppNoAnn (tyInst () cons ty) [x, xs])
         (tyInst () nil ty)

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -179,7 +179,7 @@ prodNAccessor arity index = runQuote $ do
         tn <- liftQuote $ freshTyName $ "t_" <> showText i
         pure $ TyVarDecl () tn $ Type ()
 
-    let tupleTy = mkIterTyApp () (prodN arity) (fmap (mkTyVar ()) tyVars)
+    let tupleTy = mkIterTyAppNoAnn (prodN arity) (fmap (mkTyVar ()) tyVars)
         selectedTy = mkTyVar () $ tyVars !! index
 
     args <- for [0..(arity -1)] $ \i -> do

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -2,6 +2,7 @@
 -- | @tuple@s of various sizes and related functions.
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 module PlutusCore.StdLib.Meta.Data.Tuple
     ( Tuple (..)
@@ -54,7 +55,7 @@ getSpineToTuple ann spine = liftQuote $ do
     f <- freshName "f"
     let (as, xs) = unzip spine
         caseTy = mkIterTyFun ann as $ TyVar ann r
-        y = mkIterApp ann (var ann f) xs
+        y = mkIterApp (var ann f) ((ann,) <$> xs)
     pure . Tuple as . tyAbs ann r (Type ann) $ lamAbs ann f caseTy y
 
 -- | Get the type of the ith element of a 'Tuple' along with the element itself.
@@ -163,7 +164,7 @@ prodNConstructor arity = runQuote $ do
         -- \case
         lamAbs () caseArg caseTy $
         -- case arg_1 .. arg_n
-        mkIterApp () (var () caseArg) $ fmap (mkVar ()) args
+        mkIterAppNoAnn (var () caseArg) $ fmap (mkVar ()) args
 
 -- | Given an arity @n@ and an index @i@, create a function for accessing the i'th component of a n-tuple.
 --

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Type.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE TupleSections     #-}
 
 module PlutusCore.StdLib.Type
     ( RecursiveType (..)
@@ -375,7 +376,7 @@ The code constructing the data type itself:
     [a, b, interlist, r] <- traverse freshTyName ["a", "b", "interlist", "r"]
 
     -- Define some aliases.
-    let interlistBA = mkIterTyApp () (TyVar () interlist) [TyVar () b, TyVar () a]
+    let interlistBA = mkIterTyAppNoAnn (TyVar () interlist) [TyVar () b, TyVar () a]
         nilElimTy   = TyVar () r
         consElimTy  = mkIterTyFun () [TyVar () a, TyVar () b, interlistBA] $ TyVar () r)
 
@@ -544,8 +545,8 @@ getToSpine ann = do
 
     return $ \args ->
           TyLam ann dat (argKindsToDataKindN ann $ map _tyDeclKind args)
-        . mkIterTyApp ann (TyVar ann dat)
-        $ map _tyDeclType args
+        . mkIterTyApp (TyVar ann dat)
+        $ map ((ann,) . _tyDeclType) args
 
 -- | Pack a list of 'TyDecl's as a spine using the CPS trick.
 --

--- a/plutus-core/plutus-core/test/Normalization/Type.hs
+++ b/plutus-core/plutus-core/test/Normalization/Type.hs
@@ -24,7 +24,7 @@ test_appAppLamLam = do
         Normalized integer2' = runQuote $ do
             x <- freshTyName "x"
             y <- freshTyName "y"
-            normalizeType $ mkIterTyApp ()
+            normalizeType $ mkIterTyAppNoAnn
                 (TyLam () x (Type ()) (TyLam () y (Type ()) $ TyVar () y))
                 [integer2, integer2]
     integer2 @?= integer2'

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -394,7 +394,7 @@ mkDatatypeType opts r d@(Datatype ann tn tvs _ _) = do
 
 -- | The type of a datatype-value is of the form `[TyCon tyarg1 tyarg2 ... tyargn]`
 mkDatatypeValueType :: a -> Datatype TyName Name uni a -> Type TyName uni a
-mkDatatypeValueType ann (Datatype _ tn tvs _ _)  = PIR.mkIterTyApp ann (PIR.mkTyVar ann tn) $ PIR.mkTyVar ann <$> tvs
+mkDatatypeValueType ann (Datatype _ tn tvs _ _)  = PIR.mkIterTyApp (PIR.mkTyVar ann tn) $ (ann,) . PIR.mkTyVar ann <$> tvs
 
 -- Constructors
 
@@ -514,7 +514,7 @@ mkDestructor opts dty d@(Datatype ann _ tvs _ constrs) = do
     -- This term appears *outside* the scope of the abstraction for the datatype, so we need to put in the Scott-encoded type here
     -- see note [Abstract data types]
     -- dty t_1 .. t_n
-    let appliedReal = PIR.mkIterTyApp ann (getType dty) (fmap (PIR.mkTyVar ann) tvs)
+    let appliedReal = PIR.mkIterTyApp (getType dty) (fmap ((ann,) . PIR.mkTyVar ann) tvs)
 
     xn <- safeFreshName "x"
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 -- | Functions for compiling let-bound PIR datatypes into PLC.
 module PlutusIR.Compiler.Datatype
@@ -477,7 +478,7 @@ mkConstructor opts dty d@(Datatype ann _ tvs _ constrs) index = do
                 -- \case_1 .. case_j
                 PIR.mkIterLamAbs casesAndTypes $
                 -- c_i arg_1 .. arg_m
-                PIR.mkIterApp ann thisCase (fmap (PIR.mkVar ann) argsAndTypes)
+                PIR.mkIterApp thisCase (fmap ((ann,) . PIR.mkVar ann) argsAndTypes)
 
     let constr =
             -- /\t_1 .. t_n
@@ -590,7 +591,10 @@ compileDatatype r body d = do
         vars = fmap PIR.defVar constrDefs ++ [ PIR.defVar destrDef ]
         vals = fmap PIR.defVal constrDefs ++ [ PIR.defVal destrDef ]
     -- See note [Abstract data types]
-    pure $ PIR.mkIterApp p (PIR.mkIterInst p (PIR.mkIterTyAbs tyVars (PIR.mkIterLamAbs vars body)) tys) vals
+    pure $
+      PIR.mkIterApp
+        (PIR.mkIterInst (PIR.mkIterTyAbs tyVars (PIR.mkIterLamAbs vars body)) ((p,) <$> tys))
+        ((p,) <$> vals)
 
 -- | Compile a 'Datatype' to a triple of type-constructor, data-constructors, destructor definitions.
 compileDatatypeDefs

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/Scoping.hs
@@ -117,8 +117,8 @@ establishScopingConstrTy
     -> Quote (Type TyName uni NameAnn)
 establishScopingConstrTy regSelf dataName params = goSpine where
     toDataAppliedToParams reg
-        = mkIterTyApp NotAName (TyVar (reg dataName) dataName)
-        $ map (\(TyVarDecl _ name _) -> TyVar (registerBound name) name) params
+        = mkIterTyApp (TyVar (reg dataName) dataName)
+        $ map (\(TyVarDecl _ name _) -> (NotAName, TyVar (registerBound name) name)) params
 
     goSpine (TyForall _ nameDup kindDup ty) = do
         -- Similar to 'establishScopingBinder', but uses 'TyFun' rather than whatever 'registerVia'

--- a/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 -- | Parsers for PIR terms in DefaultUni.
 
@@ -120,11 +121,13 @@ letTerm = withSpan $ \sp ->
 
 appTerm :: Parametric
 appTerm tm = withSpan $ \sp ->
-    inBrackets $ PIR.mkIterApp sp <$> tm <*> some tm
+    -- TODO: should not use the same `sp` for all arguments.
+    inBrackets $ PIR.mkIterApp <$> tm <*> (fmap (sp,) <$> some tm)
 
 tyInstTerm :: Parametric
 tyInstTerm tm = withSpan $ \sp ->
-    inBraces $ PIR.mkIterInst sp <$> tm <*> some pType
+    -- TODO: should not use the same `sp` for all arguments.
+    inBraces $ PIR.mkIterInst <$> tm <*> (fmap (sp,) <$> some pType)
 
 pTerm :: Parser PTerm
 pTerm = leadingWhitespace go

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseReduce.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseReduce.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE TupleSections #-}
+
 module PlutusIR.Transform.CaseReduce
     ( caseReduce
     ) where
@@ -14,5 +16,5 @@ caseReduce = transformOf termSubterms processTerm
 
 processTerm :: Term tyname name uni fun a -> Term tyname name uni fun a
 processTerm = \case
-    Case ann _ (Constr _ _ i args) cs | Just c <- cs ^? wix i -> mkIterApp ann c args
+    Case ann _ (Constr _ _ i args) cs | Just c <- cs ^? wix i -> mkIterApp c ((ann,) <$> args)
     t                                                         -> t

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Interesting.hs
@@ -61,9 +61,9 @@ genOverapplication = do
     TermOf ti i <- genTypedBuiltinDef typedInteger
     TermOf tj j <- genTypedBuiltinDef typedInteger
     let term =
-            mkIterApp ()
+            mkIterAppNoAnn
                 (TyInst () (Builtin () IfThenElse) . TyFun () integer $ TyFun () integer integer)
-                [ mkIterApp () (Builtin () LessThanInteger) [ti, tj]
+                [ mkIterAppNoAnn (Builtin () LessThanInteger) [ti, tj]
                 , Builtin () AddInteger
                 , Builtin () SubtractInteger
                 , ti
@@ -81,7 +81,7 @@ factorial = runQuote $ do
     return
         . LamAbs () i int
         . apply () ScottList.product
-        $ mkIterApp () ScottList.enumFromTo
+        $ mkIterAppNoAnn ScottList.enumFromTo
             [ mkConstant @Integer () 1
             , Var () i
             ]
@@ -107,17 +107,17 @@ naiveFib iv = runQuote $ do
     let
       intS = mkTyBuiltin @_ @Integer ()
       fib = LamAbs () i0 intS
-        $ mkIterApp () (mkIterInst () fix [intS, intS])
+        $ mkIterAppNoAnn (mkIterInstNoAnn fix [intS, intS])
             [   LamAbs () rec (TyFun () intS intS)
               . LamAbs () i intS
-              $ mkIterApp () (TyInst () ifThenElse intS)
-                  [ mkIterApp () (Builtin () LessThanEqualsInteger)
+              $ mkIterAppNoAnn (TyInst () ifThenElse intS)
+                  [ mkIterAppNoAnn (Builtin () LessThanEqualsInteger)
                       [Var () i, mkConstant @Integer () 1]
                   , LamAbs () u unit $ Var () i
-                  , LamAbs () u unit $ mkIterApp () (Builtin () AddInteger)
-                      [ Apply () (Var () rec) $ mkIterApp () (Builtin () SubtractInteger)
+                  , LamAbs () u unit $ mkIterAppNoAnn (Builtin () AddInteger)
+                      [ Apply () (Var () rec) $ mkIterAppNoAnn (Builtin () SubtractInteger)
                           [Var () i, mkConstant @Integer () 1]
-                      , Apply () (Var () rec) $ mkIterApp () (Builtin () SubtractInteger)
+                      , Apply () (Var () rec) $ mkIterAppNoAnn (Builtin () SubtractInteger)
                           [Var () i, mkConstant @Integer () 2]
                       ]
                   ]
@@ -164,12 +164,12 @@ natSum = runQuote $ do
     acc <- freshName "acc"
     n <- freshName "n"
     return
-        $ mkIterApp () (mkIterInst () foldList [nat, int])
+        $ mkIterAppNoAnn (mkIterInstNoAnn foldList [nat, int])
           [   LamAbs () acc int
             . LamAbs () n nat
-            . mkIterApp () add
+            . mkIterAppNoAnn add
             $ [ Var () acc
-              , mkIterApp () natToInteger [ Var () n ]
+              , mkIterAppNoAnn natToInteger [ Var () n ]
               ]
           , mkConstant @Integer () 0
           ]
@@ -195,10 +195,10 @@ genIfIntegers = do
     TermOf b bv <- genTermLoose typeRep
     TermOf i iv <- genTermLoose typedInt
     TermOf j jv <- genTermLoose typedInt
-    let instConst = Apply () $ mkIterInst () Function.const [int, unit]
+    let instConst = Apply () $ mkIterInstNoAnn Function.const [int, unit]
         value = if bv then iv else jv
         term =
-            mkIterApp ()
+            mkIterAppNoAnn
                 (TyInst () ifThenElse int)
                 [b, instConst i, instConst j]
     return $ TermOf term value
@@ -211,7 +211,7 @@ genApplyAdd1 = do
     TermOf i iv <- genTermLoose typedInt
     TermOf j jv <- genTermLoose typedInt
     let term =
-            mkIterApp () (mkIterInst () applyFun [int, int])
+            mkIterAppNoAnn (mkIterInstNoAnn applyFun [int, int])
                 [ Apply () (Builtin () AddInteger) i
                 , j
                 ]
@@ -225,7 +225,7 @@ genApplyAdd2 = do
     TermOf i iv <- genTermLoose typedInt
     TermOf j jv <- genTermLoose typedInt
     let term =
-            mkIterApp () (mkIterInst () applyFun [int, TyFun () int int])
+            mkIterAppNoAnn (mkIterInstNoAnn applyFun [int, TyFun () int int])
                 [ Builtin () AddInteger
                 , i
                 , j
@@ -237,7 +237,7 @@ genDivideByZero :: TermGen (EvaluationResult Integer)
 genDivideByZero = do
     op <- Gen.element [DivideInteger, QuotientInteger, ModInteger, RemainderInteger]
     TermOf i _ <- genTermLoose $ typeRep @Integer
-    let term = mkIterApp () (Builtin () op) [i, mkConstant @Integer () 0]
+    let term = mkIterAppNoAnn (Builtin () op) [i, mkConstant @Integer () 0]
     return $ TermOf term EvaluationFailure
 
 -- | Check that division by zero results in 'Error' even if a function doesn't use that argument.
@@ -248,9 +248,9 @@ genDivideByZeroDrop = do
         int = toTypeAst typedInt
     TermOf i iv <- genTermLoose typedInt
     let term =
-            mkIterApp () (mkIterInst () Function.const [int, int])
+            mkIterAppNoAnn (mkIterInstNoAnn Function.const [int, int])
                 [ mkConstant @Integer () iv
-                , mkIterApp () (Builtin () op) [i, mkConstant @Integer () 0]
+                , mkIterAppNoAnn (Builtin () op) [i, mkConstant @Integer () 0]
                 ]
     return $ TermOf term EvaluationFailure
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Parser.hs
@@ -1,5 +1,6 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 module UntypedPlutusCore.Parser
     ( parse
@@ -56,7 +57,8 @@ lamTerm = withSpan $ \sp ->
 
 appTerm :: Parser PTerm
 appTerm = withSpan $ \sp ->
-    inBrackets $ mkIterApp sp <$> term <*> some term
+    -- TODO: should not use the same `sp` for all arguments.
+    inBrackets $ mkIterApp <$> term <*> (fmap (sp,) <$> some term)
 
 delayTerm :: Parser PTerm
 delayTerm = withSpan $ \sp ->

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/CaseReduce.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/CaseReduce.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE TupleSections #-}
 module UntypedPlutusCore.Transform.CaseReduce
     ( caseReduce
     ) where
@@ -14,5 +15,5 @@ caseReduce = transformOf termSubterms processTerm
 
 processTerm :: Term name uni fun a -> Term name uni fun a
 processTerm = \case
-    Case ann (Constr _ i args) cs | Just c <- cs ^? wix i -> mkIterApp ann c args
+    Case ann (Constr _ i args) cs | Just c <- cs ^? wix i -> mkIterApp c ((ann,) <$> args)
     t                                                     -> t

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/Scope.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/Scope.hs
@@ -41,15 +41,15 @@ failBody99 = lamAbs99 outVar
 
 -- [(lam x (lam y x)) (con integer 1) (lam0 outVar)]
 failConst :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-failConst = mkIterApp () constFun [true, failBody0]
+failConst = mkIterAppNoAnn constFun [true, failBody0]
 
 -- [(lam x (lam y x)) (con bool true) (lam99 x_1)]
 failConst99 :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-failConst99 = mkIterApp () constFun [true, failId99]
+failConst99 = mkIterAppNoAnn constFun [true, failId99]
 
 -- [(force (builtin ifThenElse)) (con bool True) (lam0 x1) (lam99 outVar)]
 failITE :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-failITE = mkIterApp ()
+failITE = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ mkConstant @Bool () True -- pred
          , okId0 -- then

--- a/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
+++ b/plutus-core/untyped-plutus-core/test/DeBruijn/UnDeBruijnify.hs
@@ -40,15 +40,15 @@ failBody99 = lamAbs99 outVar
 
 -- [(lam x (lam y x)) (con bool true) (lam99 x_1)]
 okConst :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-okConst = mkIterApp () constFun [true, okId99]
+okConst = mkIterAppNoAnn constFun [true, okId99]
 
 -- [(lam x (lam y x)) (con integer 1) (lam0 outVar)]
 failConst :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-failConst = mkIterApp () constFun [true, failBody0]
+failConst = mkIterAppNoAnn constFun [true, failBody0]
 
 -- [(force (builtin ifThenElse)) (con bool True) (lam0 x1) (lam99 outVar)]
 failITE :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-failITE = mkIterApp ()
+failITE = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ mkConstant @Bool () True -- pred
          , okId0 -- then
@@ -91,11 +91,11 @@ failMix n = timesT n lamAbs0 $ timesT n lamAbs99 $ Var () $ DeBruijn $ n+n+1
 -- (lam0 [2 1 4 (lam99 [1 4 3 5])])
 graceElaborate :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
 graceElaborate = lamAbs0 $
-    mkIterApp () (d 2)
+    mkIterAppNoAnn (d 2)
       [
         d 1
       , d 4
-      , lamAbs99 (mkIterApp () (d 1)
+      , lamAbs99 (mkIterAppNoAnn (d 1)
                  [
                    d 4
                  , d 3

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -82,7 +82,7 @@ test_Const =
         let tC = mkConstant () c
             tB = mkConstant () b
             text = toTypeAst @_ @DefaultUni @Text Proxy
-            runConst con = mkIterApp () (mkIterInst () con [text, bool]) [tC, tB]
+            runConst con = mkIterAppNoAnn (mkIterInstNoAnn con [text, bool]) [tC, tB]
             lhs = typecheckReadKnownCek def defaultBuiltinCostModelExt $ runConst $ builtin () (Right Const)
             rhs = typecheckReadKnownCek def defaultBuiltinCostModelExt $ runConst $ mapFun @DefaultFun Left Plc.const
         lhs === Right (Right c)
@@ -108,7 +108,7 @@ test_Id =
             oneU = mkConstant @Integer @DefaultUni () 1
             -- > id {integer -> integer} ((\(i : integer) (j : integer) -> i) 1) 0
             term =
-                mkIterApp () (tyInst () (builtin () $ Right Id) (TyFun () integer integer))
+                mkIterAppNoAnn (tyInst () (builtin () $ Right Id) (TyFun () integer integer))
                     [ apply () constIntegerInteger oneT
                     , zer
                     ] where
@@ -133,7 +133,7 @@ test_IdFInteger =
             term
                 = apply () (mapFun Left Scott.sum)
                 . apply () (tyInst () (builtin () $ Right IdFInteger) Scott.listTy)
-                $ mkIterApp () (mapFun Left Scott.enumFromTo) [one, ten]
+                $ mkIterAppNoAnn (mapFun Left Scott.enumFromTo) [one, ten]
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt term @?= Right (EvaluationSuccess res)
 
 test_IdList :: TestTree
@@ -150,7 +150,7 @@ test_IdList =
             term
                 = apply () (mapFun Left Scott.sum)
                 . apply () (tyInst () (builtin () $ Right IdList) integer)
-                $ mkIterApp () (mapFun Left Scott.enumFromTo) [one, ten]
+                $ mkIterAppNoAnn (mapFun Left Scott.enumFromTo) [one, ten]
         tyAct @?= tyExp
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt term @?= Right (EvaluationSuccess res)
 
@@ -235,7 +235,7 @@ test_FailingPlus :: TestTree
 test_FailingPlus =
     testCase "FailingPlus" $ do
         let term =
-                mkIterApp () (builtin () $ Right FailingPlus)
+                mkIterAppNoAnn (builtin () $ Right FailingPlus)
                     [ mkConstant @Integer @DefaultUni @DefaultFunExt () 0
                     , mkConstant @Integer @DefaultUni () 1
                     ]
@@ -251,7 +251,7 @@ test_ExpensivePlus :: TestTree
 test_ExpensivePlus =
     testCase "ExpensivePlus" $ do
         let term =
-                mkIterApp () (builtin () $ Right ExpensivePlus)
+                mkIterAppNoAnn (builtin () $ Right ExpensivePlus)
                     [ mkConstant @Integer @DefaultUni @DefaultFunExt () 0
                     , mkConstant @Integer @DefaultUni () 1
                     ]
@@ -266,7 +266,7 @@ test_BuiltinList =
         let xs  = [1..10]
             res = mkConstant @Integer @DefaultUni () $ foldr (-) 0 xs
             term
-                = mkIterApp () (mkIterInst () Builtin.foldrList [integer, integer])
+                = mkIterAppNoAnn (mkIterInstNoAnn Builtin.foldrList [integer, integer])
                     [ Builtin () SubtractInteger
                     , mkConstant @Integer () 0
                     , mkConstant @[Integer] () xs
@@ -281,7 +281,7 @@ test_IdBuiltinList =
             xsTerm = mkConstant @[Integer] () [1..10]
             listOfInteger = mkTyBuiltin @_ @[Integer] ()
             term
-                = mkIterApp () (mkIterInst () (mapFun Left Builtin.foldrList) [integer, listOfInteger])
+                = mkIterAppNoAnn (mkIterInstNoAnn (mapFun Left Builtin.foldrList) [integer, listOfInteger])
                     [ tyInst () (builtin () $ Left MkCons) integer
                     , mkConstant @[Integer] () []
                     , xsTerm
@@ -292,7 +292,7 @@ test_BuiltinPair :: TestTree
 test_BuiltinPair =
     testCase "BuiltinPair" $ do
         let arg = mkConstant @(Integer, Bool) @DefaultUni () (1, False)
-            inst efun = mkIterInst () (builtin () efun) [integer, bool]
+            inst efun = mkIterInstNoAnn (builtin () efun) [integer, bool]
             swapped = apply () (inst $ Right Swap) arg
             fsted   = apply () (inst $ Left FstPair) arg
             snded   = apply () (inst $ Left SndPair) arg
@@ -313,17 +313,17 @@ test_SwapEls =
             res = mkConstant @Integer @DefaultUni () $
                     foldr (\p r -> r + (if snd p then -1 else 1) * fst p) 0 xs
             el = mkTyBuiltin @_ @(Integer, Bool) ()
-            instProj p = mkIterInst () (builtin () p) [integer, bool]
+            instProj p = mkIterInstNoAnn (builtin () p) [integer, bool]
             fun = runQuote $ do
                     p <- freshName "p"
                     r <- freshName "r"
                     return
                         . lamAbs () p el
                         . lamAbs () r integer
-                        $ mkIterApp () (builtin () AddInteger)
+                        $ mkIterAppNoAnn (builtin () AddInteger)
                             [ Var () r
-                            , mkIterApp () (builtin () MultiplyInteger)
-                                [ mkIterApp () (tyInst () (builtin () IfThenElse) integer)
+                            , mkIterAppNoAnn (builtin () MultiplyInteger)
+                                [ mkIterAppNoAnn (tyInst () (builtin () IfThenElse) integer)
                                     [ apply () (instProj SndPair) $ Var () p
                                     , mkConstant @Integer () (-1)
                                     , mkConstant @Integer () 1
@@ -332,7 +332,7 @@ test_SwapEls =
                                 ]
                             ]
             term
-                = mkIterApp () (mkIterInst () Builtin.foldrList [el, integer])
+                = mkIterAppNoAnn (mkIterInstNoAnn Builtin.foldrList [el, integer])
                     [ fun
                     , mkConstant @Integer () 0
                     , mkConstant () xs
@@ -347,7 +347,7 @@ test_IdBuiltinData =
         let dTerm :: TermLike term tyname name DefaultUni fun => term ()
             dTerm = mkConstant @Data () $ Map [(I 42, Constr 4 [List [B "abc", Constr 2 []], I 0])]
             emb = builtin () . Left
-            term = mkIterApp () ofoldrData
+            term = mkIterAppNoAnn ofoldrData
                 [ emb ConstrData
                 , emb MapData
                 , emb ListData
@@ -500,21 +500,21 @@ test_List = testCase "List" $ do
  where
    evalsL :: Contains DefaultUni a => a -> DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
    evalsL expectedVal b tyArg args =
-    let actualExp = mkIterApp () (tyInst () (builtin () b) tyArg) args
+    let actualExp = mkIterAppNoAnn (tyInst () (builtin () b) tyArg) args
     in  Right (EvaluationSuccess $ cons expectedVal)
         @=?
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModel actualExp
 
    failsL :: DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
    failsL b tyArg args =
-    let actualExp = mkIterApp () (tyInst () (builtin () b) tyArg) args
+    let actualExp = mkIterAppNoAnn (tyInst () (builtin () b) tyArg) args
     in  Right EvaluationFailure
         @=?
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModel actualExp
 
    -- the null function that utilizes the ChooseList builtin (through the caseList helper function)
    nullViaChooseList :: [Integer] -> Term TyName Name DefaultUni DefaultFun ()
-   nullViaChooseList l = mkIterApp ()
+   nullViaChooseList l = mkIterAppNoAnn
                       (tyInst () (apply () (tyInst () Builtin.caseList integer) $ cons l) bool)
                       [ -- zero
                         true
@@ -566,7 +566,7 @@ test_Data = testCase "Data" $ do
     evals @ByteString "\162\ETX@Ehello8c" SerialiseData [cons $ Map [(I 3, B ""), (B "hello", I $ -100)]]
 
     -- ChooseData
-    let actualExp = mkIterApp ()
+    let actualExp = mkIterAppNoAnn
                       (tyInst () (apply () caseData $ cons $ I 3) bool)
                       [ -- constr
                         runQuote $ do
@@ -629,13 +629,13 @@ test_Crypto = testCase "Crypto" $ do
 -- Test all remaining builtins of the default universe
 test_Other :: TestTree
 test_Other = testCase "Other" $ do
-    let expr1 = mkIterApp () (tyInst () (builtin () ChooseUnit) bool) [unitval, true]
+    let expr1 = mkIterAppNoAnn (tyInst () (builtin () ChooseUnit) bool) [unitval, true]
     Right (EvaluationSuccess true) @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModel expr1
 
-    let expr2 = mkIterApp () (tyInst () (builtin () IfThenElse) integer) [true, cons @Integer 1, cons @Integer 0]
+    let expr2 = mkIterAppNoAnn (tyInst () (builtin () IfThenElse) integer) [true, cons @Integer 1, cons @Integer 0]
     Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModel expr2
 
-    let expr3 = mkIterApp () (tyInst () (builtin () Trace) integer) [cons @Text "hello world", cons @Integer 1]
+    let expr3 = mkIterAppNoAnn (tyInst () (builtin () Trace) integer) [cons @Text "hello world", cons @Integer 1]
     Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModel expr3
 
 -- | Check that 'ExtensionVersion' evaluates correctly.
@@ -655,7 +655,7 @@ test_ConsByteString =
         let asciiBangWrapped = fromIntegral @Word8 @Integer maxBound
                              + 1 -- to make word8 wraparound
                              + 33 -- the index of '!' in ascii table
-            expr1 = mkIterApp () (builtin () (Left ConsByteString :: DefaultFunExt)) [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
+            expr1 = mkIterAppNoAnn (builtin () (Left ConsByteString :: DefaultFunExt)) [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
         Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV1 def) defaultBuiltinCostModelExt expr1
         Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV2 def) defaultBuiltinCostModelExt expr1
         Right EvaluationFailure @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
@@ -667,7 +667,7 @@ cons = mkConstant ()
 -- shorthand
 evals :: Contains DefaultUni a => a -> DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
 evals expectedVal b args =
-    let actualExp = mkIterApp () (builtin () b) args
+    let actualExp = mkIterAppNoAnn (builtin () b) args
     in  Right (EvaluationSuccess $ cons expectedVal)
         @=?
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModel actualExp
@@ -675,7 +675,7 @@ evals expectedVal b args =
 -- shorthand
 fails :: DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
 fails b args =
-    let actualExp = mkIterApp () (builtin () b) args
+    let actualExp = mkIterAppNoAnn (builtin () b) args
     in  Right EvaluationFailure
         @=?
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModel actualExp

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -576,7 +576,7 @@ test_Data = testCase "Data" $ do
                         -- map
                       , runQuote $ do
                               a1 <- freshName "a1"
-                              pure $ lamAbs () a1 (TyApp () Builtin.list $ mkIterTyApp () pair [dataTy,dataTy]) false
+                              pure $ lamAbs () a1 (TyApp () Builtin.list $ mkIterTyAppNoAnn pair [dataTy,dataTy]) false
                        -- list
                       , runQuote $ do
                               a1 <- freshName "a1"

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/MakeRead.hs
@@ -81,7 +81,7 @@ test_textRoundtrip =
 test_collectText :: TestTree
 test_collectText = testPropertyNamed "collectText" "collectText" . property $ do
     strs <- forAll . Gen.list (Range.linear 0 10) $ Gen.text (Range.linear 0 20) Gen.unicode
-    let step arg rest = mkIterApp () (tyInst () (builtin () Trace) unit)
+    let step arg rest = mkIterAppNoAnn (tyInst () (builtin () Trace) unit)
             [ mkConstant @Text @DefaultUni () arg
             , rest
             ]

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -40,7 +40,7 @@ import PlutusCore (DefaultFun (VerifyEcdsaSecp256k1Signature, VerifyEd25519Signa
 import PlutusCore.Default as Plutus (BuiltinVersion (..))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 
-import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
+import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import PlutusPrelude
 import Text.Show.Pretty (ppShow)
 
@@ -92,7 +92,7 @@ runTestDataWith :: forall (a :: Type) (msg :: Type) .
   PropertyT IO ()
 runTestDataWith ver testData f op = do
   let (vk, msg, sig) = getCaseData f testData
-  let actualExp = mkIterApp () (builtin () op) [
+  let actualExp = mkIterAppNoAnn (builtin () op) [
         mkConstant @ByteString () vk,
         mkConstant @ByteString () msg,
         mkConstant @ByteString () sig
@@ -447,5 +447,3 @@ genSignKey :: forall (a :: Type) . (DSIGNAlgorithm a) => Gen (SignKeyDSIGN a)
 genSignKey = do
   seed <- mkSeedFromBytes <$> (Gen.bytes . Range.linear 64 $ 128)
   pure . genKeyDSIGN $ seed
-
-

--- a/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/FreeVars.hs
@@ -38,12 +38,12 @@ outLam = mkLam outOfScope
 -- The evaluation result (success or failure) depends on how the machine
 -- ignores  the irrelevant to the computation) part of the environment.
 outConst :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outConst = mkIterApp () (mkLam $ mkLam $ Var () $ DeBruijn 2) [true, outLam]
+outConst = mkIterAppNoAnn (mkLam $ mkLam $ Var () $ DeBruijn 2) [true, outLam]
 
 -- [(force (builtin ifThenElse)) (con bool True) (con bool True) outOfScope]
 -- Both branches are evaluate *before* the predicate, so it is clear that this should fail in every case.
 outITEStrict :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outITEStrict = mkIterApp ()
+outITEStrict = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , true -- then
@@ -53,7 +53,7 @@ outITEStrict = mkIterApp ()
 -- The branches are *lazy*. The evaluation result (success or failure) depends on how the machine
 -- ignores  the irrelevant to the computation) part of the environment.
 outITELazy :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outITELazy = mkIterApp ()
+outITELazy = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , Delay () true -- then
@@ -63,7 +63,7 @@ outITELazy = mkIterApp ()
 -- [(force (builtin ifThenElse)) (con bool True) (con bool  True) (con unit ())]
 -- Note that the branches have **different** types. The machine cannot catch such a type error.
 illITEStrict :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illITEStrict = mkIterApp ()
+illITEStrict = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , true -- then
@@ -73,7 +73,7 @@ illITEStrict = mkIterApp ()
 -- [(force (builtin ifThenElse)) (con bool True) (lam x (con bool  True)) (lam x (con unit ()))]
 -- The branches are *lazy*. Note that the branches have **different** types. The machine cannot catch such a type error.
 illITELazy :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illITELazy = mkIterApp ()
+illITELazy = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , mkLam true -- then
@@ -82,7 +82,7 @@ illITELazy = mkIterApp ()
 -- [(builtin addInteger) (con integer 1) (con unit ())]
 -- Interesting because it involves a runtime type-error of a builtin.
 illAdd :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illAdd = mkIterApp ()
+illAdd = mkIterAppNoAnn
          (Builtin () AddInteger)
          [ one
          , unit
@@ -91,7 +91,7 @@ illAdd = mkIterApp ()
 -- [(builtin addInteger) (con integer 1) (con integer 1) (con integer 1)]
 -- Interesting because it involves a (builtin) over-saturation type-error, which the machine can recognize.
 illOverSat :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illOverSat = mkIterApp ()
+illOverSat = mkIterAppNoAnn
              (Builtin () AddInteger)
              [ one
              , one
@@ -100,7 +100,7 @@ illOverSat = mkIterApp ()
 -- [(lam x x) (con integer 1) (con integer 1)]
 -- Interesting because it involves a (lambda) over-saturation type-error, which the machine can recognize.
 illOverApp :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illOverApp = mkIterApp ()
+illOverApp = mkIterAppNoAnn
              (mkLam $ Var () $ DeBruijn 1) -- id
              [ one
              , one
@@ -163,7 +163,7 @@ testDischargeFree = testCase "discharge" $ do
     -- dis( y:unit |- \x-> x y outOfScope) ) === (\x -> x unit outOfScope)
     dis (VLamAbs (fakeNameDeBruijn $ DeBruijn 0)
          (n
-         (mkIterApp ()
+         (mkIterAppNoAnn
            (Var () (DeBruijn 1))
            [Var () (DeBruijn 2)
            ,outOfScope
@@ -172,7 +172,7 @@ testDischargeFree = testCase "discharge" $ do
          )
          (Env.cons (VCon $ someValue ()) Env.empty)
         )
-        @?= n (mkLam $ mkIterApp ()
+        @?= n (mkLam $ mkIterAppNoAnn
                           (Var () (DeBruijn 1))
                           [ Constant () (someValue ())
                           , outOfScope

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -160,7 +160,7 @@ stringResultFalse = mkConstant @Text () "¬(11 <= 22)"
 
 -- 11 <= 22
 lteExpr :: Term TyName Name DefaultUni DefaultFun ()
-lteExpr = mkIterApp () lte [eleven, twentytwo]
+lteExpr = mkIterAppNoAnn lte [eleven, twentytwo]
 
 
 -- Various combinations of (partial) instantiation/application for ifThenElse
@@ -181,7 +181,7 @@ iteUninstantiatedWithCond  = Apply () ite lteExpr
 -- (builtin ifThenElse) (11<=22) "11 <= 22" "¬(11<=22)" : IllTypedFails (no
 -- instantiation)
 iteUninstantiatedFullyApplied :: Term TyName Name DefaultUni DefaultFun ()
-iteUninstantiatedFullyApplied = mkIterApp () ite [lteExpr, stringResultTrue, stringResultFalse]
+iteUninstantiatedFullyApplied = mkIterAppNoAnn ite [lteExpr, stringResultTrue, stringResultFalse]
 
 -- { (builtin ifThenElse) (con integer) } : WellTypedRuns
 iteAtInteger :: Term TyName Name DefaultUni DefaultFun ()
@@ -200,7 +200,7 @@ iteAtIntegerWithCond = Apply () iteAtInteger lteExpr
 -- the builtin application machinery unlifts an argument and checks its type the moment it gets it,
 -- without waiting for full saturation.
 iteAtIntegerWrongCondTypeUnSat :: Term TyName Name DefaultUni DefaultFun ()
-iteAtIntegerWrongCondTypeUnSat = mkIterApp () iteAtInteger [stringResultTrue, stringResultFalse]
+iteAtIntegerWrongCondTypeUnSat = mkIterAppNoAnn iteAtInteger [stringResultTrue, stringResultFalse]
 
 -- [ { (builtin ifThenElse) (con integer) } "11 <= 22" "¬(11<=22)" "¬(11<=22)" ] :
 -- IllTypedFails. This is ill-typed because the first term argument is a string
@@ -209,18 +209,18 @@ iteAtIntegerWrongCondTypeUnSat = mkIterApp () iteAtInteger [stringResultTrue, st
 -- builtin function, since the builtin application is fully saturated. The older unlifting
 -- mode would also fail, but earlier before the builtin call got even saturated, see `iteAtIntegerWrongCondTypeUnSat`.
 iteAtIntegerWrongCondTypeSat :: Term TyName Name DefaultUni DefaultFun ()
-iteAtIntegerWrongCondTypeSat = mkIterApp () iteAtInteger [stringResultTrue, stringResultFalse, stringResultFalse]
+iteAtIntegerWrongCondTypeSat = mkIterAppNoAnn iteAtInteger [stringResultTrue, stringResultFalse, stringResultFalse]
 
 -- [ { (builtin ifThenElse) (con integer) } (11<=22) "11 <= 22" "¬(11<=22)" ] :
 -- IllTypedRuns.  We're instantiating at `integer` but returning a string: at
 -- execution time we only check that type instantiations and term arguments are
 -- correctly interleaved, not that instantiations are correct.
 iteAtIntegerFullyApplied :: Term TyName Name DefaultUni DefaultFun ()
-iteAtIntegerFullyApplied = mkIterApp () iteAtIntegerWithCond [stringResultTrue, stringResultFalse]
+iteAtIntegerFullyApplied = mkIterAppNoAnn iteAtIntegerWithCond [stringResultTrue, stringResultFalse]
 
 -- [ (builtin divideInteger) 1 0 ] : WellTypedFails. Division by zero.
 diFullyApplied :: Term TyName Name DefaultUni DefaultFun ()
-diFullyApplied = mkIterApp () (Builtin () DivideInteger)
+diFullyApplied = mkIterAppNoAnn (Builtin () DivideInteger)
     [ mkConstant @Integer () 1
     , mkConstant @Integer () 0
     ]
@@ -238,14 +238,14 @@ iteAtStringWithCond = Apply () iteAtString lteExpr
 -- @string@. It still runs succefully, because even in typed world (the CK machine) we don't look
 -- at types at runtime.
 iteAtStringWithCondWithIntegerWithString :: Term TyName Name DefaultUni DefaultFun ()
-iteAtStringWithCondWithIntegerWithString = mkIterApp () (iteAtStringWithCond)
+iteAtStringWithCondWithIntegerWithString = mkIterAppNoAnn (iteAtStringWithCond)
     [ mkConstant @Integer () 33
     , mkConstant @Text () "abc"
     ]
 
 -- [ { (builtin ifThenElse)  (con string) } (11<=22) "11 <= 22" "¬(11<=22)" ] : WellTypedRuns
 iteAtStringFullyApplied :: Term TyName Name DefaultUni DefaultFun ()
-iteAtStringFullyApplied = mkIterApp () iteAtStringWithCond [stringResultTrue, stringResultFalse]
+iteAtStringFullyApplied = mkIterAppNoAnn iteAtStringWithCond [stringResultTrue, stringResultFalse]
 
 -- { builtin ifThenElse (fun (con integer) (con integer)) } : WellTypedRuns
 iteAtIntegerArrowInteger :: Term TyName Name DefaultUni DefaultFun ()
@@ -258,7 +258,7 @@ iteAtIntegerArrowIntegerWithCond = Apply () iteAtIntegerArrowInteger lteExpr
 -- [ { (builtin ifThenElse) (fun (con integer) (con integer)) } (11<=22) (11 *) (22 -)] :
 -- WellTypedRuns (returns a function of type int -> int)
 iteAtIntegerArrowIntegerApplied1 ::  Term TyName Name DefaultUni DefaultFun ()
-iteAtIntegerArrowIntegerApplied1 =  mkIterApp ()
+iteAtIntegerArrowIntegerApplied1 =  mkIterAppNoAnn
                                    iteAtIntegerArrowInteger
                                    [ lteExpr
                                    , Apply () (Builtin () MultiplyInteger) eleven
@@ -268,7 +268,7 @@ iteAtIntegerArrowIntegerApplied1 =  mkIterApp ()
 -- [ { (builtin ifThenElse) (fun (con integer) (con integer)) } (11<=22) (*) (-)] :
 -- IllTypedRuns (int -> int -> int instead of int -> int).
 iteAtIntegerArrowIntegerApplied2 ::  Term TyName Name DefaultUni DefaultFun ()
-iteAtIntegerArrowIntegerApplied2 =  mkIterApp ()
+iteAtIntegerArrowIntegerApplied2 =  mkIterAppNoAnn
                                     iteAtIntegerArrowInteger
                                     [ lteExpr
                                     , Builtin () MultiplyInteger
@@ -298,7 +298,7 @@ iteAtHigherKindWithCond = Apply () iteAtHigherKind lteExpr
 -- [ {(builtin ifThenElse) (lam a . a -> a) } (11<=22) "11 <= 22" "¬(11<=22) ]" :
 -- IllTypedRuns (illegal kind)
 iteAtHigherKindFullyApplied :: Term TyName Name DefaultUni DefaultFun ()
-iteAtHigherKindFullyApplied = mkIterApp () (Apply () iteAtHigherKind lteExpr) [stringResultTrue, stringResultFalse]
+iteAtHigherKindFullyApplied = mkIterAppNoAnn (Apply () iteAtHigherKind lteExpr) [stringResultTrue, stringResultFalse]
 
 -- { {(builtin ifThenElse) integer} integer } : IllTypedFails (instantiated twice).
 iteAtIntegerAtInteger :: Term TyName Name DefaultUni DefaultFun ()
@@ -377,8 +377,8 @@ caseProd1 = runQuote $ do
     b <- freshName "b"
     c <- freshName "c"
     let branch1 = LamAbs () a integer $ LamAbs () b integer $ LamAbs () c integer $
-                    mkIterApp () (Builtin () SubtractInteger) [
-                      mkIterApp () (Builtin () AddInteger) [Var () a, Var () b]
+                    mkIterAppNoAnn (Builtin () SubtractInteger) [
+                      mkIterAppNoAnn (Builtin () AddInteger) [Var () a, Var () b]
                       , Var () c
                       ]
         branch2 = LamAbs () a string (mkConstant @Integer () 2)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Machines.hs
@@ -86,7 +86,7 @@ bunchOfIdNats =
     FolderContents [treeFolderContents "IdNat" $ map idNatFile [0 :: Int, 3.. 9]] where
         idNatFile i = plcTermFile (show i) (idNat id0 i)
         -- > id0 = foldNat {nat} succ zero
-        id0 = mkIterApp () (tyInst () Plc.foldNat $ Plc.natTy) [Plc.succ, Plc.zero]
+        id0 = mkIterAppNoAnn (tyInst () Plc.foldNat $ Plc.natTy) [Plc.succ, Plc.zero]
 
         idNat idN 0 = apply () idN $ metaIntegerToNat 10
         idNat idN n = idNat idN' (n - 1) where
@@ -102,7 +102,7 @@ bunchOfIfThenElseNats =
     FolderContents [treeFolderContents "IfThenElse" $ map ifThenElseNatFile [0 :: Int, 1.. 5]] where
         ifThenElseNatFile i = plcTermFile (show i) (ifThenElseNat id0 i)
         -- > id0 = foldNat {nat} succ zero
-        id0 = mkIterApp () (tyInst () Plc.foldNat Plc.natTy) [Plc.succ, Plc.zero]
+        id0 = mkIterAppNoAnn (tyInst () Plc.foldNat Plc.natTy) [Plc.succ, Plc.zero]
 
         ifThenElseNat idN 0 = apply () idN $ metaIntegerToNat 10
         ifThenElseNat idN n = ifThenElseNat idN' (n - 1) where
@@ -112,7 +112,7 @@ bunchOfIfThenElseNats =
             idN'
 
                 = etaExpand Plc.natTy
-                $ mkIterApp () (tyInst () (builtin () IfThenElse) $ Plc.TyFun () Plc.natTy Plc.natTy)
+                $ mkIterAppNoAnn (tyInst () (builtin () IfThenElse) $ Plc.TyFun () Plc.natTy Plc.natTy)
                     [mkConstant () $ even n, idN, idN]
 
 test_budget :: TestTree

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Regressions.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Regressions.hs
@@ -14,7 +14,7 @@ import GHC.Exts (fromListN)
 import PlutusCore (DefaultFun (VerifySchnorrSecp256k1Signature),
                    EvaluationResult (EvaluationFailure))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
-import PlutusCore.MkPlc (builtin, mkConstant, mkIterApp)
+import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import PlutusPrelude
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
@@ -26,7 +26,7 @@ schnorrVerifyRegressions =
     testCase "malformed verkey should fail" $ do
       let badVerKey = "m"
       let message = "\213"
-      let comp = mkIterApp () (builtin () VerifySchnorrSecp256k1Signature) [
+      let comp = mkIterAppNoAnn (builtin () VerifySchnorrSecp256k1Signature) [
             mkConstant @ByteString () badVerKey,
             mkConstant @ByteString () message,
             mkConstant @ByteString () signature

--- a/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
+++ b/plutus-core/untyped-plutus-core/test/Transform/Simplify.hs
@@ -141,8 +141,8 @@ multiApp = runQuote $ do
     a <- freshName "a"
     b <- freshName "b"
     c <- freshName "c"
-    let lam = LamAbs () a $ LamAbs () b $ LamAbs () c $ mkIterApp () (Var () c) [Var () a, Var () b]
-        app = mkIterApp () lam [mkConstant @Integer () 1, mkConstant @Integer () 2, mkConstant @Integer () 3]
+    let lam = LamAbs () a $ LamAbs () b $ LamAbs () c $ mkIterAppNoAnn (Var () c) [Var () a, Var () b]
+        app = mkIterAppNoAnn lam [mkConstant @Integer () 1, mkConstant @Integer () 2, mkConstant @Integer () 3]
     pure app
 
 -- TODO Fix duplication with other golden tests, quite annoying

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -95,7 +95,7 @@ mkTermToEvaluate lv pv bs args = do
     -- It decodes the program through the optimized ScriptForExecution. See `ScriptForExecution`.
     ScriptForExecution (UPLC.Program _ _ t) <- fromSerialisedScript lv pv bs
     let termArgs = fmap (UPLC.mkConstant ()) args
-        appliedT = UPLC.mkIterApp () t termArgs
+        appliedT = UPLC.mkIterAppNoAnn t termArgs
 
     -- make sure that term is closed, i.e. well-scoped
     through (liftEither . first DeBruijnError . UPLC.checkScope) appliedT

--- a/plutus-ledger-api/test/Spec/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Eval.hs
@@ -42,12 +42,12 @@ outLam = mkLam outOfScope
 -- The evaluation result (success or failure) depends on how the machine
 -- ignores  the irrelevant to the computation) part of the environment.
 outConst :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outConst = mkIterApp () (mkLam $ mkLam $ Var () $ DeBruijn 2) [true, outLam]
+outConst = mkIterAppNoAnn (mkLam $ mkLam $ Var () $ DeBruijn 2) [true, outLam]
 
 -- [(force (builtin ifThenElse)) (con bool True) (con bool True) outOfScope]
 -- Both branches are evaluate *before* the predicate, so it is clear that this should fail in every case.
 outITEStrict :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outITEStrict = mkIterApp ()
+outITEStrict = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , true -- then
@@ -57,7 +57,7 @@ outITEStrict = mkIterApp ()
 -- The branches are *lazy*. The evaluation result (success or failure) depends on how the machine
 -- ignores  the irrelevant to the computation) part of the environment.
 outITELazy :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-outITELazy = mkIterApp ()
+outITELazy = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , Delay () true -- then
@@ -67,7 +67,7 @@ outITELazy = mkIterApp ()
 -- [(force (builtin ifThenElse)) (con bool True) (con bool  True) (con unit ())]
 -- Note that the branches have **different** types. The machine cannot catch such a type error.
 illITEStrict :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illITEStrict = mkIterApp ()
+illITEStrict = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , true -- then
@@ -77,7 +77,7 @@ illITEStrict = mkIterApp ()
 -- [(force (builtin ifThenElse)) (con bool True) (lam x (con bool  True)) (lam x (con unit ()))]
 -- The branches are *lazy*. Note that the branches have **different** types. The machine cannot catch such a type error.
 illITELazy :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illITELazy = mkIterApp ()
+illITELazy = mkIterAppNoAnn
          (Force () (Builtin () IfThenElse))
          [ true -- pred
          , mkLam true -- then
@@ -86,7 +86,7 @@ illITELazy = mkIterApp ()
 -- [(builtin addInteger) (con integer 1) (con unit ())]
 -- Interesting because it involves a runtime type-error of a builtin.
 illAdd :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illAdd = mkIterApp ()
+illAdd = mkIterAppNoAnn
          (Builtin () AddInteger)
          [ one
          , unit
@@ -95,7 +95,7 @@ illAdd = mkIterApp ()
 -- [(builtin addInteger) (con integer 1) (con integer 1) (con integer 1)]
 -- Interesting because it involves a (builtin) over-saturation type-error, which the machine can recognize.
 illOverSat :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illOverSat = mkIterApp ()
+illOverSat = mkIterAppNoAnn
              (Builtin () AddInteger)
              [ one
              , one
@@ -104,7 +104,7 @@ illOverSat = mkIterApp ()
 -- [(lam x x) (con integer 1) (con integer 1)]
 -- Interesting because it involves a (lambda) over-saturation type-error, which the machine can recognize.
 illOverApp :: UPLC.Term DeBruijn DefaultUni DefaultFun ()
-illOverApp = mkIterApp ()
+illOverApp = mkIterAppNoAnn
              (mkLam $ Var () $ DeBruijn 1) -- id
              [ one
              , one

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
@@ -309,7 +310,7 @@ getMatchInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated matche
         match <- getMatch tc
         -- We drop 'RuntimeRep' arguments, see Note [Unboxed tuples]
         args' <- mapM compileTypeNorm (GHC.dropRuntimeRepArgs args)
-        pure $ PIR.mkIterInst annMayInline match args'
+        pure $ PIR.mkIterInst match $ (annMayInline,) <$> args'
     -- must be a TC app
     _ -> throwSd CompilationError $ "Cannot case on a value of a type which is not a datatype:" GHC.<+> GHC.ppr t
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -101,9 +101,9 @@ compileType t = withContextM 2 (sdToTxt $ "Compiling type:" GHC.<+> GHC.ppr t) $
 #endif
         -- ignoring 'RuntimeRep' type arguments, see Note [Unboxed tuples]
         (GHC.splitTyConApp_maybe -> Just (tc, ts)) ->
-            PIR.mkIterTyApp annMayInline
+            PIR.mkIterTyApp
                 <$> compileTyCon tc
-                <*> traverse compileType (GHC.dropRuntimeRepArgs ts)
+                <*> (traverse (fmap (annMayInline,) . compileType) (GHC.dropRuntimeRepArgs ts))
         (GHC.splitAppTy_maybe -> Just (t1, t2)) ->
             PIR.TyApp annMayInline <$> compileType t1 <*> compileType t2
         (GHC.splitForAllTyCoVar_maybe -> Just (tv, tpe)) -> mkTyForallScoped tv (compileType tpe)

--- a/plutus-tx/src/PlutusTx/Lift/TH.hs
+++ b/plutus-tx/src/PlutusTx/Lift/TH.hs
@@ -468,7 +468,7 @@ compileConstructorClause dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeV
                         -- The types are compiled in an (empty) local scope.
                         types <- flip runReaderT mempty $ sequence tyExprs'
 
-                        pure $ mkIterApp () (mkIterInst () constr types) lifts
+                        pure $ mkIterAppNoAnn (mkIterInstNoAnn constr types) lifts
                   ||]
     pure $ TH.clause [pat] (TH.normalB $ TH.unTypeQ rhsExpr) []
 

--- a/plutus-tx/src/PlutusTx/Lift/TH.hs
+++ b/plutus-tx/src/PlutusTx/Lift/TH.hs
@@ -350,7 +350,7 @@ compileTypeRep dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeVars=tvs} =
                         (_, dtvd) <- mkTyVarDecl tyName typeKind
                         tvds <- traverse (uncurry mkTyVarDecl) tvNamesAndKinds
 
-                        let resultType = mkIterTyApp () (mkTyVar () dtvd) (fmap (mkTyVar () . snd) tvds)
+                        let resultType = mkIterTyAppNoAnn (mkTyVar () dtvd) (fmap (mkTyVar () . snd) tvds)
                         matchName <- safeFreshName (T.pack "match_" <> showName tyName)
 
                         -- See Note [Occurrences of recursive names]


### PR DESCRIPTION
Changed `PlutusCore.MkPlc.mkIterApp`, `PlutusCore.MkPlc.mkIterInst` and `PlutusCore.MkPlc.mkIterTyApp`  to require an annotation to be provided for each argument. 

Also added `PlutusCore.MkPlc.mkIterAppNoAnn`, `PlutusCore.MkPlc.mkIterInstNoAnn` and `PlutusCore.MkPlc.mkIterTyAppNoAnn`.