### PR TITLE
[Test] [Names] Add more scoping tests

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
@@ -1,20 +1,28 @@
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE UndecidableInstances  #-}
+-- TODO: add @NoFieldSelectors@ once we are past antiquity, so that 'ScopeError' doesn't generate
+-- partial field selectors.
 
 module PlutusCore.Check.Scoping where
 
 import PlutusCore.Name
 import PlutusCore.Quote
 
-import Control.Monad (join, unless, (<=<))
+import Control.Monad (join, unless)
+import Data.Bifunctor
 import Data.Coerce
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict as Map
 import Data.Maybe
 import Data.Set as Set
+import Text.Pretty
+import Text.PrettyBy
 
 {- Note [Example of a scoping check]
 Consider the following type:
@@ -99,6 +107,9 @@ data NameAnn
     | NotAName
     deriving stock (Show)
 
+instance Pretty NameAnn where
+    pretty = viaShow
+
 class ToScopedName name where
     toScopedName :: name -> ScopedName
 
@@ -161,9 +172,12 @@ data ScopeEntry
 -- | A 'ScopeInfo' is a set of 'ScopedName's for each of the 'ScopeEntry'.
 -- If a 'ScopeEntry' is not present in the map, the corresponding set of 'ScopeName's is considered
 -- to be empty.
-newtype ScopeInfo = ScopeInfo
-    { unScopeInfo :: Map ScopeEntry (Set ScopedName)
-    } deriving stock (Show)
+newtype ScopeInfo = ScopeInfo (Map ScopeEntry (Set ScopedName))
+    deriving stock (Show)
+
+-- Defining manually because of plan to move to @NoFieldSelectors@.
+unScopeInfo :: ScopeInfo -> Map ScopeEntry (Set ScopedName)
+unScopeInfo = coerce
 
 -- | Extract the set stored in the provided 'ScopeInfo' at the provided 'ScopeEntry'.
 to :: ScopeEntry -> ScopeInfo -> Set ScopedName
@@ -173,27 +187,40 @@ emptyScopeInfo :: ScopeInfo
 emptyScopeInfo = ScopeInfo Map.empty
 
 -- | Check if a set is empty and report an error with the set embedded in it otherwise.
-checkEmpty :: (Set ScopedName -> ScopeError) -> Set ScopedName -> Either ScopeError ()
-checkEmpty err s = unless (Set.null s) . Left $ err s
+checkEmptyOn
+    :: (Set ScopedName -> Set ScopedName -> Set ScopedName)
+    -> (Set ScopedName -> Set ScopedName -> ScopeError)
+    -> Set ScopedName
+    -> Set ScopedName
+    -> Either ScopeError ()
+checkEmptyOn f err s1 s2 = unless (Set.null $ f s1 s2) . Left $ err s1 s2
 
--- | Merge two 'ScopeInfo's checking that they do not intersect along the way.
+-- | Merge two 'ScopeInfo's checking that binders in them do not intersect along the way.
 mergeScopeInfo :: ScopeInfo -> ScopeInfo -> Either ScopeError ScopeInfo
 mergeScopeInfo si1 si2 = do
     let disappearedBindings1 = to DisappearedBindings si1
         disappearedBindings2 = to DisappearedBindings si2
         appearedBindings1    = to AppearedBindings    si1
         appearedBindings2    = to AppearedBindings    si2
-        duplicateDisappearedBindings = disappearedBindings1 `Set.intersection` disappearedBindings2
-        duplicateAppearedBindings    = appearedBindings1    `Set.intersection` appearedBindings2
-    checkEmpty DuplicateBindersInTheInput  duplicateDisappearedBindings
-    checkEmpty DuplicateBindersInTheOutput duplicateAppearedBindings
+    checkEmptyOn
+        Set.intersection
+        DuplicateBindersInTheInput
+        disappearedBindings1
+        disappearedBindings2
+    checkEmptyOn
+        Set.intersection
+        DuplicateBindersInTheOutput
+        appearedBindings1
+        appearedBindings2
     Right $ coerce (Map.unionWith Set.union) si1 si2
 
+-- We might want to use @Validation@ or something instead of 'Either'.
 -- @newtype@-ing it for the sake of providing very convenient 'Semigroup' and 'Monoid' instances.
-newtype ScopeErrorOrInfo = ScopeErrorOrInfo
-    -- We might want to use @Validation@ or something instead of 'Either'.
-    { unScopeErrorOrInfo :: Either ScopeError ScopeInfo
-    }
+newtype ScopeErrorOrInfo = ScopeErrorOrInfo (Either ScopeError ScopeInfo)
+
+-- Defining manually because of plan to move to @NoFieldSelectors@.
+unScopeErrorOrInfo :: ScopeErrorOrInfo -> Either ScopeError ScopeInfo
+unScopeErrorOrInfo = coerce
 
 instance Semigroup ScopeErrorOrInfo where
     ScopeErrorOrInfo errOrInfo1 <> ScopeErrorOrInfo errOrInfo2 =
@@ -201,6 +228,13 @@ instance Semigroup ScopeErrorOrInfo where
 
 instance Monoid ScopeErrorOrInfo where
     mempty = ScopeErrorOrInfo $ Right emptyScopeInfo
+
+-- | Whether it's OK if the pass removes bindings. A renamer isn't supposed to do that, but for
+-- example an inliner may do it, since it's basically the entire point of an inliner.
+data BindingRemoval
+    = BindingRemovalOk
+    | BindingRemovalNotOk
+    deriving stock (Show, Eq)
 
 -- ########################################################################
 -- ## Main class for collecting scope information and relevant functions ##
@@ -276,18 +310,48 @@ establishScopingBinder binder name sort value = do
 -- | Every kind of error thrown by the scope checking machinery at different stages.
 data ScopeError
     = UnannotatedName !ScopedName
-    | NameChangedItsScope !ScopedName !ScopedName
-    | NameUnexpectedlyDisappeared !ScopedName !ScopedName
+    | NameChangedItsScope
+        { _oldName :: !ScopedName
+        , _newName :: !ScopedName
+        }
+    | NameUnexpectedlyDisappeared
+        { _oldName :: !ScopedName
+        , _newName :: !ScopedName
+        }
     | NameUnexpectedlyStayed !ScopedName
-    | DuplicateBindersInTheInput !(Set ScopedName)
-    | DuplicateBindersInTheOutput !(Set ScopedName)
-    | OldBindingsDiscordWithBoundVariables !(Set ScopedName)
-    | OldBindingsDiscordWithOutOfScopeVariables !(Set ScopedName)
-    | NewBindingsDiscordWithBoundVariables !(Set ScopedName)
-    | OldBindingsClashWithFreeVariables !(Set ScopedName)
-    | OldBindingsClashWithNewBindings !(Set ScopedName)
-    | NewBindingsClashWithFreeVariabes !(Set ScopedName)
+    | DuplicateBindersInTheInput
+        { _duplicateBindersLeft  :: !(Set ScopedName)
+        , _duplicateBindersRight :: !(Set ScopedName)
+        }
+    | DuplicateBindersInTheOutput !(Set ScopedName) !(Set ScopedName)
+    | DisappearedBindingsDiscordWithBoundVariables
+        { _disappearedBindings :: !(Set ScopedName)
+        , _boundVariables      :: !(Set ScopedName)
+        }
+    | DisappearedBindingsDiscordWithOutOfScopeVariables
+        { _disappearedBindings :: !(Set ScopedName)
+        , _outOfScopeVariables :: !(Set ScopedName)
+        }
+    | AppearedBindingsDiscordWithBoundVariables
+        { _appearedBindings :: !(Set ScopedName)
+        , _boundVariables   :: !(Set ScopedName)
+        }
+    | DisappearedBindingsClashWithFreeVariables
+        { _disappearedBindings :: !(Set ScopedName)
+        , _freeVariables       :: !(Set ScopedName)
+        }
+    | DisappearedBindingsClashWithAppearedBindings
+        { _disppearedBindings :: !(Set ScopedName)
+        , _appearedBindings   :: !(Set ScopedName)
+        }
+    | AppearedBindingsClashWithFreeVariabes
+        { _appearedBindings :: !(Set ScopedName)
+        , _freeVariables    :: !(Set ScopedName)
+        }
     deriving stock (Show)
+
+instance Pretty ScopeError where
+    pretty = viaShow
 
 -- | Override the set at the provided 'ScopeEntry' to contain only the provided 'ScopedName'.
 overrideSname :: ScopeEntry -> ScopedName -> ScopeInfo -> ScopeInfo
@@ -337,7 +401,7 @@ We start with these three relations that are based on the assumption that for ea
 at least one out-of-scope variable and at least one in-scope one:
 
 1. disappeared bindings should be the same as stayed out of scope variables
-     (an internal sanity check)
+     (ensures that old bindings disappear via renaming and not via removal)
 2. disappeared bindings should be the same as disappeared variables
      (ensures that old names consistently disappear at the binding and use sites)
 3. appeared bindings should be the same as appeared variables
@@ -353,29 +417,81 @@ so we only need to consider three more relations:
 
 The last two ensure that no new name has an old name's unique.
 -}
