### PR TITLE
refactor(uplc-evaluator): normalize measurement structure

### DIFF
--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -18,7 +18,7 @@ import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 import TestHelpers
   ( EvalError (..)
   , EvalResult (..)
-  , Measurement (..)
+  , TimingSample (..)
   , readErrorJsonOrFail
   , readResultJson
   , readResultJsonOrFail
@@ -73,33 +73,32 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify measurements array has 10-20 entries
-              let measurementCount = length (erMeasurements result)
+              -- Verify top-level budget fields are positive
               assertBool
-                ("Measurements should have 10-20 entries, got " ++ show measurementCount)
-                (measurementCount >= 10 && measurementCount <= 20)
+                ("cpu_budget should be > 0, got " ++ show (erCpuBudget result))
+                (erCpuBudget result > 0)
+              assertBool
+                ("memory_budget should be > 0, got " ++ show (erMemoryBudget result))
+                (erMemoryBudget result > 0)
+              assertBool
+                ("memory_bytes should be > 0, got " ++ show (erMemoryBytes result))
+                (erMemoryBytes result > 0)
 
-              -- Verify each measurement has the required fields
+              -- Verify timing_samples array has 10-20 entries
+              let sampleCount = length (erTimingSamples result)
+              assertBool
+                ("timing_samples should have 10-20 entries, got " ++ show sampleCount)
+                (sampleCount >= 10 && sampleCount <= 20)
+
+              -- Verify each timing sample has positive cpu_time_ms
               mapM_
-                ( \m -> do
+                ( \s -> do
                     -- Check that cpu_time_ms is in reasonable range
                     assertBool
-                      ("cpu_time_ms should be > 0, got " ++ show (mCpuTimeMs m))
-                      (mCpuTimeMs m > 0)
-                    -- Check that memory_bytes is in reasonable range
-                    assertBool
-                      ("memory_bytes should be > 0, got " ++ show (mMemoryBytes m))
-                      (mMemoryBytes m > 0)
-                    -- Check that cpu_budget is in reasonable range
-                    assertBool
-                      ("cpu_budget should be > 0, got " ++ show (mCpuBudget m))
-                      (mCpuBudget m > 0)
-                    -- Check that memory_budget is in reasonable range
-                    assertBool
-                      ("memory_budget should be > 0, got " ++ show (mMemoryBudget m))
-                      (mMemoryBudget m > 0)
+                      ("cpu_time_ms should be > 0, got " ++ show (tsCpuTimeMs s))
+                      (tsCpuTimeMs s > 0)
                 )
-                (erMeasurements result)
+                (erTimingSamples result)
 
               -- Verify original input file is renamed to .processed
               let inputFilename = UUID.toString jobId ++ ".uplc.txt"
@@ -477,51 +476,45 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Wait for result (5 second timeout)
               path <- waitForResultOrFail handle jobId 5000
               result <- readResultJsonOrFail path
-              -- Verify measurements array has 10-20 entries
-              let measurements = erMeasurements result
-                  measurementCount = length measurements
+              -- Verify timing_samples array has 10-20 entries
+              let samples = erTimingSamples result
+                  sampleCount = length samples
               assertBool
-                ("Measurements should have 10-20 entries, got " ++ show measurementCount)
-                (measurementCount >= 10 && measurementCount <= 20)
+                ("timing_samples should have 10-20 entries, got " ++ show sampleCount)
+                (sampleCount >= 10 && sampleCount <= 20)
 
-              -- Verify each measurement has values in expected ranges
-              -- Note: With real CEK evaluation, simple programs execute very fast
-              -- and have small budget values. Ranges are adjusted accordingly.
+              -- Verify top-level budget values are in expected ranges
+              -- Note: With real CEK evaluation, simple programs have small budget values.
+              let cpuBudget = erCpuBudget result
+              assertBool
+                ("cpu_budget should be >= 0 and <= 100000000, got " ++ show cpuBudget)
+                (cpuBudget >= 0 && cpuBudget <= 100000000)
+
+              let memBudget = erMemoryBudget result
+              assertBool
+                ("memory_budget should be >= 0 and <= 50000000, got " ++ show memBudget)
+                (memBudget >= 0 && memBudget <= 50000000)
+
+              -- memory_bytes is derived from ExMemory * 8 (word size)
+              let memBytes = erMemoryBytes result
+              assertBool
+                ("memory_bytes should be >= 0 and <= 10485760, got " ++ show memBytes)
+                (memBytes >= 0 && memBytes <= 10485760)
+
+              -- Verify each timing sample has cpu_time_ms in expected range
+              -- Simple programs can evaluate in microseconds
               mapM_
-                ( \m -> do
-                    -- cpu_time_ms should be non-negative and reasonable
-                    -- Simple programs can evaluate in microseconds
-                    let cpuTime = mCpuTimeMs m
+                ( \s -> do
+                    let cpuTime = tsCpuTimeMs s
                     assertBool
                       ("cpu_time_ms should be >= 0 and <= 500.0, got " ++ show cpuTime)
                       (cpuTime >= 0 && cpuTime <= 500.0)
-
-                    -- memory_bytes is derived from ExMemory * 8 (word size)
-                    -- Simple programs have small memory footprint
-                    let memBytes = mMemoryBytes m
-                    assertBool
-                      ("memory_bytes should be >= 0 and <= 10485760, got " ++ show memBytes)
-                      (memBytes >= 0 && memBytes <= 10485760)
-
-                    -- cpu_budget from CEK costing model
-                    -- Simple constants have small CPU costs
-                    let cpuBudget = mCpuBudget m
-                    assertBool
-                      ("cpu_budget should be >= 0 and <= 100000000, got " ++ show cpuBudget)
-                      (cpuBudget >= 0 && cpuBudget <= 100000000)
-
-                    -- memory_budget from CEK costing model
-                    -- Simple constants have small memory costs
-                    let memBudget = mMemoryBudget m
-                    assertBool
-                      ("memory_budget should be >= 0 and <= 50000000, got " ++ show memBudget)
-                      (memBudget >= 0 && memBudget <= 50000000)
                 )
-                measurements
+                samples
         ]
     , testGroup
         "Budget Determinism"
-        [ testCase "Same program produces identical budget values across all samples" do
+        [ testCase "Budget values are at top level (deterministic, not repeated in samples)" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
               -- Generate a UUID for this job
@@ -534,40 +527,28 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Wait for result (5 second timeout)
               path <- waitForResultOrFail handle jobId 5000
               result <- readResultJsonOrFail path
-              -- Verify we have measurements
-              let measurements = erMeasurements result
-                  measurementCount = length measurements
+              -- Verify we have timing samples
+              let samples = erTimingSamples result
+                  sampleCount = length samples
               assertBool
-                ("Should have at least 10 measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have at least 10 timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
 
-              -- Extract all cpu_budget values
-              let cpuBudgets = map mCpuBudget measurements
-                  uniqueCpuBudgets = nub cpuBudgets
-              -- All cpu_budget values should be identical
+              -- Budget values are now at top level (single deterministic value)
+              -- Just verify they exist and are positive
               assertBool
-                ( "All cpu_budget values should be identical, got "
-                    ++ show (length uniqueCpuBudgets)
-                    ++ " unique values: "
-                    ++ show uniqueCpuBudgets
-                )
-                (length uniqueCpuBudgets == 1)
-
-              -- Extract all memory_budget values
-              let memBudgets = map mMemoryBudget measurements
-                  uniqueMemBudgets = nub memBudgets
-              -- All memory_budget values should be identical
+                ("cpu_budget should be > 0, got " ++ show (erCpuBudget result))
+                (erCpuBudget result > 0)
               assertBool
-                ( "All memory_budget values should be identical, got "
-                    ++ show (length uniqueMemBudgets)
-                    ++ " unique values: "
-                    ++ show uniqueMemBudgets
-                )
-                (length uniqueMemBudgets == 1)
+                ("memory_budget should be > 0, got " ++ show (erMemoryBudget result))
+                (erMemoryBudget result > 0)
+              assertBool
+                ("memory_bytes should be > 0, got " ++ show (erMemoryBytes result))
+                (erMemoryBytes result > 0)
 
               -- cpu_time_ms values may vary (timing is non-deterministic)
               -- We just verify they exist and are positive
-              let cpuTimes = map mCpuTimeMs measurements
+              let cpuTimes = map tsCpuTimeMs samples
               mapM_
                 ( \t ->
                     assertBool
@@ -599,11 +580,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                   -- Verify status is "success" (not validation error)
                   erStatus result @?= "success"
 
-                  -- Verify we got measurements (confirms evaluation succeeded)
-                  let measurementCount = length (erMeasurements result)
+                  -- Verify we got timing samples (confirms evaluation succeeded)
+                  let sampleCount = length (erTimingSamples result)
                   assertBool
-                    ("Should have measurements, got " ++ show measurementCount)
-                    (measurementCount >= 10)
+                    ("Should have timing samples, got " ++ show sampleCount)
+                    (sampleCount >= 10)
         , testCase "Mixed case UUID v4 format is accepted" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -622,11 +603,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                   -- Verify status is "success" (not validation error)
                   erStatus result @?= "success"
 
-                  -- Verify we got measurements
-                  let measurementCount = length (erMeasurements result)
+                  -- Verify we got timing samples
+                  let sampleCount = length (erTimingSamples result)
                   assertBool
-                    ("Should have measurements, got " ++ show measurementCount)
-                    (measurementCount >= 10)
+                    ("Should have timing samples, got " ++ show sampleCount)
+                    (sampleCount >= 10)
         , testCase "Multiple randomly generated UUID v4s are accepted" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -667,10 +648,10 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                       erProgramId r2 @?= T.pack (UUID.toString jobId2)
                       erProgramId r3 @?= T.pack (UUID.toString jobId3)
 
-                      -- Verify all have measurements
-                      assertBool "First result should have measurements" (length (erMeasurements r1) >= 10)
-                      assertBool "Second result should have measurements" (length (erMeasurements r2) >= 10)
-                      assertBool "Third result should have measurements" (length (erMeasurements r3) >= 10)
+                      -- Verify all have timing samples
+                      assertBool "First result should have timing samples" (length (erTimingSamples r1) >= 10)
+                      assertBool "Second result should have timing samples" (length (erTimingSamples r2) >= 10)
+                      assertBool "Third result should have timing samples" (length (erTimingSamples r3) >= 10)
                     (Left err, _, _) -> assertFailure $ "Failed to parse first result: " ++ err
                     (_, Left err, _) -> assertFailure $ "Failed to parse second result: " ++ err
                     (_, _, Left err) -> assertFailure $ "Failed to parse third result: " ++ err
@@ -769,15 +750,15 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                   totalIds = length resultProgramIds
               uniqueIds @?= totalIds
 
-              -- Verify all results have measurements
+              -- Verify all results have timing samples
               mapM_
                 ( \result -> do
-                    let measurementCount = length (erMeasurements result)
+                    let sampleCount = length (erTimingSamples result)
                     assertBool
-                      ( "Result should have measurements, got "
-                          ++ show measurementCount
+                      ( "Result should have timing samples, got "
+                          ++ show sampleCount
                       )
-                      (measurementCount >= 10)
+                      (sampleCount >= 10)
                 )
                 results
         ]
@@ -799,11 +780,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Program with leading newlines is processed successfully" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -820,11 +801,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Program with leading tabs is processed successfully" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -841,11 +822,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Program with mixed whitespace is processed successfully" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -862,11 +843,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         ]
     , testGroup
         "SPEC.md Example Programs"
@@ -886,11 +867,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Example 2: Arithmetic with builtins" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -912,11 +893,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Example 3: Lambda application" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -940,11 +921,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         , testCase "Example 4: Constructor with version 1.1.0" do
             execPath <- findEvaluatorExecutable
             withEvaluatorService execPath \handle -> do
@@ -961,11 +942,11 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
               -- Verify status is "success"
               erStatus result @?= "success"
 
-              -- Verify we have measurements
-              let measurementCount = length (erMeasurements result)
+              -- Verify we have timing samples
+              let sampleCount = length (erTimingSamples result)
               assertBool
-                ("Should have measurements, got " ++ show measurementCount)
-                (measurementCount >= 10)
+                ("Should have timing samples, got " ++ show sampleCount)
+                (sampleCount >= 10)
         ]
     ]
 

--- a/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
+++ b/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
@@ -23,7 +23,7 @@ module TestHelpers
     -- * Types
   , EvalResult (..)
   , EvalError (..)
-  , Measurement (..)
+  , TimingSample (..)
   ) where
 
 import Control.Concurrent (threadDelay)
@@ -42,28 +42,25 @@ import System.Directory (doesFileExist)
 import System.FilePath ((</>))
 import Test.Tasty.HUnit (assertFailure)
 
--- | Measurement data for a single evaluation run
-data Measurement = Measurement
-  { mCpuTimeMs :: Double
-  , mMemoryBytes :: Integer
-  , mCpuBudget :: Integer
-  , mMemoryBudget :: Integer
+-- | Timing sample for a single evaluation run (variable data only)
+data TimingSample = TimingSample
+  { tsCpuTimeMs :: Double
   }
   deriving stock (Generic, Show, Eq)
 
-instance FromJSON Measurement where
-  parseJSON = Aeson.withObject "Measurement" \v ->
-    Measurement
+instance FromJSON TimingSample where
+  parseJSON = Aeson.withObject "TimingSample" \v ->
+    TimingSample
       <$> v .: "cpu_time_ms"
-      <*> v .: "memory_bytes"
-      <*> v .: "cpu_budget"
-      <*> v .: "memory_budget"
 
--- | Successful evaluation result
+-- | Successful evaluation result with deterministic budget at top level
 data EvalResult = EvalResult
   { erProgramId :: Text
   , erStatus :: Text
-  , erMeasurements :: [Measurement]
+  , erCpuBudget :: Integer
+  , erMemoryBudget :: Integer
+  , erMemoryBytes :: Integer
+  , erTimingSamples :: [TimingSample]
   }
   deriving stock (Generic, Show, Eq)
 
@@ -72,7 +69,10 @@ instance FromJSON EvalResult where
     EvalResult
       <$> v .: "program_id"
       <*> v .: "status"
-      <*> v .: "measurements"
+      <*> v .: "cpu_budget"
+      <*> v .: "memory_budget"
+      <*> v .: "memory_bytes"
+      <*> v .: "timing_samples"
 
 -- | Error result
 data EvalError = EvalError


### PR DESCRIPTION
## Context

- **What**: Normalize uplc-evaluator JSON output to separate deterministic budget values from variable timing data
- **Why**: The previous structure redundantly repeated identical budget values in every measurement sample, wasting space and obscuring the deterministic nature of budget consumption
- **Issue**: Relates to plutus-private#2044

## Approach

Refactored the JSON output structure to move deterministic values (cpu_budget, memory_budget, memory_bytes) to the top level, keeping only variable timing data (cpu_time_ms) in the samples array. This change builds on the real CEK evaluation implementation.

The new structure clearly communicates that budget values are computed once and are identical across all timing samples, while wall-clock execution time varies between runs. This makes the API more semantically accurate and reduces JSON payload size by eliminating redundant data.

**Previous structure:**
```json
{
  "measurements": [
    {"cpu_time_ms": 0.02, "cpu_budget": 100, "memory_budget": 100, "memory_bytes": 800},
    {"cpu_time_ms": 0.03, "cpu_budget": 100, "memory_budget": 100, "memory_bytes": 800}
  ]
}
```

**New structure:**
```json
{
  "cpu_budget": 100,
  "memory_budget": 100,
  "memory_bytes": 800,
  "timing_samples": [
    {"cpu_time_ms": 0.02},
    {"cpu_time_ms": 0.03}
  ]
}
```

Closes https://github.com/IntersectMBO/plutus-private/issues/2044