### PR TITLE
Add flag to dump PIR ASTs for certifier

### DIFF
--- a/plutus-core/executables/plutus/AnyProgram/Compile.hs
+++ b/plutus-core/executables/plutus/AnyProgram/Compile.hs
@@ -79,9 +79,9 @@ compileProgram = curry $ \case
     -- pir to plc
     ----------------------------------------
     (SPir n1@SName a1, SPlc n2 SUnit) ->
-      withA @Ord a1 $ withA @Pretty a1 $ withA @AnnInline a1 $
+      withA @Ord a1 $ withA @Pretty a1 $ withA @Show a1 $ withA @AnnInline a1 $
         -- Note: PIR.compileProgram subsumes pir typechecking
-        (PLC.runQuoteT . flip runReaderT compCtx . PIR.compileProgram)
+        (PLC.runQuoteT . flip runReaderT compCtx . PIR.compileProgram (const (return ())))
         >=> plcToOutName n1 n2
         -- completely drop annotations for now
         >=> pure . void

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -1,7 +1,7 @@
-cabal-version:   3.0
-name:            plutus-core
-version:         1.46.0.0
-license:         Apache-2.0
+cabal-version:      3.0
+name:               plutus-core
+version:            1.46.0.0
+license:            Apache-2.0
 license-files:
   LICENSE
   NOTICE
@@ -521,6 +521,7 @@ library plutus-ir
     PlutusIR.Core.Instance.Pretty
     PlutusIR.Core.Instance.Pretty.Readable
     PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Instance.ShowRocq
     PlutusIR.Core.Plated
     PlutusIR.Core.Type
     PlutusIR.Error
@@ -570,6 +571,7 @@ library plutus-ir
   build-depends:
     , algebraic-graphs     >=0.7
     , base                 >=4.9     && <5
+    , bytestring
     , containers
     , data-default-class
     , dlist
@@ -591,6 +593,7 @@ library plutus-ir
     , semigroups           >=0.19.1
     , text
     , transformers
+    , vector
     , witherable
 
 test-suite plutus-ir-test

--- a/plutus-core/plutus-core/src/PlutusCore/Name/Unique.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Name/Unique.hs
@@ -60,7 +60,7 @@ data Name = Name
   , _nameUnique :: Unique
   -- ^ A 'Unique' assigned to the name, allowing for cheap comparisons in the compiler.
   }
-  deriving stock (Show, Generic, Lift)
+  deriving stock (Generic, Lift, Show)
   deriving anyclass (NFData)
 
 -- | Allowed characters in the starting position of a non-quoted identifier.
@@ -93,7 +93,7 @@ toPrintedName txt = if isValidUnquotedName txt then txt else "`" <> txt <> "`"
 those used for terms.
 -}
 newtype TyName = TyName {unTyName :: Name}
-  deriving stock (Show, Generic, Lift)
+  deriving stock (Generic, Lift, Show)
   deriving newtype (Eq, Ord, NFData, Hashable, PrettyBy config)
 
 instance Wrapped TyName
@@ -123,7 +123,7 @@ instance Hashable Name where
 
 -- | A unique identifier
 newtype Unique = Unique {unUnique :: Int}
-  deriving stock (Eq, Show, Ord, Lift)
+  deriving stock (Eq, Ord, Lift, Generic, Show)
   deriving newtype (Enum, NFData, Pretty, Hashable)
 
 -- | The unique of a type-level name.

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler.hs
@@ -61,6 +61,7 @@ import Control.Monad.Except
 import Control.Monad.Extra (orM, whenM)
 import Data.Monoid
 import Data.Monoid.Extra (mwhen)
+import Data.Text (Text)
 import Debug.Trace (traceM)
 import PlutusCore qualified as PLC
 import PlutusCore.Error (throwingEither)
@@ -89,6 +90,8 @@ import PlutusIR.Transform.ThunkRecursions qualified as ThunkRec
 import PlutusIR.Transform.Unwrap qualified as Unwrap
 import PlutusPrelude
 
