### PR TITLE
Update nix documentation in CONTRIBUTING and RELEASE

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,13 +14,9 @@ If you _really_ cannot use Nix and still want to contribute to Plutus then xref:
 
 === Installing and setting up Nix
 
-The nix code is based on a template from the the 
-[IOGX flake](https://github.com/input-output-hk/iogx). 
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to [this document](https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md). 
 
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
-of the IOGX manual.
+If you already have nix installed and setup, you may enter the development shell by running `nix develop`.
 
 === Note on pre-commit hooks
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,71 +14,13 @@ If you _really_ cannot use Nix and still want to contribute to Plutus then xref:
 
 === Installing and setting up Nix
 
-This project uses Flakes, so you must have Nix version `>= 2.4` installed.
+The nix code is based on a template from the the 
+[IOGX flake](https://github.com/input-output-hk/iogx). 
 
-Either upgrade or install https://nixos.org/nix/[Nix] following the instructions on https://nixos.org/nix/[its website].
-
-On Linux this command should suffice: `sh <(curl -L https://nixos.org/nix/install) --daemon`
-
-=== How to get a shell environment with tools
-
-To enter the development shell run the following command in the root directory:
-
-`nix develop`
-
-If you receive this message:
-
-`error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override`
-
-Then try this:
-
-`nix develop --extra-experimental-features 'nix-command flakes'`
-
-You may now choose to edit your `/etc/nix/nix.conf` (global) or `~/.config/nix/nix.conf` (you must be a https://nixos.org/nix/manual/#ssec-multi-user[trusted user] to do this) by appending the following line:
-
-`extra-experimental-features = nix-command flakes`
-
-If you do so you will be able to enter the development shell by running `nix develop`.
-
-If you are a VSCode user, you may want to start your development session by running:
-
-`nix develop --command code`
-
-If this is your first time running `nix develop`, you may be asked the following:
-```
-do you want to allow configuration setting 'allow-import-from-derivation' to be set to 'true' (y/N)? y
-do you want to permanently mark this value as trusted (y/N)? y
-```
-Please type `y` to this and all subsequent prompts to make life easy for yourself.
-
-IMPORTANT: *It is particularly important to accept the `extra-substituters` and `extra-trusted-public-keys` settings, which will grant access to our Nix binary cache.*
-
-At this point and if this is your first time running `nix develop` then Nix will download, build and install a copious amout of dependencies.
-
-It is not uncommon for this process to take a couple of hours and to write tens of GBs to the `/nix/store`.
-
-*Rest assured that this only happens the very first time you run `nix develop`.*
-
-However you should pay attention to the output of `nix develop`: if you notice that you are _building_ GHC, it is likely that your
-caches have not been configured correctly.
-
-Accepting the configuration settings as outlined above should be sufficient to avoid this, however if your caches are still broken, you may try to append the following lines to `/etc/nix/nix.conf` and/or `~/.config/nix/nix.conf`:
-
-----
-substituters = https://cache.zw3rk.com https://cache.iog.io https://cache.nixos.org/
-trusted-public-keys = loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-extra-experimental-features = nix-command flakes
-----
-
-On NixOS, set the following NixOS options:
-----
-nix = {
-  binaryCaches          = [ "https://cache.zw3rk.com" "https://cache.iog.io" ];
-  binaryCachePublicKeys = [ "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=" "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
-};
-----
-
-You will need to restart the nix-daemon on non-NixOS for the changes to take effect, or just restart your machine.
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
+of the IOGX manual.
 
 === Note on pre-commit hooks
 
@@ -121,9 +63,9 @@ We don't have a `hie.yaml`, the implicit cradle support in HLS seems to work fin
 
 Haskell components are provisioned by Nix via link:https://github.com/input-output-hk/haskell.nix[Haskell.nix]
 
-In general you can run `nix build .#SYSTEM.plutus.library.plutus-project.hsPkgs.PACKAGE.components.COMPONENT`
+In general you can run `nix build .#cabalProject.SYSTEM.hsPkgs.PACKAGE.components.COMPONENT`
 
-For example `nix build .#x86_64-linux.plutus.library.plutus-project.hsPkgs.plutus-core.components.library`
+For example `nix build .#cabalProject.x86_64-linux.hsPkgs.plutus-core.components.library`
 
 For full documentation about the Nix code see the link:nix/README.md[Nix README].
 
@@ -179,7 +121,7 @@ Note that `cabal` itself keeps track of what index states it knows about, so whe
 The Nix code which builds our packages also cares about the index state.
 This is represented by some pinned inputs in our flake (see xref:update-nix-pins[here] for more details)
 You can update these by running:
-- `nix flake lock --update-input hackage-nix` for Hackage
+- `nix flake lock --update-input hackage` for Hackage
 - `nix flake lock --update-input CHaP` for CHaP
 
 ==== Use of `source-repository-package`s
@@ -190,7 +132,7 @@ In particular, we should not release our packages while we depend on a `source-r
 
 If we are stuck in a situation where we need a long-running fork of a package, we should release it to CHaP instead (see the https://github.com/input-output-hk/cardano-haskell-packages[CHaP README] for more).
 
-If you do add a `source-repository-package`, you need to update the `sha256` mapping in `nix/cells/plutus/library/make-plutus-project.nix`.
+If you do add a `source-repository-package`, you need to update the `sha256` mapping in `nix/project.nix`.
 For the moment you have to do this by hand, using the following command to get the sha: `nix-prefetch-git --quiet <repo-url> <rev> | jq .sha256`, or by just getting it wrong and trying to build it, in which case Nix will give you the right value.
 
 [[update-nix-pins]]
@@ -209,7 +151,7 @@ Do *not* use `nix flake update`, as that will update all the inputs, which we ty
 
 TODO: Currently not available, coming soon
 
-If you launch `nix develop .#profiled-plutus` you will get a shell where all the dependencies have been built with profiling.
+If you launch `nix develop .#profiled` you will get a shell where all the dependencies have been built with profiling.
 
 [WARNING]
 ====
@@ -291,7 +233,7 @@ We currently support the plugin on:
 === Per-version tooling
 
 We have a dev shell for each supported GHC version which you can use if you need to fix issues on that specific version.
-You can access them like this: `nix develop .#plutus-shell-810`.
+You can access them like this: `nix develop .#ghc810`.
 
 Note that HLS in particular won't work in the non-primary dev shell as it will still be built with the primary GHC version, but other tooling should work fine.
 
@@ -374,7 +316,7 @@ you could write a Note describing the trick (and justifying its usage!), and the
 We use `stylish-haskell` for Haskell code formatting, and `cabal-fmt` for cabal files.
 They are run automatically as pre-commit hooks, but CI will run them again and expect that to be a no-op, so if you somehow don’t apply them your PR will not go green.
 
-To run `stylish-haskell` or `cabal-fmt` manually over your tree, type `fix-stylish-haskell` or `fix-cabal-fmt` respectively.
+To run `stylish-haskell` or `cabal-fmt` manually over your tree, type `pre-commit run stylish-haskell` or `pre-commit run cabal-fmt` respectively.
 They are provided by the `nix develop` environment.
 
 === Code linting

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,7 +14,7 @@ If you _really_ cannot use Nix and still want to contribute to Plutus then xref:
 
 === Installing and setting up Nix
 
-For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to [this document](https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md). 
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
 
 If you already have nix installed and setup, you may enter the development shell by running `nix develop`.
 

--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -78,12 +78,11 @@ This updates versions and version bounds, and assembles the changelogs.open a PR
 +
 [source,bash]
 -------------
-# comment out with-inline-r flag from cabal.project (cannot be overriden in cli)
-nix develop github:input-output-hk/devx#ghc928-static-iog --no-write-lock-file --refresh
-cabal build pir uplc
-# The executables should be under dist-newstyle/, rename them to a convenient name and upload them:
-mv ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/plutus-core-x.y.z.0/x/pir/build/pir/pir ./pir-x86_64-linux-ghc928
-mv ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/plutus-core-x.y.z.0/x/uplc/build/uplc/uplc ./uplc-x86_64-linux-ghc928
+nix build .#hydraJobs.x86_64-linux.musl64.ghc92.pir 
+mv ./result/bin/pir ./pir-x86_64-linux-ghc928
+
+nix build .#hydraJobs.x86_64-linux.musl64.ghc92.uplc
+mv ./result/bin/uplc ./uplc-x86_64-linux-ghc928
 -------------
 7. Open a PR in the https://github.com/input-output-hk/cardano-haskell-packages[CHaP repository] for publishing the new version. Run `./scripts/add-from-github.sh "https://github.com/input-output-hk/plutus" COMMIT-SHA LIST-OF-UPDATED-PACKAGES` (see https://github.com/input-output-hk/cardano-haskell-packages#-from-github[the README on CHaP]). Example: https://github.com/input-output-hk/cardano-haskell-packages/pull/394.
 - If issues are found, create a release branch `release/x.y.z`, fix the issues on master, backport the fixes to `release/x.y.z`, tag `x.y.z.0-rc2`, and go to step 4.

--- a/doc/plutus-core-spec/Makefile
+++ b/doc/plutus-core-spec/Makefile
@@ -46,4 +46,3 @@ clean2: clean
 
 v: ${PDF}
 	${PDFVIEWER} ${PDF} 2>/dev/null &
-

--- a/doc/read-the-docs-site/README.md
+++ b/doc/read-the-docs-site/README.md
@@ -6,11 +6,11 @@ Run `nix develop` to enter a development shell with `sphinx-build` and `sphinx-a
 
 The following commands are also available:
 
-- `autobuild-docs`          
+- `develop-rtd-site`          
   Start a development server with live reload on `http://localhost:8000`
-- `build-docs`             
+- `build-rtd-site`             
   Build the docs locally in `_build/index.html`
-- `serve-docs`   
+- `serve-rtd-site`   
   Build the full site with nix (including Haddock) and serve it on `http://localhost:8002`
 
 The doc site from main is built automatically and hosted [here](https://plutus.readthedocs.io/en/latest).

--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699001676,
-        "narHash": "sha256-Qoi3b2b/wbJkICVDwmk4FOEqLVDX6FjGRuXgLZV+IdE=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "594737ac4c1aa93799633839868f50f5ac8a89fd",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR affects the CONTRIBUTING.adoc and RELEASE.adoc making those documents up-to-date. 
