### PR TITLE
Add Documentation on GHC Extensions, Flags and Pragmas

### DIFF
--- a/doc/read-the-docs-site/extensions-flags-pragmas.rst
+++ b/doc/read-the-docs-site/extensions-flags-pragmas.rst
@@ -75,7 +75,7 @@ The most reliable solution, however, is to simply turn these optimizations off.
 Another option is to bump ``-funfolding-creation-threshold`` to make it more likely for GHC to retain unfoldings for functions without the ``INLINEABLE`` pragma.
 ``-fexpose-all-unfoldings`` should be used as a last resort.
 
-There's also the ``INLINE`` pragma, which does more than the ``INLINEABLE`` in that the ``INLINE`` pragma forces the Plutus IR optimizer to inline the function.
+There's also the ``INLINE`` pragma, which does more than ``INLINEABLE`` in that the ``INLINE`` pragma forces the Plutus IR optimizer to inline the function.
 This is not currently useful, and should be avoided.
 In the future, we plan to make the ``INLINE`` pragma part of the mechanism for making certain functions non-strict in their arguments.
 This is not yet implemented.

--- a/doc/read-the-docs-site/extensions-flags-pragmas.rst
+++ b/doc/read-the-docs-site/extensions-flags-pragmas.rst
@@ -40,12 +40,11 @@ GHC has a variety of optimization flags, many of which are on by default.
 Although Plutus Tx is, syntactically, a subset of Haskell, it has different semantics and a different evaluation strategy (Haskell: non-strict semantics, call by need; Plutus Tx: strict semantics, call by value).
 As a result, some GHC optimizations are not helpful for Plutus Tx programs, and can even be harmful, in the sense that it can make Plutus Tx programs less efficient, or fail to be compiled.
 An example is the full laziness optimization, controlled by GHC flag ``-ffull-laziness``, which floats let bindings out of lambdas whenever possible.
-Since Untyped Plutus Core does not employ lazy evaluation, the full laziness optimization is never beneficial, and can sometimes make a Plutus Tx program more expensive.
+Since Untyped Plutus Core does not employ lazy evaluation, the full laziness optimization is usually not beneficial, and can sometimes make a Plutus Tx program more expensive.
 Conversely, some GHC features must be turned on in order to ensure Plutus Tx programs are compiled successfully.
 
 All Plutus Tx modules should use the following GHC flags: ::
 
-  -fplugin PlutusTx.Plugin
   -fno-ignore-interface-pragmas
   -fno-omit-interface-pragmas
   -fno-full-laziness
@@ -55,9 +54,17 @@ All Plutus Tx modules should use the following GHC flags: ::
   -fno-unbox-strict-fields
   -fno-unbox-small-strict-fields
 
-``-fplugin PlutusTx.Plugin`` enables the Plutus Tx compiler.
 ``-fno-ignore-interface-pragmas`` and ``-fno-omit-interface-pragmas`` ensure unfoldings of Plutus Tx functions are available.