+import PlutusIR.Core.Instance.ShowRocq
+
 isVerbose :: Compiling m e uni fun a => m Bool
 isVerbose = view $ ccOpts . coVerbose
 
@@ -101,11 +104,18 @@ logVerbose = whenM (orM [isVerbose, isDebug]) . traceM
 logDebug :: Compiling m e uni fun a => String -> m ()
 logDebug = whenM isDebug . traceM
 
-runCompilerPass :: (Compiling m e uni fun a, b ~ Provenance a) => m (P.Pass m tyname name uni fun b) -> Term tyname name uni fun b -> m (Term tyname name uni fun b)
-runCompilerPass mpasses t = do
+runCompilerPass
+  :: ( Compiling m e uni fun a, b ~ Provenance a
+     , ShowRocq tyname name uni fun a
+     )
+  => (Text -> m ())
+  -> m (P.Pass m tyname name uni fun b)
+  -> Term tyname name uni fun b
+  -> m (Term tyname name uni fun b)
+runCompilerPass dumpCert mpasses t = do
   passes <- mpasses
   pedantic <- view (ccOpts . coPedantic)
-  res <- runExceptT $ P.runPass logVerbose pedantic passes t
+  res <- runExceptT $ P.runPass logVerbose dumpCert pedantic passes t
   throwingEither _Error res
 
 floatOutPasses :: Compiling m e uni fun a => m (P.Pass m TyName Name uni fun (Provenance a))
@@ -181,20 +191,34 @@ dce = do
 -- to dump a "readable" version of pir (i.e. floated).
 compileToReadable
   :: forall m e uni fun a b
-  . (Compiling m e uni fun a, b ~ Provenance a)
-  => Program TyName Name uni fun b
+  . (Compiling m e uni fun a, b ~ Provenance a
+  , PLC.Everywhere uni (ComposeC Show AsRocq)
+  , PLC.GShow (AsRocqUni uni)
+  , Show fun
+  )
+  => (Text -> m ())
+  -> Program TyName Name uni fun b
   -> m (Program TyName Name uni fun b)
-compileToReadable (Program a v t) = do
+compileToReadable dumpCert (Program a v t) = do
   validateOpts v
   let pipeline :: m (P.Pass m TyName Name uni fun b)
       pipeline = ala Ap foldMap [typeCheckTerm, dce, simplifier, floatOutPasses]
-  Program a v <$> runCompilerPass pipeline t
+  Program a v <$> runCompilerPass dumpCert pipeline t
 
 -- | The 2nd half of the PIR compiler pipeline.
 -- Compiles a 'Term' into a PLC Term, by removing/translating step-by-step the PIR's language constructs to PLC.
 -- Note: the result *does* have globally unique names.
-compileReadableToPlc :: forall m e uni fun a b . (Compiling m e uni fun a, b ~ Provenance a) => Program TyName Name uni fun b -> m (PLCProgram uni fun a)
-compileReadableToPlc (Program a v t) = do
+compileReadableToPlc
+  :: forall m e uni fun a b
+  . (Compiling m e uni fun a, b ~ Provenance a
+     , PLC.Everywhere uni (ComposeC Show AsRocq)
+     , PLC.GShow (AsRocqUni uni)
+     , Show fun
+  )
+  => (Text -> m ())
+  -> Program TyName Name uni fun b
+  -> m (PLCProgram uni fun a)
+compileReadableToPlc dumpCert (Program a v t) = do
 
   let
     pipeline :: m (P.Pass m TyName Name uni fun b)
@@ -216,18 +240,23 @@ compileReadableToPlc (Program a v t) = do
         ]
 
     go =
-        runCompilerPass pipeline
+        runCompilerPass dumpCert pipeline
         >=> (<$ logVerbose "  !!! lowerTerm")
         >=> lowerTerm
 
   PLC.Program a v <$> go t
 
 --- | Compile a 'Program' into a PLC Program. Note: the result *does* have globally unique names.
