### PR TITLE
[Textual] Parse constants with parens

### DIFF
--- a/plutus-core/changelog.d/20251106_164659_effectfully_parse_constants_with_parens.md
+++ b/plutus-core/changelog.d/20251106_164659_effectfully_parse_constants_with_parens.md
@@ -1,0 +1,3 @@
+### Changed
+
+- In #7391 made the parser accept constants with extra parens in them, e.g. `(con (list data) [(I 0), (B #1234)])`.

--- a/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs
@@ -24,7 +24,7 @@ import Data.Text qualified as T
 import Data.Text.Internal.Read (hexDigitToInt)
 import Data.Vector.Strict (Vector)
 import Data.Vector.Strict qualified as Vector
-import Text.Megaparsec (customFailure, getSourcePos, takeWhileP)
+import Text.Megaparsec (customFailure, getSourcePos, takeWhileP, try)
 import Text.Megaparsec.Char (char, hexDigitChar, string)
 import Text.Megaparsec.Char.Lexer qualified as Lex
 
@@ -145,7 +145,7 @@ conBLS12_381_G2_Element = do
 -- | Parser for constants of the given type.
 constantOf :: ExpectParens -> DefaultUni (Esc a) -> Parser a
 constantOf expectParens uni =
-  case uni of
+  try (trailingWhitespace . inParens $ constantOf ExpectParensNo uni) <|> case uni of
     DefaultUniInteger                                                 -> conInteger
     DefaultUniByteString                                              -> conBS
     DefaultUniString                                                  -> conText

--- a/plutus-core/plutus-core/test/Parser/Spec.hs
+++ b/plutus-core/plutus-core/test/Parser/Spec.hs
@@ -71,6 +71,12 @@ parseValueValid = do
        \, [ ( #6161616161616161616161616161616161616161616161616161616161616161\
        \    , -100 ) ] ) ])"
 
+parseDataParens :: Assertion
+parseDataParens = do
+  expectParserSuccess code
+  where
+    code = "(con (list data) [(I 0), (B #1234)])"
+
 tests :: TestTree
 tests =
     testGroup
@@ -88,4 +94,7 @@ tests =
         , testCase
             "parser of Value should succeed"
             parseValueValid
+        , testCase
+            "parser of Data with extra parens should succeed"
+            parseDataParens
         ]


### PR DESCRIPTION
This makes the parse recognize constants with extra parens in them as requested in #7383.

I don't feel like we want to make any of those extra parens mandatory, but there's no harm in being lenient and parsing them.