### PR TITLE
Typo: the -> that

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins1.tex
+++ b/doc/plutus-core-spec/cardano/builtins1.tex
@@ -153,7 +153,7 @@ specified either in the denotation given in the table or in a relevant note.
 Recall also that a built-in function will fail if it is given an argument of the
 wrong type: this is checked in conditions involving the $\sim$ relation and the
 $\Eval$ function in Figures~\ref{fig:untyped-term-reduction}
-and~\ref{fig:untyped-cek-machine}.  Note also the some of the functions are
+and~\ref{fig:untyped-cek-machine}.  Note also that some of the functions are
 \#-polymorphic.  According to Section~\ref{sec:builtin-denotations} we
 require a denotation for every possible monomorphisation of these; however all
 of these functions are parametrically polymorphic so to simplify notation we


### PR DESCRIPTION
Just fixing a tiny typo in the PLC specification. I'll auto-merge this.