### PR TITLE
Add Enum Ratio to PlutusTx stdlib.

### DIFF
--- a/plutus-benchmark/cardano-loans/src/CardanoLoans/Validator.hs
+++ b/plutus-benchmark/cardano-loans/src/CardanoLoans/Validator.hs
@@ -41,7 +41,7 @@ module CardanoLoans.Validator
   tokenAsPubKey,
   adaSymbol,
   adaToken,
-  fromGHC,
+  fromHaskellRatio,
   unsafeRatio,
   (-),(*),(+),
   loanValidatorCode,

--- a/plutus-ledger-api/changelog.d/20251106_104633_bezirg_enum_ratio.md
+++ b/plutus-ledger-api/changelog.d/20251106_104633_bezirg_enum_ratio.md
@@ -1,0 +1,7 @@
+### Added
+
+- To v3: numerator,denominator,unsafeRatio
+
+### Changed
+
+- In v3: renamed fromGHC/toGHC to fromRatioHaskell/toRatioHaskell

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
@@ -229,8 +229,11 @@ module PlutusLedgerApi.Data.V3 (
   -- *** Ratio
   Ratio.Rational,
   Ratio.ratio,
-  Ratio.fromGHC,
-  Ratio.toGHC,
+  Ratio.unsafeRatio,
+  Ratio.numerator,
+  Ratio.denominator,
+  Ratio.fromHaskellRatio,
+  Ratio.toHaskellRatio,
 
   -- *** Association maps
   V2.Map,

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -121,10 +121,12 @@ module PlutusLedgerApi.V3 (
   V2.strictUpperBound,
 
   -- *** Ratio
-  Ratio.Rational,
   Ratio.ratio,
-  Ratio.fromGHC,
-  Ratio.toGHC,
+  Ratio.unsafeRatio,
+  Ratio.numerator,
+  Ratio.denominator,
+  Ratio.fromHaskellRatio,
+  Ratio.toHaskellRatio,
 
   -- *** Association maps
   V2.Map,

--- a/plutus-tx/changelog.d/20251106_085646_bezirg_enum_ratio.md
+++ b/plutus-tx/changelog.d/20251106_085646_bezirg_enum_ratio.md
@@ -1,0 +1,11 @@
+### Removed
+
+- PlutusTx.Ratio: half
+
+### Added
+
+- Enum Ratio instance that mimicks Haskell's instance
+
+### Changed
+
+- Renamed Ratio's fromGHC/toGHC to fromRatioHaskell/toRatioHaskell

--- a/plutus-tx/test/Rational/Laws/Construction.hs
+++ b/plutus-tx/test/Rational/Laws/Construction.hs
@@ -1,18 +1,30 @@
 -- editorconfig-checker-disable-file
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Rational.Laws.Construction (constructionLaws) where
 
+import Data.Ratio qualified as GHC
 import Hedgehog (Gen, Property, assert, cover, property, (===))
 import Hedgehog.Gen qualified as Gen
+import PlutusTx.Enum qualified as P
+import PlutusTx.List qualified as P
+import PlutusTx.Numeric qualified as P
 import PlutusTx.Prelude qualified as Plutus
-import PlutusTx.Ratio qualified as Ratio
-import Prelude
-import Rational.Laws.Helpers (forAllWithPP, genInteger, genIntegerPos, normalAndEquivalentToMaybe,
-                              testCoverProperty)
+import PlutusTx.Ratio qualified as P
+import Rational.Laws.Helpers (
+  forAllWithPP,
+  genInteger,
+  genIntegerPos,
+  genRational,
+  normalAndEquivalentToMaybe,
+  testCoverProperty,
+ )
 import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testPropertyNamed)
+import Prelude hiding (pred, succ)
 
 constructionLaws :: [TestTree]
 constructionLaws =
@@ -37,22 +49,58 @@ constructionLaws =
       "denominator (unsafeRatio x y) > 0"
       "propUnsafeRatioDenomPos"
       propUnsafeRatioDenomPos
+  , testPropertyNamed
+      "succ(r)>r"
+      "propSuccGt"
+      propSuccGt
+  , testPropertyNamed
+      "pred(r)<r"
+      "propPredLt"
+      propPredLt
+  , testPropertyNamed
+      "fromEnum . toEnum n = n"
+      "propFromToEnumId"
+      propFromToEnumId
+  , testPropertyNamed
+      "denominator . toEnum = 1"
+      "propDenomToEnum"
+      propDenomToEnum
+  , testPropertyNamed
+      "n<=m ==> length(enumFromTo n m) = abs(n-m)+1"
+      "propEnumFromToInteger"
+      propEnumFromToInteger
+  , testPropertyNamed
+      "enumFromTo = GHC.enumFromTo"
+      "propEnumFromToGHC"
+      propEnumFromToGHC
+  , testPropertyNamed
+      "x/=y ==> enumFromThenTo x y x = [x]"
+      "propEnumFromThenToLim"
+      propEnumFromThenToLim
+  , testPropertyNamed
+      "x/=y ==> enumFromThenTo = GHC.enumFromThenTo"
+      "propEnumFromThenToGHC"
+      propEnumFromThenToGHC
+  , testPropertyNamed
+      "enumFromTo x y = enumFromThenTo x (x+1) y"
+      "propEnumFromToThenTo"
+      propEnumFromToThenTo
   ]
 
 propZeroDenom :: Property
 propZeroDenom = property $ do
   x <- forAllWithPP genInteger
