### PR TITLE
Add some strictness tests for the plugin in Strictness.Spec

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -150,6 +150,7 @@ test-suite plutus-tx-tests
     Plugin.Typeclasses.Lib
     Plugin.Typeclasses.Spec
     StdLib.Spec
+    Strictness.Spec
     TH.Spec
     TH.TestTH
 

--- a/plutus-tx-plugin/test/Spec.hs
+++ b/plutus-tx-plugin/test/Spec.hs
@@ -6,6 +6,7 @@ import Lift.Spec qualified as Lift
 import Optimization.Spec qualified as Optimization
 import Plugin.Spec qualified as Plugin
 import StdLib.Spec qualified as Lib
+import Strictness.Spec qualified as Strictness
 import TH.Spec qualified as TH
 
 import Test.Tasty
@@ -23,4 +24,5 @@ tests = testGroup "tests" <$> sequence [
   , Lib.tests
   , Budget.tests
   , Optimization.tests
+  , Strictness.tests
   ]

--- a/plutus-tx-plugin/test/Strictness/Spec.hs
+++ b/plutus-tx-plugin/test/Strictness/Spec.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Strict              #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+
+module Strictness.Spec where
+
+import Test.Tasty.Extras
+
+import PlutusTx qualified as Tx
+import PlutusTx.Code
+import PlutusTx.Prelude qualified as PlutusTx
+import PlutusTx.Test
+import PlutusTx.TH (compile)
+
+tests :: TestNested
+tests =
+  testNested
+    "Strictness"
+    [ goldenEvalCekCatch "lambda-default" $ [lambdaDefault `unsafeApplyCode` bot]
+    , goldenPirReadable "lambda-default" lambdaDefault
+    , goldenUPlcReadable "lambda-default" lambdaDefault
+
+    -- FIXME: This should not crash, but it currently does.
+    , goldenEvalCekCatch "lambda-nonstrict" $ [lambdaNonStrict `unsafeApplyCode` bot]
+    , goldenPirReadable "lambda-nonstrict" lambdaNonStrict
+    , goldenUPlcReadable "lambda-nonstrict" lambdaNonStrict
+
+    , goldenEvalCekCatch "lambda-strict" $ [lambdaStrict `unsafeApplyCode` bot]
+    , goldenPirReadable "lambda-strict" lambdaStrict
+    , goldenUPlcReadable "lambda-strict" lambdaStrict
+
+    -- FIXME: This should crash (because the `Strict` extension is on), but it currently doesn't.
+    , goldenEvalCekCatch "let-default" $ [letDefault `unsafeApplyCode` one]
+    , goldenPirReadable "let-default" letDefault
+    , goldenUPlcReadable "let-default" letDefault
+
+    , goldenEvalCekCatch "let-nonstrict" $ [letNonStrict `unsafeApplyCode` one]
+    , goldenPirReadable "let-nonstrict" letNonStrict
+    , goldenUPlcReadable "let-nonstrict" letNonStrict
+
+    -- FIXME: This should crash, but it currently doesn't.
+    , goldenEvalCekCatch "let-strict" $ [letStrict `unsafeApplyCode` one]
+    , goldenPirReadable "let-strict" letStrict
+    , goldenUPlcReadable "let-strict" letStrict
+    ]
+
+lambdaDefault :: CompiledCode (Integer -> Integer -> Integer)
+lambdaDefault =
+  $$( compile
+        [||
+        \n -> \m -> n PlutusTx.+ m
+        ||]
+    )
+
+lambdaNonStrict :: CompiledCode (Integer -> Integer -> Integer)
+lambdaNonStrict =
+  $$( compile
+        [||
+        \(~n) -> \m -> n PlutusTx.+ m
+        ||]
+    )
+
+lambdaStrict :: CompiledCode (Integer -> Integer -> Integer)
+lambdaStrict =
+  $$( compile
+        [||
+        \(!n) -> \m -> n PlutusTx.+ m
+        ||]
+    )
+
+letDefault :: CompiledCode (Integer -> Integer)
+letDefault =
+  $$( compile
+        [||
+        \m ->
+          let n = PlutusTx.error () m
+           in if m PlutusTx.< 0 then n PlutusTx.+ n else m
+        ||]
+    )
+
+letNonStrict :: CompiledCode (Integer -> Integer)
+letNonStrict =
+  $$( compile
+        [||
+        \m ->
+          let ~n = PlutusTx.error () m
+           in if m PlutusTx.< 0 then n PlutusTx.+ n else m
+        ||]
+    )
+
+letStrict :: CompiledCode (Integer -> Integer)
+letStrict =
+  $$( compile
+        [||
+        \m ->
+          let !n = PlutusTx.error () m
+           in if m PlutusTx.< 0 then n PlutusTx.+ n else m
+        ||]
+    )
+
+bot :: CompiledCode Integer
+bot = $$(compile [|| PlutusTx.error () ||])
+
+one :: CompiledCode Integer
+one = Tx.liftCodeDef 1

--- a/plutus-tx-plugin/test/Strictness/lambda-default.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-default.eval-cek-catch.golden
@@ -1,0 +1,2 @@
+An error has occurred:  User error:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.

--- a/plutus-tx-plugin/test/Strictness/lambda-default.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-default.pir-readable.golden
@@ -1,0 +1,1 @@
+\(n : integer) (m : integer) -> addInteger n m

--- a/plutus-tx-plugin/test/Strictness/lambda-default.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-default.uplc-readable.golden
@@ -1,0 +1,1 @@
+program 1.1.0 (\n m -> addInteger n m)

--- a/plutus-tx-plugin/test/Strictness/lambda-nonstrict.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-nonstrict.eval-cek-catch.golden
@@ -1,0 +1,2 @@
+An error has occurred:  User error:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.

