### PR TITLE
Kwxm/count mainnet builtin usage

### DIFF
--- a/plutus-ledger-api/exe/analyse-script-events/Builtins.md
+++ b/plutus-ledger-api/exe/analyse-script-events/Builtins.md
@@ -1,0 +1,64 @@
+## Built-in functions involved in mainnet script events
+
+We ran the `count-builtins` analysis (see [README.md](./README.md)) on all
+Cardano mainnet script events up to mid-October 2023 (event file beginning
+`0000000105908766`; 21,832,781 script events in total).  The results (sorted by
+frequency) are shown below.  Builtins unreleased at the time of writing are
+omitted because they have not yet been used on the mainnet.
+
+|          Builtin name            |    Total uses   |
+|  :-----------------------------  |  -------------: |
+|  HeadList                        |    881644746    |
+|  IfThenElse                      |    854764718    |
+|  TailList                        |    492113114    |
+|  EqualsInteger                   |    483469806    |
+|  UnConstrData                    |    355025384    |
+|  SndPair                         |    325841074    |
+|  UnBData                         |    293971343    |
+|  FstPair                         |    249617361    |
+|  Trace                           |    243130037    |
+|  UnIData                         |    221383400    |
+|  AddInteger                      |    169915689    |
+|  SubtractInteger                 |    120994891    |
+|  MultiplyInteger                 |    117192596    |
+|  EqualsByteString                |     95913606    |
+|  LessThanEqualsInteger           |     79925863    |
+|  ChooseList                      |     77389297    |
+|  LessThanInteger                 |     65997741    |
+|  UnListData                      |     58771072    |
+|  DivideInteger                   |     47385959    |
+|  UnMapData                       |     40638420    |
+|  EqualsData                      |     32820944    |
+|  BData                           |     20747611    |
+|  MkCons                          |     19690536    |
+|  ConstrData                      |     14307826    |
+|  IData                           |     13598954    |
+|  ChooseData                      |     12980217    |
+|  QuotientInteger                 |      9057969    |
+|  MkNilData                       |      8665066    |
+|  LengthOfByteString              |      8448460    |
+|  AppendByteString                |      5350163    |
+|  IndexByteString                 |      4549830    |
+|  RemainderInteger                |      4300706    |
+|  MkPairData                      |      2852806    |
+|  NullList                        |      2295654    |
+|  ListData                        |      2201376    |
+|  ModInteger                      |      1835787    |
+|  LessThanEqualsByteString        |      1449792    |
+|  LessThanByteString              |      1445947    |
+|  SliceByteString                 |      1216642    |
+|  MapData                         |      1030125    |
+|  Sha3_256                        |       868748    |
+|  EqualsString                    |       778767    |
+|  ConsByteString                  |       591928    |
+|  AppendString                    |       550147    |
+|  MkNilPairData                   |       228298    |
+|  Sha2_256                        |       197746    |
+|  SerialiseData                   |       194855    |
+|  ChooseUnit                      |       171916    |
+|  VerifyEd25519Signature          |        31974    |
+|  EncodeUtf8                      |        13074    |
+|  DecodeUtf8                      |        11639    |
+|  Blake2b_256                     |         9920    |
+|  VerifyEcdsaSecp256k1Signature   |          575    |
+|  VerifySchnorrSecp256k1Signature |          575    |

--- a/plutus-ledger-api/exe/analyse-script-events/Main.hs
+++ b/plutus-ledger-api/exe/analyse-script-events/Main.hs
@@ -298,7 +298,7 @@ countBuiltins eventFiles = do
   mapM_ (analyseOneFile (analyseUnappliedScript (countBuiltinsInTerm counts))) eventFiles
   finalCounts <- P.freezePrimArray counts 0 numBuiltins
   P.itraversePrimArray_ printEntry finalCounts
-    where printEntry i c = printf "%-35s %d\n" (show (toEnum i :: DefaultFun)) c
+    where printEntry i c = printf "%-35s %12d\n" (show (toEnum i :: DefaultFun)) c
 
 -- Extract the script from an evaluation event and apply some analysis function
 analyseUnappliedScript

--- a/plutus-ledger-api/exe/analyse-script-events/README.md
+++ b/plutus-ledger-api/exe/analyse-script-events/README.md
@@ -30,12 +30,12 @@ The `dir` argument specifies the path to a directory containing uncompressed
 several hours for the analysis to complete depending on the complexity of the
 analysis and the number of files to be analysed.
 
-There are currently four analyses available:
+There are currently five analyses available:
 * `datums`: analyse the structure of `Data` objects containing transaction datums
 * `redeemers`: analyse the structure of `Data` objects containing redeemers
 * `script-data`: analyse the structure of `Data` objects occurring inside scripts
 * `values`: analyse the shape of `Value` objects occurring in script contexts
-
+* `count-builtins` : count the total number of occurrences of each builtin in validator scripts
 
 ### `Data` object analyses
 
@@ -131,4 +131,10 @@ sort -nrs | sed 's/\[ /\[/'
 rm osort.tmp
 ```
 
+### Builtin analysis
+
+The `count-builtins` analysis simply traverses the AST of each validator script
+and accumulates the total number of times each built-in function appears,
+printing out a table of frequencies once every validatorhas been processed.  See
+[Builtins.md](./Builtins.md) for an example.
 

--- a/plutus-ledger-api/plutus-ledger-api.cabal
+++ b/plutus-ledger-api/plutus-ledger-api.cabal
@@ -226,6 +226,7 @@ executable analyse-script-events
     , plutus-core                                                       ^>=1.16
     , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  ^>=1.16
     , plutus-tx                                                         ^>=1.16
+    , primitive
     , serialise
 
   default-language: Haskell2010


### PR DESCRIPTION
[PLT_8615] This adds a mainnet script dump analysis to count the number of times each builtin appears, together with the results for the entire dump up to mid-October 2023.