### PR TITLE
Remarks about replacement of Unicode surrogates

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins1.tex
+++ b/doc/plutus-core-spec/cardano/builtins1.tex
@@ -52,7 +52,10 @@ useful for tools working with Plutus Core.
 \end{table}
 
 \paragraph{Concrete syntax for strings.} Strings are represented as sequences of Unicode characters
-enclosed in double quotes, and may include standard escape sequences.
+enclosed in double quotes, and may include standard escape sequences.  Surrogate
+characters in the range \texttt{U+D800}--\texttt{U+DFFF} are replaced with the
+Unicode replacement character \texttt{U+FFFD}.
+
 
 \paragraph{Concrete syntax for higher-order types.} Types such as $\listOf{\ty{integer}}$
 and $\pairOf{\ty{bool}}{\ty{string)}}$ are represented by application at the

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -53,7 +53,13 @@ hexByte = do
 conBS :: Parser ByteString
 conBS = lexeme . fmap pack $ char '#' *> many hexByte
 
--- | Parser for string constants. They are wrapped in double quotes.
+{- | Parser for string constants (wrapped in double quotes).  Note that
+ Data.Text.pack "performs replacement on invalid scalar values", which means
+ that Unicode surrogate code points (corresponding to integers in the range
+ 0xD800-0xDFFF) are converted to the Unicode replacement character U+FFFD
+ (decimal 65533).  Thus `(con string "X\xD800Z")` parses to a `Text` object
+ whose second character is U+FFFD.
+-}
 conText :: Parser T.Text
 conText = lexeme . fmap T.pack $ char '\"' *> manyTill Lex.charLiteral (char '\"')
 


### PR DESCRIPTION
The PLC parser uses `Data.Text.pack` when parsing Unicode strings, which replaces surrogate character codes with U+FFFE.  This adds a comment and a remark in the specification to explain that.