### PR TITLE
Experiment: && vs builtinAnd vs alternatives — boolean AND chaining budget

### DIFF
--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -128,6 +128,7 @@ test-suite plutus-tx-plugin-tests
     Blueprint.Tests.Lib
     Blueprint.Tests.Lib.AsData.Blueprint
     Blueprint.Tests.Lib.AsData.Decls
+    Budget.BuiltinAndLib
     Budget.Spec
     Budget.WithGHCOptimisations
     Budget.WithoutGHCOptimisations

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   919_970
+Memory:                  5_003
+AST Size:                   63
+Flat Size:                  91
+
+(con unit ())

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.pir
@@ -1,0 +1,26 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    let
+      !b : bool = lessThanInteger x 100
+      !b : bool = lessThanInteger y 100
+      !b : bool = lessThanInteger z 100
+      !b : bool
+        = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)]
+            ()
+    in
+    case
+      (unit -> unit)
+      (case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) -> ()) ]
+      ())
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_AllTrue.golden.uplc
@@ -1,0 +1,21 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b ->
+             (\b ->
+                (\b ->
+                   case
+                     (case b [(\ds -> False), (\ds -> b)] ())
+                     [ (\ds ->
+                          (\x -> error)
+                            (force trace "conditions not met" (constr 0 [])))
+                     , (\ds -> ()) ]
+                     ())
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
+         (lessThanInteger x 100))
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.pir
@@ -1,0 +1,26 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    let
+      !b : bool = lessThanInteger x 100
+      !b : bool = lessThanInteger y 100
+      !b : bool = lessThanInteger z 100
+      !b : bool
+        = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)]
+            ()
+    in
+    case
+      (unit -> unit)
+      (case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) -> ()) ]
+      ())
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_EarlyFail.golden.uplc
@@ -1,0 +1,21 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b ->
+             (\b ->
+                (\b ->
+                   case
+                     (case b [(\ds -> False), (\ds -> b)] ())
+                     [ (\ds ->
+                          (\x -> error)
+                            (force trace "conditions not met" (constr 0 [])))
+                     , (\ds -> ()) ]
+                     ())
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
+         (lessThanInteger x 100))
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.pir
@@ -1,0 +1,26 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    let
+      !b : bool = lessThanInteger x 100
+      !b : bool = lessThanInteger y 100
+      !b : bool = lessThanInteger z 100
+      !b : bool
+        = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)]
+            ()
+    in
+    case
+      (unit -> unit)
+      (case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) -> ()) ]
+      ())
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAndIfError_LateFail.golden.uplc
@@ -1,0 +1,21 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b ->
+             (\b ->
+                (\b ->
+                   case
+                     (case b [(\ds -> False), (\ds -> b)] ())
+                     [ (\ds ->
+                          (\x -> error)
+                            (force trace "conditions not met" (constr 0 [])))
+                     , (\ds -> ()) ]
+                     ())
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
+         (lessThanInteger x 100))
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   839_970
+Memory:                  4_503
+AST Size:                   48
+Flat Size:                  58
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.pir
@@ -1,0 +1,14 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   let
+     !b : bool = lessThanInteger x 100
+     !b : bool
+       = let
+         !b : bool = lessThanInteger y 100
+         !b : bool = lessThanInteger z 100
+       in
+       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+   in
+   case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.pir
@@ -1,12 +1,10 @@
 (\(x : integer) (y : integer) (z : integer) ->
    let
      !b : bool = lessThanInteger x 100
+     !b : bool = lessThanInteger y 100
+     !b : bool = lessThanInteger z 100
      !b : bool
-       = let
-         !b : bool = lessThanInteger y 100
-         !b : bool = lessThanInteger z 100
-       in
-       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+       = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
    in
    case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
   50

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.uplc
@@ -1,0 +1,13 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b -> case b [(\ds -> False), (\ds -> b)] ())
+            ((\b ->
+                (\b -> case b [(\ds -> False), (\ds -> b)] ())
+                  (lessThanInteger z 100))
+               (lessThanInteger y 100)))
+         (lessThanInteger x 100))
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_AllTrue.golden.uplc
@@ -2,11 +2,12 @@
    1.1.0
    ((\x y z ->
        (\b ->
-          (\b -> case b [(\ds -> False), (\ds -> b)] ())
-            ((\b ->
+          (\b ->
+             (\b ->
                 (\b -> case b [(\ds -> False), (\ds -> b)] ())
-                  (lessThanInteger z 100))
-               (lessThanInteger y 100)))
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
          (lessThanInteger x 100))
       50
       60

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   839_970
+Memory:                  4_503
+AST Size:                   48
+Flat Size:                  59
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.pir
@@ -1,0 +1,14 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   let
+     !b : bool = lessThanInteger x 100
+     !b : bool
+       = let
+         !b : bool = lessThanInteger y 100
+         !b : bool = lessThanInteger z 100
+       in
+       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+   in
+   case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.pir
@@ -1,12 +1,10 @@
 (\(x : integer) (y : integer) (z : integer) ->
    let
      !b : bool = lessThanInteger x 100
+     !b : bool = lessThanInteger y 100
+     !b : bool = lessThanInteger z 100
      !b : bool
-       = let
-         !b : bool = lessThanInteger y 100
-         !b : bool = lessThanInteger z 100
-       in
-       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+       = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
    in
    case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
   150

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.uplc
@@ -1,0 +1,13 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b -> case b [(\ds -> False), (\ds -> b)] ())
+            ((\b ->
+                (\b -> case b [(\ds -> False), (\ds -> b)] ())
+                  (lessThanInteger z 100))
+               (lessThanInteger y 100)))
+         (lessThanInteger x 100))
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_EarlyFail.golden.uplc
@@ -2,11 +2,12 @@
    1.1.0
    ((\x y z ->
        (\b ->
-          (\b -> case b [(\ds -> False), (\ds -> b)] ())
-            ((\b ->
+          (\b ->
+             (\b ->
                 (\b -> case b [(\ds -> False), (\ds -> b)] ())
-                  (lessThanInteger z 100))
-               (lessThanInteger y 100)))
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
          (lessThanInteger x 100))
       150
       60

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   839_970
+Memory:                  4_503
+AST Size:                   48
+Flat Size:                  58
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.pir
@@ -1,0 +1,14 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   let
+     !b : bool = lessThanInteger x 100
+     !b : bool
+       = let
+         !b : bool = lessThanInteger y 100
+         !b : bool = lessThanInteger z 100
+       in
+       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+   in
+   case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.pir
@@ -1,12 +1,10 @@
 (\(x : integer) (y : integer) (z : integer) ->
    let
      !b : bool = lessThanInteger x 100
+     !b : bool = lessThanInteger y 100
+     !b : bool = lessThanInteger z 100
      !b : bool
-       = let
-         !b : bool = lessThanInteger y 100
-         !b : bool = lessThanInteger z 100
-       in
-       case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
+       = case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ()
    in
    case (unit -> bool) b [(\(ds : unit) -> False), (\(ds : unit) -> b)] ())
   50

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.uplc
@@ -2,11 +2,12 @@
    1.1.0
    ((\x y z ->
        (\b ->
-          (\b -> case b [(\ds -> False), (\ds -> b)] ())
-            ((\b ->
+          (\b ->
+             (\b ->
                 (\b -> case b [(\ds -> False), (\ds -> b)] ())
-                  (lessThanInteger z 100))
-               (lessThanInteger y 100)))
+                  (case b [(\ds -> False), (\ds -> b)] ()))
+               (lessThanInteger z 100))
+            (lessThanInteger y 100))
          (lessThanInteger x 100))
       50
       60

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinAnd_LateFail.golden.uplc
@@ -1,0 +1,13 @@
+(program
+   1.1.0
+   ((\x y z ->
+       (\b ->
+          (\b -> case b [(\ds -> False), (\ds -> b)] ())
+            ((\b ->
+                (\b -> case b [(\ds -> False), (\ds -> b)] ())
+                  (lessThanInteger z 100))
+               (lessThanInteger y 100)))
+         (lessThanInteger x 100))
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   727_970
+Memory:                  3_803
+AST Size:                   67
+Flat Size:                 133
+
+(con unit ())

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.pir
@@ -1,0 +1,38 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (unit -> unit)
+      (lessThanInteger x 100)
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) ->
+           case
+             (unit -> unit)
+             (lessThanInteger y 100)
+             [ (\(ds : unit) ->
+                  let
+                    !x : Unit = trace {Unit} "conditions not met" Unit
+                  in
+                  error {unit})
+             , (\(ds : unit) ->
+                  case
+                    (unit -> unit)
+                    (lessThanInteger z 100)
+                    [ (\(ds : unit) ->
+                         let
+                           !x : Unit = trace {Unit} "conditions not met" Unit
+                         in
+                         error {unit})
+                    , (\(ds : unit) -> ()) ]
+                    ()) ]
+             ()) ]
+      ())
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_AllTrue.golden.uplc
@@ -1,0 +1,26 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds ->
+              (\x -> error) (force trace "conditions not met" (constr 0 [])))
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [ (\ds ->
+                     (\x -> error)
+                       (force trace "conditions not met" (constr 0 [])))
+                , (\ds ->
+                     case
+                       (lessThanInteger z 100)
+                       [ (\ds ->
+                            (\x -> error)
+                              (force trace "conditions not met" (constr 0 [])))
+                       , (\ds -> ()) ]
+                       ()) ]
+                ()) ]
+         ())
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.pir
@@ -1,0 +1,38 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (unit -> unit)
+      (lessThanInteger x 100)
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) ->
+           case
+             (unit -> unit)
+             (lessThanInteger y 100)
+             [ (\(ds : unit) ->
+                  let
+                    !x : Unit = trace {Unit} "conditions not met" Unit
+                  in
+                  error {unit})
+             , (\(ds : unit) ->
+                  case
+                    (unit -> unit)
+                    (lessThanInteger z 100)
+                    [ (\(ds : unit) ->
+                         let
+                           !x : Unit = trace {Unit} "conditions not met" Unit
+                         in
+                         error {unit})
+                    , (\(ds : unit) -> ()) ]
+                    ()) ]
+             ()) ]
+      ())
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_EarlyFail.golden.uplc
@@ -1,0 +1,26 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds ->
+              (\x -> error) (force trace "conditions not met" (constr 0 [])))
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [ (\ds ->
+                     (\x -> error)
+                       (force trace "conditions not met" (constr 0 [])))
+                , (\ds ->
+                     case
+                       (lessThanInteger z 100)
+                       [ (\ds ->
+                            (\x -> error)
+                              (force trace "conditions not met" (constr 0 [])))
+                       , (\ds -> ()) ]
+                       ()) ]
+                ()) ]
+         ())
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.eval
@@ -1,0 +1,3 @@
+An error has occurred:
+The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
+Caused by: error

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.pir
@@ -1,0 +1,38 @@
+(let
+    data Unit | Unit_match where
+      Unit : Unit
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (unit -> unit)
+      (lessThanInteger x 100)
+      [ (\(ds : unit) ->
+           let
+             !x : Unit = trace {Unit} "conditions not met" Unit
+           in
+           error {unit})
+      , (\(ds : unit) ->
+           case
+             (unit -> unit)
+             (lessThanInteger y 100)
+             [ (\(ds : unit) ->
+                  let
+                    !x : Unit = trace {Unit} "conditions not met" Unit
+                  in
+                  error {unit})
+             , (\(ds : unit) ->
+                  case
+                    (unit -> unit)
+                    (lessThanInteger z 100)
+                    [ (\(ds : unit) ->
+                         let
+                           !x : Unit = trace {Unit} "conditions not met" Unit
+                         in
+                         error {unit})
+                    , (\(ds : unit) -> ()) ]
+                    ()) ]
+             ()) ]
+      ())
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andBuiltinIfNest_LateFail.golden.uplc
@@ -1,0 +1,26 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds ->
+              (\x -> error) (force trace "conditions not met" (constr 0 [])))
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [ (\ds ->
+                     (\x -> error)
+                       (force trace "conditions not met" (constr 0 [])))
+                , (\ds ->
+                     case
+                       (lessThanInteger z 100)
+                       [ (\ds ->
+                            (\x -> error)
+                              (force trace "conditions not met" (constr 0 [])))
+                       , (\ds -> ()) ]
+                       ()) ]
+                ()) ]
+         ())
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   647_970
+Memory:                  3_303
+AST Size:                   36
+Flat Size:                  48
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.pir
@@ -1,0 +1,20 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    ifThenElse
+      {unit -> bool}
+      (lessThanInteger x 100)
+      (\(ds : unit) ->
+         ifThenElse
+           {unit -> bool}
+           (lessThanInteger y 100)
+           (\(ds : unit) -> lessThanInteger z 100)
+           (\(ds : unit) -> False)
+           ())
+      (\(ds : unit) -> False)
+      ())
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_AllTrue.golden.uplc
@@ -1,0 +1,15 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds -> False)
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [(\ds -> False), (\ds -> lessThanInteger z 100)]
+                ()) ]
+         ())
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   349_390
+Memory:                  2_001
+AST Size:                   36
+Flat Size:                  49
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.pir
@@ -1,0 +1,20 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    ifThenElse
+      {unit -> bool}
+      (lessThanInteger x 100)
+      (\(ds : unit) ->
+         ifThenElse
+           {unit -> bool}
+           (lessThanInteger y 100)
+           (\(ds : unit) -> lessThanInteger z 100)
+           (\(ds : unit) -> False)
+           ())
+      (\(ds : unit) -> False)
+      ())
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_EarlyFail.golden.uplc
@@ -1,0 +1,15 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds -> False)
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [(\ds -> False), (\ds -> lessThanInteger z 100)]
+                ()) ]
+         ())
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   647_970
+Memory:                  3_303
+AST Size:                   36
+Flat Size:                  48
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.pir
@@ -1,0 +1,20 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    ifThenElse
+      {unit -> bool}
+      (lessThanInteger x 100)
+      (\(ds : unit) ->
+         ifThenElse
+           {unit -> bool}
+           (lessThanInteger y 100)
+           (\(ds : unit) -> lessThanInteger z 100)
+           (\(ds : unit) -> False)
+           ())
+      (\(ds : unit) -> False)
+      ())
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andDirectIfThenElse_LateFail.golden.uplc
@@ -1,0 +1,15 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ (\ds -> False)
+         , (\ds ->
+              case
+                (lessThanInteger y 100)
+                [(\ds -> False), (\ds -> lessThanInteger z 100)]
+                ()) ]
+         ())
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   551_970
+Memory:                  2_703
+AST Size:                   28
+Flat Size:                  42
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.pir
@@ -1,0 +1,15 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   case
+     (all dead. bool)
+     (lessThanInteger x 100)
+     [ (/\dead -> False)
+     , (/\dead ->
+          case
+            (all dead. bool)
+            (lessThanInteger y 100)
+            [(/\dead -> False), (/\dead -> lessThanInteger z 100)]
+            {all dead. dead}) ]
+     {all dead. dead})
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_AllTrue.golden.uplc
@@ -1,0 +1,10 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case (lessThanInteger y 100) [False, (lessThanInteger z 100)]) ])
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   301_390
+Memory:                  1_701
+AST Size:                   28
+Flat Size:                  43
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.pir
@@ -1,0 +1,15 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   case
+     (all dead. bool)
+     (lessThanInteger x 100)
+     [ (/\dead -> False)
+     , (/\dead ->
+          case
+            (all dead. bool)
+            (lessThanInteger y 100)
+            [(/\dead -> False), (/\dead -> lessThanInteger z 100)]
+            {all dead. dead}) ]
+     {all dead. dead})
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_EarlyFail.golden.uplc
@@ -1,0 +1,10 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case (lessThanInteger y 100) [False, (lessThanInteger z 100)]) ])
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   551_970
+Memory:                  2_703
+AST Size:                   28
+Flat Size:                  42
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.pir
@@ -1,0 +1,15 @@
+(\(x : integer) (y : integer) (z : integer) ->
+   case
+     (all dead. bool)
+     (lessThanInteger x 100)
+     [ (/\dead -> False)
+     , (/\dead ->
+          case
+            (all dead. bool)
+            (lessThanInteger y 100)
+            [(/\dead -> False), (/\dead -> lessThanInteger z 100)]
+            {all dead. dead}) ]
+     {all dead. dead})
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andLazy_LateFail.golden.uplc
@@ -1,0 +1,10 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case (lessThanInteger y 100) [False, (lessThanInteger z 100)]) ])
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   583_970
+Memory:                  2_903
+AST Size:                   31
+Flat Size:                  46
+
+(con bool True)

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.pir
@@ -1,0 +1,24 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (all dead. bool)
+      (ifThenElse {bool} (lessThanInteger x 100) False True)
+      [ (/\dead ->
+           case
+             (all dead. bool)
+             (ifThenElse {bool} (lessThanInteger y 100) False True)
+             [ (/\dead ->
+                  case
+                    bool
+                    (ifThenElse {bool} (lessThanInteger z 100) False True)
+                    [True, False])
+             , (/\dead -> False) ]
+             {all dead. dead})
+      , (/\dead -> False) ]
+      {all dead. dead})
+  50
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_AllTrue.golden.uplc
@@ -1,0 +1,12 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case
+              (lessThanInteger y 100)
+              [False, (case (lessThanInteger z 100) [False, True])]) ])
+      50
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   301_390
+Memory:                  1_701
+AST Size:                   31
+Flat Size:                  47
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.pir
@@ -1,0 +1,24 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (all dead. bool)
+      (ifThenElse {bool} (lessThanInteger x 100) False True)
+      [ (/\dead ->
+           case
+             (all dead. bool)
+             (ifThenElse {bool} (lessThanInteger y 100) False True)
+             [ (/\dead ->
+                  case
+                    bool
+                    (ifThenElse {bool} (lessThanInteger z 100) False True)
+                    [True, False])
+             , (/\dead -> False) ]
+             {all dead. dead})
+      , (/\dead -> False) ]
+      {all dead. dead})
+  150
+  60
+  70

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_EarlyFail.golden.uplc
@@ -1,0 +1,12 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case
+              (lessThanInteger y 100)
+              [False, (case (lessThanInteger z 100) [False, True])]) ])
+      150
+      60
+      70))

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.eval
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.eval
@@ -1,0 +1,6 @@
+CPU:                   583_970
+Memory:                  2_903
+AST Size:                   31
+Flat Size:                  46
+
+(con bool False)

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.pir
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.pir
@@ -1,0 +1,24 @@
+(let
+    !ifThenElse : all a. bool -> a -> a -> a
+      = /\a -> \(b : bool) (x : a) (y : a) -> case a b [y, x]
+  in
+  \(x : integer) (y : integer) (z : integer) ->
+    case
+      (all dead. bool)
+      (ifThenElse {bool} (lessThanInteger x 100) False True)
+      [ (/\dead ->
+           case
+             (all dead. bool)
+             (ifThenElse {bool} (lessThanInteger y 100) False True)
+             [ (/\dead ->
+                  case
+                    bool
+                    (ifThenElse {bool} (lessThanInteger z 100) False True)
+                    [True, False])
+             , (/\dead -> False) ]
+             {all dead. dead})
+      , (/\dead -> False) ]
+      {all dead. dead})
+  50
+  60
+  150

