### PR TITLE
Simplify inline hints by reordering `check` arguments

### DIFF
--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Certify/Hints.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Certify/Hints.hs
@@ -19,7 +19,6 @@ data Inline
   | InlCase Inline [Inline]
   | InlExpand Inline
   | InlDrop Inline
-  | InlLamDrop Inline
   deriving stock (Generic)
   deriving anyclass (NFData)
 

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Inline.hs
@@ -273,10 +273,9 @@ restoreApps defs t = makeLams [] t (reverse defs)
     -- `aa` is the annotation on the Apply node, and `al` is the annotation
     -- on the LamAbs node.
     makeLams args acc ((Left al, aa) : rest) =
-      -- `Left` means the binding is dropped, so `acc` should be decorated with `al`
-      -- plus `DLamDrop`.
+      -- `Left` means the binding is dropped, so `acc` should be decorated with `al`.
       -- This corresponds to Note [Inliner's Certifier Hints], #3.
-      makeLams ((Nothing, aa) : args) (decorateWith (al ^. decorations ++ [DLamDrop]) acc) rest
+      makeLams ((Nothing, aa) : args) (decorateWith (al ^. decorations) acc) rest
     makeLams args acc ((Right (Def (UVarDecl al n) rhs), aa) : rest) =
       makeLams ((Just rhs, aa) : args) (LamAbs al n acc) rest
     makeLams args acc [] =
@@ -578,17 +577,17 @@ fullyApplyAndBetaReduce av info args0 = do
     --   * ...
     --   * decorations on the innermost Apply node, plus DDrop
     --   * `av` plus DExpand.
-    --   * decorations on the first LamAbs, plus DLamDrop
-    --   * decorations on the second LamAbs, plus DLamDrop
+    --   * decorations on the first LamAbs
+    --   * decorations on the second LamAbs
     --   * ...
-    --   * decorations on the last LamAbs, plus DLamDrop
+    --   * decorations on the last LamAbs
     --
     -- See Note [Inliner's Certifier Hints].
     decorateWith
       ( concatMap (\(annApply, _arg) -> annApply ^. decorations ++ [DDrop]) (reverse args0)
           ++ av ^. decorations
           ++ [DExpand]
-          ++ concatMap (\(_name, annLam) -> annLam ^. decorations ++ [DLamDrop]) (info ^. varBinders)
+          ++ concatMap (\(_name, annLam) -> annLam ^. decorations) (info ^. varBinders)
       )
       <$> liftDupable (let Done rhsBody = info ^. varRhsBody in rhsBody)
   let go
@@ -669,8 +668,8 @@ inlineSaturatedApp t
 -- See Note [Inliner's Certifier Hints] for an overview.
 -------------------------------------------------------------------------------
 
--- | An enclosing Drop, LamDrop or Expand layer
-data Decoration = DDrop | DLamDrop | DExpand
+-- | An enclosing Drop or Expand layer
+data Decoration = DDrop | DExpand
 
 type Ann a = ([Decoration], a)
 
@@ -696,7 +695,6 @@ mkHints = go
         decorate :: CertifierHints.Inline -> [Decoration] -> CertifierHints.Inline
         decorate = foldr $ \d h -> case d of
           DDrop -> CertifierHints.InlDrop h
-          DLamDrop -> CertifierHints.InlLamDrop h
           DExpand -> CertifierHints.InlExpand h
 
         ds = termAnn t ^. decorations
@@ -727,11 +725,11 @@ inliner as a process that repeatedly performs one of the following two operation
 
 Certifier hints are then defined constructively according to the following procedure.
 In the end, the final hints mirror the post-term structure, except that each node may be
-decorated with an arbitrary number of `InlExpand`, `InlDrop` and `InlLamDrop` layers,
+decorated with an arbitrary number of `InlExpand` and `InlDrop` layers,
 reflecting the inlining operations that the inliner has performed.
 
 - Initially the hints mirror the pre-term structure, using constructors of `Inline`
-  except `InlExpand`, `InlDrop` and `InlLamDrop`. Excluding these three constructors,
+  except `InlExpand` and `InlDrop`. Excluding these two constructors,
   there is a 1-1 correspondence between hints constructors and AST constructors.
 
 - Suppose the inliner performs operation 1, substituting term `N` for variable `v`.
@@ -739,8 +737,8 @@ reflecting the inlining operations that the inliner has performed.
 
     hints(v) = decorations(InlVar)
 
-  where `decorations` denotes an arbitrary number of enclosing `InlExpand`, `InlDrop` or
-  `InlLamDrop` layers. After the substitution, the hints at this location should become
+  where `decorations` denotes an arbitrary number of enclosing `InlExpand` or `InlDrop`
+  layers. After the substitution, the hints at this location should become
 
     decorations(InlExpand hints(N))                          (#1)
 
@@ -760,11 +758,11 @@ reflecting the inlining operations that the inliner has performed.
   That is, it is decorated with `decorations₁` plus `InlDrop`.
   The hints for `M` should become
 
-    decorations₂(InlLamDrop (hints(M)))                      (#3)
+    decorations₂(hints(M))                                   (#3)
 
-  That is, it is decorated with `decorations₂`, plus `InlLamDrop`. Note that when `n = 0`,
+  That is, it is decorated with `decorations₂`. Note that when `n = 0`,
   `(\x‾ₙ y. M) X‾ₙ` becomes `M`, and therefore, `hints(M)` should be decorated with
-  `decorations₁` plus `InlDrop` plus `InlLamDrop` plus `decorations₂`.
+  `decorations₁` plus `InlDrop` plus `decorations₂`.
 
 Refer to the golden tests for examples of hints (look for files ending with
 `.golden.certifier-hints`).

--- a/plutus-core/untyped-plutus-core/test/Transform/basicInline.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/basicInline.golden.certifier-hints
@@ -18,9 +18,8 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlExpand
-      InlCon
+  InlExpand
+    InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/callsiteInline.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/callsiteInline.golden.certifier-hints
@@ -27,15 +27,13 @@ InlLam
             InlDrop
               InlDrop
                 InlExpand
-                  InlLamDrop
-                    InlLamDrop
-                      InlApply
-                        InlApply
-                          InlVar
-                          InlExpand
-                            InlCon
-                        InlExpand
-                          InlCon
+                  InlApply
+                    InlApply
+                      InlVar
+                      InlExpand
+                        InlCon
+                    InlExpand
+                      InlCon
           InlApply
             InlVar
             InlCon

--- a/plutus-core/untyped-plutus-core/test/Transform/floatDelay1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/floatDelay1.golden.certifier-hints
@@ -18,14 +18,13 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
+  InlApply
     InlApply
-      InlApply
-        InlBuiltin
-        InlExpand
-          InlCon
+      InlBuiltin
       InlExpand
         InlCon
+    InlExpand
+      InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/floatDelay3.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/floatDelay3.golden.certifier-hints
@@ -18,21 +18,19 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
+  InlApply
     InlApply
-      InlApply
-        InlBuiltin
-        InlForce
+      InlBuiltin
+      InlForce
+        InlExpand
+          InlDelay
+            InlCon
+    InlDrop
+      InlForce
+        InlExpand
           InlExpand
             InlDelay
               InlCon
-      InlDrop
-        InlLamDrop
-          InlForce
-            InlExpand
-              InlExpand
-                InlDelay
-                  InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayComplex.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayComplex.golden.certifier-hints
@@ -25,33 +25,26 @@ InlLam
           InlDrop
             InlDrop
               InlDrop
-                InlLamDrop
-                  InlLamDrop
-                    InlLamDrop
-                      InlLamDrop
-                        InlLamDrop
-                          InlLamDrop
-                            InlLamDrop
-                              InlApply
-                                InlApply
-                                  InlApply
-                                    InlApply
-                                      InlApply
-                                        InlApply
-                                          InlExpand
-                                            InlVar
-                                          InlExpand
-                                            InlCon
-                                        InlExpand
-                                          InlCon
-                                      InlExpand
-                                        InlCon
-                                    InlExpand
-                                      InlCon
-                                  InlExpand
-                                    InlCon
-                                InlExpand
-                                  InlCon
+                InlApply
+                  InlApply
+                    InlApply
+                      InlApply
+                        InlApply
+                          InlApply
+                            InlExpand
+                              InlVar
+                            InlExpand
+                              InlCon
+                          InlExpand
+                            InlCon
+                        InlExpand
+                          InlCon
+                      InlExpand
+                        InlCon
+                    InlExpand
+                      InlCon
+                  InlExpand
+                    InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiApply.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiApply.golden.certifier-hints
@@ -22,21 +22,17 @@ InlLam
     InlDrop
       InlDrop
         InlDrop
-          InlLamDrop
-            InlLamDrop
-              InlLamDrop
-                InlLamDrop
-                  InlApply
-                    InlApply
-                      InlApply
-                        InlExpand
-                          InlVar
-                        InlExpand
-                          InlCon
-                      InlExpand
-                        InlCon
-                    InlExpand
-                      InlCon
+          InlApply
+            InlApply
+              InlApply
+                InlExpand
+                  InlVar
+                InlExpand
+                  InlCon
+              InlExpand
+                InlCon
+            InlExpand
+              InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiForce.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiForce.golden.certifier-hints
@@ -18,9 +18,8 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlExpand
-      InlCon
+  InlExpand
+    InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelaySimple.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelaySimple.golden.certifier-hints
@@ -20,11 +20,8 @@ NoHints
 InlDrop
   InlDrop
     InlDrop
-      InlLamDrop
-        InlLamDrop
-          InlLamDrop
-            InlExpand
-              InlCon
+      InlExpand
+        InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure1.golden.certifier-hints
@@ -19,10 +19,9 @@ NoHints
 -- Certifier hints #7 (Inline) --
 InlLam
   InlDrop
-    InlLamDrop
-      InlLam
-        InlExpand
-          InlVar
+    InlLam
+      InlExpand
+        InlVar
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure2.golden.certifier-hints
@@ -19,10 +19,9 @@ NoHints
 -- Certifier hints #7 (Inline) --
 InlLam
   InlDrop
-    InlLamDrop
-      InlLam
-        InlExpand
-          InlVar
+    InlLam
+      InlExpand
+        InlVar
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure3.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure3.golden.certifier-hints
@@ -18,17 +18,15 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlLam
-      InlExpand
-        InlDrop
-          InlLamDrop
-            InlLam
-              InlApply
-                InlExpand
-                  InlCon
-                InlExpand
-                  InlCon
+  InlLam
+    InlExpand
+      InlDrop
+        InlLam
+          InlApply
+            InlExpand
+              InlCon
+            InlExpand
+              InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure4.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure4.golden.certifier-hints
@@ -18,19 +18,18 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlLam
-      InlExpand
-        InlApply
+  InlLam
+    InlExpand
+      InlApply
+        InlLam
           InlLam
-            InlLam
-              InlApply
-                InlVar
-                InlVar
-          InlDelay
             InlApply
-              InlError
-              InlCon
+              InlVar
+              InlVar
+        InlDelay
+          InlApply
+            InlError
+            InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/interveningLambda.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/interveningLambda.golden.certifier-hints
@@ -18,12 +18,11 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlApply
-      InlExpand
-        InlCon
-      InlExpand
-        InlCon
+  InlApply
+    InlExpand
+      InlCon
+    InlExpand
+      InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase1.golden.certifier-hints
@@ -18,8 +18,7 @@ NoHints
 
 -- Certifier hints #7 (Inline) --
 InlDrop
-  InlLamDrop
-    InlCon
+  InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase2.golden.certifier-hints
@@ -19,14 +19,13 @@ NoHints
 -- Certifier hints #7 (Inline) --
 InlLam
   InlDrop
-    InlLamDrop
+    InlApply
       InlApply
-        InlApply
-          InlBuiltin
-          InlExpand
-            InlVar
+        InlBuiltin
         InlExpand
           InlVar
+      InlExpand
+        InlVar
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutForce.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutForce.golden.certifier-hints
@@ -19,9 +19,8 @@ NoHints
 -- Certifier hints #7 (Inline) --
 InlLam
   InlDrop
-    InlLamDrop
-      InlExpand
-        InlVar
+    InlExpand
+      InlVar
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/test/Transform/multiApp.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/multiApp.golden.certifier-hints
@@ -20,17 +20,14 @@ NoHints
 InlDrop
   InlDrop
     InlDrop
-      InlLamDrop
-        InlLamDrop
-          InlLamDrop
-            InlApply
-              InlApply
-                InlExpand
-                  InlCon
-                InlExpand
-                  InlCon
-              InlExpand
-                InlCon
+      InlApply
+        InlApply
+          InlExpand
+            InlCon
+          InlExpand
+            InlCon
+        InlExpand
+          InlCon
 
 
 -- Certifier hints #8 (ApplyToCase) --

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Lib.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Lib.hs
@@ -93,7 +93,6 @@ renderCertifierHints (Trace.SimplifierTrace ss)
           <> foldMap (renderInlineHints (i + 2)) alts
       Hints.InlExpand x -> line i "InlExpand" <> renderInlineHints (i + 2) x
       Hints.InlDrop x -> line i "InlDrop" <> renderInlineHints (i + 2) x
-      Hints.InlLamDrop x -> line i "InlLamDrop" <> renderInlineHints (i + 2) x
 
     line i payload = T.replicate i " " <> payload <> "\n"
 

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -81,7 +81,6 @@ instance AgdaUnparse Hints.Inline where
     Hints.InlCase t ts -> "(case " ++ agdaUnparse t ++ " " ++ agdaUnparse ts ++ ")"
     Hints.InlExpand t -> "(expand " ++ agdaUnparse t ++ ")"
     Hints.InlDrop t -> "(" ++ agdaUnparse t ++ " ·↓)"
-    Hints.InlLamDrop t -> "(ƛ↓ " ++ agdaUnparse t ++ ")"
 
 instance AgdaUnparse Natural where
   agdaUnparse = show

--- a/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
@@ -33,7 +33,7 @@ d_runCertifier_2 ::
   [MAlonzo.Code.Utils.T__'215'__428
      MAlonzo.Code.VerifiedCompilation.Trace.T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_54
+        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
@@ -45,7 +45,7 @@ d_runCertifier_2 v0
       MAlonzo.Code.Utils.du_eitherBind_54
       (coe
          MAlonzo.Code.Utils.du_try_94
-         (coe MAlonzo.Code.VerifiedCompilation.Trace.d_toTrace_80 (coe v0))
+         (coe MAlonzo.Code.VerifiedCompilation.Trace.d_toTrace_78 (coe v0))
          (coe MAlonzo.Code.VerifiedCompilation.C_emptyDump_4))
       (coe
          (\ v1 ->
@@ -75,12 +75,12 @@ runCertifierMain ::
     (MAlonzo.Code.Utils.T__'215'__428
        MAlonzo.Code.VerifiedCompilation.Trace.T_SimplifierTag_4
        (MAlonzo.Code.Utils.T__'215'__428
-          MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_54
+          MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_52
           (MAlonzo.Code.Utils.T__'215'__428
              MAlonzo.Code.RawU.T_Untyped_208
              MAlonzo.Code.RawU.T_Untyped_208))) ->
   MAlonzo.Code.Agda.Builtin.List.T_List_10
-    () MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116 ->
+    () MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114 ->
   MAlonzo.Code.Agda.Builtin.Maybe.T_Maybe_10
     ()
     (MAlonzo.Code.Utils.T__'215'__428
@@ -90,11 +90,11 @@ d_runCertifierMain_12 ::
   [MAlonzo.Code.Utils.T__'215'__428
      MAlonzo.Code.VerifiedCompilation.Trace.T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_54
+        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114] ->
   Maybe
     (MAlonzo.Code.Utils.T__'215'__428
        Bool MAlonzo.Code.Agda.Builtin.String.T_String_6)

--- a/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
@@ -651,11 +651,11 @@ d_termSize'7510''695'_216 v0 v1
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showEvalResult
 d_showEvalResult_238 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showEvalResult_238 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_success_118 v1 v2
+      MAlonzo.Code.VerifiedCompilation.Trace.C_success_116 v1 v2
         -> coe
              MAlonzo.Code.Data.String.Base.d__'43''43'__20
              (d_'8649'__2 (coe ("Execution Cost: CPU = " :: Data.Text.Text)))
@@ -666,7 +666,7 @@ d_showEvalResult_238 v0
                    MAlonzo.Code.Data.String.Base.d__'43''43'__20
                    (", MEM = " :: Data.Text.Text)
                    (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v2)))
-      MAlonzo.Code.VerifiedCompilation.Trace.C_failure_120 v1 v2 v3
+      MAlonzo.Code.VerifiedCompilation.Trace.C_failure_118 v1 v2 v3
         -> coe
              MAlonzo.Code.Data.String.Base.d__'43''43'__20
              (d_'8649'__2 (coe ("Evaluation FAILED: " :: Data.Text.Text)))
@@ -687,7 +687,7 @@ d_showEvalResult_238 v0
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showCostPair
 d_showCostPair_250 ::
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showCostPair_250 v0
   = let v1 = "" :: Data.Text.Text in
@@ -721,13 +721,13 @@ du_tail_258 v0
 -- CertifierReport.reportPasses
 d_reportPasses_268 ::
   Integer ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60 ->
   AgdaAny ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_reportPasses_268 v0 v1 v2 v3
   = case coe v1 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_66 v4 v5 v6 v7
+      MAlonzo.Code.VerifiedCompilation.Trace.C_step_64 v4 v5 v6 v7
         -> case coe v2 of
              MAlonzo.Code.Utils.C__'44'__442 v8 v9
                -> coe
@@ -779,7 +779,7 @@ d_reportPasses_268 v0 v1 v2 v3
                                                            (d_termSize_212
                                                               (coe (0 :: Integer))
                                                               (coe
-                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_head_72
+                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_head_70
                                                                  (coe v7))))
                                                         (coe
                                                            MAlonzo.Code.Data.String.Base.d__'43''43'__20
@@ -798,7 +798,7 @@ d_reportPasses_268 v0 v1 v2 v3
                                                                        (d_showSites_190
                                                                           (coe v6)
                                                                           (coe
-                                                                             MAlonzo.Code.VerifiedCompilation.Trace.d_head_72
+                                                                             MAlonzo.Code.VerifiedCompilation.Trace.d_head_70
                                                                              (coe v7))
                                                                           (coe v4) (coe v8))
                                                                        (coe
@@ -815,7 +815,7 @@ d_reportPasses_268 v0 v1 v2 v3
                                                                                 (coe
                                                                                    v3)))))))))))))))))))))
              _ -> MAlonzo.RTE.mazUnreachableError
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_68 v4
+      MAlonzo.Code.VerifiedCompilation.Trace.C_done_66 v4
         -> coe ("" :: Data.Text.Text)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportFailure
