### PR TITLE
Adds back PlutusTx.Ratio.from/toGHC as deprecated.

### DIFF
--- a/plutus-ledger-api/changelog.d/20251127_160032_bezirg.md
+++ b/plutus-ledger-api/changelog.d/20251127_160032_bezirg.md
@@ -1,0 +1,3 @@
+### Added
+
+- Brought back Ratio.from/toGHC as deprecated.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
@@ -234,6 +234,8 @@ module PlutusLedgerApi.Data.V3
   , Ratio.denominator
   , Ratio.fromHaskellRatio
   , Ratio.toHaskellRatio
+  , Ratio.fromGHC
+  , Ratio.toGHC
 
     -- *** Association maps
   , V2.Map

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -127,6 +127,8 @@ module PlutusLedgerApi.V3
   , Ratio.denominator
   , Ratio.fromHaskellRatio
   , Ratio.toHaskellRatio
+  , Ratio.fromGHC
+  , Ratio.toGHC
 
     -- *** Association maps
   , V2.Map

--- a/plutus-tx/changelog.d/20251127_160027_bezirg.md
+++ b/plutus-tx/changelog.d/20251127_160027_bezirg.md
@@ -1,0 +1,3 @@
+### Added
+
+- Brought back Ratio.from/toGHC as deprecated.

--- a/plutus-tx/src/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/PlutusTx/Ratio.hs
@@ -36,6 +36,8 @@ module PlutusTx.Ratio
     -- * Conversion from/to Haskell
   , fromHaskellRatio
   , toHaskellRatio
+  , fromGHC
+  , toGHC
   ) where
 
 import PlutusTx.Applicative qualified as P
@@ -398,6 +400,13 @@ fromHaskellRatio r = unsafeRatio (HS.numerator r) (HS.denominator r)
 Note: Does not work on-chain. -}
 toHaskellRatio :: Rational -> HS.Rational
 toHaskellRatio (Rational n d) = n HS.% d
+
+{-# DEPRECATED fromGHC "Use fromHaskellRatio instead" #-}
+fromGHC :: HS.Rational -> Rational
+fromGHC = fromHaskellRatio
+{-# DEPRECATED toGHC "Use toHaskellRatio instead" #-}
+toGHC :: Rational -> HS.Rational
+toGHC = toHaskellRatio
 
 {- HLINT ignore -}
 


### PR DESCRIPTION
Closes https://github.com/IntersectMBO/plutus-private/issues/1975