### PR TITLE
Add -Wno-unused-packages to plutus-benchmark.cabal in a couple of places (PLT-5947 again).

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -57,6 +57,7 @@ common ghc-version-support
 
 library plutus-benchmark-common
   import:          lang
+  ghc-options:     -Wno-unused-packages
   hs-source-dirs:  common
   exposed-modules:
     PlutusBenchmark.Common
@@ -324,12 +325,12 @@ benchmark cek-calibration
 executable ed25519-costs
   import:           lang, ghc-version-support
   default-language: Haskell2010
-  hs-source-dirs:   ed25519-costs/exe ed25519-costs/src
-  main-is:          Main.hs
-  other-modules:    PlutusBenchmark.Ed25519.Common
 
   -- Without the line below we get a warning that plutus-tx-plugin is unused which causes a CI failure.
   ghc-options:      -Wno-unused-packages
+  hs-source-dirs:   ed25519-costs/exe ed25519-costs/src
+  main-is:          Main.hs
+  other-modules:    PlutusBenchmark.Ed25519.Common
   build-depends:
     , base                     >=4.9 && <5
     , bytestring
@@ -349,6 +350,7 @@ test-suite ed25519-costs-test
     buildable: False
 
   type:           exitcode-stdio-1.0
+  ghc-options:    -Wno-unused-packages
   hs-source-dirs: ed25519-costs/test ed25519-costs/src
   main-is:        Spec.hs
   other-modules:  PlutusBenchmark.Ed25519.Common


### PR DESCRIPTION
`cabal bench ed25519-costs` was printing a warning
```
<no location info>: warning: [-Wunused-packages]
    The following packages were specified via -package or -package-id flags,
    but were not needed for compilation:
      - plutus-tx-plugin-1.7.0.0-inplace
```
There's a danger that this may cause a CI failure (although it appears that there was another problem that may have prevented this from being triggered: see #5375-#5379), so this adds `-Wno-unused-pacakges` to stop that.

I don't think this requires review.