### PR TITLE
Just call adjustModel once

### DIFF
--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -362,21 +362,24 @@ modelFun <- function(path) {
             filter.and.check.nonempty (fname) %>%
             discard.upper.outliers () %>%
             discard.overhead ()
-        lm(t ~ 1, filtered)
+        m <- lm(t ~ 1, filtered)
+        return (m)
     }
 
    linearInX <- function (fname) {
         filtered <- data %>%
             filter.and.check.nonempty (fname) %>%
             discard.overhead ()
-        lm(t ~ x_mem, filtered)
+        m <- lm(t ~ x_mem, filtered)
+        return(m)
    }
 
    linearInY <- function (fname) {
         filtered <- data %>%
             filter.and.check.nonempty(fname) %>%
             discard.overhead ()
-        lm(t ~ y_mem, filtered)
+        m <- lm(t ~ y_mem, filtered)
+        return(m)
    }
 
 


### PR DESCRIPTION
This involves a small refactoring of the R cost modelling code, prompted by PLT-881.  It's possible that we generate a modelling function that has negative slope (eg, if the time is more or less constant) or negative intercept (eg, if the time is linear in x but the regression line happens to cross the t-axis below the origin).  There's a function called `adjustModel` that checks the coefficients of the generated models and replaces any non-positive values with a small positive value in order to avoid the possibility of negative costs.  That was previously called at the end of the functions that generate the individual models, but in this PR I've changed the code so that it's mapped over the full set of models before they're returned to the outside world (which is a bit tricky to do neatly because of R's weird `*apply`functions:  maybe I just haven't found the best way to do it). That should make it less easy to forget the check.  I've also taken to opportunity to be more explicit about what's returned by some functions.  

I've tested this by running `generate-cost-model` and comparing the output with `builtinCostModel.json` (there are small differences due to re-generated costs for the BLS12-381 builtins),  and also by running `cost-model-test`.