### PR TITLE
PLT-1566 Add cost semantics for basic builtins

### DIFF
--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -67,6 +67,9 @@ library
     , text
     , transformers
 
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
   exposed-modules:
     Opts
     Raw

--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -57,6 +57,7 @@ library
     , composition-prelude
     , cryptonite
     , extra
+    , ghc-prim
     , ieee754
     , megaparsec
     , memory
@@ -127,6 +128,7 @@ library
     MAlonzo.Code.Category.Monad.Indexed
     MAlonzo.Code.Check
     MAlonzo.Code.Cost
+    MAlonzo.Code.Cost.Base
     MAlonzo.Code.Data.Bool.Base
     MAlonzo.Code.Data.Bool.Properties
     MAlonzo.Code.Data.Char.Base
@@ -349,6 +351,7 @@ library
     MAlonzo.Code.Category.Monad.Indexed
     MAlonzo.Code.Check
     MAlonzo.Code.Cost
+    MAlonzo.Code.Cost.Base
     MAlonzo.Code.Data.Bool.Base
     MAlonzo.Code.Data.Bool.Properties
     MAlonzo.Code.Data.Char.Base

--- a/plutus-metatheory/src/Builtin.lagda.md
+++ b/plutus-metatheory/src/Builtin.lagda.md
@@ -16,7 +16,7 @@ open import Data.Bool using (Bool;true;false)
 open import Data.List using (List)
 open import Data.Nat using (ℕ;suc)
 open import Data.Fin using (Fin) renaming (zero to Z; suc to S)
-open import Data.List.NonEmpty using (List⁺;_∷⁺_;[_];reverse)
+open import Data.List.NonEmpty using (List⁺;_∷⁺_;[_];reverse;length)
 open import Data.Product using (Σ;proj₁;proj₂)
 open import Relation.Binary using (DecidableEquality)
 
@@ -297,6 +297,10 @@ hence need to be embedded into `n⋆ / n♯ ⊢⋆` using the postfix constructo
     signature bls12-381-finalVerify           = ∙ [ bls12-381-mlresult ↑ , bls12-381-mlresult ↑ ]⟶ bool ↑
 
 open SugaredSignature using (signature) public
+
+-- The arity of a builtin, according to its signature.
+arity : Builtin → ℕ 
+arity b = length (Sig.args (signature b))
 
 ```
 

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -445,14 +445,14 @@ tallyingReport (mp , budget) =
                                "" 
                                stepKindList
 
-    printBuiltinModel : Builtin → ExBudget → String 
-    printBuiltinModel b (mkExBudget 0 0) = "" 
-    printBuiltinModel b budget = padRight ' ' 22 (showBuiltin b) ++ " " 
+    printBuiltinCost : Builtin → ExBudget → String 
+    printBuiltinCost b (mkExBudget 0 0) = "" 
+    printBuiltinCost b budget = padRight ' ' 22 (showBuiltin b) ++ " " 
                              ++ budgetToString budget ++ "\n"
 
     printBuiltinReport : Map ExBudget → String 
     printBuiltinReport mp = 
-        L.foldr (λ b xs → printBuiltinModel b (lookup mp (BBuiltinApp b (replicate 0))) ++ xs) 
+        L.foldr (λ b xs → printBuiltinCost b (lookup mp (BBuiltinApp b (replicate 0))) ++ xs) 
               "" 
               builtinList     
     

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -28,7 +28,8 @@ import Data.List as L
 open import Data.Maybe using (Maybe;just;nothing;maybe)
 open import Data.Product using (_×_;_,_)
 open import Data.String using (String;_++_;padLeft;padRight;length)
-open import Data.Vec using (Vec;replicate;[];_∷_;sum;foldr)
+open import Data.Vec using (Vec;replicate;[];_∷_;sum;foldr) 
+                     renaming (lookup to lookupVec)
 open import Algebra using (IsMonoid)
 open import Relation.Nullary using (yes;no)
 open import Relation.Binary.PropositionalEquality using (_≡_;refl;isEquivalence;cong₂)
@@ -186,7 +187,7 @@ TODO: Finish all models.
 data CostingModel : ℕ → Set where 
    -- Any number of variables 
   constantCost       :  ∀{n} → CostingNat → CostingModel n
-  linearCost         : ∀{n} → Fin n → Intercept → Slope → CostingModel n
+  linearCostIn       : ∀{n} → Fin n → Intercept → Slope → CostingModel n
   -- at least two arguments
   addedSizes         : ∀{n} → Intercept → Slope → CostingModel (2 + n) 
   multipliedSizes    : ∀{n} → Intercept → Slope → CostingModel (2 + n)
@@ -262,9 +263,6 @@ assignModel _ = --TODO rest of builtins (or rather implement constructing model 
 Some helper functions.
 
 ```