--- a/plutus-tx-plugin/test/Strictness/lambda-nonstrict.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-nonstrict.pir-readable.golden
@@ -1,0 +1,1 @@
+\(n : integer) (m : integer) -> addInteger n m

--- a/plutus-tx-plugin/test/Strictness/lambda-nonstrict.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-nonstrict.uplc-readable.golden
@@ -1,0 +1,1 @@
+program 1.1.0 (\n m -> addInteger n m)

--- a/plutus-tx-plugin/test/Strictness/lambda-strict.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-strict.eval-cek-catch.golden
@@ -1,0 +1,2 @@
+An error has occurred:  User error:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.

--- a/plutus-tx-plugin/test/Strictness/lambda-strict.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-strict.pir-readable.golden
@@ -1,0 +1,1 @@
+\(n : integer) (m : integer) -> addInteger n m

--- a/plutus-tx-plugin/test/Strictness/lambda-strict.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/lambda-strict.uplc-readable.golden
@@ -1,0 +1,1 @@
+program 1.1.0 (\n m -> addInteger n m)

--- a/plutus-tx-plugin/test/Strictness/let-default.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/let-default.eval-cek-catch.golden
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/plutus-tx-plugin/test/Strictness/let-default.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-default.pir-readable.golden
@@ -1,0 +1,17 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+\(m : integer) ->
+  let
+    !n : all t. t = /\t -> error {integer -> t} m
+  in
+  Bool_match
+    (ifThenElse {Bool} (lessThanInteger m 0) True False)
+    {all dead. integer}
+    (/\dead -> let !y : integer = n {integer} in addInteger (n {integer}) y)
+    (/\dead -> m)
+    {all dead. dead}

--- a/plutus-tx-plugin/test/Strictness/let-default.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-default.uplc-readable.golden
@@ -1,0 +1,10 @@
+program
+  1.1.0
+  (\m ->
+     force
+       (force ifThenElse
+          (lessThanInteger m 0)
+          (delay
+             ((\n -> (\y -> addInteger (force n) y) (force n))
+                (delay (error m))))
+          (delay m)))

--- a/plutus-tx-plugin/test/Strictness/let-nonstrict.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/let-nonstrict.eval-cek-catch.golden
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/plutus-tx-plugin/test/Strictness/let-nonstrict.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-nonstrict.pir-readable.golden
@@ -1,0 +1,17 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+\(m : integer) ->
+  let
+    !n : all t. t = /\t -> error {integer -> t} m
+  in
+  Bool_match
+    (ifThenElse {Bool} (lessThanInteger m 0) True False)
+    {all dead. integer}
+    (/\dead -> let !y : integer = n {integer} in addInteger (n {integer}) y)
+    (/\dead -> m)
+    {all dead. dead}

--- a/plutus-tx-plugin/test/Strictness/let-nonstrict.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-nonstrict.uplc-readable.golden
@@ -1,0 +1,10 @@
+program
+  1.1.0
+  (\m ->
+     force
+       (force ifThenElse
+          (lessThanInteger m 0)
+          (delay
+             ((\n -> (\y -> addInteger (force n) y) (force n))
+                (delay (error m))))
+          (delay m)))

--- a/plutus-tx-plugin/test/Strictness/let-strict.eval-cek-catch.golden
+++ b/plutus-tx-plugin/test/Strictness/let-strict.eval-cek-catch.golden
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/plutus-tx-plugin/test/Strictness/let-strict.pir-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-strict.pir-readable.golden
@@ -1,0 +1,17 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  data Bool | Bool_match where
+    True : Bool
+    False : Bool
+in
+\(m : integer) ->
+  let
+    !n : all t. t = /\t -> error {integer -> t} m
+  in
+  Bool_match
+    (ifThenElse {Bool} (lessThanInteger m 0) True False)
+    {all dead. integer}
+    (/\dead -> let !y : integer = n {integer} in addInteger (n {integer}) y)
+    (/\dead -> m)
+    {all dead. dead}

--- a/plutus-tx-plugin/test/Strictness/let-strict.uplc-readable.golden
+++ b/plutus-tx-plugin/test/Strictness/let-strict.uplc-readable.golden
@@ -1,0 +1,10 @@
+program
+  1.1.0
+  (\m ->
+     force
+       (force ifThenElse
+          (lessThanInteger m 0)
+          (delay
+             ((\n -> (\y -> addInteger (force n) y) (force n))
+                (delay (error m))))
+          (delay m)))

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -23,6 +23,7 @@ module PlutusTx.Test (
 
   -- * Evaluation testing
   goldenEvalCek,
+  goldenEvalCekCatch,
   goldenEvalCekLog,
 
   -- * Budget testing
@@ -201,6 +202,11 @@ goldenPirBy config name value =
 goldenEvalCek :: (ToUPlc a PLC.DefaultUni PLC.DefaultFun) => String -> [a] -> TestNested
 goldenEvalCek name values =
   nestedGoldenVsDocM name ".eval-cek" $ prettyPlcClassicDebug <$> (rethrow $ runPlcCek values)
+
+goldenEvalCekCatch :: (ToUPlc a PLC.DefaultUni PLC.DefaultFun) => String -> [a] -> TestNested
+goldenEvalCekCatch name values =
+  nestedGoldenVsDocM name ".eval-cek-catch" $
+    either (pretty . show) prettyPlcClassicDebug <$> runExceptT (runPlcCek values)
 
 goldenEvalCekLog :: (ToUPlc a PLC.DefaultUni PLC.DefaultFun) => String -> [a] -> TestNested
 goldenEvalCekLog name values =


### PR DESCRIPTION
Added some tests to verify that when the `Strict` extension is on, the compiler does the right things wrt strictness (it currently doesn't).