-checkScopeInfo :: ScopeInfo -> Either ScopeError ()
-checkScopeInfo scopeInfo = do
+checkScopeInfo :: BindingRemoval -> ScopeInfo -> Either ScopeError ()
+checkScopeInfo bindRem scopeInfo = do
     let disappearedBindings       = to DisappearedBindings       scopeInfo
         disappearedVariables      = to DisappearedVariables      scopeInfo
         appearedBindings          = to AppearedBindings          scopeInfo
         appearedVariables         = to AppearedVariables         scopeInfo
         stayedOutOfScopeVariables = to StayedOutOfScopeVariables scopeInfo
         stayedFreeVariables       = to StayedFreeVariables       scopeInfo
-    checkEmpty OldBindingsDiscordWithOutOfScopeVariables $
-        disappearedBindings `symmetricDifference` stayedOutOfScopeVariables
-    checkEmpty OldBindingsDiscordWithBoundVariables $
-        disappearedBindings `symmetricDifference` disappearedVariables
-    checkEmpty NewBindingsDiscordWithBoundVariables $
-        appearedBindings `symmetricDifference` appearedVariables
-    checkEmpty OldBindingsClashWithFreeVariables $
-        disappearedBindings `Set.intersection` stayedFreeVariables
-    checkEmpty OldBindingsClashWithNewBindings $
-        appearedBindings  `Set.intersection` disappearedBindings
-    checkEmpty NewBindingsClashWithFreeVariabes $
-        appearedBindings `Set.intersection` stayedFreeVariables
+    unless (bindRem == BindingRemovalOk) $ do
+        checkEmptyOn
+            symmetricDifference
+            DisappearedBindingsDiscordWithOutOfScopeVariables
+            disappearedBindings
+            stayedOutOfScopeVariables
+    checkEmptyOn
+        symmetricDifference
+        DisappearedBindingsDiscordWithBoundVariables
+        disappearedBindings
+        disappearedVariables
+    checkEmptyOn
+        symmetricDifference
+        AppearedBindingsDiscordWithBoundVariables
+        appearedBindings
+        appearedVariables
+    checkEmptyOn
+        Set.intersection
+        DisappearedBindingsClashWithFreeVariables
+        disappearedBindings
+        stayedFreeVariables
+    checkEmptyOn
+        Set.intersection
+        DisappearedBindingsClashWithAppearedBindings
+        appearedBindings
+        disappearedBindings
+    checkEmptyOn
+        Set.intersection
+        AppearedBindingsClashWithFreeVariabes
+        appearedBindings
+        stayedFreeVariables
+
+-- | The type of errors that the scope checking machinery returns.
+data ScopeCheckError t = ScopeCheckError
+    { _input  :: !(t NameAnn)  -- ^ What got fed to the scoping check pass.
+    , _output :: !(t NameAnn)  -- ^ What got out of it.
+    , _error  :: !ScopeError   -- ^ The error returned by the scoping check pass.
+    }
+
+deriving stock instance Show (t NameAnn) => Show (ScopeCheckError t)
+
+instance PrettyBy config (t NameAnn) => PrettyBy config (ScopeCheckError t) where
+    prettyBy config (ScopeCheckError input output err) = vsep
+        [ pretty err
+        , "when checking that transformation of" <> hardline
+        , indent 2 $ prettyBy config input <> hardline
+        , "to" <> hardline
+        , indent 2 $ prettyBy config output <> hardline
+        , "is correct"
+        ]
 
 -- See Note [Example of a scoping check].
