### PR TITLE
Remove zipped event dump right after unzipping in s3-sync-unzip.hs

### DIFF
--- a/scripts/s3-sync-unzip.sh
+++ b/scripts/s3-sync-unzip.sh
@@ -29,6 +29,7 @@ do
   if ! [ -f "${zipped%".bz2"}" ]; then
     set -x
     bunzip2 -k "$zipped"
+    rm "$zipped"
     { set +x; } 2>/dev/null
   fi
 done


### PR DESCRIPTION
In an attempt to fix an 'out of disk space' error in script-evaluation-test
See: https://github.com/input-output-hk/plutus/actions/runs/5067207532/jobs/9097996057