### PR TITLE
Increase fetch-depth in workflows/benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # We need at least one commit before master to compare against
+          fetch-depth: 5
 
       - name: React with Rocket 
         uses: actions/github-script@v6


### PR DESCRIPTION
This attempts to fix the error in `scripts/ci-plutus-benchmark.sh`, where the line:
```
git checkout "$(git merge-base HEAD origin/master)"
```
Fails with:
```
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
```
Because `git merge-base HEAD origin/master` returns the empty string
