### PR TITLE
Remove duplicate Notes and fix references

### DIFF
--- a/cardano-constitution/test/Cardano/Constitution/Validator/Data/UnitTests.hs
+++ b/cardano-constitution/test/Cardano/Constitution/Validator/Data/UnitTests.hs
@@ -35,12 +35,7 @@ import Test.Tasty.QuickCheck
 -- All limits tested
 -- MC/DC coverage
 
-{- Note [Why de-duplicated ChangedParameters]
-\**ALL** The following ScriptContext examples *MUST* be de-duplicated Lists.
-Otherwise, both the sorted and unsorted scripts will produce
-"wrong" results (for different reasons).
-See also Guarantee(2) in README.md
--}
+-- See Note [Why de-duplicated ChangedParameters]
 
 -- all these are actually unit tests (by using QuickCheck.once)
 

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/V1/Data/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/V1/Data/ScriptContexts.hs
@@ -92,16 +92,7 @@ mkCheckScriptContext2Code sc =
    in $$(PlutusTx.compile [||checkScriptContext2||])
         `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef d
 
-{- Note [Redundant arguments to equality benchmarks]
-The arguments for the benchmarks are passed as terms created with `liftCodeDef`.
-But the benchmark still needs to _evaluate_ these terms, which adds overhead that
-distracts from the main point.
-
-We can't easily remove the overhead, but we can at least include it in both cases to
-make things fairer. Hence we include redundant arguments in the two cases to ensure
-the same work is done in both cases. There is a third case that is just this overhead
-for comparison.
--}
+-- See Note [Redundant arguments to equality benchmarks]
 
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/V2/Data/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/V2/Data/ScriptContexts.hs
@@ -152,16 +152,7 @@ mkCheckScriptContext2Code sc =
    in $$(PlutusTx.compile [||checkScriptContext2||])
         `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef d
 
-{- Note [Redundant arguments to equality benchmarks]
-The arguments for the benchmarks are passed as terms created with `liftCodeDef`.
-But the benchmark still needs to _evaluate_ these terms, which adds overhead that
-distracts from the main point.
-
-We can't easily remove the overhead, but we can at least include it in both cases to
-make things fairer. Hence we include redundant arguments in the two cases to ensure
-the same work is done in both cases. There is a third case that is just this overhead
-for comparison.
--}
+-- See Note [Redundant arguments to equality benchmarks]
 
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/V2/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/V2/ScriptContexts.hs
@@ -149,16 +149,7 @@ mkCheckScriptContext2Code sc =
    in $$(PlutusTx.compile [||checkScriptContext2||])
         `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef d
 
-{- Note [Redundant arguments to equality benchmarks]
-The arguments for the benchmarks are passed as terms created with `liftCodeDef`.
-But the benchmark still needs to _evaluate_ these terms, which adds overhead that
-distracts from the main point.
-
-We can't easily remove the overhead, but we can at least include it in both cases to
-make things fairer. Hence we include redundant arguments in the two cases to ensure
-the same work is done in both cases. There is a third case that is just this overhead
-for comparison.
--}
+-- See Note [Redundant arguments to equality benchmarks]
 
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/V3/Data/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/V3/Data/ScriptContexts.hs
@@ -196,16 +196,7 @@ mkCheckScriptContext2Code sc =
    in $$(PlutusTx.compile [||checkScriptContext2||])
         `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef d
 
-{- Note [Redundant arguments to equality benchmarks]
-The arguments for the benchmarks are passed as terms created with `liftCodeDef`.
-But the benchmark still needs to _evaluate_ these terms, which adds overhead that
-distracts from the main point.
-
-We can't easily remove the overhead, but we can at least include it in both cases to
-make things fairer. Hence we include redundant arguments in the two cases to ensure
-the same work is done in both cases. There is a third case that is just this overhead
-for comparison.
--}
+-- See Note [Redundant arguments to equality benchmarks]
 
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is

