### PR TITLE
Minor typos in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -47,12 +47,12 @@ package plutus-core
 -- when cross building for windows
 if impl(ghc < 9.0) || os(windows)
   -- Note: we enable this and then disable it conditionally, rather than enabling
-  -- it conditionally, to abvoid https://github.com/haskell/cabal/issues/9293
+  -- it conditionally, to avoid https://github.com/haskell/cabal/issues/9293
   package plutus-core
     flags: -with-cert
-  -- This is a bit silly: although we won't use plutus-cert in this case, cabal
-  -- stil considers it a "local" project and tries to solve for it. So we hack
-  -- around the dependency issue so that cabal is happy, which is fine since it
+  -- This is a bit silly. Although we won't use plutus-cert in this case, cabal
+  -- still considers it a "local" project and tries to solve for it so we hack
+  -- around the dependency issue, keeping cabal happy, which is fine since it
   -- won't actually build it.
   allow-older: plutus-cert:base
 


### PR DESCRIPTION
I'm learning about Plutus and was reading `cabal.project` in the root and found some typos. I did read the CONTRIBUTING guide but don't feel this change merits an issue.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
