### PR TITLE
[Builtins] Make elaboration customizable and unhardcode 'mkTyBuiltin'

### DIFF
--- a/plutus-core/changelog.d/20230724_195443_effectfully_make_elaboration_of_builtins_customizable.md
+++ b/plutus-core/changelog.d/20230724_195443_effectfully_make_elaboration_of_builtins_customizable.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- Separated the single `Includes` constraint into two constraints, `HasTypeLevel` and `HasTermLevel` (which together form `HasBothLevel`) in #5434.
+- Separated the single `Includes` constraint into two constraints, `HasTypeLevel` and `HasTermLevel` (which together form `HasTypeAndTermLevel`) in #5434.

--- a/plutus-core/changelog.d/20230724_195443_effectfully_make_elaboration_of_builtins_customizable.md
+++ b/plutus-core/changelog.d/20230724_195443_effectfully_make_elaboration_of_builtins_customizable.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Separated the single `Includes` constraint into two constraints, `HasTypeLevel` and `HasTermLevel` (which together form `HasBothLevel`) in #5434.

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -312,7 +312,7 @@ instance Default (BuiltinVersion NopFun) where
  -}
 
 benchNop1
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen
@@ -322,7 +322,7 @@ benchNop1 nop rand gen =
     in bgroup (show nop) [benchWith nopCostParameters (showMemoryUsage x) $ mkApp1 nop [] x]
 
 benchNop2
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen
@@ -336,7 +336,7 @@ benchNop2 nop rand gen =
            ]
 
 benchNop3
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen
@@ -353,7 +353,7 @@ benchNop3 nop rand gen =
            ]
 
 benchNop4
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen
@@ -373,7 +373,7 @@ benchNop4 nop rand gen =
            ]
 
 benchNop5
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen
@@ -396,7 +396,7 @@ benchNop5 nop rand gen =
            ]
 
 benchNop6
-    :: (ExMemoryUsage a, DefaultUni `Contains` a, NFData a)
+    :: (ExMemoryUsage a, DefaultUni `HasTermLevel` a, NFData a)
     => NopFun
     -> (StdGen -> (a, StdGen))
     -> StdGen

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Unit.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Unit.hs
@@ -14,7 +14,7 @@ import System.Random (StdGen)
 
 
 createChooseUnitBench
