### PR TITLE
[Build] Remove 'dependent-sum-template'

### DIFF
--- a/plutus-core/changelog.d/20231103_205517_effectfully_remove_dependent_sum_template.md
+++ b/plutus-core/changelog.d/20231103_205517_effectfully_remove_dependent_sum_template.md
@@ -1,0 +1,3 @@
+### Removed
+
+- A `GCompare` instance for `DefaultUni` in #5609.

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -280,7 +280,6 @@ library
     , data-default-class
     , deepseq
     , dependent-sum               >=0.7.1.0
-    , dependent-sum-template      <0.1.2
     , deriving-aeson              >=0.2.3
     , deriving-compat
     , dlist

--- a/plutus-core/plutus-core/src/PlutusCore.hs
+++ b/plutus-core/plutus-core/src/PlutusCore.hs
@@ -27,7 +27,6 @@ module PlutusCore
     , GShow (..)
     , show
     , GEq (..)
-    , deriveGEq
     , HasUniApply (..)
     , checkStar
     , withApplicable

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -180,8 +180,6 @@ instance GEq DefaultUni where
         geqRec = geqStep
         {-# NOINLINE geqRec #-}
 
-deriveGCompare ''DefaultUni
-
 -- | For pleasing the coverage checker.
 noMoreTypeFunctions :: DefaultUni (Esc (f :: a -> b -> c -> d)) -> any
 noMoreTypeFunctions (f `DefaultUniApply` _) = noMoreTypeFunctions f

--- a/plutus-core/plutus-core/src/Universe/Core.hs
+++ b/plutus-core/plutus-core/src/Universe/Core.hs
@@ -45,8 +45,6 @@ module Universe.Core
     , gshow
     , GEq (..)
     , defaultEq
-    , deriveGEq
-    , deriveGCompare
     , (:~:)(..)
     -- strictly we don't use this, but this is here
     -- partially so we have a dependency on dependent-sum
@@ -60,7 +58,6 @@ import Control.Monad
 import Control.Monad.Trans.State.Strict
 import Data.Dependent.Sum
 import Data.GADT.Compare
-import Data.GADT.Compare.TH
 import Data.GADT.DeepSeq
 import Data.GADT.Show
 import Data.Kind


### PR DESCRIPTION
This removes the `dependent-sum-template` package from dependencies, so that it doesn't complicate supporting GHC 9.8. We don't need the package for anything, however it was requested that we add a `GCompare` instance for `DefaultUni` in #4178. We could implement the instance manually, but given that we don't need it my inclination is to say that if somebody needs the instance, they can either implement it themselves or indeed just depend on `dependent-sum-template` as we used to (unless they need it for GHC 9.8 and support for that version is never added to the package).