### PR TITLE
Increase fetch-depth buffer in manual-benchmark.yml

### DIFF
--- a/.github/workflows/manual-benchmark.yml
+++ b/.github/workflows/manual-benchmark.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.3.0
         with:
-          # We need at least one commit before master to compare against
-          fetch-depth: 5
+          # It's possible that new commits get merged into master since the PR 
+          # was opened. We need a safe buffer to make sure that our use of merge-head 
+          # leter always finds the true parent of the first PR commit.
+          fetch-depth: 100
 
       - name: React With Rocket 
         uses: actions/github-script@v7.1.0

--- a/scripts/ci-plutus-benchmark.sh
+++ b/scripts/ci-plutus-benchmark.sh
@@ -60,6 +60,7 @@ echo "[ci-plutus-benchmark]: Running benchmark for PR branch at $PR_BRANCH_REF .
 2>&1 cabal bench "$BENCHMARK_NAME" | tee bench-PR.log
 
 echo "[ci-plutus-benchmark]: Switching branches ..."
+# merge-base finds the fork point, which is the true parent of the first PR commit.
 git checkout "$(git merge-base HEAD origin/master)"
 BASE_BRANCH_REF=$(git rev-parse --short HEAD)
 


### PR DESCRIPTION
Manual benchmarks may fail to run when they can't find the true parent of the first PR commit. 
This is due to not enough commit history being fetched on checkout. 
This PR addresses that.