### PR TITLE
Experiment: multi-way if vs BI.ifThenElse budget comparison

### DIFF
--- a/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.pir
@@ -1,0 +1,29 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  !traceError : all a. string -> a
+    = /\a ->
+        \(str : string) -> let !x : Unit = trace {Unit} str Unit in error {a}
+in
+\(x : integer) (y : integer) ->
+  case
+    (all dead. bool)
+    (case bool (lessThanEqualsInteger x 10) [True, False])
+    [ (/\dead ->
+         case
+           (all dead. bool)
+           (lessThanInteger y 0)
+           [ (/\dead ->
+                case
+                  (all dead. bool)
+                  (case
+                     bool
+                     (lessThanEqualsInteger (addInteger x y) 20)
+                     [True, False])
+                  [ (/\dead -> True)
+                  , (/\dead -> traceError {bool} "sum too large") ]
+                  {all dead. dead})
+           , (/\dead -> traceError {bool} "y negative") ]
+           {all dead. dead})
+    , (/\dead -> traceError {bool} "x too large") ]
+    {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfErrorPath.golden.uplc
@@ -1,0 +1,16 @@
+(program
+   1.1.0
+   (\x y ->
+      force
+        ((\traceError ->
+            case
+              (lessThanEqualsInteger x 10)
+              [ (delay (traceError "x too large"))
+              , (delay
+                   (case
+                      (lessThanInteger y 0)
+                      [ (case
+                           (lessThanEqualsInteger (addInteger x y) 20)
+                           [(traceError "sum too large"), True])
+                      , (traceError "y negative") ])) ])
+           (\str -> (\x -> error) (force trace str (constr 0 []))))))

--- a/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   778_272
+Memory:                  3_505
+AST Size:                   53
+Flat Size:                 101
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.pir
@@ -1,0 +1,29 @@
+let
+  data Unit | Unit_match where
+    Unit : Unit
+  !traceError : all a. string -> a
+    = /\a ->
+        \(str : string) -> let !x : Unit = trace {Unit} str Unit in error {a}
+in
+\(x : integer) (y : integer) ->
+  case
+    (all dead. bool)
+    (case bool (lessThanEqualsInteger x 10) [True, False])
+    [ (/\dead ->
+         case
+           (all dead. bool)
+           (lessThanInteger y 0)
+           [ (/\dead ->
+                case
+                  (all dead. bool)
+                  (case
+                     bool
+                     (lessThanEqualsInteger (addInteger x y) 20)
+                     [True, False])
+                  [ (/\dead -> True)
+                  , (/\dead -> traceError {bool} "sum too large") ]
+                  {all dead. dead})
+           , (/\dead -> traceError {bool} "y negative") ]
+           {all dead. dead})
+    , (/\dead -> traceError {bool} "x too large") ]
+    {all dead. dead}

--- a/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/guardIfHappyPath.golden.uplc
@@ -1,0 +1,16 @@
+(program
+   1.1.0
+   (\x y ->
+      force
+        ((\traceError ->
+            case
+              (lessThanEqualsInteger x 10)
+              [ (delay (traceError "x too large"))
+              , (delay
+                   (case
+                      (lessThanInteger y 0)
+                      [ (case
+                           (lessThanEqualsInteger (addInteger x y) 20)
+                           [(traceError "sum too large"), True])
+                      , (traceError "y negative") ])) ])
+           (\str -> (\x -> error) (force trace str (constr 0 []))))))

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.pir
@@ -1,0 +1,31 @@
+let
+  !ifThenElse : all a. bool -> a -> a -> a
+    = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  !greaterThanInteger : integer -> integer -> bool
+    = \(x : integer) (y : integer) ->
+        ifThenElse {bool} (lessThanEqualsInteger x y) False True
+  data Unit | Unit_match where
+    Unit : Unit
+  !traceError : all a. string -> a
+    = /\a ->
+        \(str : string) -> let !x : Unit = trace {Unit} str Unit in error {a}
+in
+\(x : integer) (y : integer) ->
+  ifThenElse
+    {unit -> bool}
+    (greaterThanInteger x 10)
+    (\(ds : unit) -> traceError {bool} "x too large")
+    (\(ds : unit) ->
+       ifThenElse
+         {unit -> bool}
+         (lessThanInteger y 0)
+         (\(ds : unit) -> traceError {bool} "y negative")
+         (\(ds : unit) ->
+            ifThenElse
+              {unit -> bool}
+              (greaterThanInteger (addInteger x y) 20)
+              (\(ds : unit) -> traceError {bool} "sum too large")
+              (\(ds : unit) -> True)
+              ())
+         ())
+    ()

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfErrorPath.golden.uplc
@@ -1,0 +1,19 @@
+(program
+   1.1.0
+   (\x y ->
+      (\traceError ->
+         case
+           (lessThanEqualsInteger x 10)
+           [ (\ds -> traceError "x too large")
+           , (\ds ->
+                case
+                  (lessThanInteger y 0)
+                  [ (\ds ->
+                       case
+                         (lessThanEqualsInteger (addInteger x y) 20)
+                         [(\ds -> traceError "sum too large"), (\ds -> True)]
+                         ())
+                  , (\ds -> traceError "y negative") ]
+                  ()) ])
+        (\str -> (\x -> error) (force trace str (constr 0 [])))
+        ()))

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   890_272
+Memory:                  4_205
+AST Size:                   62
+Flat Size:                 108
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.pir
@@ -1,0 +1,31 @@
+let
+  !ifThenElse : all a. bool -> a -> a -> a
+    = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  !greaterThanInteger : integer -> integer -> bool
+    = \(x : integer) (y : integer) ->
+        ifThenElse {bool} (lessThanEqualsInteger x y) False True
+  data Unit | Unit_match where
+    Unit : Unit
+  !traceError : all a. string -> a
+    = /\a ->
+        \(str : string) -> let !x : Unit = trace {Unit} str Unit in error {a}
+in
+\(x : integer) (y : integer) ->
+  ifThenElse
+    {unit -> bool}
+    (greaterThanInteger x 10)
+    (\(ds : unit) -> traceError {bool} "x too large")
+    (\(ds : unit) ->
+       ifThenElse
+         {unit -> bool}
+         (lessThanInteger y 0)
+         (\(ds : unit) -> traceError {bool} "y negative")
+         (\(ds : unit) ->
+            ifThenElse
+              {unit -> bool}
+              (greaterThanInteger (addInteger x y) 20)
+              (\(ds : unit) -> traceError {bool} "sum too large")
+              (\(ds : unit) -> True)
+              ())
+         ())
+    ()

--- a/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/handOptIfHappyPath.golden.uplc
@@ -1,0 +1,19 @@
+(program
+   1.1.0
+   (\x y ->
+      (\traceError ->
+         case
+           (lessThanEqualsInteger x 10)
+           [ (\ds -> traceError "x too large")
+           , (\ds ->
+                case
+                  (lessThanInteger y 0)
+                  [ (\ds ->
+                       case
+                         (lessThanEqualsInteger (addInteger x y) 20)
+                         [(\ds -> traceError "sum too large"), (\ds -> True)]
+                         ())
+                  , (\ds -> traceError "y negative") ]
+                  ()) ])
+        (\str -> (\x -> error) (force trace str (constr 0 [])))
+        ()))


### PR DESCRIPTION
> [!NOTE]
> **Not for merge** — this is an experiment to share findings.

## Context

PR #7562 replaces Haskell multi-way `if | guard -> ...` with explicit `BI.ifThenElse` + lambda-delay pattern in the linear vesting validator. This experiment verifies empirically whether the hand-optimized version actually produces better execution budgets.

## What's here

4 new budget golden tests comparing identical validation logic (3 conditional checks → `traceError` or `True`):

| Test | Pattern | Input |
|---|---|---|
| `guardIfHappyPath` | Multi-way if/guards | `(5, 3)` → all guards false → `True` |
| `guardIfErrorPath` | Multi-way if/guards | `(15, 3)` → first guard true → `traceError` |
| `handOptIfHappyPath` | `BI.ifThenElse` + `\_ ->` lambdas | `(5, 3)` → all checks false → `True` |
| `handOptIfErrorPath` | `BI.ifThenElse` + `\_ ->` lambdas | `(15, 3)` → first check true → `traceError` |

## Results (happy path — all conditions false)

| Metric | `guardIf` (multi-way if) | `handOptIf` (BI.ifThenElse) | Diff |
|---|---|---|---|
| **CPU** | 778,272 | 890,272 | **+14.4%** worse |
| **Memory** | 3,505 | 4,205 | **+20.0%** worse |
| **AST Size** | 53 | 62 | **+17.0%** worse |
| **Flat Size** | 101 | 108 | **+6.9%** worse |

## Why

The compiler optimizes multi-way if into `case` with `force`/`delay` branches:

```
-- guardIf UPLC (simplified)
force (case (lessThanEqualsInteger x 10)
  [ (delay (traceError "x too large"))
  , (delay (case ...)) ])
```

The hand-written `BI.ifThenElse` compiles to `case` with `\ds -> ...` lambda + `()` application — which adds overhead:

```
-- handOptIf UPLC (simplified)
case (lessThanEqualsInteger x 10)
  [ (\ds -> traceError "x too large")
  , (\ds -> case ... ()) ]
  ()
```

The `force`/`delay` pattern used by the compiler is cheaper than the lambda + unit application pattern.

## Conclusion

For this simple 3-condition validation, **multi-way if is cheaper** than hand-optimized `BI.ifThenElse`. The plugin's compilation of guards already produces efficient `force`/`delay` lazy evaluation, making the hand-optimization counterproductive in this case.

Full golden files (`.pir`, `.uplc`, `.eval`) are included for detailed inspection.