### PR TITLE
Release 1.15.0.0

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-core
-version:            1.15.0
+version:            1.15.0.0
 license:            Apache-2.0
 license-files:
   LICENSE

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-ledger-api
-version:         1.15.0
+version:         1.15.0.0
 license:         Apache-2.0
 license-files:
   LICENSE

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx-plugin
-version:         1.15.0
+version:         1.15.0.0
 license:         Apache-2.0
 license-files:
   LICENSE

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            plutus-tx
-version:         1.15.0
+version:         1.15.0.0
 license:         Apache-2.0
 license-files:
   LICENSE

--- a/prettyprinter-configurable/prettyprinter-configurable.cabal
+++ b/prettyprinter-configurable/prettyprinter-configurable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               prettyprinter-configurable
-version:            1.15.0
+version:            1.15.0.0
 
 -- synopsis:
 -- description:


### PR DESCRIPTION
I messed up in the earlier attempt by typing `1.15.0` instead of `1.15.0.0` in the very first step and that led to a [bad version number](https://github.com/input-output-hk/cardano-haskell-packages/pull/536) in CHaP. This fixes that by starting from scratch, but in the meantime the previous attempt got merged.  I'm not sure how that'll affect the changelogs, since they got updated in the previous attempt.