-  Ratio.ratio x Plutus.zero `normalAndEquivalentToMaybe` Nothing
+  P.ratio x Plutus.zero `normalAndEquivalentToMaybe` Nothing
 
 propOneDenom :: Property
 propOneDenom = property $ do
   x <- forAllWithPP genInteger
-  Ratio.ratio x Plutus.one `normalAndEquivalentToMaybe` (Just . Ratio.fromInteger $ x)
+  P.ratio x Plutus.one `normalAndEquivalentToMaybe` (Just . P.fromInteger $ x)
 
 propRatioSelf :: Property
 propRatioSelf = property $ do
   x <- forAllWithPP . Gen.filter (/= Plutus.zero) $ genInteger
-  Ratio.ratio x x `normalAndEquivalentToMaybe` Just Plutus.one
+  P.ratio x x `normalAndEquivalentToMaybe` Just Plutus.one
 
 propRatioSign :: Property
 propRatioSign = property $ do
@@ -60,13 +108,13 @@ propRatioSign = property $ do
   cover 30 "zero numerator" $ n == 0
   cover 30 "same signs" $ signum n == signum d
   cover 30 "different signs" $ (signum n /= signum d) && n /= 0
-  let r = Ratio.ratio n d
+  let r = P.ratio n d
   let signIndicator = Plutus.compare <$> r <*> pure Plutus.zero
   case (signum n, signum d) of
-    (0, _)   -> signIndicator === Just Plutus.EQ
+    (0, _) -> signIndicator === Just Plutus.EQ
     (-1, -1) -> signIndicator === Just Plutus.GT
-    (1, 1)   -> signIndicator === Just Plutus.GT
-    _        -> signIndicator === Just Plutus.LT
+    (1, 1) -> signIndicator === Just Plutus.GT
+    _ -> signIndicator === Just Plutus.LT
  where
   go :: Gen (Plutus.Integer, Plutus.Integer)
   go = Gen.choice [zeroNum, sameSign, diffSign]
@@ -89,31 +137,88 @@ propConstructionAgreement :: Property
 propConstructionAgreement = property $ do
   n <- forAllWithPP genInteger
   d <- forAllWithPP . Gen.filter (/= Plutus.zero) $ genInteger
-  Ratio.ratio n d `normalAndEquivalentToMaybe` (Just . Ratio.unsafeRatio n $ d)
+  P.ratio n d `normalAndEquivalentToMaybe` (Just . P.unsafeRatio n $ d)
 
 propFromIntegerNum :: Property
 propFromIntegerNum = property $ do
   x <- forAllWithPP genInteger
-  let r = Ratio.fromInteger x
-  Ratio.numerator r === x
+  let r = P.fromInteger x
+  P.numerator r === x
 
 propFromIntegerDen :: Property
 propFromIntegerDen = property $ do
   x <- forAllWithPP genInteger
-  let r = Ratio.fromInteger x
-  Ratio.denominator r === Plutus.one
+  let r = P.fromInteger x
+  P.denominator r === Plutus.one
 
 propRatioScale :: Property
 propRatioScale = property $ do
   x <- forAllWithPP genInteger
   y <- forAllWithPP genInteger
   z <- forAllWithPP . Gen.filter (/= Plutus.zero) $ genInteger
