### PR TITLE
Optimize VConstr bounds check in CEK machine

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Universe.hs
@@ -489,8 +489,8 @@ So, what to do? We adopt the following strategy:
 - We allow lifting/unlifting 'Int' via 'Int64' and 'Word' via 'Word64', constraining the conversion
   between them to 64-bit architectures where this conversion is safe.
 
-Doing this effectively bans builds on 32-bit systems, but that's fine, since we don't care about
-supporting 32-bit systems anyway, and this way any attempts to build on them will fail fast.
+Doing this effectively bans builds on all non-64-bit systems, which is acceptable since 64-bit
+systems are required for node deployment, and this way any attempts to build on them will fail fast.
 
 We used to use newtype- and via-deriving for implementations of relevant instances, but at some
 point GHC stopped attaching @INLINE@ annotations to those causing the GHC Core for builtins to have

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -927,7 +927,7 @@ enterComputeCek = computeCek
       -- Word64 value wraps to -1 as an Int64. So you can't wrap around enough to get an
       -- "apparently good" value.
       (VConstr i _)
-        | fromIntegral @_ @Integer i > fromIntegral @Int @Integer maxBound ->
+        | i > fromIntegral @Int @Word64 maxBound ->
             throwErrorDischarged (StructuralError (MissingCaseBranchMachineError i)) e
       -- Otherwise, we can safely convert the index to an Int and use it.
       (VConstr i args) -> case (V.!?) cs (fromIntegral i) of


### PR DESCRIPTION
## Summary

Optimizes the CEK machine's handling of VConstr by simplifying type conversions and updating documentation.

## Changes

### 1. Simplified Type Conversion

**Before:**
```haskell
| fromIntegral @_ @Integer i > fromIntegral @Int @Integer maxBound ->
```

**After:**
```haskell
| i > fromIntegral @Int @Word64 maxBound ->
```

Since `i` is already `Word64`, we can directly compare it to `maxBound :: Int` converted to `Word64`, eliminating the unnecessary intermediate conversion through `Integer`. This is more efficient and clearer.

### 2. Updated Documentation

Updated Note [Integral types as Integer] to clarify that **all non-64-bit systems** (not just 32-bit) are banned for node deployment. Changed wording from "we don't care about" to "64-bit systems are required for" for better tone.

## Related

Fixes #7478