--- | Check if a renamer respects scoping.
-checkRespectsScoping :: Scoping t => (t NameAnn -> t NameAnn) -> t ann -> Either ScopeError ()
-checkRespectsScoping ren =
-    checkScopeInfo <=< unScopeErrorOrInfo . collectScopeInfo . ren . runQuote . establishScoping
+-- | Check if a pass respects scoping.
+--
+-- Returns the thing that the scoping tests run on, the result of the pass and the scope checking
+-- outcome, respectively.
+checkRespectsScoping
+    :: Scoping t
+    => BindingRemoval
+    -> (t NameAnn -> t NameAnn)  -- ^ For preparation before running the scoping tests.
+                                 --   Commonly, either @runQuote . rename@ or @id@.
+    -> (t NameAnn -> t NameAnn)  -- ^ The runner of the pass.
+    -> t ann
+    -> Either (ScopeCheckError t) ()
+checkRespectsScoping bindRem prep run thing =
+    first (ScopeCheckError input output) $
+        unScopeErrorOrInfo (collectScopeInfo output) >>= checkScopeInfo bindRem
+  where
+    input  = prep . runQuote $ establishScoping thing
+    output = run input

--- a/plutus-core/plutus-core/test/Names/Spec.hs
+++ b/plutus-core/plutus-core/test/Names/Spec.hs
@@ -177,8 +177,9 @@ test_names =
         , test_equalityRename
         , test_equalityBrokenRename
         , test_equalityNoMarkRename
