### PR TITLE
Certifier: fix printing of negative integer literals

### DIFF
--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -88,7 +88,7 @@ instance AgdaUnparse Natural where
 
 instance AgdaUnparse Integer where
   agdaUnparse x
-    | x < 0 = "(ℤ.negsuc " ++ show (x - 1) ++ ")"
+    | x < 0 = "(ℤ.negsuc " ++ show (abs x - 1) ++ ")"
     | otherwise = "(ℤ.pos " ++ show x ++ ")"
 
 instance AgdaUnparse Bool where


### PR DESCRIPTION
Negative integers were incorrectly printed, which makes agda fail when type checking certificates of Marlowe and NQueens.

Agda implementation of integers: (https://github.com/agda/agda/blob/master/src/data/lib/prim/Agda/Builtin/Int.agda)
```agda
data Int : Set where
  pos    : (n : Nat) → Int
  negsuc : (n : Nat) → Int
```