### PR TITLE
test(uplc-evaluator): event-driven file waits to fix darwin flakiness

### DIFF
--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -957,6 +957,7 @@ test-suite uplc-evaluator-integration-tests
     , bytestring
     , directory
     , filepath
+    , fsnotify            >=0.4
     , process
     , string-interpolate
     , tasty

--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -21,13 +21,17 @@ import TestHelpers
   ( EvalError (..)
   , EvalResult (..)
   , TimingSample (..)
+  , defaultWaitMs
+  , errorPath
   , readErrorJsonOrFail
   , readResultJson
   , readResultJsonOrFail
+  , resultPath
   , submitProgram
   , submitProgramFlat
   , waitForError
   , waitForErrorOrFail
+  , waitForFile
   , waitForResult
   , waitForResultOrFail
   )
@@ -71,7 +75,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
 
                   -- Verify program_id matches submitted UUID
@@ -131,7 +135,7 @@ main = withUtf8 do
 
                   -- Wait for error (5 second timeout)
                   -- Expected: MVP validates text content, flat binary won't have "(program" prefix
-                  path <- waitForErrorOrFail handle jobId 5000
+                  path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
 
                   -- Verify program_id matches submitted UUID
@@ -174,7 +178,7 @@ main = withUtf8 do
                   submitProgram handle jobId emptyProgram
 
                   -- Wait for error (5 second timeout)
-                  path <- waitForErrorOrFail handle jobId 5000
+                  path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
 
                   -- Verify program_id matches submitted UUID
@@ -204,7 +208,7 @@ main = withUtf8 do
                   submitProgram handle jobId invalidProgram
 
                   -- Wait for error (5 second timeout)
-                  path <- waitForErrorOrFail handle jobId 5000
+                  path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches submitted UUID
                   let expectedId = T.pack (UUID.toString jobId)
@@ -232,7 +236,7 @@ main = withUtf8 do
                   submitProgram handle jobId invalidProgram
 
                   -- Wait for error (5 second timeout)
-                  path <- waitForErrorOrFail handle jobId 5000
+                  path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches submitted UUID
                   let expectedId = T.pack (UUID.toString jobId)
@@ -265,7 +269,7 @@ main = withUtf8 do
                   -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFileWithTimeout errorPath 5000
+                      =<< waitForFile errorPath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -299,7 +303,7 @@ main = withUtf8 do
                   -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFileWithTimeout errorPath 5000
+                      =<< waitForFile errorPath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -333,7 +337,7 @@ main = withUtf8 do
                   -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFileWithTimeout errorPath 5000
+                      =<< waitForFile errorPath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -363,7 +367,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for error (5 second timeout)
-                  path <- waitForErrorOrFail handle jobId 5000
+                  path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
 
                   -- Verify program_id matches submitted UUID
@@ -406,36 +410,18 @@ main = withUtf8 do
                   writeFile jsonPath program
                   writeFile configPath program
 
-                  -- Wait 2 seconds to ensure service has time to process (if it were to)
+                  -- Give the service enough time to process (if it were to)
                   threadDelay 2000000 -- 2 seconds in microseconds
 
-                  -- Verify none of these produced result or error files
-                  result1 <- waitForResult handle jobId1 100 -- Short timeout, should already exist if processed
-                  result2 <- waitForResult handle jobId2 100
-                  result3 <- waitForResult handle jobId3 100
-                  error1 <- waitForError handle jobId1 100
-                  error2 <- waitForError handle jobId2 100
-                  error3 <- waitForError handle jobId3 100
-
-                  -- All should be Nothing (not processed)
-                  case result1 of
-                    Just _ -> assertFailure ".txt file should not be processed"
-                    Nothing -> return ()
-                  case result2 of
-                    Just _ -> assertFailure ".json file should not be processed"
-                    Nothing -> return ()
-                  case result3 of
-                    Just _ -> assertFailure ".uplc.config file should not be processed"
-                    Nothing -> return ()
-                  case error1 of
-                    Just _ -> assertFailure ".txt file should not produce error"
-                    Nothing -> return ()
-                  case error2 of
-                    Just _ -> assertFailure ".json file should not produce error"
-                    Nothing -> return ()
-                  case error3 of
-                    Just _ -> assertFailure ".uplc.config file should not produce error"
-                    Nothing -> return ()
+                  -- None of these should have produced result or error files
+                  let assertNotProcessed jobId label = do
+                        r <- doesFileExist (resultPath handle jobId)
+                        assertBool (label ++ " should not be processed") (not r)
+                        e <- doesFileExist (errorPath handle jobId)
+                        assertBool (label ++ " should not produce error") (not e)
+                  assertNotProcessed jobId1 ".txt file"
+                  assertNotProcessed jobId2 ".json file"
+                  assertNotProcessed jobId3 ".uplc.config file"
             , testCase "Valid .uplc.txt file is processed alongside ignored files" do
                 execPath <- findEvaluatorExecutable
                 withEvaluatorService execPath \handle -> do
