### PR TITLE
Remove some redundant pragmas

### DIFF
--- a/plutus-tx-plugin/test/AsData/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/AsData/Budget/Spec.hs
@@ -1,15 +1,5 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NegativeLiterals      #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE PatternSynonyms       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}

--- a/plutus-tx-plugin/test/AsData/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/AsData/Budget/Spec.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE ViewPatterns          #-}
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NegativeLiterals      #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PatternSynonyms       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE ViewPatterns          #-}
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=0 #-}
 

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
@@ -1,14 +1,9 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TemplateHaskell  #-}
 
-{-# LANGUAGE NegativeLiterals      #-}
-{-# LANGUAGE NoStrict              #-}
+{-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE NoStrict         #-}
 
 -- | This module tests that integer literals are handled correctly, when @Strict@ is off
 -- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE NoStrict         #-}
 
--- | This module tests that integer literals are handled correctly, when @Strict@ is off
+-- | This module tests that integer literals are handled correctly when @Strict@ is off
 -- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When
 -- @NegativeLiterals@ is on, we can get @IN@ for negative integers.
 --

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NegativeLiterals/Spec.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE NegativeLiterals      #-}
 {-# LANGUAGE NoStrict              #-}
 
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
-
 -- | This module tests that integer literals are handled correctly, when @Strict@ is off
 -- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When
 -- @NegativeLiterals@ is on, we can get @IN@ for negative integers.

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
@@ -11,8 +11,6 @@
 {-# LANGUAGE NoNegativeLiterals    #-}
 {-# LANGUAGE NoStrict              #-}
 
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
-
 -- | This module tests that integer literals are handled correctly, when both @Strict@
 -- and @NegativeLiterals@ are off. These two extensions affect the Core we get.
 --

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE NoNegativeLiterals #-}
 {-# LANGUAGE NoStrict           #-}
 
--- | This module tests that integer literals are handled correctly, when both @Strict@
+-- | This module tests that integer literals are handled correctly when both @Strict@
 -- and @NegativeLiterals@ are off. These two extensions affect the Core we get.
 --
 -- See Note [Running PIR and UPLC Simplifiers in Integer literals Tests].

--- a/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/NoStrict/NoNegativeLiterals/Spec.hs
@@ -1,15 +1,9 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NegativeLiterals      #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
-{-# LANGUAGE NoNegativeLiterals    #-}
-{-# LANGUAGE NoStrict              #-}
+{-# LANGUAGE NoNegativeLiterals #-}
+{-# LANGUAGE NoStrict           #-}
 
 -- | This module tests that integer literals are handled correctly, when both @Strict@
 -- and @NegativeLiterals@ are off. These two extensions affect the Core we get.

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE Strict           #-}
 
--- | This module tests that integer literals are handled correctly, when @Strict@ is off
--- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When
--- @NegativeLiterals@ is on, we can get @IN@ for negative integers.
+-- | This module tests that integer literals are handled correctly when both
+-- @Strict@ and @NegativeLiterals@ are on. These two extensions affect the Core
+-- we get. When @NegativeLiterals@ is on, we can get @IN@ for negative integers.
 --
 -- See Note [Running PIR and UPLC Simplifiers in Integer literals Tests].
 module IntegerLiterals.Strict.NegativeLiterals.Spec where

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE NegativeLiterals      #-}
 {-# LANGUAGE Strict                #-}
 
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
-
 -- | This module tests that integer literals are handled correctly, when @Strict@ is off
 -- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When
 -- @NegativeLiterals@ is on, we can get @IN@ for negative integers.

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NegativeLiterals/Spec.hs
@@ -1,14 +1,9 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TemplateHaskell  #-}
 
-{-# LANGUAGE NegativeLiterals      #-}
-{-# LANGUAGE Strict                #-}
+{-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE Strict           #-}
 
 -- | This module tests that integer literals are handled correctly, when @Strict@ is off
 -- and @NegativeLiterals@ is on. These two extensions affect the Core we get. When

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE NoNegativeLiterals    #-}
 {-# LANGUAGE Strict                #-}
 
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
-
 -- | This module tests that integer literals are handled correctly, when @Strict@ is on
 -- and @NegativeLiterals@ is off. These two extensions affect the Core we get.
 --

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE NoNegativeLiterals #-}
 {-# LANGUAGE Strict             #-}
 
--- | This module tests that integer literals are handled correctly, when @Strict@ is on
+-- | This module tests that integer literals are handled correctly when @Strict@ is on
 -- and @NegativeLiterals@ is off. These two extensions affect the Core we get.
 --
 -- See Note [Running PIR and UPLC Simplifiers in Integer literals Tests].

--- a/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
+++ b/plutus-tx-plugin/test/IntegerLiterals/Strict/NoNegativeLiterals/Spec.hs
@@ -1,14 +1,9 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
-{-# LANGUAGE NoNegativeLiterals    #-}
-{-# LANGUAGE Strict                #-}
+{-# LANGUAGE NoNegativeLiterals #-}
+{-# LANGUAGE Strict             #-}
 
 -- | This module tests that integer literals are handled correctly, when @Strict@ is on
 -- and @NegativeLiterals@ is off. These two extensions affect the Core we get.

--- a/plutus-tx-plugin/test/Strictness/Spec.hs
+++ b/plutus-tx-plugin/test/Strictness/Spec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Strict              #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
 
 module Strictness.Spec where
 

--- a/plutus-tx-plugin/test/Strictness/Spec.hs
+++ b/plutus-tx-plugin/test/Strictness/Spec.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE Strict              #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE BangPatterns    #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE Strict          #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Strictness.Spec where
 

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:max-simplifier-iterations-pir=0 #-}

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:context-level=3 #-}
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}


### PR DESCRIPTION
A number of files in `plutus-tx-plugin/test` contain
```
{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
```
where it isn't needed.  This confused me a bit, so I've removed them.

I found some other unnecessary pragmas in these files, so I removed them too.  There are probably similar things in other tests in this package, but I didn't go through them all.