### PR TITLE
Add CaseReduce to the unimplemented-in-the-certifier category

### DIFF
--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Certify/Trace.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/Transform/Certify/Trace.hs
@@ -20,7 +20,6 @@ data CertifiedOptStage
   = FloatDelay
   | ForceDelay
   | ForceCaseDelay
-  | CaseReduce
   | Inline
   | CSE
   | ApplyToCase
@@ -37,6 +36,7 @@ at https://github.com/IntersectMBO/plutus/issues. -}
 data UncertifiedOptStage
   = CaseOfCase
   | LetFloatOut
+  | CaseReduce
   deriving stock (Show, Generic)
   deriving anyclass (NFData)
 
@@ -52,7 +52,7 @@ pattern ForceCaseDelayStage :: OptStage
 pattern ForceCaseDelayStage = Right ForceCaseDelay
 
 pattern CaseReduceStage :: OptStage
-pattern CaseReduceStage = Right CaseReduce
+pattern CaseReduceStage = Left CaseReduce
 
 pattern InlineStage :: OptStage
 pattern InlineStage = Right Inline

--- a/plutus-core/untyped-plutus-core/test/Transform/basic.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/basic.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/basicInline.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/basicInline.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/callsiteInline.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/callsiteInline.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/extraDelays.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/extraDelays.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/floatDelay1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/floatDelay1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/floatDelay2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/floatDelay2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/floatDelay3.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/floatDelay3.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps2Fail.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayNoApps2Fail.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps2Fail.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceCaseDelayWithApps2Fail.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayComplex.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayComplex.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiApply.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiApply.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiForce.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayMultiForce.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayNoApps.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayNoApps.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelayNoAppsLayered.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelayNoAppsLayered.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/forceDelaySimple.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/forceDelaySimple.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlineImpure1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlineImpure1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlineImpure2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlineImpure2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlineImpure3.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlineImpure3.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlineImpure4.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlineImpure4.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure3.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure3.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/inlinePure4.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/inlinePure4.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/interveningLambda.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/interveningLambda.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase1.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase1.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase2.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutCase2.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/letFloatOutForce.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/letFloatOutForce.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/multiApp.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/multiApp.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-core/untyped-plutus-core/test/Transform/nested.golden.certifier-hints
+++ b/plutus-core/untyped-plutus-core/test/Transform/nested.golden.certifier-hints
@@ -13,7 +13,7 @@ NoHints
 -- Certifier hints #5 (Left CaseOfCase) --
 NoHints
 
--- Certifier hints #6 (Right CaseReduce) --
+-- Certifier hints #6 (Left CaseReduce) --
 NoHints
 
 -- Certifier hints #7 (Right Inline) --

--- a/plutus-metatheory/changelog.d/20260420_202400_ana.pantilie95_move_casereduce_to_unimplementedcert.md
+++ b/plutus-metatheory/changelog.d/20260420_202400_ana.pantilie95_move_casereduce_to_unimplementedcert.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Temporarily disabled the CaseReduce certifier pass due to the discovery of bugs in the specification.

--- a/plutus-metatheory/src/CertifierReport.lagda.md
+++ b/plutus-metatheory/src/CertifierReport.lagda.md
@@ -39,7 +39,6 @@ showCertifiedOptTag : CertifiedOptTag → String
 showCertifiedOptTag floatDelayT = "Float Delay"
 showCertifiedOptTag forceDelayT = "Force-Delay Cancellation"
 showCertifiedOptTag forceCaseDelayT = "Float Force into Case Branches"
-showCertifiedOptTag caseReduceT = "Case-Constr and Case-Constant Cancellation"
 showCertifiedOptTag inlineT = "Inlining"
 showCertifiedOptTag cseT = "Common Subexpression Elimination"
 showCertifiedOptTag applyToCaseT = "Transform multi-argument applications into case-constr form"
@@ -47,6 +46,7 @@ showCertifiedOptTag applyToCaseT = "Transform multi-argument applications into c
 showUncertifiedOptTag : UncertifiedOptTag → String
 showUncertifiedOptTag caseOfCaseT = "Case-of-Case"
 showUncertifiedOptTag letFloatOutT = "Float bindings outwards"
+showUncertifiedOptTag caseReduceT = "Case-Constr and Case-Constant Cancellation"
 
 showTag : OptTag → String
 showTag (inj₁ tag) = showUncertifiedOptTag tag ++ "  ⚠ (certifier unavailable)"
@@ -117,7 +117,6 @@ numSites : {M N : 0 ⊢} (tag : CertifiedOptTag) → RelationOf (inj₂ tag) M N
 numSites forceDelayT p = numSites′ p
 numSites floatDelayT p = numSites′ p
 numSites cseT p = numSites′ p
-numSites caseReduceT p = numSites′ p
 numSites inlineT p = numSitesInline p
 numSites forceCaseDelayT p = numSites′ p
 numSites applyToCaseT p = numSites′ p

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -54,7 +54,6 @@ instance AgdaUnparse CertifiedOptStage where
   agdaUnparse FloatDelay = "floatDelayT"
   agdaUnparse ForceDelay = "forceDelayT"
   agdaUnparse ForceCaseDelay = "forceCaseDelayT"
-  agdaUnparse CaseReduce = "caseReduceT"
   agdaUnparse Inline = "inlineT"
   agdaUnparse CSE = "cseT"
   agdaUnparse ApplyToCase = "applyToCaseT"
@@ -62,6 +61,7 @@ instance AgdaUnparse CertifiedOptStage where
 instance AgdaUnparse UncertifiedOptStage where
   agdaUnparse CaseOfCase = "caseOfCaseT"
   agdaUnparse LetFloatOut = "letFloatOutT"
+  agdaUnparse CaseReduce = "caseReduceT"
 
 instance AgdaUnparse Hints.Hints where
   agdaUnparse = \case

--- a/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
@@ -33,7 +33,7 @@ d_runCertifier_2 ::
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
         MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428
@@ -77,7 +77,7 @@ runCertifierMain ::
     (MAlonzo.Code.Utils.T__'215'__428
        (MAlonzo.Code.Utils.T_Either_6
           MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
        (MAlonzo.Code.Utils.T__'215'__428
           MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_72
           (MAlonzo.Code.Utils.T__'215'__428
@@ -94,7 +94,7 @@ d_runCertifierMain_12 ::
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
         MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428
@@ -121,7 +121,7 @@ d_runCertifierMain_12 v0 v1
                           MAlonzo.Code.Utils.C__'44'__442
                           (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                           (coe
-                             MAlonzo.Code.CertifierReport.d_makeReport_286 (coe v2) (coe v1)))
+                             MAlonzo.Code.CertifierReport.d_makeReport_284 (coe v2) (coe v1)))
                 MAlonzo.Code.VerifiedCompilation.C_abort_10 v4
                   -> coe
                        MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
@@ -129,7 +129,7 @@ d_runCertifierMain_12 v0 v1
                           MAlonzo.Code.Utils.C__'44'__442
                           (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                           (coe
-                             MAlonzo.Code.CertifierReport.d_makeReport_286 (coe v2) (coe v1)))
+                             MAlonzo.Code.CertifierReport.d_makeReport_284 (coe v2) (coe v1)))
                 _ -> MAlonzo.RTE.mazUnreachableError
          MAlonzo.Code.Utils.C_inj'8322'_14 v3
            -> coe