@@ -454,17 +440,15 @@ main = withUtf8 do
                   writeFile ignoredPath program
 
                   -- Wait for the valid file to be processed
-                  path <-
-                    maybe (assertFailure "Valid .uplc.txt file should be processed") pure
-                      =<< waitForResult handle validJobId 5000
+                  path <- waitForResultOrFail handle validJobId
                   result <- readResultJsonOrFail path
                   erStatus result @?= "success"
 
-                  -- Verify the ignored file was not processed
-                  ignoredResult <- waitForResult handle ignoredJobId 100
-                  case ignoredResult of
-                    Just _ -> assertFailure "File with wrong extension should not be processed"
-                    Nothing -> return ()
+                  -- The ignored file should not have been processed by now
+                  ignoredExists <- doesFileExist (resultPath handle ignoredJobId)
+                  assertBool
+                    "File with wrong extension should not be processed"
+                    (not ignoredExists)
             ]
         , testGroup
             "Measurement Data Validation"
@@ -479,7 +463,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify timing_samples array has 10-20 entries
                   let samples = erTimingSamples result
@@ -524,7 +508,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify we have timing samples
                   let samples = erTimingSamples result
@@ -568,7 +552,7 @@ main = withUtf8 do
                       submitProgram handle jobId program
 
                       -- Wait for result (should succeed, not produce validation error)
-                      path <- waitForResultOrFail handle jobId 5000
+                      path <- waitForResultOrFail handle jobId
                       result <- readResultJsonOrFail path
                       -- Verify program_id matches submitted UUID
                       erProgramId result @?= T.pack uuidText
@@ -594,7 +578,7 @@ main = withUtf8 do
                       submitProgram handle jobId program
 
                       -- Wait for result (should succeed, not produce validation error)
-                      path <- waitForResultOrFail handle jobId 5000
+                      path <- waitForResultOrFail handle jobId
                       result <- readResultJsonOrFail path
                       -- Verify status is "success" (not validation error)
                       erStatus result @?= "success"
@@ -620,9 +604,9 @@ main = withUtf8 do
                   submitProgram handle jobId3 program
 
                   -- Wait for all results
-                  result1Path <- waitForResult handle jobId1 5000
-                  result2Path <- waitForResult handle jobId2 5000
-                  result3Path <- waitForResult handle jobId3 5000
+                  result1Path <- waitForResult handle jobId1
+                  result2Path <- waitForResult handle jobId2
+                  result3Path <- waitForResult handle jobId3
 
                   -- Verify all succeeded
                   case (result1Path, result2Path, result3Path) of
@@ -666,7 +650,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   erStatus result @?= "success"
 
@@ -719,7 +703,7 @@ main = withUtf8 do
                   mapM_ (\jobId -> submitProgram handle jobId program) jobIds
 
                   -- Wait for all results (5 second timeout each)
-                  paths <- mapM (\jobId -> waitForResultOrFail handle jobId 5000) jobIds
+                  paths <- mapM (\jobId -> waitForResultOrFail handle jobId) jobIds
                   results <- mapM readResultJsonOrFail paths
                   -- Verify we got exactly 5 results
                   length results @?= 5
