### PR TITLE
Fix onchain evaluation test

### DIFF
--- a/plutus-ledger-api/test-onchain-evaluation/Main.hs
+++ b/plutus-ledger-api/test-onchain-evaluation/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
@@ -6,30 +7,92 @@
 
 module Main (main) where
 
+import PlutusCore.Data qualified as PLC
 import PlutusCore.Pretty
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.Test.EvaluationEvent
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
 
-import Codec.Serialise qualified as CBOR
+import Codec.Serialise (Serialise, readFileDeserialise)
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (evaluate)
 import Control.Monad.Extra (whenJust)
-import Data.List.NonEmpty (nonEmpty, toList)
-import Data.Maybe (catMaybes)
-
 import Control.Monad.Writer.Strict
+import Data.List.NonEmpty (NonEmpty, nonEmpty, toList)
+import Data.Maybe (catMaybes)
+import GHC.Generics (Generic)
 import System.Directory.Extra (listFiles)
 import System.Environment (getEnv)
 import System.FilePath (isExtensionOf, takeBaseName)
 import Test.Tasty
 import Test.Tasty.HUnit
 
+{- The ScriptEvaluationData type used to contain a ProtocolVersion but now
+ contains only a MajorProtocolVersion.  The program which dumps the mainnet
+ scripts still writes both the major and minor protocol version numbers, so here
+ we provide some adaptor types which allow us to read the old format and convert
+ it to the new format.  We expect that this program will be subsumed by Marconi
+ eventually, so we just go for a quick fix here for the time being instead of
+ rewriting the script-dumper; also this strategy allows us to process existing
+ files without having to re-dump all of the scripts from the history of the
+ chain.
+-}
+
+-- Adaptor types
+
+data ProtocolVersion = ProtocolVersion
+    { pvMajor :: Int -- ^ the major component
+    , pvMinor :: Int -- ^ the minor component
+    }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass Serialise
+
+data ScriptEvaluationData2 = ScriptEvaluationData2
+    { dataProtocolVersion2 :: ProtocolVersion
+    , dataBudget2          :: ExBudget
+    , dataScript2          :: SerialisedScript
+    , dataInputs2          :: [PLC.Data]
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass (Serialise)
+
+data ScriptEvaluationEvent2
+    = PlutusV1Event2 ScriptEvaluationData2 ScriptEvaluationResult
+    | PlutusV2Event2 ScriptEvaluationData2 ScriptEvaluationResult
+    deriving stock (Show, Generic)
+    deriving anyclass (Serialise)
+
+data ScriptEvaluationEvents2 = ScriptEvaluationEvents2
+    { eventsCostParamsV1' :: Maybe [Integer]
+    -- ^ Cost parameters shared by all PlutusV1 evaluation events in `eventsEvents`, if any.
+    , eventsCostParamsV2' :: Maybe [Integer]
+    -- ^ Cost parameters shared by all PlutusV2 evaluation events in `eventsEvents`, if any.
+    , eventsEvents2       :: NonEmpty ScriptEvaluationEvent2
+    }
+    deriving stock (Show, Generic)
+    deriving anyclass Serialise
+
+-- Conversion functions
+
+data2toData :: ScriptEvaluationData2 -> ScriptEvaluationData
+data2toData (ScriptEvaluationData2 (ProtocolVersion v _)  b s i) =
+    ScriptEvaluationData (MajorProtocolVersion v) b s i
+
+event2toEvent :: ScriptEvaluationEvent2 -> ScriptEvaluationEvent
+event2toEvent (PlutusV1Event2 d r) = PlutusV1Event (data2toData d) r
+event2toEvent (PlutusV2Event2 d r) = PlutusV2Event (data2toData d) r
+
+events2toEvents :: ScriptEvaluationEvents2 -> ScriptEvaluationEvents
+events2toEvents (ScriptEvaluationEvents2 cpV1 cpV2 evs) =
+    ScriptEvaluationEvents cpV1 cpV2 (fmap event2toEvent evs)
+
+-- Back to business as usual
+
 -- | Test cases from a single event dump file
 testOneFile :: FilePath -> TestTree
 testOneFile eventFile = testCase (takeBaseName eventFile) $ do
-    events <- CBOR.readFileDeserialise @ScriptEvaluationEvents eventFile
+    events <- events2toEvents <$> readFileDeserialise @ScriptEvaluationEvents2 eventFile
 
     case ( mkContext V1.mkEvaluationContext (eventsCostParamsV1 events)
          , mkContext V2.mkEvaluationContext (eventsCostParamsV2 events)


### PR DESCRIPTION
PR #5545 removed the minor protocol version from most of the Plutus code.  The program that dumps the mainnet scripts still serialises both major and minor versions (and existing dumps contain these).  This adds some code to `plutus-ledger-api:evaluation-test` to allow it to read the old format.  I've tested it with a recent dump of the mainnet scripts and it reads them successfully.