### PR TITLE
Don't build much on aarch64-darwin

### DIFF
--- a/nix/cells/automation/ciJobs.nix
+++ b/nix/cells/automation/ciJobs.nix
@@ -49,9 +49,7 @@ let
 
   native-plutus-810-jobs = make-haskell-jobs library.plutus-project-810;
   native-plutus-92-jobs = make-haskell-jobs library.plutus-project-92;
-  native-plutus-96-jobs =
-    lib.optionalAttrs (system != aarchdarwin)
-      (make-haskell-jobs library.plutus-project-96);
+  native-plutus-96-jobs = make-haskell-jobs library.plutus-project-96;
 
   # - Only test cross on our primary dev version
   # - Cross-compiling to windows only works from linux

--- a/nix/cells/automation/ciJobs.nix
+++ b/nix/cells/automation/ciJobs.nix
@@ -10,6 +10,11 @@ let
   inherit (pkgs.stdenv) system;
   inherit (pkgs) lib;
 
+  x86linux = "x86_64-linux";
+  x86darwin = "x86_64-darwin";
+  aarchdarwin = "aarch64-darwin";
+  supportedSystems = [ x86linux x86darwin aarchdarwin ];
+
   make-haskell-jobs = project:
     let
       packages = library.haskell-nix.haskellLib.selectProjectPackages project.hsPkgs;
@@ -44,24 +49,55 @@ let
 
   native-plutus-810-jobs = make-haskell-jobs library.plutus-project-810;
   native-plutus-92-jobs = make-haskell-jobs library.plutus-project-92;
-  native-plutus-96-jobs = make-haskell-jobs library.plutus-project-96;
+  native-plutus-96-jobs =
+    lib.optionalAttrs (system != aarchdarwin)
+      (make-haskell-jobs library.plutus-project-96);
 
-  windows-plutus-92-jobs = make-haskell-jobs library.plutus-project-92.projectCross.mingwW64;
+  # - Only test cross on our primary dev version
+  # - Cross-compiling to windows only works from linux
+  windows-plutus-92-jobs =
+    lib.optionalAttrs (system == x86linux)
+      (make-haskell-jobs library.plutus-project-92.projectCross.mingwW64);
 
-  other-jobs = inputs.cells.plutus.devshells // inputs.cells.plutus.packages;
+  devshells =
+    # Note: We can't build the 9.6 shell on aarch64-darwin
+    # because of https://github.com/well-typed/cborg/issues/311
+    let s = inputs.cells.plutus.devshells;
+    in
+    if system == aarchdarwin
+    then builtins.removeAttrs s [ "plutus-shell-96" ]
+    else s;
+
+  # this just has all the package roots in, which we're going to want
+  # to be extra sure we always build
+  roots = {
+    ghc810 = native-plutus-810-jobs.roots;
+    ghc92 = native-plutus-92-jobs.roots;
+    ghc96 = native-plutus-96-jobs.roots;
+  };
 
   jobs =
-    # Drop these once we switch to 9.2 by default
-    { ghc810 = native-plutus-810-jobs; } //
-    { ghc92 = native-plutus-92-jobs; } //
-    # 9.6 is busted on aarch64-darwin because of https://github.com/well-typed/cborg/issues/311
-    lib.optionalAttrs (system != "aarch64-darwin") { ghc96 = native-plutus-96-jobs; } //
-    # Only cross-compile to windows from linux
-    lib.optionalAttrs (system == "x86_64-linux") { mingwW64 = windows-plutus-92-jobs; } //
-    # see above about 9.6 on aarch64-darwin
-    (if system == "aarch64-darwin"
-    then builtins.removeAttrs other-jobs [ "plutus-shell-96" ]
-    else other-jobs);
+    # Only build all the main packages on linux and _one_ dawin platform, to avoid doing too
+    # much work in CI. Plausibly if things build on x86 darwin then they'll build on aarch
+    # darwin, and it avoids overloading the builders.
+    lib.optionalAttrs (system == x86linux || system == x86darwin)
+      (
+        { ghc810 = native-plutus-810-jobs; }
+        //
+        { ghc92 = native-plutus-92-jobs; }
+        //
+        { ghc96 = native-plutus-96-jobs; }
+        //
+        { mingwW64 = windows-plutus-92-jobs; }
+        //
+        inputs.cells.plutus.packages
+      )
+    //
+    # Build devshells on all platforms so people can work effectively
+    devshells
+    //
+    # Build roots on all platforms so stuff doesn't get GCd
+    roots;
 
   # Hydra doesn't like these attributes hanging around in "jobsets": it thinks they're jobs!
   filtered-jobs = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations") jobs;
@@ -69,12 +105,13 @@ let
   required-job = pkgs.releaseTools.aggregate {
     name = "required-plutus";
     meta.description = "All jobs required to pass CI";
+    # require everything: there's not much point having a CI job if it isn't required!
     constituents = lib.collect lib.isDerivation filtered-jobs;
   };
 
   final-jobset =
-    if system == "x86_64-linux" || system == "x86_64-darwin" || system == "aarch64-darwin" then
-      filtered-jobs // { required = required-job; }
+    if builtins.elem system supportedSystems
+    then filtered-jobs // { required = required-job; }
     else { };
 
 in


### PR DESCRIPTION
We're low on Mac builder capacity. It's plausible that if our code
builds on `x86_64-darwin` then it builds on `aarch64-darwin`. So we just
skip building most things on `aarch64-darwin`. We _do_ want to build the
shell and the package roots, though, so anyone who is developing on
`aarch64-darwin` will get a shell and have things cached properly.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