-        , test_scopingGood (genProgram @DefaultFun) rename
-        , test_scopingBad (genProgram @DefaultFun) markNonFreshProgram renameProgramM
+        , test_scopingGood "renaming" (genProgram @DefaultFun) BindingRemovalNotOk PrerenameNo
+            rename
+        , test_scopingSpoilRenamer (genProgram @DefaultFun) markNonFreshProgram renameProgramM
         , test_alphaEquality
         , test_rebindShadowedVariable
         , test_rebindCapturedVariable

--- a/plutus-core/plutus-ir/test/NamesSpec.hs
+++ b/plutus-core/plutus-ir/test/NamesSpec.hs
@@ -2,19 +2,75 @@ module NamesSpec
     ( names
     ) where
 
+import PlutusPrelude
 
 import PlutusIR.Generators.AST
 import PlutusIR.Mark
+import PlutusIR.Transform.Beta
+import PlutusIR.Transform.CaseReduce
+import PlutusIR.Transform.CommuteFnWithConst
+import PlutusIR.Transform.DeadCode
+import PlutusIR.Transform.EvaluateBuiltins
+import PlutusIR.Transform.Inline.Inline qualified as Inline
+import PlutusIR.Transform.KnownCon
+import PlutusIR.Transform.LetFloatIn qualified as In
+import PlutusIR.Transform.LetMerge
+import PlutusIR.Transform.NonStrict
+import PlutusIR.Transform.RecSplit
 import PlutusIR.Transform.Rename
+import PlutusIR.Transform.ThunkRecursions
+import PlutusIR.Transform.Unwrap
 
+import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
 import PlutusCore.Rename
 import PlutusCore.Test
 
 import Test.Tasty
 
+-- See Note [Scoping tests API].
 names :: TestTree
