### PR TITLE
Bump requests to 2.31.0 in doc/requirements.txt

### DIFF
--- a/doc/read-the-docs-site/requirements.txt
+++ b/doc/read-the-docs-site/requirements.txt
@@ -36,7 +36,7 @@ PyStemmer==2.0.1
 pytz==2021.3
 PyYAML==6.0
 recommonmark==0.7.1
-requests==2.27.1
+requests==2.31.0
 requests-toolbelt==0.9.1
 six==1.16.0
 snowballstemmer==2.2.0


### PR DESCRIPTION
For security reasons:
https://github.com/input-output-hk/plutus/security/dependabot/3