-compileProgram :: Compiling m e uni fun a
-            => Program TyName Name uni fun a -> m (PLCProgram uni fun a)
-compileProgram =
+compileProgram :: ( Compiling m e uni fun a
+  , PLC.Everywhere uni (ComposeC Show AsRocq)
+  , PLC.GShow (AsRocqUni uni)
+  , Show fun
+  )
+            => (Text -> m ()) ->
+            Program TyName Name uni fun a -> m (PLCProgram uni fun a)
+compileProgram dumpCert =
   (pure . original)
   >=> (<$ logDebug "!!! compileToReadable")
-  >=> compileToReadable
+  >=> (compileToReadable dumpCert)
   >=> (<$ logDebug "!!! compileReadableToPlc")
-  >=> compileReadableToPlc
+  >=> (compileReadableToPlc dumpCert)

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Let.hs
@@ -41,6 +41,13 @@ Also we should pull out more stuff (e.g. see 'NonStrict' which uses unit).
 data LetKind = RecTerms | NonRecTerms | Types | DataTypes
   deriving stock (Show, Eq, Ord)
 
+kindToPass :: LetKind -> PassId
+kindToPass k = case k of
+  RecTerms    -> PassCompileLetRec
+  NonRecTerms -> PassCompileLetNonRec
+  Types       -> PassCompileLetType
+  DataTypes   -> PassCompileLetData
+
 compileLetsPassSC
   :: Compiling m e uni fun a
   => TC.PirTCConfig uni fun
@@ -57,6 +64,7 @@ compileLetsPass
 compileLetsPass tcconfig letKind =
   NamedPass "compile lets" $
     Pass
+      (kindToPass letKind)
       (compileLets letKind)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/ShowRocq.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Core/Instance/ShowRocq.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE ConstraintKinds          #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE InstanceSigs             #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