-  let lhs = Ratio.ratio x y
-  let rhs = Ratio.ratio (x Plutus.* z) (y Plutus.* z)
+  let lhs = P.ratio x y
+  let rhs = P.ratio (x Plutus.* z) (y Plutus.* z)
   lhs `normalAndEquivalentToMaybe` rhs
 
 propUnsafeRatioDenomPos :: Property
 propUnsafeRatioDenomPos = property $ do
   n <- forAllWithPP genInteger
   d <- forAllWithPP $ Gen.filter (/= Plutus.zero) genInteger
-  assert $ Ratio.denominator (Ratio.unsafeRatio n d) > 0
+  assert $ P.denominator (P.unsafeRatio n d) > 0
+
+propSuccGt :: Property
+propSuccGt = property $ do
+  n <- forAllWithPP genRational
+  assert $ P.succ n > n
+
+propPredLt :: Property
+propPredLt = property $ do
+  n <- forAllWithPP genRational
+  assert $ P.pred n < n
+
+propDenomToEnum :: Property
+propDenomToEnum = property $ do
+  n <- forAllWithPP genInteger
+  P.denominator (P.toEnum n) === 1
+
+propFromToEnumId :: Property
+propFromToEnumId = property $ do
+  n <- forAllWithPP genInteger
+  P.fromEnum @P.Rational (P.toEnum n) === n
+
+propEnumFromToInteger :: Property
+propEnumFromToInteger = property $ do
+  n <- forAllWithPP genInteger
+  m <- forAllWithPP $ Gen.filter (>= n) genInteger
+  P.length (P.enumFromTo @P.Rational (P.toEnum n) (P.toEnum m)) === abs (n - m) + 1
+
+propEnumFromThenToLim :: Property
+propEnumFromThenToLim = property $ do
+  x <- forAllWithPP genRational
+  y <- forAllWithPP $ Gen.filter (/= x) genRational
+  P.enumFromThenTo x y x === [x]
+
+propEnumFromToGHC :: Property
+propEnumFromToGHC = property $ do
+  x <- forAllWithPP genRational
+  y <- forAllWithPP genRational
+  fmap toGHC (P.enumFromTo x y) === enumFromTo (toGHC x) (toGHC y)
+
+propEnumFromThenToGHC :: Property
+propEnumFromThenToGHC = property $ do
+  x <- forAllWithPP genRational
+  y <- forAllWithPP $ Gen.filter (/= x) genRational
+  z <- forAllWithPP genRational
+  fmap toGHC (P.enumFromThenTo x y z) === enumFromThenTo (toGHC x) (toGHC y) (toGHC z)
+
+propEnumFromToThenTo :: Property
+propEnumFromToThenTo = property $ do
+  x <- forAllWithPP genRational
+  y <- forAllWithPP genRational
+  P.enumFromTo x y === P.enumFromThenTo x (x P.+ Plutus.one) y
+
+{-| Converts a 'Rational' to a GHC 'Rational', preserving value. Does not
+work on-chain.
+-}
+toGHC :: P.Rational -> Rational
+toGHC r = P.numerator r GHC.% P.denominator r

--- a/plutus-tx/test/Rational/Laws/Other.hs
+++ b/plutus-tx/test/Rational/Laws/Other.hs
@@ -141,13 +141,15 @@ propRoundHalf = property $ do
     (1, False)  -> rounded === n Plutus.+ Plutus.one
     _           -> rounded === n
  where
+  half = Ratio.unsafeRatio 1 2
+
   go :: Gen (Integer, Plutus.Rational)
   go = do
     n <- genInteger
     f <- case signum n of
-      (-1) -> pure . Ratio.negate $ Ratio.half
-      0    -> Gen.element [Ratio.half, Ratio.negate Ratio.half]
-      _    -> pure Ratio.half
+      (-1) -> pure . Ratio.negate $ half
+      0    -> Gen.element [half, Ratio.negate half]
+      _    -> pure half
     pure (n, f)
 
 propRoundLow :: Property


### PR DESCRIPTION
Added an Enum Rational instance that mimicks that of GHC and Haskell report.

I also removed the toGHC/fromGHC from plutustx since they don't work on-chain.
I think it is straightforward to re-create these two-functions for off-chain use, simply by a combination of numerator and denominator.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
