### PR TITLE
PLT-7799 Simplify progress proofs

### DIFF
--- a/plutus-metatheory/src/Algorithmic.lagda
+++ b/plutus-metatheory/src/Algorithmic.lagda
@@ -314,13 +314,13 @@ bwdMkCaseType : ∀{Φ} → Bwd (Φ ⊢Nf⋆ *) → (A : Φ ⊢Nf⋆ *) → Φ �
 bwdMkCaseType bs A = bwd-foldr _⇒_ A bs
 
 lemma-bwdfwdfunction' : ∀{Φ} {B : Φ ⊢Nf⋆ *} TS → mkCaseType B TS ≡ bwdMkCaseType ([] <>< TS) B
-lemma-bwdfwdfunction' {B = B} TS = trans (cong (mkCaseType B) (sym (lemma<>1 [] TS))) (lemma-bwd-foldr _⇒_ B ([] <>< TS))
+lemma-bwdfwdfunction' {B = B} TS = trans (cong (mkCaseType B) (sym (lemma<>1 [] TS))) (lemma-bwd-foldr _⇒_ B ([] <>< TS))         
 
 constr-cong :  ∀{Γ : Ctx Φ}{n}{i : Fin n}{A : Vec (List (Φ ⊢Nf⋆ *)) n}{ts} 
-            → (p : lookup A i ≡ ts)
+            → (p : ts ≡ lookup A i)
             → {cs : ConstrArgs Γ ts}
             → {cs' : ConstrArgs Γ (lookup A i)}
-            → (q : cs' ≡ subst (IList (Γ ⊢_)) (sym p) cs)
-            → constr i A refl cs' ≡ constr i A (sym p) cs
-constr-cong refl refl = refl            
-\end{code}   
+            → (q : cs' ≡ subst (IList (Γ ⊢_)) p cs)
+            → constr i A refl cs' ≡ constr i A p cs
+constr-cong refl refl = refl
+\end{code}

--- a/plutus-metatheory/src/Algorithmic/CC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/CC.lagda.md
@@ -51,9 +51,6 @@ dissect (wrap E) with dissect E
 dissect (unwrap E / refl) with dissect E
 ... | inj₁ refl           = inj₂ (_ ,, [] ,, unwrap-)
 ... | inj₂ (C ,, E' ,, F) = inj₂ (C ,, unwrap E' / refl ,, F)
-dissect (E l·v V) with dissect E 
-... | inj₁ refl           = inj₂ (_ ,, ([] ,, (-·v V)))
-... | inj₂ (C ,, E' ,, F) = inj₂ (_ ,, ((E' l·v V) ,, F))
 dissect (constr i TSS p {tidx} vs ts E) with dissect E 
 ... | inj₁ refl           = inj₂ (_ ,, ([] ,, (constr- i TSS p {tidx} vs ts)))
 ... | inj₂ (C ,, E' ,, F) = inj₂ (_ ,, ((constr i TSS p {tidx} vs ts E') ,, F))
@@ -64,7 +61,6 @@ dissect (case cs E)  with dissect E
 compEC : ∀{A B C} → EC A B → EC B C → EC A C
 compEC [] E' = E'
 compEC (E  l· M') E' = compEC E E' l· M'
-compEC (E l·v V) E' = (compEC E E') l·v V
 compEC (VM ·r E) E' = VM ·r compEC E E'
 compEC (E ·⋆ A / refl) E' = compEC E E' ·⋆ A / refl
 compEC (wrap E) E' = wrap (compEC E E')