+{-# LANGUAGE UndecidableSuperClasses  #-}
+
+-- | This module implements custom pretty printing of PIR terms, used for dumping
+-- compilation runs that can be parsed by the Rocq PIR certifier. The targeted
+-- syntax is very similar to that of derived Show instances, but differs in a few places:
+--
+--   * No record syntax (this cannot be parsed in Rocq)
+--   * String and ByteString literals are printed as byte sequences (literals are treated
+--     differently in Rocq)
+--
+-- In all other cases, existing instances of Show are reused.
+--
+-- This works by instantiating some type parameters differently for terms:
+--
+--    Term (AsRocq name) (AsRocq tyname) (AsRocqUni uni) fun
+--
+-- Here `AsRocq` and `AsRocqUni` are newtype wrappers that allow defining additional Show instances
+
+module PlutusIR.Core.Instance.ShowRocq where
+
+import PlutusCore.Crypto.BLS12_381.G1 qualified as BLS12_381.G1
+import PlutusCore.Crypto.BLS12_381.G2 qualified as BLS12_381.G2
+import PlutusCore.Crypto.BLS12_381.Pairing qualified as BLS12_381.Pairing
+import PlutusCore.Data (Data)
+import PlutusCore.Default
+import PlutusCore.Name.Unique
+import PlutusIR.Core.Type
+
+import Data.ByteString (ByteString, unpack)
+import Data.Kind (Constraint)
+import Data.Kind qualified as GHC
+import Data.Proxy
+import Data.Text (Text)
+import Data.Text.Encoding qualified as Text
+import Data.Vector.Strict (Vector, toList)
+import Data.Word (Word8)
+import Text.Printf
+
+type ComposeC :: forall a b. (b -> Constraint) -> (a -> b) -> a -> Constraint
+class c (f x) => ComposeC c f x
+instance c (f x) => ComposeC c f x
+
+type AsRocqK :: forall k. k -> k
+data family AsRocqK a
+
+type AsRocq = AsRocqK @GHC.Type
+newtype instance AsRocqK a = AsRocq a
+
+showAsRocq :: Show (AsRocq a) => a -> String
+showAsRocq = show . AsRocq
+
+type AsRocqUni :: (GHC.Type -> GHC.Type) -> GHC.Type -> GHC.Type
+data AsRocqUni uni a where
+    AsRocqUni :: uni (Esc a) -> AsRocqUni uni (Esc (AsRocqK a))
+
+-- | Groups all constraints needed for fully polymorphic Terms
+type ShowRocq tyname name uni fun a =
+  ( Show (AsRocq tyname)
+  , Show (AsRocq name)
+  , Show fun
+  , Everywhere uni (ComposeC Show AsRocq)
+  , GShow (AsRocqUni uni)
+  )
+
+-- | Groups all constraints needed for PIR terms (with instantiated names)
+type ShowRocqNamed uni fun a =
+  ( Show fun
+  , Everywhere uni (ComposeC Show AsRocq)
+  , GShow (AsRocqUni uni)
+  )
+
+-- * Instances for type universes
+
+instance Closed uni => Closed (AsRocqUni uni) where
+    type AsRocqUni uni `Everywhere` constr = uni `Everywhere` ComposeC constr AsRocq
+
+    bring
+        :: forall constr a r proxy. uni `Everywhere` ComposeC constr AsRocq
+        => proxy constr -> AsRocqUni uni (Esc a) -> (constr a => r) -> r
+    bring _ (AsRocqUni uni) r = bring (Proxy @(ComposeC constr AsRocq)) uni r
+
+    encodeUni (AsRocqUni uni) = encodeUni uni
+
+    withDecodedUni k = withDecodedUni $ \uni -> k (AsRocqUni uni)
+
+instance GShow (AsRocqUni DefaultUni) where
+    gshowsPrec pr (AsRocqUni a) = showsPrec pr a
+
+deriving newtype instance Show (AsRocq Integer)
+deriving newtype instance Show (AsRocq ())
+deriving newtype instance Show (AsRocq Bool)
+deriving via [AsRocq a] instance Show (AsRocq a) => Show (AsRocq [a])
+deriving via (AsRocq a, AsRocq b) instance (Show (AsRocq a), Show (AsRocq b))
+  => Show (AsRocq (a, b))
+deriving newtype instance Show (AsRocq Data)
+deriving newtype instance Show (AsRocq BLS12_381.G1.Element)
+deriving newtype instance Show (AsRocq BLS12_381.G2.Element)
+deriving newtype instance Show (AsRocq BLS12_381.Pairing.MlResult)
+
+
+instance Show (AsRocq a) => Show (AsRocq (Vector a)) where
+    showsPrec p (AsRocq v) = showsPrec p (map AsRocq (toList v))
+instance Show (AsRocq Text) where
+    showsPrec p (AsRocq text) = showsPrec p (map AsRocq (unpack $ Text.encodeUtf8 text))
+instance Show (AsRocq Word8) where
+    -- Matches constructor notation of Coq.Init.Byte
+    show (AsRocq w) = printf "x%02x" w
+instance Show (AsRocq ByteString) where
+    showsPrec p (AsRocq bs) = showsPrec p (map AsRocq (unpack bs))
+
+-- * Names
+-- These instances mimic GHC derived show instances, if they were defined without record syntax.
+
+instance Show (AsRocq Name) where
+  showsPrec p (AsRocq (Name x y)) =
+    showParen (p >= 11) $
+      showString "Name" .
+      showString " " .
+      showsPrec 11 (AsRocq x) .
+      showString " " .
+      showsPrec 11 (AsRocq y)
+
+instance Show (AsRocq TyName) where
+  showsPrec p (AsRocq (TyName x)) =
+    showParen (p >= 11) $
+      showString "TyName" .
+      showString " " .
+      showsPrec 11 (AsRocq x)
+
+instance Show (AsRocq Unique) where
+  showsPrec p (AsRocq (Unique n)) =
+    showParen (p >= 11) $
+      showString "Unique" .
+      showString " " .
+      showsPrec 11 n
+
+instance
+  ( Show (AsRocq tyname)
+  , Show (AsRocq name)
+  , GShow (AsRocqUni uni)
+  , Closed uni, AsRocqUni uni `Everywhere` Show
+  , Show fun
+  , Show ann
+  ) => Show (AsRocq (Term tyname name uni fun ann)) where
+    showsPrec pr (AsRocq term) =
+      showsPrec pr .
+      mapName AsRocq .
+      mapTyName AsRocq .
+      mapUni fTy fConst $
+        term
+      where
+        fConst (Some (ValueOf uni x)) = Some (ValueOf (AsRocqUni uni) (AsRocq x))
+        fTy (SomeTypeIn ty) = SomeTypeIn (AsRocqUni ty)
+
+

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Beta.hs
@@ -150,6 +150,7 @@ betaPass
 betaPass tcconfig =
   NamedPass "beta" $
     Pass
+      PassBeta
       (pure . beta)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseOfCase.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseOfCase.hs
@@ -47,6 +47,7 @@ caseOfCasePass ::
 caseOfCasePass tcconfig binfo conservative newAnn =
   NamedPass "case-of-case" $
     Pass
+      PassCaseOfCase
       (caseOfCase binfo conservative newAnn)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseReduce.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/CaseReduce.hs
@@ -19,7 +19,7 @@ caseReducePass
   :: (PLC.Typecheckable uni fun, PLC.GEq uni, Applicative m)
   => TC.PirTCConfig uni fun
   -> Pass m TyName Name uni fun a
-caseReducePass tcconfig = simplePass "case reduce" tcconfig caseReduce
+caseReducePass tcconfig = simplePass "case reduce" PassCaseReduce tcconfig caseReduce
 
 caseReduce :: Term tyname name uni fun a -> Term tyname name uni fun a
 caseReduce = transformOf termSubterms processTerm

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/DeadCode.hs
@@ -52,6 +52,7 @@ removeDeadBindingsPass ::
 removeDeadBindingsPass tcconfig binfo =
   NamedPass "dead code elimination" $
     Pass
+      PassDeadCode
       (removeDeadBindings binfo)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/EvaluateBuiltins.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/EvaluateBuiltins.hs
@@ -32,6 +32,7 @@ evaluateBuiltinsPass :: (PLC.Typecheckable uni fun, PLC.GEq uni, Applicative m)
 evaluateBuiltinsPass tcconfig preserveLogging binfo costModel =
   NamedPass "evaluate builtins" $
     Pass
+      PassEvaluateBuiltins
       (pure . evaluateBuiltins preserveLogging binfo costModel)
       [Typechecks tcconfig]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Inline/Inline.hs
@@ -185,6 +185,7 @@ inlinePass
 inlinePass thresh ic tcconfig hints binfo =
   NamedPass "inline" $
     Pass
+      PassInline
       (inline thresh ic hints binfo )
       [GloballyUniqueNames, Typechecks tcconfig]
       [ConstCondition GloballyUniqueNames, ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/KnownCon.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/KnownCon.hs
@@ -32,6 +32,7 @@ knownConPass ::
 knownConPass tcconfig =
   NamedPass "case of known constructor" $
     Pass
+      PassKnownConstructor
       (pure . knownCon)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloatIn.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloatIn.hs
@@ -206,6 +206,7 @@ floatTermPass ::
 floatTermPass tcconfig binfo relaxed =
   NamedPass "let float-in" $
     Pass
+      PassFloatIn
       (pure . floatTerm binfo relaxed)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloatOut.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetFloatOut.hs
@@ -414,6 +414,7 @@ floatTermPass ::
 floatTermPass tcconfig binfo =
   NamedPass "let float-out" $
     Pass
+      PassFloatOut
       (pure . floatTerm binfo)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/LetMerge.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/LetMerge.hs
@@ -36,4 +36,4 @@ letMergePass
   :: (PLC.Typecheckable uni fun, PLC.GEq uni, Applicative m)
   => TC.PirTCConfig uni fun
   -> Pass m TyName Name uni fun a
-letMergePass tcconfig = simplePass "let merge" tcconfig letMerge
+letMergePass tcconfig = simplePass "let merge" PassLetMerge tcconfig letMerge

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/NonStrict.hs
@@ -60,6 +60,7 @@ compileNonStrictBindingsPass
 compileNonStrictBindingsPass tcConfig useUnit =
   NamedPass "compile non-strict bindings" $
     Pass
+      PassCompileLetNonStrict
       (compileNonStrictBindings useUnit)
       [Typechecks tcConfig] [ConstCondition (Typechecks tcConfig)]
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/RecSplit.hs
@@ -73,7 +73,7 @@ recSplitPass
   :: (PLC.Typecheckable uni fun, PLC.GEq uni, Applicative m)
   => TC.PirTCConfig uni fun
   -> Pass m TyName Name uni fun a
-recSplitPass tcconfig = simplePass "recursive let split" tcconfig recSplit
+recSplitPass tcconfig = simplePass "recursive let split" PassRecSplit tcconfig recSplit
 
 {-|
 Apply letrec splitting, recursively in bottom-up fashion.

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/RewriteRules.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/RewriteRules.hs
@@ -45,6 +45,7 @@ rewritePass ::
 rewritePass tcconfig rules =
   NamedPass "rewrite rules" $
     Pass
+      PassRewriteRules
       (rewriteWith rules)
       [Typechecks tcconfig, GloballyUniqueNames]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/StrictifyBindings.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/StrictifyBindings.hs
@@ -59,6 +59,7 @@ strictifyBindingsPass ::
 strictifyBindingsPass tcconfig binfo =
   NamedPass "strictify bindings" $
     Pass
+      PassStrictifyBindings
       (pure . strictifyBindings binfo)
       [Typechecks tcconfig]
       [ConstCondition (Typechecks tcconfig)]

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/ThunkRecursions.hs
@@ -175,4 +175,4 @@ thunkRecursionsPass
   => TC.PirTCConfig uni fun
   -> BuiltinsInfo uni fun
   -> Pass m TyName Name uni fun a
-thunkRecursionsPass tcconfig binfo = simplePass "thunk recursions" tcconfig (thunkRecursions binfo)
+thunkRecursionsPass tcconfig binfo = simplePass "thunk recursions" PassThunkRec tcconfig (thunkRecursions binfo)

--- a/plutus-core/plutus-ir/src/PlutusIR/Transform/Unwrap.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Transform/Unwrap.hs
@@ -41,4 +41,4 @@ unwrapCancelPass
   :: (PLC.Typecheckable uni fun, PLC.GEq uni, Applicative m)
   => TC.PirTCConfig uni fun
   -> Pass m TyName Name uni fun a
-unwrapCancelPass tcconfig = simplePass "wrap-unwrap cancel" tcconfig unwrapCancel
+unwrapCancelPass tcconfig = simplePass "wrap-unwrap cancel" PassUnwrapWrap tcconfig unwrapCancel

--- a/plutus-core/plutus-ir/test/PlutusIR/Transform/StrictLetRec/Tests/Lib.hs
+++ b/plutus-core/plutus-ir/test/PlutusIR/Transform/StrictLetRec/Tests/Lib.hs
@@ -60,7 +60,7 @@ compilePirProgramOrFail
   -> m (TPLC.Program PIR.TyName Name DefaultUni DefaultFun ())
 compilePirProgramOrFail pirProgram = do
   ctx <- defaultCompilationCtx & handlePirErrorByFailing
-  PIR.compileReadableToPlc (noProvenance <$ pirProgram)
+  PIR.compileReadableToPlc (const (return ())) (noProvenance <$ pirProgram)
     & flip runReaderT (set (ccOpts . coPreserveLogging) True ctx)
     & runQuoteT
     & runExceptT

--- a/plutus-tx-plugin/src/PlutusTx/Options.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Options.hs
@@ -77,6 +77,7 @@ data PluginOptions = PluginOptions
     _posRemoveTrace                    :: Bool
   , _posDumpCompilationTrace           :: Bool
   , _posCertify                        :: Maybe String
+  , _posDumpCertTrace                  :: Bool
   }
 
 makeLenses ''PluginOptions
@@ -307,6 +308,9 @@ pluginOptions =
             rest <- many (alphaNumChar <|> char '_' <|> char '\\')
             pure (firstC : rest)
        in (k, PluginOption typeRep (plcParserOption p k) posCertify desc [])
+    , let k = "dump-cert-trace"
+          desc = "Dump trace of ASTs for certifier (currently only PIR)"
+       in (k, PluginOption typeRep (setTrue k) posDumpCertTrace desc [])
     ]
 
 flag :: (a -> a) -> OptionKey -> Maybe OptionValue -> Validation ParseError (a -> a)
@@ -379,6 +383,7 @@ defaultPluginOptions =
     , _posRemoveTrace = False
     , _posDumpCompilationTrace = False
     , _posCertify = Nothing
+    , _posDumpCertTrace = False
     }
 
 processOne ::

