### PR TITLE
Add empty string check for git command in ci-plutus-benchmark.sh

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           # We need at least one commit before master to compare against
           fetch-depth: 5
+          # And we want to prevent `git reset --hard HEAD` before fetching
+          clean: false
 
       - name: React with Rocket 
         uses: actions/github-script@v6

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           # We need at least one commit before master to compare against
           fetch-depth: 5
-          # And we want to prevent `git reset --hard HEAD` before fetching
-          clean: false
 
       - name: React with Rocket 
         uses: actions/github-script@v6

--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -38,6 +38,11 @@ fi
 
 PR_BRANCH_REF="$(git rev-parse --short HEAD)"
 
+if [ -z "$(git merge-base HEAD origin/master)" ]; then
+    echo "The command 'git merge-base HEAD origin/master' returned an empty string."
+    echo "You probably need to 'git rebase --origin master' from your branch first."
+fi
+
 echo "[ci-plutus-benchmark]: Processing benchmark comparison for benchmark '$BENCHMARK_NAME' on PR $PR_NUMBER"
 
 echo "[ci-plutus-benchmark]: Running as user:"

--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -41,6 +41,7 @@ PR_BRANCH_REF="$(git rev-parse --short HEAD)"
 if [ -z "$(git merge-base HEAD origin/master)" ]; then
     echo "The command 'git merge-base HEAD origin/master' returned an empty string."
     echo "You probably need to 'git rebase --origin master' from your branch first."
+    exit 1
 fi
 
 echo "[ci-plutus-benchmark]: Processing benchmark comparison for benchmark '$BENCHMARK_NAME' on PR $PR_NUMBER"


### PR DESCRIPTION
It's possible that one has to `git pull --rebase origin master` first in order for the `ci-plutus-benchmark.sh` to work in one's PR.

This PR adds a check that `git merge-base HEAD origin/master` does not return the empty string at the top of the `ci-plutus-benchmark.sh` file.