### PR TITLE
Rename constructors for BuiltinVersion DefaultFun to reduce risk of confusion

### DIFF
--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -15,7 +15,7 @@ import PlutusBenchmark.NaturalSort
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
-import PlutusCore.Default qualified as PLC (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default qualified as PLC (BuiltinVersion (DefaultFunBV1))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusLedgerApi.Common (PlutusLedgerLanguage (PlutusV1), evaluateTerm,
                                ledgerLanguageIntroducedIn, mkDynEvaluationContext)
@@ -139,7 +139,7 @@ mkEvalCtx :: EvaluationContext
 mkEvalCtx =
     case PLC.defaultCostModelParams of
         -- The validation benchmarks were all created from PlutusV1 scripts
-        Just p -> case mkDynEvaluationContext PLC.DefaultFunV1 p of
+        Just p -> case mkDynEvaluationContext PLC.DefaultFunBV1 p of
             Right ec -> ec
             Left err -> error $ show err
         Nothing -> error "Couldn't get cost model params"

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -155,7 +155,7 @@ n >: k =
 instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
     type CostingPart uni NopFun = NopCostModel
 
-    data BuiltinVersion NopFun = NopFunV1
+    data BuiltinVersion NopFun = NopFunNV1
 
     -- Built-in Bools
     toBuiltinMeaning
@@ -287,7 +287,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
              (runCostingFunSixArguments . paramNop6)
 
 instance Default (BuiltinVersion NopFun) where
-    def = NopFunV1
+    def = NopFunNV1
 
 ---------------- Benchmarks ----------------
 

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -226,7 +226,7 @@ instance Whatever ExBudgetStream where
 instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
     type CostingPart uni ExtensionFun = ()
 
-    data BuiltinVersion ExtensionFun = ExtensionFunV0 | ExtensionFunV1
+    data BuiltinVersion ExtensionFun = ExtensionFunEV0 | ExtensionFunEV1
         deriving stock (Enum, Bounded, Show)
 
     toBuiltinMeaning :: forall val. HasMeaningIn uni val
@@ -459,8 +459,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         makeBuiltinMeaning
             @(() -> EvaluationResult Integer)
             (\(_ :: ()) -> EvaluationSuccess $ case ver of
-                    ExtensionFunV0 -> 0
-                    ExtensionFunV1 -> 1)
+                    ExtensionFunEV0 -> 0
+                    ExtensionFunEV1 -> 1)
             whatever
 
     -- We want to know if the CEK machine releases individual budgets after accounting for them and
@@ -533,4 +533,4 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             (\_ -> unsafePerformIO . regBudgets . runCostingFunOneArgument model)
 
 instance Default (BuiltinVersion ExtensionFun) where
-    def = ExtensionFunV1
+    def = ExtensionFunEV1

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -97,7 +97,7 @@ error instead of overflowing its first argument.
 
 One denotation from each builtin is grouped into a 'BuiltinVersion'. Each Plutus Language version is
 linked to a specific 'BuiltinVersion' (done by plutus-ledger-api); e.g. plutus-v1 and plutus-v2 are