--- a/plutus-tx/testlib/PlutusTx/Test.hs
+++ b/plutus-tx/testlib/PlutusTx/Test.hs
@@ -55,6 +55,7 @@ import PlutusCore.Test (TestNested, ToTPlc (..), ToUPlc (..), catchAll, goldenSi
                         goldenUPlc, goldenUPlcReadable, nestedGoldenVsDoc, nestedGoldenVsDocM,
                         ppCatch, rethrow)
 import PlutusIR.Analysis.Builtins qualified as PIR
+import PlutusIR.Core.Instance.ShowRocq
 import PlutusIR.Core.Type (progTerm)
 import PlutusIR.Test ()
 import PlutusIR.Transform.RewriteRules as PIR
@@ -232,6 +233,7 @@ instance
   , Default (PLC.CostingPart uni fun)
   , Default (PIR.BuiltinsInfo uni fun)
   , Default (PIR.RewriteRules uni fun)
+  , ShowRocqNamed uni fun a
   )
   => ToTPlc (CompiledCodeIn uni fun a) uni fun
   where


### PR DESCRIPTION
Context
---

For my certifier in Coq, I need to get my hands on all intermediate PIR ASTs. I've added a plugin flag `dump-cert-trace`, that dumps all PIR ASTs to a single text file during a compilation.

