### PR TITLE
Update the download link and the date on the specification

### DIFF
--- a/doc/plutus-core-spec/Makefile
+++ b/doc/plutus-core-spec/Makefile
@@ -29,6 +29,7 @@ ${DOC}.pdf: ${SRC} ${BIB}
         # ^ Putting this later seems to get page references out of sync.
 	${LATEX}  ${DOC}
 	${LATEX}  ${DOC}
+	${LATEX}  ${DOC}
 
 figs:
 	cd ${FIGS} && ${MAKE}

--- a/doc/plutus-core-spec/README.md
+++ b/doc/plutus-core-spec/README.md
@@ -2,7 +2,9 @@ This directory contains a draft of a version of the Plutus Core specification
 updated so that the language is parametric over a collection of built-in types
 and functions.  It also updates the specification to reflect the fact that
 built-in functions can now be partially applied.  Click
-[here](./plutus-core-specification.pdf) to open the PDF.
+[here](https://ci.iog.io/job/input-output-hk-plutus/master/x86_64-linux.packages.plutus-core-spec/latest/download/1)
+to open a PDF of the most recent version of the specification in the main branch
+of this repository.
 
 This version is currently restricted to untyped Plutus Core only. We will add a
 specification of a typed version of Plutus Core at a later date.  For the time

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -1,7 +1,7 @@
 \documentclass[a4paper]{report}
 
 \title{Formal Specification of\\the Plutus Core Language}
-\date{August 2024}
+\date{1st September 2023}
 \author{Plutus Core Team}
 
 \input{header.tex}


### PR DESCRIPTION
The README file in the directory containing the PLC specification had a broken link to the PDF (we don't have a checked-in PDF any more) and this is supposed to fix it.  I also changed the date on the PDF because it's not 2024 yet.