### PR TITLE
Add TypeOperators to silence a warning about ~

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Pretty/Readable.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 -- | A "readable" Agda-like way to pretty-print PLC entities.


### PR DESCRIPTION
Apparently I failed to add `TypeOperators` to suppress a warning about `~` in #5382 (and didn't get a CI warning in the original PR).   I'll set this to auto-merge if it passes.