### PR TITLE
Fix flaky uplc-evaluator-integration-tests and re-enable

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -902,7 +902,6 @@ executable uplc-evaluator
 
 test-suite uplc-evaluator-integration-tests
   import:             lang, os-support
-  buildable:          False
   type:               exitcode-stdio-1.0
   main-is:            Spec.hs
   other-modules:


### PR DESCRIPTION
## Summary

- Fix race condition causing intermittent test failures in uplc-evaluator-integration-tests
- Re-enable the test suite (disabled in #7567)

## Problem

The tests were flaky because of a race condition between file writing and service reading:

1. Test's `writeFile` creates an empty file, then writes content
2. Service polls at 100ms intervals and sees the new file
3. On loaded CI systems, the service could read the file while still empty
4. Service reports "Program file is empty" → test fails

Example from CI log:
```
Processing job: f21aa4b4-3c90-4c3e-8477-5a06b24ca71f
Program file is empty
Wrote error: .../f21aa4b4-3c90-4c3e-8477-5a06b24ca71f.error.json
```

## Solution

Use atomic file creation in `submitProgram` and `submitProgramFlat`:
- Write to a temporary file (`.tmp`) first
- Use `renameFile` to atomically move it to the final location

This mirrors the pattern already used by the service itself for writing output files (`writeResult`, `writeError`).

## Test plan

- [x] Run `cabal test plutus-benchmark:uplc-evaluator-integration-tests` - all 28 tests pass
- [x] Run the specific flaky test multiple times - passes consistently
- [x] Run full test suite 5 times in a row - all pass