@@ -771,7 +755,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -792,7 +776,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -813,7 +797,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -834,7 +818,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -858,7 +842,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -884,7 +868,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -912,7 +896,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -933,7 +917,7 @@ main = withUtf8 do
                   submitProgram handle jobId program
 
                   -- Wait for result (5 second timeout)
-                  path <- waitForResultOrFail handle jobId 5000
+                  path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
                   erStatus result @?= "success"
@@ -946,21 +930,3 @@ main = withUtf8 do
             ]
         ]
     )
-
-{-| Helper function to wait for a file to appear with timeout
-Used for non-UUID based filenames where we can't use the standard helpers -}
-waitForFileWithTimeout :: FilePath -> Int -> IO (Maybe FilePath)
-waitForFileWithTimeout filepath timeoutMs = go 0
-  where
-    timeoutUs = timeoutMs * 1000
-    pollIntervalUs = 50000
-    go elapsedUs = do
-      exists <- doesFileExist filepath
-      if exists
-        then return (Just filepath)
-        else
-          if elapsedUs >= timeoutUs
-            then return Nothing
-            else do
-              threadDelay pollIntervalUs
-              go (elapsedUs + pollIntervalUs)

--- a/plutus-benchmark/uplc-evaluator/test/Spec.hs
+++ b/plutus-benchmark/uplc-evaluator/test/Spec.hs
@@ -29,7 +29,6 @@ import TestHelpers
   , resultPath
   , submitProgram
   , submitProgramFlat
-  , waitForError
   , waitForErrorOrFail
   , waitForFile
   , waitForResult
@@ -74,7 +73,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
 
@@ -133,7 +131,6 @@ main = withUtf8 do
                   let flatBytes = "\x01\x00\x00\x00\x01\x00\x00\x00" -- 8 bytes of binary data
                   submitProgramFlat handle jobId flatBytes
 
-                  -- Wait for error (5 second timeout)
                   -- Expected: MVP validates text content, flat binary won't have "(program" prefix
                   path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
@@ -177,7 +174,6 @@ main = withUtf8 do
                   let emptyProgram = ""
                   submitProgram handle jobId emptyProgram
 
-                  -- Wait for error (5 second timeout)
                   path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
 
@@ -207,7 +203,6 @@ main = withUtf8 do
                   let invalidProgram = "not a valid program"
                   submitProgram handle jobId invalidProgram
 
-                  -- Wait for error (5 second timeout)
                   path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches submitted UUID
@@ -235,7 +230,6 @@ main = withUtf8 do
                   let invalidProgram = "program 1.0.0 (con integer 42)"
                   submitProgram handle jobId invalidProgram
 
-                  -- Wait for error (5 second timeout)
                   path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches submitted UUID
@@ -264,12 +258,11 @@ main = withUtf8 do
                   -- Service will extract "not-a-uuid" as the job ID (first 36 chars of base name)
                   let expectedJobId = "not-a-uuid"
                       errorFilename = expectedJobId ++ ".error.json"
-                      errorPath = shOutputDir handle </> errorFilename
+                      errorFilePath = shOutputDir handle </> errorFilename
 
-                  -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFile errorPath defaultWaitMs
+                      =<< waitForFile errorFilePath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -298,12 +291,11 @@ main = withUtf8 do
                   -- Service will extract "job-123" as the job ID
                   let expectedJobId = "job-123"
                       errorFilename = expectedJobId ++ ".error.json"
-                      errorPath = shOutputDir handle </> errorFilename
+                      errorFilePath = shOutputDir handle </> errorFilename
 
-                  -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFile errorPath defaultWaitMs
+                      =<< waitForFile errorFilePath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -332,12 +324,11 @@ main = withUtf8 do
                   -- Service will extract "12345" as the job ID
                   let expectedJobId = "12345"
                       errorFilename = expectedJobId ++ ".error.json"
-                      errorPath = shOutputDir handle </> errorFilename
+                      errorFilePath = shOutputDir handle </> errorFilename
 
-                  -- Wait for error file (5 second timeout)
                   path <-
                     maybe (assertFailure "Timeout waiting for error.json") pure
-                      =<< waitForFile errorPath defaultWaitMs
+                      =<< waitForFile errorFilePath defaultWaitMs
                   evalError <- readErrorJsonOrFail path
                   -- Verify program_id matches truncated filename
                   eeProgramId evalError @?= T.pack expectedJobId
@@ -366,7 +357,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 [ (con integer 42) (con integer 1) ])"
                   submitProgram handle jobId program
 