-linked to 'DefaultFunV1', whereas plutus-v3 changes the set of denotations to 'DefaultFunV2' (thus
+linked to 'DefaultFunBV1', whereas plutus-v3 changes the set of denotations to 'DefaultFunBV2' (thus
  fixing 'ConsByteString').
 
 Each 'BuiltinVersion' (grouping) can change the denotation of one or more builtins --- or none, but

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1046,7 +1046,11 @@ do it quite yet, even though it worked (the Plutus Tx part wasn't implemented).
 instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     type CostingPart uni DefaultFun = BuiltinCostModel
 
-    data BuiltinVersion DefaultFun = DefaultFunV1 | DefaultFunV2
+    {- | Allow different versions of builtins with different implementations, and
+       possibly different semantics.  Note that DefaultFunBV1, DefaultFunBV2
+       etc. DO NOT correspond directly to PlutusV1, PlutusV2 etc. in
+       plutus-ledger-api.  See Note [Versioned builtins]. -}
+    data BuiltinVersion DefaultFun = DefaultFunBV1 | DefaultFunBV2
         deriving stock (Enum, Bounded, Show)
 
     -- Integers
@@ -1107,7 +1111,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             costingFun = runCostingFunTwoArguments . paramConsByteString
         -- See Note [Versioned builtins]
         in case ver of
-            DefaultFunV1 -> makeBuiltinMeaning
+            DefaultFunBV1 -> makeBuiltinMeaning
                @(Integer -> BS.ByteString -> BS.ByteString)
                (\n xs -> BS.cons (fromIntegral @Integer n) xs)
                costingFun
@@ -1158,8 +1162,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     toBuiltinMeaning ver VerifyEd25519Signature =
         let verifyEd25519Signature =
                 case ver of
-                  DefaultFunV1 -> verifyEd25519Signature_V1
-                  _            -> verifyEd25519Signature_V2
+                  DefaultFunBV1 -> verifyEd25519Signature_V1
+                  _             -> verifyEd25519Signature_V2
         in makeBuiltinMeaning
            verifyEd25519Signature
            -- Benchmarks indicate that the two versions have very similar
@@ -1482,7 +1486,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     {-# INLINE toBuiltinMeaning #-}
 
 instance Default (BuiltinVersion DefaultFun) where
-    def = DefaultFunV2
+    def = DefaultFunBV2
 
 instance Pretty (BuiltinVersion DefaultFun) where
     pretty = viaShow

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -32,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit PLC.DefaultFunV1 defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -32,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit PLC.def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -8,6 +8,7 @@ import Evaluation.Builtins.Common
 
 import PlutusCore qualified as PLC
 import PlutusCore.Default qualified as PLC
+import PlutusCore.Default.Builtins qualified as Builtins (def)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import UntypedPlutusCore qualified as UPLC
@@ -32,7 +33,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit PLC.def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit Builtins.def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -7,10 +7,9 @@ where
 import Evaluation.Builtins.Common
 
 import PlutusCore qualified as PLC
-import PlutusCore.Default qualified as PLC
-import PlutusCore.Default.Builtins qualified as Builtins (def)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
+import PlutusPrelude (def)
 import UntypedPlutusCore qualified as UPLC
 
 import Data.Bits (complement, xor, (.&.), (.|.))
@@ -33,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit Builtins.def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -742,7 +742,7 @@ test_Version :: TestTree
 test_Version =
     testCase "Version" $ do
         let expr1 = apply () (builtin () $ Right ExtensionVersion) unitval
-        Right (EvaluationSuccess $ cons @Integer 0) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunV0) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @Integer 0) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunEV0) defaultBuiltinCostModelExt expr1
         Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def def) defaultBuiltinCostModelExt expr1
 
 -- | Check that 'ConsByteString' wraps around for plutus' builtin-version == 1, and fails in plutus's builtin-versions >=2.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -754,8 +754,8 @@ test_ConsByteString =
                              + 1 -- to make word8 wraparound
                              + 33 -- the index of '!' in ascii table
             expr1 = mkIterAppNoAnn (builtin () (Left ConsByteString :: DefaultFunExt)) [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
-        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV1 def) defaultBuiltinCostModelExt expr1
-        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV2 def) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV1 def) defaultBuiltinCostModelExt expr1
+        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV2 def) defaultBuiltinCostModelExt expr1
         Right EvaluationFailure @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
 
 -- shorthand

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -76,10 +76,10 @@ ed25519Prop ver = do
   runTestDataWith ver testCase id VerifyEd25519Signature
 
 ed25519_V1Prop :: PropertyT IO ()
-ed25519_V1Prop = ed25519Prop DefaultFunV1
+ed25519_V1Prop = ed25519Prop DefaultFunBV1
 
 ed25519_V2Prop :: PropertyT IO ()
-ed25519_V2Prop = ed25519Prop DefaultFunV2
+ed25519_V2Prop = ed25519Prop DefaultFunBV2
 
 -- Helpers
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -11,7 +11,7 @@ module PlutusLedgerApi.V1.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.ParamName as V1
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -30,4 +30,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V1.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V2.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V2.ParamName as V2
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V2.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V3.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V3.ParamName as V3
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV2))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV2))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V3.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV2
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV2


### PR DESCRIPTION
The constructors for `BuiltinVersion` were called `DefaultFunV1` and `DefaultFunV2`, which risks confusion with `PlutusV1`, `PlutusV2` etc (as seen in [this issue](https://github.com/input-output-hk/plutus/issues/5475)).   This PR changes them to `DefaultFunBV1` and `DefaultFunBV2` in an attempt to clarify things. 