-names =
-    testGroup "names"
-        [ test_scopingGood genProgram rename
-        , test_scopingBad genProgram markNonFreshProgram renameProgramM
-        ]
+names = testGroup "names"
+    [ test_scopingGood "beta-reduction" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . beta
+    , test_scopingGood "case-of-known-constructor" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . caseReduce
+    , test_scopingGood "'commuteDefaultFun'" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . commuteDefaultFun
+    , -- We say that it's fine to remove bindings, because they never actually get removed,
+      -- because the scope checking machinery doesn't create unused bindings, every binding
+      -- gets referenced at some point at least once (usually very close to the binding site).
+      -- So this test doesn't really test much.
+      test_scopingGood "dead code elimination" genTerm BindingRemovalNotOk PrerenameNo $
+        removeDeadBindings def
+    , test_scopingGood "constant folding" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . evaluateBuiltins False def defaultBuiltinCostModel
+    , -- At the moment the inliner does not preserve global uniqueness (contrary to what it
+      -- promises) due to the lack of marking in it (or initial renaming of the entire program,
+      -- which would perform marking too).
+      test_scopingBad "inlining" genTerm BindingRemovalOk PrerenameYes $
+        Inline.inline mempty def
+    , test_scopingGood "match-against-known-constructor" genTerm BindingRemovalNotOk PrerenameNo $
+        knownCon
+    , test_scopingGood "floating bindings inwards" genTerm BindingRemovalNotOk PrerenameNo $
+        In.floatTerm def True
+    -- Can't test 'Out.floatTerm', because it requires the type of annotations to implement
+    -- 'Semigroup' and it's not clear what that means for 'NameAnn'.
+    , test_scopingGood "merging lets" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . letMerge
+    , -- The pass breaks global uniqueness, but it's not clear whether this is by design or not.
+      test_scopingBad "compilation of non-strict bindings" genTerm BindingRemovalOk PrerenameYes $
+        compileNonStrictBindings True
+    , test_scopingGood "match-against-known-constructor" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . recSplit
+    , test_scopingGood "renaming" genProgram BindingRemovalNotOk PrerenameNo $
+        rename
+    , test_scopingSpoilRenamer genProgram markNonFreshProgram
+        renameProgramM
+    -- Can't test substitution procedures at the moment, because that requires generating
+    -- functions.
+    , -- The pass breals global uniqueness by design.
+      test_scopingBad "thunking recursions" genTerm BindingRemovalOk PrerenameYes $
+        pure . thunkRecursions def
+    , test_scopingGood "unwrap-wrap cancelling" genTerm BindingRemovalNotOk PrerenameYes $
+        pure . unwrapCancel
+    ]

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -39,10 +39,12 @@ module PlutusCore.Test (
   runUPlcProfile,
   runUPlcProfileExec,
   brokenRename,
+  Prerename (..),
+  BindingRemoval (..),
   prop_scopingFor,
   test_scopingGood,
   test_scopingBad,
-
+  test_scopingSpoilRenamer,
   -- * Tasty extras
   module TastyExtras,
 ) where
@@ -76,7 +78,7 @@ import Data.Text (Text)
 import Hedgehog
 import Prettyprinter qualified as PP
 import System.IO.Unsafe
-import Test.Tasty
+import Test.Tasty hiding (after)
 import Test.Tasty.Hedgehog
 import Test.Tasty.HUnit
 
@@ -423,47 +425,137 @@ brokenRename ::
   m t
 brokenRename mark renM = through mark >=> runBrokenRenameT . renM
 
