### PR TITLE
[Experiment] Turn off float in and float out and other simplifier passes.

### DIFF
--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -114,27 +114,27 @@ applyPass pass = runIf (_shouldRun pass) $ through check <=< \term -> do
 
 availablePasses :: [Pass uni fun]
 availablePasses =
-    [ Pass "unwrap cancel"        (onOption coDoSimplifierUnwrapCancel)       (pure . Unwrap.unwrapCancel)
-    , Pass "case reduce"          (onOption coDoSimplifierCaseReduce)         (pure . CaseReduce.caseReduce)
-    , Pass "known constructor"    (onOption coDoSimplifierKnownCon)           KnownCon.knownCon
-    , Pass "beta"                 (onOption coDoSimplifierBeta)               (pure . Beta.beta)
-    , Pass "strictify bindings"   (onOption coDoSimplifierStrictifyBindings)  (\t ->
-                                                                                 do
-                                                                                  semvar <- view ccBuiltinSemanticsVariant
-                                                                                  pure $ StrictifyBindings.strictifyBindings semvar t
-                                                                              )
-    , Pass "evaluate builtins"    (onOption coDoSimplifierEvaluateBuiltins)   (\t -> do
-                                                                                  semvar <- view ccBuiltinSemanticsVariant
-                                                                                  costModel <- view ccBuiltinCostModel
-                                                                                  preserveLogging <- view (ccOpts . coPreserveLogging)
-                                                                                  pure $ EvaluateBuiltins.evaluateBuiltins preserveLogging semvar costModel t
-                                                                              )
-    , Pass "inline"               (onOption coDoSimplifierInline)             (\t -> do
+    -- [ Pass "unwrap cancel"        (onOption coDoSimplifierUnwrapCancel)       (pure . Unwrap.unwrapCancel)
+    -- , Pass "case reduce"          (onOption coDoSimplifierCaseReduce)         (pure . CaseReduce.caseReduce)
+    -- , Pass "known constructor"    (onOption coDoSimplifierKnownCon)           KnownCon.knownCon
+    -- , Pass "beta"                 (onOption coDoSimplifierBeta)               (pure . Beta.beta)
+    -- , Pass "strictify bindings"   (onOption coDoSimplifierStrictifyBindings)  (\t ->
+    --                                                                              do
+    --                                                                               semvar <- view ccBuiltinSemanticsVariant
+    --                                                                               pure $ StrictifyBindings.strictifyBindings semvar t
+    --                                                                           )
+    -- , Pass "evaluate builtins"    (onOption coDoSimplifierEvaluateBuiltins)   (\t -> do
+    --                                                                               semvar <- view ccBuiltinSemanticsVariant
+    --                                                                               costModel <- view ccBuiltinCostModel
+    --                                                                               preserveLogging <- view (ccOpts . coPreserveLogging)
+    --                                                                               pure $ EvaluateBuiltins.evaluateBuiltins preserveLogging semvar costModel t
+    --                                                                           )
+    [ Pass "inline"               (onOption coDoSimplifierInline)             (\t -> do
                                                                                   hints <- view (ccOpts . coInlineHints)
                                                                                   semvar <- view ccBuiltinSemanticsVariant
                                                                                   Inline.inline hints semvar t
                                                                               )
-    , Pass "commuteFnWithConst" (onOption coDoSimplifiercommuteFnWithConst) (pure . CommuteFnWithConst.commuteFnWithConst)
+    -- , Pass "commuteFnWithConst" (onOption coDoSimplifiercommuteFnWithConst) (pure . CommuteFnWithConst.commuteFnWithConst)
     ]
 
 -- | Actual simplifier
@@ -234,10 +234,10 @@ compileToReadable (Program a v t) =
 compileReadableToPlc :: (Compiling m e uni fun a, b ~ Provenance a) => Program TyName Name uni fun b -> m (PLCProgram uni fun a)
 compileReadableToPlc (Program a v t) =
   let pipeline =
-        (<$ logVerbose "  !!! floatIn")
-        >=> floatIn
-        >=> through check
-        >=> (<$ logVerbose "  !!! compileNonStrictBindings")
+        -- (<$ logVerbose "  !!! floatIn")
+        -- >=> floatIn
+        -- >=> through check
+        (<$ logVerbose "  !!! compileNonStrictBindings")
         >=> NonStrict.compileNonStrictBindings False
         >=> through check
         >=> (<$ logVerbose "  !!! thunkRecursions")

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
@@ -23,6 +23,7 @@ import Control.Lens hiding (Strict)
 import Data.Foldable
 import Data.List.NonEmpty hiding (partition, reverse)
 import Data.List.NonEmpty qualified as NE
+import PlutusCore.Pretty (display)
 
 {- Note [Extra definitions while compiling let-bindings]
 The let-compiling passes can generate some additional definitions, so we use the
@@ -63,7 +64,12 @@ compileRecBindings kind body bs =
       case NE.head singleGroup of
          TermBind {} -> compileRecTermBindings kind body singleGroup
          DatatypeBind {} ->  lift $ compileRecDataBindings kind body singleGroup
-         TypeBind {} -> lift $ getEnclosing >>= \p -> throwing _Error $ CompilationError p "Type bindings cannot appear in recursive let, use datatypebind instead"
+         tb@TypeBind {} ->
+            lift $ getEnclosing >>= \p -> throwing _Error $
+                CompilationError p
+                    ("Type bindings cannot appear in recursive let, use datatypebind instead"
+                    <> "The type binding is \n "
+                    <> display tb)
     -- only one single group should appear, we do not allow mixing of bind styles
     _ -> lift $ getEnclosing >>= \p -> throwing _Error $ CompilationError p "Mixed term/type/data bindings in recursive let"
   where


### PR DESCRIPTION
Looks like when I turn off some passes the PIR compiler throws an error when building the script context tests.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
