### PR TITLE
Add service-level warmup and pre-measurement GC to uplc-evaluator

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -885,6 +885,7 @@ executable uplc-evaluator
   default-language: Haskell2010
   main-is:          Main.hs
   hs-source-dirs:   uplc-evaluator
+  ghc-options:      -rtsopts -with-rtsopts=-I0
   build-depends:
     , aeson                  >=2.0
     , base                   >=4.9   && <5


### PR DESCRIPTION
## Summary

- Add a **service-level warmup** at startup that parses and evaluates a trivial UPLC program (`(con integer 42)`) through the full pipeline (parse → NamedDeBruijn → CEK evaluation with timing), priming CPU caches, GHC RTS, and OS pages so the first real submission gets consistent timing.
- Add **`performGC` before each program's measurement collection** to drain accumulated heap garbage, preventing major GC pauses mid-sample.
- Add **`performMinorGC` between each timing sample** (following criterion's approach) to prevent garbage from earlier samples triggering collection during later ones.
- Set **`-I0` RTS flag** to disable idle GC, preventing background collections during poll-interval sleeps from firing right before the next evaluation.

## Test plan

- [x] `cabal build plutus-benchmark:uplc-evaluator` compiles successfully
- [x] `cabal test uplc-evaluator-integration-tests` — all 28 tests pass
- [x] Warmup log messages visible in test stderr output
- [x] Note: `-N1` was tested but breaks signal handling in integration tests; omitted since the service is already single-threaded