### PR TITLE
Normalize JSON indentation in cost model data files

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -57,8 +57,10 @@ let
         package = pkgs.shellcheck;
       };
       prettier = {
-        enable = false;
+        enable = true;
         package = pkgs.prettier;
+        types_or = [ "json" ];
+        files = "^plutus-core/cost-model/data/.*\\.json$";
       };
       editorconfig-checker = {
         enable = true;

--- a/plutus-core/cost-model/data/builtinCostModelA.json
+++ b/plutus-core/cost-model/data/builtinCostModelA.json
@@ -1225,10 +1225,10 @@
         "constant": 213283,
         "model": {
           "arguments": {
-             "intercept": 618401,
-             "slope1": 1998,
-             "slope2": 28258
-           },
+            "intercept": 618401,
+            "slope1": 1998,
+            "slope2": 28258
+          },
           "type": "linear_in_x_and_y"
         }
       },
@@ -1240,37 +1240,37 @@
     }
   },
   "valueData": {
-      "cpu": {
-          "arguments": {
-              "intercept": 1000,
-              "slope": 38159
-          },
-          "type": "linear_in_x"
+    "cpu": {
+      "arguments": {
+        "intercept": 1000,
+        "slope": 38159
       },
-      "memory": {
-          "arguments": {
-              "intercept": 2,
-              "slope": 22
-          },
-          "type": "linear_in_x"
-      }
+      "type": "linear_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 2,
+        "slope": 22
+      },
+      "type": "linear_in_x"
+    }
   },
   "unValueData": {
-      "cpu": {
-          "arguments": {
-              "c0": 1000,
-              "c1": 95933,
-              "c2": 1
-          },
-          "type": "quadratic_in_x"
+    "cpu": {
+      "arguments": {
+        "c0": 1000,
+        "c1": 95933,
+        "c2": 1
       },
-      "memory": {
-          "arguments": {
-              "intercept": 1,
-              "slope": 11
-          },
-          "type": "linear_in_x"
-      }
+      "type": "quadratic_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 1,
+        "slope": 11
+      },
+      "type": "linear_in_x"
+    }
   },
   "insertCoin": {
     "cpu": {

--- a/plutus-core/cost-model/data/builtinCostModelB.json
+++ b/plutus-core/cost-model/data/builtinCostModelB.json
@@ -1225,10 +1225,10 @@
         "constant": 213283,
         "model": {
           "arguments": {
-             "intercept": 618401,
-             "slope1": 1998,
-             "slope2": 28258
-           },
+            "intercept": 618401,
+            "slope1": 1998,
+            "slope2": 28258
+          },
           "type": "linear_in_x_and_y"
         }
       },
@@ -1240,37 +1240,37 @@
     }
   },
   "valueData": {
-      "cpu": {
-          "arguments": {
-              "intercept": 1000,
-              "slope": 38159
-          },
-          "type": "linear_in_x"
+    "cpu": {
+      "arguments": {
+        "intercept": 1000,
+        "slope": 38159
       },
-      "memory": {
-          "arguments": {
-              "intercept": 2,
-              "slope": 22
-          },
-          "type": "linear_in_x"
-      }
+      "type": "linear_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 2,
+        "slope": 22
+      },
+      "type": "linear_in_x"
+    }
   },
   "unValueData": {
-      "cpu": {
-          "arguments": {
-              "c0": 1000,
-              "c1": 95933,
-              "c2": 1
-          },
-          "type": "quadratic_in_x"
+    "cpu": {
+      "arguments": {
+        "c0": 1000,
+        "c1": 95933,
+        "c2": 1
       },
-      "memory": {
-          "arguments": {
-              "intercept": 1,
-              "slope": 11
-          },
-          "type": "linear_in_x"
-      }
+      "type": "quadratic_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 1,
+        "slope": 11
+      },
+      "type": "linear_in_x"
+    }
   },
   "insertCoin": {
     "cpu": {

--- a/plutus-core/cost-model/data/builtinCostModelC.json
+++ b/plutus-core/cost-model/data/builtinCostModelC.json
@@ -1243,10 +1243,10 @@
         "constant": 213283,
         "model": {
           "arguments": {
-             "intercept": 618401,
-             "slope1": 1998,
-             "slope2": 28258
-           },
+            "intercept": 618401,
+            "slope1": 1998,
+            "slope2": 28258
+          },
           "type": "linear_in_x_and_y"
         }
       },
