### PR TITLE
Expose 'unSatInt' and 'fromSatInt' from V2 and V3 as well

### DIFF
--- a/plutus-ledger-api/changelog.d/20231109_213954_effectfully_expose_fromSatInt_and_add_some_instances.md
+++ b/plutus-ledger-api/changelog.d/20231109_213954_effectfully_expose_fromSatInt_and_add_some_instances.md
@@ -1,0 +1,3 @@
+### Added
+
+- Exposed `unSatInt` and `fromSatInt` from `plutus-ledger-api`. Added `NFData` and `NoThunks` for `CostModelApplyError`.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -27,7 +27,8 @@ module PlutusLedgerApi.V2 (
   ExBudget (..),
   ExCPU (..),
   ExMemory (..),
-  SatInt,
+  SatInt (unSatInt),
+  fromSatInt,
 
   -- ** Cost model
   EvaluationContext,

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -43,7 +43,8 @@ module PlutusLedgerApi.V3 (
   ExBudget (..),
   V2.ExCPU (..),
   V2.ExMemory (..),
-  V2.SatInt,
+  V2.SatInt (V2.unSatInt),
+  V2.fromSatInt,
 
   -- ** Cost model
   EvaluationContext,


### PR DESCRIPTION
#5618 wasn't ready for merging, this one does for V2 and V3 the same as the previous one did for V1 and adds a changelog entry.