### PR TITLE
 Rename "builtin versions" to "builtin semantics variants" to reduce risk of confusion

### DIFF
--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -15,7 +15,7 @@ import PlutusBenchmark.NaturalSort
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
-import PlutusCore.Default qualified as PLC (BuiltinVersion (DefaultFunBV1))
+import PlutusCore.Default qualified as PLC (BuiltinSemanticsVariant (DefaultFunSemanticsVariant1))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusLedgerApi.Common (PlutusLedgerLanguage (PlutusV1), evaluateTerm,
                                ledgerLanguageIntroducedIn, mkDynEvaluationContext)
@@ -139,7 +139,7 @@ mkEvalCtx :: EvaluationContext
 mkEvalCtx =
     case PLC.defaultCostModelParams of
         -- The validation benchmarks were all created from PlutusV1 scripts
-        Just p -> case mkDynEvaluationContext PLC.DefaultFunBV1 p of
+        Just p -> case mkDynEvaluationContext PLC.DefaultFunSemanticsVariant1 p of
             Right ec -> ec
             Left err -> error $ show err
         Nothing -> error "Couldn't get cost model params"

--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -15,7 +15,7 @@ import PlutusBenchmark.NaturalSort
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
 import PlutusCore.Data qualified as PLC
-import PlutusCore.Default qualified as PLC (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default qualified as PLC (BuiltinVersion (DefaultFunBV1))
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults qualified as PLC
 import PlutusLedgerApi.Common (PlutusLedgerLanguage (PlutusV1), evaluateTerm,
                                ledgerLanguageIntroducedIn, mkDynEvaluationContext)
@@ -139,7 +139,7 @@ mkEvalCtx :: EvaluationContext
 mkEvalCtx =
     case PLC.defaultCostModelParams of
         -- The validation benchmarks were all created from PlutusV1 scripts
-        Just p -> case mkDynEvaluationContext PLC.DefaultFunV1 p of
+        Just p -> case mkDynEvaluationContext PLC.DefaultFunBV1 p of
             Right ec -> ec
             Left err -> error $ show err
         Nothing -> error "Couldn't get cost model params"

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -155,115 +155,117 @@ n >: k =
 instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
     type CostingPart uni NopFun = NopCostModel
 
-    data BuiltinVersion NopFun = NopFunNV1
+    data BuiltinSemanticsVariant NopFun = NopFunSemanticsVariant1
 
     -- Built-in Bools
     toBuiltinMeaning
         :: forall val . HasMeaningIn uni val
-        => BuiltinVersion NopFun -> NopFun -> BuiltinMeaning val NopCostModel
-    toBuiltinMeaning _ver Nop1b =
+        => BuiltinSemanticsVariant NopFun
+        -> NopFun
+        -> BuiltinMeaning val NopCostModel
+    toBuiltinMeaning _semvar Nop1b =
         makeBuiltinMeaning
              @(Bool -> Bool)
              (\_ -> True)
              (runCostingFunOneArgument . paramNop1)
-    toBuiltinMeaning _ver Nop2b =
+    toBuiltinMeaning _semvar Nop2b =
         makeBuiltinMeaning
              @(Bool -> Bool -> Bool)
              (\_ _ -> True)
              (runCostingFunTwoArguments . paramNop2)
-    toBuiltinMeaning _ver Nop3b =
+    toBuiltinMeaning _semvar Nop3b =
         makeBuiltinMeaning
              @(Bool -> Bool -> Bool -> Bool)
              (\_ _ _ -> True)
              (runCostingFunThreeArguments . paramNop3)
-    toBuiltinMeaning _ver Nop4b =
+    toBuiltinMeaning _semvar Nop4b =
         makeBuiltinMeaning
              @(Bool -> Bool -> Bool -> Bool -> Bool)
              (\_ _ _ _ -> True)
              (runCostingFunFourArguments . paramNop4)
-    toBuiltinMeaning _ver Nop5b =
+    toBuiltinMeaning _semvar Nop5b =
         makeBuiltinMeaning
              @(Bool -> Bool -> Bool -> Bool -> Bool -> Bool)
              (\_ _ _ _ _ -> True)
              (runCostingFunFiveArguments . paramNop5)
-    toBuiltinMeaning _ver Nop6b =
+    toBuiltinMeaning _semvar Nop6b =
         makeBuiltinMeaning
              @(Bool -> Bool -> Bool -> Bool -> Bool -> Bool -> Bool)
              (\_ _ _ _ _ _ -> True)
              (runCostingFunSixArguments . paramNop6)
     -- Built-in Integers
-    toBuiltinMeaning _ver Nop1i =
+    toBuiltinMeaning _semvar Nop1i =
         makeBuiltinMeaning
              @(Integer -> Integer)
              (\_ -> 11)
              (runCostingFunOneArgument . paramNop1)
-    toBuiltinMeaning _ver Nop2i =
+    toBuiltinMeaning _semvar Nop2i =
         makeBuiltinMeaning
              @(Integer -> Integer -> Integer)
              (\_ _ -> 22)
              (runCostingFunTwoArguments . paramNop2)
-    toBuiltinMeaning _ver Nop3i =
+    toBuiltinMeaning _semvar Nop3i =
         makeBuiltinMeaning
              @(Integer -> Integer -> Integer -> Integer)
              (\_ _ _ -> 33)
              (runCostingFunThreeArguments . paramNop3)
-    toBuiltinMeaning _ver Nop4i =
+    toBuiltinMeaning _semvar Nop4i =
         makeBuiltinMeaning
              @(Integer -> Integer -> Integer -> Integer -> Integer)
              (\_ _ _ _ -> 44)
              (runCostingFunFourArguments . paramNop4)
-    toBuiltinMeaning _ver Nop5i =
+    toBuiltinMeaning _semvar Nop5i =
         makeBuiltinMeaning
              @(Integer -> Integer -> Integer -> Integer -> Integer -> Integer)
              (\_ _ _ _ _ -> 55)
              (runCostingFunFiveArguments . paramNop5)
-    toBuiltinMeaning _ver Nop6i =
+    toBuiltinMeaning _semvar Nop6i =
         makeBuiltinMeaning
              @(Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer)
              (\_ _ _ _ _ _ -> 66)
              (runCostingFunSixArguments . paramNop6)
     -- Integers unlifted via SomeConstant
-    toBuiltinMeaning _ver Nop1c =
+    toBuiltinMeaning _semvar Nop1c =
         makeBuiltinMeaning
              (\c1 -> c1 >: EvaluationSuccess 11)
              (runCostingFunOneArgument . paramNop1)
-    toBuiltinMeaning _ver Nop2c =
+    toBuiltinMeaning _semvar Nop2c =
         makeBuiltinMeaning
              (\c1 c2 -> c1 >: c2 >: EvaluationSuccess 22)
              (runCostingFunTwoArguments . paramNop2)
-    toBuiltinMeaning _ver Nop3c =
+    toBuiltinMeaning _semvar Nop3c =
         makeBuiltinMeaning
              (\c1 c2 c3 -> c1 >: c2 >: c3 >: EvaluationSuccess 33)
              (runCostingFunThreeArguments . paramNop3)
-    toBuiltinMeaning _ver Nop4c =
+    toBuiltinMeaning _semvar Nop4c =
         makeBuiltinMeaning
              (\c1 c2 c3 c4 -> c1 >: c2 >: c3 >: c4 >: EvaluationSuccess 44)
              (runCostingFunFourArguments . paramNop4)
-    toBuiltinMeaning _ver Nop5c =
+    toBuiltinMeaning _semvar Nop5c =
         makeBuiltinMeaning
              (\c1 c2 c3 c4 c5 -> c1 >: c2 >: c3 >: c4 >: c5 >: EvaluationSuccess 55)
              (runCostingFunFiveArguments . paramNop5)
-    toBuiltinMeaning _ver Nop6c =
+    toBuiltinMeaning _semvar Nop6c =
         makeBuiltinMeaning
              (\c1 c2 c3 c4 c5 c6 -> c1 >: c2 >: c3 >: c4 >: c5 >: c6 >: EvaluationSuccess 66)
              (runCostingFunSixArguments . paramNop6)
     -- Opaque Integers
-    toBuiltinMeaning _ver Nop1o =
+    toBuiltinMeaning _semvar Nop1o =
         makeBuiltinMeaning
              @(Opaque val Integer -> Opaque val Integer)
              (\_ -> fromValueOf DefaultUniInteger 11)
              (runCostingFunOneArgument . paramNop1)
-    toBuiltinMeaning _ver Nop2o =
+    toBuiltinMeaning _semvar Nop2o =
         makeBuiltinMeaning
              @(Opaque val Integer -> Opaque val Integer-> Opaque val Integer)
              (\_ _ -> fromValueOf DefaultUniInteger 22)
              (runCostingFunTwoArguments . paramNop2)
-    toBuiltinMeaning _ver Nop3o =
+    toBuiltinMeaning _semvar Nop3o =
         makeBuiltinMeaning
              @(Opaque val Integer -> Opaque val Integer-> Opaque val Integer-> Opaque val Integer)
              (\_ _ _ -> fromValueOf DefaultUniInteger 33)
              (runCostingFunThreeArguments . paramNop3)
-    toBuiltinMeaning _ver Nop4o =
+    toBuiltinMeaning _semvar Nop4o =
         makeBuiltinMeaning
              @(Opaque val Integer
                 -> Opaque val Integer
@@ -272,13 +274,13 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
                 -> Opaque val Integer)
              (\_ _ _ _ -> fromValueOf DefaultUniInteger 44)
              (runCostingFunFourArguments . paramNop4)
-    toBuiltinMeaning _ver Nop5o =
+    toBuiltinMeaning _semvar Nop5o =
         makeBuiltinMeaning
              @(Opaque val Integer -> Opaque val Integer-> Opaque val Integer
                -> Opaque val Integer -> Opaque val Integer -> Opaque val Integer)
              (\_ _ _ _ _ -> fromValueOf DefaultUniInteger 55)
              (runCostingFunFiveArguments . paramNop5)
-    toBuiltinMeaning _ver Nop6o =
+    toBuiltinMeaning _semvar Nop6o =
         makeBuiltinMeaning
              @(Opaque val Integer -> Opaque val Integer-> Opaque val Integer
                -> Opaque val Integer -> Opaque val Integer -> Opaque val Integer
@@ -286,8 +288,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
              (\_ _ _ _ _ _ -> fromValueOf DefaultUniInteger 66)
              (runCostingFunSixArguments . paramNop6)
 
-instance Default (BuiltinVersion NopFun) where
-    def = NopFunNV1
+instance Default (BuiltinSemanticsVariant NopFun) where
+    def = NopFunSemanticsVariant1
 
 ---------------- Benchmarks ----------------
 

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Nops.hs
@@ -155,7 +155,7 @@ n >: k =
 instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
     type CostingPart uni NopFun = NopCostModel
 
-    data BuiltinVersion NopFun = NopFunV1
+    data BuiltinVersion NopFun = NopFunNV1
 
     -- Built-in Bools
     toBuiltinMeaning
@@ -287,7 +287,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni NopFun where
              (runCostingFunSixArguments . paramNop6)
 
 instance Default (BuiltinVersion NopFun) where
-    def = NopFunV1
+    def = NopFunNV1
 
 ---------------- Benchmarks ----------------
 

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -226,7 +226,7 @@ instance Whatever ExBudgetStream where
 instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
     type CostingPart uni ExtensionFun = ()
 
-    data BuiltinVersion ExtensionFun = ExtensionFunV0 | ExtensionFunV1
+    data BuiltinVersion ExtensionFun = ExtensionFunEV0 | ExtensionFunEV1
         deriving stock (Enum, Bounded, Show)
 
     toBuiltinMeaning :: forall val. HasMeaningIn uni val
@@ -459,8 +459,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         makeBuiltinMeaning
             @(() -> EvaluationResult Integer)
             (\(_ :: ()) -> EvaluationSuccess $ case ver of
-                    ExtensionFunV0 -> 0
-                    ExtensionFunV1 -> 1)
+                    ExtensionFunEV0 -> 0
+                    ExtensionFunEV1 -> 1)
             whatever
 
     -- We want to know if the CEK machine releases individual budgets after accounting for them and
@@ -533,4 +533,4 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             (\_ -> unsafePerformIO . regBudgets . runCostingFunOneArgument model)
 
 instance Default (BuiltinVersion ExtensionFun) where
-    def = ExtensionFunV1
+    def = ExtensionFunEV1

--- a/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
+++ b/plutus-core/plutus-core/examples/PlutusCore/Examples/Builtins.hs
@@ -143,21 +143,22 @@ data ExtensionFun
 instance Pretty ExtensionFun where pretty = viaShow
 
 instance (ToBuiltinMeaning uni fun1, ToBuiltinMeaning uni fun2
-         , Default (BuiltinVersion fun1), Default (BuiltinVersion fun2)
+         , Default (BuiltinSemanticsVariant fun1), Default (BuiltinSemanticsVariant fun2)
          ) => ToBuiltinMeaning uni (Either fun1 fun2) where
 
     type CostingPart uni (Either fun1 fun2) = (CostingPart uni fun1, CostingPart uni fun2)
 
-    data BuiltinVersion (Either fun1 fun2) = PairV (BuiltinVersion fun1) (BuiltinVersion fun2)
-    toBuiltinMeaning (PairV verL _) (Left  fun) = case toBuiltinMeaning verL fun of
+    data BuiltinSemanticsVariant (Either fun1 fun2) =
+        PairV (BuiltinSemanticsVariant fun1) (BuiltinSemanticsVariant fun2)
+    toBuiltinMeaning (PairV semvarL _) (Left  fun) = case toBuiltinMeaning semvarL fun of
         BuiltinMeaning tySch toF denot ->
             BuiltinMeaning tySch toF (denot . fst)
-    toBuiltinMeaning (PairV _ verR) (Right fun) = case toBuiltinMeaning verR fun of
+    toBuiltinMeaning (PairV _ semvarR) (Right fun) = case toBuiltinMeaning semvarR fun of
         BuiltinMeaning tySch toF denot ->
             BuiltinMeaning tySch toF (denot . snd)
 
-instance (Default (BuiltinVersion fun1), Default (BuiltinVersion fun2))
-         => Default (BuiltinVersion (Either fun1 fun2)) where
+instance (Default (BuiltinSemanticsVariant fun1), Default (BuiltinSemanticsVariant fun2))
+         => Default (BuiltinSemanticsVariant (Either fun1 fun2)) where
     def = PairV def def
 
 -- | Normally @forall@ in the type of a Haskell function gets detected and instantiated
@@ -226,20 +227,22 @@ instance Whatever ExBudgetStream where
 instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
     type CostingPart uni ExtensionFun = ()
 
-    data BuiltinVersion ExtensionFun = ExtensionFunEV0 | ExtensionFunEV1
+    data BuiltinSemanticsVariant ExtensionFun =
+              ExtensionFunSemanticsVariant0
+            | ExtensionFunSemanticsVariant1
         deriving stock (Enum, Bounded, Show)
 
     toBuiltinMeaning :: forall val. HasMeaningIn uni val
-                     => BuiltinVersion ExtensionFun
+                     => BuiltinSemanticsVariant ExtensionFun
                      -> ExtensionFun
                      -> BuiltinMeaning val ()
 
-    toBuiltinMeaning _ver Factorial =
+    toBuiltinMeaning _semvar Factorial =
         makeBuiltinMeaning
             (\(n :: Integer) -> product [1..n])
             whatever
 
-    toBuiltinMeaning _ver ForallFortyTwo =
+    toBuiltinMeaning _semvar ForallFortyTwo =
         makeBuiltinMeaning
             forallFortyTwo
             whatever
@@ -247,27 +250,27 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         forallFortyTwo :: MetaForall ('TyNameRep @GHC.Type "a" 0) Integer
         forallFortyTwo = MetaForall 42
 
-    toBuiltinMeaning _ver SumInteger =
+    toBuiltinMeaning _semvar SumInteger =
         makeBuiltinMeaning
             (sum :: [Integer] -> Integer)
             whatever
 
-    toBuiltinMeaning _ver Const =
+    toBuiltinMeaning _semvar Const =
         makeBuiltinMeaning
             const
             whatever
 
-    toBuiltinMeaning _ver Id =
+    toBuiltinMeaning _semvar Id =
         makeBuiltinMeaning
             Prelude.id
             whatever
 
-    toBuiltinMeaning _ver IdAssumeBool =
+    toBuiltinMeaning _semvar IdAssumeBool =
         makeBuiltinMeaning
             (Prelude.id :: Opaque val Bool -> Opaque val Bool)
             whatever
 
-    toBuiltinMeaning _ver IdAssumeCheckBool =
+    toBuiltinMeaning _semvar IdAssumeCheckBool =
         makeBuiltinMeaning
             idAssumeCheckBoolPlc
             whatever
@@ -278,7 +281,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
                 Right (Some (ValueOf DefaultUniBool b)) -> EvaluationSuccess b
                 _                                       -> EvaluationFailure
 
-    toBuiltinMeaning _ver IdSomeConstantBool =
+    toBuiltinMeaning _semvar IdSomeConstantBool =
         makeBuiltinMeaning
             idSomeConstantBoolPlc
             whatever
@@ -288,7 +291,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             SomeConstant (Some (ValueOf DefaultUniBool b)) -> EvaluationSuccess b
             _                                              -> EvaluationFailure
 
-    toBuiltinMeaning _ver IdIntegerAsBool =
+    toBuiltinMeaning _semvar IdIntegerAsBool =
         makeBuiltinMeaning
             idIntegerAsBool
             whatever
@@ -298,24 +301,24 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             con@(SomeConstant (Some (ValueOf DefaultUniBool _))) -> EvaluationSuccess con
             _                                                    -> EvaluationFailure
 
-    toBuiltinMeaning _ver IdFInteger =
+    toBuiltinMeaning _semvar IdFInteger =
         makeBuiltinMeaning
             (Prelude.id :: fi ~ Opaque val (f `TyAppRep` Integer) => fi -> fi)
             whatever
 
-    toBuiltinMeaning _ver IdList =
+    toBuiltinMeaning _semvar IdList =
         makeBuiltinMeaning
             (Prelude.id :: la ~ Opaque val (PlcListRep a) => la -> la)
             whatever
 
-    toBuiltinMeaning _ver IdRank2 =
+    toBuiltinMeaning _semvar IdRank2 =
         makeBuiltinMeaning
             (Prelude.id
                 :: afa ~ Opaque val (TyForallRep @GHC.Type a (TyVarRep f `TyAppRep` TyVarRep a))
                 => afa -> afa)
             whatever
 
-    toBuiltinMeaning _ver ScottToMetaUnit =
+    toBuiltinMeaning _semvar ScottToMetaUnit =
         makeBuiltinMeaning
             ((\_ -> ())
                 -- @(->)@ switches from the Rep context to the Type one. We could make @(->)@
@@ -327,31 +330,31 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
                 => Opaque val (TyForallRep a (oa -> oa)) -> ())
             whatever
 
-    toBuiltinMeaning _ver FailingSucc =
+    toBuiltinMeaning _semvar FailingSucc =
         makeBuiltinMeaning
             @(Integer -> Integer)
             (\_ -> throw BuiltinErrorCall)
             whatever
 
-    toBuiltinMeaning _ver ExpensiveSucc =
+    toBuiltinMeaning _semvar ExpensiveSucc =
         makeBuiltinMeaning
             @(Integer -> Integer)
             (\_ -> throw BuiltinErrorCall)
             (\_ _ -> ExBudgetLast $ unExRestrictingBudget enormousBudget)
 
-    toBuiltinMeaning _ver FailingPlus =
+    toBuiltinMeaning _semvar FailingPlus =
         makeBuiltinMeaning
             @(Integer -> Integer -> Integer)
             (\_ _ -> throw BuiltinErrorCall)
             whatever
 
-    toBuiltinMeaning _ver ExpensivePlus =
+    toBuiltinMeaning _semvar ExpensivePlus =
         makeBuiltinMeaning
             @(Integer -> Integer -> Integer)
             (\_ _ -> throw BuiltinErrorCall)
             (\_ _ _ -> ExBudgetLast $ unExRestrictingBudget enormousBudget)
 
-    toBuiltinMeaning _ver IsConstant =
+    toBuiltinMeaning _semvar IsConstant =
         makeBuiltinMeaning
             isConstantPlc
             whatever
@@ -360,7 +363,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         isConstantPlc :: Opaque val a -> Bool
         isConstantPlc = isRight . asConstant
 
-    toBuiltinMeaning _ver UnsafeCoerce =
+    toBuiltinMeaning _semvar UnsafeCoerce =
         makeBuiltinMeaning
             unsafeCoercePlc
             whatever
@@ -369,7 +372,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         unsafeCoercePlc :: Opaque val a -> Opaque val b
         unsafeCoercePlc = Opaque . unOpaque
 
-    toBuiltinMeaning _ver UnsafeCoerceEl =
+    toBuiltinMeaning _semvar UnsafeCoerceEl =
         makeBuiltinMeaning
             unsafeCoerceElPlc
             whatever
@@ -381,22 +384,22 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             DefaultUniList _ <- pure uniList
             pure $ fromValueOf uniList xs
 
-    toBuiltinMeaning _ver Undefined =
+    toBuiltinMeaning _semvar Undefined =
         makeBuiltinMeaning
             undefined
             whatever
 
-    toBuiltinMeaning _ver Absurd =
+    toBuiltinMeaning _semvar Absurd =
         makeBuiltinMeaning
             absurd
             whatever
 
-    toBuiltinMeaning _ver ErrorPrime =
+    toBuiltinMeaning _semvar ErrorPrime =
         makeBuiltinMeaning
             EvaluationFailure
             whatever
 
-    toBuiltinMeaning _ver Comma =
+    toBuiltinMeaning _semvar Comma =
         makeBuiltinMeaning
             commaPlc
             whatever
@@ -408,7 +411,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
         commaPlc (SomeConstant (Some (ValueOf uniA x))) (SomeConstant (Some (ValueOf uniB y))) =
             fromValueOf (DefaultUniPair uniA uniB) (x, y)
 
-    toBuiltinMeaning _ver BiconstPair =
+    toBuiltinMeaning _semvar BiconstPair =
         makeBuiltinMeaning
             biconstPairPlc
             whatever
@@ -427,7 +430,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
                 Just Refl <- pure $ uniB `geq` uniB'
                 pure $ fromValueOf uniPairAB (x, y)
 
-    toBuiltinMeaning _ver Swap =
+    toBuiltinMeaning _semvar Swap =
         makeBuiltinMeaning
             swapPlc
             whatever
@@ -439,7 +442,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             DefaultUniPair uniA uniB <- pure uniPairAB
             pure $ fromValueOf (DefaultUniPair uniB uniA) (snd p, fst p)
 
-    toBuiltinMeaning _ver SwapEls =
+    toBuiltinMeaning _semvar SwapEls =
         makeBuiltinMeaning
             swapElsPlc
             whatever
@@ -454,13 +457,13 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             pure . fromValueOf uniList' $ map swap xs
 
     -- A dummy builtin to reflect the builtin-version of the 'ExtensionFun'.
-    -- See Note [Versioned builtins]
-    toBuiltinMeaning ver ExtensionVersion =
+    -- See Note [Builtin semantics variants]
+    toBuiltinMeaning semvar ExtensionVersion =
         makeBuiltinMeaning
             @(() -> EvaluationResult Integer)
-            (\(_ :: ()) -> EvaluationSuccess $ case ver of
-                    ExtensionFunEV0 -> 0
-                    ExtensionFunEV1 -> 1)
+            (\(_ :: ()) -> EvaluationSuccess $ case semvar of
+                    ExtensionFunSemanticsVariant0 -> 0
+                    ExtensionFunSemanticsVariant1 -> 1)
             whatever
 
     -- We want to know if the CEK machine releases individual budgets after accounting for them and
@@ -532,5 +535,5 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni ExtensionFun where
             (\_ -> unsafePerformIO $ reverse <$> readMVar numsOfGcedVar)
             (\_ -> unsafePerformIO . regBudgets . runCostingFunOneArgument model)
 
-instance Default (BuiltinVersion ExtensionFun) where
-    def = ExtensionFunEV1
+instance Default (BuiltinSemanticsVariant ExtensionFun) where
+    def = ExtensionFunSemanticsVariant1

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -103,7 +103,8 @@ typeOfBuiltinFunction semvar fun =
     case toBuiltinMeaning @_ @_ @(Term TyName Name uni fun ()) semvar fun of
         BuiltinMeaning sch _ _ -> typeSchemeToType sch
 
-{- Note [Builtin semantics variants] The purpose of the "builtin semantics
+{- Note [Builtin semantics variants] 
+The purpose of the "builtin semantics
 variant" feature is to provide multiple, different denotations (implementations)
 for the same builtin(s).  An example use of this feature is for "fixing" the
 behaviour of `ConsByteString` builtin to throw an error instead of overflowing

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -70,57 +70,76 @@ data BuiltinMeaning val cost =
 type HasMeaningIn uni val = (Typeable val, ExMemoryUsage val, HasConstantIn uni val)
 
 -- | A type class for \"each function from a set of built-in functions has a 'BuiltinMeaning'\".
-class (Typeable uni, Typeable fun, Bounded fun, Enum fun, Ix fun, Default (BuiltinVersion fun)) =>
-            ToBuiltinMeaning uni fun where
+class ( Typeable uni
+      , Typeable fun
+      , Bounded fun
+      , Enum fun
+      , Ix fun
+      , Default (BuiltinSemanticsVariant fun)
+      )
+    => ToBuiltinMeaning uni fun
+    where
+
     -- | The @cost@ part of 'BuiltinMeaning'.
     type CostingPart uni fun
 
-    -- | See Note [Versioned builtins]
-    data BuiltinVersion fun
+    -- | See Note [Builtin semantics variants]
+    data BuiltinSemanticsVariant fun
 
     -- | Get the 'BuiltinMeaning' of a built-in function.
-    toBuiltinMeaning :: HasMeaningIn uni val =>
-        BuiltinVersion fun -> fun -> BuiltinMeaning val (CostingPart uni fun)
+    toBuiltinMeaning
+        :: HasMeaningIn uni val
+        => BuiltinSemanticsVariant fun
+        -> fun
+        -> BuiltinMeaning val (CostingPart uni fun)
 
 -- | Get the type of a built-in function.
-typeOfBuiltinFunction :: forall uni fun. ToBuiltinMeaning uni fun =>
-    BuiltinVersion fun -> fun -> Type TyName uni ()
-typeOfBuiltinFunction ver fun =
-    case toBuiltinMeaning @_ @_ @(Term TyName Name uni fun ()) ver fun of
+typeOfBuiltinFunction
+    :: forall uni fun. ToBuiltinMeaning uni fun
+    => BuiltinSemanticsVariant fun
+    -> fun
+    -> Type TyName uni ()
+typeOfBuiltinFunction semvar fun =
+    case toBuiltinMeaning @_ @_ @(Term TyName Name uni fun ()) semvar fun of
         BuiltinMeaning sch _ _ -> typeSchemeToType sch
 
-{- Note [Versioned builtins]
-The purpose of the "versioned builtins" feature is to provide multiple, different denotations
-(implementations) for the same builtin(s).
-An example use of this feature is for "fixing" the behaviour of `ConsByteString` builtin to throw an
-error instead of overflowing its first argument.
+{- Note [Builtin semantics variants] The purpose of the "builtin semantics
+variant" feature is to provide multiple, different denotations (implementations)
+for the same builtin(s).  An example use of this feature is for "fixing" the
+behaviour of `ConsByteString` builtin to throw an error instead of overflowing
+its first argument.
 
-One denotation from each builtin is grouped into a 'BuiltinVersion'. Each Plutus Language version is
-linked to a specific 'BuiltinVersion' (done by plutus-ledger-api); e.g. plutus-v1 and plutus-v2 are
-linked to 'DefaultFunBV1', whereas plutus-v3 changes the set of denotations to 'DefaultFunBV2' (thus
- fixing 'ConsByteString').
+One denotation from each builtin is grouped into a
+'BuiltinSemanticsVariant'. Each Plutus Language version is linked to a specific
+'BuiltinSemanticsVariant' (done by plutus-ledger-api); e.g. plutus-v1 and
+plutus-v2 are linked to 'DefaultFunSemanticsVariant1', whereas plutus-v3 changes
+the set of denotations to 'DefaultFunSemanticsVariant2' (thus fixing
+'ConsByteString').
 
-Each 'BuiltinVersion' (grouping) can change the denotation of one or more builtins --- or none, but
-what's the point in that.
+Each 'BuiltinSemanticsVariant' (grouping) can change the denotation of one or
+more builtins --- or none, but what's the point in that?
 
-This 'BuiltinVersion' is modelled as a datatype *associated* to the `fun`. This associated datatype
-is required to provide an instance of 'Default' for quality-of-life purpose; the `def`ault builtin
-version is expected to point to the builtin-version that the plutus-tx/plutus-ir compiler is
-currently targeting.
+This 'BuiltinSemanticsVariant' is modelled as a datatype *associated* to the
+`fun`. This associated datatype is required to provide an instance of 'Default'
+for quality-of-life purpose; the `def`ault builtin semantics variant is expected
+to point to the builtin semantics variant that the plutus-tx/plutus-ir compiler
+is currently targeting.
 
-Note that, (old) denotations of a 'BuiltinVersion' cannot be removed or deprecated, once published
-to the chain.
+Note that (old) denotations of a 'BuiltinSemanticsVariant' cannot be removed or
+deprecated once published to the chain.
 
 The way that this feature is implemented buys us more than we currently need:
 - allows also a versioned change to a builtin's *type signature*, i.e. type of arguments/result as
 well as number of arguments.
 - allows also a versioned change to a builtin's cost model parameters
 
-Besides having no need for this currently, it complicates the codebase since the typechecker
-now pointlessly wants to know the builtin-version before typechecking. To alleviate this,
-we use the 'Default.def' builtin version during typechecking / lifting. @effectfully:
-the solution to the problem would be to establish what kind of backwards compatibility we're willing
-to maintain and pull all of that into a separate data type and make it a part of BuiltinMeaning.
+Besides having no need for this currently, it complicates the codebase since the
+typechecker now pointlessly wants to know the builtin semantics before
+typechecking. To alleviate this, we use the 'Default.def' builtin semantics
+variant during typechecking / lifting. @effectfully: the solution to the problem
+would be to establish what kind of backwards compatibility we're willing to
+maintain and pull all of that into a separate data type and make it a part of
+BuiltinMeaning.
 -}
 
 {- Note [Automatic derivation of type schemes]
@@ -379,9 +398,11 @@ toBuiltinRuntime cost (BuiltinMeaning _ _ denot) = denot cost
 -- and a cost model.
 toBuiltinsRuntime
     :: (cost ~ CostingPart uni fun, ToBuiltinMeaning uni fun, HasMeaningIn uni val)
-    => BuiltinVersion fun -> cost -> BuiltinsRuntime fun val
-toBuiltinsRuntime ver cost =
-    let runtime = BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning ver
+    => BuiltinSemanticsVariant fun
+    -> cost
+    -> BuiltinsRuntime fun val
+toBuiltinsRuntime semvar cost =
+    let runtime = BuiltinsRuntime $ toBuiltinRuntime cost . inline toBuiltinMeaning semvar
         -- This pragma is very important, removing it destroys the carefully set up optimizations of
         -- of costing functions (see Note [Optimizations of runCostingFun*]). The reason for that is
         -- that if @runtime@ doesn't have a pragma, then GHC sees that it's only referenced once and

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -103,19 +103,17 @@ typeOfBuiltinFunction semvar fun =
     case toBuiltinMeaning @_ @_ @(Term TyName Name uni fun ()) semvar fun of
         BuiltinMeaning sch _ _ -> typeSchemeToType sch
 
-{- Note [Builtin semantics variants] 
-The purpose of the "builtin semantics
-variant" feature is to provide multiple, different denotations (implementations)
-for the same builtin(s).  An example use of this feature is for "fixing" the
-behaviour of `ConsByteString` builtin to throw an error instead of overflowing
-its first argument.
+{- Note [Builtin semantics variants]
+The purpose of the "builtin semantics variant" feature is to provide multiple,
+different denotations (implementations) for the same builtin(s).  An example use
+of this feature is for "fixing" the behaviour of `ConsByteString` builtin to
+throw an error instead of overflowing its first argument.
 
-One denotation from each builtin is grouped into a
-'BuiltinSemanticsVariant'. Each Plutus Language version is linked to a specific
-'BuiltinSemanticsVariant' (done by plutus-ledger-api); e.g. plutus-v1 and
-plutus-v2 are linked to 'DefaultFunSemanticsVariant1', whereas plutus-v3 changes
-the set of denotations to 'DefaultFunSemanticsVariant2' (thus fixing
-'ConsByteString').
+One denotation from each builtin is grouped into a 'BuiltinSemanticsVariant'.
+Each Plutus Language version is linked to a specific 'BuiltinSemanticsVariant'
+(done by plutus-ledger-api); e.g. plutus-v1 and plutus-v2 are linked to
+'DefaultFunSemanticsVariant1', whereas plutus-v3 changes the set of denotations
+to 'DefaultFunSemanticsVariant2' (thus fixing 'ConsByteString').
 
 Each 'BuiltinSemanticsVariant' (grouping) can change the denotation of one or
 more builtins --- or none, but what's the point in that?

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/Meaning.hs
@@ -97,7 +97,7 @@ error instead of overflowing its first argument.
 
 One denotation from each builtin is grouped into a 'BuiltinVersion'. Each Plutus Language version is
 linked to a specific 'BuiltinVersion' (done by plutus-ledger-api); e.g. plutus-v1 and plutus-v2 are
-linked to 'DefaultFunV1', whereas plutus-v3 changes the set of denotations to 'DefaultFunV2' (thus
+linked to 'DefaultFunBV1', whereas plutus-v3 changes the set of denotations to 'DefaultFunBV2' (thus
  fixing 'ConsByteString').
 
 Each 'BuiltinVersion' (grouping) can change the denotation of one or more builtins --- or none, but

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1046,7 +1046,11 @@ do it quite yet, even though it worked (the Plutus Tx part wasn't implemented).
 instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     type CostingPart uni DefaultFun = BuiltinCostModel
 
-    data BuiltinVersion DefaultFun = DefaultFunV1 | DefaultFunV2
+    {- | Allow different versions of builtins with different implementations, and
+       possibly different semantics.  Note that DefaultFunBV1, DefaultFunBV2
+       etc. DO NOT correspond directly to PlutusV1, PlutusV2 etc. in
+       plutus-ledger-api.  See Note [Versioned builtins]. -}
+    data BuiltinVersion DefaultFun = DefaultFunBV1 | DefaultFunBV2
         deriving stock (Enum, Bounded, Show)
 
     -- Integers
@@ -1107,7 +1111,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             costingFun = runCostingFunTwoArguments . paramConsByteString
         -- See Note [Versioned builtins]
         in case ver of
-            DefaultFunV1 -> makeBuiltinMeaning
+            DefaultFunBV1 -> makeBuiltinMeaning
                @(Integer -> BS.ByteString -> BS.ByteString)
                (\n xs -> BS.cons (fromIntegral @Integer n) xs)
                costingFun
@@ -1158,8 +1162,8 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     toBuiltinMeaning ver VerifyEd25519Signature =
         let verifyEd25519Signature =
                 case ver of
-                  DefaultFunV1 -> verifyEd25519Signature_V1
-                  _            -> verifyEd25519Signature_V2
+                  DefaultFunBV1 -> verifyEd25519Signature_V1
+                  _             -> verifyEd25519Signature_V2
         in makeBuiltinMeaning
            verifyEd25519Signature
            -- Benchmarks indicate that the two versions have very similar
@@ -1482,7 +1486,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     {-# INLINE toBuiltinMeaning #-}
 
 instance Default (BuiltinVersion DefaultFun) where
-    def = DefaultFunV2
+    def = DefaultFunBV2
 
 instance Pretty (BuiltinVersion DefaultFun) where
     pretty = viaShow

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -234,14 +234,17 @@ comment: https://github.com/input-output-hk/plutus/issues/4306#issuecomment-1003
 In order to add a new built-in function one needs to add a constructor to 'DefaultFun' and handle
 it within the @ToBuiltinMeaning uni DefaultFun@ instance like this:
 
-    toBuiltinMeaning <Name> =
+    toBuiltinMeaning <semanticsVariant> <Name> =
         makeBuiltinMeaning
             <denotation>
             <costingFunction>
 
 'makeBuiltinMeaning' creates a Plutus builtin out of its denotation (i.e. Haskell implementation)
 and a costing function for it. Once a builtin is added, its Plutus type is kind-checked and printed
-to a golden file automatically (consult @git status@).
+to a golden file automatically (consult @git status@). 'toBuiltinMeaning' also takes a
+'BuiltinSemanticsVariant' argument which allows a particular builtin name to have multiple
+associated denotations (see Note [Builtin semantics variants]), but for simplicity we assume in
+the examplesbelow that all names have a single meaning.
 
 Below we will enumerate what kind of denotations are accepted by 'makeBuiltinMeaning' without
 touching any costing stuff.
@@ -253,7 +256,7 @@ built-in types and returns a value of a built-in type as well. For example
 
 You can feed 'encodeUtf8' directly to 'makeBuiltinMeaning' without specifying any types:
 
-    toBuiltinMeaning EncodeUtf8 =
+    toBuiltinMeaning _ EncodeUtf8 =
         makeBuiltinMeaning
             encodeUtf8
             <costingFunction>
@@ -269,14 +272,14 @@ annotation or type application or using any other way of specifying types.
 
 Here's how it looks with a type application instantiating the type variable of @(+)@:
 
-    toBuiltinMeaning AddInteger =
+    toBuiltinMeaning _ AddInteger =
         makeBuiltinMeaning
             ((+) @Integer)
             <costingFunction>
 
 Or we can specify the whole type of the denotation by type-applying 'makeBuiltinMeaning':
 
-    toBuiltinMeaning AddInteger =
+    toBuiltinMeaning _ AddInteger =
         makeBuiltinMeaning
             @(Integer -> Integer -> Integer)
             (+)
@@ -284,7 +287,7 @@ Or we can specify the whole type of the denotation by type-applying 'makeBuiltin
 
 Or we can simply annotate @(+)@ with its monomorphized type:
 
-    toBuiltinMeaning AddInteger =
+    toBuiltinMeaning _ AddInteger =
         makeBuiltinMeaning
             ((+) :: Integer -> Integer -> Integer)
             <costingFunction>
@@ -294,7 +297,7 @@ All of these are equivalent.
 It works the same way for a built-in function that has monomorphized polymorphic built-in types in
 its type signature, for example:
 
-    toBuiltinMeaning SumInteger =
+    toBuiltinMeaning _ SumInteger =
         makeBuiltinMeaning
             (sum :: [Integer] -> Integer)
             <costingFunction>
@@ -302,7 +305,7 @@ its type signature, for example:
 3. Unconstrained type variables are fine, you don't need to instantiate them (but you may want to if
 you want some builtin to be less general than what Haskell infers for its denotation). For example
 
-    toBuiltinMeaning IfThenElse =
+    toBuiltinMeaning _ IfThenElse =
         makeBuiltinMeaning
             (\b x y -> if b then x else y)
             <costingFunction>
@@ -328,7 +331,7 @@ have 'Int' as a built-in, but we have 'Integer' and we can represent the former 
 latter. The conversions between the two types are handled by 'makeBuiltinMeaning', so that the user
 doesn't need to write them themselves and can just write
 
-    toBuiltinMeaning LengthOfByteString =
+    toBuiltinMeaning _ LengthOfByteString =
         makeBuiltinMeaning
             BS.length
             <costingFunction>
@@ -371,7 +374,7 @@ something that happens commonly.
 One simple example is a monomorphic function matching on a certain constructor and failing in all
 other cases:
 
-    toBuiltinMeaning UnIData =
+    toBuiltinMeaning _ UnIData =
         makeBuiltinMeaning
             (\case
                 I i -> EvaluationSuccess i
@@ -403,7 +406,7 @@ An argument of a builtin can't have 'EvaluationResult' in its type -- only the r
 are the same as with 'EvaluationResult': 'Emitter' can't appear in the type of an argument and
 polymorphism is fine. For example:
 
-    toBuiltinMeaning Trace =
+    toBuiltinMeaning _ Trace =
         makeBuiltinMeaning
             (\text a -> a <$ emit text)
             <costingFunction>
@@ -430,7 +433,7 @@ polymorphism gets elaborated, so read Note [Elaboration of polymorphism] next.
 {- Note [Elaboration of polymorphism]
 In Note [How to add a built-in function: simple cases] we defined the following builtin:
 
-    toBuiltinMeaning IfThenElse =
+    toBuiltinMeaning _ IfThenElse =
         makeBuiltinMeaning
             (\b x y -> if b then x else y)
             <costingFunction>
@@ -499,7 +502,7 @@ to specify any types when creating built-in functions out of simple polymorphic 
 If we wanted to specify the type explicitly, we could do it like this (leaving out the @Var0@ thing
 for the elaboration machinery to figure out):
 
-    toBuiltinMeaning IfThenElse =
+    toBuiltinMeaning _ IfThenElse =
         makeBuiltinMeaning
             @(Bool -> Opaque val _ -> Opaque val _ -> Opaque val _)
             (\b x y -> if b then x else y)
@@ -514,7 +517,7 @@ Another thing we could do is define an auxiliary function with a type signature 
     ifThenElse :: Bool -> Opaque val a -> Opaque val a -> Opaque val a
     ifThenElse b x y = if b then x else y
 
-    toBuiltinMeaning IfThenElse =
+    toBuiltinMeaning _ IfThenElse =
         makeBuiltinMeaning
             ifThenElse
             <costingFunction>
@@ -539,7 +542,7 @@ which is the Plutus type of the 'IfThenElse' builtin.
 
 It's of course allowed to have multiple type variables, e.g. in the following snippet:
 
-    toBuiltinMeaning Const =
+    toBuiltinMeaning _ Const =
         makeBuiltinMeaning
             Prelude.const
             <costingFunction>
@@ -562,7 +565,7 @@ the elaboration machinery wouldn't make a fuss about that.
 
 As a final simple example, consider
 
-    toBuiltinMeaning Trace =
+    toBuiltinMeaning _ Trace =
         makeBuiltinMeaning
             (\text a -> a <$ emit text)
             <costingFunction>
@@ -579,7 +582,7 @@ Elaboration machinery is able to look under 'Emitter' and 'EvaluationResult' eve
 variable inside that does not appear anywhere else in the type signature, for example the inferred
 type of the denotation in
 
-    toBuiltinMeaning ErrorPrime =
+    toBuiltinMeaning _ ErrorPrime =
         makeBuiltinMeaning
             EvaluationFailure
             <costingFunction>
@@ -606,7 +609,7 @@ Now let's talk about more complicated built-in functions.
 @Opaque val VarN@ and we learned that this type can be used directly as opposed to being inferred.
 However there exist more ways to use 'Opaque' explicitly. Here's a simple example:
 
-    toBuiltinMeaning IdAssumeBool =
+    toBuiltinMeaning _ IdAssumeBool =
         makeBuiltinMeaning
             (Prelude.id :: Opaque val Bool -> Opaque val Bool)
             <costingFunction>
@@ -617,7 +620,7 @@ This creates a built-in function whose Plutus type is
 
 i.e. the Plutus type signature of the built-in function is the same as with
 
-    toBuiltinMeaning IdBool =
+    toBuiltinMeaning _ IdBool =
         makeBuiltinMeaning
             (Prelude.id :: Bool -> Bool)
             <costingFunction>
@@ -637,7 +640,7 @@ makes it possible to unlift @val@ as a constant or lift a constant back into @va
 reason, wanted to have 'Opaque' in the type signature of the denotation, but still unlift the
 argument as a 'Bool', we could do that:
 
-    toBuiltinMeaning IdAssumeCheckBool =
+    toBuiltinMeaning _ IdAssumeCheckBool =
         makeBuiltinMeaning
             idAssumeCheckBoolPlc
             <costingFunction>
@@ -675,7 +678,7 @@ The difference is that 'Opaque' is a wrapper around an arbitrary value and 'Some
 wrapper around a constant. 'SomeConstant' allows one to automatically unlift an argument of a
 built-in function as a constant with all 'asConstant' business kept behind the scenes, for example:
 
-    toBuiltinMeaning IdSomeConstantBool =
+    toBuiltinMeaning _ IdSomeConstantBool =
         makeBuiltinMeaning
             idSomeConstantBoolPlc
             <costingFunction>
@@ -692,7 +695,7 @@ However it's not always possible to use automatic unlifting, see next.
 
 4. If we try to define the following built-in function:
 
-    toBuiltinMeaning NullList =
+    toBuiltinMeaning _ NullList =
         makeBuiltinMeaning
             (null :: [a] -> Bool)
             <costingFunction>
@@ -704,7 +707,7 @@ general case, plus it has to be very inefficient.
 Instead we have to use 'SomeConstant' to automatically unlift the argument as a constant and then
 check that the value inside of it is a list (by matching on the type tag):
 
-    toBuiltinMeaning NullList =
+    toBuiltinMeaning _ NullList =
         makeBuiltinMeaning
             nullPlc
             <costingFunction>
@@ -724,7 +727,7 @@ in any way.
 
 Here's a similar built-in function:
 
-    toBuiltinMeaning FstPair =
+    toBuiltinMeaning _ FstPair =
         makeBuiltinMeaning
             fstPlc
             <costingFunction>
@@ -741,7 +744,7 @@ element [2] (extracted from the type tag for the whole pair constant [1]).
 Note that it's fine to mix automatic unlifting for polymorphism not related to built-in types and
 manual unlifting for arguments having non-monomorphized polymorphic built-in types, for example:
 
-    toBuiltinMeaning ChooseList =
+    toBuiltinMeaning _ ChooseList =
         makeBuiltinMeaning
             choosePlc
             <costingFunction>
@@ -760,7 +763,7 @@ machinery will do it for us.
 
 Our final example is this:
 
-    toBuiltinMeaning MkCons =
+    toBuiltinMeaning _ MkCons =
         makeBuiltinMeaning
             consPlc
             <costingFunction>
@@ -802,7 +805,7 @@ actually does. Let's look at some examples.
 
 1. The following built-in function unlifts to 'Bool' and lifts the result back:
 
-    toBuiltinMeaning IdIntegerAsBool =
+    toBuiltinMeaning _ IdIntegerAsBool =
         makeBuiltinMeaning
             idIntegerAsBool
             <costingFunction>
@@ -828,7 +831,7 @@ it's respecting its type signature is what causes a failure, not disrespecting i
 2. Another example of an unsafe built-in function is this one that checks whether an argument is a
 constant or not:
 
-    toBuiltinMeaning IsConstant =
+    toBuiltinMeaning _ IsConstant =
         makeBuiltinMeaning
             isConstantPlc
             <costingFunction>
@@ -847,7 +850,7 @@ built-in function.
 
 3. Finally, we can have a Plutus version of @unsafeCoerce@:
 
-    toBuiltinMeaning UnsafeCoerce =
+    toBuiltinMeaning _ UnsafeCoerce =
         makeBuiltinMeaning
             unsafeCoercePlc
             <costingFunction>
@@ -1046,127 +1049,134 @@ do it quite yet, even though it worked (the Plutus Tx part wasn't implemented).
 instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     type CostingPart uni DefaultFun = BuiltinCostModel
 
-    {- | Allow different versions of builtins with different implementations, and
-       possibly different semantics.  Note that DefaultFunBV1, DefaultFunBV2
-       etc. DO NOT correspond directly to PlutusV1, PlutusV2 etc. in
-       plutus-ledger-api.  See Note [Versioned builtins]. -}
-    data BuiltinVersion DefaultFun = DefaultFunBV1 | DefaultFunBV2
+    {- | Allow different variants of builtins with different implementations, and
+       possibly different semantics.  Note that DefaultFunSemanticsVariant1,
+       DefaultFunSemanticsVariant1 etc. do not correspond directly to PlutusV1,
+       PlutusV2 etc. in plutus-ledger-api: see Note [Builtin semantics variants]. -}
+    data BuiltinSemanticsVariant DefaultFun =
+              DefaultFunSemanticsVariant1
+            | DefaultFunSemanticsVariant2
         deriving stock (Enum, Bounded, Show)
 
     -- Integers
     toBuiltinMeaning
         :: forall val. HasMeaningIn uni val
-        => BuiltinVersion DefaultFun -> DefaultFun -> BuiltinMeaning val BuiltinCostModel
-    toBuiltinMeaning _ver AddInteger =
+        => BuiltinSemanticsVariant DefaultFun
+        -> DefaultFun
+        -> BuiltinMeaning val BuiltinCostModel
+    toBuiltinMeaning _semvar AddInteger =
         makeBuiltinMeaning
             ((+) @Integer)
             (runCostingFunTwoArguments . paramAddInteger)
-    toBuiltinMeaning _ver SubtractInteger =
+    toBuiltinMeaning _semvar SubtractInteger =
         makeBuiltinMeaning
             ((-) @Integer)
             (runCostingFunTwoArguments . paramSubtractInteger)
-    toBuiltinMeaning _ver MultiplyInteger =
+    toBuiltinMeaning _semvar MultiplyInteger =
         makeBuiltinMeaning
             ((*) @Integer)
             (runCostingFunTwoArguments . paramMultiplyInteger)
-    toBuiltinMeaning _ver DivideInteger =
+    toBuiltinMeaning _semvar DivideInteger =
         makeBuiltinMeaning
             (nonZeroArg div)
             (runCostingFunTwoArguments . paramDivideInteger)
-    toBuiltinMeaning _ver QuotientInteger =
+    toBuiltinMeaning _semvar QuotientInteger =
         makeBuiltinMeaning
             (nonZeroArg quot)
             (runCostingFunTwoArguments . paramQuotientInteger)
-    toBuiltinMeaning _ver RemainderInteger =
+    toBuiltinMeaning _semvar RemainderInteger =
         makeBuiltinMeaning
             (nonZeroArg rem)
             (runCostingFunTwoArguments . paramRemainderInteger)
-    toBuiltinMeaning _ver ModInteger =
+    toBuiltinMeaning _semvar ModInteger =
         makeBuiltinMeaning
             (nonZeroArg mod)
             (runCostingFunTwoArguments . paramModInteger)
-    toBuiltinMeaning _ver EqualsInteger =
+    toBuiltinMeaning _semvar EqualsInteger =
         makeBuiltinMeaning
             ((==) @Integer)
             (runCostingFunTwoArguments . paramEqualsInteger)
-    toBuiltinMeaning _ver LessThanInteger =
+    toBuiltinMeaning _semvar LessThanInteger =
         makeBuiltinMeaning
             ((<) @Integer)
             (runCostingFunTwoArguments . paramLessThanInteger)
-    toBuiltinMeaning _ver LessThanEqualsInteger =
+    toBuiltinMeaning _semvar LessThanEqualsInteger =
         makeBuiltinMeaning
             ((<=) @Integer)
             (runCostingFunTwoArguments . paramLessThanEqualsInteger)
     -- Bytestrings
-    toBuiltinMeaning _ver AppendByteString =
+    toBuiltinMeaning _semvar AppendByteString =
         makeBuiltinMeaning
             BS.append
             (runCostingFunTwoArguments . paramAppendByteString)
-    toBuiltinMeaning ver ConsByteString =
-        -- The costing function is the same for all versions of this builtin, but since the
-        -- denotation of the builtin accepts constants of different types ('Integer' vs 'Word8'),
-        -- the costing function needs to by polymorphic over the type of constant.
+    toBuiltinMeaning semvar ConsByteString =
+        -- The costing function is the same for all variants of this builtin,
+        -- but since the denotation of the builtin accepts constants of
+        -- different types ('Integer' vs 'Word8'), the costing function needs to
+        -- by polymorphic over the type of constant.
         let costingFun
                 :: ExMemoryUsage a => BuiltinCostModel -> a -> BS.ByteString -> ExBudgetStream
             costingFun = runCostingFunTwoArguments . paramConsByteString
-        -- See Note [Versioned builtins]
-        in case ver of
-            DefaultFunBV1 -> makeBuiltinMeaning
+        -- See Note [Builtin semantics variants]
+        in case semvar of
+            DefaultFunSemanticsVariant1 -> makeBuiltinMeaning
                @(Integer -> BS.ByteString -> BS.ByteString)
                (\n xs -> BS.cons (fromIntegral @Integer n) xs)
                costingFun
-            -- For versions other (i.e. larger) than V1, the first input must be in range [0..255].
-            -- See Note [How to add a built-in function: simple cases]
-            _ -> makeBuiltinMeaning
+            -- For builtin semantics variants other (i.e. larger) than
+            -- DefaultFunSemanticsVariant1, the first input must be in range
+            -- [0..255].  See Note [How to add a built-in function: simple
+            -- cases]
+            DefaultFunSemanticsVariant2 -> makeBuiltinMeaning
               @(Word8 -> BS.ByteString -> BS.ByteString)
               BS.cons
               costingFun
-    toBuiltinMeaning _ver SliceByteString =
+    toBuiltinMeaning _semvar SliceByteString =
         makeBuiltinMeaning
             (\start n xs -> BS.take n (BS.drop start xs))
             (runCostingFunThreeArguments . paramSliceByteString)
-    toBuiltinMeaning _ver LengthOfByteString =
+    toBuiltinMeaning _semvar LengthOfByteString =
         makeBuiltinMeaning
             BS.length
             (runCostingFunOneArgument . paramLengthOfByteString)
-    toBuiltinMeaning _ver IndexByteString =
+    toBuiltinMeaning _semvar IndexByteString =
         makeBuiltinMeaning
             (\xs n -> if n >= 0 && n < BS.length xs then EvaluationSuccess $ toInteger $ BS.index xs n else EvaluationFailure)
             -- TODO: fix the mess above with `indexMaybe` from `ghc>=9.2,bytestring >= 0.11.0.0`.
             (runCostingFunTwoArguments . paramIndexByteString)
-    toBuiltinMeaning _ver EqualsByteString =
+    toBuiltinMeaning _semvar EqualsByteString =
         makeBuiltinMeaning
             ((==) @BS.ByteString)
             (runCostingFunTwoArguments . paramEqualsByteString)
-    toBuiltinMeaning _ver LessThanByteString =
+    toBuiltinMeaning _semvar LessThanByteString =
         makeBuiltinMeaning
             ((<) @BS.ByteString)
             (runCostingFunTwoArguments . paramLessThanByteString)
-    toBuiltinMeaning _ver LessThanEqualsByteString =
+    toBuiltinMeaning _semvar LessThanEqualsByteString =
         makeBuiltinMeaning
             ((<=) @BS.ByteString)
             (runCostingFunTwoArguments . paramLessThanEqualsByteString)
     -- Cryptography and hashes
-    toBuiltinMeaning _ver Sha2_256 =
+    toBuiltinMeaning _semvar Sha2_256 =
         makeBuiltinMeaning
             Hash.sha2_256
             (runCostingFunOneArgument . paramSha2_256)
-    toBuiltinMeaning _ver Sha3_256 =
+    toBuiltinMeaning _semvar Sha3_256 =
         makeBuiltinMeaning
             Hash.sha3_256
             (runCostingFunOneArgument . paramSha3_256)
-    toBuiltinMeaning _ver Blake2b_256 =
+    toBuiltinMeaning _semvar Blake2b_256 =
         makeBuiltinMeaning
             Hash.blake2b_256
             (runCostingFunOneArgument . paramBlake2b_256)
-    toBuiltinMeaning ver VerifyEd25519Signature =
+    toBuiltinMeaning semvar VerifyEd25519Signature =
         let verifyEd25519Signature =
-                case ver of
-                  DefaultFunBV1 -> verifyEd25519Signature_V1
-                  _             -> verifyEd25519Signature_V2
+                case semvar of
+                  DefaultFunSemanticsVariant1 -> verifyEd25519Signature_V1
+                  DefaultFunSemanticsVariant2 -> verifyEd25519Signature_V2
         in makeBuiltinMeaning
            verifyEd25519Signature
-           -- Benchmarks indicate that the two versions have very similar
+           -- Benchmarks indicate that the two variants have very similar
            -- execution times, so it's safe to use the same costing function for
            -- both.
            (runCostingFunThreeArguments . paramVerifyEd25519Signature)
@@ -1182,52 +1192,52 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
 
           https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#LOW_S
 
-       and the implementation of secp256k1_ecdsa_verify in
+       and the implementation of secp256k1_ecdsa_semvarify in
 
           https://github.com/bitcoin-core/secp256k1.
      -}
-    toBuiltinMeaning _ver VerifyEcdsaSecp256k1Signature =
+    toBuiltinMeaning _semvar VerifyEcdsaSecp256k1Signature =
         makeBuiltinMeaning
             verifyEcdsaSecp256k1Signature
             (runCostingFunThreeArguments . paramVerifyEcdsaSecp256k1Signature)
-    toBuiltinMeaning _ver VerifySchnorrSecp256k1Signature =
+    toBuiltinMeaning _semvar VerifySchnorrSecp256k1Signature =
         makeBuiltinMeaning
             verifySchnorrSecp256k1Signature
             (runCostingFunThreeArguments . paramVerifySchnorrSecp256k1Signature)
     -- Strings
-    toBuiltinMeaning _ver AppendString =
+    toBuiltinMeaning _semvar AppendString =
         makeBuiltinMeaning
             ((<>) @Text)
             (runCostingFunTwoArguments . paramAppendString)
-    toBuiltinMeaning _ver EqualsString =
+    toBuiltinMeaning _semvar EqualsString =
         makeBuiltinMeaning
             ((==) @Text)
             (runCostingFunTwoArguments . paramEqualsString)
-    toBuiltinMeaning _ver EncodeUtf8 =
+    toBuiltinMeaning _semvar EncodeUtf8 =
         makeBuiltinMeaning
             encodeUtf8
             (runCostingFunOneArgument . paramEncodeUtf8)
-    toBuiltinMeaning _ver DecodeUtf8 =
+    toBuiltinMeaning _semvar DecodeUtf8 =
         makeBuiltinMeaning
             (reoption @_ @EvaluationResult . decodeUtf8')
             (runCostingFunOneArgument . paramDecodeUtf8)
     -- Bool
-    toBuiltinMeaning _ver IfThenElse =
+    toBuiltinMeaning _semvar IfThenElse =
         makeBuiltinMeaning
             (\b x y -> if b then x else y)
             (runCostingFunThreeArguments . paramIfThenElse)
     -- Unit
-    toBuiltinMeaning _ver ChooseUnit =
+    toBuiltinMeaning _semvar ChooseUnit =
         makeBuiltinMeaning
             (\() a -> a)
             (runCostingFunTwoArguments . paramChooseUnit)
     -- Tracing
-    toBuiltinMeaning _ver Trace =
+    toBuiltinMeaning _semvar Trace =
         makeBuiltinMeaning
             (\text a -> a <$ emit text)
             (runCostingFunTwoArguments . paramTrace)
     -- Pairs
-    toBuiltinMeaning _ver FstPair =
+    toBuiltinMeaning _semvar FstPair =
         makeBuiltinMeaning
             fstPlc
             (runCostingFunOneArgument . paramFstPair)
@@ -1237,7 +1247,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
               DefaultUniPair uniA _ <- pure uniPairAB
               pure . fromValueOf uniA $ fst xy
           {-# INLINE fstPlc #-}
-    toBuiltinMeaning _ver SndPair =
+    toBuiltinMeaning _semvar SndPair =
         makeBuiltinMeaning
             sndPlc
             (runCostingFunOneArgument . paramSndPair)
@@ -1248,7 +1258,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
               pure . fromValueOf uniB $ snd xy
           {-# INLINE sndPlc #-}
     -- Lists
-    toBuiltinMeaning _ver ChooseList =
+    toBuiltinMeaning _semvar ChooseList =
         makeBuiltinMeaning
             choosePlc
             (runCostingFunThreeArguments . paramChooseList)
@@ -1260,7 +1270,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                 []    -> a
                 _ : _ -> b
           {-# INLINE choosePlc #-}
-    toBuiltinMeaning _ver MkCons =
+    toBuiltinMeaning _semvar MkCons =
         makeBuiltinMeaning
             consPlc
             (runCostingFunTwoArguments . paramMkCons)
@@ -1280,7 +1290,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                 Just Refl <- pure $ uniA `geq` uniA'
                 pure . fromValueOf uniListA $ x : xs
           {-# INLINE consPlc #-}
-    toBuiltinMeaning _ver HeadList =
+    toBuiltinMeaning _semvar HeadList =
         makeBuiltinMeaning
             headPlc
             (runCostingFunOneArgument . paramHeadList)
@@ -1291,7 +1301,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
               x : _ <- pure xs
               pure $ fromValueOf uniA x
           {-# INLINE headPlc #-}
-    toBuiltinMeaning _ver TailList =
+    toBuiltinMeaning _semvar TailList =
         makeBuiltinMeaning
             tailPlc
             (runCostingFunOneArgument . paramTailList)
@@ -1302,7 +1312,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
               _ : xs' <- pure xs
               pure $ fromValueOf uniListA xs'
           {-# INLINE tailPlc #-}
-    toBuiltinMeaning _ver NullList =
+    toBuiltinMeaning _semvar NullList =
         makeBuiltinMeaning
             nullPlc
             (runCostingFunOneArgument . paramNullList)
@@ -1314,7 +1324,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
           {-# INLINE nullPlc #-}
 
     -- Data
-    toBuiltinMeaning _ver ChooseData =
+    toBuiltinMeaning _semvar ChooseData =
         makeBuiltinMeaning
             (\d
               xConstr
@@ -1326,77 +1336,77 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
                     I      {} -> xI
                     B      {} -> xB)
             (runCostingFunSixArguments . paramChooseData)
-    toBuiltinMeaning _ver ConstrData =
+    toBuiltinMeaning _semvar ConstrData =
         makeBuiltinMeaning
             Constr
             (runCostingFunTwoArguments . paramConstrData)
-    toBuiltinMeaning _ver MapData =
+    toBuiltinMeaning _semvar MapData =
         makeBuiltinMeaning
             Map
             (runCostingFunOneArgument . paramMapData)
-    toBuiltinMeaning _ver ListData =
+    toBuiltinMeaning _semvar ListData =
         makeBuiltinMeaning
             List
             (runCostingFunOneArgument . paramListData)
-    toBuiltinMeaning _ver IData =
+    toBuiltinMeaning _semvar IData =
         makeBuiltinMeaning
             I
             (runCostingFunOneArgument . paramIData)
-    toBuiltinMeaning _ver BData =
+    toBuiltinMeaning _semvar BData =
         makeBuiltinMeaning
             B
             (runCostingFunOneArgument . paramBData)
-    toBuiltinMeaning _ver UnConstrData =
+    toBuiltinMeaning _semvar UnConstrData =
         makeBuiltinMeaning
             (\case
                 Constr i ds -> EvaluationSuccess (i, ds)
                 _           -> EvaluationFailure)
             (runCostingFunOneArgument . paramUnConstrData)
-    toBuiltinMeaning _ver UnMapData =
+    toBuiltinMeaning _semvar UnMapData =
         makeBuiltinMeaning
             (\case
                 Map es -> EvaluationSuccess es
                 _      -> EvaluationFailure)
             (runCostingFunOneArgument . paramUnMapData)
-    toBuiltinMeaning _ver UnListData =
+    toBuiltinMeaning _semvar UnListData =
         makeBuiltinMeaning
             (\case
                 List ds -> EvaluationSuccess ds
                 _       -> EvaluationFailure)
             (runCostingFunOneArgument . paramUnListData)
-    toBuiltinMeaning _ver UnIData =
+    toBuiltinMeaning _semvar UnIData =
         makeBuiltinMeaning
             (\case
                 I i -> EvaluationSuccess i
                 _   -> EvaluationFailure)
             (runCostingFunOneArgument . paramUnIData)
-    toBuiltinMeaning _ver UnBData =
+    toBuiltinMeaning _semvar UnBData =
         makeBuiltinMeaning
             (\case
                 B b -> EvaluationSuccess b
                 _   -> EvaluationFailure)
             (runCostingFunOneArgument . paramUnBData)
-    toBuiltinMeaning _ver EqualsData =
+    toBuiltinMeaning _semvar EqualsData =
         makeBuiltinMeaning
             ((==) @Data)
             (runCostingFunTwoArguments . paramEqualsData)
-    toBuiltinMeaning _ver SerialiseData =
+    toBuiltinMeaning _semvar SerialiseData =
         makeBuiltinMeaning
             (BSL.toStrict . serialise @Data)
             (runCostingFunOneArgument . paramSerialiseData)
     -- Misc constructors
-    toBuiltinMeaning _ver MkPairData =
+    toBuiltinMeaning _semvar MkPairData =
         makeBuiltinMeaning
             ((,) @Data @Data)
             (runCostingFunTwoArguments . paramMkPairData)
-    toBuiltinMeaning _ver MkNilData =
+    toBuiltinMeaning _semvar MkNilData =
         -- Nullary built-in functions don't work, so we need a unit argument.
         -- We don't really need this built-in function, see Note [Constants vs built-in functions],
         -- but we keep it around for historical reasons and convenience.
         makeBuiltinMeaning
             (\() -> [] @Data)
             (runCostingFunOneArgument . paramMkNilData)
-    toBuiltinMeaning _ver MkNilPairData =
+    toBuiltinMeaning _semvar MkNilPairData =
         -- Nullary built-in functions don't work, so we need a unit argument.
         -- We don't really need this built-in function, see Note [Constants vs built-in functions],
         -- but we keep it around for historical reasons and convenience.
@@ -1404,91 +1414,91 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
             (\() -> [] @(Data,Data))
             (runCostingFunOneArgument . paramMkNilPairData)
     -- BLS12_381.G1
-    toBuiltinMeaning _ver Bls12_381_G1_add =
+    toBuiltinMeaning _semvar Bls12_381_G1_add =
         makeBuiltinMeaning
             BLS12_381.G1.add
             (runCostingFunTwoArguments . paramBls12_381_G1_add)
-    toBuiltinMeaning _ver Bls12_381_G1_neg =
+    toBuiltinMeaning _semvar Bls12_381_G1_neg =
         makeBuiltinMeaning
             BLS12_381.G1.neg
             (runCostingFunOneArgument . paramBls12_381_G1_neg)
-    toBuiltinMeaning _ver Bls12_381_G1_scalarMul =
+    toBuiltinMeaning _semvar Bls12_381_G1_scalarMul =
         makeBuiltinMeaning
             BLS12_381.G1.scalarMul
             (runCostingFunTwoArguments . paramBls12_381_G1_scalarMul)
-    toBuiltinMeaning _ver Bls12_381_G1_compress =
+    toBuiltinMeaning _semvar Bls12_381_G1_compress =
         makeBuiltinMeaning
             BLS12_381.G1.compress
             (runCostingFunOneArgument . paramBls12_381_G1_compress)
-    toBuiltinMeaning _ver Bls12_381_G1_uncompress =
+    toBuiltinMeaning _semvar Bls12_381_G1_uncompress =
         makeBuiltinMeaning
             (eitherToEmitter . BLS12_381.G1.uncompress)
             (runCostingFunOneArgument . paramBls12_381_G1_uncompress)
-    toBuiltinMeaning _ver Bls12_381_G1_hashToGroup =
+    toBuiltinMeaning _semvar Bls12_381_G1_hashToGroup =
         makeBuiltinMeaning
             (eitherToEmitter .* BLS12_381.G1.hashToGroup)
             (runCostingFunTwoArguments . paramBls12_381_G1_hashToGroup)
-    toBuiltinMeaning _ver Bls12_381_G1_equal =
+    toBuiltinMeaning _semvar Bls12_381_G1_equal =
         makeBuiltinMeaning
             ((==) @BLS12_381.G1.Element)
             (runCostingFunTwoArguments . paramBls12_381_G1_equal)
     -- BLS12_381.G2
-    toBuiltinMeaning _ver Bls12_381_G2_add =
+    toBuiltinMeaning _semvar Bls12_381_G2_add =
         makeBuiltinMeaning
             BLS12_381.G2.add
             (runCostingFunTwoArguments . paramBls12_381_G2_add)
-    toBuiltinMeaning _ver Bls12_381_G2_neg =
+    toBuiltinMeaning _semvar Bls12_381_G2_neg =
         makeBuiltinMeaning
             BLS12_381.G2.neg
             (runCostingFunOneArgument . paramBls12_381_G2_neg)
-    toBuiltinMeaning _ver Bls12_381_G2_scalarMul =
+    toBuiltinMeaning _semvar Bls12_381_G2_scalarMul =
         makeBuiltinMeaning
             BLS12_381.G2.scalarMul
             (runCostingFunTwoArguments . paramBls12_381_G2_scalarMul)
-    toBuiltinMeaning _ver Bls12_381_G2_compress =
+    toBuiltinMeaning _semvar Bls12_381_G2_compress =
         makeBuiltinMeaning
             BLS12_381.G2.compress
             (runCostingFunOneArgument . paramBls12_381_G2_compress)
-    toBuiltinMeaning _ver Bls12_381_G2_uncompress =
+    toBuiltinMeaning _semvar Bls12_381_G2_uncompress =
         makeBuiltinMeaning
             (eitherToEmitter . BLS12_381.G2.uncompress)
             (runCostingFunOneArgument . paramBls12_381_G2_uncompress)
-    toBuiltinMeaning _ver Bls12_381_G2_hashToGroup =
+    toBuiltinMeaning _semvar Bls12_381_G2_hashToGroup =
         makeBuiltinMeaning
             (eitherToEmitter .* BLS12_381.G2.hashToGroup)
             (runCostingFunTwoArguments . paramBls12_381_G2_hashToGroup)
-    toBuiltinMeaning _ver Bls12_381_G2_equal =
+    toBuiltinMeaning _semvar Bls12_381_G2_equal =
         makeBuiltinMeaning
             ((==) @BLS12_381.G2.Element)
             (runCostingFunTwoArguments . paramBls12_381_G2_equal)
     -- BLS12_381.Pairing
-    toBuiltinMeaning _ver Bls12_381_millerLoop =
+    toBuiltinMeaning _semvar Bls12_381_millerLoop =
         makeBuiltinMeaning
             BLS12_381.Pairing.millerLoop
             (runCostingFunTwoArguments . paramBls12_381_millerLoop)
-    toBuiltinMeaning _ver Bls12_381_mulMlResult =
+    toBuiltinMeaning _semvar Bls12_381_mulMlResult =
         makeBuiltinMeaning
             BLS12_381.Pairing.mulMlResult
             (runCostingFunTwoArguments . paramBls12_381_mulMlResult)
-    toBuiltinMeaning _ver Bls12_381_finalVerify =
+    toBuiltinMeaning _semvar Bls12_381_finalVerify =
         makeBuiltinMeaning
             BLS12_381.Pairing.finalVerify
             (runCostingFunTwoArguments . paramBls12_381_finalVerify)
-    toBuiltinMeaning _ver Keccak_256 =
+    toBuiltinMeaning _semvar Keccak_256 =
         makeBuiltinMeaning
             Hash.keccak_256
             (runCostingFunOneArgument . paramKeccak_256)
-    toBuiltinMeaning _ver Blake2b_224 =
+    toBuiltinMeaning _semvar Blake2b_224 =
         makeBuiltinMeaning
             Hash.blake2b_224
             (runCostingFunOneArgument . paramBlake2b_224)
     -- See Note [Inlining meanings of builtins].
     {-# INLINE toBuiltinMeaning #-}
 
-instance Default (BuiltinVersion DefaultFun) where
-    def = DefaultFunBV2
+instance Default (BuiltinSemanticsVariant DefaultFun) where
+    def = DefaultFunSemanticsVariant2
 
-instance Pretty (BuiltinVersion DefaultFun) where
+instance Pretty (BuiltinSemanticsVariant DefaultFun) where
     pretty = viaShow
 
 -- It's set deliberately to give us "extra room" in the binary format to add things without running

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -83,9 +83,9 @@ mkMachineParameters ::
     , HasMeaningIn uni val
     , ToBuiltinMeaning uni fun
     )
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> CostModel machinecosts builtincosts
     -> MachineParameters machinecosts fun val
-mkMachineParameters ver (CostModel mchnCosts builtinCosts) =
-    MachineParameters mchnCosts (inline toBuiltinsRuntime ver builtinCosts)
+mkMachineParameters semvar (CostModel mchnCosts builtinCosts) =
+    MachineParameters mchnCosts (inline toBuiltinsRuntime semvar builtinCosts)
 {-# INLINE mkMachineParameters #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters/Default.hs
@@ -39,12 +39,13 @@ as we did have cases where sticking 'inline' on something that already had @INLI
 inlining).
 -}
 
-mkMachineParametersFor :: (MonadError CostModelApplyError m)
-                       => BuiltinVersion DefaultFun
-                       -> CostModelParams
-                       -> m DefaultMachineParameters
-mkMachineParametersFor ver newCMP =
-    inline mkMachineParameters ver <$>
+mkMachineParametersFor
+    :: (MonadError CostModelApplyError m)
+    => BuiltinSemanticsVariant DefaultFun
+    -> CostModelParams
+    -> m DefaultMachineParameters
+mkMachineParametersFor semvar newCMP =
+    inline mkMachineParameters semvar <$>
         applyCostModelParams defaultCekCostModel newCMP
 -- Not marking this function with @INLINE@, since at this point everything we wanted to be inlined
 -- is inlined and there's zero reason to duplicate thousands and thousands of lines of Core down

--- a/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/TypeCheck.hs
@@ -53,10 +53,12 @@ defKindCheckConfig = KindCheckConfig DetectNameMismatches
 -- corresponding 'Type' for each built-in function.
 builtinMeaningsToTypes
     :: (MonadKindCheck err term uni fun ann m, Typecheckable uni fun)
-    => BuiltinVersion fun -> ann -> m (BuiltinTypes uni fun)
-builtinMeaningsToTypes ver ann =
+    => BuiltinSemanticsVariant fun
+    -> ann
+    -> m (BuiltinTypes uni fun)
+builtinMeaningsToTypes semvar ann =
     runQuoteT . fmap BuiltinTypes . sequence . tabulateArray $ \fun -> do
-        let ty = typeOfBuiltinFunction ver fun
+        let ty = typeOfBuiltinFunction semvar fun
         _ <- inferKind defKindCheckConfig $ ann <$ ty
         dupable <$> normalizeType ty
 

--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -48,12 +48,12 @@ type Term uni fun = PLC.Term TyName Name uni fun ()
 test_builtinsDon'tThrow :: TestTree
 test_builtinsDon'tThrow =
     testGroup "Builtins don't throw" $
-        enumerate @(BuiltinVersion DefaultFun) <&> \ver ->
-            testGroup (fromString . render $ "Version: " <> pretty ver) $
-                let runtimes = toBuiltinsRuntime ver defaultBuiltinCostModel
+        enumerate @(BuiltinSemanticsVariant DefaultFun) <&> \semvar ->
+            testGroup (fromString . render $ "Version: " <> pretty semvar) $
+                let runtimes = toBuiltinsRuntime semvar defaultBuiltinCostModel
                 in enumerate @DefaultFun <&> \fun ->
                     -- Perhaps using @maxBound@ (with @Enum@, @Bounded@) is indeed better than
-                    -- @Default@ for BuiltinVersions
+                    -- @Default@ for BuiltinSemanticsVariants
                     testPropertyNamed
                         (display fun)
                         (fromString $ display fun)
@@ -79,15 +79,15 @@ instance Pretty AlwaysThrows where
 
 instance uni ~ DefaultUni => ToBuiltinMeaning uni AlwaysThrows where
     type CostingPart uni AlwaysThrows = ()
-    data BuiltinVersion AlwaysThrows = AlwaysThrowsV1
+    data BuiltinSemanticsVariant AlwaysThrows = AlwaysThrowsV1
 
-    toBuiltinMeaning _ver AlwaysThrows = makeBuiltinMeaning f $ \_ _ -> ExBudgetLast mempty
+    toBuiltinMeaning _semvar AlwaysThrows = makeBuiltinMeaning f $ \_ _ -> ExBudgetLast mempty
       where
         f :: Integer -> Integer
         f _ = error "This builtin function always throws an exception."
 
-instance Default (BuiltinVersion AlwaysThrows) where
-    def = AlwaysThrowsV1
+instance Default (BuiltinSemanticsVariant AlwaysThrows) where
+    def = AlwaysThrowsSemanticsVariant1
 
 {- | This test verifies that if evaluating a builtin function actually throws an exception,
  we'd get a `Left` value, which would cause `test_builtinsDon'tThrow` to fail.
@@ -97,11 +97,11 @@ test_alwaysThrows =
     testGroup
         "Builtins throwing exceptions should cause tests to fail"
         [ testPropertyNamed (display AlwaysThrows) (fromString . display $ AlwaysThrows) $
-            prop_builtinEvaluation @_ @AlwaysThrows runtimes AlwaysThrows (genArgsWellTyped ver) f
+            prop_builtinEvaluation @_ @AlwaysThrows runtimes AlwaysThrows (genArgsWellTyped semvar) f
         ]
   where
-    ver = AlwaysThrowsV1
-    runtimes = toBuiltinsRuntime ver ()
+    semvar = AlwaysThrowsSemanticsVariant1
+    runtimes = toBuiltinsRuntime semvar ()
     f bn args = \case
         Left _ -> success
         Right _ -> do
@@ -141,29 +141,29 @@ prop_builtinEvaluation runtimes bn mkGen f = property $ do
 genArgsWellTyped ::
     forall uni fun.
     (GenTypedTerm uni, ToBuiltinMeaning uni fun)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> fun
     -> Gen [Term uni fun]
-genArgsWellTyped ver = genArgs ver genTypedTerm
+genArgsWellTyped semvar = genArgs semvar genTypedTerm
 
 -- | Generate arbitrary (most likely ill-typed) Term arguments to a builtin function.
 genArgsArbitrary ::
     forall uni fun.
     (GenArbitraryTerm uni, ToBuiltinMeaning uni fun)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> fun ->
     Gen [Term uni fun]
-genArgsArbitrary ver = genArgs ver (\_ -> genArbitraryTerm @uni)
+genArgsArbitrary semvar = genArgs semvar (\_ -> genArbitraryTerm @uni)
 
 -- | Generate value arguments to a builtin function based on its `TypeScheme`.
 genArgs ::
     forall uni fun.
     ToBuiltinMeaning uni fun
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> (forall (a :: GHC.Type). TypeRep a -> Gen (Term uni fun))
     -> fun
     -> Gen [Term uni fun]
-genArgs ver genArg bn = sequenceA $ case meaning of
+genArgs semvar genArg bn = sequenceA $ case meaning of
     BuiltinMeaning tySch _ _ -> go tySch
       where
         go :: forall args res. TypeScheme (Term uni fun) args res -> [Gen (Term uni fun)]
@@ -173,7 +173,7 @@ genArgs ver genArg bn = sequenceA $ case meaning of
             TypeSchemeAll _ sch -> go sch
   where
     meaning :: BuiltinMeaning (Term uni fun) (CostingPart uni fun)
-    meaning = toBuiltinMeaning ver bn
+    meaning = toBuiltinMeaning semvar bn
 
 type family Head a where
     Head (x ': xs) = x

--- a/plutus-core/plutus-core/test/Evaluation/Spec.hs
+++ b/plutus-core/plutus-core/test/Evaluation/Spec.hs
@@ -79,7 +79,7 @@ instance Pretty AlwaysThrows where
 
 instance uni ~ DefaultUni => ToBuiltinMeaning uni AlwaysThrows where
     type CostingPart uni AlwaysThrows = ()
-    data BuiltinSemanticsVariant AlwaysThrows = AlwaysThrowsV1
+    data BuiltinSemanticsVariant AlwaysThrows = AlwaysThrowsSemanticsVariant1
 
     toBuiltinMeaning _semvar AlwaysThrows = makeBuiltinMeaning f $ \_ _ -> ExBudgetLast mempty
       where

--- a/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Analysis/RetainedSize.hs
@@ -175,12 +175,12 @@ hasSizeIn (DirectionRetentionMap ss) (Variable (PLC.Unique i)) = i `IntMap.membe
 -- | Compute the retention map of a term.
 termRetentionMap
     :: (HasUnique tyname TypeUnique, HasUnique name TermUnique, ToBuiltinMeaning uni fun)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> Term tyname name uni fun ann
     -> IntMap Size
-termRetentionMap ver term = depsRetentionMap sizeInfo deps where
+termRetentionMap semvar term = depsRetentionMap sizeInfo deps where
     sizeInfo = toDirectionRetentionMap term
-    deps = C.induce (hasSizeIn sizeInfo) $ fst $ runTermDeps ver term
+    deps = C.induce (hasSizeIn sizeInfo) $ fst $ runTermDeps semvar term
 
 -- | Apply a function to the annotation of each part of every 'Binding' in a term.
 reannotateBindings
@@ -217,12 +217,12 @@ reannotateBindings f = goTerm where
 -- | Annotate each part of every 'Binding' in a term with the size that it retains.
 annotateWithRetainedSize
     :: (HasUnique name TermUnique, HasUnique tyname TypeUnique, ToBuiltinMeaning uni fun)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> Term tyname name uni fun ann
     -> Term tyname name uni fun RetainedSize
 -- @reannotateBindings@ only processes annotations "associated with" a unique, so it can't change
 -- the type. Therefore we need to set all the bindings to an appropriate type beforehand.
-annotateWithRetainedSize ver term = reannotateBindings (upd . unUnique) $ NotARetainer <$ term where
-    retentionMap = termRetentionMap ver term
+annotateWithRetainedSize semvar term = reannotateBindings (upd . unUnique) $ NotARetainer <$ term where
+    retentionMap = termRetentionMap semvar term
     -- If a binding is not in the retention map, then it's still a retainer, just retains zero size.
     upd i _ = Retains $ IntMap.findWithDefault (Size 0) i retentionMap

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Types.hs
@@ -121,17 +121,20 @@ defaultCompilationOpts = CompilationOpts
   }
 
 data CompilationCtx uni fun a = CompilationCtx {
-    _ccOpts               :: CompilationOpts a
-    , _ccEnclosing        :: Provenance a
+    _ccOpts                      :: CompilationOpts a
+    , _ccEnclosing               :: Provenance a
     -- | Decide to either typecheck (passing a specific tcconfig) or not by passing 'Nothing'.
-    , _ccTypeCheckConfig  :: Maybe (PirTCConfig uni fun)
-    , _ccBuiltinVer       :: PLC.BuiltinVersion fun
-    , _ccBuiltinCostModel :: PLC.CostingPart uni fun
+    , _ccTypeCheckConfig         :: Maybe (PirTCConfig uni fun)
+    , _ccBuiltinSemanticsVariant :: PLC.BuiltinSemanticsVariant fun
+    , _ccBuiltinCostModel        :: PLC.CostingPart uni fun
     }
 
 makeLenses ''CompilationCtx
 
-toDefaultCompilationCtx :: (Default (PLC.BuiltinVersion fun), Default (PLC.CostingPart uni fun)) => PLC.TypeCheckConfig uni fun -> CompilationCtx uni fun a
+toDefaultCompilationCtx
+    :: (Default (PLC.BuiltinSemanticsVariant fun), Default (PLC.CostingPart uni fun))
+    => PLC.TypeCheckConfig uni fun
+    -> CompilationCtx uni fun a
 toDefaultCompilationCtx configPlc =
     CompilationCtx defaultCompilationOpts noProvenance
         (Just $ PirTCConfig configPlc YesEscape)

--- a/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Purity.hs
@@ -47,11 +47,11 @@ saturatesScheme (TermArg _ : _) TypeSchemeAll{}          = Nothing
 isSaturated
     :: forall tyname name uni fun a
     . ToBuiltinMeaning uni fun
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> BuiltinApp tyname name uni fun a
     -> Maybe Bool
-isSaturated ver (BuiltinApp fun args) =
-    case toBuiltinMeaning @uni @fun @(Term TyName Name uni fun ()) ver fun of
+isSaturated semvar (BuiltinApp fun args) =
+    case toBuiltinMeaning @uni @fun @(Term TyName Name uni fun ()) semvar fun of
         BuiltinMeaning sch _ _ -> saturatesScheme args sch
 
 -- | View a 'Term' as a 'BuiltinApp' if possible.
@@ -82,11 +82,11 @@ must be *conservative* (i.e. if you don't know, it's non-strict).
 -- things that can't be returned from the machine (as they'd be ill-scoped).
 isPure ::
     ToBuiltinMeaning uni fun =>
-    BuiltinVersion fun ->
+    BuiltinSemanticsVariant fun ->
     (name -> Strictness) ->
     Term tyname name uni fun a ->
     Bool
-isPure ver varStrictness = go
+isPure semvar varStrictness = go
     where
         go = \case
             -- See Note [Purity, strictness, and variables]
@@ -116,7 +116,7 @@ isPure ver varStrictness = go
 
             x | Just bapp@(BuiltinApp _ args) <- asBuiltinApp x ->
                 -- Pure only if we can tell that the builtin application is not saturated
-                maybe False not (isSaturated ver bapp)
+                maybe False not (isSaturated semvar bapp)
                 &&
                 -- But all the arguments need to also be effect-free, since they will be evaluated
                 -- when we evaluate the application.

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
@@ -32,25 +32,25 @@ import Witherable (Witherable (wither))
 removeDeadBindings
     :: (PLC.HasUnique name PLC.TermUnique,
        PLC.ToBuiltinMeaning uni fun, PLC.MonadQuote m)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> Term TyName name uni fun a
     -> m (Term TyName name uni fun a)
-removeDeadBindings ver t = do
+removeDeadBindings semvar t = do
     tRen <- PLC.rename t
-    liftQuote $ runReaderT (transformMOf termSubterms processTerm tRen) (calculateLiveness ver tRen)
+    liftQuote $ runReaderT (transformMOf termSubterms processTerm tRen) (calculateLiveness semvar tRen)
 
 type Liveness = Set.Set Deps.Node
 
 calculateLiveness
     :: (PLC.HasUnique name PLC.TermUnique, PLC.HasUnique tyname PLC.TypeUnique,
        PLC.ToBuiltinMeaning uni fun)
-    => PLC.BuiltinVersion fun
+    => PLC.BuiltinSemanticsVariant fun
     -> Term tyname name uni fun a
     -> Liveness
-calculateLiveness ver t =
+calculateLiveness semvar t =
     let
         depGraph :: G.Graph Deps.Node
-        depGraph = fst $ Deps.runTermDeps ver t
+        depGraph = fst $ Deps.runTermDeps semvar t
     in Set.fromList $ T.reachable depGraph Deps.Root
 
 live :: (MonadReader Liveness m, PLC.HasUnique n unique) => n -> m Bool

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/EvaluateBuiltins.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/EvaluateBuiltins.hs
@@ -23,11 +23,11 @@ evaluateBuiltins
   , Typeable name)
   => Bool
   -- ^ Whether to be conservative and try to retain logging behaviour.
-  -> BuiltinVersion fun
+  -> BuiltinSemanticsVariant fun
   -> CostingPart uni fun
   -> Term tyname name uni fun a
   -> Term tyname name uni fun a
-evaluateBuiltins conservative ver costModel = transformOf termSubterms processTerm
+evaluateBuiltins conservative semvar costModel = transformOf termSubterms processTerm
   where
     -- Nothing means "leave the original term as it was"
     eval
@@ -60,7 +60,7 @@ evaluateBuiltins conservative ver costModel = transformOf termSubterms processTe
     processTerm :: Term tyname name uni fun a -> Term tyname name uni fun a
     -- See Note [Context splitting in a recursive pass]
     processTerm t@(splitApplication -> (Builtin x bn, argCtx)) =
-      let runtime = toBuiltinRuntime costModel (toBuiltinMeaning ver bn)
+      let runtime = toBuiltinRuntime costModel (toBuiltinMeaning semvar bn)
       in case eval runtime argCtx of
            -- Builtin evaluation gives us a fresh term with no annotation.
            -- Use the annotation of the builtin node, arbitrarily. This is slightly

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
@@ -161,15 +161,15 @@ inline
     :: forall tyname name uni fun ann m
     . ExternalConstraints tyname name uni fun m
     => InlineHints name ann
-    -> PLC.BuiltinVersion fun
+    -> PLC.BuiltinSemanticsVariant fun
     -> Term tyname name uni fun ann
     -> m (Term tyname name uni fun ann)
-inline hints ver t = let
+inline hints semvar t = let
         inlineInfo :: InlineInfo name fun ann
-        inlineInfo = InlineInfo (snd deps) usgs hints ver
+        inlineInfo = InlineInfo (snd deps) usgs hints semvar
         -- We actually just want the variable strictness information here!
         deps :: (G.Graph Deps.Node, Map.Map PLC.Unique Strictness)
-        deps = Deps.runTermDeps ver t
+        deps = Deps.runTermDeps semvar t
         usgs :: Usages.Usages
         usgs = Usages.termUsages t
     in liftQuote $ flip evalStateT mempty $ flip runReaderT inlineInfo $ processTerm t

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
@@ -63,7 +63,7 @@ data InlineInfo name fun ann = InlineInfo
     , _iiHints                   :: InlineHints name ann
     -- ^ have we explicitly been told to inline?
     , _iiBuiltinSemanticsVariant :: PLC.BuiltinSemanticsVariant fun
-    -- ^ the builtin version.
+    -- ^ the semantics variant.
     }
 makeLenses ''InlineInfo
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Utils.hs
@@ -56,13 +56,13 @@ type InliningConstraints tyname name uni fun =
 --
 -- See [Inlining and global uniqueness] for caveats about this information.
 data InlineInfo name fun ann = InlineInfo
-    { _iiStrictnessMap :: Deps.StrictnessMap
+    { _iiStrictnessMap           :: Deps.StrictnessMap
     -- ^ Is it strict? Only needed for PIR, not UPLC
-    , _iiUsages        :: Usages.Usages
+    , _iiUsages                  :: Usages.Usages
     -- ^ how many times is it used?
-    , _iiHints         :: InlineHints name ann
+    , _iiHints                   :: InlineHints name ann
     -- ^ have we explicitly been told to inline?
-    , _iiBuiltinVer    :: PLC.BuiltinVersion fun
+    , _iiBuiltinSemanticsVariant :: PLC.BuiltinSemanticsVariant fun
     -- ^ the builtin version.
     }
 makeLenses ''InlineInfo
@@ -252,9 +252,9 @@ checkPurity
     => Term tyname name uni fun ann -> InlineM tyname name uni fun ann Bool
 checkPurity t = do
     strctMap <- view iiStrictnessMap
-    builtinVer <- view iiBuiltinVer
+    builtinSemVar <- view iiBuiltinSemanticsVariant
     let strictnessFun n' = Map.findWithDefault NonStrict (n' ^. theUnique) strctMap
-    pure $ isPure builtinVer strictnessFun t
+    pure $ isPure builtinSemVar strictnessFun t
 
 -- | Checks if a binding is pure, i.e. will evaluating it have effects
 isTermBindingPure :: forall tyname name uni fun ann. InliningConstraints tyname name uni fun

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/StrictifyBindings.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/StrictifyBindings.hs
@@ -14,20 +14,20 @@ import Control.Lens (transformOf)
 
 strictifyBindingsStep
     :: (ToBuiltinMeaning uni fun)
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> Term tyname name uni fun a
     -> Term tyname name uni fun a
-strictifyBindingsStep ver = \case
+strictifyBindingsStep semvar = \case
     Let a s bs t -> Let a s (fmap strictifyBinding bs) t
       where
         strictifyBinding (TermBind x NonStrict vd rhs)
-          | isPure ver (const NonStrict) rhs = TermBind x Strict vd rhs
+          | isPure semvar (const NonStrict) rhs = TermBind x Strict vd rhs
         strictifyBinding b = b
     t                                    -> t
 
 strictifyBindings
     :: (ToBuiltinMeaning uni fun)
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> Term tyname name uni fun a
     -> Term tyname name uni fun a
-strictifyBindings ver = transformOf termSubterms (strictifyBindingsStep ver)
+strictifyBindings semvar = transformOf termSubterms (strictifyBindingsStep semvar)

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -32,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit PLC.DefaultFunV1 defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -32,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit PLC.def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -8,6 +8,7 @@ import Evaluation.Builtins.Common
 
 import PlutusCore qualified as PLC
 import PlutusCore.Default qualified as PLC
+import PlutusCore.Default.Builtins qualified as Builtins (def)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
 import UntypedPlutusCore qualified as UPLC
@@ -32,7 +33,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit PLC.def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit Builtins.def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/BLS12_381/Utils.hs
@@ -7,10 +7,9 @@ where
 import Evaluation.Builtins.Common
 
 import PlutusCore qualified as PLC
-import PlutusCore.Default qualified as PLC
-import PlutusCore.Default.Builtins qualified as Builtins (def)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultBuiltinCostModel)
 import PlutusCore.MkPlc (builtin, mkConstant, mkIterAppNoAnn)
+import PlutusPrelude (def)
 import UntypedPlutusCore qualified as UPLC
 
 import Data.Bits (complement, xor, (.&.), (.|.))
@@ -33,7 +32,7 @@ data CekResult =
 
 evalTerm :: PlcTerm -> CekResult
 evalTerm term =
-    case typecheckEvaluateCekNoEmit Builtins.def defaultBuiltinCostModel term
+    case typecheckEvaluateCekNoEmit def defaultBuiltinCostModel term
     of Left e -> TypeCheckError e
        Right x  ->
            case x of

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Common.hs
@@ -34,18 +34,18 @@ typecheckAnd
     :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , Closed uni, uni `Everywhere` ExMemoryUsage
        )
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> (MachineParameters CekMachineCosts fun (CekValue uni fun ()) ->
             UPLC.Term Name uni fun () -> a)
     -> CostingPart uni fun -> TPLC.Term TyName Name uni fun () -> m a
-typecheckAnd ver action costingPart term = TPLC.runQuoteT $ do
-    -- here we don't use `getDefTypeCheckConfig`, to cover the
-    -- absurd case where versioned-builtins can change their type.
-    tcConfig <- TypeCheckConfig defKindCheckConfig <$> builtinMeaningsToTypes ver ()
+typecheckAnd semvar action costingPart term = TPLC.runQuoteT $ do
+    -- Here we don't use `getDefTypeCheckConfig`, to cover the absurd case where
+    -- builtins can change their type according to their BuiltinSemanticsVariant
+    tcConfig <- TypeCheckConfig defKindCheckConfig <$> builtinMeaningsToTypes semvar ()
     _ <- TPLC.inferType tcConfig term
     return . action runtime $ TPLC.eraseTerm term
     where
-      runtime = mkMachineParameters ver $
+      runtime = mkMachineParameters semvar $
                    CostModel defaultCekMachineCosts costingPart
 
 -- | Type check and evaluate a term, logging enabled.
@@ -53,22 +53,22 @@ typecheckEvaluateCek
     :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        )
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> CostingPart uni fun
     -> TPLC.Term TyName Name uni fun ()
     -> m (EvaluationResult (UPLC.Term Name uni fun ()), [Text])
-typecheckEvaluateCek ver = typecheckAnd ver $ unsafeEvaluateCek logEmitter
+typecheckEvaluateCek semvar = typecheckAnd semvar $ unsafeEvaluateCek logEmitter
 
 -- | Type check and evaluate a term, logging disabled.
 typecheckEvaluateCekNoEmit
     :: ( MonadError (TPLC.Error uni fun ()) m, TPLC.Typecheckable uni fun, GEq uni
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        )
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> CostingPart uni fun
     -> TPLC.Term TyName Name uni fun ()
     -> m (EvaluationResult (UPLC.Term Name uni fun ()))
-typecheckEvaluateCekNoEmit ver = typecheckAnd ver unsafeEvaluateCekNoEmit
+typecheckEvaluateCekNoEmit semvar = typecheckAnd semvar unsafeEvaluateCekNoEmit
 
 -- | Type check and convert a Plutus Core term to a Haskell value.
 typecheckReadKnownCek
@@ -76,8 +76,8 @@ typecheckReadKnownCek
        , uni `Everywhere` ExMemoryUsage, PrettyUni uni, Pretty fun
        , ReadKnown (UPLC.Term Name uni fun ()) a
        )
-    => BuiltinVersion fun
+    => BuiltinSemanticsVariant fun
     -> CostingPart uni fun
     -> TPLC.Term TyName Name uni fun ()
     -> m (Either (CekEvaluationException Name uni fun) a)
-typecheckReadKnownCek ver = typecheckAnd ver readKnownCek
+typecheckReadKnownCek semvar = typecheckAnd semvar readKnownCek

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -742,7 +742,7 @@ test_Version :: TestTree
 test_Version =
     testCase "Version" $ do
         let expr1 = apply () (builtin () $ Right ExtensionVersion) unitval
-        Right (EvaluationSuccess $ cons @Integer 0) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunV0) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @Integer 0) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunEV0) defaultBuiltinCostModelExt expr1
         Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def def) defaultBuiltinCostModelExt expr1
 
 -- | Check that 'ConsByteString' wraps around for plutus' builtin-version == 1, and fails in plutus's builtin-versions >=2.

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -737,7 +737,7 @@ test_Other = testCase "Other" $ do
     Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModel expr3
 
 -- | Check that 'ExtensionVersion' evaluates correctly.
--- See Note [Versioned builtins]
+-- See Note [Builtin semantics variants]
 test_Version :: TestTree
 test_Version =
     testCase "Version" $ do
@@ -746,7 +746,7 @@ test_Version =
         Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def def) defaultBuiltinCostModelExt expr1
 
 -- | Check that 'ConsByteString' wraps around for plutus' builtin-version == 1, and fails in plutus's builtin-versions >=2.
--- See Note [Versioned builtins]
+-- See Note [Builtin semantics variants]
 test_ConsByteString :: TestTree
 test_ConsByteString =
     testCase "ConsVersion" $ do

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -754,8 +754,8 @@ test_ConsByteString =
                              + 1 -- to make word8 wraparound
                              + 33 -- the index of '!' in ascii table
             expr1 = mkIterAppNoAnn (builtin () (Left ConsByteString :: DefaultFunExt)) [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
-        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV1 def) defaultBuiltinCostModelExt expr1
-        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunV2 def) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV1 def) defaultBuiltinCostModelExt expr1
+        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV2 def) defaultBuiltinCostModelExt expr1
         Right EvaluationFailure @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
 
 -- shorthand

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/Definition.hs
@@ -41,8 +41,8 @@ import PlutusCore.StdLib.Data.Unit
 
 import Evaluation.Builtins.BLS12_381 (test_BLS12_381)
 import Evaluation.Builtins.Common
-import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519_V1Prop,
-                                                  ed25519_V2Prop, schnorrSecp256k1Prop)
+import Evaluation.Builtins.SignatureVerification (ecdsaSecp256k1Prop, ed25519_Variant1Prop,
+                                                  ed25519_Variant2Prop, schnorrSecp256k1Prop)
 
 
 import Control.Exception
@@ -742,8 +742,10 @@ test_Version :: TestTree
 test_Version =
     testCase "Version" $ do
         let expr1 = apply () (builtin () $ Right ExtensionVersion) unitval
-        Right (EvaluationSuccess $ cons @Integer 0) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunEV0) defaultBuiltinCostModelExt expr1
-        Right (EvaluationSuccess $ cons @Integer 1) @=? typecheckEvaluateCekNoEmit (PairV @DefaultFun def def) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @Integer 0) @=?
+              typecheckEvaluateCekNoEmit (PairV @DefaultFun def ExtensionFunSemanticsVariant0) defaultBuiltinCostModelExt expr1
+        Right (EvaluationSuccess $ cons @Integer 1) @=?
+              typecheckEvaluateCekNoEmit (PairV @DefaultFun def def) defaultBuiltinCostModelExt expr1
 
 -- | Check that 'ConsByteString' wraps around for plutus' builtin-version == 1, and fails in plutus's builtin-versions >=2.
 -- See Note [Builtin semantics variants]
@@ -753,10 +755,14 @@ test_ConsByteString =
         let asciiBangWrapped = fromIntegral @Word8 @Integer maxBound
                              + 1 -- to make word8 wraparound
                              + 33 -- the index of '!' in ascii table
-            expr1 = mkIterAppNoAnn (builtin () (Left ConsByteString :: DefaultFunExt)) [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
-        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV1 def) defaultBuiltinCostModelExt expr1
-        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit (PairV DefaultFunBV2 def) defaultBuiltinCostModelExt expr1
-        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
+            expr1 = mkIterAppNoAnn (builtin () (Left ConsByteString :: DefaultFunExt))
+                    [cons @Integer asciiBangWrapped, cons @ByteString "hello world"]
+        Right (EvaluationSuccess $ cons @ByteString "!hello world")  @=?
+              typecheckEvaluateCekNoEmit (PairV DefaultFunSemanticsVariant1 def) defaultBuiltinCostModelExt expr1
+        Right EvaluationFailure @=? typecheckEvaluateCekNoEmit
+                  (PairV DefaultFunSemanticsVariant2 def) defaultBuiltinCostModelExt expr1
+        Right EvaluationFailure @=?
+              typecheckEvaluateCekNoEmit def defaultBuiltinCostModelExt expr1
 
 -- shorthand
 cons :: (DefaultUni `HasTermLevel` a, TermLike term tyname name DefaultUni fun) => a -> term ()
@@ -783,17 +789,17 @@ test_SignatureVerification :: TestTree
 test_SignatureVerification =
   adjustOption (\x -> max x . HedgehogTestLimit . Just $ 8000) .
   testGroup "Signature verification" $ [
-        testGroup "Ed25519 signatures (V1)"
+        testGroup "Ed25519 signatures (Variant1)"
                       [ testPropertyNamed
-                        "Ed25519_V1 verification behaves correctly on all inputs"
-                        "ed25519_V1_correct"
-                        . property $ ed25519_V1Prop
+                        "Ed25519_Variant1 verification behaves correctly on all inputs"
+                        "ed25519_Variant1_correct"
+                        . property $ ed25519_Variant1Prop
                       ],
-        testGroup "Ed25519 signatures (V2)"
+        testGroup "Ed25519 signatures (Variant2)"
                       [ testPropertyNamed
-                        "Ed25519_V2 verification behaves correctly on all inputs"
-                        "ed25519_V2_correct"
-                        . property $ ed25519_V2Prop
+                        "Ed25519_Variant2 verification behaves correctly on all inputs"
+                        "ed25519_Variant2_correct"
+                        . property $ ed25519_Variant2Prop
                       ],
         testGroup "Signatures on the SECP256k1 curve"
                       [ testPropertyNamed

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -10,8 +10,8 @@
 
 module Evaluation.Builtins.SignatureVerification (
   ecdsaSecp256k1Prop,
-  ed25519_V1Prop,
-  ed25519_V2Prop,
+  ed25519_Variant1Prop,
+  ed25519_Variant2Prop,
   schnorrSecp256k1Prop,
   ) where
 
@@ -75,11 +75,11 @@ ed25519Prop semvar = do
   cover 18 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
   runTestDataWith semvar testCase id VerifyEd25519Signature
 
-ed25519_V1Prop :: PropertyT IO ()
-ed25519_V1Prop = ed25519Prop DefaultFunBV1
+ed25519_Variant1Prop :: PropertyT IO ()
+ed25519_Variant1Prop = ed25519Prop DefaultFunSemanticsVariant1
 
-ed25519_V2Prop :: PropertyT IO ()
-ed25519_V2Prop = ed25519Prop DefaultFunBV2
+ed25519_Variant2Prop :: PropertyT IO ()
+ed25519_Variant2Prop = ed25519Prop DefaultFunSemanticsVariant2
 
 -- Helpers
 

--- a/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/test/Evaluation/Builtins/SignatureVerification.hs
@@ -76,10 +76,10 @@ ed25519Prop ver = do
   runTestDataWith ver testCase id VerifyEd25519Signature
 
 ed25519_V1Prop :: PropertyT IO ()
-ed25519_V1Prop = ed25519Prop DefaultFunV1
+ed25519_V1Prop = ed25519Prop DefaultFunBV1
 
 ed25519_V2Prop :: PropertyT IO ()
-ed25519_V2Prop = ed25519Prop DefaultFunV2
+ed25519_V2Prop = ed25519Prop DefaultFunBV2
 
 -- Helpers
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -127,9 +127,13 @@ See Note [Inlining meanings of builtins].
 IMPORTANT: The evaluation context of every Plutus version must be recreated upon a protocol update
 with the updated cost model parameters.
 -}
-mkDynEvaluationContext :: MonadError CostModelApplyError m => BuiltinVersion DefaultFun -> Plutus.CostModelParams -> m EvaluationContext
-mkDynEvaluationContext ver newCMP =
-    EvaluationContext <$> mkMachineParametersFor ver newCMP
+mkDynEvaluationContext
+    :: MonadError CostModelApplyError m
+    => BuiltinSemanticsVariant DefaultFun
+    -> Plutus.CostModelParams
+    -> m EvaluationContext
+mkDynEvaluationContext semvar newCMP =
+    EvaluationContext <$> mkMachineParametersFor semvar newCMP
 
 -- FIXME: remove this function
 assertWellFormedCostModelParams :: MonadError CostModelApplyError m => Plutus.CostModelParams -> m ()

--- a/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Common/Eval.hs
@@ -119,7 +119,7 @@ newtype EvaluationContext = EvaluationContext
     deriving stock Generic
     deriving anyclass (NFData, NoThunks)
 
-{-|  Create an 'EvaluationContext' for a given plutus-builtins' version.
+{-|  Create an 'EvaluationContext' for a given builtin semantics variant.
 
 The input is a `Map` of `Text`s to cost integer values (aka `Plutus.CostModelParams`, `Alonzo.CostModel`)
 See Note [Inlining meanings of builtins].
@@ -174,12 +174,12 @@ Note: Parameterized over the 'LedgerPlutusVersion' since
 -}
 evaluateScriptRestricting
     :: PlutusLedgerLanguage -- ^ The Plutus ledger language of the script under execution.
-    -> ProtocolVersion -- ^ Which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
-    -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> ExBudget        -- ^ The resource budget which must not be exceeded during evaluation
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [Plutus.Data]          -- ^ The arguments to the script
+    -> ProtocolVersion      -- ^ Which protocol version to run the operation in
+    -> VerboseMode          -- ^ Whether to produce log output
+    -> EvaluationContext    -- ^ Includes the cost model to use for tallying up the execution costs
+    -> ExBudget             -- ^ The resource budget which must not be exceeded during evaluation
+    -> SerialisedScript     -- ^ The script to evaluate
+    -> [Plutus.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptRestricting lv pv verbose ectx budget p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate lv pv p args
@@ -198,11 +198,11 @@ Note: Parameterized over the ledger-plutus-version since the builtins allowed (d
 -}
 evaluateScriptCounting
     :: PlutusLedgerLanguage -- ^ The Plutus ledger language of the script under execution.
-    -> ProtocolVersion -- ^ Which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
-    -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [Plutus.Data]          -- ^ The arguments to the script
+    -> ProtocolVersion      -- ^ Which protocol version to run the operation in
+    -> VerboseMode          -- ^ Whether to produce log output
+    -> EvaluationContext    -- ^ Includes the cost model to use for tallying up the execution costs
+    -> SerialisedScript     -- ^ The script to evaluate
+    -> [Plutus.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptCounting lv pv verbose ectx p args = swap $ runWriter @LogOutput $ runExceptT $ do
     appliedTerm <- mkTermToEvaluate lv pv p args

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -145,10 +145,11 @@ anything, we're just going to create new versions.
 
 -- | Check if a 'Script' is "valid" according to a protocol version. At the moment this means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and the script does not mention any builtins unavailable in the given protocol version.
-assertScriptWellFormed :: MonadError ScriptDecodeError m
-                       => ProtocolVersion -- ^ which protocol version to run the operation in
-                       -> SerialisedScript -- ^ the script to check for well-formedness
-                       -> m ()
+assertScriptWellFormed
+    :: MonadError ScriptDecodeError m
+    => ProtocolVersion -- ^ which protocol version to run the operation in
+    -> SerialisedScript -- ^ the script to check for well-formedness
+    -> m ()
 assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 
 -- | Evaluates a script, returning the minimum budget that the script would need
@@ -156,11 +157,11 @@ assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 -- limit the execution time of the script also, you can use 'evaluateScriptRestricting', which
 -- also returns the used budget.
 evaluateScriptCounting
-    :: ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
+    :: ProtocolVersion   -- ^ Which protocol version to run the operation in
+    -> VerboseMode       -- ^ Whether to produce log output
     -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    -> SerialisedScript  -- ^ The script to evaluate
+    -> [PLC.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 
@@ -171,11 +172,11 @@ evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 -- Can be used to calculate budgets for scripts, but even in this case you must give
 -- a limit to guard against scripts that run for a long time or loop.
 evaluateScriptRestricting
-    :: ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
+    :: ProtocolVersion   -- ^ Which protocol version to run the operation in
+    -> VerboseMode       -- ^ Whether to produce log output
     -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> ExBudget        -- ^ The resource budget which must not be exceeded during evaluation
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    -> ExBudget          -- ^ The resource budget which must not be exceeded during evaluation
+    -> SerialisedScript  -- ^ The script to evaluate
+    -> [PLC.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptRestricting = Common.evaluateScriptRestricting thisLedgerLanguage

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -11,7 +11,7 @@ module PlutusLedgerApi.V1.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.ParamName as V1
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -30,4 +30,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V1.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/EvaluationContext.hs
@@ -11,7 +11,7 @@ module PlutusLedgerApi.V1.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.ParamName as V1
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
+import PlutusCore.Default as Plutus (BuiltinSemanticsVariant (DefaultFunSemanticsVariant1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -30,4 +30,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V1.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunSemanticsVariant1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -125,10 +125,11 @@ thisLedgerLanguage = PlutusV2
 
 -- | Check if a 'Script' is "valid" according to a protocol version. At the moment this means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and the script does not mention any builtins unavailable in the given protocol version.
-assertScriptWellFormed :: MonadError ScriptDecodeError  m
-                       => ProtocolVersion -- ^ which protocol version to run the operation in
-                       -> SerialisedScript -- ^ the script to check for well-formedness
-                       -> m ()
+assertScriptWellFormed
+    :: MonadError ScriptDecodeError  m
+    => ProtocolVersion -- ^ which protocol version to run the operation in
+    -> SerialisedScript -- ^ the script to check for well-formedness
+    -> m ()
 assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 
 -- | Evaluates a script, returning the minimum budget that the script would need
@@ -136,11 +137,11 @@ assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 -- limit the execution time of the script also, you can use 'evaluateScriptRestricting', which
 -- also returns the used budget.
 evaluateScriptCounting
-    :: ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
+    :: ProtocolVersion   -- ^ Which protocol version to run the operation in
+    -> VerboseMode       -- ^ Whether to produce log output
     -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    -> SerialisedScript  -- ^ The script to evaluate
+    -> [PLC.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 
@@ -151,11 +152,11 @@ evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 -- Can be used to calculate budgets for scripts, but even in this case you must give
 -- a limit to guard against scripts that run for a long time or loop.
 evaluateScriptRestricting
-    :: ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
+    :: ProtocolVersion   -- ^ Which protocol version to run the operation in
+    -> VerboseMode       -- ^ Whether to produce log output
     -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> ExBudget        -- ^ The resource budget which must not be exceeded during evaluation
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    -> ExBudget          -- ^ The resource budget which must not be exceeded during evaluation
+    -> SerialisedScript  -- ^ The script to evaluate
+    -> [PLC.Data]        -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptRestricting = Common.evaluateScriptRestricting thisLedgerLanguage

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V2.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V2.ParamName as V2
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV1))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V2.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia      #-}
 {-# LANGUAGE TypeApplications #-}
 module PlutusLedgerApi.V2.EvaluationContext
     ( EvaluationContext

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V2.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V2.ParamName as V2
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV1))
+import PlutusCore.Default as Plutus (BuiltinSemanticsVariant (DefaultFunSemanticsVariant1))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V2.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunBV1
+                    >=> mkDynEvaluationContext Plutus.DefaultFunSemanticsVariant1

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -136,10 +136,11 @@ thisLedgerLanguage = PlutusV3
 
 -- | Check if a 'Script' is "valid" according to a protocol version. At the moment this means "deserialises correctly", which in particular
 -- implies that it is (almost certainly) an encoded script and the script does not mention any builtins unavailable in the given protocol version.
-assertScriptWellFormed :: MonadError ScriptDecodeError m
-                       => Common.ProtocolVersion -- ^ which protocol version to run the operation in
-                       -> SerialisedScript -- ^ the script to check for well-formedness
-                       -> m ()
+assertScriptWellFormed
+    :: MonadError ScriptDecodeError m
+    => Common.ProtocolVersion -- ^ which protocol version to run the operation in
+    -> SerialisedScript -- ^ the script to check for well-formedness
+    -> m ()
 assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 
 -- | Evaluates a script, returning the minimum budget that the script would need
@@ -147,11 +148,11 @@ assertScriptWellFormed = Common.assertScriptWellFormed thisLedgerLanguage
 -- limit the execution time of the script also, you can use 'evaluateScriptRestricting', which
 -- also returns the used budget.
 evaluateScriptCounting
-    :: Common.ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
-    -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    :: Common.ProtocolVersion -- ^ Which protocol version to run the operation in
+    -> VerboseMode            -- ^ Whether to produce log output
+    -> EvaluationContext      -- ^ Includes the cost model to use for tallying up the execution costs
+    -> SerialisedScript       -- ^ The script to evaluate
+    -> [PLC.Data]             -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 
@@ -162,11 +163,11 @@ evaluateScriptCounting = Common.evaluateScriptCounting thisLedgerLanguage
 -- Can be used to calculate budgets for scripts, but even in this case you must give
 -- a limit to guard against scripts that run for a long time or loop.
 evaluateScriptRestricting
-    :: Common.ProtocolVersion -- ^ which protocol version to run the operation in
-    -> VerboseMode     -- ^ Whether to produce log output
-    -> EvaluationContext -- ^ Includes the cost model to use for tallying up the execution costs
-    -> ExBudget        -- ^ The resource budget which must not be exceeded during evaluation
-    -> SerialisedScript          -- ^ The script to evaluate
-    -> [PLC.Data]          -- ^ The arguments to the script
+    :: Common.ProtocolVersion -- ^ Which protocol version to run the operation in
+    -> VerboseMode            -- ^ Whether to produce log output
+    -> EvaluationContext      -- ^ Includes the cost model to use for tallying up the execution costs
+    -> ExBudget               -- ^ The resource budget which must not be exceeded during evaluation
+    -> SerialisedScript       -- ^ The script to evaluate
+    -> [PLC.Data]             -- ^ The arguments to the script
     -> (LogOutput, Either EvaluationError ExBudget)
 evaluateScriptRestricting = Common.evaluateScriptRestricting thisLedgerLanguage

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V3.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V3.ParamName as V3
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV2))
+import PlutusCore.Default as Plutus (BuiltinSemanticsVariant (DefaultFunSemanticsVariant2))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V3.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunBV2
+                    >=> mkDynEvaluationContext Plutus.DefaultFunSemanticsVariant2

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia      #-}
 {-# LANGUAGE TypeApplications #-}
 module PlutusLedgerApi.V3.EvaluationContext
     ( EvaluationContext

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/EvaluationContext.hs
@@ -12,7 +12,7 @@ module PlutusLedgerApi.V3.EvaluationContext
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V3.ParamName as V3
 
-import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunV2))
+import PlutusCore.Default as Plutus (BuiltinVersion (DefaultFunBV2))
 
 import Control.Monad
 import Control.Monad.Except
@@ -31,4 +31,4 @@ mkEvaluationContext :: (MonadError CostModelApplyError m, MonadWriter [CostModel
                     -> m EvaluationContext
 mkEvaluationContext = tagWithParamNames @V3.ParamName
                     >=> pure . toCostModelParams
-                    >=> mkDynEvaluationContext Plutus.DefaultFunV2
+                    >=> mkDynEvaluationContext Plutus.DefaultFunBV2

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/EvaluationEvent.hs
@@ -143,8 +143,8 @@ data TestFailure
 renderTestFailure :: TestFailure -> String
 renderTestFailure = \case
     InvalidResult err -> display err
-    MissingCostParametersFor ver -> [fmt|
-        Missing cost parameters for {show ver}.
+    MissingCostParametersFor lang -> [fmt|
+        Missing cost parameters for {show lang}.
         Report this as a bug against the script dumper in plutus-apps.
     |]
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -276,9 +276,9 @@ defineBuiltinTerm :: CompilingDefault uni fun m ann => Ann -> TH.Name -> PIRTerm
 defineBuiltinTerm ann name term = do
     ghcId <- GHC.tyThingId <$> getThing name
     var <- compileVarFresh ann ghcId
-    ver <- asks ccBuiltinVer
+    semvar <- asks ccBuiltinSemanticsVariant
     -- See Note [Builtin terms and values]
-    let strictness = if PIR.isPure ver (const PIR.NonStrict) term then PIR.Strict else PIR.NonStrict
+    let strictness = if PIR.isPure semvar (const PIR.NonStrict) term then PIR.Strict else PIR.NonStrict
         def = PIR.Def var (term, strictness)
     PIR.defineTerm (LexName $ GHC.getName ghcId) def mempty
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -650,7 +650,7 @@ compileExpr ::
   m (PIRTerm uni fun)
 compileExpr e = traceCompilation 2 ("Compiling expr:" GHC.<+> GHC.ppr e) $ do
   -- See Note [Scopes]
-  CompileContext{ccScope = scope, ccNameInfo = nameInfo, ccModBreaks = maybeModBreaks, ccBuiltinVer = ver} <- ask
+  CompileContext{ccScope = scope, ccNameInfo = nameInfo, ccModBreaks = maybeModBreaks, ccBuiltinSemanticsVariant = semvar} <- ask
 
   -- TODO: Maybe share this to avoid repeated lookups. Probably cheap, though.
   (stringTyName, sbsName) <- case (Map.lookup ''Builtins.BuiltinString nameInfo, Map.lookup 'Builtins.stringToBuiltinString nameInfo) of
@@ -859,7 +859,7 @@ compileExpr e = traceCompilation 2 ("Compiling expr:" GHC.<+> GHC.ppr e) $ do
               return (nonDelayedAlt, delayedAlt)
             Nothing -> throwSd CompilationError $ "No alternative for:" GHC.<+> GHC.ppr dc
         let
-          isPureAlt = compiledAlts <&> \(nonDelayed, _) -> PIR.isPure ver (const PIR.NonStrict) nonDelayed
+          isPureAlt = compiledAlts <&> \(nonDelayed, _) -> PIR.isPure semvar (const PIR.NonStrict) nonDelayed
           lazyCase = not (and isPureAlt || length dcs == 1)
           branches =
             compiledAlts <&> \(nonDelayedAlt, delayedAlt) ->

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Types.hs
@@ -49,17 +49,17 @@ data CompileOptions = CompileOptions {
     }
 
 data CompileContext uni fun = CompileContext {
-    ccOpts             :: CompileOptions,
-    ccFlags            :: GHC.DynFlags,
-    ccFamInstEnvs      :: GHC.FamInstEnvs,
-    ccNameInfo         :: NameInfo,
-    ccScope            :: Scope uni,
-    ccBlackholed       :: Set.Set GHC.Name,
-    ccCurDef           :: Maybe LexName,
-    ccModBreaks        :: Maybe GHC.ModBreaks,
-    ccBuiltinVer       :: PLC.BuiltinVersion fun,
-    ccBuiltinCostModel :: PLC.CostingPart uni fun,
-    ccDebugTraceOn     :: Bool
+    ccOpts                    :: CompileOptions,
+    ccFlags                   :: GHC.DynFlags,
+    ccFamInstEnvs             :: GHC.FamInstEnvs,
+    ccNameInfo                :: NameInfo,
+    ccScope                   :: Scope uni,
+    ccBlackholed              :: Set.Set GHC.Name,
+    ccCurDef                  :: Maybe LexName,
+    ccModBreaks               :: Maybe GHC.ModBreaks,
+    ccBuiltinSemanticsVariant :: PLC.BuiltinSemanticsVariant fun,
+    ccBuiltinCostModel        :: PLC.CostingPart uni fun,
+    ccDebugTraceOn            :: Bool
     }
 
 data CompileState = CompileState

--- a/plutus-tx-plugin/src/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Plugin.hs
@@ -404,7 +404,7 @@ compileMarkedExpr locStr codeTy origE = do
             ccBlackholed = mempty,
             ccCurDef = Nothing,
             ccModBreaks = modBreaks,
-            ccBuiltinVer = def,
+            ccBuiltinSemanticsVariant = def,
             ccBuiltinCostModel = def,
             ccDebugTraceOn = _posDumpCompilationTrace opts
             }
@@ -500,7 +500,7 @@ runCompiler moduleName opts expr = do
                     (if plcVersion < PLC.plcVersion110
                         then PIR.ScottEncoding else PIR.SumsOfProducts)
                  -- TODO: ensure the same as the one used in the plugin
-                 & set PIR.ccBuiltinVer def
+                 & set PIR.ccBuiltinSemanticsVariant def
                  & set PIR.ccBuiltinCostModel def
         plcOpts = PLC.defaultCompilationOpts
             & set (PLC.coSimplifyOpts . UPLC.soMaxSimplifierIterations)

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -197,14 +197,14 @@ typeCheckAgainst p (PLC.Program _ v plcTerm) = do
         ty <- Lift.typeRep p
         pure $ TyInst () PLC.idFun ty
     let applied = Apply () idFun term
-    -- Here we use a 'Default' builtin version, because the typechecker needs
-    -- to be handed a builtin version (implementation detail).
-    -- See Note [Versioned builtins]
+    -- Here we use a 'Default' builtin semantics variant, because the
+    -- typechecker needs to be handed a builtin semantics variant (implementation detail).
+    -- See Note [Builtin semantics variants]
     tcConfig <- PLC.getDefTypeCheckConfig (Original ())
-    -- The PIR compiler *pointfully* needs a builtin version, but in this instance of only "lifting"
-    -- it is safe to default to any builtin version, since the 'Lift'
-    -- is impervious to builtins and will not generate code containing builtins.
-    -- See Note [Versioned builtins]
+    -- The PIR compiler *pointfully* needs a builtin semantics variant, but in
+    -- this instance of only "lifting" it is safe to default to any builtin
+    -- semantics variant, since the 'Lift' is impervious to builtins and will
+    -- not generate code containing builtins.  See Note [Builtin semantics variants]
     compiled <- flip runReaderT (toDefaultCompilationCtx tcConfig) $ compileProgram (Program () v applied)
     -- PLC errors are parameterized over PLC.Terms, whereas PIR errors over PIR.Terms and as such, these prism errors cannot be unified.
     -- We instead run the ExceptT, collect any PLC error and explicitly lift into a PIR error by wrapping with PIR._PLCError


### PR DESCRIPTION
[PLT-7306]

The `ToBuiltinMeaning` class in PlutusCore.Builtin.Meaning has an associated class called `BuiltinVersion` and in PlutusCore.Default.Builtins this is instantiated as `data BuiltinVersion DefaultFun = DefaultFunV1 | DefaultFunV2`
This risks confusion with PlutusV1, PlutusV2 etc. (as seen in [this issue](https://github.com/input-output-hk/plutus/issues/5475)).

After some Slack discussion we’ve decided to rename `BuiltinVersion` to `BuiltinSemanticsVariant` and `DefaultFunV1` to `DefaultFunSemanticsVariant1` , etc. I've also tried to remove all mentions of "builtin versions" in comments.

[PLT-7306]: https://input-output.atlassian.net/browse/PLT-7306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