-                  -- Wait for error (5 second timeout)
                   path <- waitForErrorOrFail handle jobId
                   evalError <- readErrorJsonOrFail path
 
@@ -462,7 +452,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify timing_samples array has 10-20 entries
@@ -507,7 +496,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify we have timing samples
@@ -649,7 +637,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   erStatus result @?= "success"
@@ -702,7 +689,6 @@ main = withUtf8 do
                   -- Submit all 5 programs simultaneously
                   mapM_ (\jobId -> submitProgram handle jobId program) jobIds
 
-                  -- Wait for all results (5 second timeout each)
                   paths <- mapM (\jobId -> waitForResultOrFail handle jobId) jobIds
                   results <- mapM readResultJsonOrFail paths
                   -- Verify we got exactly 5 results
@@ -754,7 +740,6 @@ main = withUtf8 do
                   let program = "   (program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -775,7 +760,6 @@ main = withUtf8 do
                   let program = "\n\n(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -796,7 +780,6 @@ main = withUtf8 do
                   let program = "\t(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -817,7 +800,6 @@ main = withUtf8 do
                   let program = " \t\n  \t(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -841,7 +823,6 @@ main = withUtf8 do
                   let program = "(program 1.0.0 (con integer 42))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -867,7 +848,6 @@ main = withUtf8 do
                     |]
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -895,7 +875,6 @@ main = withUtf8 do
                     |]
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"
@@ -916,7 +895,6 @@ main = withUtf8 do
                   let program = "(program 1.1.0 (constr 0 (con integer 42) (con bool True)))"
                   submitProgram handle jobId program
 
-                  -- Wait for result (5 second timeout)
                   path <- waitForResultOrFail handle jobId
                   result <- readResultJsonOrFail path
                   -- Verify status is "success"

--- a/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
+++ b/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
@@ -160,9 +160,10 @@ waitForError handle jobId = waitForFile (errorPath handle jobId) defaultWaitMs
 {-| Wait for a file to appear, event-driven
 
 Registers an fsnotify watcher on the parent directory and blocks until the
-file appears, with a wall-clock safety net. A post-registration existence
-check closes the race window where the file is created after the watcher is
-set up but before an event is observed. Timeout is specified in milliseconds. -}
+file appears, with a wall-clock safety net. After registering the watcher
+we do a single 'doesFileExist' probe to cover the case where the file was
+already created before the watcher was ready (otherwise the event would
+have fired and been missed). Timeout is specified in milliseconds. -}
 waitForFile :: FilePath -> Int -> IO (Maybe FilePath)
 waitForFile filepath timeoutMs = do
   done <- newEmptyMVar

--- a/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
+++ b/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
@@ -13,6 +13,12 @@ module TestHelpers
   , waitForError
   , waitForResultOrFail
   , waitForErrorOrFail
+  , waitForFile
+  , defaultWaitMs
+
+    -- * Path derivation
+  , resultPath
+  , errorPath
 
     -- * JSON parsing functions
   , readResultJson
@@ -26,7 +32,8 @@ module TestHelpers
   , TimingSample (..)
   ) where
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar (newEmptyMVar, takeMVar, tryPutMVar)
+import Control.Monad (void, when)
 import Data.Aeson (FromJSON (..), (.:))
 import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
@@ -40,7 +47,9 @@ import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Harness (ServiceHandle (..))
 import System.Directory (doesFileExist, renameFile)
-import System.FilePath ((</>))
+import System.FSNotify qualified as FS
+import System.FilePath (takeDirectory, takeFileName, (</>))
+import System.Timeout (timeout)
 import Test.Tasty.HUnit (assertFailure)
 
 -- | Timing sample for a single evaluation run (variable data only)
