### PR TITLE
Fix JS regex syntax

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const regex = '^\/benchmark\s*(.*?)\s*$';
+            const regex = /^\/benchmark\s*(.*?)\s*$/;
             const comment = context.payload.comment.body;
             const match = comment.match(regex)
             if (match !== null && match.length == 2)


### PR DESCRIPTION
When specifying a regex as a string, backslashes need to be double-escaped, so the `\s`s were not working. We could double-escape them, but it's simpler to use the JS regex literal syntax.