### PR TITLE
Replace use of tail with drop 1 in PlutusTx/Enum/TH.hs

### DIFF
--- a/plutus-tx/src/PlutusTx/Enum/TH.hs
+++ b/plutus-tx/src/PlutusTx/Enum/TH.hs
@@ -50,7 +50,7 @@ deriveEnum name = do
     <$> instanceD
       (pure [])
       (pure instanceType)
-      [ funD 'succ (fmap (deriveSuccPred Succ) (zip cons (tail (Just <$> cons) ++ [Nothing])))
+      [ funD 'succ (fmap (deriveSuccPred Succ) (zip cons (drop 1 (Just <$> cons) ++ [Nothing])))
       , TH.pragInlD 'succ TH.Inlinable TH.FunLike TH.AllPhases
       , funD 'pred (fmap (deriveSuccPred Pred) (zip cons (Nothing : init (Just <$> cons))))
       , TH.pragInlD 'pred TH.Inlinable TH.FunLike TH.AllPhases


### PR DESCRIPTION
Fixes this error:
```
src/PlutusTx/Enum/TH.hs:53:59: error: [GHC-63394] [-Wx-partial, -Werror=x-partial]
    In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
53 |       [ funD 'succ (fmap (deriveSuccPred Succ) (zip cons (tail (Just <$> cons) ++ [Nothing])))
   |     
```