### PR TITLE
Another example with a missing file

### DIFF
--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -37,6 +37,8 @@ module PlutusCore.Executable.Common
     , writeToFileOrStd
     ) where
 
+import PlutusCore.NOSUCHFILE (nosuchconstant)
+
 import PlutusPrelude
 
 import PlutusCore.Executable.AstIO
@@ -592,6 +594,8 @@ runPrintBuiltinSignatures = do
     mapM_
       (\x -> putStr (printf "%-35s: %s\n" (show $ PP.pretty x) (show $ getSignature x)))
       builtins
+    putStrLn ""
+    putStrLn $ "The nonexistent constant is " ++ show nosuchconstant
   where
     getSignature (PLC.toBuiltinMeaning @_ @_ @(PlcTerm ()) def -> PLC.BuiltinMeaning sch _ _) =
         typeSchemeToSignature sch

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -131,6 +131,7 @@ library
     PlutusCore.Name
     PlutusCore.Normalize
     PlutusCore.Normalize.Internal
+    PlutusCore.NOSUCHFILE
     PlutusCore.Parser
     PlutusCore.Pretty
     PlutusCore.Quote


### PR DESCRIPTION
Here's another example that uses a file that's not been committed to GitHub.  This time it's in the `plutus-core` library and it's used in the `uplc` executable.