### PR TITLE
Add branch URL parameter support with Copy Link button

### DIFF
--- a/doc/cost-models/lookupcoin/index.html
+++ b/doc/cost-models/lookupcoin/index.html
@@ -30,7 +30,10 @@
       <div class="controls-content">
         <div class="control-group-vertical">
           <label for="branch-name">Branch name:</label>
-          <input type="text" id="branch-name" placeholder="master" style="width: 100%; font-family: monospace;">
+          <div class="branch-input-row">
+            <input type="text" id="branch-name" placeholder="master">
+            <button id="copy-link" title="Copy shareable link">Copy Link</button>
+          </div>
         </div>
         <div class="control-group-vertical">
           <label for="csv-url">CSV file URL:</label>

--- a/doc/cost-models/lookupcoin/plot.js
+++ b/doc/cost-models/lookupcoin/plot.js
@@ -39,10 +39,11 @@ function getFileUrls(baseUrl) {
   };
 }
 
-// Load settings from localStorage
+// Load settings from localStorage (URL param takes precedence)
 function loadSettings() {
+  const urlBranch = getBranchFromUrl();
   return {
-    branch: localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
+    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
     csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
     jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
     collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
@@ -135,6 +136,20 @@ async function init() {
 
   // Set up plot control event listeners (only once)
   setupControls();
+
+  // Set up copy link button
+  document.getElementById('copy-link').addEventListener('click', () => {
+    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+    const url = new URL(window.location.href);
+    url.search = '';
+    url.searchParams.set('branch', branch);
+    navigator.clipboard.writeText(url.toString());
+    // Brief visual feedback
+    const btn = document.getElementById('copy-link');
+    const original = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => btn.textContent = original, 1500);
+  });
 
   // Initial load
   await loadAndRenderData();

--- a/doc/cost-models/shared/styles.css
+++ b/doc/cost-models/shared/styles.css
@@ -273,6 +273,22 @@ nav a.active {
   color: var(--academic-gray);
 }
 
+.branch-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.branch-input-row input {
+  flex: 1;
+  font-family: 'Monaco', 'Courier New', monospace;
+}
+
+.branch-input-row button {
+  padding: 6px 12px;
+  font-size: 0.85em;
+}
+
 button {
   background-color: var(--cardano-blue);
   color: white;

--- a/doc/cost-models/shared/utils.js
+++ b/doc/cost-models/shared/utils.js
@@ -381,3 +381,12 @@ async function loadData(csvUrl, jsonUrl) {
     throw error;
   }
 }
+
+/**
+ * Get branch name from URL query parameter
+ * @returns {string|null} Branch name or null if not specified
+ */
+function getBranchFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('branch');
+}

--- a/doc/cost-models/unvaluedata/index.html
+++ b/doc/cost-models/unvaluedata/index.html
@@ -30,7 +30,10 @@
       <div class="controls-content">
         <div class="control-group-vertical">
           <label for="branch-name">Branch name:</label>
-          <input type="text" id="branch-name" placeholder="master" style="width: 100%; font-family: monospace;">
+          <div class="branch-input-row">
+            <input type="text" id="branch-name" placeholder="master">
+            <button id="copy-link" title="Copy shareable link">Copy Link</button>
+          </div>
         </div>
         <div class="control-group-vertical">
           <label for="csv-url">CSV file URL:</label>

--- a/doc/cost-models/unvaluedata/plot.js
+++ b/doc/cost-models/unvaluedata/plot.js
@@ -39,10 +39,11 @@ function getFileUrls(baseUrl) {
   };
 }
 