-scaleLinearly : Intercept → Slope → CostingNat → CostingNat 
-scaleLinearly intercept slope n = intercept + slope * n
-
 prod : ∀ {n} → Vec ℕ n → ℕ
 prod = foldr _ _*_ 1
 
@@ -278,8 +276,7 @@ Given a model and the sizes of the arguments we can compute a cost.
 ```
 runModel : ∀{n} → CostingModel n → Vec CostingNat n → CostingNat 
 runModel (constantCost x) _ = x
-runModel (linearCost zero i s) (a ∷ _) = i + s * a
-runModel (linearCost (suc n) i s) (_ ∷ xs) = runModel (linearCost n i s) xs
+runModel (linearCostIn n i s) xs = i + s * lookupVec xs n
 runModel (addedSizes i s) xs = i + s * (sum xs)
 runModel (multipliedSizes i s) xs = i + s * (prod xs)
 runModel (minSize i s) xs = i + s * minimum xs

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -417,17 +417,17 @@ tallyingReport (mp , budget) =
     ++ "\n\n"
     ++ printBuiltinReport mp 
     ++ "\n" 
-    ++ "Total builtin costs:   " ++ budgetToString totalBuiltinModels ++ "\n"
+    ++ "Total builtin costs:   " ++ budgetToString totalBuiltinCosts ++ "\n"
      -- We would like to be able to print the following  number as "%4.2f" 
      -- but Agda's printf currently doesn't support it.
-    ++ printf "Time spent executing builtins:  %f%%\n" (fromℕ 100 *f (getCPU totalBuiltinModels) ÷ (getCPU budget)) ++ "\n"
+    ++ printf "Time spent executing builtins:  %f%%\n" (fromℕ 100 *f (getCPU totalBuiltinCosts) ÷ (getCPU budget)) ++ "\n"
     ++ "\n"
     ++ "Total budget spent:    " ++ budgetToString budget ++ "\n"
     ++  "Predicted execution time: " ++ formatTimePicoseconds (getCPU budget)
   where 
-    totalComputeCost totalBuiltinModels : ExBudget 
+    totalComputeCost totalBuiltinCosts : ExBudget 
     totalComputeCost = L.foldr (λ x acc → (lookup mp (BStep x)) ∙€ acc) ε€ stepKindList
-    totalBuiltinModels = L.foldr _∙€_ ε€ (L.map (lookup mp ∘ (λ b → BBuiltinApp b (replicate 0))) builtinList)
+    totalBuiltinCosts = L.foldr _∙€_ ε€ (L.map (lookup mp ∘ (λ b → BBuiltinApp b (replicate 0))) builtinList)
 
     getCPU : ExBudget → Float
     getCPU n = fromℕ (ExCPU n)   

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -14,39 +14,51 @@ module Cost where
 
 ```
 open import Function using (_∘_)
-open import Data.Bool
-open import Data.List using (List;foldr)
-open import Data.Nat using (ℕ;_+_)
-open import Data.Integer using (ℤ)
-open import Data.Float using (Float;fromℕ;_÷_;_*_;_≤ᵇ_) renaming (show to show𝔽)
+open import Data.Bool using (if_then_else_)
+open import Data.Fin using (Fin;zero;suc)
+open import Data.Integer using (+_)
+open import Data.Nat using (ℕ;zero;suc;_+_;_*_;_∸_;_⊔_;_⊓_;_<?_)
+open import Data.Nat.DivMod using (_/_)
 open import Data.Nat.Properties using (+-assoc;+-identityʳ)
 open import Data.Nat.Show using () renaming (show to showℕ)
-open import Data.Maybe using (Maybe;just;nothing;fromMaybe;maybe)
+open import Data.Integer using (ℤ;∣_∣)
+open import Data.Float using (Float;fromℕ;_÷_;_≤ᵇ_) renaming (show to show𝔽;_*_ to _*f_)
+import Data.List as L
+
+open import Data.Maybe using (Maybe;just;nothing;maybe)
 open import Data.Product using (_×_;_,_)
-open import Data.String using (String;_++_;tail;padLeft;padRight)
+open import Data.String using (String;_++_;padLeft;padRight;length)
+open import Data.Vec using (Vec;replicate;[];_∷_;sum;foldr)
 open import Algebra using (IsMonoid)
