### PR TITLE
Benchmark regular apply vs case apply

### DIFF
--- a/plutus-benchmark/casing/bench/Bench.hs
+++ b/plutus-benchmark/casing/bench/Bench.hs
@@ -30,11 +30,16 @@ benchmarks ctx =
       , mkBMs "integer" Casing.casingInteger
       , mkBMs "list" Casing.casingList
       , mkBMs "list one branch" Casing.casingListOneBranch
+      , mkBMsSmall "regularApply" Casing.regularApply
+      , mkBMsSmall "caseApply" Casing.caseApply
       ]
     ]
     where
       mkBMs name f =
         bgroup name $ [2000, 4000..12000] <&> \n ->
+          bench (show n) $ benchTermCek ctx (f n)
+      mkBMsSmall name f =
+        bgroup name $ [3, 10, 30, 100, 500, 1000] <&> \n ->
           bench (show n) $ benchTermCek ctx (f n)
 
 main :: IO ()


### PR DESCRIPTION
Please don't merge. 

Compares 
```hs
[[[[(\a b c ... x y z -> ...) ()]()]...()]()]
```

to 

```hs
(case 
  (constr 0 () () () ... () () ())
  (\a b c ... x y z -> ...))
```

The budget differences are:

| Input | CPU regularApply | CPU caseApply |    CPU % Diff | MEM regularApply | MEM caseApply |    MEM % Diff | Size regularApply | Size caseApply |   Size % Diff |
|------:|-----------------:|--------------:|--------------:|-----------------:|--------------:|--------------:|------------------:|---------------:|--------------:|
|     3 |          160,100 |       144,100 |  **-9.9938%** |            1,100 |         1,000 |  **-9.0909%** |                10 |              9 | **-10.0000%** |
|    10 |          496,100 |       368,100 | **-25.8012%** |            3,200 |         2,400 | **-25.0000%** |                31 |             23 | **-25.8065%** |
|    30 |        1,456,100 |     1,008,100 | **-30.7671%** |            9,200 |         6,400 | **-30.4348%** |                91 |             63 | **-30.7692%** |
|   100 |        4,816,100 |     3,248,100 | **-32.5575%** |           30,200 |        20,400 | **-32.4503%** |               301 |            203 | **-32.5581%** |
|   500 |       24,016,100 |    16,048,100 | **-33.1777%** |          150,200 |       100,400 | **-33.1558%** |             1,501 |          1,003 | **-33.1779%** |
|  1000 |       48,016,100 |    32,048,100 | **-33.2555%** |          300,200 |       200,400 | **-33.2445%** |             3,001 |          2,003 | **-33.2556%** |

Percent change converges to 33% because as we try to apply more terms we exert fixed cost of the `Constant` node. So both scripts' costs increase linear with fixed factor.