### PR TITLE
Fix metatheory deployment workflow: checkout gh-pages before deleting oldest build

### DIFF
--- a/.github/workflows/metatheory-site.yml
+++ b/.github/workflows/metatheory-site.yml
@@ -52,10 +52,10 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - name: Checkout
+      - name: Checkout gh-pages
         uses: actions/checkout@v6.0.1
         with:
-          ref: ${{ inputs.ref || github.ref_name }}
+          ref: gh-pages
 
       - name: Delete Oldest Build
         run: |
@@ -70,6 +70,11 @@ jobs:
             git commit -am "Delete oldest metatheory build $OLDEST_BUILD"
             git push origin gh-pages
           fi  
+
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Build Site
         run: | 


### PR DESCRIPTION
## Summary

- The `metatheory-site.yml` workflow was checking out the source ref first,
  then attempting to delete the oldest build from the `metatheory/` folder —
  but that folder doesn't exist in the source checkout, only in `gh-pages`.
- Fixed by checking out `gh-pages` first (matching the pattern already used
  in `haddock-site.yml`), then checking out the source ref before building.

Closes IntersectMBO/plutus-private#2101