### PR TITLE
Enable `NoFieldSelectors` in `PlutusCore.Check.Scoping`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs
@@ -2,12 +2,10 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
-
--- TODO: add @NoFieldSelectors@ once we are past antiquity, so that 'ScopeError' doesn't generate
--- partial field selectors.
 
 module PlutusCore.Check.Scoping where
 


### PR DESCRIPTION
## Summary

- Addresses the TODO in [`Scoping.hs`](plutus-core/plutus-core/src/PlutusCore/Check/Scoping.hs) asking for `NoFieldSelectors` once the project moved past GHC 8.x.
- The project now builds on GHC 9.6 and 9.12 (both support the pragma, introduced in GHC 9.2), so enable `{-# LANGUAGE NoFieldSelectors #-}` and drop the TODO comment.
- `ScopeError` uses record syntax across several constructors; the resulting partial field selectors are no longer generated. A grep across the repo confirms none of those selectors (`_oldName`, `_newName`, `_duplicateBindersLeft`, `_disappearedBindings`, etc.) are used outside the definition site.

## Test plan

- [ ] `cabal build plutus-core` succeeds.