### PR TITLE
Standardize cost model type names to snake_case

### DIFF
--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -131,33 +131,34 @@ const CostModelEvaluators = {
     return (coeffs.c0 || 0) + (coeffs.c1 || 0) * args[1] + (coeffs.c2 || 0) * args[2];
   },
 
-  addedSizes: (coeffs, args) => {
-    // addedSizes models cost as linear in sum of sizes
+  added_sizes: (coeffs, args) => {
+    // added_sizes models cost as linear in sum of sizes
     const sum = args.reduce((a, b) => a + b, 0);
-    return (coeffs.c0 || 0) + (coeffs.c1 || 0) * sum;
+    const c0 = coeffs.c0 || coeffs.intercept || 0;
+    const c1 = coeffs.c1 || coeffs.slope || 0;
+    return c0 + c1 * sum;
   },
 
-  multipliedSizes: (coeffs, args) => {
-    // multipliedSizes models cost as linear in product of sizes
+  multiplied_sizes: (coeffs, args) => {
+    // multiplied_sizes models cost as linear in product of sizes
     const product = args.reduce((a, b) => a * b, 1);
     const c0 = coeffs.c0 || coeffs.intercept || 0;
     const c1 = coeffs.c1 || coeffs.slope || 0;
     return c0 + c1 * product;
   },
 
-  multiplied_sizes: (coeffs, args) => {
-    // Alias for multipliedSizes (snake_case version)
-    return CostModelEvaluators.multipliedSizes(coeffs, args);
-  },
-
-  minSize: (coeffs, args) => {
+  min_size: (coeffs, args) => {
     const min = Math.min(...args);
-    return (coeffs.c0 || 0) + (coeffs.c1 || 0) * min;
+    const c0 = coeffs.c0 || coeffs.intercept || 0;
+    const c1 = coeffs.c1 || coeffs.slope || 0;
+    return c0 + c1 * min;
   },
 
-  maxSize: (coeffs, args) => {
+  max_size: (coeffs, args) => {
     const max = Math.max(...args);
-    return (coeffs.c0 || 0) + (coeffs.c1 || 0) * max;
+    const c0 = coeffs.c0 || coeffs.intercept || 0;
+    const c1 = coeffs.c1 || coeffs.slope || 0;
+    return c0 + c1 * max;
   },
 
   linear_in_max_yz: (coeffs, args) => {
@@ -301,17 +302,16 @@ function formatModelFormula(modelType, coefficients) {
     case 'linear_in_yz':
       return `${formatCoeff(c0)} + ${formatCoeff(c1)} × (arg2) + ${formatCoeff(c2)} × (arg3) picoseconds`;
 
-    case 'addedSizes':
+    case 'added_sizes':
       return `${formatCoeff(c0)} + ${formatCoeff(c1)} × (sum of args) picoseconds`;
 
-    case 'multipliedSizes':
     case 'multiplied_sizes':
       return `${formatCoeff(c0)} + ${formatCoeff(c1)} × (product of args) picoseconds`;
 
-    case 'minSize':
+    case 'min_size':
       return `${formatCoeff(c0)} + ${formatCoeff(c1)} × (min of args) picoseconds`;
 
-    case 'maxSize':
+    case 'max_size':
       return `${formatCoeff(c0)} + ${formatCoeff(c1)} × (max of args) picoseconds`;
 
     case 'linear_in_max_yz':


### PR DESCRIPTION
## Summary
- Fixes cost model visualization site to use snake_case type names matching JSON data
- Enables visualization of `added_sizes` model type (needed for ValueContains)

## Changes
The JavaScript code used camelCase (`addedSizes`, `multipliedSizes`, `minSize`, `maxSize`) while the JSON cost model files consistently use snake_case (`added_sizes`, `multiplied_sizes`, `min_size`, `max_size`).

This standardizes the JavaScript to match the JSON format.

## Test plan
- [ ] Open https://plutus.cardano.intersectmbo.org/cost-models/valuecontains/index.html
- [ ] Set branch to `yura/tmp/valuecontains_added_sizes`
- [ ] Verify the plot renders correctly with `added_sizes` model type