--- a/plutus-benchmark/script-contexts/src/PlutusBenchmark/V3/ScriptContexts.hs
+++ b/plutus-benchmark/script-contexts/src/PlutusBenchmark/V3/ScriptContexts.hs
@@ -113,16 +113,7 @@ mkCheckScriptContext2Code sc =
    in $$(PlutusTx.compile [||checkScriptContext2||])
         `PlutusTx.unsafeApplyCode` PlutusTx.liftCodeDef d
 
-{- Note [Redundant arguments to equality benchmarks]
-The arguments for the benchmarks are passed as terms created with `liftCodeDef`.
-But the benchmark still needs to _evaluate_ these terms, which adds overhead that
-distracts from the main point.
-
-We can't easily remove the overhead, but we can at least include it in both cases to
-make things fairer. Hence we include redundant arguments in the two cases to ensure
-the same work is done in both cases. There is a third case that is just this overhead
-for comparison.
--}
+-- See Note [Redundant arguments to equality benchmarks]
 
 -- This example checks the script context for equality (with itself) when encoded as `Data`.
 -- That means it just takes a single builtin call, which is fast (so long as the builtin is

--- a/plutus-benchmark/uplc-evaluator/Main.hs
+++ b/plutus-benchmark/uplc-evaluator/Main.hs
@@ -322,7 +322,7 @@ processProgram Config {..} inputPath = do
       -- Read the file content as Text
       -- TODO [Flat Encoding Support]: For .uplc.flat files, read as ByteString
       -- and use binary deserialization instead of text parsing.
-      -- See Note [Flat Encoding Support] at isUplcFile.
+      -- See [Flat Encoding Support] at isUplcFile.
       readResult <- try @SomeException $ TIO.readFile inputPath
 
       case readResult of

--- a/plutus-core/cost-model/budgeting-bench/Common.hs
+++ b/plutus-core/cost-model/budgeting-bench/Common.hs
@@ -331,15 +331,6 @@ createOneTermBuiltinBench_NF
   -> Benchmark
 createOneTermBuiltinBench_NF = createOneTermBuiltinBenchWithWrapper_NF id
 
-{- Note [Adjusting the memory usage of arguments of costing benchmarks] In some
-  cases we want to measure the (so-called) "memory usage" of a builtin argument
-  in a nonstandard way for benchmarking and costing purposes. This function
-  allows you to supply suitable wrapping functions in the benchmarks to achieve
-  this.  NB: wrappers used in benchmarks *MUST* be the same as wrappers used in
-  builtin denotations to make sure that during script execution the inputs to
-  the costing functions are costed in the same way as the are in the
-  benchmmarks.
--}
 -- FIXME: can we add a `Normaliser` argument to remove some of the overlap with
 -- `createOneTermBuiltinBenchWithWrapper` here?  We only want to use this in
 -- exceptional circumstances though, so we probably don't want to add an extra

--- a/plutus-core/executables/traceToStacks/Common.hs
+++ b/plutus-core/executables/traceToStacks/Common.hs
@@ -64,7 +64,7 @@ parseProfileEvent valIx (LogRow str vals) =
   let val = vals !! (valIx - 1)
    in case words str of
         [transition, var] ->
-          -- See Note [Profiling Marker]
+          -- See Note [Profiling Markers]
           case transition of
             "->" -> MkProfileEvent val Enter (T.pack var)
             "<-" -> MkProfileEvent val Exit (T.pack var)

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/HasConstant.hs
@@ -25,8 +25,8 @@ We don't really need 'HasConstant' and could get away with only having 'HasConst
 defining the latter directly as a @class@ instead of a type synonym in terms of the former is
 detrimental to performance, see the comments in https://github.com/IntersectMBO/plutus/pull/4417
 
-This is likely due to the same reason as in 'mkMachineParameters',
-see Note [The CostingPart constraint in mkMachineParameters].
+This is likely due to the same reason as in 'mkMachineVariantParameters',
+see Note [The CostingPart constraint in mkMachineVariantParameters].
 -}
 
 -- See Note [Existence of HasConstant].

--- a/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Builtin/KnownType.hs
@@ -355,7 +355,7 @@ headSpine :: a -> [b] -> HeadSpine err a b
 headSpine h [] = HeadOnly h
 headSpine h (x : xs) =
   -- It's critical to use 'foldr' here, so that deforestation kicks in.
