### PR TITLE
PLT-894: Improve the error reporting of 'CBOR.DeserialiseFailure'

### DIFF
--- a/plutus-ledger-api/changelog.d/20230808_144833_bezirg_cborfailureinterp.md
+++ b/plutus-ledger-api/changelog.d/20230808_144833_bezirg_cborfailureinterp.md
@@ -1,0 +1,4 @@
+### Changed
+
+- A CBOR script deserialization error now contains more descriptive (typed) errors,
+  see `DeserialiseFailureInfo`.

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -50,6 +50,7 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   exposed-modules:
+    Codec.CBOR.Extras
     PlutusLedgerApi.Common
     PlutusLedgerApi.Common.Versions
     PlutusLedgerApi.V1
@@ -77,7 +78,6 @@ library
     PlutusLedgerApi.V3.ParamName
 
   other-modules:
-    Codec.CBOR.Extras
     PlutusLedgerApi.Common.Eval
     PlutusLedgerApi.Common.ParamName
     PlutusLedgerApi.Common.ProtocolVersions
@@ -131,6 +131,7 @@ test-suite plutus-ledger-api-test
   main-is:        Spec.hs
   hs-source-dirs: test
   other-modules:
+    Spec.CBOR.DeserialiseFailureInfo
     Spec.CostModelParams
     Spec.Eval
     Spec.Interval
@@ -140,6 +141,7 @@ test-suite plutus-ledger-api-test
   build-depends:
     , base                                                              >=4.9  && <5
     , bytestring
+    , cborg
     , containers
     , extra
     , hedgehog

