### PR TITLE
[UPLC] [Optimization] Improve case-of-case

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Compiler/Types.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Compiler/Types.hs
@@ -12,9 +12,10 @@ type Compiling m uni fun name a =
   ( ToBuiltinMeaning uni fun
   , MonadQuote m
   , CaseBuiltin uni
-  , GEq uni
   , Closed uni
+  , GEq uni
   , Everywhere uni Eq
+  , Everywhere uni Hashable
   , HasUnique name TermUnique
   , Ord name
   , Typeable name

--- a/plutus-core/testlib/PlutusCore/Test.hs
+++ b/plutus-core/testlib/PlutusCore/Test.hs
@@ -192,7 +192,7 @@ instance
   ( TPLC.Typecheckable uni fun
   , CaseBuiltin uni
   , Hashable fun
-  , TPLC.GEq uni, TPLC.Closed uni, TPLC.Everywhere uni Eq
+  , TPLC.GEq uni, TPLC.Closed uni, TPLC.Everywhere uni Eq, TPLC.Everywhere uni Hashable
   )
   => ToUPlc (TPLC.Program TPLC.TyName UPLC.Name uni fun ()) uni fun where
   toUPlc =

--- a/plutus-core/testlib/PlutusIR/Test.hs
+++ b/plutus-core/testlib/PlutusIR/Test.hs
@@ -71,7 +71,8 @@ instance
 
 instance
   ( PLC.GEq uni
-  , uni `PLC.Everywhere` Eq
+  , PLC.Everywhere uni Eq
+  , PLC.Everywhere uni Hashable
   , PLC.Typecheckable uni fun
   , PLC.CaseBuiltin uni
   , PLC.PrettyUni uni

--- a/plutus-tx/src/PlutusTx/Lift.hs
+++ b/plutus-tx/src/PlutusTx/Lift.hs
@@ -74,6 +74,7 @@ safeLiftWith
    . ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -119,6 +120,7 @@ safeLift
    . ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -143,6 +145,7 @@ safeLiftUnopt
    . ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -171,6 +174,7 @@ safeLiftProgram
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -194,6 +198,7 @@ safeLiftProgramUnopt
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -214,6 +219,7 @@ safeLiftCode
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -240,6 +246,7 @@ safeLiftCodeUnopt
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , MonadError (PIR.Error uni fun (Provenance ())) m
      , MonadQuote m
      , PLC.Typecheckable uni fun
@@ -278,6 +285,7 @@ lift
      , PLC.Typecheckable uni fun
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , PLC.CaseBuiltin uni
      , Default (PLC.CostingPart uni fun)
      , Default (PIR.BuiltinsInfo uni fun)
@@ -298,6 +306,7 @@ liftUnopt
      , PLC.Typecheckable uni fun
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , PLC.CaseBuiltin uni
      , Default (PLC.CostingPart uni fun)
      , Default (PIR.BuiltinsInfo uni fun)
@@ -316,6 +325,7 @@ liftProgram
      , PLC.Typecheckable uni fun
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , PLC.CaseBuiltin uni
      , Default (PLC.CostingPart uni fun)
      , Default (PIR.BuiltinsInfo uni fun)
@@ -336,6 +346,7 @@ liftProgramUnopt
      , PLC.Typecheckable uni fun
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , PLC.CaseBuiltin uni
      , Default (PLC.CostingPart uni fun)
      , Default (PIR.BuiltinsInfo uni fun)
@@ -372,6 +383,7 @@ liftCode
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , ThrowableBuiltins uni fun
      , PLC.Typecheckable uni fun
      , PLC.CaseBuiltin uni
@@ -390,6 +402,7 @@ liftCodeUnopt
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , ThrowableBuiltins uni fun
      , PLC.Typecheckable uni fun
      , PLC.CaseBuiltin uni
@@ -406,6 +419,7 @@ liftCodeDef
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , ThrowableBuiltins uni fun
      , PLC.Typecheckable uni fun
      , PLC.CaseBuiltin uni
@@ -424,6 +438,7 @@ liftCodeDefUnopt
   :: ( Lift.Lift uni a
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , ThrowableBuiltins uni fun
      , PLC.Typecheckable uni fun
      , PLC.CaseBuiltin uni
@@ -495,6 +510,7 @@ typeCode
      , MonadQuote m
      , PLC.GEq uni
      , PLC.Everywhere uni Eq
+     , PLC.Everywhere uni Hashable
      , PLC.Typecheckable uni fun
      , PLC.CaseBuiltin uni
      , PrettyUni uni


### PR DESCRIPTION
Makes UPLC case-of-case a bit less restrictive by allowing it to produce duplicate branches if they're small enough. Doesn't seem to have any effect on anything (provided I implemented it right, there's no tests), so is probably not worth it.