### PR TITLE
filip(fix): apply EAA amends for docs site

### DIFF
--- a/doc/docusaurus/docusaurus.config.ts
+++ b/doc/docusaurus/docusaurus.config.ts
@@ -91,7 +91,7 @@ const config: Config = {
           type: "html",
           position: "right",
           value:
-            '<a href="https://github.com/IntersectMBO/plutus" class="github-link" target="_blank"></a>'
+            '<a href="https://github.com/IntersectMBO/plutus" class="github-link" target="_blank" aria-label="Github"></a>'
         }
       ]
     },

--- a/doc/docusaurus/src/theme/Footer/index.js
+++ b/doc/docusaurus/src/theme/Footer/index.js
@@ -21,6 +21,7 @@ export default function Footer(props) {
             href="https://github.com/IntersectMBO/plutus"
             class="github-link"
             target="_blank"
+            aria-label="Github"
           ></a>
         </div>
       </div>


### PR DESCRIPTION
Added aria labels to logo links

Contrast: Navigation Logo, Footer Logo, Footer copyright and Footer button colour all have too low a contrast ratio with their respective backgrounds to be in line with WCAG AA and AAA standards