### PR TITLE
fix(bench): prevent ValueData benchmark crash

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Values.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Values.hs
@@ -281,9 +281,7 @@ unValueDataBenchmark gen =
     DataNodeCount
     UnValueData
     []
-    ((unsafeFromBuiltinResult . Value.valueData) <$> generateTestValues gen)
-
--- FIXME: account properly for out-of-range errors when test values are too big.
+    (unsafeFromBuiltinResult . Value.valueData <$> generateTestValues gen)
 
 ----------------------------------------------------------------------------------------------------
 -- InsertCoin --------------------------------------------------------------------------------------
@@ -390,11 +388,9 @@ buildValue policyIds tokenNames amt =
       | pId <- policyIds
       ]
 
--- Number of benchmarking inputs for `valueData` and `unValueData`.
-maxValueEntries :: Int
-maxValueEntries = 50_000
-
--- | Test values for benchmarking `valueData` and `unValueData`
+{-| Test values for benchmarking `valueData` and `unValueData`.
+The upper bound on the number of entries is tied to `Value.valueDataMaxSize`
+so that every generated `Value` is a valid input to `valueData`. -}
 generateTestValues :: StdGen -> [Value]
 generateTestValues gen = runStateGen_ gen \g ->
   -- Empty value as edge case
@@ -403,13 +399,14 @@ generateTestValues gen = runStateGen_ gen \g ->
     -- Random tests for parameter spread (100 combinations)
     replicateM 100 (generateValue g)
   where
-    -- \| Generate Value with random number of entries between 1 and maxValueEntries
+    -- Generate Value with random number of entries between 1 and
+    -- `Value.valueDataMaxSize`.
     generateValue :: StatefulGen g m => g -> m Value
     generateValue g = do
-      numEntries <- uniformRM (1, maxValueEntries) g
+      numEntries <- uniformRM (1, Value.valueDataMaxSize) g
       generateValueMaxEntries numEntries g
 
-    -- \| Generate Value within total size budget
+    -- Generate Value within total size budget
     generateValueMaxEntries :: StatefulGen g m => Int -> g -> m Value
     generateValueMaxEntries maxEntries g = do
       -- Uniform random distribution: cover full range from many policies (few tokens each)

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -69,6 +69,7 @@ common lang
     FlexibleContexts
     GeneralizedNewtypeDeriving
     ImportQualifiedPost
+    NumericUnderscores
     ScopedTypeVariables
     StandaloneDeriving
 

--- a/plutus-core/plutus-core/src/PlutusCore/Value.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Value.hs
@@ -34,6 +34,7 @@ module PlutusCore.Value
   , valueContains
   , unionValue
   , valueData
+  , valueDataMaxSize
   , unValueData
   ) where
 
@@ -449,7 +450,7 @@ unionValue vA vB
 {-# INLINEABLE unionValue #-}
 
 valueDataMaxSize :: Int
-valueDataMaxSize = 40000
+valueDataMaxSize = 40_000
 
 {-| \(O(n)\). Encodes `Value` as `Data`, in the same way as non-builtin @Value@.
 This is the denotation of @ValueData@ in Plutus V1, V2 and V3. -}


### PR DESCRIPTION
Closes https://github.com/IntersectMBO/plutus-private/issues/2161

- [x] Exported `valueDataMaxSize` from `PlutusCore.Value`.
- [x] Bound `generateTestValues` to `Value.valueDataMaxSize` (replaces the local `maxValueEntries = 50_000`), so every generated `Value` satisfies `totalSize v <= valueDataMaxSize` by construction.
- [x] Removed the now-obsolete `-- FIXME: ...` comment in `Benchmarks/Values.hs`.
- [x] Enabled `NumericUnderscores` in `plutus-core`'s shared `default-extensions` and rewrote `valueDataMaxSize = 40000` as `40_000`.
