### PR TITLE
drop x86_64-darwin hydra jobs

### DIFF
--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -131,7 +131,6 @@ jobs:
 
               const checkRunWatchlist = [
                 "ci/hydra-build:aarch64-darwin.required",
-                "ci/hydra-build:x86_64-darwin.required",
                 "ci/hydra-build:x86_64-linux.required",
                 "ci/eval"
               ];

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -129,14 +129,7 @@ let
       { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
       { required = hydra-required-job; };
     "x86_64-darwin" =
-      { ghc96 = project-variants-hydra-jobs.ghc96; } //
-      { ghc912 = project-variants-hydra-jobs.ghc912; } //
-      { devShells.ghc96 = devShells.ghc96; } //
-      { devShells.ghc912 = devShells.ghc912; } //
-      { devShells.ghc96-profiled = devShells.ghc96-profiled; } //
-      { devShells.ghc912-profiled = devShells.ghc912-profiled; } //
-      { devShells.metatheory-jailbreak = metatheory-jailbreak-shell; } //
-      { required = hydra-required-job; };
+      { };
     "aarch64-linux" =
       { };
     "aarch64-darwin" =


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

<!--
IMPORTANT: if you are an external contributor, make sure you have read the "External contributors" section of CONTRIBUTING.

Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

Pre-submit checklist:
- Branch
    - [x] ~~Tests are provided (if possible)~~
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] ~~Changelog fragments have been written (if appropriate)~~
    - [x] ~~Relevant tickets are mentioned in commit messages~~
    - [x] ~~Formatting, PNG optimization, etc. are updated~~
- PR
    - [x] ~~(For external contributions) Corresponding issue exists and is linked in the description~~
    - [x] Targeting master unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