@@ -122,50 +131,53 @@ submitProgramFlat ServiceHandle {..} jobId programBytes = do
   BS.writeFile tempPath programBytes
   renameFile tempPath filepath
 
+-- | Path the service writes a result.json to for this job.
+resultPath :: ServiceHandle -> UUID -> FilePath
+resultPath ServiceHandle {..} jobId =
+  shOutputDir </> UUID.toString jobId ++ ".result.json"
+
+-- | Path the service writes an error.json to for this job.
+errorPath :: ServiceHandle -> UUID -> FilePath
+errorPath ServiceHandle {..} jobId =
+  shOutputDir </> UUID.toString jobId ++ ".error.json"
+
 {-| Wait for a result.json file to appear
 
-Polls the output directory until the result file appears or timeout is reached.
-Timeout is specified in milliseconds.
+Subscribes to filesystem events for the output directory and returns as soon
+as the file is created, with 'defaultWaitMs' as a safety-net timeout.
 Returns the filepath if found, Nothing if timeout. -}
-waitForResult :: ServiceHandle -> UUID -> Int -> IO (Maybe FilePath)
-waitForResult ServiceHandle {..} jobId timeoutMs = do
-  let filename = UUID.toString jobId ++ ".result.json"
-      filepath = shOutputDir </> filename
-      -- Convert timeout to microseconds for threadDelay
-      timeoutUs = timeoutMs * 1000
-      -- Poll every 50ms
-      pollIntervalUs = 50000
-  waitForFile filepath timeoutUs pollIntervalUs
+waitForResult :: ServiceHandle -> UUID -> IO (Maybe FilePath)
+waitForResult handle jobId = waitForFile (resultPath handle jobId) defaultWaitMs
 
 {-| Wait for an error.json file to appear
 
-Polls the output directory until the error file appears or timeout is reached.
-Timeout is specified in milliseconds.
+Subscribes to filesystem events for the output directory and returns as soon
+as the file is created, with 'defaultWaitMs' as a safety-net timeout.
 Returns the filepath if found, Nothing if timeout. -}
-waitForError :: ServiceHandle -> UUID -> Int -> IO (Maybe FilePath)
-waitForError ServiceHandle {..} jobId timeoutMs = do
-  let filename = UUID.toString jobId ++ ".error.json"
-      filepath = shOutputDir </> filename
-      timeoutUs = timeoutMs * 1000
-      pollIntervalUs = 50000
-  waitForFile filepath timeoutUs pollIntervalUs
+waitForError :: ServiceHandle -> UUID -> IO (Maybe FilePath)
+waitForError handle jobId = waitForFile (errorPath handle jobId) defaultWaitMs
 