-  -- See Note [Definition of foldl'] in "GHC.List" and related Notes around for an explanation
+  -- See Note "Definition of foldl'" in "GHC.List" and related Notes around for an explanation
   -- of the trick.
   HeadSpine h $ foldr (\x2 r x1 -> SpineCons x1 $ r x2) SpineLast xs x
 {-# INLINE headSpine #-}

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -1890,7 +1890,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
     let dropListDenotation
           :: IntegerCostedLiterally -> SomeConstant uni [a] -> BuiltinResult (Opaque val [a])
         dropListDenotation i (SomeConstant (Some (ValueOf uniListA xs))) = do
-          -- See Note [Operational vs structural errors within builtins].
+          -- See Note [Structural vs operational errors within builtins].
           case uniListA of
             DefaultUniList _ ->
               -- The fastest way of dropping elements from a list is by operating on

--- a/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/MachineParameters.hs
@@ -71,25 +71,27 @@ instance (NoThunks machinecosts, Bounded fun, Enum fun) => NoThunks (MachinePara
     allNoThunks [noThunks ctx caser, noThunks ctx varPars]
 
 {- Note [The CostingPart constraint in mkMachineVariantParameters]
-Discharging the @CostingPart uni fun ~ builtincosts@ constraint in 'mkMachineParameters' causes GHC
-to fail to inline the function at its call site regardless of the @INLINE@ pragma and an explicit
-'inline' call.
+Discharging the @CostingPart uni fun ~ builtincosts@ constraint in
+'mkMachineVariantParameters' causes GHC to fail to inline the function at its
+call site regardless of the @INLINE@ pragma and an explicit 'inline' call.
 
-We think that this is because discharging the @CostingPart uni fun ~ builtincosts@ constraint in the
-type of 'mkMachineParameters' somehow causes it to be compiled into @expr `Cast@` co@ , where @co@'s
-type is
+We think that this is because discharging the @CostingPart uni fun ~
+builtincosts@ constraint in the type of 'mkMachineVariantParameters'
+somehow causes it to be compiled into @expr `Cast@` co@ , where @co@'s type is
 
     (CostingPart DefaultUni DefaultFun) ... ~R# ... BuiltinCostModel ...
 
-and this fails to inline, because in order for @inline f@ to work, @f@ must be compiled into either
-a @Var@, or an @App@ whose head is a @Var@, according to https://gitlab.haskell.org/ghc/ghc/-/blob/1f02b7430b2fbab403d7ffdde9cfd006e884678e/compiler/prelude/PrelRules.hs#L1442-1449
-And if @f@ is compiled into a @Cast@ like 'mkMachineParameters' with the discharged constraint, then
-inlining won't work. We don't know why it's implemented this way in GHC.
+and this fails to inline, because in order for @inline f@ to work, @f@ must be
+compiled into either a @Var@, or an @App@ whose head is a @Var@, according to
+https://gitlab.haskell.org/ghc/ghc/-/blob/1f02b7430b2fbab403d7ffdde9cfd006e884678e/compiler/prelude/PrelRules.hs#L1442-1449
+And if @f@ is compiled into a @Cast@ like 'mkMachineVariantParameters' with the
+discharged constraint, then inlining won't work. We don't know why it's
+implemented this way in GHC.
 
 It seems fully applying @f@ helps, i.e.
 
-    - inline mkMachineParameters unlMode <$> <...>
-    + (\x -> inline (mkMachineParameters unlMode x)) <$> <...>
+    - inline mkMachineVariantParameters unlMode <$> <...>
+    + (\x -> inline (mkMachineVariantParameters unlMode x)) <$> <...>
 
 which makes sense: if @f@ receives all its type and term args then there's less reason to throw a
 @Cast@ in there.
@@ -99,7 +101,7 @@ which makes sense: if @f@ receives all its type and term args then there's less 
 -- | This just uses 'toBuiltinsRuntime' function to convert a BuiltinCostModel to a BuiltinsRuntime.
 mkMachineVariantParameters
   :: ( -- WARNING: do not discharge the equality constraint as that causes GHC to fail to inline the
-       -- function at its call site, see Note [The CostingPart constraint in mkMachineParameters].
+       -- function at its call site, see Note [The CostingPart constraint in mkMachineVariantParameters].
        CostingPart uni fun ~ builtincosts
      , HasMeaningIn uni val
      , ToBuiltinMeaning uni fun

--- a/plutus-core/prelude/PlutusPrelude.hs
+++ b/plutus-core/prelude/PlutusPrelude.hs
@@ -207,7 +207,7 @@ coerceRes :: Coercible s t => (a -> s) -> a -> t
 coerceRes = coerce
 {-# INLINE coerceRes #-}
 
--- See Note [Function coercion] in GHC.Internal.Data.Functor.Utils.
+-- See Note "Function coercion" in GHC.Internal.Data.Functor.Utils.
 -- | Same as @(.)@, but ignores the first argument and uses a no-op coerction instead.
 (#.) :: Coercible b c => (b -> c) -> (a -> b) -> a -> c
 (#.) _ = coerce

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Evaluation/Machine/Cek/EmitterMode.hs
@@ -95,7 +95,7 @@ logWithCallTraceEmitter = EmitterMode $ \_ -> do
         go l [] = l
         go [] l = l
         go (x : xs) l =
-          -- See Note [Profiling Marker]
+          -- See Note [Profiling Markers]
           case (T.words (last l), T.words x) of
             ("->" : enterRest, "<-" : exitRest) | enterRest == exitRest -> go xs (init l)
             _ -> go xs (l <> [x])

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V1.hs
@@ -201,23 +201,7 @@ import PlutusLedgerApi.V1.Scripts as Scripts
 thisLedgerLanguage :: PlutusLedgerLanguage
 thisLedgerLanguage = PlutusV1
 
-{- Note [Abstract types in the ledger API]
-We need to support old versions of the ledger API as we update the code that
-it depends on. You might think that we should therefore make the types that
-we expose abstract, and only expose specific functions for constructing and
-working with them. However the situation is slightly different for us.
-
-Normally, when you are in this situation, you want to retain the same *interface*
-as the old version, but with the new types and functions underneath. Abstraction
-lets you do this easily. But we actually want to keep the old *implementation*,
-because things really have to work the same, bug-for-bug. And the types have to
-translate into Plutus Core in exactly the same way, and so on.
-
-So we're going to end up with multiple versions of the types and functions that
-we expose here, even internally. That means we don't lose anything by exposing
-all the details: we're never going to remove anything, we're just going to create
-new versions.
--}
+-- See Note [Abstract types in the ledger API]
 
 {-| The deserialization from a serialised script into a `ScriptForEvaluation`,
 ready to be evaluated on-chain.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Contexts.hs
@@ -96,16 +96,7 @@ import PlutusLedgerApi.V1.Data.Value (CurrencySymbol (..), Value)
 import PlutusLedgerApi.V1.Scripts
 import Prelude qualified as Haskell
 
-{- Note [Script types in pending transactions]
-To validate a transaction, we have to evaluate the validation script of each of
-the transaction's inputs. The validation script sees the data of the
-transaction output it validates, and the redeemer of the transaction input of
-the transaction that consumes it.
-In addition, the validation script also needs information on the transaction as
-a whole (not just the output-input pair it is concerned with). This information
-is provided by the `TxInfo` type. A `TxInfo` contains the hashes of
-redeemer and data scripts of all of its inputs and outputs.
--}
+-- See Note [Script types in pending transactions]
 
 -- | An input of a pending transaction.
 PlutusTx.asData
@@ -306,29 +297,7 @@ getContinuingOutputs _ =
   traceError "Lf" -- "Can't get any continuing outputs"
 {-# INLINEABLE getContinuingOutputs #-}
 
-{- Note [Hashes in validator scripts]
-
-We need to deal with hashes of four different things in a validator script:
-
-1. Transactions
-2. Validator scripts
-3. Data scripts
-4. Redeemer scripts
-
-The mockchain code in 'Ledger.Tx' only deals with the hashes of(1)
-and (2), and uses the 'Ledger.Tx.TxId' and `Digest SHA256` types for
-them.
-
-In PLC validator scripts the situation is different: First, they need to work
-with hashes of (1-4). Second, the `Digest SHA256` type is not available in PLC
-- we have to represent all hashes as `ByteStrings`.
-
-To ensure that we only compare hashes of the correct type inside a validator
-script, we define a newtype for each of them, as well as functions for creating
-them from the correct types in Haskell, and for comparing them (in
-`Language.Plutus.Runtime.TH`).
-
--}
+-- See Note [Hashes in validator scripts]
 
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: TxInfo -> PubKeyHash -> Bool

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Interval.hs
@@ -550,28 +550,7 @@ after
 after h (Interval _ t) = upperBound h > t
 {-# INLINEABLE after #-}
 
-{- Note [Enumerable Intervals]
-The 'Interval' type is set up to handle open intervals, where we have non-inclusive
-bounds. These are only meaningful for orders where there do not exist (computable)
-joins and meets over all elements greater or less than an element.
-
-If those do exist, we can eliminate non-inclusive bounds in favour of inclusive bounds.
-For example, in the integers, (x, y) is equivalent to [x+1, y-1], because
-x+1 = sup { z | z > x} and y-1 = inf { z | z < y }.
-
-Checking equality, containment etc. of intervals with non-inclusive bounds is
-tricky. For example, to know if (x, y) is empty, we need to know if there is a
-value between x and y. We don't have a typeclass for that!
-
-In practice, most of the intervals we care about are enumerable (have 'Enum'
-instances). We assume that `pred` and `succ` calculate the infima/suprema described
-above, and so we can turn non-inclusive bounds into inclusive bounds, which
-makes things much easier. The downside is that some of the `Enum` instances have
-partial implementations, which means that, e.g. `isEmpty (False, True]` will
-throw.
-
-The upshot of this is that many functions in this module require 'Enum'.
--}
+-- See Note [Enumerable Intervals]
 
 ----------------------------------------------------------------------------------------------------
 -- TH Splices --------------------------------------------------------------------------------------

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -246,26 +246,7 @@ assetClass :: CurrencySymbol -> TokenName -> AssetClass
 assetClass s t = AssetClass (s, t)
 {-# INLINEABLE assetClass #-}
 
-{- Note [Value vs value]
-We call two completely different things "values": the 'Value' type and a value within a key-value
-pair. To distinguish between the two we write the former with a capital "V" and enclosed in single
-quotes and we write the latter with a lower case "v" and without the quotes, i.e. 'Value' vs value.
--}
-
-{- Note [Optimising Value]
-
-We have attempted to improve the performance of 'Value' and other usages of
-'PlutusTx.AssocMap.Map' by choosing a different representation for 'PlutusTx.AssocMap.Map',
-see https://github.com/IntersectMBO/plutus/pull/5697.
-This approach has been found to not be suitable, as the PR's description mentions.
-
-Another approach was to define a specialised 'ByteStringMap', where the key type was 'BuiltinByteString',
-since that is the representation of both 'CurrencySymbol' and 'TokenName'.
-Unfortunately, this approach actually had worse performance in practice. We believe it is worse
-because having two map libraries would make some optimisations, such as CSE, less effective.
-We base this on the fact that turning off all optimisations ended up making the code more performant.
-See https://github.com/IntersectMBO/plutus/pull/5779 for details on the experiment done.
--}
+-- See Note [Optimising Value]
 
 -- See Note [Value vs value].
 -- See Note [Optimising Value].

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/MintValue.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3/Data/MintValue.hs
@@ -44,17 +44,7 @@ import Prettyprinter (Pretty)
 import Prettyprinter.Extras (PrettyShow (PrettyShow))
 import Prelude qualified as Haskell
 
-{- Note [MintValue vs Value]
-
-'MintValue' differs conceptually from 'Value' in how negative quantities are interpreted:
-
-In 'MintValue', negative quantities are interpreted as assets being burned. For 'Value',
-negative quantities are either don't make sense (e.g. in a transaction output) or interpreted
-as a negative balance.
-
-We want to distinguish these at the type level to avoid using 'MintValue' where 'Value' is assumed.
-Users should project 'MintValue' into 'Value' using 'mintValueMinted' or 'mintValueBurned'.
--}
+--  See Note [MintValue vs Value]
 
 -- | A 'MintValue' represents assets that are minted and burned in a transaction.
 newtype MintValue = UnsafeMintValue (Map CurrencySymbol (Map TokenName Integer))

--- a/plutus-ledger-api/test/Spec/Data/Eval.hs
+++ b/plutus-ledger-api/test/Spec/Data/Eval.hs
@@ -35,13 +35,7 @@ import Test.Tasty
 import Test.Tasty.Extras (ignoreTestWhenHpcEnabled)
 import Test.Tasty.HUnit
 
-{- Note [Direct UPLC code]
-For this test-suite we write the programs directly in the UPLC AST,
-bypassing the GHC typechecker & compiler, the PIR typechecker & compiler and the PLC typechecker.
-The reason is that users can submit such hand-crafted code, and we want to test how it behaves.
-Because this is part of our API, we have to be careful not to change the behaviour of even weird untypeable programs.
-In particular, we test the online part (API module).
--}
+-- See Note [Direct UPLC code]
 
 type T = Term DeBruijn DefaultUni DefaultFun ()
 

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -779,11 +779,11 @@ entryExitTracingInside lamName displayName = go mempty
        in entryExitTracing lamName displayName e ty'
 
 {- Note [Profiling Markers]
-   The @profile-all@ will insert trarces when entering and exciting functions. These
-   traces have a string marker to indicate that a given traces message is for enter/exit
-   marking. Markers are just simple strings: "->" and "<-". So for any reason in the
-   future this marker needs to be changed, all of utilities that uses this marker will
-   need to be updated.
+   The @profile-all@ option will insert traces when entering and exiting
+   functions. These traces have a string marker to indicate that a given trace
+   message is for enter/exit marking. Markers are just simple strings: "->" and
+   "<-". So if for any reason in the future this marker needs to be changed, all
+   of utilities that uses this marker will need to be updated.
 
    This list will track of all of the utilities that uses this marker:
    - plutus-core:traceToStacks
@@ -805,7 +805,7 @@ entryExitTracing lamName displayName e ty =
         annMayInline
         ( mkTrace
             (PLC.TyFun annMayInline defaultUnitTy ty) -- ()-> ty
-            -- See Note [Profiling Marker]
+            -- See Note [Profiling Markers]
             ("-> " <> displayName)
             -- \() -> trace @c "exiting f" e
             (LamAbs annMayInline lamName defaultUnitTy (mkTrace ty ("<- " <> displayName) e))

--- a/scripts/check-Notes.awk
+++ b/scripts/check-Notes.awk
@@ -163,8 +163,8 @@ maybeSplitReference && /^[- \t-]*\[/ {
     noteName = getNoteName()
     if (defined[noteName]) {
         if (longOutput) {
-            printf ("Duplicate Note [%s] at %s:%d and %s", noteName, FILENAME, FNR, defined[noteName])
-            printf ("> %s\n\n", $0)
+            printf ("Duplicate Note [%s]\nat  %s:%d\nand %s", noteName, FILENAME, FNR, defined[noteName])
+            printf ("\n\n", $0)
         }
         else printf ("Duplicate Note [%s]\n", noteName)
     }


### PR DESCRIPTION
There were some problems with the Notes in the code, and this should fix them all.

There were many duplicates that had been pasted from one file into another and in those cases I've removed the duplicates to leave one definitive version of the Note to avoid things getting out of sync.  

There were also a number of references to non-existent Notes:  these were generally due to mistakes in the name of the Note being referred to so I've fixed them.  

I found all of these using `scripts/check-Notes.sh` and `scripts/list-Notes.sh`.  There were a number of references to Notes in the GHC codebase as well and I've changed the format of those because the scripts couldn't tell that they weren't referring to code outside our codebase.