@@ -140,5 +140,5 @@ d_runCertifierMain_12 v0 v1
                       MAlonzo.Code.Utils.C__'44'__442
                       (coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10)
                       (coe
-                         MAlonzo.Code.CertifierReport.d_makeReport_286 (coe v2) (coe v1))))
+                         MAlonzo.Code.CertifierReport.d_makeReport_284 (coe v2) (coe v1))))
          _ -> MAlonzo.RTE.mazUnreachableError)

--- a/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
@@ -51,19 +51,16 @@ d_hl_8
        Data.Text.Text)
 -- CertifierReport.showCertifiedOptTag
 d_showCertifiedOptTag_10 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showCertifiedOptTag_10 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_12
+      MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_14
         -> coe ("Float Delay" :: Data.Text.Text)
-      MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_14
+      MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_16
         -> coe ("Force-Delay Cancellation" :: Data.Text.Text)
-      MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_16
+      MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_18
         -> coe ("Float Force into Case Branches" :: Data.Text.Text)
-      MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_18
-        -> coe
-             ("Case-Constr and Case-Constant Cancellation" :: Data.Text.Text)
       MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_20
         -> coe ("Inlining" :: Data.Text.Text)
       MAlonzo.Code.VerifiedCompilation.Trace.C_cseT_22
@@ -84,12 +81,15 @@ d_showUncertifiedOptTag_12 v0
         -> coe ("Case-of-Case" :: Data.Text.Text)
       MAlonzo.Code.VerifiedCompilation.Trace.C_letFloatOutT_8
         -> coe ("Float bindings outwards" :: Data.Text.Text)
+      MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_10
+        -> coe
+             ("Case-Constr and Case-Constant Cancellation" :: Data.Text.Text)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showTag
 d_showTag_14 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showTag_14 v0
   = case coe v0 of
@@ -559,17 +559,15 @@ d_numSitesInline_140 v0 v1 v2 v3 v4 v5 v6 v7
 d_numSites_178 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny -> Integer
 d_numSites_178 v0 v1 v2 v3
   = case coe v2 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_12
+      MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_14
         -> coe du_numSites'8242'_26 v0 v1 v3
-      MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_14
+      MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_16
         -> coe du_numSites'8242'_26 v0 v1 v3
-      MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_16
-        -> coe du_numSites'8242'_26 v0 v1 v3
-      MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_18
+      MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_18
         -> coe du_numSites'8242'_26 v0 v1 v3
       MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_20
         -> coe
@@ -584,14 +582,14 @@ d_numSites_178 v0 v1 v2 v3
         -> coe du_numSites'8242'_26 v0 v1 v3
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showSites
-d_showSites_200 ::
+d_showSites_198 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny -> MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showSites_200 v0 v1 v2 v3
+d_showSites_198 v0 v1 v2 v3
   = case coe v2 of
       MAlonzo.Code.Utils.C_inj'8321'_12 v4 -> coe ("" :: Data.Text.Text)
       MAlonzo.Code.Utils.C_inj'8322'_14 v4
@@ -605,59 +603,59 @@ d_showSites_200 v0 v1 v2 v3
                    (d_numSites_178 (coe v0) (coe v1) (coe v4) (coe v3))))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.termSize
-d_termSize_208 ::
+d_termSize_206 ::
   Integer -> MAlonzo.Code.Untyped.T__'8866'_14 -> Integer
-d_termSize_208 v0 v1
+d_termSize_206 v0 v1
   = case coe v1 of
       MAlonzo.Code.Untyped.C_'96'_18 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_ƛ_20 v2
         -> coe
              addInt (coe (1 :: Integer))
              (coe
-                d_termSize_208 (coe addInt (coe (1 :: Integer)) (coe v0)) (coe v2))
+                d_termSize_206 (coe addInt (coe (1 :: Integer)) (coe v0)) (coe v2))
       MAlonzo.Code.Untyped.C__'183'__22 v2 v3
         -> coe
              addInt
              (coe
-                addInt (coe (1 :: Integer)) (coe d_termSize_208 (coe v0) (coe v2)))
-             (coe d_termSize_208 (coe v0) (coe v3))
+                addInt (coe (1 :: Integer)) (coe d_termSize_206 (coe v0) (coe v2)))
+             (coe d_termSize_206 (coe v0) (coe v3))
       MAlonzo.Code.Untyped.C_force_24 v2
         -> coe
-             addInt (coe (1 :: Integer)) (coe d_termSize_208 (coe v0) (coe v2))
+             addInt (coe (1 :: Integer)) (coe d_termSize_206 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_delay_26 v2
         -> coe
-             addInt (coe (1 :: Integer)) (coe d_termSize_208 (coe v0) (coe v2))
+             addInt (coe (1 :: Integer)) (coe d_termSize_206 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_con_28 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_constr_34 v2 v3
         -> coe
              addInt (coe (1 :: Integer))
-             (coe d_termSize'7510''695'_212 (coe v0) (coe v3))
+             (coe d_termSize'7510''695'_210 (coe v0) (coe v3))
       MAlonzo.Code.Untyped.C_case_40 v2 v3
         -> coe
              addInt
              (coe
                 addInt (coe (1 :: Integer))
-                (coe d_termSize'7510''695'_212 (coe v0) (coe v3)))
-             (coe d_termSize_208 (coe v0) (coe v2))
+                (coe d_termSize'7510''695'_210 (coe v0) (coe v3)))
+             (coe d_termSize_206 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_builtin_44 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_error_46 -> coe (1 :: Integer)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.termSizeᵖʷ
-d_termSize'7510''695'_212 ::
+d_termSize'7510''695'_210 ::
   Integer -> [MAlonzo.Code.Untyped.T__'8866'_14] -> Integer
-d_termSize'7510''695'_212 v0 v1
+d_termSize'7510''695'_210 v0 v1
   = case coe v1 of
       [] -> coe (0 :: Integer)
       (:) v2 v3
         -> coe
-             addInt (coe d_termSize'7510''695'_212 (coe v0) (coe v3))
-             (coe d_termSize_208 (coe v0) (coe v2))
+             addInt (coe d_termSize'7510''695'_210 (coe v0) (coe v3))
+             (coe d_termSize_206 (coe v0) (coe v2))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showEvalResult
-d_showEvalResult_234 ::
+d_showEvalResult_232 ::
   MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_134 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showEvalResult_234 v0
+d_showEvalResult_232 v0
   = case coe v0 of
       MAlonzo.Code.VerifiedCompilation.Trace.C_success_136 v1 v2
         -> coe
@@ -690,10 +688,10 @@ d_showEvalResult_234 v0
                             (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v3))))))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showCostPair
