### PR TITLE
plutus-benchmark.cabal: Add missing ghc-version-support

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -929,7 +929,7 @@ test-suite uplc-evaluator-integration-tests
     , with-utf8
 
 benchmark certifier-bench
-  import:           lang, os-support
+  import:           lang, ghc-version-support, os-support
   type:             exitcode-stdio-1.0
   default-language: Haskell2010
   main-is:          Main.hs


### PR DESCRIPTION
`plutus-metatheory` only builds with `ghc-9.6` (currently) so anything that depends on it should also not be buildable.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Changelog fragments have been written (if appropriate)
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting master unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
