### PR TITLE
Fix haskell syntax highlighting in quickstart

### DIFF
--- a/doc/read-the-docs-site/quick-start.rst
+++ b/doc/read-the-docs-site/quick-start.rst
@@ -85,6 +85,7 @@ Next, write the ``main`` function in ``Main.hs``, which does two things:
 Here is what ``Main.hs`` may look like:
 
 .. literalinclude:: tutorials/QuickStart.hs
+   :language: haskell
    :start-after: BLOCK1
    :end-before: BLOCK2
 


### PR DESCRIPTION
The other tutorials don't have this since they set it globally at the top. We don't want that here since we have some non-Haskell code blocks too.