@@ -870,7 +870,7 @@ d_makeReport_290 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.T_Error_2
     MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_116] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_114] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_makeReport_290 v0 v1
   = coe

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
@@ -85,7 +85,7 @@ d_hasRelation_16 v0
 -- VerifiedCompilation.certifyPass
 d_certifyPass_24 ::
   MAlonzo.Code.VerifiedCompilation.Trace.T_SimplifierTag_4 ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_54 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_52 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_CertResult_12
@@ -122,13 +122,13 @@ d_certifyPass_24 v0 v1
                 (coe (0 :: Integer)))
       MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16
         -> case coe v1 of
-             MAlonzo.Code.VerifiedCompilation.Trace.C_inline_56 v2
+             MAlonzo.Code.VerifiedCompilation.Trace.C_inline_54 v2
                -> coe
                     MAlonzo.Code.VerifiedCompilation.Certificate.du_checker_156
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UInline.d_top'45'check_718
                        (coe v2))
-             MAlonzo.Code.VerifiedCompilation.Trace.C_none_58
+             MAlonzo.Code.VerifiedCompilation.Trace.C_none_56
                -> coe
                     MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_32 (coe v0)
              _ -> MAlonzo.RTE.mazUnreachableError
@@ -157,19 +157,19 @@ d_certifyPass_24 v0 v1
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate
 d_Certificate_32 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62 -> ()
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60 -> ()
 d_Certificate_32 = erased
 -- VerifiedCompilation.certify
 d_certify_44 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60 ->
   MAlonzo.Code.Utils.T_Either_6 T_Error_2 AgdaAny
 d_certify_44 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_66 v1 v2 v3 v4
