### PR TITLE
We don't want 'find' to find .cabal

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -33,5 +33,6 @@ sed -i "s/\(^version:\s*\).*/\1$VERSION/" "./$PACKAGE/$PACKAGE.cabal"
 # - ", plutus-core:{plutus-core, plutus-core-testlib}  ^>=1.0"
 #
 # and updates the version bounds to "^>={major version}"
+# The ?* pattern prevents 'find' from attempting to modify ".cabal" (no basename).
 echo "Updating version bounds on $PACKAGE to '^>=$major_version'"
-find . -name "*.cabal" -exec sed -i "s/\(, $PACKAGE[^^]*\).*/\1 ^>=$major_version/" {} \;
+find . -name "?*.cabal" -exec sed -i "s/\(, $PACKAGE[^^]*\).*/\1 ^>=$major_version/" {} \;


### PR DESCRIPTION
Running `./scripts/prepare-release.sh 1.15.0`, I got messages like 
```
Updating versions ...
Updating version of plutus-core to 1.15.0
Updating version bounds on plutus-core to '^>=1.15'
sed: couldn't edit ./pkgs/.cabal: not a regular file
Updating version of plutus-ledger-api to 1.15.0
Updating version bounds on plutus-ledger-api to '^>=1.15'
sed: couldn't edit ./pkgs/.cabal: not a regular file
...
```
including alarming but harmless warnings about not being able to edit `./pkgs/.cabal`.  This was because there's a line in `update-version.sh` saying
```
find . -name "*.cabal" -exec sed -i ...
```
The  asterisk in `*.cabal` matches the empty string, so it's finding the  `.cabal`  directory.  Changing it to `?*.cabal` prevents this by ensuring that `find` only finds `.cabal` files whose basename contains at least one character.

I'm not totally sure where `pkgs` came from, but we probably don't want to be matching `.cabal` anyway.