+{- Note [Scoping tests API]
+If you want to test how a certain pass handles scoping you should use either 'test_scopingGood' or
+'test_scopingBad' depending on whether the pass is expected to preserve global uniqueness and not
+change scoping of its argument. Regarding the last one: substitution, for example, may remove free
+variables and scoping tests, being initially developed only to test renamers, will fail upon seeing
+that a free variable was removed. So any scoping test failure needs to be carefully scrutinized
+before concluding that it reveals a bug.
+
+As it turns out, most AST transformations don't do anything that would cause the scoping tests to
+false-positively report a bug:
+
+- a lot of passes simply do not do anything with names apart from maybe moving them around
+- those that do change names may produce alpha-equivalent results and this is one thing that the
+  scoping machinery is designed to test
+- some passes such as inlining may duplicate binders, but that is also fine as long as the
+  duplicates are properly renamed, since the scoping machinery doesn't count binders or variable
+  usages, it only expects free names to stay free, bound names to change together with their binders
+  and global uniqueness to be preserved (see 'ScopeError' for the full list of possible errors)
+- some passes such as inlining may remove bindings and there's special support implemented for
+  handling this: when invoking either 'test_scopingGood' or 'test_scopingBad' you need to provide a
+  'BindingRemoval' argument specifying whether binding removal is expected for the pass. Conversily,
+  make it 'BindingRemovalOk' whenever you use 'test_scopingBad' to emphasize that even with binding
+  removal allowed tests still fail
+- some passes do not perform renaming of the input themselves, in that case you need to provide
+  'PrerenameYes' for the 'Prerename' argument that both the test runners expect. It doesn't matter
+  whether the pass relies on global uniqueness itself, because the scoping tests rely on it anyway.
+  If the pass renames its input, and only in this case, provide 'PrerenameNo' for the 'Prerename'
+  argument, this will allow the scoping tests to ensure that the pass does indeed rename its input
+- due to a very specific design of the scoping tests some passes don't give false positives, but
+  don't get tested properly either. For example dead code elimination is a no-op within the scoping
+  tests, because internally all types/terms/programs only contain bindings that get referenced
+
+There's also 'test_scopingSpoilRenamer', this one is used to test that the scoping tests do catch
+various kinds of bugs. Don't use it with any passes that aren't renamers.
+
+All in all, in order to use the scoping tests you have to understand how they work, which is an
+unfortunate but seemingly inevitable requirement. On the bright side, it's worth the effort, because
+the tests do catch bugs occasionally.
+
+Whenever you use 'test_scopingBad' make sure to explain why, so that it's clear whether there's
+something wrong with the pass or it's just a limitation of the scoping tests.
+-}
+
+-- | Determines whether to perform renaming before running the scoping tests. Needed for passes that
+-- don't perform renaming themselves.
+data Prerename =
+  PrerenameYes |
+  PrerenameNo
+
+runPrerename :: TPLC.Rename a => Prerename -> a -> a
+runPrerename PrerenameYes = TPLC.runQuote . TPLC.rename
+runPrerename PrerenameNo  = id
+
 -- | Test scoping for a renamer.
 prop_scopingFor ::
-  (Pretty (t ann), Scoping t) =>
+  (PrettyPlc (t NameAnn), TPLC.Rename (t NameAnn), Scoping t) =>
+  -- | A generator of types\/terms\/programs.
   AstGen (t ann) ->
+  -- | Whether binding removal is expected for the pass.
+  BindingRemoval ->
+  -- | Whether renaming is required before running the scoping tests. Note that the scoping tests
+  -- rely on global uniqueness themselves, hence for any pass that doesn't perform renaming
+  -- internally this needs to be 'PrerenameYes'.
+  Prerename ->
+  -- | The runner of the pass.
   (t NameAnn -> TPLC.Quote (t NameAnn)) ->
   Property
-prop_scopingFor gen ren = property $ do
-  prog <- forAllPretty $ runAstGen gen
+prop_scopingFor gen bindRem preren run = withTests 1000 . property $ do
+  prog <- forAllNoShow $ runAstGen gen
   let catchEverything = unsafePerformIO . try @SomeException . evaluate
-  case catchEverything $ checkRespectsScoping (TPLC.runQuote . ren) prog of
-    Left exc         -> fail $ show exc
-    Right (Left err) -> fail $ show err
+      prep = runPrerename preren
+  case catchEverything $ checkRespectsScoping bindRem prep (TPLC.runQuote . run) prog of
+    Left exc         -> fail $ displayException exc
+    Right (Left err) -> fail $ displayPlcDef err
     Right (Right ()) -> success
 