--- a/plutus-ledger-api/src/Codec/CBOR/Extras.hs
+++ b/plutus-ledger-api/src/Codec/CBOR/Extras.hs
@@ -1,11 +1,19 @@
-module Codec.CBOR.Extras where
+-- editorconfig-checker-disable-file
+{-# LANGUAGE LambdaCase #-}
+module Codec.CBOR.Extras
+    ( SerialiseViaFlat (..)
+    , decodeViaFlat
+    , DeserialiseFailureInfo (..)
+    , DeserialiseFailureReason (..)
+    , readDeserialiseFailureInfo
+    ) where
 
 import Codec.CBOR.Decoding as CBOR
+import Codec.CBOR.Read as CBOR
 import Codec.Serialise (Serialise, decode, encode)
 import Data.Either.Extras
 import Flat qualified
 import Flat.Decoder qualified as Flat
-
 
 -- | Newtype to provide 'Serialise' instances for types with a 'Flat' instance that
 -- just encodes the flat-serialized value as a CBOR bytestring
@@ -20,3 +28,43 @@ decodeViaFlat decoder = do
     -- lift any flat's failures to be cborg failures (MonadFail)
     fromRightM (fail . show) $
         Flat.unflatWith decoder bs
+
+{- | The errors returned by `cborg` are plain strings (untyped). With this function we try to
+map onto datatypes, those cborg error messages that we are interested in.
+
+Currently we are only interested in error messages returned by the `CBOR.decodeBytes` decoder;
+see `PlutusLedgerApi.Common.SerialisedScript.scriptCBORDecoder`.
+-}
+readDeserialiseFailureInfo :: CBOR.DeserialiseFailure -> DeserialiseFailureInfo
+readDeserialiseFailureInfo (CBOR.DeserialiseFailure byteOffset reason) =
+    DeserialiseFailureInfo byteOffset $ interpretReason reason
+  where
+    -- Note that this is subject to change if `cborg` dependency changes. Currently: cborg-0.2.9.0
+    interpretReason :: String -> DeserialiseFailureReason
+    interpretReason = \case
+        -- Relevant Sources:
+        -- <https://github.com/well-typed/cborg/blob/cborg-0.2.9.0/cborg/src/Codec/CBOR/Read.hs#L226>
+        -- <https://github.com/well-typed/cborg/blob/cborg-0.2.9.0/cborg/src/Codec/CBOR/Read.hs#L1424>
+        -- <https://github.com/well-typed/cborg/blob/cborg-0.2.9.0/cborg/src/Codec/CBOR/Read.hs#L1441>
+        "end of input"   -> EndOfInput
+        -- Relevant Sources:
+        -- <https://github.com/well-typed/cborg/blob/cborg-0.2.9.0/cborg/src/Codec/CBOR/Read.hs#L1051>
+        "expected bytes" -> ExpectedBytes
+        msg              -> OtherReason msg
+
+-- | Similar to `CBOR.DeserialiseFailure`, with the difference that plain string reason
+-- messages are turned into the datatype: `DeserialiseFailureReason`.
+data DeserialiseFailureInfo
+    = DeserialiseFailureInfo
+        { dfOffset :: CBOR.ByteOffset
+        , dfReason :: DeserialiseFailureReason
+        }
+    deriving stock (Eq, Show)
+
+-- | The reason of the cbor failure as a datatype, not as a plain string.
+data DeserialiseFailureReason
+    = EndOfInput -- ^ Not enough input provided
+    | ExpectedBytes -- ^ The bytes inside the input are malformed.
+    | OtherReason String -- ^ A failure reason we (plutus) are not aware of, use whatever
+                         -- message that `cborg` returns.
+    deriving stock (Eq, Show)

--- a/plutus-ledger-api/test/Spec.hs
+++ b/plutus-ledger-api/test/Spec.hs
@@ -5,6 +5,7 @@ import PlutusLedgerApi.Common.Versions
 import PlutusLedgerApi.Test.EvaluationContext (evalCtxForTesting)
 import PlutusLedgerApi.Test.Examples
 import PlutusLedgerApi.V1
+import Spec.CBOR.DeserialiseFailureInfo qualified
 import Spec.CostModelParams qualified
 import Spec.Eval qualified
 import Spec.Interval qualified
@@ -96,4 +97,5 @@ tests = testGroup "plutus-ledger-api" [
     , Spec.Versions.tests
     , Spec.CostModelParams.tests
     , Spec.NoThunks.tests
+    , Spec.CBOR.DeserialiseFailureInfo.tests
     ]

--- a/plutus-ledger-api/test/Spec/CBOR/DeserialiseFailureInfo.hs
+++ b/plutus-ledger-api/test/Spec/CBOR/DeserialiseFailureInfo.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE RankNTypes      #-}
+module Spec.CBOR.DeserialiseFailureInfo (tests)
+where
+
+import Codec.CBOR.Decoding as CBOR
+import Codec.CBOR.Extras as CBOR
+import Codec.CBOR.Read as CBOR
+
+import Data.Bifunctor
+import Data.ByteString.Lazy qualified as LBS
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "cbor failure intepretation tests"
+     [ testCase "end-of-input" $
+         (CBOR.decodeBytes `failsWith` CBOR.EndOfInput) []
+     , testCase "expected-bytes" $
+         (CBOR.decodeBytes `failsWith` CBOR.ExpectedBytes) [0x5c]
+     , testCase "other" $
+         (CBOR.decodeBool `failsWith` CBOR.OtherReason "expected bool") [0x5c]
+     ]
+  where
+    failsWith :: (Eq a, Show a)
+              => (forall s. Decoder s a) -> DeserialiseFailureReason -> LBS.ByteString -> Assertion
+    failsWith decoder reason inp =
+        let res = CBOR.deserialiseFromBytes decoder inp
+        in Left reason @=? first (CBOR.dfReason . readDeserialiseFailureInfo) res


### PR DESCRIPTION
The ledger team has requested long time ago,  to have more descriptive errors when a script fails to deserialize because of some CBOR problem.

The `cborg` library returns plain messages (strings) as deserialization failure reasons, and this PR maps only those that can occur during a plutus script deserialisation to some datatypes.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Changelog fragments have been written (if appropriate)
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
