### PR TITLE
use timesInt2# in satint

### DIFF
--- a/plutus-core/satint/src/Data/SatInt.hs
+++ b/plutus-core/satint/src/Data/SatInt.hs
@@ -144,8 +144,8 @@ minusSI (SI (I# x#)) (SI (I# y#)) =
 
 timesSI :: SatInt -> SatInt -> SatInt
 timesSI (SI (I# x#)) (SI (I# y#)) =
-  case mulIntMayOflo# x# y# of
-    0# -> SI (I# (x# *# y#))
+  case timesInt2# x# y# of
+    (# 0#, _, lo# #) -> SI (I# lo#)
     -- Overflow
     _ ->
       if isTrue# ((x# ># 0#) `andI#` (y# ># 0#))


### PR DESCRIPTION
`mulIntMayOflo#` appears to work fine at least on GHC 9.6 and 64 bit architectures (which is all we care about), but just to be future proof - GHC often does unpredictable things in a new version - it's better to switch to `timesInt2#`.