-open import Relation.Binary.PropositionalEquality using (_≡_;refl;trans;isEquivalence;cong₂)
+open import Relation.Nullary using (yes;no)
+open import Relation.Binary.PropositionalEquality using (_≡_;refl;isEquivalence;cong₂)
 open import Text.Printf using (printf)
 
-open import Utils.Reflection using (defDec;defShow;defListConstructors)
+open import Utils using (_,_;_∷_;[];DATA)
+open DATA
 
 open import Relation.Binary using (StrictTotalOrder)
 open import Data.Char using (_≈ᵇ_)
-open import Data.String
 open import Data.String.Properties using (<-strictTotalOrder-≈)
-open import Data.Tree.AVL.Map <-strictTotalOrder-≈ as AVL using (Map;empty;unionWith;singleton) renaming (lookup to lookupAVL)
-open import Builtin using (Builtin;showBuiltin;builtinList)
+open import Data.Tree.AVL.Map <-strictTotalOrder-≈ as AVL 
+          using (Map;empty;unionWith;singleton) 
+          renaming (lookup to lookupAVL)
+open import Builtin using (Builtin;showBuiltin;builtinList;lengthBS;arity)
+open Builtin.Builtin
+open import Builtin.Signature using (_⊢♯)
+open _⊢♯
+open import RawU using (TmCon) 
+open TmCon
+open import Builtin.Constant.AtomicType using (AtomicTyCon)
+open AtomicTyCon
+open import Cost.Base 
 ``` 
 
 ## Execution Budget
 
-We will represent costs with Naturals. In the implementation `SatInt` is used, (integers that don't overflow, but saturate). 
-As long as the budget is less than the maxInt then the result should be the same.
+An execution budget consist of two costs: CPU and memory costs.
 
 ```
-CostingNat : Set 
-CostingNat = ℕ
-
 record ExBudget : Set where
   constructor mkExBudget 
   field
@@ -56,7 +68,8 @@ record ExBudget : Set where
 open ExBudget
 ```
 
-`ExBudget` is a Monoid.
+The type for execution budget should be a Monoid.
+We show that this is the case for `ExBudget`.
 
 ```
 -- unit of the monoid
@@ -79,73 +92,213 @@ isMonoidExBudget = record {
      ; identity = (λ x → refl) , λ x → cong₂ mkExBudget (+-identityʳ (ExCPU x)) (+-identityʳ (ExMem x)) }
 ``` 
 
-We define one constructor for each possible type of node in a UPLC term.
+## Memory usage of type constants
+
+For each type constant we calculate its size, as a measure of memory usage.
+
+First we bring some functions from Haskell world.
 
 ```