--- | Test that a good renamer does not destroy scoping.
+-- | Test that a pass does not break global uniqueness.
 test_scopingGood ::
-  (Pretty (t ann), Scoping t) =>
+  (PrettyPlc (t NameAnn), TPLC.Rename (t NameAnn), Scoping t) =>
+  -- | The name of the pass we're about to test.
+  String ->
+  -- | A generator of types\/terms\/programs.
   AstGen (t ann) ->
+  -- | Whether binding removal is expected for the pass.
+  BindingRemoval ->
+  -- | Whether renaming is required before running the scoping tests. Note that the scoping tests
+  -- rely on global uniqueness themselves, hence for any pass that doesn't perform renaming
+  -- internally this needs to be 'PrerenameYes'.
+  Prerename ->
+  -- | The runner of the pass.
   (t NameAnn -> TPLC.Quote (t NameAnn)) ->
   TestTree
-test_scopingGood gen ren =
-  testPropertyNamed "renamer does not destroy scoping" "test_scopingGood" $
-    prop_scopingFor gen ren
+test_scopingGood pass gen bindRem preren run =
+  testPropertyNamed (pass ++ " does not break scoping and global uniqueness") "test_scopingGood" $
+    prop_scopingFor gen bindRem preren run
 
--- | Test that a renaming machinery destroys scoping when a bad renamer is chosen.
+-- | Test that a pass breaks global uniqueness.
 test_scopingBad ::
-  (Pretty (t ann), Scoping t, Monoid ren) =>
+  (PrettyPlc (t NameAnn), TPLC.Rename (t NameAnn), Scoping t) =>
+  -- | The name of the pass we're about to test.
+  String ->
+  -- | A generator of types\/terms\/programs.
+  AstGen (t ann) ->
+  -- | Whether binding removal is expected for the pass.
+  BindingRemoval ->
+  -- | Whether renaming is required before running the scoping tests. Note that the scoping tests
+  -- rely on global uniqueness themselves, hence for any pass that doesn't perform renaming
+  -- internally this needs to be 'PrerenameYes'.
+  Prerename ->
+  -- | The runner of the pass.
+  (t NameAnn -> TPLC.Quote (t NameAnn)) ->
+  TestTree
+test_scopingBad pass gen bindRem preren run =
+  testCase (pass ++ " breaks scoping or global uniqueness") . checkFails $
+    prop_scopingFor gen bindRem preren run
+
+-- | Test that the scoping machinery fails when the given renamer is spoiled in some way
+-- (e.g. marking is removed) to ensure that the machinery does catch bugs.
+test_scopingSpoilRenamer ::
+  (PrettyPlc (t NameAnn), TPLC.Rename (t NameAnn), Scoping t, Monoid ren) =>
   AstGen (t ann) ->
   (t NameAnn -> TPLC.Quote ()) ->
   (forall m. (TPLC.MonadQuote m, MonadReader ren m) => t NameAnn -> m (t NameAnn)) ->
   TestTree
-test_scopingBad gen mark renM =
+test_scopingSpoilRenamer gen mark renM =
   testGroup
-    "scoping bad"
-    [ testCase "wrong renaming destroys scoping" $
-        checkFails . prop_scopingFor gen $
-          brokenRename mark renM
-    , testCase "no renaming does not result in global uniqueness" $
-        checkFails . prop_scopingFor gen $
-          noRename mark renM
-    , testCase "renaming with no marking destroys scoping" $
-        checkFails . prop_scopingFor gen $
-          noMarkRename renM
+    "bad renaming"
+    [ test_scopingBad "wrong renaming" gen BindingRemovalNotOk PrerenameNo $
+        brokenRename mark renM
+    , test_scopingBad "no renaming" gen BindingRemovalNotOk PrerenameNo $
+        noRename mark renM
+    , test_scopingBad "renaming with no marking" gen BindingRemovalNotOk PrerenameNo $
+        noMarkRename renM
     ]


### PR DESCRIPTION
This utilizes scoping tests for all PIR transformations that we have (previously it was only renaming). 