-The rest are GHC optimizations that are bad for Plutus Tx, and should thus be turned off.
+The rest are GHC optimizations that are generally bad for Plutus Tx, and should thus be turned off.
+
+These flags can be specified either in a Haskell module, e.g.: ::
+
+  {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+
+or in a build file. E.g., if your project is built using Cabal, you can add the flags to the ``.cabal`` files, like so:
+
+  ghc-options:
+    -fno-ignore-interface-pragmas
 
 Note that this section only covers GHC flags, not Plutus Tx compiler flags.
 Information about the latter can be found in :ref:`plutus_tx_options`.
@@ -76,8 +83,3 @@ Therefore, ``INLINEABLE`` is preferred over ``-fexpose-all-unfoldings`` even tho
 The most reliable solution, however, is to simply turn these optimizations off.
 Another option is to bump ``-funfolding-creation-threshold`` to make it more likely for GHC to retain unfoldings for functions without the ``INLINEABLE`` pragma.
 ``-fexpose-all-unfoldings`` should be used as a last resort.
-
-There's also the ``INLINE`` pragma, which does more than ``INLINEABLE`` in that the ``INLINE`` pragma forces the Plutus IR optimizer to inline the function.
-This is not currently useful, and should be avoided.
-In the future, we plan to make the ``INLINE`` pragma part of the mechanism for making certain functions non-strict in their arguments.
-This is not yet implemented.

--- a/doc/read-the-docs-site/extensions-flags-pragmas.rst
+++ b/doc/read-the-docs-site/extensions-flags-pragmas.rst
@@ -1,3 +1,5 @@
+.. _extensions_flags_pragmas:
+
 GHC Extensions, Flags and Pragmas
 =================================
 

--- a/doc/read-the-docs-site/extensions-flags-pragmas.rst
+++ b/doc/read-the-docs-site/extensions-flags-pragmas.rst
@@ -17,7 +17,7 @@ Plutus Tx modules should use the ``Strict`` extension: ::
 
 Unlike in Haskell, function applications in Plutus Tx are strict.
 In other words, when evaluating ``(\x -> 42) (3 + 4)`` the expression ``3 + 4`` is evaluated first, before evaluating the function body (``42``), even though ``x`` is not used in the function body.
-The ``Strict`` extension ensures that let bindings are also (by default) strict, for instance, evaluating
+The ``Strict`` extension ensures that let bindings and patterns are also (by default) strict, for instance, evaluating
 ``let x = 3 + 4 in 42`` evaluates ``3 + 4`` first, even though ``x`` is not used.
 
 Bang patterns and lazy patterns can be used to explicitly specify whether a let binding is strict or non-strict, as in ``let !x = 3 + 4 in 42`` (strict) and ``let ~x = 3 + 4 in 42`` (non-strict).

--- a/doc/read-the-docs-site/extensions-flags-pragmas.rst
+++ b/doc/read-the-docs-site/extensions-flags-pragmas.rst
@@ -1,0 +1,81 @@
+GHC Extensions, Flags and Pragmas
+=================================
+
+Plutus Tx is a subset of Haskell and is compiled to Untyped Plutus Core by the Plutus Tx compiler, a GHC (Glasgow Haskell Compiler) plugin.
+
+In order to ensure the success and correct compilation of Plutus Tx programs, all Plutus Tx modules (that is, Haskell modules that contain code to be compiled by the Plutus Tx compiler) should use the following GHC extensions, flags and pragmas.
+
+
+Extensions
+-------------------------------------------------
+
+Plutus Tx modules should use the ``Strict`` extension: ::
+
+  {-# LANGUAGE Strict #-}
+
+Unlike in Haskell, function applications in Plutus Tx are strict.
+In other words, when evaluating ``(\x -> 42) (3 + 4)`` the expression ``3 + 4`` is evaluated first, before evaluating the function body (``42``), even though ``x`` is not used in the function body.
+The ``Strict`` extension ensures that let bindings are also (by default) strict, for instance, evaluating
+``let x = 3 + 4 in 42`` evaluates ``3 + 4`` first, even though ``x`` is not used.
+
+Bang patterns and lazy patterns can be used to explicitly specify whether a let binding is strict or non-strict, as in ``let !x = 3 + 4 in 42`` (strict) and ``let ~x = 3 + 4 in 42`` (non-strict).
+At this time, it is not possible to make function applications non-strict: ``(\(~x) -> 42) (3 + 4)`` still evaluates ``3 + 4`` strictly.
+
+Making let bindings strict by default has the following advantages:
+
+* It makes let bindings and function applications semantically equivalent, e.g., ``let x = 3 + 4 in 42`` has the same semantics as ``(\x -> 42) (3 + 4)``.
+  This is what one would come to expect, as it is the case in most other programming languages, regardless of whether the language is strict or non-strict.
+* Untyped Plutus Core programs, which are compiled from Plutus Tx, are not evaluated lazily (unlike Haskell), that is, there is no memoization of the results of evaluated expressions.
+  Thus using non-strict bindings can cause an expression to be inadvertently evaluated for an unbounded number of times.
+  Consider ``let x = <expensive> in \y -> x + y``.
+  If ``x`` is non-strict, ``<expensive>`` will be evalutated every time ``\y -> x + y`` is applied to an argument, which means it can be evaluated 0 time, 1 time, 2 times, or any number of times (this is not the case if lazy evaluation was employed).
+  On the other hand, if ``x`` is strict, it is always evaluated once, which is at most one more time than what is necessary.
+
+Flags
+-------------------------------------------------
+
+GHC has a variety of optimization flags, many of which are on by default.
+Although Plutus Tx is, syntactically, a subset of Haskell, it has different semantics and a different evaluation strategy (Haskell: non-strict semantics, call by need; Plutus Tx: strict semantics, call by value).
+As a result, some GHC optimizations are not helpful for Plutus Tx programs, and can even be harmful, in the sense that it can make Plutus Tx programs less efficient, or fail to be compiled.
+An example is the full laziness optimization, controlled by GHC flag ``-ffull-laziness``, which floats let bindings out of lambdas whenever possible.
+Since Untyped Plutus Core does not employ lazy evaluation, the full laziness optimization is never beneficial, and can sometimes make a Plutus Tx program more expensive.
+Conversely, some GHC features must be turned on in order to ensure Plutus Tx programs are compiled successfully.
+
+All Plutus Tx modules should use the following GHC flags: ::
+
+  -fplugin PlutusTx.Plugin
+  -fno-ignore-interface-pragmas
+  -fno-omit-interface-pragmas
+  -fno-full-laziness
+  -fno-spec-constr
+  -fno-specialise
+  -fno-strictness
+  -fno-unbox-strict-fields
+  -fno-unbox-small-strict-fields
+
+``-fplugin PlutusTx.Plugin`` enables the Plutus Tx compiler.
+``-fno-ignore-interface-pragmas`` and ``-fno-omit-interface-pragmas`` ensure unfoldings of Plutus Tx functions are available.
+The rest are GHC optimizations that are bad for Plutus Tx, and should thus be turned off.
+
+Note that this section only covers GHC flags, not Plutus Tx compiler flags.
+Information about the latter can be found in :ref:`plutus_tx_options`.
+
+Pragmas
+-------------------------------------------------
+
+All functions and methods should have the ``INLINEABLE`` pragma, so that their unfoldings are made available to the Plutus Tx compiler.
+
+The ``-fexpose-all-unfoldings`` flag also makes GHC expose all unfoldings, but unfoldings exposed this way can be more optimized than unfoldings exposed via ``INLINEABLE``.
+In general we do not want GHC to perform optimizations, since GHC optimizes a program based on the assumption that it has non-strict semantics and is evaluated lazily (call by need), which is not true for Plutus Tx programs.
+Therefore, ``INLINEABLE`` is preferred over ``-fexpose-all-unfoldings`` even though the latter is simpler.
+
+``-fexpose-all-unfoldings`` can be useful for functions that are generated by GHC and do not have the ``INLINEABLE`` pragma.
+``-fspecialise`` and ``-fspec-constr`` are two examples of optimizations that can generate such functions.
+The most reliable solution, however, is to simply turn these optimizations off.
+Another option is to bump ``-funfolding-creation-threshold`` to make it more likely for GHC to retain unfoldings for functions without the ``INLINEABLE`` pragma.
+``-fexpose-all-unfoldings`` should be used as a last resort.
+
+There's also the ``INLINE`` pragma, which does more than the ``INLINEABLE`` in that the ``INLINE`` pragma forces the Plutus IR optimizer to inline the function.
+This is not currently useful, and should be avoided.
+In the future, we plan to make the ``INLINE`` pragma part of the mechanism for making certain functions non-strict in their arguments.
+This is not yet implemented.

--- a/doc/read-the-docs-site/index.rst
+++ b/doc/read-the-docs-site/index.rst
@@ -4,34 +4,34 @@ Plutus Core and Plutus Tx user guide
 Plutus Core
 ---------------------
 
-The Plutus project consists of Plutus Core, the programming language used for 
-scripts on Cardano; tooling and compilers for compiling various intermediate 
-languages into Plutus Core; and Plutus Tx, the compiler that compiles the Haskell 
-source code into Plutus Core to form the on-chain part of a contract application. 
-All of this is used in combination to write Plutus Core scripts that run on the 
-Cardano blockchain. 
+The Plutus project consists of Plutus Core, the programming language used for
+scripts on Cardano; tooling and compilers for compiling various intermediate
+languages into Plutus Core; and Plutus Tx, the compiler that compiles the Haskell
+source code into Plutus Core to form the on-chain part of a contract application.
+All of this is used in combination to write Plutus Core scripts that run on the
+Cardano blockchain.
 
-This documentation introduces the Plutus Core programming language and programming 
-with Plutus Tx. It includes explanations, tutorials, how-to instructions, 
-troubleshooting, and reference information. 
+This documentation introduces the Plutus Core programming language and programming
+with Plutus Tx. It includes explanations, tutorials, how-to instructions,
+troubleshooting, and reference information.
 
-The intended audience of this documentation includes people who want to implement 
-smart contracts on the Cardano blockchain. This involves using Plutus Tx to write 
-scripts, requiring some knowledge of the Haskell programming language. 
+The intended audience of this documentation includes people who want to implement
+smart contracts on the Cardano blockchain. This involves using Plutus Tx to write
+scripts, requiring some knowledge of the Haskell programming language.
 
-This guide is also meant for certification companies, certification auditors, 
-and people who need an accurate specification. See, for example: 
+This guide is also meant for certification companies, certification auditors,
+and people who need an accurate specification. See, for example:
 
-* the `Cardano Ledger Specification <https://github.com/input-output-hk/cardano-ledger#cardano-ledger>`_ and 
-* the `Plutus Core Specification <https://github.com/input-output-hk/plutus#specifications-and-design>`_. 
+* the `Cardano Ledger Specification <https://github.com/input-output-hk/cardano-ledger#cardano-ledger>`_ and
+* the `Plutus Core Specification <https://github.com/input-output-hk/plutus#specifications-and-design>`_.
 
 The Plutus repository
 ----------------------------------
 
-The `Plutus repository <https://github.com/input-output-hk/plutus>`_ contains 
-the implementation, specification, and mechanized metatheory of Plutus Core. 
-It also contains the Plutus Tx compiler and the libraries, such as ``PlutusTx.List``, 
-for writing Haskell code that can be compiled to Plutus Core. 
+The `Plutus repository <https://github.com/input-output-hk/plutus>`_ contains
+the implementation, specification, and mechanized metatheory of Plutus Core.
+It also contains the Plutus Tx compiler and the libraries, such as ``PlutusTx.List``,
+for writing Haskell code that can be compiled to Plutus Core.
 
 .. toctree::
    :caption: Explore Plutus
@@ -39,6 +39,7 @@ for writing Haskell code that can be compiled to Plutus Core.
 
    explanations/index
    simple-example
+   extensions-flags-pragmas
    tutorials/index
    howtos/index
    troubleshooting


### PR DESCRIPTION
The `Strict` extension section can potentially be extended and probably deserves its own page. That is future work.