Dumping to file
---

To prevent keeping all intermediate ASTs in memory, I'm dumping ASTs directly after a pass has run (rather than collecting a pure list of ASTs and dumping them at the end of the pipeline). To that end, I've added a parameter `dumpCert :: Text -> m ()` to `runPass` (in the pass abstraction), which can be used to append text to the dump file. It needs to be of type `Text -> m ()` rather than `Text -> IO ()`, since the monad stack `m` does not necessarily have IO in it (the pass abstraction does not require it). The concrete monad stack in Compiler.hs does have `IO`, so it can be lifted into `m`.

As a consequence, this new argument also shows up in functions like `PIR.compileProgram`, `PIR.compileToReadable`, `PIR.compileReadableToPlc`. This feels very clumsy, but I couldn't find a nice way to do it. Here are two ideas:

- The dump function could go in `CompilationCtx` as a `Text -> IO ()`, but that requires a `MonadIO` constraint in `Compiling` type and the `runPass` function in order to actually run it. I'm not sure if that is desired.
- Similar to how logging works (which uses `traceM`), use unsafePerformIO and add a "pure" function `Monad m => Text -> m ()` in the `CompilationCtx`

Any other suggestions?

Pretty printing ASTs
---

The dumping format is textual, and easily parseable in the proof assistant. It's _almost_ `Show`, but without record syntax and uses `Text` instead of `String` for performance. I've added a new typeclass `SimpleShow` in module `Text.SimpleShow`, which has some basic instances and the possibility for deriving using GHC generics. I've also written/derived instances for all PIR AST types.

I've added the `SimpleShow` constraints to the `Compiling` type/constraint synonym, this required me turning on the following extensions in some places:

- `QuantifiedConstraints` (because of the constraint `forall t. SimpleShow (uni t)`)
- `ImpredicativeTypes`, to add the constraint `forall t. SimpleShow (uni t)` to the `Compiling` type synonym.

Pretty printing pass information
---

In addition to ASTs I'm also dumping information about which pass was run. Here I've added the `PassId` type, which is used as an additional field for every basic `Pass` constructor.