-data StepKind : Set where 
-    BConst 
-      BVar
-      BLamAbs
-      BApply
-      BDelay
-      BForce
-      BBuiltin -- Cost of evaluating a Builtin AST node, not the function itself
-      BConstr 
-      BCase : StepKind
+postulate ℕtoWords : ℤ → CostingNat 
+postulate g1ElementCost : CostingNat
+postulate g2ElementCost : CostingNat
+postulate mlResultElementCost : CostingNat 
+
+{-# FOREIGN GHC {-# LANGUAGE MagicHash #-} #-}
+{-# FOREIGN GHC import GHC.Exts (Int (I#)) #-}
+{-# FOREIGN GHC import GHC.Integer  #-}
+{-# FOREIGN GHC import GHC.Integer.Logarithms  #-}
+{-# FOREIGN GHC import GHC.Prim #-}
+{-# FOREIGN GHC import PlutusCore.Crypto.BLS12_381.G1 as BLS12_381.G1 #-}
+{-# FOREIGN GHC import PlutusCore.Crypto.BLS12_381.G2 as BLS12_381.G2 #-}
+{-# FOREIGN GHC import PlutusCore.Crypto.BLS12_381.Pairing as BLS12_381.Pairing #-}
+
+{-# COMPILE GHC  ℕtoWords = \i -> fromIntegral $ I# (integerLog2# (abs i) `quotInt#` integerToInt 64) + 1 #-}
+{-# COMPILE GHC g1ElementCost = toInteger (BLS12_381.G1.memSizeBytes `div` 8) #-}
+{-# COMPILE GHC g2ElementCost = toInteger (BLS12_381.G2.memSizeBytes `div` 8) #-}
+{-# COMPILE GHC mlResultElementCost = toInteger (BLS12_381.Pairing.mlResultMemSizeBytes `div` 8) #-}
 ```
 
-We define a show function for StepKinds
+For each constant we return the corresponding size.
 
 ```
-showStepKind' : StepKind → String 
-unquoteDef showStepKind' = defShow (quote StepKind) showStepKind' 
+byteStringSize : Utils.ByteString → CostingNat 
+byteStringSize x = let n = ∣ lengthBS x ∣ in ((n ∸ 1) / 8) + 1
 
-showStepKind : StepKind → String 
-showStepKind s = fromMaybe "" (tail (showStepKind' s))   
+defaultConstantMeasure : TmCon → CostingNat
+defaultConstantMeasure (tmCon (atomic aInteger) x) = ℕtoWords x
+defaultConstantMeasure (tmCon (atomic aBytestring) x) = byteStringSize x
+defaultConstantMeasure (tmCon (atomic aString) x) = length x -- each Char costs 1
+defaultConstantMeasure (tmCon (atomic aUnit) x) = 1
+defaultConstantMeasure (tmCon (atomic aBool) x) = 1
+defaultConstantMeasure (tmCon (atomic aData) (ConstrDATA _ [])) = 0
+defaultConstantMeasure (tmCon (atomic aData) (ConstrDATA i (x ∷ xs))) = 
+     defaultConstantMeasure (tmCon (atomic aData) x) 
+   + defaultConstantMeasure (tmCon (atomic aData) (ConstrDATA i xs))
+defaultConstantMeasure (tmCon (atomic aData) (MapDATA [])) = 0
+defaultConstantMeasure (tmCon (atomic aData) (MapDATA ((x , y) ∷ xs))) =
+     defaultConstantMeasure (tmCon (atomic aData) x) 
+   + defaultConstantMeasure (tmCon (atomic aData) y) 
+   + defaultConstantMeasure (tmCon (atomic aData) (MapDATA xs)) 
+defaultConstantMeasure (tmCon (atomic aData) (ListDATA [])) = 0
+defaultConstantMeasure (tmCon (atomic aData) (ListDATA (x ∷ xs))) =
+     defaultConstantMeasure (tmCon (atomic aData) x) 
+   + defaultConstantMeasure (tmCon (atomic aData) (ListDATA xs))
+defaultConstantMeasure (tmCon (atomic aData) (iDATA x)) =  ℕtoWords x
+defaultConstantMeasure (tmCon (atomic aData) (bDATA x)) = byteStringSize x
+defaultConstantMeasure (tmCon (atomic aBls12-381-g1-element) x) = g1ElementCost
+defaultConstantMeasure (tmCon (atomic aBls12-381-g2-element) x) = g2ElementCost
+defaultConstantMeasure (tmCon (atomic aBls12-381-mlresult) x) = mlResultElementCost
+defaultConstantMeasure (tmCon (list t) []) = 0
+defaultConstantMeasure (tmCon (list t) (x ∷ xs)) = 
+       defaultConstantMeasure (tmCon t x) 
+     + defaultConstantMeasure (tmCon (list t) xs)
+defaultConstantMeasure (tmCon (pair t u) (x , y)) = 
+      1 + defaultConstantMeasure (tmCon t x) 
+        + defaultConstantMeasure (tmCon u y)
 ```
 
-and a list of constructors names
+## Builtin Cost Models
+
+### Basic Definitions
+
+```
+Intercept : Set 
+Intercept = CostingNat 
+
+Slope : Set 
+Slope = CostingNat 
+```
+
+### Models
+
+A model is indexed by the number of arguments.
+
+For example, for `ifThenElse` we would assign a model `constantCost : CostingModel 3`,
+which is a model for a builtin that takes three arguments.
+
+For `linearCost` the model takes an index indicating on which argument the cost
+should be calculated.
+
+TODO: Finish all models.
 
 ``` 
-stepKindList : List StepKind
-unquoteDef stepKindList = defListConstructors (quote StepKind) stepKindList 
+data CostingModel : ℕ → Set where 
+   -- Any number of variables 
+  constantCost       :  ∀{n} → CostingNat → CostingModel n
+  linearCost         : ∀{n} → Fin n → Intercept → Slope → CostingModel n
+  -- at least two arguments
+  addedSizes         : ∀{n} → Intercept → Slope → CostingModel (2 + n) 
+  multipliedSizes    : ∀{n} → Intercept → Slope → CostingModel (2 + n)
+  minSize            : ∀{n} → Intercept → Slope → CostingModel (2 + n)
+  maxSize            : ∀{n} → Intercept → Slope → CostingModel (2 + n)
+   -- exactly two arguments 
+--  twoArgumentsLinearInXAndY      : Intercept → Slope → Slope → CostingModel 2
+  twoArgumentsSubtractedSizes    : Intercept → Slope → CostingNat → CostingModel 2
+
+--  twoArgumentsLinearOnDiagonal   : CostingNat → Intercept → Slope → CostingModel 2
+  twoArgumentsConstAboveDiagonal : CostingNat → CostingModel 2 → CostingModel 2
+--  twoArgumentsConstBelowDiagonal : CostingNat → CostingModel 2 → CostingModel 2
 ``` 
 
-## Recording expenditure
-
-The following data structure is use to defines the categories for which we
-record expenditure.
+A model of a builtin consists of a pair of costing models, one for CPU and one for memory.
 
 ```
-data ExBudgetCategory : Set where
-    BStep       : StepKind → ExBudgetCategory
-    BBuiltinApp : Builtin → ExBudgetCategory  -- Cost of evaluating a fully applied builtin function
-    BStartup    : ExBudgetCategory
-```
-
-## Machine Parameters
-
-The CEK machine is parameterised by the following machine parameters.
-
-```
-record MachineParameters (A : Set) : Set where
+record BuiltinModel (b : Builtin) : Set where 
     field 
-      startupCost : A 
-      cekMachineCost : ExBudgetCategory → A
-      ε : A
-      _∙_ : A → A → A
-      costMonoid : IsMonoid _≡_ _∙_ ε
+        costingCPU costingMem : CostingModel (arity b)
+        
+open BuiltinModel 
 ```
 
-## Builtin Cost Model 
+For now, we define a static function to assign a model to the arithmetic builtins,
+and `ifThenElse`.
 
-TODO
+TODO: Construct the assignment for all builtins from json file.
 
 ```
-builtinCost : Builtin → ExBudget
---builtinCost _ = ε€ --TODO implement builtin costs
-builtinCost _ = mkExBudget 1 0
+assignModel : (b : Builtin) → BuiltinModel b
+assignModel addInteger = 
+    record { costingCPU = maxSize 205665 812 
+           ; costingMem = maxSize 1 1 }
+assignModel subtractInteger = 
+    record { costingCPU = maxSize 205665 812 
+           ; costingMem = maxSize 1 1 }
+assignModel multiplyInteger = 
+    record { costingCPU = addedSizes 69522 11687 
+           ; costingMem = addedSizes 0 1 }    
+assignModel divideInteger =
+    record { costingCPU = twoArgumentsConstAboveDiagonal 196500 (multipliedSizes 453240 220) 
+           ; costingMem = twoArgumentsSubtractedSizes 0 1 1 }    
+assignModel quotientInteger =
+    record { costingCPU = twoArgumentsConstAboveDiagonal 196500 (multipliedSizes 453240 220) 
+           ; costingMem = twoArgumentsSubtractedSizes 0 1 1 }    
+assignModel remainderInteger =
+    record { costingCPU = twoArgumentsConstAboveDiagonal 196500 (multipliedSizes 453240 220) 
+           ; costingMem = twoArgumentsSubtractedSizes 0 1 1 }
+assignModel modInteger =
+    record { costingCPU = twoArgumentsConstAboveDiagonal 196500 (multipliedSizes 453240 220) 
+           ; costingMem = twoArgumentsSubtractedSizes 0 1 1 }
+assignModel equalsInteger =
+    record { costingCPU = minSize 208512 421 
+           ; costingMem = constantCost 1 }
+assignModel lessThanInteger =
+    record { costingCPU = minSize 208896 511 
+           ; costingMem = constantCost 1 }
+assignModel lessThanEqualsInteger =
+    record { costingCPU = minSize 204924 473 
+           ; costingMem = constantCost 1 }
+assignModel ifThenElse = 
+    record { costingCPU = constantCost 80556 
+           ; costingMem = constantCost 1 }
+assignModel _ = --TODO rest of builtins (or rather implement constructing model from json)
+    record { costingCPU = constantCost 0 
+           ; costingMem = constantCost 0 }
 
+``` 
+
+### Model interpretations
+
+Some helper functions.
+
+```
+scaleLinearly : Intercept → Slope → CostingNat → CostingNat 
+scaleLinearly intercept slope n = intercept + slope * n
+
+prod : ∀ {n} → Vec ℕ n → ℕ
+prod = foldr _ _*_ 1
+
+maximum minimum : ∀ {n} → Vec ℕ (suc n) → ℕ
+maximum (a ∷ xs) = foldr _ _⊔_ a xs
+minimum (a ∷ xs) = foldr _ _⊓_ a xs
+``` 
+
+Given a model and the sizes of the arguments we can compute a cost.
+
+```
+runModel : ∀{n} → CostingModel n → Vec CostingNat n → CostingNat 
+runModel (constantCost x) _ = x
+runModel (linearCost zero i s) (a ∷ _) = i + s * a
+runModel (linearCost (suc n) i s) (_ ∷ xs) = runModel (linearCost n i s) xs
+runModel (addedSizes i s) xs = i + s * (sum xs)
+runModel (multipliedSizes i s) xs = i + s * (prod xs)
+runModel (minSize i s) xs = i + s * minimum xs
+runModel (maxSize i s) xs = i + s * maximum xs
+runModel (twoArgumentsSubtractedSizes i s min) (a ∷ b ∷ []) = i + s * (min ⊔ (a ∸ b))
+runModel (twoArgumentsConstAboveDiagonal c m) (a ∷ b ∷ [])  with a <? b 
+... | yes _  = c 
+... | no  _  = runModel m (a ∷ b ∷ [])
+```
+
+### Cost of executing a builtin
+
+To calculate the cost of a builtin we obtain the corresponding builtin model, 
+and run the cpu and memory model using the vector of argument sizes.
+
+```
+builtinCost : (b : Builtin) → Vec CostingNat (arity b) → ExBudget
+builtinCost b cs = let bc = assignModel b 
+                   in mkExBudget (runModel (costingCPU bc) cs) (runModel (costingMem bc) cs)
 ```
 
 ## Default Machine Parameters
@@ -153,19 +306,19 @@ builtinCost _ = mkExBudget 1 0
 The default machine parameters for `ExBudget`.
 
 TODO : For now we will define fixed costs. Later, we should 
-implement getting these values from the cekMachineCosts.json file.
+implement getting these values from the `cekMachineCosts.json` file.
 Probably, we will do this by reusing Haskell code.
  
 ```
 defaultCekMachineCost : StepKind → ExBudget
-defaultCekMachineCost s = mkExBudget 23000 100
+defaultCekMachineCost _ = mkExBudget 23000 100
 
 defaultCekStartupCost : ExBudget 
 defaultCekStartupCost = mkExBudget 100 100
 
 exBudgetCategoryCost : ExBudgetCategory → ExBudget 
 exBudgetCategoryCost (BStep x) = defaultCekMachineCost x
-exBudgetCategoryCost (BBuiltinApp b) = builtinCost b
+exBudgetCategoryCost (BBuiltinApp b cs) = builtinCost b cs
 exBudgetCategoryCost BStartup = defaultCekStartupCost
 
 defaultMachineParameters : MachineParameters ExBudget
@@ -175,6 +328,7 @@ defaultMachineParameters = record {
   ; ε = ε€
   ; _∙_ = _∙€_
   ; costMonoid = isMonoidExBudget
+  ; constantMeasure = defaultConstantMeasure 
  } 
 
 countingReport : ExBudget → String 
@@ -185,6 +339,9 @@ countingReport (mkExBudget cpu mem) =
  
  ## Tallying budget 
 
+These functions define a type for Budgets that can record detailed cost information
+about nodes and builtins.
+
 We need a map from `ExBudgetCategory` into `ExBudget`. 
 It's not the most efficient, but the simplest thing to do is to 
 transform `ExBudgetCategory` into a string, and use that as keys.
@@ -192,7 +349,7 @@ transform `ExBudgetCategory` into a string, and use that as keys.
 ```
 mkKeyFromExBudgetCategory : ExBudgetCategory → String 
 mkKeyFromExBudgetCategory (BStep x) = "0" ++ showStepKind x
-mkKeyFromExBudgetCategory (BBuiltinApp x) = "1"++ showBuiltin x
+mkKeyFromExBudgetCategory (BBuiltinApp x _) = "1"++ showBuiltin x
 mkKeyFromExBudgetCategory BStartup = "2"
 
 TallyingBudget : Set 
@@ -204,7 +361,7 @@ lookup m k with lookupAVL (mkKeyFromExBudgetCategory k) m
 ... | nothing = ε€
 ```
 
-TallyingBudget is a monoid. 
+As required, `TallyingBudget` is a monoid. 
 
 ```
 --unit of TallyingBudget 
@@ -242,12 +399,15 @@ tallyingMachineParameters = record {
       ; ε = εT
       ; _∙_ = _∙T_
       ; costMonoid = isMonoidTallyingBudget
+      ; constantMeasure = defaultConstantMeasure
       } 
 
 tallyingReport : TallyingBudget → String
 tallyingReport (mp , budget) =  
        countingReport budget
     ++ "\n"
+    ++ " DEBUG : ℕtoWords 1 = " ++ showℕ (ℕtoWords (+ 1)) 
+    ++ " DEBUG : ℕtoWords 2 = " ++ showℕ (ℕtoWords (+ 2))
     ++ "\n"
     ++ printStepReport mp
     ++ "\n"
@@ -257,17 +417,17 @@ tallyingReport (mp , budget) =
     ++ "\n\n"
     ++ printBuiltinReport mp 
     ++ "\n" 
-    ++ "Total builtin costs:   " ++ budgetToString totalBuiltinCosts ++ "\n"
+    ++ "Total builtin costs:   " ++ budgetToString totalBuiltinModels ++ "\n"
      -- We would like to be able to print the following  number as "%4.2f" 
      -- but Agda's printf currently doesn't support it.
-    ++ printf "Time spent executing builtins:  %f%%\n" (fromℕ 100 * (getCPU totalBuiltinCosts) ÷ (getCPU budget)) ++ "\n"
+    ++ printf "Time spent executing builtins:  %f%%\n" (fromℕ 100 *f (getCPU totalBuiltinModels) ÷ (getCPU budget)) ++ "\n"
     ++ "\n"
     ++ "Total budget spent:    " ++ budgetToString budget ++ "\n"
     ++  "Predicted execution time: " ++ formatTimePicoseconds (getCPU budget)
   where 
-    totalComputeCost totalBuiltinCosts : ExBudget 
-    totalComputeCost = foldr (λ x acc → (lookup mp (BStep x)) ∙€ acc) ε€ stepKindList
-    totalBuiltinCosts = foldr _∙€_ ε€ (Data.List.map (lookup mp ∘ BBuiltinApp) builtinList)
+    totalComputeCost totalBuiltinModels : ExBudget 
+    totalComputeCost = L.foldr (λ x acc → (lookup mp (BStep x)) ∙€ acc) ε€ stepKindList
+    totalBuiltinModels = L.foldr _∙€_ ε€ (L.map (lookup mp ∘ (λ b → BBuiltinApp b (replicate 0))) builtinList)
 
     getCPU : ExBudget → Float
     getCPU n = fromℕ (ExCPU n)   
@@ -281,28 +441,25 @@ tallyingReport (mp , budget) =
                            ++ padLeft ' ' 20 (budgetToString budget) ++ "\n"
 
     printStepReport : Map ExBudget → String 
-    printStepReport mp = foldr (λ s xs → printStepCost s (lookup mp (BStep s)) ++ xs)
+    printStepReport mp = L.foldr (λ s xs → printStepCost s (lookup mp (BStep s)) ++ xs)
                                "" 
                                stepKindList
 
-    printBuiltinCost : Builtin → ExBudget → String 
-    printBuiltinCost b (mkExBudget 0 0) = "" 
-    printBuiltinCost b budget = padRight ' ' 22 (showBuiltin b) ++ " " 
+    printBuiltinModel : Builtin → ExBudget → String 
+    printBuiltinModel b (mkExBudget 0 0) = "" 
+    printBuiltinModel b budget = padRight ' ' 22 (showBuiltin b) ++ " " 
                              ++ budgetToString budget ++ "\n"
 
     printBuiltinReport : Map ExBudget → String 
     printBuiltinReport mp = 
-        foldr (λ b xs → printBuiltinCost b (lookup mp (BBuiltinApp b)) ++ xs) 
+        L.foldr (λ b xs → printBuiltinModel b (lookup mp (BBuiltinApp b (replicate 0))) ++ xs) 
               "" 
               builtinList     
     
     formatTimePicoseconds : Float → String
-    formatTimePicoseconds t = if 1e12 ≤ᵇ t then  (printf "%f s" (t ÷ 1e12)) else
+    formatTimePicoseconds t = if 1e12 ≤ᵇ t then (printf "%f s" (t ÷ 1e12)) else
                               if 1e9 ≤ᵇ t then  (printf "%f ms" (t ÷ 1e9)) else
                               if 1e6 ≤ᵇ t then  (printf "%f μs" (t ÷ 1e6)) else
                               if 1e3 ≤ᵇ t then  (printf "%f ns" (t ÷ 1e3)) else
-                              printf "%f ps" t                
-
+                              printf "%f ps" t
  ```
-
- 

--- a/plutus-metatheory/src/Cost.lagda.md
+++ b/plutus-metatheory/src/Cost.lagda.md
@@ -406,8 +406,6 @@ tallyingReport : TallyingBudget → String
 tallyingReport (mp , budget) =  
        countingReport budget
     ++ "\n"
-    ++ " DEBUG : ℕtoWords 1 = " ++ showℕ (ℕtoWords (+ 1)) 
-    ++ " DEBUG : ℕtoWords 2 = " ++ showℕ (ℕtoWords (+ 2))
     ++ "\n"
     ++ printStepReport mp
     ++ "\n"

--- a/plutus-metatheory/src/Cost/Base.lagda.md
+++ b/plutus-metatheory/src/Cost/Base.lagda.md
@@ -1,0 +1,93 @@
+
+```
+module Cost.Base where 
+
+```
+
+## Imports
+
+```
+open import Algebra using (IsMonoid)
+open import Data.List using (List)
+open import Data.Maybe using (Maybe;fromMaybe)
+open import Data.Nat using (ℕ)
+open import Data.String using (String;tail)
+open import Data.Vec using (Vec)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+
+open import Utils.Reflection using (defDec;defShow;defListConstructors)
+open import RawU using (TmCon)
+open import Builtin using (Builtin;arity)
+```
+
+We will represent costs with Naturals. In the implementation `SatInt` is used, (integers that don't overflow, but saturate). 
+As long as the budget is less than the maxInt then the result should be the same.
+
+```
+CostingNat : Set 
+CostingNat = ℕ
+```
+
+We define one constructor for each possible type of node in a UPLC term.
+
+```
+data StepKind : Set where 
+    BConst 
+      BVar
+      BLamAbs
+      BApply
+      BDelay
+      BForce
+      BBuiltin -- Cost of evaluating a Builtin AST node, not the function itself
+      BConstr 
+      BCase : StepKind
+```
+
+We define a show function for StepKinds
+
+```
+showStepKind' : StepKind → String 
+unquoteDef showStepKind' = defShow (quote StepKind) showStepKind' 
+
+showStepKind : StepKind → String 
+showStepKind s = fromMaybe "" (tail (showStepKind' s))   
+```
+
+and a list of constructors names
+
+``` 
+stepKindList : List StepKind
+unquoteDef stepKindList = defListConstructors (quote StepKind) stepKindList 
+``` 
+
+## Recording expenditure
+
+The following data structure is used to define the categories for which we
+record expenditure.
+
+```
+data ExBudgetCategory : Set where
+      -- Cost of Evaluating a machine step
+    BStep       : StepKind → ExBudgetCategory
+
+     -- Cost of evaluating a fully applied builtin function
+    BBuiltinApp : (b : Builtin) → Vec CostingNat (arity b) → ExBudgetCategory  
+
+    -- Startup Cost
+    BStartup    : ExBudgetCategory
+```
+
+## Machine Parameters
+
+The CEK machine is parameterised by the following machine parameters.
+
+```
+record MachineParameters (Cost : Set) : Set where
+    field 
+      startupCost : Cost 
+      cekMachineCost : ExBudgetCategory → Cost
+      ε : Cost
+      _∙_ : Cost → Cost → Cost
+      costMonoid : IsMonoid _≡_ _∙_ ε
+      constantMeasure : TmCon → CostingNat
+```

--- a/plutus-metatheory/src/Untyped/CEKWithCost.lagda.md
+++ b/plutus-metatheory/src/Untyped/CEKWithCost.lagda.md
@@ -60,7 +60,7 @@ spendStartupCost : CekM ⊤
 spendStartupCost = tell startupCost
 ```
 
-In order to calculate the cost of executing a builting, we obtain a vector with 
+In order to calculate the cost of executing a builtin, we obtain a vector with 
 the size of each constant argument using `extractArgSizes`. 
 
 Non-constant argument should only occur in places where the builtin is polymorphic


### PR DESCRIPTION
Cost semantics in the metatheory for the following builtin functions, and their corresponding costing models.

```
addInteger
subtractInteger
multiplyInteger
divideInteger
quotientInteger
remainderInteger
modInteger
equalsInteger
lessThanInteger
lessThanEqualsInteger
ifThenElse
```
