### PR TITLE
Add abs to memoryUsage for `NumBytesCostedAsNumWords`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemoryUsage.hs
@@ -280,7 +280,7 @@ instance ExMemoryUsage Word8 where
 newtype NumBytesCostedAsNumWords = NumBytesCostedAsNumWords {unNumBytesCostedAsNumWords :: Integer}
 
 instance ExMemoryUsage NumBytesCostedAsNumWords where
-  memoryUsage (NumBytesCostedAsNumWords n) = singletonRose . fromIntegral $ ((n - 1) `div` 8) + 1
+  memoryUsage (NumBytesCostedAsNumWords n) = singletonRose . fromIntegral $ ((abs n - 1) `div` 8) + 1
   {-# INLINE memoryUsage #-}
 
 -- Note that this uses `fromIntegral`, which will narrow large values to


### PR DESCRIPTION
The `ExMemoryUsage` instance for `NumBytesCostedAsNumWords` was missing an `abs`, meaning that it could return a negative value for negative numbers.  This didn't actually matter because the only builtins using `NumBytesCostedAsNumWords` fail on negative inputs, but let's make sure that the value is always non-negative in case we use it for anything else later.  Tests for non-negativity will follow in a later PR.