-// Load settings from localStorage
+// Load settings from localStorage (URL param takes precedence)
 function loadSettings() {
+  const urlBranch = getBranchFromUrl();
   return {
-    branch: localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
+    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
     csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
     jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
     collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
@@ -135,6 +136,20 @@ async function init() {
 
   // Set up plot control event listeners (only once)
   setupControls();
+
+  // Set up copy link button
+  document.getElementById('copy-link').addEventListener('click', () => {
+    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+    const url = new URL(window.location.href);
+    url.search = '';
+    url.searchParams.set('branch', branch);
+    navigator.clipboard.writeText(url.toString());
+    // Brief visual feedback
+    const btn = document.getElementById('copy-link');
+    const original = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => btn.textContent = original, 1500);
+  });
 
   // Initial load
   await loadAndRenderData();

--- a/doc/cost-models/valuecontains/index.html
+++ b/doc/cost-models/valuecontains/index.html
@@ -30,7 +30,10 @@
       <div class="controls-content">
         <div class="control-group-vertical">
           <label for="branch-name">Branch name:</label>
-          <input type="text" id="branch-name" placeholder="master" style="width: 100%; font-family: monospace;">
+          <div class="branch-input-row">
+            <input type="text" id="branch-name" placeholder="master">
+            <button id="copy-link" title="Copy shareable link">Copy Link</button>
+          </div>
         </div>
         <div class="control-group-vertical">
           <label for="csv-url">CSV file URL:</label>

--- a/doc/cost-models/valuecontains/plot.js
+++ b/doc/cost-models/valuecontains/plot.js
@@ -39,10 +39,11 @@ function getFileUrls(baseUrl) {
   };
 }
 
-// Load settings from localStorage
+// Load settings from localStorage (URL param takes precedence)
 function loadSettings() {
+  const urlBranch = getBranchFromUrl();
   return {
-    branch: localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
+    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
     csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
     jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
     collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
@@ -135,6 +136,20 @@ async function init() {
 
   // Set up plot control event listeners (only once)
   setupControls();
+
+  // Set up copy link button
+  document.getElementById('copy-link').addEventListener('click', () => {
+    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+    const url = new URL(window.location.href);
+    url.search = '';
+    url.searchParams.set('branch', branch);
+    navigator.clipboard.writeText(url.toString());
+    // Brief visual feedback
+    const btn = document.getElementById('copy-link');
+    const original = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => btn.textContent = original, 1500);
+  });
 
   // Initial load
   await loadAndRenderData();

--- a/doc/cost-models/valuedata/index.html
+++ b/doc/cost-models/valuedata/index.html
@@ -30,7 +30,10 @@
       <div class="controls-content">
         <div class="control-group-vertical">
           <label for="branch-name">Branch name:</label>
-          <input type="text" id="branch-name" placeholder="master" style="width: 100%; font-family: monospace;">
+          <div class="branch-input-row">
+            <input type="text" id="branch-name" placeholder="master">
+            <button id="copy-link" title="Copy shareable link">Copy Link</button>
+          </div>
         </div>
         <div class="control-group-vertical">
           <label for="csv-url">CSV file URL:</label>

--- a/doc/cost-models/valuedata/plot.js
+++ b/doc/cost-models/valuedata/plot.js
@@ -39,10 +39,11 @@ function getFileUrls(baseUrl) {
   };
 }
 
-// Load settings from localStorage
+// Load settings from localStorage (URL param takes precedence)
 function loadSettings() {
+  const urlBranch = getBranchFromUrl();
   return {
-    branch: localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
+    branch: urlBranch || localStorage.getItem(STORAGE_KEYS.BRANCH) || DEFAULT_BRANCH,
     csvUrl: localStorage.getItem(STORAGE_KEYS.CSV_URL) || '',
     jsonUrl: localStorage.getItem(STORAGE_KEYS.JSON_URL) || '',
     collapsed: localStorage.getItem(STORAGE_KEYS.DATA_SOURCE_COLLAPSED) === 'true'
@@ -135,6 +136,20 @@ async function init() {
 
   // Set up plot control event listeners (only once)
   setupControls();
+
+  // Set up copy link button
+  document.getElementById('copy-link').addEventListener('click', () => {
+    const branch = document.getElementById('branch-name').value.trim() || DEFAULT_BRANCH;
+    const url = new URL(window.location.href);
+    url.search = '';
+    url.searchParams.set('branch', branch);
+    navigator.clipboard.writeText(url.toString());
+    // Brief visual feedback
+    const btn = document.getElementById('copy-link');
+    const original = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => btn.textContent = original, 1500);
+  });
 
   // Initial load
   await loadAndRenderData();


### PR DESCRIPTION
## Summary
- Add `?branch=` URL parameter support for shareable visualization links
- Add "Copy Link" button to easily copy shareable URLs

## Changes
- Added `getBranchFromUrl()` utility in shared/utils.js
- Added Copy Link button next to branch input in all 4 visualization pages
- URL parameter takes precedence over localStorage for branch selection
- Button shows brief "Copied!" feedback after copying

## Usage
URLs can now include a branch parameter:
```
https://plutus.cardano.intersectmbo.org/cost-models/valuecontains/?branch=my-feature-branch
```

Or click "Copy Link" to generate a shareable URL with the current branch.

## Test plan
- [ ] Open any visualization page
- [ ] Enter a branch name and click "Copy Link"
- [ ] Verify URL is copied with `?branch=` parameter
- [ ] Navigate to a URL with `?branch=` parameter
- [ ] Verify branch is auto-populated and data loads from that branch