-d_showCostPair_246 ::
+d_showCostPair_244 ::
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_134] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showCostPair_246 v0
+d_showCostPair_244 v0
   = let v1 = "" :: Data.Text.Text in
     coe
       (case coe v0 of
@@ -702,7 +700,7 @@ d_showCostPair_246 v0
                 (:) v4 v5
                   -> coe
                        MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                       (d_showEvalResult_234 (coe v2))
+                       (d_showEvalResult_232 (coe v2))
                        (coe
                           MAlonzo.Code.Data.String.Base.d__'43''43'__20
                           (" (before)" :: Data.Text.Text)
@@ -710,26 +708,26 @@ d_showCostPair_246 v0
                              MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_nl_6
                              (coe
                                 MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                (d_showEvalResult_234 (coe v4)) (" (after)" :: Data.Text.Text))))
+                                (d_showEvalResult_232 (coe v4)) (" (after)" :: Data.Text.Text))))
                 _ -> coe v1
          _ -> coe v1)
 -- CertifierReport.tail
-d_tail_254 :: () -> [AgdaAny] -> [AgdaAny]
-d_tail_254 ~v0 v1 = du_tail_254 v1
-du_tail_254 :: [AgdaAny] -> [AgdaAny]
-du_tail_254 v0
+d_tail_252 :: () -> [AgdaAny] -> [AgdaAny]
+d_tail_252 ~v0 v1 = du_tail_252 v1
+du_tail_252 :: [AgdaAny] -> [AgdaAny]
+du_tail_252 v0
   = case coe v0 of
       [] -> coe v0
       (:) v1 v2 -> coe v2
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportPasses
-d_reportPasses_264 ::
+d_reportPasses_262 ::
   Integer ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_80 ->
   AgdaAny ->
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_134] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_reportPasses_264 v0 v1 v2 v3
+d_reportPasses_262 v0 v1 v2 v3
   = case coe v1 of
       MAlonzo.Code.VerifiedCompilation.Trace.C_step_84 v4 v5 v6 v7
         -> case coe v2 of
@@ -757,7 +755,7 @@ d_reportPasses_264 v0 v1 v2 v3
                                          MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                          (coe
                                             MAlonzo.Code.Data.Nat.Show.d_show_56
-                                            (d_termSize_208 (coe (0 :: Integer)) (coe v6)))
+                                            (d_termSize_206 (coe (0 :: Integer)) (coe v6)))
                                          (coe
                                             MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                             (" (before)" :: Data.Text.Text)
@@ -771,7 +769,7 @@ d_reportPasses_264 v0 v1 v2 v3
                                                      MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                      (coe
                                                         MAlonzo.Code.Data.Nat.Show.d_show_56
-                                                        (d_termSize_208
+                                                        (d_termSize_206
                                                            (coe (0 :: Integer))
                                                            (coe
                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_head_90
@@ -784,13 +782,13 @@ d_reportPasses_264 v0 v1 v2 v3
                                                            d_nl_6
                                                            (coe
                                                               MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                              (d_showCostPair_246 (coe v3))
+                                                              (d_showCostPair_244 (coe v3))
                                                               (coe
                                                                  MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                                  d_nl_6
                                                                  (coe
                                                                     MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                    (d_showSites_200
+                                                                    (d_showSites_198
                                                                        (coe v6)
                                                                        (coe
                                                                           MAlonzo.Code.VerifiedCompilation.Trace.d_head_90
@@ -799,14 +797,14 @@ d_reportPasses_264 v0 v1 v2 v3
                                                                     (coe
                                                                        MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                                        d_nl_6
-                                                                       (d_reportPasses_264
+                                                                       (d_reportPasses_262
                                                                           (coe
                                                                              addInt
                                                                              (coe (1 :: Integer))
                                                                              (coe v0))
                                                                           (coe v7) (coe v9)
                                                                           (coe
-                                                                             du_tail_254
+                                                                             du_tail_252
                                                                              (coe
                                                                                 v3))))))))))))))))))))
              _ -> MAlonzo.RTE.mazUnreachableError
@@ -814,10 +812,10 @@ d_reportPasses_264 v0 v1 v2 v3
         -> coe ("" :: Data.Text.Text)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportFailure
-d_reportFailure_280 ::
+d_reportFailure_278 ::
   MAlonzo.Code.VerifiedCompilation.T_Error_2 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_reportFailure_280 v0
+d_reportFailure_278 v0
   = case coe v0 of
       MAlonzo.Code.VerifiedCompilation.C_emptyDump_4
         -> coe
@@ -861,24 +859,24 @@ d_reportFailure_280 v0
                       ("  \10060 FAILED" :: Data.Text.Text) d_hl_8)))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.makeReport
-d_makeReport_286 ::
+d_makeReport_284 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.T_Error_2
     MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_134] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_makeReport_286 v0 v1
+d_makeReport_284 v0 v1
   = coe
       MAlonzo.Code.Data.String.Base.d__'43''43'__20
       ("UPLC OPTIMIZATION: CERTIFIER REPORT" :: Data.Text.Text)
       (coe
          MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_nl_6
          (coe
-            MAlonzo.Code.Utils.du_either_22 (coe v0) (coe d_reportFailure_280)
+            MAlonzo.Code.Utils.du_either_22 (coe v0) (coe d_reportFailure_278)
             (coe
                (\ v2 ->
                   case coe v2 of
                     MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 v3 v4
                       -> coe
-                           d_reportPasses_264 (coe (1 :: Integer)) (coe v3) (coe v4) (coe v1)
+                           d_reportPasses_262 (coe (1 :: Integer)) (coe v3) (coe v4) (coe v1)
                     _ -> MAlonzo.RTE.mazUnreachableError))))

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
@@ -28,7 +28,6 @@ import qualified MAlonzo.Code.VerifiedCompilation.NotImplemented
 import qualified MAlonzo.Code.VerifiedCompilation.Trace
 import qualified MAlonzo.Code.VerifiedCompilation.UApplyToCase
 import qualified MAlonzo.Code.VerifiedCompilation.UCSE
-import qualified MAlonzo.Code.VerifiedCompilation.UCaseReduce
 import qualified MAlonzo.Code.VerifiedCompilation.UFloatDelay
 import qualified MAlonzo.Code.VerifiedCompilation.UForceCaseDelay
 import qualified MAlonzo.Code.VerifiedCompilation.UForceDelay
@@ -40,13 +39,13 @@ data T_Error_2
   = C_emptyDump_4 | C_illScoped_6 |
     C_counterExample_8 (MAlonzo.Code.Utils.T_Either_6
                           MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-                          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10) |
