### PR TITLE
scripts/interactive-release.sh: use path: prefix for flake refs

### DIFF
--- a/scripts/interactive-release.sh
+++ b/scripts/interactive-release.sh
@@ -237,10 +237,10 @@ generate-release-notes() {
 
 publish-gh-release() {
   for EXEC in uplc pir plc plutus; do
-    nix build ".#packages.x86_64-linux.musl64-$EXEC"
+    nix build "path:.#packages.x86_64-linux.musl64-$EXEC"
     upx -9 ./result/bin/$EXEC -o $EXEC-x86_64-linux-ghc96 --force-overwrite
   done
-  nix build ".#metatheory-agda-library"
+  nix build "path:.#metatheory-agda-library"
   cp -f ./result/plutus-metatheory.tar.gz .
   local NOTES_FILE=$(mktemp)
   generate-release-notes > $NOTES_FILE


### PR DESCRIPTION
In a bare-repo + git-worktree layout, Nix's default `.#` flake ref treats the flake as a Git input and errors with `Path 'flake.nix' in the repository is not tracked by Git` — even though the file is tracked in the bare repo. Prefixing with `path:` tells Nix to read the directory directly; standard clones see identical behaviour.

I hit this during the Plutus 1.62.0.0 release when step 6 (`publish-gh-release`) ran `nix build ".#..."`. The two invocations in that function are the only `.#` flake refs in the script; both now use `path:.#`.