### PR TITLE
Order V3.ParamName alphabetically

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/ParamName.hs
@@ -29,15 +29,60 @@ data ParamName =
   | AppendString'memory'arguments'slope
   | BData'cpu'arguments
   | BData'memory'arguments
+  | Blake2b_224'cpu'arguments'intercept
+  | Blake2b_224'cpu'arguments'slope
+  | Blake2b_224'memory'arguments
   | Blake2b_256'cpu'arguments'intercept
   | Blake2b_256'cpu'arguments'slope
   | Blake2b_256'memory'arguments
+  | Bls12_381_G1_add'cpu'arguments
+  | Bls12_381_G1_add'memory'arguments
+  | Bls12_381_G1_compress'cpu'arguments
+  | Bls12_381_G1_compress'memory'arguments
+  | Bls12_381_G1_equal'cpu'arguments
+  | Bls12_381_G1_equal'memory'arguments
+  | Bls12_381_G1_hashToGroup'cpu'arguments'intercept
+  | Bls12_381_G1_hashToGroup'cpu'arguments'slope
+  | Bls12_381_G1_hashToGroup'memory'arguments
+  | Bls12_381_G1_neg'cpu'arguments
+  | Bls12_381_G1_neg'memory'arguments
+  | Bls12_381_G1_scalarMul'cpu'arguments'intercept
+  | Bls12_381_G1_scalarMul'cpu'arguments'slope
+  | Bls12_381_G1_scalarMul'memory'arguments
+  | Bls12_381_G1_uncompress'cpu'arguments
+  | Bls12_381_G1_uncompress'memory'arguments
+  | Bls12_381_G2_add'cpu'arguments
+  | Bls12_381_G2_add'memory'arguments
+  | Bls12_381_G2_compress'cpu'arguments
+  | Bls12_381_G2_compress'memory'arguments
+  | Bls12_381_G2_equal'cpu'arguments
+  | Bls12_381_G2_equal'memory'arguments
+  | Bls12_381_G2_hashToGroup'cpu'arguments'intercept
+  | Bls12_381_G2_hashToGroup'cpu'arguments'slope
+  | Bls12_381_G2_hashToGroup'memory'arguments
+  | Bls12_381_G2_neg'cpu'arguments
+  | Bls12_381_G2_neg'memory'arguments
+  | Bls12_381_G2_scalarMul'cpu'arguments'intercept
+  | Bls12_381_G2_scalarMul'cpu'arguments'slope
+  | Bls12_381_G2_scalarMul'memory'arguments
+  | Bls12_381_G2_uncompress'cpu'arguments
+  | Bls12_381_G2_uncompress'memory'arguments
+  | Bls12_381_finalVerify'cpu'arguments
+  | Bls12_381_finalVerify'memory'arguments
+  | Bls12_381_millerLoop'cpu'arguments
+  | Bls12_381_millerLoop'memory'arguments
+  | Bls12_381_mulMlResult'cpu'arguments
+  | Bls12_381_mulMlResult'memory'arguments
   | CekApplyCost'exBudgetCPU
   | CekApplyCost'exBudgetMemory
   | CekBuiltinCost'exBudgetCPU
   | CekBuiltinCost'exBudgetMemory
+  | CekCaseCost'exBudgetCPU
+  | CekCaseCost'exBudgetMemory
   | CekConstCost'exBudgetCPU
   | CekConstCost'exBudgetMemory
+  | CekConstrCost'exBudgetCPU
+  | CekConstrCost'exBudgetMemory
   | CekDelayCost'exBudgetCPU
   | CekDelayCost'exBudgetMemory
   | CekForceCost'exBudgetCPU
@@ -98,6 +143,9 @@ data ParamName =
   | IfThenElse'memory'arguments
   | IndexByteString'cpu'arguments
   | IndexByteString'memory'arguments