@@ -1258,37 +1258,37 @@
     }
   },
   "valueData": {
-      "cpu": {
-          "arguments": {
-              "intercept": 1000,
-              "slope": 38159
-          },
-          "type": "linear_in_x"
+    "cpu": {
+      "arguments": {
+        "intercept": 1000,
+        "slope": 38159
       },
-      "memory": {
-          "arguments": {
-              "intercept": 2,
-              "slope": 22
-          },
-          "type": "linear_in_x"
-      }
+      "type": "linear_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 2,
+        "slope": 22
+      },
+      "type": "linear_in_x"
+    }
   },
   "unValueData": {
-      "cpu": {
-          "arguments": {
-              "c0": 1000,
-              "c1": 95933,
-              "c2": 1
-          },
-          "type": "quadratic_in_x"
+    "cpu": {
+      "arguments": {
+        "c0": 1000,
+        "c1": 95933,
+        "c2": 1
       },
-      "memory": {
-          "arguments": {
-              "intercept": 1,
-              "slope": 11
-          },
-          "type": "linear_in_x"
-      }
+      "type": "quadratic_in_x"
+    },
+    "memory": {
+      "arguments": {
+        "intercept": 1,
+        "slope": 11
+      },
+      "type": "linear_in_x"
+    }
   },
   "insertCoin": {
     "cpu": {

--- a/plutus-core/cost-model/data/cekMachineCostsA.json
+++ b/plutus-core/cost-model/data/cekMachineCostsA.json
@@ -1,13 +1,12 @@
 {
-    "cekStartupCost" : {"exBudgetCPU":     100, "exBudgetMemory": 100},
-    "cekVarCost"     : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekConstCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekLamCost"     : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekDelayCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekForceCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekApplyCost"   : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekBuiltinCost" : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekConstrCost"  : {"exBudgetCPU":   23000, "exBudgetMemory": 100},
-    "cekCaseCost"    : {"exBudgetCPU":   23000, "exBudgetMemory": 100}
+  "cekStartupCost": { "exBudgetCPU": 100, "exBudgetMemory": 100 },
+  "cekVarCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekConstCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekLamCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekDelayCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekForceCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekApplyCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekBuiltinCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekConstrCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 },
+  "cekCaseCost": { "exBudgetCPU": 23000, "exBudgetMemory": 100 }
 }
-

--- a/plutus-core/cost-model/data/cekMachineCostsB.json
+++ b/plutus-core/cost-model/data/cekMachineCostsB.json
@@ -1,13 +1,12 @@
 {
-    "cekStartupCost" : {"exBudgetCPU":     100, "exBudgetMemory": 100},
-    "cekVarCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekConstCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekLamCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekDelayCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekForceCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekApplyCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekBuiltinCost" : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekConstrCost"  : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekCaseCost"    : {"exBudgetCPU":   16000, "exBudgetMemory": 100}
+  "cekStartupCost": { "exBudgetCPU": 100, "exBudgetMemory": 100 },
+  "cekVarCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekConstCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekLamCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekDelayCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekForceCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekApplyCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekBuiltinCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekConstrCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekCaseCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 }
 }
-

--- a/plutus-core/cost-model/data/cekMachineCostsC.json
+++ b/plutus-core/cost-model/data/cekMachineCostsC.json
@@ -1,13 +1,12 @@
 {
-    "cekStartupCost" : {"exBudgetCPU":     100, "exBudgetMemory": 100},
-    "cekVarCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekConstCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekLamCost"     : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekDelayCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekForceCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekApplyCost"   : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekBuiltinCost" : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekConstrCost"  : {"exBudgetCPU":   16000, "exBudgetMemory": 100},
-    "cekCaseCost"    : {"exBudgetCPU":   16000, "exBudgetMemory": 100}
+  "cekStartupCost": { "exBudgetCPU": 100, "exBudgetMemory": 100 },
+  "cekVarCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekConstCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekLamCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekDelayCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekForceCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekApplyCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekBuiltinCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekConstrCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 },
+  "cekCaseCost": { "exBudgetCPU": 16000, "exBudgetMemory": 100 }
 }
-


### PR DESCRIPTION
## Summary

- Reformat all 6 cost model JSON files in `plutus-core/cost-model/data/` to consistent 2-space indentation using prettier
- Enable a scoped prettier pre-commit hook (`^plutus-core/cost-model/data/.*\.json$`) to prevent future drift
- Whitespace-only changes to data files; no functional changes

## Context

The `cekMachineCostsA/B/C.json` files used 4-space column-aligned formatting while `builtinCostModelA/B/C.json` used 2-space indent (with some inconsistent sections). This normalizes everything to 2-space.

Closes #7620

## Test plan

- [x] `prettier --check plutus-core/cost-model/data/*.json` passes
- [x] `cabal build plutus-core` succeeds (cost model files are embedded via Template Haskell)
- [x] CI passes