+                          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12) |
     C_abort_10 (MAlonzo.Code.Utils.T_Either_6
                   MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
 -- VerifiedCompilation.tagToRelation
 d_tagToRelation_12 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 -> ()
 d_tagToRelation_12 = erased
@@ -54,7 +53,7 @@ d_tagToRelation_12 = erased
 d_RelationOf_14 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 -> ()
 d_RelationOf_14 = erased
@@ -62,14 +61,14 @@ d_RelationOf_14 = erased
 d_hasRelation_18 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   Bool
 d_hasRelation_18 = coe MAlonzo.Code.Utils.du_is'45'inj'8322'_46
 -- VerifiedCompilation.certifyPass
 d_certifyPass_26 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_72 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -83,29 +82,23 @@ d_certifyPass_26 v0 v1
                   MAlonzo.Code.VerifiedCompilation.NotImplemented.du_certNotImplemented_22)
       MAlonzo.Code.Utils.C_inj'8322'_14 v2
         -> case coe v2 of
-             MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_12
+             MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_14
                -> coe
                     MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UFloatDelay.d_isFloatDelay'63'_488
                        (coe (0 :: Integer)))
-             MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_14
+             MAlonzo.Code.VerifiedCompilation.Trace.C_forceDelayT_16
                -> coe
                     MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UForceDelay.d_isForceDelay'63'_178
                        (coe (0 :: Integer)))
-             MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_16
+             MAlonzo.Code.VerifiedCompilation.Trace.C_forceCaseDelayT_18
                -> coe
                     MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
                     (coe
                        MAlonzo.Code.VerifiedCompilation.UForceCaseDelay.d_isForceCaseDelay'63'_94
-                       (coe (0 :: Integer)))
-             MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_18
-               -> coe
-                    MAlonzo.Code.VerifiedCompilation.Certificate.du_decider_192
-                    (coe
-                       MAlonzo.Code.VerifiedCompilation.UCaseReduce.d_isCaseReduce'63'_26
                        (coe (0 :: Integer)))
              MAlonzo.Code.VerifiedCompilation.Trace.C_inlineT_20
                -> case coe v1 of
@@ -118,7 +111,7 @@ d_certifyPass_26 v0 v1
                     MAlonzo.Code.VerifiedCompilation.Trace.C_none_76
                       -> coe
                            MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_32
-                           (coe MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36)
+                           (coe MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34)
                     _ -> MAlonzo.RTE.mazUnreachableError
              MAlonzo.Code.VerifiedCompilation.Trace.C_cseT_22
                -> coe

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Certificate.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Certificate.hs
@@ -33,11 +33,11 @@ data T_CertResult_12
   = C_proof_18 AgdaAny |
     C_ce_26 (MAlonzo.Code.Utils.T_Either_6
                MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-               MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+               MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
             AgdaAny AgdaAny |
     C_abort_32 (MAlonzo.Code.Utils.T_Either_6
                   MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
                AgdaAny AgdaAny
 -- VerifiedCompilation.Certificate.ProofOrCE
 d_ProofOrCE_38 a0 a1 = ()
@@ -45,7 +45,7 @@ data T_ProofOrCE_38
   = C_proof_44 AgdaAny |
     C_ce_52 (MAlonzo.Code.Utils.T_Either_6
                MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-               MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+               MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
             AgdaAny AgdaAny
 -- VerifiedCompilation.Certificate.isProof?
 d_isProof'63'_56 ::
@@ -74,7 +74,7 @@ data T_Proof'63'_66
   = C_proof_72 AgdaAny |
     C_abort_78 (MAlonzo.Code.Utils.T_Either_6
                   MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10)
+                  MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
                AgdaAny AgdaAny
 -- VerifiedCompilation.Certificate._>>=_
 d__'62''62''61'__88 ::
@@ -145,14 +145,14 @@ d_decToPCE_234 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20 ->
   AgdaAny -> AgdaAny -> T_ProofOrCE_38
 d_decToPCE_234 ~v0 ~v1 v2 v3 v4 v5 = du_decToPCE_234 v2 v3 v4 v5
 du_decToPCE_234 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20 ->
   AgdaAny -> AgdaAny -> T_ProofOrCE_38
 du_decToPCE_234 v0 v1 v2 v3
@@ -195,7 +195,7 @@ d_matchOrCE_262 ::
   (AgdaAny -> AgdaAny -> ()) ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (AgdaAny ->
    AgdaAny ->
    MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20) ->
@@ -205,7 +205,7 @@ d_matchOrCE_262 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
 du_matchOrCE_262 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (AgdaAny ->
    AgdaAny ->
    MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20) ->
@@ -230,7 +230,7 @@ d_pcePointwise_304 ::
   (AgdaAny -> AgdaAny -> ()) ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
   [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_38
 d_pcePointwise_304 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
@@ -238,7 +238,7 @@ d_pcePointwise_304 ~v0 ~v1 ~v2 ~v3 v4 v5 v6 v7
 du_pcePointwise_304 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (AgdaAny -> AgdaAny -> T_ProofOrCE_38) ->
   [AgdaAny] -> [AgdaAny] -> T_ProofOrCE_38
 du_pcePointwise_304 v0 v1 v2 v3

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
@@ -31,46 +31,46 @@ d_UncertifiedOptTag_4 = ()
 type T_UncertifiedOptTag_4 = UncertifiedOptStage
 pattern C_caseOfCaseT_6 = CaseOfCase
 pattern C_letFloatOutT_8 = LetFloatOut
+pattern C_caseReduceT_10 = CaseReduce
 check_caseOfCaseT_6 :: T_UncertifiedOptTag_4
 check_caseOfCaseT_6 = CaseOfCase
 check_letFloatOutT_8 :: T_UncertifiedOptTag_4
 check_letFloatOutT_8 = LetFloatOut
+check_caseReduceT_10 :: T_UncertifiedOptTag_4
+check_caseReduceT_10 = CaseReduce
 cover_UncertifiedOptTag_4 :: UncertifiedOptStage -> ()
 cover_UncertifiedOptTag_4 x
   = case x of
       CaseOfCase -> ()
       LetFloatOut -> ()
+      CaseReduce -> ()
 -- VerifiedCompilation.Trace.CertifiedOptTag
-d_CertifiedOptTag_10 = ()
-type T_CertifiedOptTag_10 = CertifiedOptStage
-pattern C_floatDelayT_12 = FloatDelay
-pattern C_forceDelayT_14 = ForceDelay
-pattern C_forceCaseDelayT_16 = ForceCaseDelay
-pattern C_caseReduceT_18 = CaseReduce
+d_CertifiedOptTag_12 = ()
+type T_CertifiedOptTag_12 = CertifiedOptStage
+pattern C_floatDelayT_14 = FloatDelay
+pattern C_forceDelayT_16 = ForceDelay
+pattern C_forceCaseDelayT_18 = ForceCaseDelay
 pattern C_inlineT_20 = Inline
 pattern C_cseT_22 = CSE
 pattern C_applyToCaseT_24 = ApplyToCase
-check_floatDelayT_12 :: T_CertifiedOptTag_10
-check_floatDelayT_12 = FloatDelay
-check_forceDelayT_14 :: T_CertifiedOptTag_10
-check_forceDelayT_14 = ForceDelay
-check_forceCaseDelayT_16 :: T_CertifiedOptTag_10
-check_forceCaseDelayT_16 = ForceCaseDelay
-check_caseReduceT_18 :: T_CertifiedOptTag_10
-check_caseReduceT_18 = CaseReduce
-check_inlineT_20 :: T_CertifiedOptTag_10
+check_floatDelayT_14 :: T_CertifiedOptTag_12
+check_floatDelayT_14 = FloatDelay
+check_forceDelayT_16 :: T_CertifiedOptTag_12
+check_forceDelayT_16 = ForceDelay
+check_forceCaseDelayT_18 :: T_CertifiedOptTag_12
+check_forceCaseDelayT_18 = ForceCaseDelay
+check_inlineT_20 :: T_CertifiedOptTag_12
 check_inlineT_20 = Inline
-check_cseT_22 :: T_CertifiedOptTag_10
+check_cseT_22 :: T_CertifiedOptTag_12
 check_cseT_22 = CSE
-check_applyToCaseT_24 :: T_CertifiedOptTag_10
+check_applyToCaseT_24 :: T_CertifiedOptTag_12
 check_applyToCaseT_24 = ApplyToCase
-cover_CertifiedOptTag_10 :: CertifiedOptStage -> ()
-cover_CertifiedOptTag_10 x
+cover_CertifiedOptTag_12 :: CertifiedOptStage -> ()
+cover_CertifiedOptTag_12 x
   = case x of
       FloatDelay -> ()
       ForceDelay -> ()
       ForceCaseDelay -> ()
-      CaseReduce -> ()
       Inline -> ()
       CSE -> ()
       ApplyToCase -> ()
@@ -80,56 +80,56 @@ d_OptTag_26 = erased
 -- VerifiedCompilation.Trace.FloatDelayT
 d_FloatDelayT_28 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
 d_FloatDelayT_28
-  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_floatDelayT_12)
+  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_floatDelayT_14)
 -- VerifiedCompilation.Trace.ForceDelayT
 d_ForceDelayT_30 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
 d_ForceDelayT_30
-  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_forceDelayT_14)
+  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_forceDelayT_16)
 -- VerifiedCompilation.Trace.ForceCaseDelayT
 d_ForceCaseDelayT_32 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
 d_ForceCaseDelayT_32
