### PR TITLE
Bump lower bound on cardano-crypto-class

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -263,7 +263,7 @@ library
     , bimap
     , bytestring
     , cardano-crypto
-    , cardano-crypto-class        ^>=2.1.0.2
+    , cardano-crypto-class        ^>=2.1.2
     , cassava
     , cborg
     , composition-prelude         >=1.1.0.1


### PR DESCRIPTION
This is the version that actually added the BLST support.