### PR TITLE
Show budget and traces output when uplc evaluate fails

### DIFF
--- a/plutus-core/executables/uplc/Main.hs
+++ b/plutus-core/executables/uplc/Main.hs
@@ -305,7 +305,7 @@ runEval (EvalOptions inp ifmt printMode budgetMode traceMode
                                 _   -> error "Timing evaluations returned inconsistent results"
                 handleResults t (res, budget, logs) = do
                     case res of
-                        Left err -> hPrint stderr err >> exitFailure
+                        Left err -> hPrint stderr err
                         Right v  -> writeToFileOrStd outputMode (show (getPrintMethod printMode v))
                     case budgetMode of
                         Silent    -> pure ()
@@ -313,6 +313,9 @@ runEval (EvalOptions inp ifmt printMode budgetMode traceMode
                     case traceMode of
                         None -> pure ()
                         _    -> writeToFileOrStd outputMode (T.unpack (T.intercalate "\n" logs))
+                    case res of
+                        Left _  -> exitFailure
+                        Right _ -> pure ()
 
 ---------------- Debugging ----------------
 


### PR DESCRIPTION
Currently it's impossible to see the evaluation traces in case of a failure. This fixes that.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
