### PR TITLE
Remove superfluous tests

### DIFF
--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
@@ -33,9 +33,7 @@ import Evaluation.Builtins.Integer.QuotRemProperties (test_integer_quot_rem_prop
 import Evaluation.Builtins.Integer.RingProperties (test_integer_ring_properties)
 import Evaluation.Builtins.SignatureVerification
   ( ecdsaSecp256k1Prop
-  , ed25519_VariantAProp
-  , ed25519_VariantBProp
-  , ed25519_VariantCProp
+  , ed25519Prop
   , schnorrSecp256k1Prop
   )
 
@@ -1755,28 +1753,12 @@ test_SignatureVerification =
   testGroup
     "Signature verification"
     [ testGroup
-        "Ed25519 signatures (VariantA)"
+        "Ed25519 signatures"
         [ testPropertyNamed
-            "Ed25519_VariantA verification behaves correctly on all inputs"
-            "ed25519_VariantA_correct"
+            "Ed25519 verification behaves correctly on all inputs"
+            "ed25519_correct"
             . mapTestLimitAtLeast 99 (`div` 10)
-            $ property ed25519_VariantAProp
-        ]
-    , testGroup
-        "Ed25519 signatures (VariantB)"
-        [ testPropertyNamed
-            "Ed25519_VariantB verification behaves correctly on all inputs"
-            "ed25519_VariantB_correct"
-            . mapTestLimitAtLeast 99 (`div` 10)
-            $ property ed25519_VariantBProp
-        ]
-    , testGroup
-        "Ed25519 signatures (VariantC)"
-        [ testPropertyNamed
-            "Ed25519_VariantC verification behaves correctly on all inputs"
-            "ed25519_VariantC_correct"
-            . mapTestLimitAtLeast 99 (`div` 10)
-            $ property ed25519_VariantCProp
+            $ property ed25519Prop
         ]
     , testGroup
         "Signatures on the SECP256k1 curve"

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/SignatureVerification.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/SignatureVerification.hs
@@ -10,9 +10,7 @@
 
 module Evaluation.Builtins.SignatureVerification
   ( ecdsaSecp256k1Prop
-  , ed25519_VariantAProp
-  , ed25519_VariantBProp
-  , ed25519_VariantCProp
+  , ed25519Prop
   , schnorrSecp256k1Prop
   ) where
 
@@ -82,24 +80,15 @@ schnorrSecp256k1Prop = do
   cover 5 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
   runTestDataWith def testCase id VerifySchnorrSecp256k1Signature
 
-ed25519Prop :: BuiltinSemanticsVariant DefaultFun -> PropertyT IO ()
-ed25519Prop semvar = do
+ed25519Prop :: PropertyT IO ()
+ed25519Prop = do
   testCase <- forAllWith ppShow genEd25519Case
   cover 5 "malformed verification key" . is (_ShouldError . _BadVerKey) $ testCase
   cover 5 "malformed signature" . is (_ShouldError . _BadSignature) $ testCase
   cover 5 "mismatch of signing key and verification key" . is (_Shouldn'tError . _WrongVerKey) $ testCase
   cover 5 "mismatch of message and signature" . is (_Shouldn'tError . _WrongSignature) $ testCase
   cover 5 "happy path" . is (_Shouldn'tError . _AllGood) $ testCase
-  runTestDataWith semvar testCase id VerifyEd25519Signature
-
-ed25519_VariantAProp :: PropertyT IO ()
-ed25519_VariantAProp = ed25519Prop DefaultFunSemanticsVariantA
-
-ed25519_VariantBProp :: PropertyT IO ()
-ed25519_VariantBProp = ed25519Prop DefaultFunSemanticsVariantB
-
-ed25519_VariantCProp :: PropertyT IO ()
-ed25519_VariantCProp = ed25519Prop DefaultFunSemanticsVariantC
+  runTestDataWith def testCase id VerifyEd25519Signature
 
 -- Helpers
 


### PR DESCRIPTION
For a while we had two variants of `verifyEd25519Signature` because we were temporarily supporting a deprecated library.  We got rid of that some time ago, so now the tests for `verifyEd25519Signature` don't need to depend on the variant.