### PR TITLE
[Builtins] [Evaluation] Retain 'cost' in a different way

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -382,9 +382,21 @@ toBuiltinsRuntime
     => BuiltinVersion fun -> cost -> BuiltinsRuntime fun val
 toBuiltinsRuntime ver cost =
     let runtime = BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning ver
-        -- TODO: explain
-       -- Force each 'BuiltinRuntime' to WHNF, so that the thunk is allocated and forced at
-       -- initialization time rather than at runtime. Not that we'd lose much by not forcing all
-       -- 'BuiltinRuntime's here, but why pay even very little if there's an easy way not to pay.
-    in force runtime
+        -- This pragma is very important, removing it destroys the carefully set up optimizations of
+        -- of costing functions (see Note [Optimizations of runCostingFun*]). The reason for that is
+        -- that if @runtime@ doesn't have a pragma, then GHC sees that it's only referenced once and
+        -- inlines it below, together with this entire function (since we tell GHC to), at which
+        -- point everything's inlined and we're completely at GHC's mercy to optimize things
+        -- properly. Unfortunately, GHC doesn't want to cooperate and push 'toBuiltinRuntime' to
+        -- the inside of the inlined to 'toBuiltinMeaning' call, creating lots of 'BuiltinMeaning's
+        -- instead of 'BuiltinRuntime's with the former hiding the costing optimizations behind a
+        -- lambda binding the @cost@ variable, which renders all the optimizations useless. By
+        -- using a @NOINLINE@ pragma we tell GHC to create a separate thunk, which it can properly
+        -- optimize, because the other bazillion things don't get in the way.
+        {-# NOINLINE runtime #-}
+    in
+        -- Force each 'BuiltinRuntime' to WHNF, so that the thunk is allocated and forced at
+        -- initialization time rather than at runtime. Not that we'd lose much by not forcing all
+        -- 'BuiltinRuntime's here, but why pay even very little if there's an easy way not to pay.
+        force runtime
 {-# INLINE toBuiltinsRuntime #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -383,7 +383,6 @@ toBuiltinsRuntime
 toBuiltinsRuntime ver cost =
     let runtime = BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning ver
         -- TODO: explain
-        {-# NOINLINE runtime #-}
        -- Force each 'BuiltinRuntime' to WHNF, so that the thunk is allocated and forced at
        -- initialization time rather than at runtime. Not that we'd lose much by not forcing all
        -- 'BuiltinRuntime's here, but why pay even very little if there's an easy way not to pay.


### PR DESCRIPTION
Our current approach to creating thunks for individual `BuiltinRuntime`s and sharing them during evaluation turned out to have a flaw: it randomly duplicates `BuiltinRuntime`s for a few builtins (while doing the right thing for the majority of them).

For example, in the current Core we have this for `AddInteger` :

```
    AddInteger -> lvl366_sbwr4;
```

as well as this:

```
    AddInteger ->
      let! { __DEFAULT ~ <- lvl366_sbwr4 } in jump go5_i86oX ys_i86p3;
```

and both point to the same thunk, `lvl366_sbwr4`.

But for `IndexByteString` the two thunks are different, it's 

```
    IndexByteString -> lvl370_sbwBp;
```

vs

```
    IndexByteString ->
      let! { __DEFAULT ~ <- lvl367_sbx56 } in jump go5_i86oX ys_i86p3;
```

i.e. `lvl370_sbwBp` vs `lvl367_sbx56`. Both bindings have to point to the same implementation, but duplicating the implementation still results in extra noise and confusion as to why one of them even exists, if it gets forced and dropped on the floor immediately afterwards.

This isn't a big deal, since we don't get any wrong behavior from `BuiltinRuntime` duplication or any noticeable slowdown, but it still makes sense to fix the problem if there's a way. This PR implements an alternative approach, which looks like it results in the same `BuiltinRuntime` sharing while being both simpler and much more reliable.