### PR TITLE
Extra conformance tests for chooseList

### DIFF
--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
@@ -1,2 +1,2 @@
 -- chooseList should accept arbitrary terms in the branches
-(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ 0, 1, 2 ])] (lam x x)] (lam x x)])
+(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ 0, 1, 2 ])] (lam x x)] (lam y (lam z z)])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
@@ -1,0 +1,2 @@
+-- chooseList should accept arbitrary terms in the branches
+(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ 0, 1, 2 ])] (lam x x)] (lam x x)])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc
@@ -1,2 +1,2 @@
 -- chooseList should accept arbitrary terms in the branches
-(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ 0, 1, 2 ])] (lam x x)] (lam y (lam z z)])
+(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ 0, 1, 2 ])] (lam x x)] (lam y (lam z z))])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
@@ -1,0 +1,1 @@
+(program 0.0.0 (lam x x))

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
@@ -1,1 +1,1 @@
-(program 0.0.0 (lam x x))
+parse error

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList3/chooseList3.uplc.expected
@@ -1,1 +1,1 @@
-parse error
+(program 0.0.0 (lam y (lam z z)))

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc
@@ -1,0 +1,2 @@
+-- chooseList should accept arbitrary terms in the branches
+(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ ])] (lam x x)] (lam x x)])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc
@@ -1,2 +1,2 @@
 -- chooseList should accept arbitrary terms in the branches
-(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ ])] (lam x x)] (lam x x)])
+(program 0.0.0 [[[(force (force (builtin chooseList))) (con (list integer) [ ])] (lam x x)] (lam y (lam z z))])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseList/chooseList4/chooseList4.uplc.expected
@@ -1,0 +1,1 @@
+(program 0.0.0 (lam x x))

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseUnit2/chooseUnit2.uplc
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseUnit2/chooseUnit2.uplc
@@ -1,0 +1,2 @@
+-- chooseUnit should accept arbitrary terms for the second argument
+(program 0.0.0 [[(force (builtin chooseUnit)) (con unit ())] (lam x x)])

--- a/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseUnit2/chooseUnit2.uplc.expected
+++ b/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/chooseUnit2/chooseUnit2.uplc.expected
@@ -1,0 +1,1 @@
+(program 0.0.0 (lam a a))


### PR DESCRIPTION
`chooseList` is *-polymorphic in its second and third arguments and we weren't checking this.  We should do this for all *-polymorphic arguments and check that builtins with #-polymorphic arguments fail when given non-constant terms (but later).

The present PR adds tests for the problem that got fixed in #5657.