### PR TITLE
Re-run the Agda benchmarks.

### DIFF
--- a/plutus-benchmark/nofib/bench/BenchAgdaCek.hs
+++ b/plutus-benchmark/nofib/bench/BenchAgdaCek.hs
@@ -5,5 +5,6 @@ module Main where
 import PlutusBenchmark.Agda.Common (benchTermAgdaCek)
 import Shared (benchWith)
 
+
 main :: IO ()
 main = benchWith benchTermAgdaCek


### PR DESCRIPTION
We have some benchmarks for the Agda evaluator that we haven't run for a long time.  This is just to re-run them to compare the results with the Haskell CEK machine.