### PR TITLE
Improve error messages in ScriptContext benchmarks

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -79,6 +79,7 @@ library plutus-benchmark-common
     , tasty
     , tasty-golden
     , temporary
+    , text
 
 ---------------- nofib ----------------
 
@@ -481,6 +482,7 @@ test-suite plutus-benchmark-script-contexts-tests
     , script-contexts-internal
     , tasty
     , tasty-hunit
+    , text
 
 ---------------- Marlowe scripts ----------------
 

--- a/plutus-benchmark/script-contexts/test/Spec.hs
+++ b/plutus-benchmark/script-contexts/test/Spec.hs
@@ -1,25 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
+
+import Data.Text qualified as Text
 
 import Test.Tasty
 import Test.Tasty.Extras (TestNested, runTestNestedIn)
 import Test.Tasty.HUnit
 
-import PlutusBenchmark.Common (compiledCodeToTerm, runTermCek)
-
+import PlutusBenchmark.Common (Term, compiledCodeToTerm, runTermCek, unsafeRunTermCek)
 import PlutusBenchmark.ScriptContexts
 
 import PlutusCore.Evaluation.Result
+import PlutusCore.Pretty
 import PlutusTx.Test qualified as Tx
 
 runTestNested :: TestNested -> TestTree
 runTestNested = runTestNestedIn ["script-contexts", "test"]
 
+assertSucceeded :: Term -> Assertion
+assertSucceeded t =
+    case runTermCek t of
+        (Right _, _)  -> pure ()
+        (Left err, logs) -> assertFailure . Text.unpack . Text.intercalate "\n" $
+            [ render (prettyPlcClassicDebug err)
+            , "Cek logs:"
+            ] ++ logs
+
+assertFailed :: Term -> Assertion
+assertFailed t =
+    -- Using `unsafeRunTermCek` here, so that only user errors make the test pass.
+    -- Machine errors still make the test fail.
+    case unsafeRunTermCek t of
+        EvaluationFailure   -> pure ()
+        EvaluationSuccess _ -> assertFailure "Evaluation succeeded unexpectedly"
+
 testCheckSc1 :: TestTree
 testCheckSc1 = testGroup "checkScriptContext1"
-    [ testCase "succeed on 4" $ assertBool "evaluation failed" $ isEvaluationSuccess $
-        runTermCek $ compiledCodeToTerm $ mkCheckScriptContext1Code (mkScriptContext 4)
-    , testCase "fails on 5" $ assertBool "evaluation succeeded" $ isEvaluationFailure $
-        runTermCek $ compiledCodeToTerm $ mkCheckScriptContext1Code (mkScriptContext 5)
+    [ testCase "succeed on 4" . assertSucceeded $
+        compiledCodeToTerm $ mkCheckScriptContext1Code (mkScriptContext 4)
+    , testCase "fails on 5" . assertFailed $
+        compiledCodeToTerm $ mkCheckScriptContext1Code (mkScriptContext 5)
     , Tx.fitsInto "checkScriptContext1 (size)" (mkCheckScriptContext1Code (mkScriptContext 1)) 1982
     , runTestNested $ Tx.goldenBudget "checkScriptContext1-4" $
         mkCheckScriptContext1Code (mkScriptContext 4)
@@ -29,10 +50,10 @@ testCheckSc1 = testGroup "checkScriptContext1"
 
 testCheckSc2 :: TestTree
 testCheckSc2 = testGroup "checkScriptContext2"
-    [ testCase "succeed on 4" $ assertBool "evaluation failed" $ isEvaluationSuccess $
-          runTermCek $ compiledCodeToTerm $ mkCheckScriptContext2Code (mkScriptContext 4)
-    , testCase "succeed on 5" $ assertBool "evaluation failed" $ isEvaluationSuccess $
-          runTermCek $ compiledCodeToTerm $ mkCheckScriptContext2Code (mkScriptContext 5)
+    [ testCase "succeed on 4" . assertSucceeded $
+          compiledCodeToTerm $ mkCheckScriptContext2Code (mkScriptContext 4)
+    , testCase "succeed on 5" . assertSucceeded $
+          compiledCodeToTerm $ mkCheckScriptContext2Code (mkScriptContext 5)
     , Tx.fitsInto "checkScriptContext2 (size)" (mkCheckScriptContext2Code (mkScriptContext 1)) 1919
     , runTestNested $ Tx.goldenBudget "checkScriptContext2-4" $
           mkCheckScriptContext2Code (mkScriptContext 4)


### PR DESCRIPTION
When a test fails, rather than `"evaluation failed"`, it now prints the actual error message and Cek logs.