+      MAlonzo.Code.VerifiedCompilation.Trace.C_step_64 v1 v2 v3 v4
         -> let v5
                  = coe
                      d_certifyPass_24 v1 v2 v3
-                     (MAlonzo.Code.VerifiedCompilation.Trace.d_head_72 (coe v4)) in
+                     (MAlonzo.Code.VerifiedCompilation.Trace.d_head_70 (coe v4)) in
            coe
              (case coe v5 of
                 MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_18 v6
@@ -186,14 +186,14 @@ d_certify_44 v0
                 MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_32 v8 v9 v10
                   -> coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_abort_10 (coe v8))
                 _ -> MAlonzo.RTE.mazUnreachableError)
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_68 v1
+      MAlonzo.Code.VerifiedCompilation.Trace.C_done_66 v1
         -> coe
              MAlonzo.Code.Utils.C_inj'8322'_14
              (coe MAlonzo.Code.Agda.Builtin.Unit.C_tt_8)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.cert
 d_cert_94 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60 ->
   MAlonzo.Code.Utils.T_Either_6 T_Error_2 AgdaAny ->
   AgdaAny -> AgdaAny
 d_cert_94 ~v0 v1 v2 = du_cert_94 v1 v2
@@ -214,11 +214,11 @@ d_checkScope_98 v0
       (coe MAlonzo.Code.Untyped.d_scopeCheckU0_276 (coe v0))
 -- VerifiedCompilation.checkScopeᵗ
 d_checkScope'7511'_100 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62 ->
-  Maybe MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_62
+  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60 ->
+  Maybe MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_60
 d_checkScope'7511'_100 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_66 v1 v2 v3 v4
+      MAlonzo.Code.VerifiedCompilation.Trace.C_step_64 v1 v2 v3 v4
         -> coe
              MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
              (coe d_checkScope_98 (coe v3))
@@ -232,9 +232,9 @@ d_checkScope'7511'_100 v0
                            coe
                              MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
                              (coe
-                                MAlonzo.Code.VerifiedCompilation.Trace.C_step_66 (coe v1) (coe v2)
+                                MAlonzo.Code.VerifiedCompilation.Trace.C_step_64 (coe v1) (coe v2)
                                 (coe v5) (coe v6))))))
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_68 v1
+      MAlonzo.Code.VerifiedCompilation.Trace.C_done_66 v1
         -> coe
              MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
              (coe d_checkScope_98 (coe v1))
@@ -242,5 +242,5 @@ d_checkScope'7511'_100 v0
                 (\ v2 ->
                    coe
                      MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
-                     (coe MAlonzo.Code.VerifiedCompilation.Trace.C_done_68 (coe v2))))
+                     (coe MAlonzo.Code.VerifiedCompilation.Trace.C_done_66 (coe v2))))
       _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
@@ -79,55 +79,51 @@ type T_InlineHints_26 = Hints.Inline
 pattern C_var_28 = Hints.InlVar
 pattern C_expand_30 a0 = Hints.InlExpand a0
 pattern C_ƛ_32 a0 = Hints.InlLam a0
-pattern C_ƛ'8595'_34 a0 = Hints.InlLamDrop a0
-pattern C__'183'__36 a0 a1 = Hints.InlApply a0 a1
-pattern C__'183''8595'_38 a0 = Hints.InlDrop a0
-pattern C_force_40 a0 = Hints.InlForce a0
-pattern C_delay_42 a0 = Hints.InlDelay a0
-pattern C_con_44 = Hints.InlCon
-pattern C_builtin_46 = Hints.InlBuiltin
-pattern C_error_48 = Hints.InlError
-pattern C_constr_50 a0 = Hints.InlConstr a0
-pattern C_case_52 a0 a1 = Hints.InlCase a0 a1
+pattern C__'183'__34 a0 a1 = Hints.InlApply a0 a1
+pattern C__'183''8595'_36 a0 = Hints.InlDrop a0
+pattern C_force_38 a0 = Hints.InlForce a0
+pattern C_delay_40 a0 = Hints.InlDelay a0
+pattern C_con_42 = Hints.InlCon
+pattern C_builtin_44 = Hints.InlBuiltin
+pattern C_error_46 = Hints.InlError
+pattern C_constr_48 a0 = Hints.InlConstr a0
+pattern C_case_50 a0 a1 = Hints.InlCase a0 a1
 check_var_28 :: T_InlineHints_26
 check_var_28 = Hints.InlVar
 check_expand_30 :: T_InlineHints_26 -> T_InlineHints_26
 check_expand_30 = Hints.InlExpand
 check_ƛ_32 :: T_InlineHints_26 -> T_InlineHints_26
 check_ƛ_32 = Hints.InlLam
-check_ƛ'8595'_34 :: T_InlineHints_26 -> T_InlineHints_26
-check_ƛ'8595'_34 = Hints.InlLamDrop
-check__'183'__36 ::
+check__'183'__34 ::
   T_InlineHints_26 -> T_InlineHints_26 -> T_InlineHints_26
-check__'183'__36 = Hints.InlApply
-check__'183''8595'_38 :: T_InlineHints_26 -> T_InlineHints_26
-check__'183''8595'_38 = Hints.InlDrop
-check_force_40 :: T_InlineHints_26 -> T_InlineHints_26
-check_force_40 = Hints.InlForce
-check_delay_42 :: T_InlineHints_26 -> T_InlineHints_26
-check_delay_42 = Hints.InlDelay
-check_con_44 :: T_InlineHints_26
-check_con_44 = Hints.InlCon
-check_builtin_46 :: T_InlineHints_26
-check_builtin_46 = Hints.InlBuiltin
-check_error_48 :: T_InlineHints_26
-check_error_48 = Hints.InlError
-check_constr_50 ::
+check__'183'__34 = Hints.InlApply
+check__'183''8595'_36 :: T_InlineHints_26 -> T_InlineHints_26
+check__'183''8595'_36 = Hints.InlDrop
+check_force_38 :: T_InlineHints_26 -> T_InlineHints_26
+check_force_38 = Hints.InlForce
+check_delay_40 :: T_InlineHints_26 -> T_InlineHints_26
+check_delay_40 = Hints.InlDelay
+check_con_42 :: T_InlineHints_26
+check_con_42 = Hints.InlCon
+check_builtin_44 :: T_InlineHints_26
+check_builtin_44 = Hints.InlBuiltin
+check_error_46 :: T_InlineHints_26
+check_error_46 = Hints.InlError
+check_constr_48 ::
   MAlonzo.Code.Agda.Builtin.List.T_List_10 () T_InlineHints_26 ->
   T_InlineHints_26
-check_constr_50 = Hints.InlConstr
-check_case_52 ::
+check_constr_48 = Hints.InlConstr
+check_case_50 ::
   T_InlineHints_26 ->
   MAlonzo.Code.Agda.Builtin.List.T_List_10 () T_InlineHints_26 ->
   T_InlineHints_26
-check_case_52 = Hints.InlCase
+check_case_50 = Hints.InlCase
 cover_InlineHints_26 :: Hints.Inline -> ()
 cover_InlineHints_26 x
   = case x of
       Hints.InlVar -> ()
       Hints.InlExpand _ -> ()
       Hints.InlLam _ -> ()
-      Hints.InlLamDrop _ -> ()
       Hints.InlApply _ _ -> ()
       Hints.InlDrop _ -> ()
       Hints.InlForce _ -> ()
@@ -138,101 +134,101 @@ cover_InlineHints_26 x
       Hints.InlConstr _ -> ()
       Hints.InlCase _ _ -> ()
 -- VerifiedCompilation.Trace.Hints
-d_Hints_54 = ()
-type T_Hints_54 = Hints.Hints
-pattern C_inline_56 a0 = Hints.Inline a0
-pattern C_none_58 = Hints.NoHints
-check_inline_56 :: T_InlineHints_26 -> T_Hints_54
-check_inline_56 = Hints.Inline
-check_none_58 :: T_Hints_54
-check_none_58 = Hints.NoHints
-cover_Hints_54 :: Hints.Hints -> ()
-cover_Hints_54 x
+d_Hints_52 = ()
+type T_Hints_52 = Hints.Hints
+pattern C_inline_54 a0 = Hints.Inline a0
+pattern C_none_56 = Hints.NoHints
+check_inline_54 :: T_InlineHints_26 -> T_Hints_52
+check_inline_54 = Hints.Inline
+check_none_56 :: T_Hints_52
+check_none_56 = Hints.NoHints
+cover_Hints_52 :: Hints.Hints -> ()
+cover_Hints_52 x
   = case x of
       Hints.Inline _ -> ()
       Hints.NoHints -> ()
 -- VerifiedCompilation.Trace.Trace
-d_Trace_62 a0 = ()
-data T_Trace_62
-  = C_step_66 T_SimplifierTag_4 T_Hints_54 AgdaAny T_Trace_62 |
-    C_done_68 AgdaAny
+d_Trace_60 a0 = ()
+data T_Trace_60
+  = C_step_64 T_SimplifierTag_4 T_Hints_52 AgdaAny T_Trace_60 |
+    C_done_66 AgdaAny
 -- VerifiedCompilation.Trace.head
-d_head_72 :: T_Trace_62 -> AgdaAny
-d_head_72 v0
+d_head_70 :: T_Trace_60 -> AgdaAny
+d_head_70 v0
   = case coe v0 of
