### PR TITLE
fix pragmas, indentation and expose `plutus-benchmark-common`

### DIFF
--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase          #-}
 
 {- | Miscellaneous shared code for benchmarking-related things. -}

--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase          #-}
 
 {- | Miscellaneous shared code for benchmarking-related things. -}
 module PlutusBenchmark.Common
@@ -245,16 +246,17 @@ checkGoldenFileExists path = do
   fullPath <- makeAbsolute path
   fileExists <- doesFileExist path
   if not fileExists
-  then errorWithExplanation $ "golden file " ++ fullPath ++ " does not exist."
-  else do
-    perms <- getPermissions path
-    if not (writable perms)
-    then errorWithExplanation $ "golden file " ++ fullPath ++ " is not writable."
-    else pure ()
-    where errorWithExplanation s =
-              let msg = "\n* ERROR: " ++ s ++ "\n"
-                        ++ "* To ensure that the correct path is used, either use `cabal test` "
-                        ++ "or run the test in the root directory of the relevant package.\n"
-                        ++ "* If this is the first time this test has been run, create an "
-                        ++ "initial golden file manually."
-              in error msg
+    then errorWithExplanation $ "golden file " ++ fullPath ++ " does not exist."
+    else do
+      perms <- getPermissions path
+      if not (writable perms)
+        then errorWithExplanation $ "golden file " ++ fullPath ++ " is not writable."
+        else pure ()
+  where
+    errorWithExplanation s =
+      let msg = "\n* ERROR: " ++ s ++ "\n"
+              ++ "* To ensure that the correct path is used, either use `cabal test` "
+              ++ "or run the test in the root directory of the relevant package.\n"
+              ++ "* If this is the first time this test has been run, create an "
+              ++ "initial golden file manually."
+      in error msg

--- a/plutus-benchmark/common/PlutusBenchmark/NaturalSort.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/NaturalSort.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module PlutusBenchmark.NaturalSort (naturalSort)
 where

--- a/plutus-benchmark/common/PlutusBenchmark/NaturalSort.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/NaturalSort.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingStrategies #-}
 
 module PlutusBenchmark.NaturalSort (naturalSort)
 where

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -78,6 +78,7 @@ common lang
 ---------------- Common code for benchmarking ----------------
 
 library plutus-benchmark-common
+  visibility:      public
   import:          lang, os-support
   hs-source-dirs:  common
   exposed-modules:


### PR DESCRIPTION
I often like to depend on this lib outside of plutus to experiements and test how costly things are. Like I did [here](https://github.com/perturbing/plutus-MiMC/blob/a29963d0e8092d4f3c04bf80e805e811201ad17c/plutus-mimc/bench/Bls/Run.hs#L18) (note that this depends on a custom fork already exposing this lib).

Can we permanently expose this lib in plutus?