### PR TITLE
Remove redundant recursive alias in genTerm

### DIFF
--- a/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
+++ b/plutus-core/testlib/PlutusCore/Generators/Hedgehog/Entity.hs
@@ -195,11 +195,10 @@ genTerm genBase context0 depth0 = Morph.hoist runQuoteT . go context0 depth0
       -> TypeRep r
       -> GenT (QuoteT m) (TermOf (Plain Term uni fun) r)
     go context depth tr
-      -- FIXME: should be using 'variables' but this is now the same as 'recursive'
       | depth == 0 = choiceDef (liftT $ genBase tr) []
-      | depth == 1 = choiceDef (liftT $ genBase tr) $ variables ++ recursive
-      | depth == 2 = Gen.frequency $ stopOrDeeper ++ map (3,) variables ++ map (5,) recursive
-      | depth == 3 = Gen.frequency $ stopOrDeeper ++ map (3,) recursive
+      | depth == 1 = choiceDef (liftT $ genBase tr) variables
+      | depth == 2 = Gen.frequency $ stopOrDeeper ++ map (5,) variables
+      | depth == 3 = Gen.frequency $ stopOrDeeper ++ map (3,) variables
       | otherwise = Gen.frequency stopOrDeeper
       where
         stopOrDeeper = [(1, liftT $ genBase tr), (5, lambdaApply)]
@@ -209,10 +208,8 @@ genTerm genBase context0 depth0 = Morph.hoist runQuoteT . go context0 depth0
         -- Generate arguments for functions recursively or return a variable.
         proceed (DenotationContextMember denotation) =
           fmap iterAppValueToTermOf . hoistSupply builtinGens $ genIterAppValue denotation
-        -- A list of variables generators.
+        -- Context lookup: terms of the right type already in scope.
         variables = map proceed $ lookupInContext tr context
-        -- A list of recursive generators.
-        recursive = map proceed $ lookupInContext tr context
         -- Generate a lambda and immediately apply it to a generated argument of a generated type.
         lambdaApply = withTypedBuiltinGen (Proxy @fun) $ \argTr -> do
           -- Generate a name for the name representing the argument.


### PR DESCRIPTION
## Summary

In `genTerm`'s inner `go` helper (`PlutusCore/Generators/Hedgehog/Entity.hs`), the `recursive` where-binding was byte-for-byte identical to `variables`:

```haskell
variables = map proceed $ lookupInContext tr context
recursive = map proceed $ lookupInContext tr context
```

These were not always aliases. Back when PLC had a size system, `variables` looked up the type as written while `recursive` looked it up with sizes erased, so two different keys could yield two different result sets — `variables ++ recursive` was actually mixing them.

PR #934 (0ed93972a6) ripped sizes out of the language. The size-erasure step turned into a no-op, both bindings collapsed onto the same lookup, and a FIXME was left behind instead of a real fix. The duplication then rode along through later refactors (2064f49cea, 65b2c34d5a, e9c420da4d) untouched.

So today `variables ++ recursive` is just `xs ++ xs`, and the `Gen.frequency` calls were silently double-weighting the same set. This PR removes the duplication: one binding (`variables`), referenced once in each guard.

If anyone wants the doubled weight back at depth 2, a single `map (8,) variables` would say so honestly — but that doubling was an accident, not a design choice, so this PR drops it.

## Test plan
- [ ] `cabal build plutus-core:test:plutus-core-test`
- [ ] `cabal test plutus-core:test:plutus-core-test`