### PR TITLE
Replace inelegant elemIndex+!! with lookup in compileDataConRef

### DIFF
--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs
@@ -296,14 +296,11 @@ compileDataConRef dc = do
   dcs <- getDataCons tc
   constrs <- getConstructors tc
 
-  -- TODO: this is inelegant
-  index <- case elemIndex dc dcs of
-    Just i -> pure i
+  case lookup dc (zip dcs constrs) of
+    Just constr -> pure constr
     Nothing ->
       throwPlain $
         CompilationError "Data constructor not in the type constructor's list of constructors"
-
-  pure $ constrs !! index
   where
     tc = GHC.dataConTyCon dc
 


### PR DESCRIPTION
## Summary

- Addresses the TODO comment at `plutus-tx-plugin/src/PlutusTx/Compiler/Expr.hs:299`
- Replaces the two-step `elemIndex dc dcs` + partial `constrs !! index` with a single safe `lookup dc (zip dcs constrs)`
- Removes the intermediate `index` variable and the partial `!!` function

## Notes for reviewer

The change is semantically equivalent: `zip dcs constrs` pairs each constructor with its compiled term, and `lookup dc` finds the right one directly. The `elemIndex` import is retained — it's still used elsewhere in the file (line 1240).