### PR TITLE
Remove stale "Compute address again" TODO from outValue docstrings

### DIFF
--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Tx.hs
@@ -158,8 +158,7 @@ outAddress = lens txOutAddress s
   where
     s tx a = tx {txOutAddress = a}
 
-{-| The value of a transaction output.
-| TODO: Compute address again -}
+-- | The value of a transaction output.
 outValue :: Lens' TxOut Value
 outValue = lens txOutValue s
   where

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Tx.hs
@@ -140,8 +140,7 @@ outAddress = lens txOutAddress s
   where
     s tx a = tx {txOutAddress = a}
 
-{-| The value of a transaction output.
-| TODO: Compute address again -}
+-- | The value of a transaction output.
 outValue :: Lens' TxOut Value
 outValue = lens txOutValue s
   where

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Data/Tx.hs
@@ -142,8 +142,7 @@ outDatum = lens txOutDatum s
   where
     s tx v = tx {txOutDatum = v}
 
-{-| The value of a transaction output.
-| TODO: Compute address again -}
+-- | The value of a transaction output.
 outValue :: Lens' TxOut Value
 outValue = lens txOutValue s
   where

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2/Tx.hs
@@ -121,8 +121,7 @@ outDatum = lens txOutDatum s
   where
     s tx v = tx {txOutDatum = v}
 
-{-| The value of a transaction output.
-| TODO: Compute address again -}
+-- | The value of a transaction output.
 outValue :: Lens' TxOut Value
 outValue = lens txOutValue s
   where


### PR DESCRIPTION
## Summary

The four `outValue` lenses in `PlutusLedgerApi.{V1,V2}.{,.Data}.Tx` carried an orphan `| TODO: Compute address again` line in their Haddock, almost certainly a copy-paste leftover from the `outAddress` lens docstring a few lines above, since `outValue` has nothing to do with addresses.

This PR replaces the two-line block
