### PR TITLE
feat(uplc-evaluator): use integer nanoseconds for timing measurements

### DIFF
--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -90,13 +90,13 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                 ("timing_samples should have 10-20 entries, got " ++ show sampleCount)
                 (sampleCount >= 10 && sampleCount <= 20)
 
-              -- Verify each timing sample has positive cpu_time_ms
+              -- Verify each timing sample has positive cpu_time_ns
               mapM_
                 ( \s -> do
-                    -- Check that cpu_time_ms is in reasonable range
+                    -- Check that cpu_time_ns is in reasonable range
                     assertBool
-                      ("cpu_time_ms should be > 0, got " ++ show (tsCpuTimeMs s))
-                      (tsCpuTimeMs s > 0)
+                      ("cpu_time_ns should be > 0, got " ++ show (tsCpuTimeNs s))
+                      (tsCpuTimeNs s > 0)
                 )
                 (erTimingSamples result)
 
@@ -501,14 +501,14 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                 ("memory_bytes should be >= 0 and <= 10485760, got " ++ show memBytes)
                 (memBytes >= 0 && memBytes <= 10485760)
 
-              -- Verify each timing sample has cpu_time_ms in expected range
+              -- Verify each timing sample has cpu_time_ns in expected range
               -- Simple programs can evaluate in microseconds
               mapM_
                 ( \s -> do
-                    let cpuTime = tsCpuTimeMs s
+                    let cpuTime = tsCpuTimeNs s
                     assertBool
-                      ("cpu_time_ms should be >= 0 and <= 500.0, got " ++ show cpuTime)
-                      (cpuTime >= 0 && cpuTime <= 500.0)
+                      ("cpu_time_ns should be >= 0 and <= 500000000, got " ++ show cpuTime)
+                      (cpuTime >= 0 && cpuTime <= 500000000)
                 )
                 samples
         ]
@@ -546,13 +546,13 @@ main = defaultMain $ testGroup "uplc-evaluator integration tests" do
                 ("memory_bytes should be > 0, got " ++ show (erMemoryBytes result))
                 (erMemoryBytes result > 0)
 
-              -- cpu_time_ms values may vary (timing is non-deterministic)
+              -- cpu_time_ns values may vary (timing is non-deterministic)
               -- We just verify they exist and are positive
-              let cpuTimes = map tsCpuTimeMs samples
+              let cpuTimes = map tsCpuTimeNs samples
               mapM_
                 ( \t ->
                     assertBool
-                      ("cpu_time_ms should be > 0, got " ++ show t)
+                      ("cpu_time_ns should be > 0, got " ++ show t)
                       (t > 0)
                 )
                 cpuTimes

--- a/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
+++ b/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
@@ -36,6 +36,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.UUID (UUID)
 import Data.UUID qualified as UUID
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Harness (ServiceHandle (..))
 import System.Directory (doesFileExist)
@@ -43,15 +44,15 @@ import System.FilePath ((</>))
 import Test.Tasty.HUnit (assertFailure)
 
 -- | Timing sample for a single evaluation run (variable data only)
-data TimingSample = TimingSample
-  { tsCpuTimeMs :: Double
+newtype TimingSample = TimingSample
+  { tsCpuTimeNs :: Word64
   }
   deriving stock (Generic, Show, Eq)
 
 instance FromJSON TimingSample where
   parseJSON = Aeson.withObject "TimingSample" \v ->
     TimingSample
-      <$> v .: "cpu_time_ms"
+      <$> v .: "cpu_time_ns"
 
 -- | Successful evaluation result with deterministic budget at top level
 data EvalResult = EvalResult


### PR DESCRIPTION
## Context

- **What**: Replace floating-point millisecond timing with integer nanosecond measurements
- **Why**: Eliminate floating-point representation inconsistencies across platforms and precision loss in JSON serialization
- **Issue**: Closes IntersectMBO/plutus-private#2045 (Parent Epic: IntersectMBO/plutus-private#2031)

## Approach

Changed the timing measurement representation from `Double` milliseconds to `Word64` nanoseconds throughout the uplc-evaluator codebase. This eliminates floating-point quirks and provides clean integer values in the API response.

The implementation involved three key changes:

1. **Type System Update**: Changed `TimingSample` from `data` with `tsCpuTimeMs :: Double` to `newtype` with `tsCpuTimeNs :: Word64`. The newtype change provides zero-cost abstraction while maintaining type safety.

2. **Measurement Conversion**: Updated `measureExecution` to convert criterion-measurement's seconds to nanoseconds by multiplying by `1e9` and using `round` to obtain `Word64` values. This maintains the full precision of criterion-measurement's high-resolution timer while presenting results as integers.

3. **API Contract Change**: Renamed the JSON field from `"cpu_time_ms"` to `"cpu_time_ns"` in both serialization (`ToJSON`) and deserialization (`FromJSON`) instances, making the unit explicit in the API.

The choice of nanoseconds provides sufficient precision for benchmarking (criterion-measurement already works at nanosecond resolution) without the excessive magnitude of picoseconds. Simple UPLC programs evaluate in the 100,000-500,000 nanosecond range (0.1-0.5ms), which are clean integer values.

## Changes

### Core Implementation
- Changed `TimingSample` from `data` to `newtype` with `tsCpuTimeNs :: Word64` field (Main.hs:80)
- Updated `measureExecution` return type from `(a, Double)` to `(a, Word64)` and changed conversion from `* 1000` (ms) to `* 1e9` (ns) with `round` (Main.hs:166-176)
- Updated `buildTimingSample` helper to work with `Word64` instead of `Double` (Main.hs:275-278)
- Added `import Data.Word (Word64)` to both Main.hs and TestHelpers.hs

### API Contract
- Changed JSON serialization field from `"cpu_time_ms"` to `"cpu_time_ns"` in `ToJSON` instance (Main.hs:86)
- Updated `FromJSON` instance in test helpers to parse `"cpu_time_ns"` (TestHelpers.hs:54)

### Test Suite Updates
- Updated all test assertions to use `tsCpuTimeNs` accessor instead of `tsCpuTimeMs` (Spec.hs)
- Changed range validation from `<= 500.0` ms to `<= 500000000` ns (500ms in nanoseconds) (Spec.hs:510)
- Updated assertion messages from "cpu_time_ms" to "cpu_time_ns" throughout test suite

### Documentation
- Updated SPEC.md field documentation: changed type from "Number (floating-point)" to "Integer", unit from "Milliseconds" to "Nanoseconds"
- Updated JSON schema examples to show integer nanosecond values (e.g., `421000` instead of `0.421`)
- Changed all example outputs in SPEC.md to use `"cpu_time_ns"` with integer values
- Updated jq command examples to work with nanoseconds, including conversion to milliseconds for display: `jq '[.timing_samples[].cpu_time_ns] | add / length / 1000000'`
- Updated prose references from `cpu_time_ms` to `cpu_time_ns` throughout documentation

## Breaking Changes

⚠️ **This is a breaking API change.** Consumers expecting `cpu_time_ms` as a floating-point field will need to update to parse `cpu_time_ns` as an integer.

