### PR TITLE
Add meta.mainProgram to frankenAgdaBin

### DIFF
--- a/nix/agda-tools.nix
+++ b/nix/agda-tools.nix
@@ -53,6 +53,7 @@ let
         name = "agda";
         version = Agda.identifier.version;
         paths = [ Agda.components.exes.agda Agda.components.exes.agda-mode ];
+        meta.mainProgram = "agda";
       };
 
       frankenAgda = frankenAgdaBin // {
@@ -152,5 +153,6 @@ in
     agda-packages
     agda-stdlib
     agda-with-stdlib
+    agda-project
     NIX_AGDA_STDLIB;
 }


### PR DESCRIPTION
This removes the warnings: 
```
getExe: Package agda does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```