-      C_step_66 v1 v2 v3 v4 -> coe v3
-      C_done_68 v1 -> coe v1
+      C_step_64 v1 v2 v3 v4 -> coe v3
+      C_done_66 v1 -> coe v1
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Trace.Dump
-d_Dump_78 :: ()
-d_Dump_78 = erased
+d_Dump_76 :: ()
+d_Dump_76 = erased
 -- VerifiedCompilation.Trace.toTrace
-d_toTrace_80 ::
+d_toTrace_78 ::
   [MAlonzo.Code.Utils.T__'215'__428
      T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        T_Hints_54
+        T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
-  Maybe T_Trace_62
-d_toTrace_80 v0
+  Maybe T_Trace_60
+d_toTrace_78 v0
   = case coe v0 of
       [] -> coe MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
       (:) v1 v2
         -> coe
              MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
-             (coe du_go_90 (coe v1) (coe v2))
+             (coe du_go_88 (coe v1) (coe v2))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Trace._.go
-d_go_90 ::
+d_go_88 ::
   MAlonzo.Code.Utils.T__'215'__428
     T_SimplifierTag_4
     (MAlonzo.Code.Utils.T__'215'__428
-       T_Hints_54
+       T_Hints_52
        (MAlonzo.Code.Utils.T__'215'__428
           MAlonzo.Code.RawU.T_Untyped_208
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        T_Hints_54
+        T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
   MAlonzo.Code.Utils.T__'215'__428
     T_SimplifierTag_4
     (MAlonzo.Code.Utils.T__'215'__428
-       T_Hints_54
+       T_Hints_52
        (MAlonzo.Code.Utils.T__'215'__428
           MAlonzo.Code.RawU.T_Untyped_208
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        T_Hints_54
+        T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
-  T_Trace_62
-d_go_90 ~v0 ~v1 v2 v3 = du_go_90 v2 v3
-du_go_90 ::
+  T_Trace_60
+d_go_88 ~v0 ~v1 v2 v3 = du_go_88 v2 v3
+du_go_88 ::
   MAlonzo.Code.Utils.T__'215'__428
     T_SimplifierTag_4
     (MAlonzo.Code.Utils.T__'215'__428
-       T_Hints_54
+       T_Hints_52
        (MAlonzo.Code.Utils.T__'215'__428
           MAlonzo.Code.RawU.T_Untyped_208
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      T_SimplifierTag_4
      (MAlonzo.Code.Utils.T__'215'__428
-        T_Hints_54
+        T_Hints_52
         (MAlonzo.Code.Utils.T__'215'__428
            MAlonzo.Code.RawU.T_Untyped_208
            MAlonzo.Code.RawU.T_Untyped_208))] ->
-  T_Trace_62
-du_go_90 v0 v1
+  T_Trace_60
+du_go_88 v0 v1
   = case coe v0 of
       MAlonzo.Code.Utils.C__'44'__442 v2 v3
         -> case coe v3 of
@@ -242,7 +238,7 @@ du_go_90 v0 v1
                       -> case coe v1 of
                            []
                              -> coe
-                                  C_step_66 (coe v2) (coe v4) (coe v6) (coe C_done_68 (coe v7))
+                                  C_step_64 (coe v2) (coe v4) (coe v6) (coe C_done_66 (coe v7))
                            (:) v8 v9
                              -> case coe v8 of
                                   MAlonzo.Code.Utils.C__'44'__442 v10 v11
@@ -251,9 +247,9 @@ du_go_90 v0 v1
                                            -> case coe v13 of
                                                 MAlonzo.Code.Utils.C__'44'__442 v14 v15
                                                   -> coe
-                                                       C_step_66 (coe v2) (coe v4) (coe v6)
+                                                       C_step_64 (coe v2) (coe v4) (coe v6)
                                                        (coe
-                                                          du_go_90
+                                                          du_go_88
                                                           (coe
                                                              MAlonzo.Code.Utils.C__'44'__442
                                                              (coe v10)
@@ -272,18 +268,18 @@ du_go_90 v0 v1
              _ -> MAlonzo.RTE.mazUnreachableError
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Trace.EvalResult
-d_EvalResult_116 = ()
-type T_EvalResult_116 = EvalResult
-pattern C_success_118 a0 a1 = EvalSuccess a0 a1
-pattern C_failure_120 a0 a1 a2 = EvalFailure a0 a1 a2
-check_success_118 :: Integer -> Integer -> T_EvalResult_116
-check_success_118 = EvalSuccess
-check_failure_120 ::
+d_EvalResult_114 = ()
+type T_EvalResult_114 = EvalResult
+pattern C_success_116 a0 a1 = EvalSuccess a0 a1
+pattern C_failure_118 a0 a1 a2 = EvalFailure a0 a1 a2
+check_success_116 :: Integer -> Integer -> T_EvalResult_114
+check_success_116 = EvalSuccess
+check_failure_118 ::
   MAlonzo.Code.Agda.Builtin.String.T_String_6 ->
-  Integer -> Integer -> T_EvalResult_116
-check_failure_120 = EvalFailure
-cover_EvalResult_116 :: EvalResult -> ()
-cover_EvalResult_116 x
+  Integer -> Integer -> T_EvalResult_114
+check_failure_118 = EvalFailure
+cover_EvalResult_114 :: EvalResult -> ()
+cover_EvalResult_114 x
   = case x of
       EvalSuccess _ _ -> ()
       EvalFailure _ _ _ -> ()

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
@@ -330,8 +330,8 @@ d_checkPointwise_304 v0 v1 v2 v3 v4 v5 v6 v7
                          -> coe
                               MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                               (coe
-                                 d_check_316 (coe v0) (coe v1) (coe v2) (coe v9) (coe v4) (coe v5)
-                                 (coe v11) (coe v13))
+                                 d_check_316 (coe v0) (coe v1) (coe v2) (coe v4) (coe v11) (coe v5)
+                                 (coe v9) (coe v13))
                               (coe
                                  (\ v15 ->
                                     coe
@@ -354,23 +354,23 @@ d_check_316 ::
   Integer ->
   T__'8605'_28 ->
   T__'8605'_28 ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
-  T__'8829'__102 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T__'8829'__102 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_Proof'63'_66
 d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
   = let v8
           = coe
               MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-              (coe MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16) v6 v7 in
+              (coe MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16) v4 v7 in
     coe
-      (case coe v3 of
-         MAlonzo.Code.VerifiedCompilation.Trace.C_var_28
+      (case coe v4 of
+         MAlonzo.Code.Untyped.C_'96'_18 v9
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_'96'_18 v9
+                MAlonzo.Code.VerifiedCompilation.Trace.C_var_28
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_'96'_18 v10
                          -> let v11
@@ -387,7 +387,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
                                                    (coe
                                                       MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                   v6 v7 in
+                                                   v4 v7 in
                                          coe
                                            (case coe v13 of
                                               MAlonzo.Code.Agda.Builtin.Bool.C_true_10
@@ -421,7 +421,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
                                                                                            (coe
                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                                                           v6 v6
+                                                                                           v4 v4
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
                                                                           _ -> coe v15
                                                                    _ -> coe v15
@@ -430,37 +430,34 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                               _ -> coe v15)
                                     _ -> MAlonzo.RTE.mazUnreachableError))
                        _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_expand_30 v9
-           -> case coe v6 of
-                MAlonzo.Code.Untyped.C_'96'_18 v10
+                MAlonzo.Code.VerifiedCompilation.Trace.C_expand_30 v10
                   -> coe
                        MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                        (coe
-                          d_check_316 (coe v0) (coe v1) (coe v2) (coe v9) (coe v4) (coe v5)
-                          (coe v4 v10) (coe v7))
+                          d_check_316 (coe v0) (coe v1) (coe v2) (coe v3) (coe v3 v9)
+                          (coe v5) (coe v10) (coe v7))
                        (coe
                           (\ v11 ->
                              coe
                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
                                (coe C_'96''8595'_234 v11)))
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_ƛ_32 v9
+         MAlonzo.Code.Untyped.C_ƛ_20 v9
            -> case coe v5 of
                 C_'9633'_106
                   -> case coe v6 of
-                       MAlonzo.Code.Untyped.C_ƛ_20 v10
+                       MAlonzo.Code.VerifiedCompilation.Trace.C_ƛ_32 v10
                          -> case coe v7 of
                               MAlonzo.Code.Untyped.C_ƛ_20 v11
                                 -> coe
                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                                      (coe
                                         d_check_316 (coe addInt (coe (1 :: Integer)) (coe v0))
-                                        (coe C_'9633'_32) (coe C_'9633'_32) (coe v9)
+                                        (coe C_'9633'_32) (coe C_'9633'_32)
                                         (coe
                                            MAlonzo.Code.Untyped.RenamingSubstitution.du_lifts_378
-                                           (coe v0) (coe v4))
-                                        (coe v5) (coe v10) (coe v11))
+                                           (coe v0) (coe v3))
+                                        (coe v9) (coe v5) (coe v10) (coe v11))
                                      (coe
                                         (\ v12 ->
                                            coe
@@ -474,7 +471,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                          -> case coe v2 of
                               C__'183'__34 v16 v17
                                 -> case coe v6 of
-                                     MAlonzo.Code.Untyped.C_ƛ_20 v18
+                                     MAlonzo.Code.VerifiedCompilation.Trace.C_ƛ_32 v18
                                        -> case coe v7 of
                                             MAlonzo.Code.Untyped.C_ƛ_20 v19
                                               -> coe
@@ -484,15 +481,15 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                       (coe addInt (coe (1 :: Integer)) (coe v0))
                                                       (coe d__'8593''7611'_40 (coe v0) (coe v14))
                                                       (coe d__'8593''7611'_40 (coe v0) (coe v16))
-                                                      (coe v9)
                                                       (coe
                                                          MAlonzo.Code.Untyped.RenamingSubstitution.du_extend_454
                                                          (coe
                                                             MAlonzo.Code.Untyped.RenamingSubstitution.du__'8593''738'_470
-                                                            (coe v0) (coe v4))
+                                                            (coe v0) (coe v3))
                                                          (coe
                                                             MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
                                                             (coe v0) (coe v15)))
+                                                      (coe v9)
                                                       (coe
                                                          du__'8593''7611''7611'_126 (coe v14)
                                                          (coe v16) (coe v13))
@@ -506,57 +503,50 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                      _ -> coe v8
                               _ -> coe v8
                        _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_ƛ'8595'_34 v9
-           -> case coe v5 of
                 C_drop_122 v13
                   -> case coe v1 of
                        C__'183'__34 v14 v15
                          -> case coe v2 of
                               C__'183'__34 v16 v17
-                                -> case coe v6 of
-                                     MAlonzo.Code.Untyped.C_ƛ_20 v18
-                                       -> coe
-                                            MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
-                                            (coe
-                                               d_check_316
-                                               (coe addInt (coe (1 :: Integer)) (coe v0))
-                                               (coe d__'8593''7611'_40 (coe v0) (coe v14))
-                                               (coe d__'8593''7611'_40 (coe v0) (coe v16)) (coe v9)
-                                               (coe
-                                                  MAlonzo.Code.Untyped.RenamingSubstitution.du_extend_454
-                                                  (coe
-                                                     MAlonzo.Code.Untyped.RenamingSubstitution.du__'8593''738'_470
-                                                     (coe v0) (coe v4))
-                                                  (coe
-                                                     MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
-                                                     (coe v0) (coe v15)))
-                                               (coe
-                                                  du__'8593''7611''7611'_126 (coe v14) (coe v16)
-                                                  (coe v13))
-                                               (coe v18)
-                                               (coe
-                                                  MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
-                                                  (coe v0) (coe v7)))
-                                            (coe
-                                               (\ v19 ->
-                                                  coe
-                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
-                                                    (coe C_ƛ'8595'_244 v19)))
-                                     _ -> coe v8
+                                -> coe
+                                     MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                     (coe
+                                        d_check_316 (coe addInt (coe (1 :: Integer)) (coe v0))
+                                        (coe d__'8593''7611'_40 (coe v0) (coe v14))
+                                        (coe d__'8593''7611'_40 (coe v0) (coe v16))
+                                        (coe
+                                           MAlonzo.Code.Untyped.RenamingSubstitution.du_extend_454
+                                           (coe
+                                              MAlonzo.Code.Untyped.RenamingSubstitution.du__'8593''738'_470
+                                              (coe v0) (coe v3))
+                                           (coe
+                                              MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                              (coe v0) (coe v15)))
+                                        (coe v9)
+                                        (coe
+                                           du__'8593''7611''7611'_126 (coe v14) (coe v16) (coe v13))
+                                        (coe v6)
+                                        (coe
+                                           MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                           (coe v0) (coe v7)))
+                                     (coe
+                                        (\ v18 ->
+                                           coe
+                                             MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                             (coe C_ƛ'8595'_244 v18)))
                               _ -> coe v8
                        _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C__'183'__36 v9 v10
+                _ -> MAlonzo.RTE.mazUnreachableError
+         MAlonzo.Code.Untyped.C__'183'__22 v9 v10
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C__'183'__22 v11 v12
+                MAlonzo.Code.VerifiedCompilation.Trace.C__'183'__34 v11 v12
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C__'183'__22 v13 v14
                          -> coe
                               MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                               (coe
-                                 d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v12))
-                                 (coe C__'183'__34 (coe v2) (coe v12)) (coe v9) (coe v4)
+                                 d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v10))
+                                 (coe C__'183'__34 (coe v2) (coe v10)) (coe v3) (coe v9)
                                  (coe C_keep_114 v5) (coe v11) (coe v13))
                               (coe
                                  (\ v15 ->
@@ -564,39 +554,36 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                       MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                                       (coe
                                          d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32)
-                                         (coe v10) (coe v4) (coe C_'9633'_106) (coe v12) (coe v14))
+                                         (coe v3) (coe v10) (coe C_'9633'_106) (coe v12) (coe v14))
                                       (coe
                                          (\ v16 ->
                                             coe
                                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
                                               (coe C__'183'__250 v15 v16)))))
                        _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C__'183''8595'_38 v9
-           -> case coe v6 of
-                MAlonzo.Code.Untyped.C__'183'__22 v10 v11
+                MAlonzo.Code.VerifiedCompilation.Trace.C__'183''8595'_36 v11
                   -> coe
                        MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                        (coe
-                          d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v11))
-                          (coe C__'183'__34 (coe v2) (coe v11)) (coe v9) (coe v4)
-                          (coe C_drop_122 v5) (coe v10) (coe v7))
+                          d_check_316 (coe v0) (coe C__'183'__34 (coe v1) (coe v10))
+                          (coe C__'183'__34 (coe v2) (coe v10)) (coe v3) (coe v9)
+                          (coe C_drop_122 v5) (coe v11) (coe v7))
                        (coe
                           (\ v12 ->
                              coe
                                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
                                (coe C__'183''8595'_254 v12)))
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_force_40 v9
+         MAlonzo.Code.Untyped.C_force_24 v9
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_force_24 v10
+                MAlonzo.Code.VerifiedCompilation.Trace.C_force_38 v10
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_force_24 v11
                          -> coe
                               MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                               (coe
-                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v9)
-                                 (coe v4) (coe C_'9633'_106) (coe v10) (coe v11))
+                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
+                                 (coe v9) (coe C_'9633'_106) (coe v10) (coe v11))
                               (coe
                                  (\ v12 ->
                                     coe
@@ -604,16 +591,16 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                       (coe C_force_258 v12)))
                        _ -> coe v8
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_delay_42 v9
+         MAlonzo.Code.Untyped.C_delay_26 v9
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_delay_26 v10
+                MAlonzo.Code.VerifiedCompilation.Trace.C_delay_40 v10
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_delay_26 v11
                          -> coe
                               MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
                               (coe
-                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v9)
-                                 (coe v4) (coe C_'9633'_106) (coe v10) (coe v11))
+                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
+                                 (coe v9) (coe C_'9633'_106) (coe v10) (coe v11))
                               (coe
                                  (\ v12 ->
                                     coe
@@ -621,9 +608,9 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                       (coe C_delay_262 v12)))
                        _ -> coe v8
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_con_44
+         MAlonzo.Code.Untyped.C_con_28 v9
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_con_28 v9
+                MAlonzo.Code.VerifiedCompilation.Trace.C_con_42
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_con_28 v10
                          -> let v11
