### PR TITLE
Correct definition of psi in finalVerify

### DIFF
--- a/doc/plutus-core-spec/cardano/builtins4.tex
+++ b/doc/plutus-core-spec/cardano/builtins4.tex
@@ -569,7 +569,7 @@ for $E_1$ and $E_2$~\cite{Vercauteren}.
 \item $\mu_r = \{x \in \units{\FF}: x^r=1\}$, the group of $r$th roots of unity in $\FF$.
 (There are $r$ distinct $r$th roots of unity in $\FF$ because the embedding
 degree of $E_1$ and $E_2$ with respect to $r$ is 12 (see~\cite[4.1]{Costello-pairings}).)
-\item $\psi(x) = x^{\frac{q-1}{r}}$.
+\item $\psi(x) = x^{\frac{q^{12}-1}{r}}$.
 \end{itemize}
 
 \noindent The functions \texttt{bls12\_381\_millerLoop} and (especially)

--- a/doc/plutus-core-spec/plutus-core-specification.tex
+++ b/doc/plutus-core-spec/plutus-core-specification.tex
@@ -5,7 +5,7 @@
   \LARGE{\red{\textsf{DRAFT}}}
 }
 
-\date{17th September 2025}
+\date{18th Decemeber 2025}
 \author{Plutus Core Team}
 
 \input{header.tex}


### PR DESCRIPTION
This corrects an inaccuracy in the description of the `finalVerify` builtin.  Thanks to Mark Petruska for spotting that.