### PR TITLE
certifier: add two more output options

### DIFF
--- a/plutus-executables/plutus-executables.cabal
+++ b/plutus-executables/plutus-executables.cabal
@@ -116,6 +116,7 @@ executable uplc
     , serialise
     , split
     , text
+    , time
 
 test-suite test-simple
   import:             lang, os-support, ghc-version-support

--- a/plutus-executables/test/certifier/Test/Certifier/Executable.hs
+++ b/plutus-executables/test/certifier/Test/Certifier/Executable.hs
@@ -108,6 +108,7 @@ makeExampleM testname = do
           <> " and error: "
           <> err
     ExitSuccess -> do
+      -- FIXME: ?????
       let certDir = find (fstToUpper testNameCert `isPrefixOf`) . concatMap words . lines $ output
       case certDir of
         Just certDir' -> do


### PR DESCRIPTION
The certifier now has three output options:

1. basic - just print pass or fail
2. produce a human readable report of the certification process (not yet implemented, just a placeholder)
3. (the current one) produce an Agda project

The corresponding command line arguments not yet added. It currently defaults to 3.