### PR TITLE
Fix longitudinal benchmark

### DIFF
--- a/plutus-benchmark/validation/Common.hs
+++ b/plutus-benchmark/validation/Common.hs
@@ -129,7 +129,7 @@ benchWith act = do
 
     mkScriptBM :: FilePath -> FilePath -> Benchmark
     mkScriptBM dir file =
-        env (BS.readFile $ dir </> file) $ \scriptBS ->
+        env (BS.readFile $ dir </> file) $ \(~scriptBS) ->
             bench (dropExtension file) $ act file scriptBS
 
 -- | Create the evaluation context for the benchmarks. This doesn't exactly match how it's done
@@ -168,4 +168,3 @@ peelDataArguments = go []
             Left _  -> (t, acc)
             Right d -> go (d:acc) t'
         go acc t = (t, acc)
-


### PR DESCRIPTION
This was broken by https://github.com/input-output-hk/plutus/pull/5371

"The function that receives the environment must use lazy pattern matching": https://hackage.haskell.org/package/criterion-1.6.3.0/docs/Criterion.html#v:env

Otherwise
```
validation: Criterion atttempted to retrieve a non-existent environment!
	Perhaps you forgot to use lazy pattern matching in a function which
	constructs benchmarks from an environment?
	(see the documentation for `env` for details)
```