@@ -644,13 +631,81 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
                                                   (coe
                                                      MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                  v6 v7)
+                                                  v4 v7)
                                  _ -> MAlonzo.RTE.mazUnreachableError)
                        _ -> coe v8
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_builtin_46
+         MAlonzo.Code.Untyped.C_constr_34 v9 v10
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_builtin_44 v9
+                MAlonzo.Code.VerifiedCompilation.Trace.C_constr_48 v11
+                  -> case coe v7 of
+                       MAlonzo.Code.Untyped.C_constr_34 v12 v13
+                         -> let v14
+                                  = coe
+                                      MAlonzo.Code.Relation.Nullary.Decidable.Core.du_map'8242'_178
+                                      erased
+                                      (\ v14 ->
+                                         coe
+                                           MAlonzo.Code.Data.Nat.Properties.du_'8801''8658''8801''7495'_2786
+                                           (coe v9))
+                                      (coe
+                                         MAlonzo.Code.Relation.Nullary.Decidable.Core.d_T'63'_72
+                                         (coe eqInt (coe v9) (coe v12))) in
+                            coe
+                              (case coe v14 of
+                                 MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32 v15 v16
+                                   -> if coe v15
+                                        then coe
+                                               seq (coe v16)
+                                               (coe
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                                  (coe
+                                                     d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
+                                                     (coe C_'9633'_32) (coe v11) (coe v3)
+                                                     (coe C_'9633'_106) (coe v10) (coe v13))
+                                                  (coe
+                                                     (\ v17 ->
+                                                        coe
+                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                                          (coe C_constr_280 v17))))
+                                        else coe
+                                               seq (coe v16)
+                                               (coe
+                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
+                                                  (coe
+                                                     MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
+                                                  v4 v7)
+                                 _ -> MAlonzo.RTE.mazUnreachableError)
+                       _ -> coe v8
+                _ -> coe v8
+         MAlonzo.Code.Untyped.C_case_40 v9 v10
+           -> case coe v6 of
+                MAlonzo.Code.VerifiedCompilation.Trace.C_case_50 v11 v12
+                  -> case coe v7 of
+                       MAlonzo.Code.Untyped.C_case_40 v13 v14
+                         -> coe
+                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                              (coe
+                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v3)
+                                 (coe v9) (coe C_'9633'_106) (coe v11) (coe v13))
+                              (coe
+                                 (\ v15 ->
+                                    coe
+                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
+                                      (coe
+                                         d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
+                                         (coe C_'9633'_32) (coe v12) (coe v3) (coe C_'9633'_106)
+                                         (coe v10) (coe v14))
+                                      (coe
+                                         (\ v16 ->
+                                            coe
+                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
+                                              (coe C_case_290 v15 v16)))))
+                       _ -> coe v8
+                _ -> coe v8
+         MAlonzo.Code.Untyped.C_builtin_44 v9
+           -> case coe v6 of
+                MAlonzo.Code.VerifiedCompilation.Trace.C_builtin_44
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_builtin_44 v10
                          -> let v11
@@ -703,7 +758,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
                                                                    (coe
                                                                       MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                                   v6 v7)
+                                                                   v4 v7)
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         else (let v14
                                                     = seq
@@ -728,87 +783,19 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
                                                                     (coe
                                                                        MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                                    v6 v7)
+                                                                    v4 v7)
                                                    _ -> MAlonzo.RTE.mazUnreachableError))
                                  _ -> MAlonzo.RTE.mazUnreachableError)
                        _ -> coe v8
                 _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_error_48
+         MAlonzo.Code.Untyped.C_error_46
            -> case coe v6 of
