### PR TITLE
Reduce gh-pages size when uploading Haddock

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           folder: dist
           target-folder: ${{ github.ref_name }}
-          # single-commit: true
+          # We publish our haddock, which is non-trivially big. 
+          # So keeping the whole history is expensive, and anyway we don't need it.
+          single-commit: true

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,5 +1,6 @@
 name: "Build and Deploy to Github Pages"
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -6,12 +6,18 @@ on:
 jobs:
   build-haddock-site:
     runs-on: ubuntu-latest
+
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+
     environment:
       name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - uses: actions/checkout@v3
+
       - uses: nixbuild/nix-quick-install-action@v25
         with:
           # 2.14.1 seems to have issues, see https://github.com/nixbuild/nix-quick-install-action/issues/29
@@ -19,12 +25,19 @@ jobs:
           nix_conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
+
       - name: Build haddock site
         run: |
           nix build .#combined-plutus-haddock
           mkdir dist
           cp -RL ./result/share/doc/* ./dist/
-      - uses: JamesIves/github-pages-deploy-action@v4
+
+      - name: Upload pages artifacts 
+        uses: actions/upload-pages-artifact@v1
         with:
-          folder: dist
+          path: ./dist
           target-folder: ${{ github.ref_name }}
+
+      - name: Deploy pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,24 +1,17 @@
 name: "Build and Deploy to Github Pages"
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
 jobs:
   build-haddock-site:
     runs-on: ubuntu-latest
-
     permissions:
-      pages: write
-      id-token: write
-
+      contents: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - uses: actions/checkout@v3
-
       - uses: nixbuild/nix-quick-install-action@v25
         with:
           # 2.14.1 seems to have issues, see https://github.com/nixbuild/nix-quick-install-action/issues/29
@@ -26,19 +19,13 @@ jobs:
           nix_conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
-
       - name: Build haddock site
         run: |
           nix build .#combined-plutus-haddock
           mkdir dist
           cp -RL ./result/share/doc/* ./dist/
-
-      - name: Upload pages artifacts 
-        uses: actions/upload-pages-artifact@v1
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: ./dist
+          folder: dist
           target-folder: ${{ github.ref_name }}
-
-      - name: Deploy pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+          # single-commit: true


### PR DESCRIPTION
The git history for the gh-pages branch makes the repo quite heavy.
This PR sets the `single-commit` flag of the github-pages-deploy action to true:
See here: https://github.com/JamesIves/github-pages-deploy-action#optional-choices

> This option can be toggled to true if you'd prefer to have a single commit on the deployment branch instead of maintaining the full history. Using this option will also cause any existing history to be wiped from the deployment branch.