--- a/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.uplc
+++ b/plutus-tx-plugin/test/Budget/9.6/andMultiWayIf_LateFail.golden.uplc
@@ -1,0 +1,12 @@
+(program
+   1.1.0
+   ((\x y z ->
+       case
+         (lessThanInteger x 100)
+         [ False
+         , (case
+              (lessThanInteger y 100)
+              [False, (case (lessThanInteger z 100) [False, True])]) ])
+      50
+      60
+      150))

--- a/plutus-tx-plugin/test/Budget/BuiltinAndLib.hs
+++ b/plutus-tx-plugin/test/Budget/BuiltinAndLib.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use const" #-}
+{-# OPTIONS_GHC -fno-full-laziness #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-spec-constr #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-strictness #-}
+{-# OPTIONS_GHC -fno-unbox-small-strict-fields #-}
+{-# OPTIONS_GHC -fno-unbox-strict-fields #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:conservative-optimisation #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:datatypes=BuiltinCasing #-}
+
+{-| Separate module with GHC optimisation flags disabled, matching the flags
+used by Philip DiSarro in PR #7562 (ValidatorOptimized.hs). This ensures
+that INLINE pragmas behave as intended and builtinAnd gets inlined at the
+call site before the plugin compiles, preserving short-circuit semantics. -}
+module Budget.BuiltinAndLib where
+
+import PlutusTx.Bool (Bool (..))
+import PlutusTx.Builtins.Internal qualified as BI
+import PlutusTx.Integer (Integer)
+import PlutusTx.Ord ((<))
+
+{-# INLINE builtinIf #-}
+builtinIf :: Bool -> (BI.BuiltinUnit -> a) -> (BI.BuiltinUnit -> a) -> a
+builtinIf cond t f = BI.ifThenElse cond t f BI.unitval
+
+{-# INLINE builtinAnd #-}
+builtinAnd :: Bool -> Bool -> Bool
+builtinAnd b1 b2 = builtinIf b1 (\_ -> b2) (\_ -> False)
+
+{-# INLINE andBuiltinAndPattern #-}
+andBuiltinAndPattern :: Integer -> Integer -> Integer -> Bool
+andBuiltinAndPattern x y z =
+  builtinAnd (x < 100) (builtinAnd (y < 100) (z < 100))
+
+{-# INLINE andDirectIfThenElsePattern #-}
+andDirectIfThenElsePattern :: Integer -> Integer -> Integer -> Bool
+andDirectIfThenElsePattern x y z =
+  BI.ifThenElse
+    (x < 100)
+    ( \_ ->
+        BI.ifThenElse
+          (y < 100)
+          (\_ -> z < 100)
+          (\_ -> False)
+          BI.unitval
+    )
+    (\_ -> False)
+    BI.unitval

--- a/plutus-tx-plugin/test/Budget/Spec.hs
+++ b/plutus-tx-plugin/test/Budget/Spec.hs
@@ -126,6 +126,14 @@ tests =
         goldenBundle' "andDirectIfThenElse_AllTrue" andDirectIfThenElse_AllTrue
       , goldenBundle' "andDirectIfThenElse_EarlyFail" andDirectIfThenElse_EarlyFail
       , goldenBundle' "andDirectIfThenElse_LateFail" andDirectIfThenElse_LateFail
+      , -- Pattern 5: Philip's claim — if (builtinAnd a $ builtinAnd b c) then ok else error
+        goldenBundle' "andBuiltinAndIfError_AllTrue" andBuiltinAndIfError_AllTrue
+      , goldenBundle' "andBuiltinAndIfError_EarlyFail" andBuiltinAndIfError_EarlyFail
+      , goldenBundle' "andBuiltinAndIfError_LateFail" andBuiltinAndIfError_LateFail
+      , -- Pattern 6: Nested builtinIf (Philip's actual validator pattern)
+        goldenBundle' "andBuiltinIfNest_AllTrue" andBuiltinIfNest_AllTrue
+      , goldenBundle' "andBuiltinIfNest_EarlyFail" andBuiltinIfNest_EarlyFail
+      , goldenBundle' "andBuiltinIfNest_LateFail" andBuiltinIfNest_LateFail
       ]
 
 compiledSum :: CompiledCode Integer
@@ -767,6 +775,50 @@ andDirectIfThenElse_EarlyFail =
 andDirectIfThenElse_LateFail :: CompiledCode Bool
 andDirectIfThenElse_LateFail =
   $$(compile [||BuiltinAndLib.andDirectIfThenElsePattern||])
+    `unsafeApplyCode` liftCodeDef 50
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 150
+
+-- Pattern 5: Philip's claim — if (builtinAnd a $ builtinAnd b c) then ok else error
+andBuiltinAndIfError_AllTrue :: CompiledCode BuiltinUnit
+andBuiltinAndIfError_AllTrue =
+  $$(compile [||BuiltinAndLib.andBuiltinAndIfErrorPattern||])
+    `unsafeApplyCode` liftCodeDef 50
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 70
+
+andBuiltinAndIfError_EarlyFail :: CompiledCode BuiltinUnit
+andBuiltinAndIfError_EarlyFail =
+  $$(compile [||BuiltinAndLib.andBuiltinAndIfErrorPattern||])
+    `unsafeApplyCode` liftCodeDef 150
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 70
+
+andBuiltinAndIfError_LateFail :: CompiledCode BuiltinUnit
+andBuiltinAndIfError_LateFail =
+  $$(compile [||BuiltinAndLib.andBuiltinAndIfErrorPattern||])
+    `unsafeApplyCode` liftCodeDef 50
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 150
+
+-- Pattern 6: Nested builtinIf (Philip's actual validator pattern)
+andBuiltinIfNest_AllTrue :: CompiledCode BuiltinUnit
+andBuiltinIfNest_AllTrue =
+  $$(compile [||BuiltinAndLib.andBuiltinIfNestPattern||])
+    `unsafeApplyCode` liftCodeDef 50
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 70
+
+andBuiltinIfNest_EarlyFail :: CompiledCode BuiltinUnit
+andBuiltinIfNest_EarlyFail =
+  $$(compile [||BuiltinAndLib.andBuiltinIfNestPattern||])
+    `unsafeApplyCode` liftCodeDef 150
+    `unsafeApplyCode` liftCodeDef 60
+    `unsafeApplyCode` liftCodeDef 70
+
+andBuiltinIfNest_LateFail :: CompiledCode BuiltinUnit
+andBuiltinIfNest_LateFail =
+  $$(compile [||BuiltinAndLib.andBuiltinIfNestPattern||])
     `unsafeApplyCode` liftCodeDef 50
     `unsafeApplyCode` liftCodeDef 60
     `unsafeApplyCode` liftCodeDef 150


### PR DESCRIPTION
> [!NOTE]
> **Not for merge** — this is an experiment to share findings with colleagues. Related to PR #7562.

## Context

Philip DiSarro's PR #7562 introduces `builtinAnd` and `builtinIf` helpers as alternatives to standard `&&` for boolean condition chaining in Plutus validators. The claim is that `builtinAnd` (using `BI.ifThenElse` + lambda/unit) avoids `delay`/`force` overhead and is cheaper than `&&`.

This experiment measures the actual execution budget across 6 patterns with 3 test scenarios each (18 golden tests total).

## Patterns tested

### Patterns returning `Bool` (1–4)

1. **Standard `&&`** — lazy, plugin-rewritten to `delay`/`force`
2. **`builtinAnd`** — Philip's helper using `BI.ifThenElse` + lambda/unit
3. **Multi-way if** — negated guards
4. **Direct `BI.ifThenElse`** — fully hand-written lambda/unit chain

### Patterns returning `BuiltinUnit` with `traceError` on failure (5–6)

5. **`builtinAnd` + if/error** — Philip's exact claimed usage: `if (builtinAnd a $ builtinAnd b c) then ok else error`
6. **Nested `builtinIf`** — Philip's actual validator pattern from PR #7562

## Fairness

Patterns 2, 4, 5, 6 are compiled in a separate module (`BuiltinAndLib.hs`) with Philip's exact GHC flags from `ValidatorOptimized.hs`:
- `-fno-full-laziness`, `-fno-strictness`, `-fno-specialise`, `-fno-spec-constr`
- `-fno-ignore-interface-pragmas`, `-fno-omit-interface-pragmas`
- `-fno-unbox-small-strict-fields`, `-fno-unbox-strict-fields`
- `-fplugin-opt PlutusTx.Plugin:conservative-optimisation`
- `-fplugin-opt PlutusTx.Plugin:datatypes=BuiltinCasing`
- `{-# INLINE #-}` pragmas (not `INLINEABLE`)

## Results

### Patterns 1–4 (return `Bool`)

| Pattern | AllTrue CPU | EarlyFail CPU | LateFail CPU | Short-circuits? |
|---|---:|---:|---:|:---:|
| 1. `&&` (lazy) | 551,970 | **301,390** | 551,970 | Yes |
| 2. `builtinAnd` | **839,970** | **839,970** | **839,970** | **No** |
| 3. Multi-way if | 583,970 | **301,390** | 583,970 | Yes |
| 4. Direct `BI.ifThenElse` | 647,970 | 349,390 | 647,970 | Yes |

### Patterns 5–6 (return `BuiltinUnit`, `traceError` on failure)

| Pattern | AllTrue CPU | EarlyFail | LateFail | Short-circuits? |
|---|---:|:---:|:---:|:---:|
| 5. `builtinAnd` + if/error | **919,970** | error | error | **No** |
| 6. Nested `builtinIf` | 727,970 | error | error | Yes |

(Fail cases produce `traceError`, so no budget is reported — this is the intended validator behavior.)

## Key findings

1. **`builtinAnd` does not short-circuit.** `builtinAnd :: Bool -> Bool -> Bool` takes strict arguments — both `Bool` values are computed before the function body runs. All 3 scenarios produce identical budgets (839,970 CPU). This holds even with Philip's exact GHC flags and `INLINE` pragmas.

2. **`builtinAnd` is the most expensive pattern.** It costs 52% more CPU than standard `&&` (839,970 vs 551,970) in the AllTrue case, and 178% more in the EarlyFail case (839,970 vs 301,390).

3. **Standard `&&` is the cheapest pattern overall.** It properly short-circuits and has the lowest CPU cost in all scenarios.

4. **Nested `builtinIf` works** (pattern 6). When conditions are placed inside lambda bodies, short-circuiting is preserved. This is what Philip's actual validator code in PR #7562 does — but it's a different pattern from `builtinAnd`.

5. **The UPLC confirms it.** Pattern 2 compiles all `lessThanInteger` calls into let-bindings before any `case` expression. Pattern 6 nests `lessThanInteger` inside lambda bodies.

## UPLC comparison

**Pattern 2 (`builtinAnd`) — no short-circuiting:**
```
(\x y z ->
    (\b ->         -- z < 100 computed here
       (\b ->      -- y < 100 computed here
          (\b ->   -- x < 100 computed here
             (\b -> case b [(\ds -> False), (\ds -> b)] ())
               (case b [(\ds -> False), (\ds -> b)] ()))
            (lessThanInteger z 100))
         (lessThanInteger y 100))
      (lessThanInteger x 100))
```

**Pattern 6 (nested `builtinIf`) — proper short-circuiting:**
```
(\x y z ->
    case (lessThanInteger x 100)
      [(\ds -> error)
      ,(\ds -> case (lessThanInteger y 100)      -- only if x < 100
                 [(\ds -> error)
                 ,(\ds -> case (lessThanInteger z 100)  -- only if y < 100
                            [(\ds -> error)
                            ,(\ds -> ())]
                            ())]
                 ())]
      ())
```