-                MAlonzo.Code.Untyped.C_error_46
+                MAlonzo.Code.VerifiedCompilation.Trace.C_error_46
                   -> case coe v7 of
                        MAlonzo.Code.Untyped.C_error_46
                          -> coe
                               MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
                               (coe C_error_292)
-                       _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_constr_50 v9
-           -> case coe v6 of
-                MAlonzo.Code.Untyped.C_constr_34 v10 v11
-                  -> case coe v7 of
-                       MAlonzo.Code.Untyped.C_constr_34 v12 v13
-                         -> let v14
-                                  = coe
-                                      MAlonzo.Code.Relation.Nullary.Decidable.Core.du_map'8242'_178
-                                      erased
-                                      (\ v14 ->
-                                         coe
-                                           MAlonzo.Code.Data.Nat.Properties.du_'8801''8658''8801''7495'_2786
-                                           (coe v10))
-                                      (coe
-                                         MAlonzo.Code.Relation.Nullary.Decidable.Core.d_T'63'_72
-                                         (coe eqInt (coe v10) (coe v12))) in
-                            coe
-                              (case coe v14 of
-                                 MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32 v15 v16
-                                   -> if coe v15
-                                        then coe
-                                               seq (coe v16)
-                                               (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
-                                                  (coe
-                                                     d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
-                                                     (coe C_'9633'_32) (coe v9) (coe v4)
-                                                     (coe C_'9633'_106) (coe v11) (coe v13))
-                                                  (coe
-                                                     (\ v17 ->
-                                                        coe
-                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
-                                                          (coe C_constr_280 v17))))
-                                        else coe
-                                               seq (coe v16)
-                                               (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                  (coe
-                                                     MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_16)
-                                                  v6 v7)
-                                 _ -> MAlonzo.RTE.mazUnreachableError)
-                       _ -> coe v8
-                _ -> coe v8
-         MAlonzo.Code.VerifiedCompilation.Trace.C_case_52 v9 v10
-           -> case coe v6 of
-                MAlonzo.Code.Untyped.C_case_40 v11 v12
-                  -> case coe v7 of
-                       MAlonzo.Code.Untyped.C_case_40 v13 v14
-                         -> coe
-                              MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
-                              (coe
-                                 d_check_316 (coe v0) (coe C_'9633'_32) (coe C_'9633'_32) (coe v9)
-                                 (coe v4) (coe C_'9633'_106) (coe v11) (coe v13))
-                              (coe
-                                 (\ v15 ->
-                                    coe
-                                      MAlonzo.Code.VerifiedCompilation.Certificate.du__'62''62''61'__88
-                                      (coe
-                                         d_checkPointwise_304 (coe v0) (coe C_'9633'_32)
-                                         (coe C_'9633'_32) (coe v10) (coe v4) (coe C_'9633'_106)
-                                         (coe v12) (coe v14))
-                                      (coe
-                                         (\ v16 ->
-                                            coe
-                                              MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_72
-                                              (coe C_case_290 v15 v16)))))
                        _ -> coe v8
                 _ -> coe v8
          _ -> MAlonzo.RTE.mazUnreachableError)
@@ -821,7 +808,7 @@ d_top'45'check_718 ::
 d_top'45'check_718 v0 v1 v2
   = coe
       d_check_316 (coe (0 :: Integer)) (coe C_'9633'_32)
-      (coe C_'9633'_32) (coe v0) erased (coe C_'9633'_106) (coe v1)
+      (coe C_'9633'_32) erased (coe v1) (coe C_'9633'_106) (coe v0)
       (coe v2)
 -- VerifiedCompilation.UInline.reflexiveᴬ
 d_reflexive'7468'_732 ::
@@ -999,37 +986,26 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                            C_drop_122 v23
                              -> case coe v5 of
                                   MAlonzo.Code.Untyped.C_ƛ_20 v24
-                                    -> let v25
-                                             = d_complete_806
-                                                 (coe addInt (coe (1 :: Integer)) (coe v0))
-                                                 (coe d__'8593''7611'_40 (coe v0) (coe v16))
-                                                 (coe d__'8593''7611'_40 (coe v0) (coe v18))
-                                                 (coe
-                                                    MAlonzo.Code.Untyped.RenamingSubstitution.du_extend_454
-                                                    (coe
-                                                       MAlonzo.Code.Untyped.RenamingSubstitution.du__'8593''738'_470
-                                                       (coe v0) (coe v3))
-                                                    (coe
-                                                       MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
-                                                       (coe v0) (coe v17)))
-                                                 (coe
-                                                    du__'8593''7611''7611'_126 (coe v16) (coe v18)
-                                                    (coe v23))
-                                                 (coe v24)
-                                                 (coe
-                                                    MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
-                                                    (coe v0) (coe v6))
-                                                 (coe v15) in
-                                       coe
-                                         (case coe v25 of
-                                            MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 v26 v27
-                                              -> coe
-                                                   MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
-                                                   (coe
-                                                      MAlonzo.Code.VerifiedCompilation.Trace.C_ƛ'8595'_34
-                                                      (coe v26))
-                                                   erased
-                                            _ -> MAlonzo.RTE.mazUnreachableError)
+                                    -> coe
+                                         d_complete_806 (coe addInt (coe (1 :: Integer)) (coe v0))
+                                         (coe d__'8593''7611'_40 (coe v0) (coe v16))
+                                         (coe d__'8593''7611'_40 (coe v0) (coe v18))
+                                         (coe
+                                            MAlonzo.Code.Untyped.RenamingSubstitution.du_extend_454
+                                            (coe
+                                               MAlonzo.Code.Untyped.RenamingSubstitution.du__'8593''738'_470
+                                               (coe v0) (coe v3))
+                                            (coe
+                                               MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                               (coe v0) (coe v17)))
+                                         (coe
+                                            du__'8593''7611''7611'_126 (coe v16) (coe v18)
+                                            (coe v23))
+                                         (coe v24)
+                                         (coe
+                                            MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                            (coe v0) (coe v6))
+                                         (coe v15)
                                   _ -> MAlonzo.RTE.mazUnreachableError
                            _ -> MAlonzo.RTE.mazUnreachableError
                     _ -> MAlonzo.RTE.mazUnreachableError
@@ -1057,7 +1033,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                                           -> coe
                                                MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Trace.C__'183'__36
+                                                  MAlonzo.Code.VerifiedCompilation.Trace.C__'183'__34
                                                   (coe v24) (coe v26))
                                                erased
                                         _ -> MAlonzo.RTE.mazUnreachableError
@@ -1078,7 +1054,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                          -> coe
                               MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                               (coe
-                                 MAlonzo.Code.VerifiedCompilation.Trace.C__'183''8595'_38 (coe v19))
+                                 MAlonzo.Code.VerifiedCompilation.Trace.C__'183''8595'_36 (coe v19))
                               erased
                        _ -> MAlonzo.RTE.mazUnreachableError)
              _ -> MAlonzo.RTE.mazUnreachableError
@@ -1097,7 +1073,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                                 -> coe
                                      MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                      (coe
-                                        MAlonzo.Code.VerifiedCompilation.Trace.C_force_40 (coe v18))
+                                        MAlonzo.Code.VerifiedCompilation.Trace.C_force_38 (coe v18))
                                      erased
                               _ -> MAlonzo.RTE.mazUnreachableError)
                     _ -> MAlonzo.RTE.mazUnreachableError
@@ -1117,7 +1093,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                                 -> coe
                                      MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                      (coe
-                                        MAlonzo.Code.VerifiedCompilation.Trace.C_delay_42 (coe v18))
+                                        MAlonzo.Code.VerifiedCompilation.Trace.C_delay_40 (coe v18))
                                      erased
                               _ -> MAlonzo.RTE.mazUnreachableError)
                     _ -> MAlonzo.RTE.mazUnreachableError
@@ -1125,11 +1101,11 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
       C_con_266
         -> coe
              MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
-             (coe MAlonzo.Code.VerifiedCompilation.Trace.C_con_44) erased
+             (coe MAlonzo.Code.VerifiedCompilation.Trace.C_con_42) erased
       C_builtin_270
         -> coe
              MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
-             (coe MAlonzo.Code.VerifiedCompilation.Trace.C_builtin_46) erased
+             (coe MAlonzo.Code.VerifiedCompilation.Trace.C_builtin_44) erased
       C_constr_280 v15
         -> case coe v5 of
              MAlonzo.Code.Untyped.C_constr_34 v16 v17
@@ -1145,7 +1121,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                                 -> coe
                                      MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                      (coe
-                                        MAlonzo.Code.VerifiedCompilation.Trace.C_constr_50
+                                        MAlonzo.Code.VerifiedCompilation.Trace.C_constr_48
                                         (coe v21))
                                      erased
                               _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1173,7 +1149,7 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                                           -> coe
                                                MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                (coe
-                                                  MAlonzo.Code.VerifiedCompilation.Trace.C_case_52
+                                                  MAlonzo.Code.VerifiedCompilation.Trace.C_case_50
                                                   (coe v24) (coe v26))
                                                erased
                                         _ -> MAlonzo.RTE.mazUnreachableError
@@ -1187,35 +1163,19 @@ d_complete_806 v0 v1 v2 v3 v4 v5 v6 v7
                 seq (coe v6)
                 (coe
                    MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
-                   (coe MAlonzo.Code.VerifiedCompilation.Trace.C_error_48) erased))
+                   (coe MAlonzo.Code.VerifiedCompilation.Trace.C_error_46) erased))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.UInline._.e′
-d_e'8242'_844 ::
-  Integer ->
-  T__'8605'_28 ->
-  T__'8605'_28 ->
-  (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
-   MAlonzo.Code.Untyped.T__'8866'_14) ->
-  T__'8829'__102 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  T_Inline_224 ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
-  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
-  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_844 = erased
--- VerifiedCompilation.UInline._.e′
-d_e'8242'_860 ::
+d_e'8242'_818 ::
   Integer ->
   T__'8605'_28 ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
   MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_860 = erased
+d_e'8242'_818 = erased
 -- VerifiedCompilation.UInline._.e′