-    :: (DefaultUni `Includes` a, ExMemoryUsage a, NFData a)
+    :: (DefaultUni `HasTermLevel` a, ExMemoryUsage a, NFData a)
     => Type TyName DefaultUni ()
     -> [a]
     -> Benchmark

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -169,24 +169,25 @@ instance (Default (BuiltinVersion fun1), Default (BuiltinVersion fun2))
 newtype MetaForall name a = MetaForall a
 instance
         ( name ~ 'TyNameRep @kind text uniq, KnownSymbol text, KnownNat uniq
-        , KnownKind kind, KnownTypeAst uni a
-        ) => KnownTypeAst uni (MetaForall name a) where
-    type IsBuiltin (MetaForall name a) = 'False
-    type ToHoles (MetaForall name a) = '[TypeHole a]
-    type ToBinds acc (MetaForall name a) = ToBinds (Insert ('GADT.Some name) acc) a
+        , KnownKind kind, KnownTypeAst tyname uni a
+        ) => KnownTypeAst tyname uni (MetaForall name a) where
+    type IsBuiltin _ (MetaForall name a) = 'False
+    type ToHoles _ (MetaForall name a) = '[TypeHole a]
+    type ToBinds uni acc (MetaForall name a) = ToBinds uni (Insert ('GADT.Some name) acc) a
     toTypeAst _ = toTypeAst $ Proxy @a
 instance MakeKnownIn DefaultUni term a => MakeKnownIn DefaultUni term (MetaForall name a) where
     makeKnown (MetaForall x) = makeKnown x
 -- 'ReadKnownIn' doesn't make sense for 'MetaForall'.
 
 data PlcListRep (a :: GHC.Type)
-instance KnownTypeAst uni a => KnownTypeAst uni (PlcListRep a) where
-    type IsBuiltin (PlcListRep a) = 'False
-    type ToHoles (PlcListRep a) = '[RepHole a]
-    type ToBinds acc (PlcListRep a) = ToBinds acc a
+instance (tyname ~ TyName, KnownTypeAst tyname uni a) =>
+        KnownTypeAst tyname uni (PlcListRep a) where
+    type IsBuiltin _ (PlcListRep a) = 'False
+    type ToHoles _ (PlcListRep a) = '[RepHole a]
+    type ToBinds uni acc (PlcListRep a) = ToBinds uni acc a
     toTypeAst _ = TyApp () Plc.listTy . toTypeAst $ Proxy @a
 
-instance KnownTypeAst DefaultUni Void where
+instance tyname ~ TyName => KnownTypeAst tyname DefaultUni Void where
     toTypeAst _ = runQuote $ do
         a <- freshTyName "a"
         pure $ TyForall () a (Type ()) $ TyVar () a

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Data.hs
@@ -102,7 +102,7 @@ ofoldrData = runQuote $ do
             ]
 
 -- | Just a random 'Data' object.
-exampleData :: Term TyName Name DefaultUni (Either DefaultFun ExtensionFun) ()
+exampleData :: Term tyname Name DefaultUni (Either DefaultFun ExtensionFun) ()
 exampleData = runQuote $ do
     x <- freshName "x"
     pure

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -98,7 +98,7 @@ interCons = runQuote $ do
           , Var () xs
           ]
 
-foldrInterList :: uni `HasBothLevel` () => Term TyName Name uni fun ()
+foldrInterList :: uni `HasTypeAndTermLevel` () => Term TyName Name uni fun ()
 foldrInterList = runQuote $ do
     let interlist = _recursiveType interListData
     a0  <- freshTyName "a0"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/InterList.hs
@@ -17,8 +17,6 @@ import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Unit
 import PlutusCore.StdLib.Type
 
-import Universe
-
 {- Note [InterList]
 We encode the following in this module:
 
@@ -100,7 +98,7 @@ interCons = runQuote $ do
           , Var () xs
           ]
 
-foldrInterList :: uni `Includes` () => Term TyName Name uni fun ()
+foldrInterList :: uni `HasBothLevel` () => Term TyName Name uni fun ()
 foldrInterList = runQuote $ do
     let interlist = _recursiveType interListData
     a0  <- freshTyName "a0"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
@@ -14,12 +14,10 @@ import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
 
-import Universe
-
 -- |
 --
 -- > getShadF a = \(rec :: * -> *) (i :: *) -> a -> all (a :: * -> *). a i -> integer
-getShadF :: uni `Includes` Integer => TyName -> Quote (Type TyName uni ())
+getShadF :: uni `HasTypeLevel` Integer => TyName -> Quote (Type TyName uni ())
 getShadF a = do
     rec <- freshTyName "rec"
     i   <- freshTyName "i"
@@ -34,7 +32,7 @@ getShadF a = do
 -- |
 --
 -- > \(a :: *) -> ifix (getShadF a) a
-shad :: uni `Includes` Integer => Type TyName uni ()
+shad :: uni `HasTypeLevel` Integer => Type TyName uni ()
 shad = runQuote $ do
     a     <- freshTyName "a"
     shadF <- getShadF a
@@ -62,7 +60,7 @@ shad = runQuote $ do
 -- But that problem is already solved before type checking starts as we rename the program and that
 -- makes all binders uniques, so no variable capture is possible due to the outer and inner bindings
 -- being distinct.
-mkShad :: uni `Includes` Integer => Term TyName Name uni fun ()
+mkShad :: uni `HasBothLevel` Integer => Term TyName Name uni fun ()
 mkShad = runQuote $ do
     a     <- freshTyName "a"
     f     <- freshTyName "f"
@@ -96,7 +94,7 @@ recUnitF = runQuote $ do
 -- |
 --
 -- > ifix recUnitF ()
-recUnit :: uni `Includes` () => Type TyName uni ()
+recUnit :: uni `HasTypeLevel` () => Type TyName uni ()
 recUnit = TyIFix () recUnitF $ mkTyBuiltin @_ @() ()
 
 -- |  Test that a binder in a pattern functor does not get duplicated. The definition is as follows:
@@ -117,7 +115,7 @@ recUnit = TyIFix () recUnitF $ mkTyBuiltin @_ @() ()
 -- But this doesn't happen in the actual code, since when a variable gets looked up during type
 -- normalization, its value gets renamed, which means that a fresh variable will be generated for
 -- the inner binder and there will be no shadowing.
-runRecUnit :: uni `Includes` () => Term TyName Name uni fun ()
+runRecUnit :: uni `HasBothLevel` () => Term TyName Name uni fun ()
 runRecUnit = runQuote $ do
     a  <- freshTyName "a"
     ru <- freshName "ru"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Shad.hs
@@ -60,7 +60,7 @@ shad = runQuote $ do
 -- But that problem is already solved before type checking starts as we rename the program and that
 -- makes all binders uniques, so no variable capture is possible due to the outer and inner bindings
 -- being distinct.
-mkShad :: uni `HasBothLevel` Integer => Term TyName Name uni fun ()
+mkShad :: uni `HasTypeAndTermLevel` Integer => Term TyName Name uni fun ()
 mkShad = runQuote $ do
     a     <- freshTyName "a"
     f     <- freshTyName "f"
@@ -115,7 +115,7 @@ recUnit = TyIFix () recUnitF $ mkTyBuiltin @_ @() ()
 -- But this doesn't happen in the actual code, since when a variable gets looked up during type
 -- normalization, its value gets renamed, which means that a fresh variable will be generated for
 -- the inner binder and there will be no shadowing.
-runRecUnit :: uni `HasBothLevel` () => Term TyName Name uni fun ()
+runRecUnit :: uni `HasTypeAndTermLevel` () => Term TyName Name uni fun ()
 runRecUnit = runQuote $ do
     a  <- freshTyName "a"
     ru <- freshName "ru"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
@@ -19,8 +19,6 @@ import PlutusCore.Quote
 import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Unit
 
-import Universe
-
 -- |
 --
 -- > natK = (* -> *) -> * -> *
@@ -321,7 +319,7 @@ scottCons = runQuote $ do
 -- >             {\(p :: natK) -> p (\(z :: *) -> a) unit}
 -- >             (/\(p :: natK) (x : a) (xs' : scottVec a p) -> x)
 -- >             unitval
-scottHead :: uni `Includes` () => Term TyName Name uni fun ()
+scottHead :: uni `HasBothLevel` () => Term TyName Name uni fun ()
 scottHead = runQuote $ do
     a <- freshTyName "a"
     n <- freshTyName "n"
@@ -361,7 +359,7 @@ scottHead = runQuote $ do
 -- >             (\(coe : scottVec Integer n -> scottVec integer zero) -> 0)
 -- >             (/\(xs' :: scottVec Integer n) -> xs')
 scottSumHeadsOr0
-    :: (uni `Includes` Integer, uni `Includes` ())
+    :: (uni `HasBothLevel` Integer, uni `HasBothLevel` ())
     => Term TyName Name uni DefaultFun ()
 scottSumHeadsOr0 = runQuote $ do
     n <- freshTyName "n"

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Data/Vec.hs
@@ -319,7 +319,7 @@ scottCons = runQuote $ do
 -- >             {\(p :: natK) -> p (\(z :: *) -> a) unit}
 -- >             (/\(p :: natK) (x : a) (xs' : scottVec a p) -> x)
 -- >             unitval
-scottHead :: uni `HasBothLevel` () => Term TyName Name uni fun ()
+scottHead :: uni `HasTypeAndTermLevel` () => Term TyName Name uni fun ()
 scottHead = runQuote $ do
     a <- freshTyName "a"
     n <- freshTyName "n"
@@ -359,7 +359,7 @@ scottHead = runQuote $ do
 -- >             (\(coe : scottVec Integer n -> scottVec integer zero) -> 0)
 -- >             (/\(xs' :: scottVec Integer n) -> xs')
 scottSumHeadsOr0
-    :: (uni `HasBothLevel` Integer, uni `HasBothLevel` ())
+    :: (uni `HasTypeAndTermLevel` Integer, uni `HasTypeAndTermLevel` ())
     => Term TyName Name uni DefaultFun ()
 scottSumHeadsOr0 = runQuote $ do
     n <- freshTyName "n"

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -21,7 +21,6 @@ module PlutusCore
     , someValueType
     , Esc
     , Contains (..)
-    , Includes
     , Closed (..)
     , EverywhereAll
     , knownUniOf
@@ -34,6 +33,9 @@ module PlutusCore
     , withApplicable
     , (:~:) (..)
     , type (<:)
+    , HasTypeLevel
+    , HasTermLevel
+    , HasBothLevel
     , DefaultUni (..)
     , pattern DefaultUniList
     , pattern DefaultUniPair

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -35,7 +35,7 @@ module PlutusCore
     , type (<:)
     , HasTypeLevel
     , HasTermLevel
-    , HasBothLevel
+    , HasTypeAndTermLevel
     , DefaultUni (..)
     , pattern DefaultUniList
     , pattern DefaultUniPair

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Debug.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Debug.hs
@@ -28,7 +28,7 @@ import PlutusCore.Name as Export
 --   :: (TyVarRep ('TyNameRep "a" 0), TyVarRep ('TyNameRep "b" 1))
 --      -> TyVarRep ('TyNameRep "a" 0)
 elaborateDebug
-    :: forall a j. ElaborateFromTo 0 j (Term TyName Name DefaultUni DefaultFun ()) a
+    :: forall a j. ElaborateFromTo DefaultUni 0 j (Term TyName Name DefaultUni DefaultFun ()) a
     => a -> a
 elaborateDebug = id
 
@@ -45,7 +45,7 @@ elaborateDebug = id
 --       If you still want a built-in function, add a dummy ‘()’ argument
 --     • In the expression: makeBuiltinMeaningDebug False
 -- >>> :t makeBuiltinMeaningDebug $ 0 + 42
--- <interactive>:1:27: error:
+-- <interactive>:1:29: error:
 --     • Built-in functions are not allowed to have constraints
 --       To fix this error instantiate all constrained type variables
 --     • In the second argument of ‘($)’, namely ‘0 + 42’
@@ -61,14 +61,15 @@ elaborateDebug = id
 --         alongside the instance for the built-in type.
 --       Otherwise you may need to add a new built-in type
 --         (provided you're doing something that can be supported in principle)
---     • In the expression: makeBuiltinMeaningDebug $ Just ()
+--     • In the first argument of ‘($)’, namely ‘makeBuiltinMeaningDebug’
+--       In the expression: makeBuiltinMeaningDebug $ Just ()
 -- >>> :t makeBuiltinMeaningDebug fst
 -- <interactive>:1:1: error:
 --     • An unwrapped built-in type constructor can't be applied to a type variable
 --       Are you trying to define a polymorphic built-in function over a polymorphic type?
 --       In that case you need to wrap all polymorphic built-in types applied to type
---         variables with either ‘SomeConstant’ or ‘Opaque’ depending on whether its the
---         type of an argument or the type of the result, respectively
+--        variables with either ‘SomeConstant’ or ‘Opaque’ depending on whether its the
+--        type of an argument or the type of the result, respectively
 --     • In the expression: makeBuiltinMeaningDebug fst
 -- >>> :t makeBuiltinMeaningDebug null
 -- <interactive>:1:1: error:
@@ -76,11 +77,6 @@ elaborateDebug = id
 --       To fix this error specialize all higher-kinded type variables
 --     • In the expression: makeBuiltinMeaningDebug null
 -- >>> :t makeBuiltinMeaningDebug (undefined :: Opaque val (f Bool) -> ())
--- <interactive>:1:1: error:
---     • A built-in function is not allowed to have applied type variables in its type
---       To fix this error apply type variables via explicit ‘TyAppRep’
---     • In the expression:
---         makeBuiltinMeaningDebug (undefined :: Opaque val (f Bool) -> ())
 -- <interactive>:1:1: error:
 --     • No instance for ‘KnownTypeAst DefaultUni (TyVarRep
 --                                                   ('TyNameRep "f" 0) Bool)’
@@ -92,6 +88,11 @@ elaborateDebug = id
 --         alongside the instance for the built-in type.
 --       Otherwise you may need to add a new built-in type
 --         (provided you're doing something that can be supported in principle)
+--     • In the expression:
+--         makeBuiltinMeaningDebug (undefined :: Opaque val (f Bool) -> ())
+-- <interactive>:1:1: error:
+--     • A built-in function is not allowed to have applied type variables in its type
+--       To fix this error apply type variables via explicit ‘TyAppRep’
 --     • In the expression:
 --         makeBuiltinMeaningDebug (undefined :: Opaque val (f Bool) -> ())
 makeBuiltinMeaningDebug

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Elaborate.hs
@@ -173,28 +173,28 @@ instance {-# INCOHERENT #-} TrySpecializeAsVar i j mw a => TrySpecializeAsUnappl
 -- that using 'HandleHoles'.
 -- @i@ is a fresh id and @j@ is a final one as in 'TrySpecializeAsVar', but since 'HandleHole' can
 -- specialize multiple variables, @j@ can be equal to @i + n@ for any @n@ (including @0@).
-type HandleHole :: Nat -> Nat -> GHC.Type -> Hole -> GHC.Constraint
-class HandleHole i j val hole | i val hole -> j
+type HandleHole :: (GHC.Type -> GHC.Type) -> Nat -> Nat -> GHC.Type -> Hole -> GHC.Constraint
+class HandleHole uni i j val hole | uni i val hole -> j
 -- In the Rep context @x@ is attempted to be specialized as a 'TyVarRep'.
 instance
     ( TrySpecializeAsUnappliedVar i j RepHole 'Nothing x
-    , HandleHoles j k val x
-    ) => HandleHole i k val (RepHole x)
+    , HandleHoles uni j k val x
+    ) => HandleHole uni i k val (RepHole x)
 -- In the Type context @a@ is attempted to be specialized as a 'TyVarRep' wrapped in @Opaque val@.
 instance
     ( TrySpecializeAsUnappliedVar i j TypeHole ('Just (Opaque val)) a
-    , HandleHoles j k val a
-    ) => HandleHole i k val (TypeHole a)
+    , HandleHoles uni j k val a
+    ) => HandleHole uni i k val (TypeHole a)
 
 -- | Call 'HandleHole' over each hole from the list, threading the state (the fresh unique) through
 -- the calls.
-type HandleHolesGo :: Nat -> Nat -> GHC.Type -> [Hole] -> GHC.Constraint
-class HandleHolesGo i j val holes | i val holes -> j
-instance i ~ j => HandleHolesGo i j val '[]
+type HandleHolesGo :: (GHC.Type -> GHC.Type) -> Nat -> Nat -> GHC.Type -> [Hole] -> GHC.Constraint
+class HandleHolesGo uni i j val holes | uni i val holes -> j
+instance i ~ j => HandleHolesGo uni i j val '[]
 instance
-    ( HandleHole i j val hole
-    , HandleHolesGo j k val holes
-    ) => HandleHolesGo i k val (hole ': holes)
+    ( HandleHole uni i j val hole
+    , HandleHolesGo uni j k val holes
+    ) => HandleHolesGo uni i k val (hole ': holes)
 
 -- | If the outermost constructor of the second argument is known and happens to be one of the
 -- constructors of the list data type, then the second argument is returned back. Otherwise the
@@ -224,15 +224,17 @@ type family UnknownTypeError val x where
         )
 
 -- | Get the holes of @x@ and recurse into them.
-type HandleHoles :: forall a. Nat -> Nat -> GHC.Type -> a -> GHC.Constraint
-type HandleHoles i j val x =
+type HandleHoles
+    :: forall a. (GHC.Type -> GHC.Type) -> Nat -> Nat -> GHC.Type -> a -> GHC.Constraint
+type HandleHoles uni i j val x =
     -- Here we detect a stuck application of 'ToHoles' and throw 'UnknownTypeError' on it.
     -- See https://blog.csongor.co.uk/report-stuck-families for a detailed description of how
     -- detection of stuck type families works.
-    HandleHolesGo i j val (ThrowOnStuckList (UnknownTypeError val x) (ToHoles x))
+    HandleHolesGo uni i j val (ThrowOnStuckList (UnknownTypeError val x) (ToHoles uni x))
 
 -- | Specialize each Haskell type variable in @a@ as a type representing a PLC type variable.
 -- @i@ is a fresh id and @j@ is a final one as in 'TrySpecializeAsVar', but since 'HandleHole' can
 -- specialize multiple variables, @j@ can be equal to @i + n@ for any @n@ (including @0@).
-type ElaborateFromTo :: Nat -> Nat -> GHC.Type -> GHC.Type -> GHC.Constraint
-type ElaborateFromTo i j val a = HandleHole i j val (TypeHole a)
+type ElaborateFromTo
+    :: (GHC.Type -> GHC.Type) -> Nat -> Nat -> GHC.Type -> GHC.Type -> GHC.Constraint
+type ElaborateFromTo uni i j val a = HandleHole uni i j val (TypeHole a)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -38,7 +38,7 @@ fromValueOf uni = fromConstant . someValueOf uni
 {-# INLINE fromValueOf #-}
 
 -- | Wrap a Haskell value (provided its type is in the universe) as a @term@.
-fromValue :: (HasConstant term, UniOf term `Includes` a) => a -> term
+fromValue :: (HasConstant term, UniOf term `Contains` a) => a -> term
 fromValue = fromValueOf knownUni
 {-# INLINE fromValue #-}
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -38,7 +38,7 @@ fromValueOf uni = fromConstant . someValueOf uni
 {-# INLINE fromValueOf #-}
 
 -- | Wrap a Haskell value (provided its type is in the universe) as a @term@.
-fromValue :: (HasConstant term, UniOf term `Contains` a) => a -> term
+fromValue :: (HasConstant term, UniOf term `HasTermLevel` a) => a -> term
 fromValue = fromValueOf knownUni
 {-# INLINE fromValue #-}
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -52,7 +52,7 @@ import Universe
 -- | A constraint for \"@a@ is a 'ReadKnownIn' and 'MakeKnownIn' by means of being included
 -- in @uni@\".
 type KnownBuiltinTypeIn uni val a =
-    (HasConstantIn uni val, PrettyParens (SomeTypeIn uni), GEq uni, uni `Contains` a)
+    (HasConstantIn uni val, PrettyParens (SomeTypeIn uni), GEq uni, uni `HasTermLevel` a)
 
 -- | A constraint for \"@a@ is a 'ReadKnownIn' and 'MakeKnownIn' by means of being included
 -- in @UniOf term@\".

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
@@ -168,10 +168,6 @@ codebase. And when we don't want or can't have generality, we instantiate @tynam
 type HasTypeLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
 type HasTypeLevel uni x = KnownTypeAst Void uni (ElaborateBuiltin uni x)
 
--- | Specifies that the given type is a built-in one and its values can be embedded into a 'Term'.
-type HasTermLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
-type HasTermLevel uni = Includes uni
-
 -- | The product of 'HasTypeLevel' and 'HasTermLevel'.
 type HasBothLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
 type HasBothLevel uni x = (uni `HasTypeLevel` x, uni `HasTermLevel` x)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownTypeAst.hs
@@ -21,7 +21,7 @@ module PlutusCore.Builtin.KnownTypeAst
     , RepHole
     , HasTermLevel
     , HasTypeLevel
-    , HasBothLevel
+    , HasTypeAndTermLevel
     , mkTyBuiltin
     , TypeHole
     , KnownBuiltinTypeAst
@@ -169,8 +169,8 @@ type HasTypeLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
 type HasTypeLevel uni x = KnownTypeAst Void uni (ElaborateBuiltin uni x)
 
 -- | The product of 'HasTypeLevel' and 'HasTermLevel'.
-type HasBothLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
-type HasBothLevel uni x = (uni `HasTypeLevel` x, uni `HasTermLevel` x)
+type HasTypeAndTermLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
+type HasTypeAndTermLevel uni x = (uni `HasTypeLevel` x, uni `HasTermLevel` x)
 
 -- See Note [Name generality of KnownTypeAst].
 -- TODO: make it @forall {a}@ once we have that.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -209,7 +209,7 @@ class KnownMonotype val args res where
 
 -- | Once we've run out of term-level arguments, we return a
 -- 'TypeSchemeResult'/'RuntimeSchemeResult'.
-instance (Typeable res, KnownTypeAst (UniOf val) res, MakeKnown val res) =>
+instance (Typeable res, KnownTypeAst TyName (UniOf val) res, MakeKnown val res) =>
             KnownMonotype val '[] res where
     knownMonotype = TypeSchemeResult
 
@@ -260,7 +260,7 @@ evaluation anyway, hence we care much more about optimizing the happy path.
 
 -- | Every term-level argument becomes a 'TypeSchemeArrow'/'RuntimeSchemeArrow'.
 instance
-        ( Typeable arg, KnownTypeAst (UniOf val) arg, MakeKnown val arg, ReadKnown val arg
+        ( Typeable arg, KnownTypeAst TyName (UniOf val) arg, MakeKnown val arg, ReadKnown val arg
         , KnownMonotype val args res
         ) => KnownMonotype val (arg ': args) res where
     knownMonotype = TypeSchemeArrow knownMonotype
@@ -351,9 +351,9 @@ class MakeBuiltinMeaning a val where
         -> (cost -> FoldArgs (GetArgs a) ExBudgetStream)
         -> BuiltinMeaning val cost
 instance
-        ( binds ~ ToBinds '[] a, args ~ GetArgs a, a ~ FoldArgs args res
-        , ThrowOnBothEmpty binds args (IsBuiltin a) a
-        , ElaborateFromTo 0 j val a, KnownPolytype binds val args res
+        ( uni ~ UniOf val, binds ~ ToBinds uni '[] a, args ~ GetArgs a, a ~ FoldArgs args res
+        , ThrowOnBothEmpty binds args (IsBuiltin uni a) a
+        , ElaborateFromTo uni 0 j val a, KnownPolytype binds val args res
         ) => MakeBuiltinMeaning a val where
     makeBuiltinMeaning f toExF =
         BuiltinMeaning (knownPolytype @binds @val @args @res) f $ \cost ->

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Polymorphism.hs
@@ -1,11 +1,13 @@
 -- editorconfig-checker-disable-file
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
 
 module PlutusCore.Builtin.Polymorphism
     ( Opaque (..)
@@ -14,6 +16,10 @@ module PlutusCore.Builtin.Polymorphism
     , TyVarRep
     , TyAppRep
     , TyForallRep
+    , BuiltinHead
+    , ElaborateBuiltin
+    , AllElaboratedArgs
+    , AllBuiltinArgs
     ) where
 
 import PlutusPrelude
@@ -22,7 +28,7 @@ import PlutusCore.Builtin.HasConstant
 import PlutusCore.Core
 import PlutusCore.Evaluation.Machine.ExMemoryUsage
 
-import Data.Kind qualified as GHC (Type)
+import Data.Kind qualified as GHC
 import GHC.Ix
 import GHC.TypeLits
 import Universe
@@ -172,6 +178,40 @@ data family TyAppRep (fun :: dom -> cod) (arg :: dom) :: cod
 
 -- | Representation of of an intrinsically-kinded universal quantifier: a bound name and a body.
 data family TyForallRep (name :: TyNameRep kind) (a :: GHC.Type) :: GHC.Type
+
+-- | For annotating an uninstantiated built-in type, so that it gets handled by the right instance
+-- or type family.
+type BuiltinHead :: forall a. a -> a
+data family BuiltinHead x
+
+-- | Take an iterated application of a built-in type and elaborate every function application
+-- inside of it to 'TyAppRep' and annotate the head with 'BuiltinHead'.
+--
+-- The idea is that we don't need to process built-in types manually if we simply add some
+-- annotations for instance resolution to look for. Think what we'd have to do manually for, say,
+-- 'ToHoles': traverse the spine of the application and collect all the holes into a list, which is
+-- troubling, because type applications are left-nested and lists are right-nested, so we'd have to
+-- use accumulators or an explicit 'Reverse' type family. And then we also have 'KnownTypeAst' and
+-- 'ToBinds', so handling built-in types in a special way for each of those would be a hassle,
+-- especially given the fact that type-level Haskell is not exactly good at computing things.
+-- With the 'ElaborateBuiltin' approach we get 'KnownTypeAst', 'ToHoles' and 'ToBinds' for free.
+--
+-- We make this an open type family, so that elaboration is customizable for each universe.
+type ElaborateBuiltin :: forall a. (GHC.Type -> GHC.Type) -> a -> a
+type family ElaborateBuiltin uni x
+
+-- | Take a constraint and use it to constrain every argument of a possibly 0-ary elaborated
+-- application of a built-in type.
+type AllElaboratedArgs :: forall a. (GHC.Type -> GHC.Constraint) -> a -> GHC.Constraint
+type family AllElaboratedArgs constr x where
+    AllElaboratedArgs constr (f `TyAppRep` x) = (constr x, AllElaboratedArgs constr f)
+    AllElaboratedArgs _      (BuiltinHead _)  = ()
+
+-- | Take a constraint and use it to constrain every argument of a possibly 0-ary application of a
+-- built-in type.
+type AllBuiltinArgs
+        :: forall a. (GHC.Type -> GHC.Type) -> (GHC.Type -> GHC.Constraint) -> a -> GHC.Constraint
+type AllBuiltinArgs uni constr x = AllElaboratedArgs constr (ElaborateBuiltin uni x)
 
 -- Custom type errors to guide the programmer adding a new built-in function.
 

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/TestKnown.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/TestKnown.hs
@@ -21,8 +21,10 @@ import Universe
 
 -- | For providing a 'KnownTypeAst' instance for a built-in type it's enough for that type to
 -- satisfy 'KnownBuiltinTypeAst'.
-class    (KnownBuiltinTypeAst uni a => KnownTypeAst uni a) => ImplementedKnownTypeAst uni a
-instance (KnownBuiltinTypeAst uni a => KnownTypeAst uni a) => ImplementedKnownTypeAst uni a
+class    (forall tyname. KnownBuiltinTypeAst tyname uni a => KnownTypeAst tyname uni a) =>
+    ImplementedKnownTypeAst uni a
+instance (forall tyname. KnownBuiltinTypeAst tyname uni a => KnownTypeAst tyname uni a) =>
+    ImplementedKnownTypeAst uni a
 
 -- | For providing a 'ReadKnownIn' instance for a built-in type it's enough for that type to
 -- satisfy 'KnownBuiltinTypeIn'.

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/TypeScheme.hs
@@ -59,10 +59,10 @@ on readability of the Core output.
 -- E.g. @Text -> Bool -> Integer@ is encoded as @TypeScheme val [Text, Bool] Integer@.
 data TypeScheme val (args :: [GHC.Type]) res where
     TypeSchemeResult
-        :: (Typeable res, KnownTypeAst (UniOf val) res, MakeKnown val res)
+        :: (Typeable res, KnownTypeAst TyName (UniOf val) res, MakeKnown val res)
         => TypeScheme val '[] res
     TypeSchemeArrow
-        :: (Typeable arg, KnownTypeAst (UniOf val) arg, MakeKnown val arg, ReadKnown val arg)
+        :: (Typeable arg, KnownTypeAst TyName (UniOf val) arg, MakeKnown val arg, ReadKnown val arg)
         => TypeScheme val args res -> TypeScheme val (arg ': args) res
     TypeSchemeAll
         :: (KnownSymbol text, KnownNat uniq, KnownKind kind)

--- a/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Core/Type.hs
@@ -24,6 +24,7 @@ module PlutusCore.Core.Type
     , Type (..)
     , Term (..)
     , Program (..)
+    , HasTermLevel
     , UniOf
     , Normalized (..)
     , TyVarDecl (..)
@@ -145,6 +146,10 @@ deriving stock instance (Show tyname, Show name, GShow uni, Everywhere uni Show,
 
 deriving anyclass instance (NFData tyname, NFData name, Everywhere uni NFData, NFData fun, NFData ann, Closed uni)
     => NFData (Program tyname name uni fun ann)
+
+-- | Specifies that the given type is a built-in one and its values can be embedded into a 'Term'.
+type HasTermLevel :: forall a. (GHC.Type -> GHC.Type) -> a -> GHC.Constraint
+type HasTermLevel uni = Includes uni
 
 -- | Extract the universe from a type.
 type family UniOf a :: GHC.Type -> GHC.Type

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -14,6 +14,9 @@
 module PlutusCore.MkPlc
     ( TermLike (..)
     , UniOf
+    , HasTypeLevel
+    , HasTermLevel
+    , HasBothLevel
     , mkTyBuiltinOf
     , mkTyBuiltin
     , mkConstantOf
@@ -54,6 +57,7 @@ module PlutusCore.MkPlc
 import PlutusPrelude
 import Prelude hiding (error)
 
+import PlutusCore.Builtin
 import PlutusCore.Core
 
 import Data.Word
@@ -86,14 +90,6 @@ class TermLike term tyname name uni fun | term -> tyname name uni fun where
 mkTyBuiltinOf :: forall k (a :: k) uni tyname ann. ann -> uni (Esc a) -> Type tyname uni ann
 mkTyBuiltinOf ann = TyBuiltin ann . SomeTypeIn
 
--- TODO: make it @forall {k}@ once we have that.
--- (see https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0099-explicit-specificity.rst)
--- | Embed a type (provided it's in the universe) into a PLC type.
-mkTyBuiltin
-    :: forall k (a :: k) uni tyname ann. uni `Contains` a
-    => ann -> Type tyname uni ann
-mkTyBuiltin ann = mkTyBuiltinOf ann $ knownUni @_ @uni @a
-
 -- | Embed a Haskell value (given its explicit type tag) into a PLC term.
 mkConstantOf
     :: forall a uni fun term tyname name ann. TermLike term tyname name uni fun
@@ -102,7 +98,8 @@ mkConstantOf ann uni = constant ann . someValueOf uni
 
 -- | Embed a Haskell value (provided its type is in the universe) into a PLC term.
 mkConstant
-    :: forall a uni fun term tyname name ann. (TermLike term tyname name uni fun, uni `Includes` a)
+    :: forall a uni fun term tyname name ann.
+       (TermLike term tyname name uni fun, uni `HasTermLevel` a)
     => ann -> a -> term ann
 mkConstant ann = constant ann . someValue
 

--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -16,7 +16,7 @@ module PlutusCore.MkPlc
     , UniOf
     , HasTypeLevel
     , HasTermLevel
-    , HasBothLevel
+    , HasTypeAndTermLevel
     , mkTyBuiltinOf
     , mkTyBuiltin
     , mkConstantOf

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -432,7 +432,7 @@ someValueOf :: forall a uni. uni (Esc a) -> a -> Some (ValueOf uni)
 someValueOf uni = Some . ValueOf uni
 
 -- | Wrap a value into @Some (ValueOf uni)@, provided its type is in the universe.
-someValue :: forall a uni. uni `Includes` a => a -> Some (ValueOf uni)
+someValue :: forall a uni. uni `Contains` a => a -> Some (ValueOf uni)
 someValue = someValueOf knownUni
 
 someValueType :: Some (ValueOf uni) -> SomeTypeIn uni

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
@@ -37,7 +37,7 @@ false = mkConstant () False
 ifThenElse
     :: forall term uni.
        ( TermLike term TyName Name uni DefaultFun
-       , uni `HasBothLevel` Bool, uni `HasBothLevel` ()
+       , uni `HasTypeAndTermLevel` Bool, uni `HasTypeAndTermLevel` ()
        )
     => term ()
 ifThenElse = runQuote $ do

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Bool.hs
@@ -19,26 +19,25 @@ import PlutusCore.Quote
 
 import PlutusCore.StdLib.Data.Unit
 
-import Universe
-
 -- | 'Bool' as a PLC type.
-bool :: uni `Includes` Bool => Type tyname uni ()
+bool :: uni `HasTypeLevel` Bool => Type tyname uni ()
 bool = mkTyBuiltin @_ @Bool ()
 
 -- | 'True' as a PLC term.
-true :: (TermLike term tyname name uni fun, uni `Includes` Bool) => term ()
+true :: (TermLike term tyname name uni fun, uni `HasTermLevel` Bool) => term ()
 true = mkConstant () True
 
 -- | 'False' as a PLC term.
-false :: (TermLike term tyname name uni fun, uni `Includes` Bool) => term ()
+false :: (TermLike term tyname name uni fun, uni `HasTermLevel` Bool) => term ()
 false = mkConstant () False
 
 -- | @if_then_else_@ as a PLC term.
 --
 -- > /\(A :: *) -> \(b : Bool) (x y : () -> A) -> IfThenElse {() -> A} b x y ()
 ifThenElse
-    :: ( TermLike term TyName Name uni DefaultFun
-       , uni `Includes` Bool, uni `Includes` ()
+    :: forall term uni.
+       ( TermLike term TyName Name uni DefaultFun
+       , uni `HasBothLevel` Bool, uni `HasBothLevel` ()
        )
     => term ()
 ifThenElse = runQuote $ do

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Data.hs
@@ -25,7 +25,7 @@ import PlutusCore.StdLib.Data.Pair
 import PlutusCore.StdLib.Data.Unit
 
 -- | @Data@ as a built-in PLC type.
-dataTy :: uni `Contains` Data => Type tyname uni ()
+dataTy :: uni `HasTypeLevel` Data => Type tyname uni ()
 dataTy = mkTyBuiltin @_ @Data ()
 
 -- | Pattern matching over 'Data' inside PLC.

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
@@ -21,7 +21,8 @@ integer = mkTyBuiltin @_ @Integer ()
 -- |  @succ :: Integer -> Integer@ as a PLC term.
 --
 -- > \(i : integer) -> addInteger i 1
-succInteger :: (TermLike term tyname Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
+succInteger
+    :: (TermLike term tyname Name uni DefaultFun, uni `HasTypeAndTermLevel` Integer) => term ()
 succInteger = runQuote $ do
     i  <- freshName "i"
     return

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Integer.hs
@@ -15,15 +15,13 @@ import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
 
-import Universe
-
-integer :: uni `Includes` Integer => Type tyname uni ()
+integer :: uni `HasTypeLevel` Integer => Type tyname uni ()
 integer = mkTyBuiltin @_ @Integer ()
 
 -- |  @succ :: Integer -> Integer@ as a PLC term.
 --
 -- > \(i : integer) -> addInteger i 1
-succInteger :: (TermLike term tyname Name uni DefaultFun, uni `Includes` Integer) => term ()
+succInteger :: (TermLike term tyname Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
 succInteger = runQuote $ do
     i  <- freshName "i"
     return

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/List.hs
@@ -26,7 +26,7 @@ import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Data.Unit
 
 -- | @[]@ as a built-in PLC type.
-list :: uni `Contains` [] => Type tyname uni ()
+list :: uni `HasTypeLevel` [] => Type tyname uni ()
 list = mkTyBuiltin @_ @[] ()
 
 -- See Note [Pattern matching on built-in types].

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
@@ -25,8 +25,6 @@ import PlutusCore.Quote
 import PlutusCore.StdLib.Data.Function
 import PlutusCore.StdLib.Type
 
-import Universe
-
 -- | @Nat@ as a PLC type.
 --
 -- > fix \(nat :: *) -> all r. r -> (nat -> r) -> r
@@ -136,7 +134,7 @@ foldNat = runQuote $ do
 -- | Convert a @nat@ to an @integer@.
 --
 -- > foldNat {integer} (addInteger 1) 1
-natToInteger :: (TermLike term TyName Name uni DefaultFun, uni `Includes` Integer) => term ()
+natToInteger :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
 natToInteger = runQuote $ do
     return $
         mkIterAppNoAnn (tyInst () foldNat $ mkTyBuiltin @_ @Integer ())

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Nat.hs
@@ -134,7 +134,8 @@ foldNat = runQuote $ do
 -- | Convert a @nat@ to an @integer@.
 --
 -- > foldNat {integer} (addInteger 1) 1
-natToInteger :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
+natToInteger
+    :: (TermLike term TyName Name uni DefaultFun, uni `HasTypeAndTermLevel` Integer) => term ()
 natToInteger = runQuote $ do
     return $
         mkIterAppNoAnn (tyInst () foldNat $ mkTyBuiltin @_ @Integer ())

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Pair.hs
@@ -20,7 +20,7 @@ import PlutusCore.Name
 import PlutusCore.Quote
 
 -- | @(,)@ as a built-in PLC type.
-pair :: uni `Contains` (,) => Type tyname uni ()
+pair :: uni `HasTypeLevel` (,) => Type tyname uni ()
 pair = mkTyBuiltin @_ @(,) ()
 
 -- | @fst@ as a PLC term.

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
@@ -217,7 +217,9 @@ reverse = runQuote $ do
 -- >         n
 enumFromTo
     :: ( TermLike term TyName Name uni DefaultFun
-       , uni `HasBothLevel` Integer, uni `HasBothLevel` (), uni `HasBothLevel` Bool
+       , uni `HasTypeAndTermLevel` Integer
+       , uni `HasTypeAndTermLevel` ()
+       , uni `HasTypeAndTermLevel` Bool
        )
     => term ()
 enumFromTo = runQuote $ do
@@ -251,7 +253,7 @@ enumFromTo = runQuote $ do
 -- |  'sum' as a PLC term.
 --
 -- > foldList {integer} {integer} addInteger 0
-sum :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
+sum :: (TermLike term TyName Name uni DefaultFun, uni `HasTypeAndTermLevel` Integer) => term ()
 sum = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
@@ -260,7 +262,7 @@ sum = runQuote $ do
         $ [ add , mkConstant @Integer () 0]
 
 -- > foldrList {integer} {integer} 0 addInteger
-sumr :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
+sumr :: (TermLike term TyName Name uni DefaultFun, uni `HasTypeAndTermLevel` Integer) => term ()
 sumr = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
@@ -271,7 +273,7 @@ sumr = runQuote $ do
 -- |  'product' as a PLC term.
 --
 -- > foldList {integer} {integer} multiplyInteger 1
-product :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
+product :: (TermLike term TyName Name uni DefaultFun, uni `HasTypeAndTermLevel` Integer) => term ()
 product = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         mul = builtin () MultiplyInteger

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/ScottList.hs
@@ -33,8 +33,6 @@ import PlutusCore.StdLib.Data.Integer
 import PlutusCore.StdLib.Data.Unit
 import PlutusCore.StdLib.Type
 
-import Universe
-
 -- | @List@ as a PLC type.
 --
 -- > fix \(list :: * -> *) (a :: *) -> all (r :: *). r -> (a -> list a -> r) -> r
@@ -219,7 +217,7 @@ reverse = runQuote $ do
 -- >         n
 enumFromTo
     :: ( TermLike term TyName Name uni DefaultFun
-       , uni `Includes` Integer, uni `Includes` (), uni `Includes` Bool
+       , uni `HasBothLevel` Integer, uni `HasBothLevel` (), uni `HasBothLevel` Bool
        )
     => term ()
 enumFromTo = runQuote $ do
@@ -253,7 +251,7 @@ enumFromTo = runQuote $ do
 -- |  'sum' as a PLC term.
 --
 -- > foldList {integer} {integer} addInteger 0
-sum :: (TermLike term TyName Name uni DefaultFun, uni `Includes` Integer) => term ()
+sum :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
 sum = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
@@ -262,7 +260,7 @@ sum = runQuote $ do
         $ [ add , mkConstant @Integer () 0]
 
 -- > foldrList {integer} {integer} 0 addInteger
-sumr :: (TermLike term TyName Name uni DefaultFun, uni `Includes` Integer) => term ()
+sumr :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
 sumr = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         add = builtin () AddInteger
@@ -273,7 +271,7 @@ sumr = runQuote $ do
 -- |  'product' as a PLC term.
 --
 -- > foldList {integer} {integer} multiplyInteger 1
-product :: (TermLike term TyName Name uni DefaultFun, uni `Includes` Integer) => term ()
+product :: (TermLike term TyName Name uni DefaultFun, uni `HasBothLevel` Integer) => term ()
 product = runQuote $ do
     let int = mkTyBuiltin @_ @Integer ()
         mul = builtin () MultiplyInteger

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Unit.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Unit.hs
@@ -24,7 +24,7 @@ unitval :: (TermLike term tyname name uni fun, uni `HasTermLevel` ()) => term ()
 unitval = mkConstant () ()
 
 -- | 'seq' specified to '()' as a PLC term.
-sequ :: (TermLike term tyname Name uni fun, uni `HasBothLevel` ()) => term ()
+sequ :: (TermLike term tyname Name uni fun, uni `HasTypeAndTermLevel` ()) => term ()
 sequ = runQuote $ do
     x <- freshName "x"
     y <- freshName "y"

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Unit.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Data/Unit.hs
@@ -15,18 +15,16 @@ import PlutusCore.MkPlc
 import PlutusCore.Name
 import PlutusCore.Quote
 
-import Universe
-
 -- | '()' as a PLC type.
-unit :: uni `Includes` () => Type tyname uni ()
+unit :: uni `HasTypeLevel` () => Type tyname uni ()
 unit = mkTyBuiltin @_ @() ()
 
 -- | '()' as a PLC term.
-unitval :: (TermLike term tyname name uni fun, uni `Includes` ()) => term ()
+unitval :: (TermLike term tyname name uni fun, uni `HasTermLevel` ()) => term ()
 unitval = mkConstant () ()
 
 -- | 'seq' specified to '()' as a PLC term.
-sequ :: (TermLike term tyname Name uni fun, uni `Includes` ()) => term ()
+sequ :: (TermLike term tyname Name uni fun, uni `HasBothLevel` ()) => term ()
 sequ = runQuote $ do
     x <- freshName "x"
     y <- freshName "y"

--- a/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
+++ b/plutus-core/plutus-core/test/TypeSynthesis/Spec.hs
@@ -16,7 +16,6 @@ import PlutusCore
 import PlutusCore.Builtin
 import PlutusCore.Error
 import PlutusCore.FsTree
-import PlutusCore.MkPlc
 import PlutusCore.Pretty
 
 import PlutusCore.Examples.Builtins

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Builtin.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Builtin.hs
@@ -72,7 +72,7 @@ class GenArbitraryTerm uni where
 instance GenArbitraryTerm DefaultUni where
     genArbitraryTerm = runAstGen genTerm
 
-data SomeGen uni = forall a. uni `Contains` a => SomeGen (Gen a)
+data SomeGen uni = forall a. uni `HasTermLevel` a => SomeGen (Gen a)
 
 genConstant :: forall (a :: GHC.Type). TypeRep a -> SomeGen DefaultUni
 genConstant tr

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Denotation.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Denotation.hs
@@ -28,7 +28,7 @@ import Data.Dependent.Map qualified as DMap
 import Data.Functor.Compose
 import Type.Reflection
 
-type KnownType val a = (KnownTypeAst (UniOf val) a, MakeKnown val a)
+type KnownType val a = (KnownTypeAst TyName (UniOf val) a, MakeKnown val a)
 
 -- | Haskell denotation of a PLC object. An object can be a 'Builtin' or a variable for example.
 data Denotation term object res = forall args. Denotation

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
@@ -110,7 +110,7 @@ revealUnique (Name name uniq) =
 withTypedBuiltinGen
     :: Monad m
     => Proxy fun
-    -> (forall a. (KnownTypeAst DefaultUni a, MakeKnown (Plain Term DefaultUni fun) a) =>
+    -> (forall a. (KnownTypeAst TyName DefaultUni a, MakeKnown (Plain Term DefaultUni fun) a) =>
             TypeRep a -> GenT m c)
     -> GenT m c
 withTypedBuiltinGen _ k = Gen.choice

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Test.hs
@@ -41,7 +41,7 @@ import System.FilePath ((</>))
 -- | Generate a term using a given generator and check that it's well-typed and evaluates correctly.
 getSampleTermValue
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        )
     => TermGen a
     -> IO (TermOf (Term TyName Name uni fun ()) (EvaluationResult (Term TyName Name uni fun ())))
@@ -50,7 +50,7 @@ getSampleTermValue genTerm = Gen.sample $ unsafeTypeEvalCheck <$> genTerm
 -- | Generate a program using a given generator and check that it's well-typed and evaluates correctly.
 getSampleProgramAndValue
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        )
     => TermGen a -> IO (Program TyName Name uni fun (), EvaluationResult (Term TyName Name uni fun ()))
 getSampleProgramAndValue genTerm =
@@ -61,7 +61,7 @@ getSampleProgramAndValue genTerm =
 -- and pretty-print it to stdout using the default pretty-printing mode.
 printSampleProgramAndValue
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        )
     => TermGen a -> IO ()
 printSampleProgramAndValue =
@@ -75,7 +75,7 @@ printSampleProgramAndValue =
 -- the second file contains the result of evaluation of the term.
 sampleProgramValueGolden
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        )
     => String     -- ^ @folder@
     -> String     -- ^ @name@
@@ -93,7 +93,7 @@ sampleProgramValueGolden folder name genTerm = do
 -- indeed computes to that value according to the provided evaluate.
 propEvaluate
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        , PrettyPlc internal
        )
     => (Term TyName Name uni fun () ->

--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/TypeEvalCheck.hs
@@ -93,7 +93,7 @@ type TypeEvalCheckM uni fun = Either (TypeEvalCheckError uni fun)
 -- | Type check and evaluate a term and check that the expected result is equal to the actual one.
 typeEvalCheckBy
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        , PrettyPlc internal
        )
     => (Term TyName Name uni fun () ->
@@ -122,7 +122,7 @@ typeEvalCheckBy eval (TermOf term (x :: a)) = TermOf term <$> do
 -- Throw an error in case something goes wrong.
 unsafeTypeEvalCheck
     :: ( uni ~ DefaultUni, fun ~ DefaultFun
-       , KnownTypeAst uni a, MakeKnown (Term TyName Name uni fun ()) a
+       , KnownTypeAst TyName uni a, MakeKnown (Term TyName Name uni fun ()) a
        )
     => TermOf (Term TyName Name uni fun ()) a
     -> TermOf (Term TyName Name uni fun ()) (EvaluationResult (Term TyName Name uni fun ()))

--- a/plutus-core/testlib/PlutusCore/Generators/QuickCheck/ShrinkTypes.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/QuickCheck/ShrinkTypes.hs
@@ -16,7 +16,6 @@ import PlutusCore.Generators.QuickCheck.GenTm
 import PlutusCore.Builtin
 import PlutusCore.Core
 import PlutusCore.Default
-import PlutusCore.MkPlc (mkTyBuiltin)
 import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Subst

--- a/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
+++ b/plutus-core/testlib/PlutusIR/Generators/QuickCheck/ShrinkTerms.hs
@@ -23,7 +23,7 @@ import PlutusCore.Crypto.BLS12_381.G2 qualified as BLS12_381.G2 (zero)
 import PlutusCore.Crypto.BLS12_381.Pairing qualified as BLS12_381.Pairing (identityMlResult)
 import PlutusCore.Data
 import PlutusCore.Default
-import PlutusCore.MkPlc (mkConstantOf, mkTyBuiltin, mkTyBuiltinOf)
+import PlutusCore.MkPlc (mkConstantOf, mkTyBuiltinOf)
 import PlutusCore.Name
 import PlutusCore.Pretty
 import PlutusCore.Subst (typeSubstClosedType)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
 
 
 -- Sure GHC, I'm enabling the extension just so that you can warn me about its usages.
@@ -500,7 +501,7 @@ test_List = testCase "List" $ do
     Right (EvaluationSuccess false)  @=?  typecheckEvaluateCekNoEmit def defaultBuiltinCostModel (nullViaChooseList [1..10])
 
  where
-   evalsL :: Contains DefaultUni a => a -> DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
+   evalsL :: DefaultUni `HasTermLevel` a => a -> DefaultFun -> Type TyName DefaultUni () -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
    evalsL expectedVal b tyArg args =
     let actualExp = mkIterAppNoAnn (tyInst () (builtin () b) tyArg) args
     in  Right (EvaluationSuccess $ cons expectedVal)
@@ -663,11 +664,11 @@ test_ConsByteString =
         Right EvaluationFailure @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
 
 -- shorthand
-cons :: (Contains DefaultUni a, TermLike term tyname name DefaultUni fun) => a -> term ()
+cons :: (DefaultUni `HasTermLevel` a, TermLike term tyname name DefaultUni fun) => a -> term ()
 cons = mkConstant ()
 
 -- shorthand
-evals :: Contains DefaultUni a => a -> DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
+evals :: DefaultUni `HasTermLevel` a => a -> DefaultFun -> [Term TyName Name DefaultUni DefaultFun ()]  -> Assertion
 evals expectedVal b args =
     let actualExp = mkIterAppNoAnn (builtin () b) args
     in  Right (EvaluationSuccess $ cons expectedVal)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -83,7 +83,7 @@ test_Const =
         b <- forAll Gen.bool
         let tC = mkConstant () c
             tB = mkConstant () b
-            text = toTypeAst @_ @DefaultUni @Text Proxy
+            text = toTypeAst @_ @_ @DefaultUni @Text Proxy
             runConst con = mkIterAppNoAnn (mkIterInstNoAnn con [text, bool]) [tC, tB]
             lhs = typecheckReadKnownCek def defaultBuiltinCostModelExt $ runConst $ builtin () (Right Const)
             rhs = typecheckReadKnownCek def defaultBuiltinCostModelExt $ runConst $ mapFun @DefaultFun Left Plc.const

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -42,7 +42,7 @@ integer = mkTyBuiltin @_ @Integer ()
 string :: uni `HasTypeLevel` Text => Type TyName uni ()
 string = mkTyBuiltin @_ @Text ()
 
-evenAndOdd :: uni `HasBothLevel` Bool => Tuple (Term TyName Name uni fun) uni ()
+evenAndOdd :: uni `HasTypeAndTermLevel` Bool => Tuple (Term TyName Name uni fun) uni ()
 evenAndOdd = runQuote $ do
     let nat = _recursiveType natData
 
@@ -60,7 +60,7 @@ evenAndOdd = runQuote $ do
 
     getMutualFixOf () (fixN 2 fixBy) [evenF, oddF]
 
-even :: uni `HasBothLevel` Bool => Term TyName Name uni fun ()
+even :: uni `HasTypeAndTermLevel` Bool => Term TyName Name uni fun ()
 even = runQuote $ tupleTermAt () 0 evenAndOdd
 
 evenAndOddList :: Tuple (Term TyName Name uni fun) uni ()
@@ -115,7 +115,7 @@ polyError = runQuote $ do
 
 -- | For checking that evaluating a term to a non-constant results in all remaining variables
 -- being instantiated.
-closure :: uni `HasBothLevel` Integer => Term TyName Name uni fun ()
+closure :: uni `HasTypeAndTermLevel` Integer => Term TyName Name uni fun ()
 closure = runQuote $ do
     i <- freshName "i"
     j <- freshName "j"

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Golden.hs
@@ -35,14 +35,14 @@ import Test.Tasty
 import Test.Tasty.Golden
 
 -- (con integer)
-integer :: uni `Includes` Integer => Type TyName uni ()
+integer :: uni `HasTypeLevel` Integer => Type TyName uni ()
 integer = mkTyBuiltin @_ @Integer ()
 
 -- (con string)
-string :: uni `Includes` Text => Type TyName uni ()
+string :: uni `HasTypeLevel` Text => Type TyName uni ()
 string = mkTyBuiltin @_ @Text ()
 
-evenAndOdd :: uni `Includes` Bool => Tuple (Term TyName Name uni fun) uni ()
+evenAndOdd :: uni `HasBothLevel` Bool => Tuple (Term TyName Name uni fun) uni ()
 evenAndOdd = runQuote $ do
     let nat = _recursiveType natData
 
@@ -60,7 +60,7 @@ evenAndOdd = runQuote $ do
 
     getMutualFixOf () (fixN 2 fixBy) [evenF, oddF]
 
-even :: uni `Includes` Bool => Term TyName Name uni fun ()
+even :: uni `HasBothLevel` Bool => Term TyName Name uni fun ()
 even = runQuote $ tupleTermAt () 0 evenAndOdd
 
 evenAndOddList :: Tuple (Term TyName Name uni fun) uni ()
@@ -115,7 +115,7 @@ polyError = runQuote $ do
 
 -- | For checking that evaluating a term to a non-constant results in all remaining variables
 -- being instantiated.
-closure :: uni `Includes` Integer => Term TyName Name uni fun ()
+closure :: uni `HasBothLevel` Integer => Term TyName Name uni fun ()
 closure = runQuote $ do
     i <- freshName "i"
     j <- freshName "j"

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -511,7 +511,7 @@ maybeProfileRhs var t = do
     else pure t
 
 mkTrace
-    :: (PLC.Contains uni T.Text)
+    :: (uni `PLC.HasTermLevel` T.Text)
     => PLC.Type PLC.TyName uni Ann
     -> T.Text
     -> PIRTerm uni PLC.DefaultFun

--- a/plutus-tx/src/PlutusTx/Lift/Class.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Class.hs
@@ -115,12 +115,12 @@ instance Typeable uni (->) where
 -- Primitives
 
 typeRepBuiltin
-    :: forall (a :: GHC.Type) uni fun. uni `PLC.Includes` a
+    :: forall (a :: GHC.Type) uni fun. uni `PLC.HasTypeLevel` a
     => Proxy a -> RTCompile uni fun (Type TyName uni ())
 typeRepBuiltin (_ :: Proxy a) = pure $ mkTyBuiltin @_ @a ()
 
 liftBuiltin
-    :: forall a uni fun. uni `PLC.Includes` a
+    :: forall a uni fun. uni `PLC.HasTermLevel` a
     => a -> RTCompile uni fun (Term TyName Name uni fun ())
 liftBuiltin = pure . mkConstant ()
 
@@ -132,53 +132,59 @@ instance (TypeError ('Text "Int is not supported, use Integer instead"))
     => Lift uni Int where
     lift = Haskell.error "unsupported"
 
-instance uni `PLC.Includes` Integer => Typeable uni Integer where
+instance uni `PLC.HasTypeLevel` Integer => Typeable uni Integer where
     typeRep = typeRepBuiltin
 
-instance uni `PLC.Includes` Integer => Lift uni Integer where
+instance uni `PLC.HasTermLevel` Integer => Lift uni Integer where
     lift = liftBuiltin
 
-instance uni `PLC.Includes` BS.ByteString => Typeable uni BS.ByteString where
+instance uni `PLC.HasTypeLevel` BS.ByteString => Typeable uni BS.ByteString where
     typeRep = typeRepBuiltin
 
-instance uni `PLC.Includes` BS.ByteString => Lift uni BS.ByteString where
+instance uni `PLC.HasTermLevel` BS.ByteString => Lift uni BS.ByteString where
     lift = liftBuiltin
 
-instance uni `PLC.Includes` Data => Typeable uni BuiltinData where
+instance uni `PLC.HasTypeLevel` Data => Typeable uni BuiltinData where
     typeRep _ = typeRepBuiltin (Proxy @Data)
 
-instance uni `PLC.Includes` Data => Lift uni BuiltinData where
+instance uni `PLC.HasTermLevel` Data => Lift uni BuiltinData where
     lift = liftBuiltin . builtinDataToData
 
-instance uni `PLC.Includes` BS.ByteString => Typeable uni BuiltinByteString where
+instance uni `PLC.HasTypeLevel` BS.ByteString => Typeable uni BuiltinByteString where
     typeRep _proxyPByteString = typeRepBuiltin (Proxy @BS.ByteString)
 
-instance uni `PLC.Includes` BS.ByteString => Lift uni BuiltinByteString where
+instance uni `PLC.HasTermLevel` BS.ByteString => Lift uni BuiltinByteString where
     lift = liftBuiltin . fromBuiltin
 
-instance uni `PLC.Includes` T.Text => Typeable uni BuiltinString where
+instance uni `PLC.HasTypeLevel` T.Text => Typeable uni BuiltinString where
     typeRep _proxyPByteString = typeRepBuiltin (Proxy @T.Text)
 
-instance uni `PLC.Includes` T.Text => Lift uni BuiltinString where
+instance uni `PLC.HasTermLevel` T.Text => Lift uni BuiltinString where
     lift = liftBuiltin . fromBuiltin
 
-instance (FromBuiltin arep a, uni `PLC.Includes` [a]) => Lift uni (BuiltinList arep) where
+instance (FromBuiltin arep a, uni `PLC.HasTermLevel` [a]) => Lift uni (BuiltinList arep) where
     lift = liftBuiltin . fromBuiltin
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.G1.Element => Typeable uni BuiltinBLS12_381_G1_Element where
+instance uni `PLC.HasTypeLevel` PlutusCore.Crypto.BLS12_381.G1.Element =>
+        Typeable uni BuiltinBLS12_381_G1_Element where
     typeRep _ = typeRepBuiltin (Proxy @PlutusCore.Crypto.BLS12_381.G1.Element)
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.G1.Element => Lift uni BuiltinBLS12_381_G1_Element where
+instance uni `PLC.HasTermLevel` PlutusCore.Crypto.BLS12_381.G1.Element =>
+        Lift uni BuiltinBLS12_381_G1_Element where
     lift = liftBuiltin . fromBuiltin
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.G2.Element => Typeable uni BuiltinBLS12_381_G2_Element where
+instance uni `PLC.HasTypeLevel` PlutusCore.Crypto.BLS12_381.G2.Element =>
+        Typeable uni BuiltinBLS12_381_G2_Element where
     typeRep _ = typeRepBuiltin (Proxy @PlutusCore.Crypto.BLS12_381.G2.Element)
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.G2.Element => Lift uni BuiltinBLS12_381_G2_Element where
+instance uni `PLC.HasTermLevel` PlutusCore.Crypto.BLS12_381.G2.Element =>
+        Lift uni BuiltinBLS12_381_G2_Element where
     lift = liftBuiltin . fromBuiltin
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.Pairing.MlResult => Typeable uni BuiltinBLS12_381_MlResult where
+instance uni `PLC.HasTypeLevel` PlutusCore.Crypto.BLS12_381.Pairing.MlResult =>
+        Typeable uni BuiltinBLS12_381_MlResult where
     typeRep _ = typeRepBuiltin (Proxy @PlutusCore.Crypto.BLS12_381.Pairing.MlResult)
 
-instance uni `PLC.Includes` PlutusCore.Crypto.BLS12_381.Pairing.MlResult => Lift uni BuiltinBLS12_381_MlResult where
+instance uni `PLC.HasTermLevel` PlutusCore.Crypto.BLS12_381.Pairing.MlResult =>
+        Lift uni BuiltinBLS12_381_MlResult where
     lift = liftBuiltin . fromBuiltin

--- a/plutus-tx/src/PlutusTx/Show.hs
+++ b/plutus-tx/src/PlutusTx/Show.hs
@@ -108,7 +108,7 @@ instance Show () where
 
 -- It is possible to make it so that when `a` is a builtin type, `show (xs :: [a])`
 -- is compiled into a single `showConstant` call, rathern than `length xs` calls.
--- To do so the plugin would need to try to solve the @uni `Contains` [a]@ constraint,
+-- To do so the plugin would need to try to solve the @uni `HasTermLevel` [a]@ constraint,
 -- and branch based on whether it is solvable. But the complexity doesn't seem to
 -- be worth it: the saving in budget is likely small, and on mainnet the trace messages
 -- are often erased anyway.


### PR DESCRIPTION
This separates the single `Includes` constraint into two constraints, `HasTypeLevel` and `HasTermLevel` (which together form `HasBothLevel`). This is a prerequisite for splitting the universe of built-in types into two universes, one for the type level and the other for the term level, which is going to bring plenty of benefits:

1. make the implementation complaint with the metatheory
2. allow for simpler and more efficient implementation of `DefaultUni` as per #4781
3. allow for supporting partially applied types as built-in types without `newtype`-wrapping them (which is what @kwxm had to do with `BlstBindings.Point1`, `BlstBindings.Point2` and `BlstBindings.PT`)
4. simplify turning `Some (ValueOf DefaultUni)` into a `data family`
5. allow for erasable built-in types (a.k.a built-in newtypes, we'll talk about those a bit later)
6. make it clear if a definition uses a built-in type or values of the built-in type or both, thus providing a bit more type-level insight

This PR doesn't change any behavior, only type-level stuff. Behavioral changes are for future PRs.