-  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_forceCaseDelayT_16)
--- VerifiedCompilation.Trace.CaseReduceT
-d_CaseReduceT_34 ::
-  MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_CaseReduceT_34
-  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_caseReduceT_18)
+  = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_forceCaseDelayT_18)
 -- VerifiedCompilation.Trace.InlineT
-d_InlineT_36 ::
+d_InlineT_34 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_InlineT_36
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_InlineT_34
   = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_inlineT_20)
 -- VerifiedCompilation.Trace.CseT
-d_CseT_38 ::
+d_CseT_36 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_CseT_38 = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_cseT_22)
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_CseT_36 = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_cseT_22)
 -- VerifiedCompilation.Trace.ApplyToCaseT
-d_ApplyToCaseT_40 ::
+d_ApplyToCaseT_38 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_ApplyToCaseT_40
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_ApplyToCaseT_38
   = coe MAlonzo.Code.Utils.C_inj'8322'_14 (coe C_applyToCaseT_24)
 -- VerifiedCompilation.Trace.CaseOfCaseT
-d_CaseOfCaseT_42 ::
+d_CaseOfCaseT_40 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_CaseOfCaseT_42
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_CaseOfCaseT_40
   = coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_caseOfCaseT_6)
 -- VerifiedCompilation.Trace.LetFloatOutT
-d_LetFloatOutT_44 ::
+d_LetFloatOutT_42 ::
   MAlonzo.Code.Utils.T_Either_6
-    T_UncertifiedOptTag_4 T_CertifiedOptTag_10
-d_LetFloatOutT_44
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_LetFloatOutT_42
   = coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_letFloatOutT_8)
+-- VerifiedCompilation.Trace.CaseReduceT
+d_CaseReduceT_44 ::
+  MAlonzo.Code.Utils.T_Either_6
+    T_UncertifiedOptTag_4 T_CertifiedOptTag_12
+d_CaseReduceT_44
+  = coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_caseReduceT_10)
 -- VerifiedCompilation.Trace.InlineHints
 d_InlineHints_46 = ()
 type T_InlineHints_46 = Hints.Inline