-d_e'8242'_906 ::
+d_e'8242'_864 ::
   Integer ->
   T__'8605'_28 ->
   T__'8605'_28 ->
@@ -1228,12 +1188,28 @@ d_e'8242'_906 ::
   MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_906 = erased
+d_e'8242'_864 = erased
+-- VerifiedCompilation.UInline._.e′
+d_e'8242'_898 ::
+  Integer ->
+  (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
+   MAlonzo.Code.Untyped.T__'8866'_14) ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T_Inline_224 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
+  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
+  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
+d_e'8242'_898 = erased
 -- VerifiedCompilation.UInline._.e′
 d_e'8242'_940 ::
   Integer ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
+  T__'8605'_28 ->
+  T__'8605'_28 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T__'8829'__102 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   T_Inline_224 ->
@@ -1278,21 +1254,23 @@ d_e'8243'_1036 ::
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
 d_e'8243'_1036 = erased
 -- VerifiedCompilation.UInline._.e′
-d_e'8242'_1078 ::
+d_e'8242'_1082 ::
   Integer ->
+  T__'8605'_28 ->
+  T__'8605'_28 ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
+  T__'8829'__102 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   T_Inline_224 ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
-  T__'8605'_28 ->
-  T__'8605'_28 ->
-  T__'8829'__102 -> MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_1078 = erased
+  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
+d_e'8242'_1082 = erased
 -- VerifiedCompilation.UInline._.e′
-d_e'8242'_1116 ::
+d_e'8242'_1120 ::
   Integer ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
@@ -1304,9 +1282,23 @@ d_e'8242'_1116 ::
   T__'8605'_28 ->
   T__'8605'_28 ->
   T__'8829'__102 -> MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_1116 = erased
+d_e'8242'_1120 = erased
+-- VerifiedCompilation.UInline._.e′
+d_e'8242'_1158 ::
+  Integer ->
+  (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
+   MAlonzo.Code.Untyped.T__'8866'_14) ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T_Inline_224 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
+  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
+  T__'8605'_28 ->
+  T__'8605'_28 ->
+  T__'8829'__102 -> MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
+d_e'8242'_1158 = erased
 -- VerifiedCompilation.UInline._.e
-d_e_1132 ::
+d_e_1174 ::
   Integer ->
   T__'8605'_28 ->
   T__'8605'_28 ->
@@ -1315,9 +1307,9 @@ d_e_1132 ::
   T__'8829'__102 ->
   MAlonzo.Code.RawU.T_TmCon_202 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e_1132 = erased
+d_e_1174 = erased
 -- VerifiedCompilation.UInline._.e
-d_e_1148 ::
+d_e_1190 ::
   Integer ->
   T__'8605'_28 ->
   T__'8605'_28 ->
@@ -1326,9 +1318,9 @@ d_e_1148 ::
   T__'8829'__102 ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e_1148 = erased
+d_e_1190 = erased
 -- VerifiedCompilation.UInline._.e′
-d_e'8242'_1190 ::
+d_e'8242'_1232 ::
   Integer ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
@@ -1341,9 +1333,9 @@ d_e'8242'_1190 ::
   T__'8605'_28 ->
   T__'8829'__102 ->
   Integer -> MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_1190 = erased
+d_e'8242'_1232 = erased
 -- VerifiedCompilation.UInline._.e″
-d_e'8243'_1248 ::
+d_e'8243'_1290 ::
   Integer ->
   (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
    MAlonzo.Code.Untyped.T__'8866'_14) ->
@@ -1360,23 +1352,7 @@ d_e'8243'_1248 ::
   T__'8605'_28 ->
   T__'8605'_28 ->
   T__'8829'__102 -> MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8243'_1248 = erased
--- VerifiedCompilation.UInline._.e′
-d_e'8242'_1298 ::
-  Integer ->
-  (MAlonzo.Code.Data.Fin.Base.T_Fin_10 ->
-   MAlonzo.Code.Untyped.T__'8866'_14) ->
-  T__'8605'_28 ->
-  T__'8605'_28 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  T__'8829'__102 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  T_Inline_224 ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_InlineHints_26 ->
-  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
-  MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
-d_e'8242'_1298 = erased
+d_e'8243'_1290 = erased
 -- VerifiedCompilation.UInline._.e″
 d_e'8243'_1356 ::
   Integer ->

--- a/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
@@ -46,7 +46,6 @@ data InlineHints : Set where
   var     : InlineHints
   expand  : InlineHints → InlineHints
   ƛ       : InlineHints → InlineHints
-  ƛ↓      : InlineHints → InlineHints
   _·_     : InlineHints → InlineHints → InlineHints
   _·↓     : InlineHints → InlineHints
   force   : InlineHints → InlineHints
