### PR TITLE
Bump urllib version in read-the-docs-site/requirements.txt

### DIFF
--- a/doc/read-the-docs-site/requirements.txt
+++ b/doc/read-the-docs-site/requirements.txt
@@ -34,7 +34,7 @@ pyparsing==3.0.6
 PySocks==1.7.1
 PyStemmer==2.0.1
 pytz==2021.3
-PyYAML==6.0
+PyYAML==6.0.1
 recommonmark==0.7.1
 requests==2.31.0
 requests-toolbelt==0.9.1

--- a/doc/read-the-docs-site/requirements.txt
+++ b/doc/read-the-docs-site/requirements.txt
@@ -56,7 +56,7 @@ sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4
 sphinxemoji==0.1.6
 toml==0.10.2
-urllib3==1.26.8
+urllib3>=1.26.18
 wcwidth==0.2.5
 xmltodict==0.12.0
 yq==2.13.0


### PR DESCRIPTION
This is to address a security issue as per https://github.com/input-output-hk/plutus/security/dependabot/7
Also `PyYAML` has been updated to fix this build error: https://readthedocs.org/projects/plutus/builds/22350594/