@@ -208,7 +208,7 @@ cover_Hints_72 x
 d_Trace_80 a0 = ()
 data T_Trace_80
   = C_step_84 (MAlonzo.Code.Utils.T_Either_6
-                 T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+                 T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
               T_Hints_72 AgdaAny T_Trace_80 |
     C_done_86 AgdaAny
 -- VerifiedCompilation.Trace.head
@@ -225,7 +225,7 @@ d_Dump_96 = erased
 d_toTrace_98 ::
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428
@@ -244,7 +244,7 @@ d_toTrace_98 v0
 d_go_108 ::
   MAlonzo.Code.Utils.T__'215'__428
     (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
     (MAlonzo.Code.Utils.T__'215'__428
        T_Hints_72
        (MAlonzo.Code.Utils.T__'215'__428
@@ -252,7 +252,7 @@ d_go_108 ::
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428
@@ -260,7 +260,7 @@ d_go_108 ::
            MAlonzo.Code.RawU.T_Untyped_208))] ->
   MAlonzo.Code.Utils.T__'215'__428
     (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
     (MAlonzo.Code.Utils.T__'215'__428
        T_Hints_72
        (MAlonzo.Code.Utils.T__'215'__428
@@ -268,7 +268,7 @@ d_go_108 ::
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428
@@ -279,7 +279,7 @@ d_go_108 ~v0 ~v1 v2 v3 = du_go_108 v2 v3
 du_go_108 ::
   MAlonzo.Code.Utils.T__'215'__428
     (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
     (MAlonzo.Code.Utils.T__'215'__428
        T_Hints_72
        (MAlonzo.Code.Utils.T__'215'__428
@@ -287,7 +287,7 @@ du_go_108 ::
           MAlonzo.Code.RawU.T_Untyped_208)) ->
   [MAlonzo.Code.Utils.T__'215'__428
      (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_10)
+        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
      (MAlonzo.Code.Utils.T__'215'__428
         T_Hints_72
         (MAlonzo.Code.Utils.T__'215'__428

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
@@ -44,7 +44,7 @@ d_a2c'63''7580''7580'_24 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_164
       (coe v0)
-      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40)
+      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38)
       (coe d_a2c'63'_32)
 -- VerifiedCompilation.UApplyToCase.a2c?
 d_a2c'63'_32 ::
@@ -75,31 +75,31 @@ d_a2c'63'_32 v0 v1 v2
             MAlonzo.Code.Untyped.C_'96'_18 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_ƛ_20 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C__'183'__22 v5 v6
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_force_24 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_delay_26 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_con_28 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_constr_34 v5 v6
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_case_40 v5 v6
               -> let v7
                        = coe
@@ -241,18 +241,18 @@ d_a2c'63'_32 v0 v1 v2
                                                       seq (coe v12)
                                                       (coe
                                                          MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                                                         MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40
+                                                         MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38
                                                          v1 v2)
                                         _ -> MAlonzo.RTE.mazUnreachableError))
                       _ -> MAlonzo.RTE.mazUnreachableError)
             MAlonzo.Code.Untyped.C_builtin_44 v5
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             MAlonzo.Code.Untyped.C_error_46
               -> coe
                    MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_40 v1 v2
+                   MAlonzo.Code.VerifiedCompilation.Trace.d_ApplyToCaseT_38 v1 v2
             _ -> MAlonzo.RTE.mazUnreachableError))
 -- VerifiedCompilation.UApplyToCase..extendedlambda0
 d_'46'extendedlambda0_48 ::
@@ -276,7 +276,7 @@ d_'46'extendedlambda1_94 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   T_ApplyToCase_4 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCSE.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCSE.hs
@@ -47,7 +47,7 @@ d_isUntypedCSE'63'_26 ::
 d_isUntypedCSE'63'_26 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_164
-      (coe v0) (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_38)
+      (coe v0) (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_36)
       (coe d_isUCSE'63'_30)
 -- VerifiedCompilation.UCSE.isUCSE?
 d_isUCSE'63'_30 ::
@@ -116,7 +116,7 @@ d_isUCSE'63'_30 v0 v1 v2
                        seq (coe v5)
                        (coe
                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_38 v1 v2)
+                          MAlonzo.Code.VerifiedCompilation.Trace.d_CseT_36 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UCSE..extendedlambda0
 d_'46'extendedlambda0_46 ::
@@ -139,7 +139,7 @@ d_'46'extendedlambda1_78 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny -> T_UCSE_4 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda1_78 = erased

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseOfCase.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseOfCase.hs
@@ -560,7 +560,7 @@ d_isCaseOfCase'63'_256 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_164
       (coe v0)
-      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42)
+      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40)
       (coe d_isCoC'63'_264)
 -- VerifiedCompilation.UCaseOfCase.isCoC?
 d_isCoC'63'_264 ::
