### PR TITLE
feat(nix): expose uplc-evaluator executable in nix packages

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -47,6 +47,7 @@ let
     plc = project.flake'.packages."plutus-executables:exe:plc";
     pir = project.flake'.packages."plutus-executables:exe:pir";
     plutus = project.flake'.packages."plutus-core:exe:plutus";
+    uplc-evaluator = project.flake'.packages."plutus-benchmark:exe:uplc-evaluator";
   };
 
   static-haskell-packages = {


### PR DESCRIPTION
## Summary
Adds `uplc-evaluator` to `exposed-haskell-packages` in `nix/outputs.nix`, making it available as a nix package.

## Changes
- Added `uplc-evaluator = project.flake'.packages."plutus-benchmark:exe:uplc-evaluator";` to the exposed packages list

## Usage
Users can now build and run the uplc-evaluator service via nix:
```bash
nix build .#uplc-evaluator
nix run .#uplc-evaluator -- --help
```

## Context
The uplc-evaluator executable was added in #7546 but was not exposed as a nix package. This makes it accessible via standard nix commands, consistent with other executables like `uplc`, `plc`, and `pir`.