### PR TITLE
File in plutus-core-execlib not committed

### DIFF
--- a/plutus-core/executables/src/PlutusCore/Executable/Common.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Common.hs
@@ -37,6 +37,8 @@ module PlutusCore.Executable.Common
     , writeToFileOrStd
     ) where
 
+import PlutusCore.Executable.NOSUCHFILE (nosuchconstant)
+
 import PlutusPrelude
 
 import PlutusCore.Executable.AstIO
@@ -592,6 +594,8 @@ runPrintBuiltinSignatures = do
     mapM_
       (\x -> putStr (printf "%-35s: %s\n" (show $ PP.pretty x) (show $ getSignature x)))
       builtins
+    putStrLn ""
+    putStrLn $ "The nonexistent constant is " ++ show nosuchconstant
   where
     getSignature (PLC.toBuiltinMeaning @_ @_ @(PlcTerm ()) def -> PLC.BuiltinMeaning sch _ _) =
         typeSchemeToSignature sch

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -610,6 +610,7 @@ library plutus-core-execlib
   exposed-modules:
     PlutusCore.Executable.AstIO
     PlutusCore.Executable.Common
+    PlutusCore.Executable.NOSUCHFILE
     PlutusCore.Executable.Parsers
     PlutusCore.Executable.Types
 


### PR DESCRIPTION
This is like #5376, but with a missing file in the internal library `plutus-core-execlib`.