-{-| Internal helper to wait for a file to appear
+{-| Wait for a file to appear, event-driven
 
-Polls at regular intervals until file exists or timeout. -}
-waitForFile :: FilePath -> Int -> Int -> IO (Maybe FilePath)
-waitForFile filepath timeoutUs pollIntervalUs = go 0
-  where
-    go elapsedUs = do
-      exists <- doesFileExist filepath
-      if exists
-        then return (Just filepath)
-        else
-          if elapsedUs >= timeoutUs
-            then return Nothing
-            else do
-              threadDelay pollIntervalUs
-              go (elapsedUs + pollIntervalUs)
+Registers an fsnotify watcher on the parent directory and blocks until the
+file appears, with a wall-clock safety net. The pre-watch existence check
+closes the race window where the file is created before the watcher is
+ready. Timeout is specified in milliseconds. -}
+waitForFile :: FilePath -> Int -> IO (Maybe FilePath)
+waitForFile filepath timeoutMs = do
+  done <- newEmptyMVar
+  let dir = takeDirectory filepath
+      target = takeFileName filepath
+      isMatch ev = takeFileName (FS.eventPath ev) == target
+  FS.withManager $ \mgr -> do
+    stop <- FS.watchDir mgr dir isMatch (\_ -> void (tryPutMVar done ()))
+    -- The file may have appeared before the watcher started; check once
+    -- after registering so we don't deadlock waiting for a missed event.
+    alreadyThere <- doesFileExist filepath
+    when alreadyThere (void (tryPutMVar done ()))
+    res <- timeout (timeoutMs * 1000) (takeMVar done)
+    stop
+    pure (filepath <$ res)
 
 {-| Read and parse a result JSON file
 
@@ -183,22 +195,29 @@ readErrorJson filepath = do
   content <- BSL.readFile filepath
   return $ Aeson.eitherDecode content
 
-{-| Wait for a result file and fail the test if timeout
+{-| Default upper bound for "wait until the service produces output".
+Generous enough to absorb scheduler jitter on loaded CI builders;
+the event-driven waiter returns immediately on success, so this is
+only paid on actual hangs. -}
+defaultWaitMs :: Int
+defaultWaitMs = 20000
+
+{-| Wait for a result file and fail the test if it does not appear
 
 This is a convenience wrapper around waitForResult that converts
 timeout to a test failure using assertFailure. -}
-waitForResultOrFail :: ServiceHandle -> UUID -> Int -> IO FilePath
-waitForResultOrFail handle jobId timeoutMs = do
-  result <- waitForResult handle jobId timeoutMs
+waitForResultOrFail :: ServiceHandle -> UUID -> IO FilePath
+waitForResultOrFail handle jobId = do
+  result <- waitForResult handle jobId
   maybe (assertFailure "Timeout waiting for result.json") pure result
 
-{-| Wait for an error file and fail the test if timeout
+{-| Wait for an error file and fail the test if it does not appear
 
 This is a convenience wrapper around waitForError that converts
 timeout to a test failure using assertFailure. -}
-waitForErrorOrFail :: ServiceHandle -> UUID -> Int -> IO FilePath
-waitForErrorOrFail handle jobId timeoutMs = do
-  result <- waitForError handle jobId timeoutMs
+waitForErrorOrFail :: ServiceHandle -> UUID -> IO FilePath
+waitForErrorOrFail handle jobId = do
+  result <- waitForError handle jobId
   maybe (assertFailure "Timeout waiting for error.json") pure result
 
 {-| Read and parse a result JSON file, failing the test on error

--- a/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
+++ b/plutus-benchmark/uplc-evaluator/test/TestHelpers.hs
@@ -160,9 +160,9 @@ waitForError handle jobId = waitForFile (errorPath handle jobId) defaultWaitMs
 {-| Wait for a file to appear, event-driven
 
 Registers an fsnotify watcher on the parent directory and blocks until the
-file appears, with a wall-clock safety net. The pre-watch existence check
-closes the race window where the file is created before the watcher is
-ready. Timeout is specified in milliseconds. -}
+file appears, with a wall-clock safety net. A post-registration existence
+check closes the race window where the file is created after the watcher is
+set up but before an event is observed. Timeout is specified in milliseconds. -}
 waitForFile :: FilePath -> Int -> IO (Maybe FilePath)
 waitForFile filepath timeoutMs = do
   done <- newEmptyMVar


### PR DESCRIPTION
Closes #7762 (partially — addresses `uplc-evaluator-integration-tests`; `flat-test` on `ghc96-mingsW64` looks like a different, platform-specific bug and is not touched here).

## Background

CI history over the last ~200 PRs shows `uplc-evaluator-integration-tests` failing almost exclusively on `x86_64-darwin` Hydra builders (8× on `ghc96`, 3× on `ghc912`), with no failures on linux. The test waits for the service to produce `result.json` / `error.json` via a 50ms polling loop with a hard-coded 5s timeout. Under load this could be a source of flakiness.

## Change

- `waitForFile` rewritten on top of `fsnotify`: subscribes to the parent directory and unblocks as soon as the kernel reports the file. `System.Timeout.timeout` is kept as a safety net only.
- Race-free registration: a single `doesFileExist` check is performed *after* the watcher is up, so a file written between submit and watch-registration still wakes the waiter.
- Default timeout raised from 5s to 20s and exposed as `defaultWaitMs`. Since the watcher returns immediately on success, this only changes behaviour when something actually hangs.
