### PR TITLE
fix(cek): prevent variable capture in dischargeCekValue (#7526)

### DIFF
--- a/plutus-core/changelog.d/20260127_160932_yuriy.lazaryev_issue_7526_discharge_cek_value_open_terms.md
+++ b/plutus-core/changelog.d/20260127_160932_yuriy.lazaryev_issue_7526_discharge_cek_value_open_terms.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Fixed variable capture bug in `dischargeCekValue` where free variables in discharged terms could be incorrectly captured by outer lambda bindings, causing wrong variable references in the output term.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn.hs
@@ -35,6 +35,7 @@ module PlutusCore.DeBruijn
   , deBruijnInitIndex
   , fromFake
   , toFake
+  , shiftNamedDeBruijn
   ) where
 
 import PlutusCore.DeBruijn.Internal

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -108,7 +108,9 @@ newtype Index = Index Word64
 deBruijnInitIndex :: Index
 deBruijnInitIndex = 0
 
--- | Shift a 'NamedDeBruijn' index by a given amount.
+{-| Shift a 'NamedDeBruijn' index by a given amount.
+The addition is unchecked and will silently wrap on 'Word64' overflow,
+which is safe in practice since terms with @2^64@ nested binders cannot be constructed. -}
 shiftNamedDeBruijn :: Word64 -> NamedDeBruijn -> NamedDeBruijn
 shiftNamedDeBruijn i (NamedDeBruijn t (Index n)) = NamedDeBruijn t (Index (n + i))
 

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -42,6 +42,7 @@ module PlutusCore.DeBruijn.Internal
   , deBruijnInitIndex
   , toFake
   , fromFake
+  , shiftNamedDeBruijn
   ) where
 
 import PlutusCore.Name.Unique
@@ -106,6 +107,10 @@ newtype Index = Index Word64
 -- | The LamAbs index (for debruijn indices) and the starting level of DeBruijn monad
 deBruijnInitIndex :: Index
 deBruijnInitIndex = 0
+
+-- | Shift a 'NamedDeBruijn' index by a given amount.
+shiftNamedDeBruijn :: Word64 -> NamedDeBruijn -> NamedDeBruijn
+shiftNamedDeBruijn i (NamedDeBruijn t (Index n)) = NamedDeBruijn t (Index (n + i))
 
 -- The bangs gave us a speedup of 6%.
 

--- a/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/DeBruijn/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -112,7 +113,7 @@ deBruijnInitIndex = 0
 The addition is unchecked and will silently wrap on 'Word64' overflow,
 which is safe in practice since terms with @2^64@ nested binders cannot be constructed. -}
 shiftNamedDeBruijn :: Word64 -> NamedDeBruijn -> NamedDeBruijn
-shiftNamedDeBruijn i (NamedDeBruijn t (Index n)) = NamedDeBruijn t (Index (n + i))
+shiftNamedDeBruijn !i (NamedDeBruijn t (Index n)) = NamedDeBruijn t (Index (n + i))
 
 -- The bangs gave us a speedup of 6%.
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/Internal.hs
@@ -673,6 +673,10 @@ dischargeCekValue value0 = DischargeNonConstant $ goValue 0 value0
       -- We only return a discharged builtin application when (a) it's being returned by the
       -- machine, or (b) it's needed for an error message.
       -- @term@ is fully discharged, so we can return it directly without any further discharging.
+      -- In particular, no @global@ shifting is needed because the @term@ field of 'VBuiltin'
+      -- is maintained during evaluation as a fully-applied UPLC term whose variables already
+      -- refer to the correct scope — it is never stored in an environment to be discharged
+      -- under additional binders later.
       VBuiltin _ term _ -> term
       VConstr ind args -> Constr () ind . map (goValue global) $ argStackToList args
 


### PR DESCRIPTION
## Context

- **What**: Fix variable capture bug in CEK machine's `dischargeCekValue` function
- **Why**: Free variables in environment values were incorrectly bound when discharged under lambda binders, causing semantic errors in term reconstruction
- **Issue**: Fixes #7526

## Approach

The bug occurred in `dischargeCekValue` when reconstructing terms from CEK runtime values. When an environment value containing free variables was discharged under lambda binders, those free variables would incorrectly capture to the lambda binder instead of remaining free.

**Root Cause:** `goValue` was called directly on environment values without accounting for the `shift` parameter tracking lambda depth. This meant free variables in environment values weren't shifted to preserve their "freeness" relative to the enclosing lambda context.

**Solution:** Instead of a two-pass approach (discharge + separate `shiftTermBy` post-pass), we fuse the shifting directly into the discharge traversal by threading a `global` shift parameter through `goValue` and `goValEnv`:

- `goValue` gains a `Word64` parameter (`global`) that accumulates shifts from outer discharge contexts
- When a variable is found in the env, `goValue (global + shift)` passes the accumulated shift into the recursive discharge
- When a variable is truly free (not in the env), `shiftNamedDeBruijn (global + shift)` shifts it directly
- A new `shiftNamedDeBruijn` utility is added to `PlutusCore.DeBruijn`
- The standalone `shiftTermBy` function is removed entirely

This single-pass approach avoids a redundant traversal and handles truly free variables (not found in the environment) consistently.

## Tests

Comprehensive discharge tests in `Evaluation.FreeVars`:
- Variable capture scenarios from the original bug (empty env with free vars under lambdas)
- Nested closures with accumulated shifts across multiple env lookups
- Truly free variables past non-empty environments (with and without lambdas, nested, and mixed bound/free vars)
- Boundary condition: `shift == idx` verifying bound variable detection
- Constructor (`VConstr`) arguments containing free variables under lambdas