@@ -74,7 +70,7 @@ compEC (case cs E) E' = case cs (compEC E E')
 
 extEC : ∀{A B C}(E : EC A B)(F : Frame B C) → EC A C
 extEC [] (-· M') = [] l· M'
-extEC [] (-·v V) = [] l·v V
+extEC [] (-·v V) = [] l· deval V
 extEC [] (VM ·-) = VM ·r []
 extEC [] (-·⋆ A) = [] ·⋆ A / refl
 extEC [] wrap- = wrap []
@@ -82,7 +78,6 @@ extEC [] unwrap- = unwrap [] / refl
 extEC [] (constr- i TSS p {tidx} vs ts) = constr i TSS p {tidx} vs ts []
 extEC [] (case- cs) = case cs []
 extEC (E l· M') F = extEC E F l· M'
-extEC (E l·v V) F = extEC E F l·v V
 extEC (VM ·r E) F = VM ·r extEC E F
 extEC (E ·⋆ A / refl) F = extEC E F ·⋆ A / refl
 extEC (wrap E) F = wrap (extEC E F)

--- a/plutus-metatheory/src/Algorithmic/Evaluation.lagda
+++ b/plutus-metatheory/src/Algorithmic/Evaluation.lagda
@@ -6,7 +6,7 @@ module Algorithmic.Evaluation where
 
 \begin{code}
 open import Data.Nat using (ℕ;zero;suc)
-
+open import Relation.Binary.PropositionalEquality using (refl)
 open import Utils using (*;Either;inj₁;RuntimeError;return)
 open RuntimeError
 
@@ -14,8 +14,8 @@ open import Type using (∅)
 open import Type.BetaNormal using (_⊢Nf⋆_)
 open import Algorithmic using (_⊢_;∅)
 open _⊢_
-open import Algorithmic.ReductionEC using (Value;Error;_—↠_;_—→_)
-open import Algorithmic.ReductionEC.Progress using  (Progress;done;error;progress;step)
+open import Algorithmic.ReductionEC using (Value;Error;_—↠_;_—→_;E-error)
+open import Algorithmic.ReductionEC.Progress using  (Progress;done;progress;step)
 open _—↠_
 \end{code}
 
@@ -74,9 +74,9 @@ evalProg : ∀{A : ∅ ⊢Nf⋆ *} → Gas → {t : ∅ ⊢ A} → Progress t �
 eval (gas zero) M = steps refl—↠ out-of-gas
 eval (gas (suc n)) M = evalProg (gas n) (progress M)
 
+evalProg g (step {N = .(error _)} (_—→_.ruleErr Algorithmic.ReductionEC.[] refl)) = steps refl—↠ (error E-error)
 evalProg g (step {N = t'} p)  = eval—→ p (eval g t')
 evalProg g (done VM) = steps refl—↠ (done _ VM)
-evalProg g (error e) = steps refl—↠ (error e)
 
 stepper : {A : ∅ ⊢Nf⋆ *} → ∅ ⊢ A → ℕ → Either RuntimeError (∅ ⊢ A)
 stepper {A} t n with eval (gas n) t
@@ -85,3 +85,4 @@ stepper {A} t n with eval (gas n) t
 ... | steps x (error _)   = return (error A)
 
 \end{code}
+ 

--- a/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
+++ b/plutus-metatheory/src/Algorithmic/ReductionEC.lagda.md
@@ -137,7 +137,7 @@ data Value where
           → ∀{YS} → (q : YS ≡ [] <>< XS)
           → {ts : IBwd (∅ ⊢_) YS}
           → (vs : VList ts)
-          → ∀ {ts' : IList (∅ ⊢_) XS} → (IBwd2IList q ts ≡ ts')
+          → ∀ {ts' : IList (∅ ⊢_) XS} → (IBwd2IList (lemma<>1' _ _ q) ts ≡ ts')
           → Value (constr e TSS p ts')
 
 red2cekVal : ∀{A}{L : ∅ ⊢ A} → Value L → CEK.Value A
@@ -185,9 +185,6 @@ data Error :  ∀ {Φ Γ} {A : Φ ⊢Nf⋆ *} → Γ ⊢ A → Set where
 
 Frames used by the CC and the CK machine, and their plugging function.
 
-Frames for constructors need to differentiate between evaluated arguments
-and arguments which are not yet evaluated. This is modelled by VListZipper. 
-
 ```
 data Frame : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
   -·_     : {A B : ∅ ⊢Nf⋆ *} → ∅ ⊢ A → Frame B (A ⇒ B)
@@ -223,8 +220,7 @@ case- cs         [ L ]ᶠ = case L cs
 ```
 data EC : (T : ∅ ⊢Nf⋆ *) → (H : ∅ ⊢Nf⋆ *) → Set where
   []   : {A : ∅ ⊢Nf⋆ *} → EC A A
-  _l·_ : {A B C : ∅ ⊢Nf⋆ *} → EC (A ⇒ B) C → ∅ ⊢ A → EC B C
-  _l·v_ : {A B C : ∅ ⊢Nf⋆ *} → EC (A ⇒ B) C → {t : ∅ ⊢ A} → Value t → EC B C
+  _l·_ : {A B C : ∅ ⊢Nf⋆ *} → EC (A ⇒ B) C → (t : ∅ ⊢ A) → EC B C
   _·r_ : {A B C : ∅ ⊢Nf⋆ *}{t : ∅ ⊢ A ⇒ B} → Value t → EC A C → EC B C
   _·⋆_/_ : ∀{K}{B : ∅ ,⋆ K ⊢Nf⋆ *}{C}{X}
     → EC (Π B) C → (A : ∅ ⊢Nf⋆ K) → X ≡ B [ A ]Nf → EC X C
@@ -253,8 +249,7 @@ _[_]ᴱ : ∀{A B : ∅ ⊢Nf⋆ *} → EC B A → ∅ ⊢ A → ∅ ⊢ B
 (E ·⋆ A / q) [ L ]ᴱ = E [ L ]ᴱ ·⋆ A / q
 (wrap   E) [ L ]ᴱ = wrap _ _ (E [ L ]ᴱ)
 (unwrap E / q) [ L ]ᴱ = unwrap (E [ L ]ᴱ) q
-(E l·v V) [ L ]ᴱ = E  [ L ]ᴱ · deval V
-constr i TSS refl {idx} {tvs} vs ts E [ L ]ᴱ = constr i TSS (sym (lem-≣-<>> idx)) (tvs <>>I (E [ L ]ᴱ ∷ ts))
+constr i TSS p {idx} {tvs} vs ts E [ L ]ᴱ = constr i TSS (trans (sym (lem-≣-<>> idx)) p) (tvs <>>I (E [ L ]ᴱ ∷ ts))
 case cs E [ L ]ᴱ = case (E [ L ]ᴱ) cs
 ```
 
@@ -309,7 +304,7 @@ data _—→⋆_ : {A : ∅ ⊢Nf⋆ *} → (∅ ⊢ A) → (∅ ⊢ A) → Set 
     → ∀{YS} → (q : YS ≡ [] <>< Vec.lookup TSS e)
     → {ts : IBwd (∅ ⊢_) YS}
     → (vs : VList ts)
-    → ∀ {ts' : IList (∅ ⊢_) (Vec.lookup TSS e)} → (IBwd2IList q ts ≡ ts')
+    → ∀ {ts' : IList (∅ ⊢_) (Vec.lookup TSS e)} → (IBwd2IList (lemma<>1' _ _ q) ts ≡ ts')
     → (cases : Cases ∅ A TSS)
     → case (constr e TSS refl ts') cases —→⋆ applyCase (lookupCase e cases) ts'
 -- -}

--- a/plutus-metatheory/src/Utils/List.lagda.md
+++ b/plutus-metatheory/src/Utils/List.lagda.md
@@ -68,9 +68,15 @@ lemma<>1 : ∀{A}(xs : Bwd A)(ys : List A) → (xs <>< ys) <>> [] ≡ xs <>> ys
 lemma<>1 xs []       = refl
 lemma<>1 xs (x ∷ ys) = lemma<>1 (xs :< x) ys
 
+lemma<>1' : ∀{A}(xs : Bwd A)(ys : List A) → xs ≡ [] <>< ys → xs <>> [] ≡ ys
+lemma<>1' xs ys refl = lemma<>1 [] ys
+
 lemma<>2 : ∀{A}(xs : Bwd A)(ys : List A) → ([] <>< (xs <>> ys)) ≡ xs <>< ys
 lemma<>2 [] ys = refl
 lemma<>2 (xs :< x) ys = lemma<>2 xs (x ∷ ys)
+
+lemma<>2' : ∀{A}(xs : Bwd A)(ys : List A) → xs <>> [] ≡ ys → [] <>< ys ≡ xs
+lemma<>2' xs ys refl = lemma<>2 xs []
 
 lemma-<>>-++ : ∀{A : Set} bs (as as' : List A) →  bs <>> (as ++ as') ≡ (bs <>> as) ++ as'
 lemma-<>>-++ [] as as' = refl
@@ -138,8 +144,8 @@ lemma<>I2 : ∀{A}{B : A → Set}{xs : Bwd A}{ys : List A}(ixs : IBwd B xs)(iys 
 lemma<>I2 [] iys = refl
 lemma<>I2 (ixs :< ix) iys = lemma<>I2 ixs (ix ∷ iys)
 
-IBwd2IList : ∀{A}{B : A → Set}{bs}{ts} → (bs ≡ [] <>< ts) → IBwd B bs → IList B ts
-IBwd2IList {ts = ts} p tbs = subst (IList _) (trans (cong (_<>> []) p) (lemma<>1 [] ts)) (tbs <>>I [])
+IBwd2IList : ∀{A}{B : A → Set}{bs}{ts} → (bs <>> [] ≡ ts) → IBwd B bs → IList B ts
+IBwd2IList p tbs = subst (IList _) p (tbs <>>I [])
 ```
 
 ## A type for Zipper indexes
@@ -196,14 +202,6 @@ data _≣I_<>>_ {A : Set}{B : A → Set}{tot}(itot : IList B tot) :
          → (itot ≣I ibs <>> (it ∷ ils)) idx
            ------------------------------------------
          → (itot ≣I (ibs :< it) <>> ils) (bubble idx)
-
-getIdx≡I : ∀{A : Set}{B : A → Set}{tot}{itot : IList B tot}{bs ts}
-                                      → {ibs : IBwd B bs}
-                                      → {ils : IList B ts}
-                                      → {idx : tot ≣ bs <>> ts}
-                                      → (itot ≣I ibs <>> ils) idx
-                                      → tot ≣ bs <>> ts
-getIdx≡I {idx = idx} _ = idx
 
 lem-≣I-<>>1 : ∀{A : Set}{B : A → Set}{tot : List A}{itot : IList B tot}{bs} 
                                 {ibs : IBwd B bs}{ls}{ils : IList B ls}  


### PR DESCRIPTION
This PR removes a duplication of representation in the Progress proofs.
Errors could be represented in two ways: with the error constructor, or as an error step in the empty context.
The duplication is solved by removing the error constructor. 
Not only this simplifies proofs, but also will enable the simplification of the determinism proof by reusing the progress proof.

Also, other simplifications to the progress proof were done.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