+  | Keccak_256'cpu'arguments'intercept
+  | Keccak_256'cpu'arguments'slope
+  | Keccak_256'memory'arguments
   | LengthOfByteString'cpu'arguments
   | LengthOfByteString'memory'arguments
   | LessThanByteString'cpu'arguments'intercept
@@ -190,53 +238,5 @@ data ParamName =
   | VerifySchnorrSecp256k1Signature'cpu'arguments'intercept
   | VerifySchnorrSecp256k1Signature'cpu'arguments'slope
   | VerifySchnorrSecp256k1Signature'memory'arguments
-  | CekConstrCost'exBudgetCPU
-  | CekConstrCost'exBudgetMemory
-  | CekCaseCost'exBudgetCPU
-  | CekCaseCost'exBudgetMemory
-  | Bls12_381_G1_add'cpu'arguments
-  | Bls12_381_G1_add'memory'arguments
-  | Bls12_381_G1_compress'cpu'arguments
-  | Bls12_381_G1_compress'memory'arguments
-  | Bls12_381_G1_equal'cpu'arguments
-  | Bls12_381_G1_equal'memory'arguments
-  | Bls12_381_G1_hashToGroup'cpu'arguments'intercept
-  | Bls12_381_G1_hashToGroup'cpu'arguments'slope
-  | Bls12_381_G1_hashToGroup'memory'arguments
-  | Bls12_381_G1_neg'cpu'arguments
-  | Bls12_381_G1_neg'memory'arguments
-  | Bls12_381_G1_scalarMul'cpu'arguments'intercept
-  | Bls12_381_G1_scalarMul'cpu'arguments'slope
-  | Bls12_381_G1_scalarMul'memory'arguments
-  | Bls12_381_G1_uncompress'cpu'arguments
-  | Bls12_381_G1_uncompress'memory'arguments
-  | Bls12_381_G2_add'cpu'arguments
-  | Bls12_381_G2_add'memory'arguments
-  | Bls12_381_G2_compress'cpu'arguments
-  | Bls12_381_G2_compress'memory'arguments
-  | Bls12_381_G2_equal'cpu'arguments
-  | Bls12_381_G2_equal'memory'arguments
-  | Bls12_381_G2_hashToGroup'cpu'arguments'intercept
-  | Bls12_381_G2_hashToGroup'cpu'arguments'slope
-  | Bls12_381_G2_hashToGroup'memory'arguments
-  | Bls12_381_G2_neg'cpu'arguments
-  | Bls12_381_G2_neg'memory'arguments
-  | Bls12_381_G2_scalarMul'cpu'arguments'intercept
-  | Bls12_381_G2_scalarMul'cpu'arguments'slope
-  | Bls12_381_G2_scalarMul'memory'arguments
-  | Bls12_381_G2_uncompress'cpu'arguments
-  | Bls12_381_G2_uncompress'memory'arguments
-  | Bls12_381_finalVerify'cpu'arguments
-  | Bls12_381_finalVerify'memory'arguments
-  | Bls12_381_millerLoop'cpu'arguments
-  | Bls12_381_millerLoop'memory'arguments
-  | Bls12_381_mulMlResult'cpu'arguments
-  | Bls12_381_mulMlResult'memory'arguments
-  | Keccak_256'cpu'arguments'intercept
-  | Keccak_256'cpu'arguments'slope
-  | Keccak_256'memory'arguments
-  | Blake2b_224'cpu'arguments'intercept
-  | Blake2b_224'cpu'arguments'slope
-  | Blake2b_224'memory'arguments
     deriving stock (Eq, Ord, Enum, Ix, Bounded, Generic)
     deriving IsParamName via (GenericParamName ParamName)


### PR DESCRIPTION
Since V3 is new, there's no reason not to order it alphabetically. Doing so makes it easier to generate the genesis file for Plutus V3.

Only when we add new builtins in the future, after V3 is already in production, do we need to append the new builtins at the end.