@@ -63,7 +62,7 @@ data Hints : Set where
 
 {-# FOREIGN GHC import UntypedPlutusCore.Transform.Certify.Trace #-}
 {-# FOREIGN GHC import qualified UntypedPlutusCore.Transform.Certify.Hints as Hints #-}
-{-# COMPILE GHC InlineHints = data Hints.Inline (Hints.InlVar | Hints.InlExpand | Hints.InlLam | Hints.InlLamDrop | Hints.InlApply | Hints.InlDrop | Hints.InlForce | Hints.InlDelay | Hints.InlCon | Hints.InlBuiltin | Hints.InlError | Hints.InlConstr | Hints.InlCase) #-}
+{-# COMPILE GHC InlineHints = data Hints.Inline (Hints.InlVar | Hints.InlExpand | Hints.InlLam | Hints.InlApply | Hints.InlDrop | Hints.InlForce | Hints.InlDelay | Hints.InlCon | Hints.InlBuiltin | Hints.InlError | Hints.InlConstr | Hints.InlCase) #-}
 {-# COMPILE GHC Hints = data Hints.Hints (Hints.Inline | Hints.NoHints) #-}
 ```
 

--- a/plutus-metatheory/src/VerifiedCompilation/UInline.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/UInline.lagda.md
@@ -36,7 +36,7 @@ open import Untyped.RenamingSubstitution using (weaken)
 open import Data.Empty using (⊥)
 import Relation.Binary.PropositionalEquality as Eq
 open Eq using (_≡_; refl)
-open import VerifiedCompilation.Certificate using (Proof?; _>>=_; InlineHints; var; expand; ƛ; ƛ↓; _·_; _·↓; force; delay; con; builtin; error; constr; case; abort; proof; inlineT)
+open import VerifiedCompilation.Certificate using (Proof?; _>>=_; InlineHints; var; expand; ƛ; _·_; _·↓; force; delay; con; builtin; error; constr; case; abort; proof; inlineT)
 ```
 
 # Zippers, and relating two zippers
@@ -209,81 +209,82 @@ checkPointwise :
         (Ms M′s : List (X ⊢))
         → Proof? (Pointwise (Inline σ zz) Ms M′s)
 
-check : (h : InlineHints)
-        (σ : Sub X X)
+check : (σ : Sub X X)
+        (M : X ⊢)
         (zz : z ≽ z′)
-        (M M′ : X ⊢)
+        (h : InlineHints)
+        (M′ : X ⊢)
         → Proof? (Inline σ zz M M′)
-check {z = z} {z′ = z′} var σ zz M@(` x) M′@(` x′)
+check {z = z} {z′ = z′} σ M@(` x) zz var M′@(` x′)
   with x Fin.≟ x′ | z ≟ᶻ z′
 ... | yes refl | yes refl
     with zz ≟ᶻᶻ idᶻᶻ z
 ...   | just refl = proof (` x)
 ...   | nothing = abort inlineT M M′
-check var σ zz M@(` x) M′@(` x′)
+check σ M@(` x) zz var M′@(` x′)
     | _ | _ = abort inlineT M M′
 
-check (expand h) σ zz (` x) M′ =
-   do r ← check h σ zz (σ x) M′
+check σ (` x) zz (expand h) M′ =
+   do r ← check σ (σ x) zz h M′
       proof (`↓ r)
 
-check (ƛ h) σ □ (ƛ N) (ƛ N′) =
-   do t ← check h (lifts σ) □ N N′
+check σ (ƛ N) □ (ƛ h) (ƛ N′) =
+   do t ← check (lifts σ) N □ h N′
       proof (ƛ□ t)
 
-check (ƛ h) σ (keep M zz) (ƛ N) (ƛ N′)  =
-   do t ← check h (extend (σ ↑ˢ) (weaken M)) (zz ↑ᶻᶻ) N N′
+check σ (ƛ N) (keep M zz) (ƛ h) (ƛ N′)  =
+   do t ← check (extend (σ ↑ˢ) (weaken M)) N (zz ↑ᶻᶻ) h N′
       proof (ƛ t)
 
-check (ƛ↓ h) σ (drop M zz) (ƛ N) N′ =
-   do t ← check h (extend (σ ↑ˢ) (weaken M)) (zz ↑ᶻᶻ) N (weaken N′)
+check σ (ƛ N) (drop M zz) h N′ =
+   do t ← check (extend (σ ↑ˢ) (weaken M)) N (zz ↑ᶻᶻ) h (weaken N′)
       proof (ƛ↓ t)
 
-check (h · h′) σ zz (L · M) (L′ · M′) =
-   do r ← check h σ (keep M zz) L L′
-      s ← check h′ σ □ M M′
+check σ (L · M) zz (h · h′) (L′ · M′) =
+   do r ← check σ L (keep M zz) h L′
+      s ← check σ M □ h′ M′
       proof (r · s)
 
-check (h ·↓) σ zz (L · M) N′ =
-   do r ← check h σ (drop M zz) L N′
+check σ (L · M) zz (h ·↓) N′ =
+   do r ← check σ L (drop M zz) h N′
       proof (r ·↓)
 
-check (force h) σ zz (force M) (force M′) =
-   do r ← check h σ □ M M′
+check σ (force M) zz (force h) (force M′) =
+   do r ← check σ M □ h M′
       proof (force r)
 
-check (delay h) σ zz (delay M) (delay M′) =
-   do r ← check h σ □ M M′
+check σ (delay M) zz (delay h) (delay M′) =
+   do r ← check σ M □ h M′
       proof (delay r)
 
-check con σ zz M@(con c) M′@(con c′)
+check σ M@(con c) zz con M′@(con c′)
   with c ≟ c′
 ... | yes refl = proof con
 ... | no  _ = abort inlineT M M′
 
-check builtin σ zz M@(builtin b) M′@(builtin b′)
+check σ M@(builtin b) zz builtin M′@(builtin b′)
   with b ≟ b′
 ... | yes refl = proof builtin
 ... | no  _ = abort inlineT M M′
 
-check (constr hs) σ zz M@(constr i Ms) M′@(constr i′ M′s) with i ≟ i′
+check σ M@(constr i Ms) zz (constr hs) M′@(constr i′ M′s) with i ≟ i′
 ... | yes refl =
    do rs ← checkPointwise hs σ □ Ms M′s
       proof (constr rs)
 ... | no _ = abort inlineT M M′
 
-check (case h hs) σ zz (case M Ms) (case M′ M′s) =
-  do r ← check h σ □ M M′
+check σ (case M Ms) zz (case h hs) (case M′ M′s) =
+  do r ← check σ M □ h M′
      rs ← checkPointwise hs σ □ Ms M′s
      proof (case r rs)
 
-check error σ zz error error = proof error
+check σ error zz error error = proof error
 
-check h σ zz M M′ = abort inlineT M M′
+check σ M zz h M′ = abort inlineT M M′
 
 checkPointwise [] σ zz [] [] = proof Pointwise.[]
 checkPointwise (h ∷ hs) σ zz (M ∷ Ms) (M′ ∷ M′s) =
-   do p ← check h σ zz M M′
+   do p ← check σ M zz h M′
       ps ← checkPointwise hs σ zz Ms M′s
       proof (p Pointwise.∷ ps)
 checkPointwise _ _ _ Ms M′s = abort inlineT Ms M′s
@@ -293,7 +294,7 @@ checkPointwise _ _ _ Ms M′s = abort inlineT Ms M′s
 ```
 top-check : (h : InlineHints) (M M′ : 0 ⊢)
             → Proof? (Inline (λ()) □ M M′)
-top-check h M M′ = check h (λ()) □ M M′
+top-check h M M′ = check (λ()) M □ h M′
 ```
 
 # Lemmas
@@ -324,80 +325,80 @@ complete :
   (zz : z ≽ z′)
   (M M′ : X ⊢)
   (s : Inline σ zz M M′)
-  → ∃[ h ] (check h σ zz M M′ ≡ proof s)
-complete σ zz (L · M) N′ (r ·↓)
-  with complete σ (drop M zz) L N′ r
-... | (h , e) = (h ·↓ , e′)
-  where
-  e′ : check (h ·↓) σ zz (L · M) N′ ≡ proof (r ·↓)
-  e′ rewrite e = refl
+  → ∃[ h ] (check σ M zz h M′ ≡ proof s)
 complete {z = z} σ .(idᶻᶻ z) .(` x) .(` x) (` x) = (var , e′)
   where
-  e′ : check var σ (idᶻᶻ z) (` x) (` x) ≡ proof (` x)
+  e′ : check σ (` x) (idᶻᶻ z) var (` x) ≡ proof (` x)
   e′ rewrite reflexiveᴬ Fin._≟_ x | reflexiveᴬ _≟ᶻ_ z | reflexiveᶻᶻ (idᶻᶻ z) = refl
 complete σ zz (` x) M′ (`↓ s)
   with complete σ zz (σ x) M′ s
 ... | (h , e) = (expand h , e′)
   where
-  e′ : check (expand h) σ zz (` x) M′ ≡ proof (`↓ s)
+  e′ : check σ (` x) zz (expand h) M′ ≡ proof (`↓ s)
   e′ rewrite e = refl
 complete σ □ (ƛ N) (ƛ N′) (ƛ□ t)
   with complete (lifts σ) □ N N′ t
 ... | (h , e) = (ƛ h , e′)
   where
-  e′ : check (ƛ h) σ □ (ƛ N) (ƛ N′) ≡ proof (ƛ□ t)
+  e′ : check σ (ƛ N) □ (ƛ h) (ƛ N′) ≡ proof (ƛ□ t)
   e′ rewrite e = refl
 complete σ (keep M zz) (ƛ N) (ƛ N′) (ƛ t)
   with complete (extend (σ ↑ˢ) (weaken M)) (zz ↑ᶻᶻ) N N′ t
 ... | (h , e) = (ƛ h , e′)
   where
-  e′ : check (ƛ h) σ (keep M zz) (ƛ N) (ƛ N′) ≡ proof (ƛ t)
+  e′ : check σ (ƛ N) (keep M zz) (ƛ h) (ƛ N′) ≡ proof (ƛ t)
+  e′ rewrite e = refl
+complete σ (drop M zz) (ƛ N) N′ (ƛ↓ t)
+  with complete (extend (σ ↑ˢ) (weaken M)) (zz ↑ᶻᶻ) N (weaken N′) t
+... | (h , e) = (h , e′)
+  where
+  e′ : check σ (ƛ N) (drop M zz) h N′ ≡ proof (ƛ↓ t)
   e′ rewrite e = refl
 complete σ zz (L · M) (L′ · M′) (r · s)
   with complete σ (keep M zz) L L′ r | complete σ □ M M′ s
 ... | (h , e) | (h′ , e′) = (h · h′ , e″)
   where
-  e″ : check (h · h′) σ zz (L · M) (L′ · M′) ≡ proof (r · s)
+  e″ : check σ (L · M) zz (h · h′) (L′ · M′) ≡ proof (r · s)
   e″ rewrite e | e′ = refl
+complete σ zz (L · M) N′ (r ·↓)
+  with complete σ (drop M zz) L N′ r
+... | (h , e) = (h ·↓ , e′)
+  where
+  e′ : check σ (L · M) zz (h ·↓) N′ ≡ proof (r ·↓)
+  e′ rewrite e = refl
 complete σ zz (force M) (force M′) (force r)
   with complete σ □ M M′ r
 ... | (h , e) = (force h , e′)
   where
-  e′ : check (force h) σ zz (force M) (force M′) ≡ proof (force r)
+  e′ : check σ (force M) zz (force h) (force M′) ≡ proof (force r)
   e′ rewrite e = refl
 complete σ zz (delay M) (delay M′) (delay r)
   with complete σ □ M M′ r
 ... | (h , e) = (delay h , e′)
   where
-  e′ : check (delay h) σ zz (delay M) (delay M′) ≡ proof (delay r)
+  e′ : check σ (delay M) zz (delay h) (delay M′) ≡ proof (delay r)
   e′ rewrite e = refl
 complete σ zz (con c) .(con c) con = (con , e)
   where
-  e : check con σ zz (con c) (con c) ≡ proof con
+  e : check σ (con c) zz con (con c) ≡ proof con
   e rewrite reflexiveᴬ _≟_ c = refl
 complete σ zz (builtin b) .(builtin b) builtin = (builtin , e)
   where
-  e : check builtin σ zz (builtin b) (builtin b) ≡ proof builtin
+  e : check σ (builtin b) zz builtin (builtin b) ≡ proof builtin
   e rewrite reflexiveᴬ _≟_ b = refl
 complete σ zz (constr i Ms) (constr .i M′s) (constr rs)
   with completePointwise σ □ Ms M′s rs
 ... | (hs , e) = (constr hs , e′)
   where
-  e′ : check (constr hs) σ zz (constr i Ms) (constr i M′s) ≡ proof (constr rs)
+  e′ : check σ (constr i Ms) zz (constr hs) (constr i M′s) ≡ proof (constr rs)
   e′ rewrite reflexiveᴬ _≟_ i | e = refl
 complete σ zz (case M Ms) (case M′ M′s) (case r rs)
   with complete σ □ M M′ r | completePointwise σ □ Ms M′s rs
 ... | (h , e) | (hs , e′) = (case h hs , e″)
   where
-  e″ : check (case h hs) σ zz (case M Ms) (case M′ M′s) ≡ proof (case r rs)
+  e″ : check σ (case M Ms) zz (case h hs) (case M′ M′s) ≡ proof (case r rs)
   e″ rewrite e | e′ = refl
 complete σ zz error error error = (error , refl)
-complete σ (drop M zz) (ƛ N) N′ (ƛ↓ t)
-  with complete (extend (σ ↑ˢ) (weaken M)) (zz ↑ᶻᶻ) N (weaken N′) t
-... | (h , e) = (ƛ↓ h , e′)
-  where
-  e′ : check (ƛ↓ h) σ (drop M zz) (ƛ N) N′ ≡ proof (ƛ↓ t)
-  e′ rewrite e = refl
 
 completePointwise σ zz [] [] Pointwise.[] = ([] , refl)
 completePointwise σ zz (M ∷ Ms) (M′ ∷ M′s) (p Pointwise.∷ ps)

--- a/plutus-metatheory/src/VerifiedCompilation/UInline.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/UInline.lagda.md
@@ -201,6 +201,19 @@ data Inline {X : ℕ} :
 
 # Check aided by hints
 
+The order of `check`'s arguments is important to ensure the completeness proof works.
+In particular:
+
+- `M` must be before `h` for `check σ (ƛ N) (drop M zz) h N′` to be reducible.
+  Splitting on `h` before `M` would cause reduction of this term to be stuck, since
+  it doesn't match on `h`.
+- `M` must be before `zz` for `check σ (L · M) zz (h ·↓) N′` to be reducible.
+  Splitting on `zz` before `M` would cause reduction of this term to be stuck, since
+  it doesn't match on `zz`.
+
+The position of `σ` doesn't matter since no clause matches on it.
+
+
 ```
 checkPointwise :
         (hs : List InlineHints)


### PR DESCRIPTION
This allows removing the `ƛ↓` constructor of `InlineHints`, simplifying inliner implementation. To do so, the case tree of `check` must first split on the pre-term, then `zz`, hints, and post-term. So `check`'s arguments should be in this order.