### PR TITLE
Add --builtin-semantics-version option to plc and uplc commands

### DIFF
--- a/plutus-core/changelog.d/20230901_114457_kenneth.mackenzie_builtin_semantics_option.md
+++ b/plutus-core/changelog.d/20230901_114457_kenneth.mackenzie_builtin_semantics_option.md
@@ -1,0 +1,4 @@
+### Added
+
+- A `-B`/`--builtin-semantics-variant` option for the `plc` and `uplc` commands to allow the user to select which variant of the builtin semantics to use.
+

--- a/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
+++ b/plutus-core/executables/src/PlutusCore/Executable/Parsers.hs
@@ -4,6 +4,7 @@
 
 module PlutusCore.Executable.Parsers where
 
+import PlutusCore.Default (BuiltinSemanticsVariant (..), DefaultFun)
 import PlutusCore.Executable.Types
 
 import Options.Applicative
@@ -159,6 +160,32 @@ exampleSingle = ExampleSingle <$> exampleName
 exampleOpts :: Parser ExampleOptions
 exampleOpts = ExampleOptions <$> exampleMode
 
+builtinSemanticsVariantReader :: String -> Maybe (BuiltinSemanticsVariant DefaultFun)
+builtinSemanticsVariantReader =
+    \case
+     "1" -> Just DefaultFunSemanticsVariant1
+     "2" -> Just DefaultFunSemanticsVariant2
+     _   -> Nothing
+
+-- This is used to make the help message show you what you actually need to type.
+showBuiltinSemanticsVariant :: BuiltinSemanticsVariant DefaultFun -> String
+showBuiltinSemanticsVariant =
+    \case
+     DefaultFunSemanticsVariant1 -> "1"
+     DefaultFunSemanticsVariant2 -> "2"
+
+builtinSemanticsVariant :: Parser (BuiltinSemanticsVariant DefaultFun)
+builtinSemanticsVariant = option (maybeReader builtinSemanticsVariantReader)
+  (  long "builtin-semantics-variant"
+  <> short 'B'
+  <> metavar "VARIANT"
+  <> value DefaultFunSemanticsVariant2
+  <> showDefaultWith showBuiltinSemanticsVariant
+  <> help
+    ("Builtin semantics variant: 1 -> DefaultFunSemanticsVariant1, "
+     <> "2 -> DefaultFunSemanticsVariant2"
+    )
+  )
 
 -- Specialised parsers for PIR, which only supports ASTs over the Textual and
 -- Named types.
@@ -191,6 +218,8 @@ pPirOutputFormat = option (maybeReader pirFormatReader)
   <> value TextualPir
   <> showDefault
   <> help ("Output format: " ++ pirFormatHelp))
+
+-- Which language: PLC or UPLC?
 
 languageReader :: String -> Maybe Language
 languageReader =

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExBudgetingDefaults.hs
@@ -4,7 +4,8 @@
 {-# LANGUAGE TypeFamilies    #-}
 
 module PlutusCore.Evaluation.Machine.ExBudgetingDefaults
-    ( defaultBuiltinsRuntime
+    ( defaultBuiltinsRuntimeForSemanticsVariant
+    , defaultBuiltinsRuntime
     , defaultCekCostModel
     , defaultCekMachineCosts
     , defaultCekParameters
@@ -90,7 +91,16 @@ unitCekParameters =
     noinline mkMachineParameters def $
         CostModel unitCekMachineCosts unitCostBuiltinCostModel
 
-defaultBuiltinsRuntime :: HasMeaningIn DefaultUni term => BuiltinsRuntime DefaultFun term
+defaultBuiltinsRuntimeForSemanticsVariant
+    :: HasMeaningIn DefaultUni term
+    => BuiltinSemanticsVariant DefaultFun
+    -> BuiltinsRuntime DefaultFun term
+-- See Note [noinline for saving on ticks].
+defaultBuiltinsRuntimeForSemanticsVariant semvar = noinline toBuiltinsRuntime semvar defaultBuiltinCostModel
+
+defaultBuiltinsRuntime
+    :: HasMeaningIn DefaultUni term
+    => BuiltinsRuntime DefaultFun term
 -- See Note [noinline for saving on ticks].
 defaultBuiltinsRuntime = noinline toBuiltinsRuntime def defaultBuiltinCostModel
 


### PR DESCRIPTION
This adds an option to the `plc` and `uplc` commands so that we can say which variant of the builtin semantics we want to use.
This is a step towards PLT-372, but we may want to make it take the ledger language version and/or the PLC language version configurable too.  That would probably require us to move the executables elsewhere though, maybe into a package of their own.

```
$ cat cons.plc
(program 1.0.0
[(builtin consByteString) (con integer 400) (con bytestring #213123213421)]
)

$ cabal run uplc evaluate -- -i cons.uplc -B1
(con bytestring #90213123213421)

$ cabal run uplc evaluate -- -i cons.uplc -B2
An error has occurred:  User error:
The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
Caused by: (consByteString 400 #213123213421)