@@ -671,7 +671,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                                  = coe
                                                                                                                                                                                                      MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
                                                                                                                                                                                                      (coe
-                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42)
+                                                                                                                                                                                                        MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40)
                                                                                                                                                                                                      (coe
                                                                                                                                                                                                         d_isCaseOfCase'63'_256
                                                                                                                                                                                                         (coe
@@ -688,7 +688,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                                            = coe
                                                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
                                                                                                                                                                                                                (coe
-                                                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42)
+                                                                                                                                                                                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40)
                                                                                                                                                                                                                (coe
                                                                                                                                                                                                                   d_isCaseOfCase'63'_256
                                                                                                                                                                                                                   (coe
@@ -705,7 +705,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                                                      = coe
                                                                                                                                                                                                                          MAlonzo.Code.VerifiedCompilation.Certificate.du_pcePointwise_304
                                                                                                                                                                                                                          (coe
-                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42)
+                                                                                                                                                                                                                            MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40)
                                                                                                                                                                                                                          (coe
                                                                                                                                                                                                                             d_isCaseOfCase'63'_256
                                                                                                                                                                                                                             (coe
@@ -754,7 +754,7 @@ d_isCoC'63'_264 v0 v1 v2
                                                                                                                                                                                v40)
                                                                                                                                                                             (coe
                                                                                                                                                                                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42
+                                                                                                                                                                               MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40
                                                                                                                                                                                (coe
                                                                                                                                                                                   MAlonzo.Code.Untyped.C_case_40
                                                                                                                                                                                   (coe
@@ -826,7 +826,7 @@ d_isCoC'63'_264 v0 v1 v2
                        seq (coe v5)
                        (coe
                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_42 v1 v2)
+                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseOfCaseT_40 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UCaseOfCase..extendedlambda4
 d_'46'extendedlambda4_280 ::
@@ -867,7 +867,7 @@ d_'46'extendedlambda6_444 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -890,7 +890,7 @@ d_'46'extendedlambda7_524 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
@@ -914,7 +914,7 @@ d_'46'extendedlambda8_608 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
@@ -50,7 +50,7 @@ d_isCaseReduce'63'_26 v0
   = coe
       MAlonzo.Code.VerifiedCompilation.UntypedTranslation.du_translation'63'_164
       (coe v0)
-      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_34)
+      (coe MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_44)
       (coe d_isCR'63'_42)
 -- VerifiedCompilation.UCaseReduce.justEq
 d_justEq_34 ::
@@ -133,7 +133,7 @@ d_isCR'63'_42 v0 v1 v2
                                                                    MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
                                                                      -> coe
                                                                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_34
+                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_44
                                                                           v1 v2
                                                                    _ -> MAlonzo.RTE.mazUnreachableError)))
                                                    _ -> MAlonzo.RTE.mazUnreachableError
@@ -145,7 +145,7 @@ d_isCR'63'_42 v0 v1 v2
                        seq (coe v5)
                        (coe
                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
-                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_34 v1 v2)
+                          MAlonzo.Code.VerifiedCompilation.Trace.d_CaseReduceT_44 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- VerifiedCompilation.UCaseReduce..extendedlambda0
 d_'46'extendedlambda0_58 ::
@@ -192,7 +192,7 @@ d_'46'extendedlambda3_142 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UFloatDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UFloatDelay.hs
@@ -773,7 +773,7 @@ d_'46'extendedlambda10_582 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -791,7 +791,7 @@ d_'46'extendedlambda11_630 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceCaseDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceCaseDelay.hs
@@ -382,7 +382,7 @@ d_'46'extendedlambda4_228 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
@@ -401,7 +401,7 @@ d_'46'extendedlambda5_280 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceDelay.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UForceDelay.hs
@@ -2255,7 +2255,7 @@ d_'46'extendedlambda2_246 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny -> T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda2_246 = erased
@@ -2273,7 +2273,7 @@ d_'46'extendedlambda3_320 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.VerifiedCompilation.UntypedViews.T_isForce_270 ->
@@ -2292,7 +2292,7 @@ d_'46'extendedlambda4_348 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2322,7 +2322,7 @@ d_'46'extendedlambda6_476 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2334,7 +2334,7 @@ d_'46'extendedlambda6_476 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny -> T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda6_476 = erased
@@ -2354,7 +2354,7 @@ d_'46'extendedlambda7_518 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny -> T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
 d_'46'extendedlambda7_518 = erased
@@ -2381,7 +2381,7 @@ d_'46'extendedlambda8_634 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2410,7 +2410,7 @@ d_'46'extendedlambda9_688 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2434,7 +2434,7 @@ d_'46'extendedlambda10_750 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2446,7 +2446,7 @@ d_'46'extendedlambda10_750 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2470,7 +2470,7 @@ d_'46'extendedlambda11_814 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2481,7 +2481,7 @@ d_'46'extendedlambda11_814 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2506,7 +2506,7 @@ d_'46'extendedlambda12_880 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Builtin.T_Builtin_2 ->
@@ -2516,7 +2516,7 @@ d_'46'extendedlambda12_880 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2546,7 +2546,7 @@ d_'46'extendedlambda13_1034 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2567,7 +2567,7 @@ d_'46'extendedlambda14_1074 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->
@@ -2584,7 +2584,7 @@ d_'46'extendedlambda15_1190 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2592,7 +2592,7 @@ d_'46'extendedlambda15_1190 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
@@ -2610,7 +2610,7 @@ d_'46'extendedlambda16_1214 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
@@ -2629,7 +2629,7 @@ d_'46'extendedlambda17_1238 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
@@ -2661,7 +2661,7 @@ d_'46'extendedlambda19_1340 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.VerifiedCompilation.UntypedViews.T_isDelay_356 ->
@@ -2681,7 +2681,7 @@ d_'46'extendedlambda20_1454 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (T_FD_112 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
@@ -2689,7 +2689,7 @@ d_'46'extendedlambda20_1454 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2706,7 +2706,7 @@ d_'46'extendedlambda21_1480 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2724,7 +2724,7 @@ d_'46'extendedlambda22_1506 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2742,7 +2742,7 @@ d_'46'extendedlambda23_1574 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
@@ -2780,7 +2780,7 @@ d_'46'extendedlambda25_1698 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   (MAlonzo.Code.VerifiedCompilation.UntypedViews.T_isForce_270 ->
@@ -2803,7 +2803,7 @@ d_'46'extendedlambda26_1732 ::
   () ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny ->
   AgdaAny ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38 ->

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UInline.hs
@@ -308,7 +308,7 @@ d_checkPointwise_304 v0 v1 v2 v3 v4 v5 v6 v7
   = let v8
           = coe
               MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-              MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36 v6 v7 in
+              MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34 v6 v7 in
     coe
       (case coe v3 of
          []
@@ -365,7 +365,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
   = let v8
           = coe
               MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-              MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36 v4 v7 in
+              MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34 v4 v7 in
     coe
       (case coe v4 of
          MAlonzo.Code.Untyped.C_'96'_18 v9
@@ -385,7 +385,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                       -> let v15
                                                = coe
                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                    v4 v7 in
                                          coe
                                            (case coe v13 of
@@ -418,7 +418,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                                     MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
                                                                                       -> coe
                                                                                            MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                                                           MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                                                           MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                                                            v4 v4
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
                                                                           _ -> coe v15
@@ -627,7 +627,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                seq (coe v13)
                                                (coe
                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                   v4 v7)
                                  _ -> MAlonzo.RTE.mazUnreachableError)
                        _ -> coe v8
@@ -669,7 +669,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                seq (coe v16)
                                                (coe
                                                   MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                   v4 v7)
                                  _ -> MAlonzo.RTE.mazUnreachableError)
                        _ -> coe v8
@@ -752,7 +752,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                 seq (coe v16)
                                                                 (coe
                                                                    MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                                   MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                                    v4 v7)
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         else (let v14
@@ -776,7 +776,7 @@ d_check_316 v0 v1 v2 v3 v4 v5 v6 v7
                                                                  seq (coe v16)
                                                                  (coe
                                                                     MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_78
-                                                                    MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_36
+                                                                    MAlonzo.Code.VerifiedCompilation.Trace.d_InlineT_34
                                                                     v4 v7)
                                                    _ -> MAlonzo.RTE.mazUnreachableError))
                                  _ -> MAlonzo.RTE.mazUnreachableError)

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UntypedTranslation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UntypedTranslation.hs
@@ -87,7 +87,7 @@ d_translation'63'_164 ::
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -101,7 +101,7 @@ du_translation'63'_164 ::
   Integer ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2927,7 +2927,7 @@ d_decPointwiseTranslation'63'_176 ::
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2941,7 +2941,7 @@ du_decPointwiseTranslation'63'_176 ::
   Integer ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_10 ->
+    MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->

--- a/plutus-metatheory/src/VerifiedCompilation.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation.lagda.md
@@ -75,7 +75,6 @@ tagToRelation : CertifiedOptTag → (0 ⊢ → 0 ⊢ → Set)
 tagToRelation floatDelayT = UFlD.FloatDelay
 tagToRelation forceDelayT = UFD.ForceDelay
 tagToRelation forceCaseDelayT = UFCD.ForceCaseDelay
-tagToRelation caseReduceT = UCR.UCaseReduce
 tagToRelation inlineT = UInline.Inline (λ()) UInline.□
 tagToRelation cseT = UCSE.UntypedCSE
 tagToRelation applyToCaseT = UA2C.UApplyToCase
@@ -100,7 +99,6 @@ certifyPass (inj₁ _) _ = certNotImplemented
 certifyPass (inj₂ floatDelayT) _ = decider UFlD.isFloatDelay?
 certifyPass (inj₂ forceDelayT) _ = decider UFD.isForceDelay?
 certifyPass (inj₂ forceCaseDelayT) _ = decider UFCD.isForceCaseDelay?
-certifyPass (inj₂ caseReduceT) _ = decider UCR.isCaseReduce?
 certifyPass (inj₂ inlineT) (inline hs) = checker (UInline.top-check hs)
 certifyPass (inj₂ inlineT) none = λ M M' → abort InlineT M M'
 certifyPass (inj₂ cseT) _ = decider UCSE.isUntypedCSE?

--- a/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
@@ -28,12 +28,12 @@ We enumerate the known passes and partition them into two categories:
 data UncertifiedOptTag : Set where
   caseOfCaseT : UncertifiedOptTag
   letFloatOutT : UncertifiedOptTag
+  caseReduceT : UncertifiedOptTag
 
 data CertifiedOptTag : Set where
   floatDelayT : CertifiedOptTag
   forceDelayT : CertifiedOptTag
   forceCaseDelayT : CertifiedOptTag
-  caseReduceT : CertifiedOptTag
   inlineT : CertifiedOptTag
   cseT : CertifiedOptTag
   applyToCaseT : CertifiedOptTag
@@ -46,8 +46,6 @@ ForceDelayT : OptTag
 ForceDelayT = Utils.inj₂ forceDelayT
 ForceCaseDelayT : OptTag
 ForceCaseDelayT = Utils.inj₂ forceCaseDelayT
-CaseReduceT : OptTag
-CaseReduceT = Utils.inj₂ caseReduceT
 InlineT : OptTag
 InlineT = Utils.inj₂ inlineT
 CseT : OptTag
@@ -59,9 +57,11 @@ CaseOfCaseT : OptTag
 CaseOfCaseT = Utils.inj₁ caseOfCaseT
 LetFloatOutT : OptTag
 LetFloatOutT = Utils.inj₁ letFloatOutT
+CaseReduceT : OptTag
+CaseReduceT = Utils.inj₁ caseReduceT
 
-{-# COMPILE GHC CertifiedOptTag = data CertifiedOptStage (FloatDelay | ForceDelay | ForceCaseDelay | CaseReduce | Inline | CSE | ApplyToCase) #-}
-{-# COMPILE GHC UncertifiedOptTag = data UncertifiedOptStage (CaseOfCase | LetFloatOut) #-}
+{-# COMPILE GHC CertifiedOptTag = data CertifiedOptStage (FloatDelay | ForceDelay | ForceCaseDelay | Inline | CSE | ApplyToCase) #-}
+{-# COMPILE GHC UncertifiedOptTag = data UncertifiedOptStage (CaseOfCase | LetFloatOut | CaseReduce) #-}
 ```
 
 ## Hints

--- a/plutus-metatheory/test/certifier-report/golden/n-queens.golden.report
+++ b/plutus-metatheory/test/certifier-report/golden/n-queens.golden.report
@@ -46,13 +46,13 @@ Pass 5: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 6: Case-Constr and Case-Constant Cancellation  ✅
+Pass 6: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 3280 (before)
   Program Size: 3280 (after)
   Execution Cost: CPU = 275603093782, MEM = 1672462255 (before)
   Execution Cost: CPU = 275603093782, MEM = 1672462255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 7: Inlining  ✅
@@ -109,13 +109,13 @@ Pass 12: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 13: Case-Constr and Case-Constant Cancellation  ✅
+Pass 13: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 2910 (before)
   Program Size: 2910 (after)
   Execution Cost: CPU = 254090741782, MEM = 1538010055 (before)
   Execution Cost: CPU = 254090741782, MEM = 1538010055 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 14: Inlining  ✅
@@ -172,13 +172,13 @@ Pass 19: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 20: Case-Constr and Case-Constant Cancellation  ✅
+Pass 20: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 2357 (before)
   Program Size: 2357 (after)
   Execution Cost: CPU = 204103557782, MEM = 1225590155 (before)
   Execution Cost: CPU = 204103557782, MEM = 1225590155 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 21: Inlining  ✅
@@ -235,13 +235,13 @@ Pass 26: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 27: Case-Constr and Case-Constant Cancellation  ✅
+Pass 27: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 2266 (before)
   Program Size: 2266 (after)
   Execution Cost: CPU = 161169253782, MEM = 957250755 (before)
   Execution Cost: CPU = 161169253782, MEM = 957250755 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 28: Inlining  ✅
@@ -298,13 +298,13 @@ Pass 33: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 34: Case-Constr and Case-Constant Cancellation  ✅
+Pass 34: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1820 (before)
   Program Size: 1820 (after)
   Execution Cost: CPU = 118337877782, MEM = 689554655 (before)
   Execution Cost: CPU = 118337877782, MEM = 689554655 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 35: Inlining  ✅
@@ -361,13 +361,13 @@ Pass 40: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 41: Case-Constr and Case-Constant Cancellation  ✅
+Pass 41: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1767 (before)
   Program Size: 1767 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 42: Inlining  ✅
@@ -424,13 +424,13 @@ Pass 47: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 48: Case-Constr and Case-Constant Cancellation  ✅
+Pass 48: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 49: Inlining  ✅
@@ -487,13 +487,13 @@ Pass 54: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 55: Case-Constr and Case-Constant Cancellation  ✅
+Pass 55: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 56: Inlining  ✅
@@ -550,13 +550,13 @@ Pass 61: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 62: Case-Constr and Case-Constant Cancellation  ✅
+Pass 62: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 63: Inlining  ✅
@@ -613,13 +613,13 @@ Pass 68: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 69: Case-Constr and Case-Constant Cancellation  ✅
+Pass 69: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 70: Inlining  ✅
@@ -676,13 +676,13 @@ Pass 75: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 76: Case-Constr and Case-Constant Cancellation  ✅
+Pass 76: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 77: Inlining  ✅
@@ -739,13 +739,13 @@ Pass 82: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 83: Case-Constr and Case-Constant Cancellation  ✅
+Pass 83: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1764 (before)
   Program Size: 1764 (after)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (before)
   Execution Cost: CPU = 117353973782, MEM = 683405255 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 84: Inlining  ✅
@@ -811,13 +811,13 @@ Pass 90: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 91: Case-Constr and Case-Constant Cancellation  ✅
+Pass 91: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1773 (before)
   Program Size: 1773 (after)
   Execution Cost: CPU = 117353877782, MEM = 683404655 (before)
   Execution Cost: CPU = 117353877782, MEM = 683404655 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 92: Inlining  ✅
@@ -883,13 +883,13 @@ Pass 98: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 99: Case-Constr and Case-Constant Cancellation  ✅
+Pass 99: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1770 (before)
   Program Size: 1770 (after)
   Execution Cost: CPU = 117353829782, MEM = 683404355 (before)
   Execution Cost: CPU = 117353829782, MEM = 683404355 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 100: Inlining  ✅
@@ -955,13 +955,13 @@ Pass 106: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 107: Case-Constr and Case-Constant Cancellation  ✅
+Pass 107: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1756 (before)
   Program Size: 1756 (after)
   Execution Cost: CPU = 117353781782, MEM = 683404055 (before)
   Execution Cost: CPU = 117353781782, MEM = 683404055 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 108: Inlining  ✅
@@ -1027,13 +1027,13 @@ Pass 114: Case-of-Case  ⚠ (certifier unavailable)
 
 
 ──────────────────────────────────────────────────────
-Pass 115: Case-Constr and Case-Constant Cancellation  ✅
+Pass 115: Case-Constr and Case-Constant Cancellation  ⚠ (certifier unavailable)
 ──────────────────────────────────────────────────────
   Program Size: 1756 (before)
   Program Size: 1756 (after)
   Execution Cost: CPU = 117353781782, MEM = 683404055 (before)
   Execution Cost: CPU = 117353781782, MEM = 683404055 (after)
-  Optimization sites: 0
+
 
 ──────────────────────────────────────────────────────
 Pass 116: Inlining  ✅


### PR DESCRIPTION
`CaseReduce` is currently not implemented correctly in the certifier (https://github.com/IntersectMBO/plutus-private/issues/2082). We need to turn it off until it is fixed.