### PR TITLE
[Chore] Extract shared term constructors into Transform.Lib

### DIFF
--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -491,6 +491,7 @@ library untyped-plutus-core-testlib
     Transform.CaseOfCase.Spec
     Transform.EvaluateBuiltins.Spec
     Transform.Inline.Spec
+    Transform.Lib
     Transform.Simplify.Lib
     Transform.Simplify.Spec
 

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -491,10 +491,10 @@ library untyped-plutus-core-testlib
     Transform.CaseOfCase.Spec
     Transform.EvaluateBuiltins.Spec
     Transform.Inline.Spec
-    Transform.Lib
     Transform.Simplify.Lib
     Transform.Simplify.Spec
 
+  other-modules:      Transform.Lib
   build-depends:
     , base                             >=4.9   && <5
     , base16-bytestring

--- a/plutus-core/untyped-plutus-core/testlib/Transform/CaseOfCase/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/CaseOfCase/Spec.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Transform.CaseOfCase.Spec where
 
 import Data.ByteString.Lazy qualified as BSL
 import Data.Text.Encoding (encodeUtf8)
-import Data.Vector qualified as V
 import PlutusCore qualified as PLC
 import PlutusCore.Evaluation.Machine.BuiltinCostModel (BuiltinCostModel)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults
@@ -19,13 +17,13 @@ import PlutusCore.Evaluation.Machine.MachineParameters
   , mkMachineVariantParameters
   )
 import PlutusCore.Evaluation.Machine.MachineParameters.Default (DefaultMachineParameters)
-import PlutusCore.MkPlc (mkConstant, mkIterApp)
+import PlutusCore.MkPlc (mkConstant)
 import PlutusCore.Pretty
-import PlutusCore.Quote (freshName, runQuote)
 import PlutusPrelude (Default (def))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsString)
 import Test.Tasty.HUnit (testCase, (@?=))
+import Transform.Lib (builtinTrue, case_, con, constr, err, ite, sopFalse, sopTrue, var)
 import UntypedPlutusCore (DefaultFun, DefaultUni, Name, Term (..))
 import UntypedPlutusCore.Core qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
@@ -50,42 +48,26 @@ test_caseOfCase =
     ]
 
 caseOfCase1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase1 = runQuote do
-  b <- freshName "b"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Constr () 0 []
-      false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase1 =
+  case_
+    (ite (var "b") sopTrue sopFalse)
+    [ con 1 -- True branch
+    , con 2 -- False branch
+    ]
 
 {-| This should not simplify, because one of the branches of `ifThenElse` is not a `Constr`.
 Unless both branches are known constructors, the case-of-case transformation
 may increase the program size. -}
 caseOfCase2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase2 = runQuote do
-  b <- freshName "b"
-  t <- freshName "t"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Var () t
-      false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase2 = case_ (ite (var "b") (var "t") sopFalse) [con 1, con 2]
 
 {-| Similar to `caseOfCase1`, but the type of the @true@ and @false@ branches is
-@[Integer]@ rather than Bool (note that @Constr 0@ has two parameters, @x@ and @xs@). -}
+@[Integer]@ rather than Bool (note that @constr 0@ has two parameters, @x@ and @xs@). -}
 caseOfCase3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase3 = runQuote do
-  b <- freshName "b"
-  x <- freshName "x"
-  xs <- freshName "xs"
-  f <- freshName "f"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Constr () 0 [Var () x, Var () xs]
-      false = Constr () 1 []
-      altTrue = Var () f
-      altFalse = mkConstant @Integer () 2
-      alts = V.fromList [altTrue, altFalse]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase3 =
+  case_
+    (ite (var "b") (constr 0 [var "x", var "xs"]) sopFalse)
+    [var "f", con 2]
 
 {-|
 
@@ -104,17 +86,7 @@ After the `CaseOfCase` transformation the program should evaluate to `()` as wel
   force ((force ifThenElse) True (delay ()) (delay _|_))
 @ -}
 caseOfCaseWithError :: Term Name DefaultUni DefaultFun ()
-caseOfCaseWithError =
-  Case
-    ()
-    ( mkIterApp
-        (Force () (Builtin () PLC.IfThenElse))
-        [ ((), mkConstant @Bool () True)
-        , ((), Constr () 0 []) -- True
-        , ((), Constr () 1 []) -- False
-        ]
-    )
-    (V.fromList [mkConstant @() () (), Error ()])
+caseOfCaseWithError = case_ (ite builtinTrue sopTrue sopFalse) [mkConstant @() () (), err]
 
 testCaseOfCaseWithError :: TestTree
 testCaseOfCaseWithError =
@@ -145,8 +117,10 @@ evaluateUplc = unsafeSplitStructuralOperational . fst <$> evaluateCek noEmitter 
       MachineParameters def $ mkMachineVariantParameters def costModel
 
 goldenVsSimplified :: String -> Term Name PLC.DefaultUni PLC.DefaultFun () -> TestTree
-goldenVsSimplified name =
-  goldenVsString name ("untyped-plutus-core/test/Transform/CaseOfCase/" ++ name ++ ".golden.uplc")
+goldenVsSimplified testName =
+  goldenVsString
+    testName
+    ("untyped-plutus-core/test/Transform/CaseOfCase/" ++ testName ++ ".golden.uplc")
     . pure
     . BSL.fromStrict
     . encodeUtf8

--- a/plutus-core/untyped-plutus-core/testlib/Transform/EvaluateBuiltins/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/EvaluateBuiltins/Spec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Transform.EvaluateBuiltins.Spec where
@@ -6,12 +5,11 @@ module Transform.EvaluateBuiltins.Spec where
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as BS8
-import Data.Text (Text)
 import PlutusCore qualified as PLC
-import PlutusCore.MkPlc (mkConstant, mkIterApp)
-import PlutusCore.Quote (freshName, runQuote)
+import PlutusCore.MkPlc (mkConstant)
 import PlutusPrelude (Default (def))
 import Test.Tasty (TestTree, testGroup)
+import Transform.Lib (app, builtin, builtinTrue, con, force, ite, lam, text, var)
 import Transform.Simplify.Lib (goldenVsPretty)
 import UntypedPlutusCore (DefaultFun, DefaultUni, Name, Term (..))
 import UntypedPlutusCore.Transform.EvaluateBuiltins (evaluateBuiltinsPass)
@@ -39,8 +37,8 @@ test_evaluateBuiltins =
         ]
 
 goldenVsEvaluated :: Bool -> String -> Term Name DefaultUni DefaultFun () -> TestTree
-goldenVsEvaluated conservative name =
-  goldenVsPretty ".golden.uplc" ("EvaluateBuiltins/" ++ name)
+goldenVsEvaluated conservative testName =
+  goldenVsPretty ".golden.uplc" ("EvaluateBuiltins/" ++ testName)
     . runEvaluateBuiltins conservative
 
 runEvaluateBuiltins
@@ -50,73 +48,36 @@ runEvaluateBuiltins
 runEvaluateBuiltins conservative = evalOptimizer . evaluateBuiltinsPass conservative def def
 
 addIntegerTerm :: Term Name DefaultUni DefaultFun ()
-addIntegerTerm =
-  Apply
-    ()
-    (Apply () (Builtin () PLC.AddInteger) (mkConstant @Integer () 1))
-    (mkConstant @Integer () 2)
+addIntegerTerm = builtin PLC.AddInteger `app` con 1 `app` con 2
 
 ifThenElseTerm :: Term Name DefaultUni DefaultFun ()
-ifThenElseTerm =
-  mkIterApp
-    (Force () (Builtin () PLC.IfThenElse))
-    [ ((), mkConstant @Bool () True)
-    , ((), mkConstant @Integer () 1)
-    , ((), mkConstant @Integer () 2)
-    ]
+ifThenElseTerm = ite builtinTrue (con 1) (con 2)
 
 -- Used for both traceConservative (unchanged) and traceNonConservative (reduced to 1)
 traceTerm :: Term Name DefaultUni DefaultFun ()
-traceTerm =
-  Apply
-    ()
-    (Apply () (Force () (Builtin () PLC.Trace)) (mkConstant @Text () "hello"))
-    (mkConstant @Integer () 1)
+traceTerm = force (builtin PLC.Trace) `app` text "hello" `app` con 1
 
 -- Division by zero; evaluates to error so should be left in place
 failingBuiltinTerm :: Term Name DefaultUni DefaultFun ()
-failingBuiltinTerm =
-  Apply
-    ()
-    (Apply () (Builtin () PLC.DivideInteger) (mkConstant @Integer () 1))
-    (mkConstant @Integer () 0)
+failingBuiltinTerm = builtin PLC.DivideInteger `app` con 1 `app` con 0
 
 -- The variable argument prevents evaluation
 nonConstantArgTerm :: Term Name DefaultUni DefaultFun ()
-nonConstantArgTerm = runQuote $ do
-  x <- freshName "x"
-  pure $
-    Apply
-      ()
-      (Apply () (Builtin () PLC.AddInteger) (Var () x))
-      (mkConstant @Integer () 2)
+nonConstantArgTerm = builtin PLC.AddInteger `app` var "x" `app` con 2
 
 -- ifThenElse returns a function (lambda), then applied to an extra argument
 overApplicationTerm :: Term Name DefaultUni DefaultFun ()
-overApplicationTerm = runQuote $ do
-  x <- freshName "x"
-  pure $
-    Apply
-      ()
-      ( mkIterApp
-          (Force () (Builtin () PLC.IfThenElse))
-          [ ((), mkConstant @Bool () True)
-          , ((), LamAbs () x (mkConstant @Integer () 1))
-          , ((), LamAbs () x (mkConstant @Integer () 2))
-          ]
-      )
-      (mkConstant @Integer () 3)
+overApplicationTerm = ite builtinTrue (lam "x" (con 1)) (lam "x" (con 2)) `app` con 3
 
 -- Missing an argument, should be left unchanged
 underApplicationTerm :: Term Name DefaultUni DefaultFun ()
-underApplicationTerm =
-  Apply () (Builtin () PLC.AddInteger) (mkConstant @Integer () 1)
+underApplicationTerm = builtin PLC.AddInteger `app` con 1
 
 -- In both conservative and non-conservative mode: left unchanged because the
 -- result (a G2 element) is an unserializable constant
 uncompressBlsG2Term :: Term Name DefaultUni DefaultFun ()
 uncompressBlsG2Term =
-  Apply () (Builtin () PLC.Bls12_381_G2_uncompress) (mkConstant @BS.ByteString () blsG2Bytes)
+  builtin PLC.Bls12_381_G2_uncompress `app` mkConstant @BS.ByteString () blsG2Bytes
   where
     blsG2Bytes =
       decodeHex
@@ -128,14 +89,9 @@ uncompressBlsG2Term =
 -- (G1 elements) are unserializable, so we can't evaluate through them
 uncompressAndEqualBlsTerm :: Term Name DefaultUni DefaultFun ()
 uncompressAndEqualBlsTerm =
-  Apply
-    ()
-    ( Apply
-        ()
-        (Builtin () PLC.Bls12_381_G1_equal)
-        (Apply () (Builtin () PLC.Bls12_381_G1_uncompress) blsG1BytesTerm)
-    )
-    (Apply () (Builtin () PLC.Bls12_381_G1_uncompress) blsG1BytesTerm)
+  builtin PLC.Bls12_381_G1_equal
+    `app` (builtin PLC.Bls12_381_G1_uncompress `app` blsG1BytesTerm)
+    `app` (builtin PLC.Bls12_381_G1_uncompress `app` blsG1BytesTerm)
   where
     blsG1BytesTerm =
       mkConstant @BS.ByteString () $

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Inline/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Inline/Spec.hs
@@ -1,21 +1,19 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Transform.Inline.Spec where
 
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.State (runStateT)
-import Data.Text qualified as Text
-import GHC.Exts (fromList)
 import PlutusCore.Annotation (Inline (MayInline))
 import PlutusCore.Default (DefaultFun (..), DefaultUni)
-import PlutusCore.Name.Unique (Name (..), Unique (..))
+import PlutusCore.Name.Unique (Name)
 import PlutusCore.Quote (runQuote)
 import PlutusPrelude (def)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
+import Transform.Lib (T, app, builtin, case_, delay, lam, name, var)
 import UntypedPlutusCore.AstSize (AstSize (..))
 import UntypedPlutusCore.Core (Term (..))
 import UntypedPlutusCore.Transform.Inline
@@ -60,11 +58,11 @@ test_inline =
 testVarBeforeAfterEffects :: Assertion
 testVarBeforeAfterEffects = do
   assertBool "a is evaluated before effects" do
-    isFirstVarBeforeEffects def a term
+    isFirstVarBeforeEffects def (name "a") term
   assertBool "b is evaluated before effects" do
-    isFirstVarBeforeEffects def b term
+    isFirstVarBeforeEffects def (name "b") term
   assertBool "c is not evaluated before effects" $ not do
-    isFirstVarBeforeEffects def c term
+    isFirstVarBeforeEffects def (name "c") term
   where
     term :: Term Name DefaultUni DefaultFun ()
     term =
@@ -72,78 +70,67 @@ testVarBeforeAfterEffects = do
 
         1. pure work-free: a
         2. pure work-free: b
-        3. impure? maybe work?: addInteger a b
+        3. impure? maybe work?: plus a b
         4. pure work-free: c
-        5. impure? maybe work?: addInteger (addInteger a b) c
+        5. impure? maybe work?: plus (plus a b) c
       -}
-      addInteger (addInteger (var a) (var b)) (var c)
-    (a, b, c, _) = makeUniqueNames
+      plus (plus (var "a") (var "b")) (var "c")
 
 testVarIsEventuallyEvaluatedDelay :: Assertion
 testVarIsEventuallyEvaluatedDelay = do
   assertBool "var 'a' is not eventually evaluated in delay" $
-    not (isStrictIn a term)
+    not (isStrictIn (name "a") term)
   assertBool "var 'b' is eventually evaluated outside of the delay" $
-    isStrictIn b term
+    isStrictIn (name "b") term
   assertBool "it's not known if var 'c' is eventually evaluated" $
-    not (isStrictIn c term)
+    not (isStrictIn (name "c") term)
   where
     term :: Term Name DefaultUni DefaultFun ()
-    term = delay (var a `addInteger` var b) `addInteger` var b
-
-    (a, b, c, _) = makeUniqueNames
+    term = delay (var "a" `plus` var "b") `plus` var "b"
 
 testVarIsEventuallyEvaluatedLambda :: Assertion
 testVarIsEventuallyEvaluatedLambda = do
   assertBool "var 'a' is not eventually evaluated in lambda body" $
-    not (isStrictIn a term)
+    not (isStrictIn (name "a") term)
   assertBool "var 'c' is eventually evaluated outside of the lambda" $
-    isStrictIn c term
+    isStrictIn (name "c") term
   assertBool "it's not known if var 'd' is eventually evaluated" $
-    not (isStrictIn d term)
+    not (isStrictIn (name "d") term)
   where
     term :: Term Name DefaultUni DefaultFun ()
-    term = lam b (var a `addInteger` var c) `app` var c
-
-    (a, b, c, d) = makeUniqueNames
+    term = lam "b" (var "a" `plus` var "c") `app` var "c"
 
 testVarIsEventuallyEvaluatedCaseBranch :: Assertion
 testVarIsEventuallyEvaluatedCaseBranch = do
   assertBool "var 'a' is not eventually evaluated in case branch" $
-    not (isStrictIn a term)
+    not (isStrictIn (name "a") term)
   assertBool "var 'b' is eventually evaluated outside of the case branch" $
-    isStrictIn b term
+    isStrictIn (name "b") term
   assertBool "it is not known if var 'd' is eventually evaluated" $
-    not (isStrictIn d term)
+    not (isStrictIn (name "d") term)
   where
     term :: Term Name DefaultUni DefaultFun ()
-    term = case_ (var b) [var a, var b, var c]
-
-    (a, b, c, d) = makeUniqueNames
+    term = case_ (var "b") [var "a", var "b", var "c"]
 
 testEffectSafePreservedLogs :: Assertion
 testEffectSafePreservedLogs = do
   assertBool "an immediately eval'd var is not \"effect safe\"" $
-    runInlineWithLogging (not <$> effectSafe term c False)
+    runInlineWithLogging (not <$> effectSafe term (name "c") False)
   assertBool "a var before effects is \"effect safe\"" $
-    runInlineWithLogging (effectSafe term a False)
+    runInlineWithLogging (effectSafe term (name "a") False)
   where
     term :: Term Name DefaultUni DefaultFun ()
-    term = (var a `addInteger` var b) `addInteger` var c
-
-    (a, b, c, _) = makeUniqueNames
+    term = (var "a" `plus` var "b") `plus` var "c"
 
 testEffectSafeWithoutPreservedLogs :: Assertion
 testEffectSafeWithoutPreservedLogs = do
   assertBool "an immediately eval'd var is \"effect safe\"" $
-    runInlineWithoutLogging (effectSafe term c False)
+    runInlineWithoutLogging (effectSafe term (name "c") False)
   assertBool "a var before effects is \"effect safe\"" $
-    runInlineWithoutLogging (effectSafe term a False)
+    runInlineWithoutLogging (effectSafe term (name "a") False)
   where
     term :: Term Name DefaultUni DefaultFun ()
-    term = (var a `addInteger` var b) `addInteger` var c
-
-    (a, b, c, _) = makeUniqueNames
+    term = (var "a" `plus` var "b") `plus` var "c"
 
 --------------------------------------------------------------------------------
 -- InlineM runner --------------------------------------------------------------
@@ -174,36 +161,7 @@ runInlineM preserveLogging m = result
     initialState = S {_subst = Subst (TermEnv mempty), _vars = mempty}
 
 --------------------------------------------------------------------------------
--- UPLC Term constructors ------------------------------------------------------
+-- Local helpers ---------------------------------------------------------------
 
-type T = Term Name DefaultUni DefaultFun ()
-
-var :: Name -> T
-var = Var ()
-
-lam :: Name -> T -> T
-lam = LamAbs ()
-
-app :: T -> T -> T
-app = Apply ()
-
-delay :: T -> T
-delay = Delay ()
-
-case_ :: T -> [T] -> T
-case_ scrut branches = Case () scrut (fromList branches)
-
-addInteger :: T -> T -> T
-addInteger i j = builtin AddInteger `app` i `app` j
-
-builtin :: DefaultFun -> T
-builtin = Builtin ()
-
---------------------------------------------------------------------------------
--- Unique names ----------------------------------------------------------------
-
-makeUniqueNames :: (Name, Name, Name, Name)
-makeUniqueNames = (name "a" 0, name "b" 1, name "c" 2, name "d" 3)
-
-name :: String -> Int -> Name
-name n u = Name (Text.pack n) (Unique u)
+plus :: T -> T -> T
+plus i j = builtin AddInteger `app` i `app` j

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Lib.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Lib.hs
@@ -3,8 +3,8 @@
 {-| Common UPLC term-construction helpers shared across the
 @Transform.*.Spec@ test modules.
 
-Variables are referred to by a textual hint: @var "x"@ is an occurrence, @lam "x"
-body@ a binder, and @name "x"@ the bare 'Name'. See Note [Names from textual hints]. -}
+Variables are referred to by name: @var "x"@ is an occurrence, @lam "x"
+body@ a binder, and @name "x"@ the bare 'Name'. See Note [Names from strings]. -}
 module Transform.Lib
   ( T
   , var
@@ -35,22 +35,18 @@ import PlutusCore.MkPlc (mkConstant)
 import PlutusCore.Name.Unique (Name (..), Unique (..))
 import UntypedPlutusCore.Core.Type (Term (..))
 
-{- Note [Names from textual hints]
-These test modules build UPLC terms purely, without threading a 'Quote' supply to
-allocate fresh uniques. A variable is identified entirely by a textual hint:
-'name' maps a hint to a 'Name' whose 'Unique' is derived deterministically (and
-injectively) from the hint text via 'uniqueFromText', and 'var' / 'lam' wrap
-'name' for occurrences and binders.
+{- Note [Names from strings]
+These test modules build UPLC terms purely, without using the 'Quote' monad to
+allocate fresh uniques. A variable is identified entirely by its name: 'name'
+maps a 'String' to a 'Name' whose 'Unique' is derived injectively from it via
+'uniqueFromText', and 'var' / 'lam' wrap 'name' for occurrences and binders.
 
-The invariant is: one hint denotes one variable. Terms built from the same hint
-share a 'Unique' and so are the same variable; distinct hints yield distinct
-variables. This is what lets a binder and its occurrences be written
-independently (@lam "a" (var "a")@) yet still refer to the same variable, and
-lets an assertion mention a free variable by hint (@isStrictIn (name "a") term@)
-with no plumbing.
+This lets a binder and its occurrences be written independently
+(@lam "a" (var "a")@) yet still refer to the same variable, and lets an assertion
+mention a free variable by name (@isStrictIn (name "a") term@) with no plumbing.
 
 The trade-off against 'QuoteT' is that freshness is no longer correct by
-construction: reusing one hint for two variables meant to differ silently aliases
+construction: reusing one name for two variables meant to differ silently aliases
 them, since 'Name' equality compares only the 'Unique'. For these small,
 hand-written test terms that is an acceptable price for dropping the monadic
 plumbing; where capture is a genuine concern, 'QuoteT' remains available.
@@ -61,21 +57,21 @@ Alternatives considered: an 'IsString' or 'IsLabel' instance for 'Name'
 read as if @x@ were a bound Haskell variable. The plain @String -> Name@ used
 here is the simplest: no orphan instance and no language extension at all.
 
-'uniqueFromText' is injective only on short ASCII hints, so it fails fast on
-non-ASCII characters or on hints long enough to overflow the 'Int' rather than
+'uniqueFromText' is injective only on short ASCII names, so it fails fast on
+non-ASCII characters or on names long enough to overflow the 'Int' rather than
 aliasing silently.
 -}
 
 -- | Convenient alias used throughout the test modules.
 type T = Term Name DefaultUni DefaultFun ()
 
-{-| A 'Var' occurrence of the variable with the given hint.
-See Note [Names from textual hints] -}
+{-| A 'Var' occurrence of the variable with the given name.
+See Note [Names from strings] -}
 var :: String -> T
 var = Var () . name
 
-{-| A lambda binding the variable with the given hint.
-See Note [Names from textual hints] -}
+{-| A lambda binding the variable with the given name.
+See Note [Names from strings] -}
 lam :: String -> T -> T
 lam = LamAbs () . name
 
@@ -129,18 +125,18 @@ text = mkConstant @Text () . Text.pack
 err :: T
 err = Error ()
 
--- | Build a 'Name' from a hint. See Note [Names from textual hints]
+-- | Build a 'Name' from a 'String'. See Note [Names from strings]
 name :: String -> Name
 name s = Name t (Unique (uniqueFromText t))
   where
     t = Text.pack s
 
-{-| Pack the hint's bytes big-endian into an 'Int' (> 7 bytes overflow).
-See Note [Names from textual hints] for the injectivity and fail-fast contract. -}
+{-| Pack the string's bytes big-endian into an 'Int' (> 7 bytes overflow).
+See Note [Names from strings] for the injectivity and fail-fast contract. -}
 uniqueFromText :: Text -> Int
 uniqueFromText t
   | Text.any ((> 127) . fromEnum) t =
-      error ("Transform.Lib: non-ASCII name hint: " <> show t)
+      error ("Transform.Lib: non-ASCII name: " <> show t)
   | Text.length t > 7 =
-      error ("Transform.Lib: name hint too long (would overflow Unique): " <> show t)
+      error ("Transform.Lib: name too long (would overflow Unique): " <> show t)
   | otherwise = Text.foldl' (\acc c -> acc * 256 + fromEnum c) 0 t

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Lib.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Lib.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE TypeApplications #-}
+
+{-| Common UPLC term-construction helpers shared across the
+@Transform.*.Spec@ test modules.
+
+Variables are referred to by a textual hint: @var "x"@ is an occurrence, @lam "x"
+body@ a binder, and @name "x"@ the bare 'Name'. See Note [Names from textual hints]. -}
+module Transform.Lib
+  ( T
+  , var
+  , lam
+  , app
+  , force
+  , delay
+  , case_
+  , builtin
+  , constr
+  , sopTrue
+  , sopFalse
+  , builtinTrue
+  , builtinFalse
+  , ite
+  , con
+  , text
+  , err
+  , name
+  ) where
+
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Word (Word64)
+import GHC.Exts (fromList)
+import PlutusCore.Default (DefaultFun (IfThenElse), DefaultUni)
+import PlutusCore.MkPlc (mkConstant)
+import PlutusCore.Name.Unique (Name (..), Unique (..))
+import UntypedPlutusCore.Core.Type (Term (..))
+
+{- Note [Names from textual hints]
+These test modules build UPLC terms purely, without threading a 'Quote' supply to
+allocate fresh uniques. A variable is identified entirely by a textual hint:
+'name' maps a hint to a 'Name' whose 'Unique' is derived deterministically (and
+injectively) from the hint text via 'uniqueFromText', and 'var' / 'lam' wrap
+'name' for occurrences and binders.
+
+The invariant is: one hint denotes one variable. Terms built from the same hint
+share a 'Unique' and so are the same variable; distinct hints yield distinct
+variables. This is what lets a binder and its occurrences be written
+independently (@lam "a" (var "a")@) yet still refer to the same variable, and
+lets an assertion mention a free variable by hint (@isStrictIn (name "a") term@)
+with no plumbing.
+
+The trade-off against 'QuoteT' is that freshness is no longer correct by
+construction: reusing one hint for two variables meant to differ silently aliases
+them, since 'Name' equality compares only the 'Unique'. For these small,
+hand-written test terms that is an acceptable price for dropping the monadic
+plumbing; where capture is a genuine concern, 'QuoteT' remains available.
+
+Alternatives considered: an 'IsString' or 'IsLabel' instance for 'Name'
+(@"a" :: Name@ / @#a@), which would be an orphan on a core type; and
+'OverloadedRecordDot' handles (@var.x@), which need that uncommon extension and
+read as if @x@ were a bound Haskell variable. The plain @String -> Name@ used
+here is the simplest: no orphan instance and no language extension at all.
+
+'uniqueFromText' is injective only on short ASCII hints, so it fails fast on
+non-ASCII characters or on hints long enough to overflow the 'Int' rather than
+aliasing silently.
+-}
+
+-- | Convenient alias used throughout the test modules.
+type T = Term Name DefaultUni DefaultFun ()
+
+{-| A 'Var' occurrence of the variable with the given hint.
+See Note [Names from textual hints] -}
+var :: String -> T
+var = Var () . name
+
+{-| A lambda binding the variable with the given hint.
+See Note [Names from textual hints] -}
+lam :: String -> T -> T
+lam = LamAbs () . name
+
+app :: T -> T -> T
+app = Apply ()
+
+force :: T -> T
+force = Force ()
+
+delay :: T -> T
+delay = Delay ()
+
+case_ :: T -> [T] -> T
+case_ scrut branches = Case () scrut (fromList branches)
+
+builtin :: DefaultFun -> T
+builtin = Builtin ()
+
+-- | A 'Constr' term tagged with the given index.
+constr :: Word64 -> [T] -> T
+constr = Constr ()
+
+-- | @True@ as a sum-of-products value, @Constr 0 []@ (the datatype encoding of @Bool@).
+sopTrue :: T
+sopTrue = constr 0 []
+
+-- | @False@ as a sum-of-products value, @Constr 1 []@.
+sopFalse :: T
+sopFalse = constr 1 []
+
+-- | @True@ as the builtin @bool@ constant.
+builtinTrue :: T
+builtinTrue = mkConstant @Bool () True
+
+-- | @False@ as the builtin @bool@ constant.
+builtinFalse :: T
+builtinFalse = mkConstant @Bool () False
+
+-- | @ifThenElse@ forced and applied to a condition and the two branches.
+ite :: T -> T -> T -> T
+ite cond t f = force (builtin IfThenElse) `app` cond `app` t `app` f
+
+-- | An 'Integer' constant.
+con :: Integer -> T
+con = mkConstant @Integer ()
+
+-- | A 'Text' constant from a literal.
+text :: String -> T
+text = mkConstant @Text () . Text.pack
+
+err :: T
+err = Error ()
+
+-- | Build a 'Name' from a hint. See Note [Names from textual hints]
+name :: String -> Name
+name s = Name t (Unique (uniqueFromText t))
+  where
+    t = Text.pack s
+
+{-| Pack the hint's bytes big-endian into an 'Int' (> 7 bytes overflow).
+See Note [Names from textual hints] for the injectivity and fail-fast contract. -}
+uniqueFromText :: Text -> Int
+uniqueFromText t
+  | Text.any ((> 127) . fromEnum) t =
+      error ("Transform.Lib: non-ASCII name hint: " <> show t)
+  | Text.length t > 7 =
+      error ("Transform.Lib: name hint too long (would overflow Unique): " <> show t)
+  | otherwise = Text.foldl' (\acc c -> acc * 256 + fromEnum c) 0 t

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Spec.hs
@@ -153,7 +153,10 @@ inlineImpure3 =
 to an impure term such as @error@. -}
 inlineImpure4 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
 inlineImpure4 =
-  mkInlinePurityTest ([name "a"], force . force . force . delay $ delay (var "a"))
+  mkInlinePurityTest
+    ( [name "a"]
+    , force . force . force . delay . delay $ var "a"
+    )
 
 {-| @(\a -> f (a 0 1) (a 2)) (\x y -> g x y)@
 

--- a/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Spec.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Transform/Simplify/Spec.hs
@@ -1,14 +1,26 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
-
 module Transform.Simplify.Spec where
 
-import Data.Text (Text)
-import Data.Vector qualified as V
 import PlutusCore qualified as PLC
-import PlutusCore.MkPlc (mkConstant, mkIterApp, mkIterAppNoAnn)
-import PlutusCore.Quote (Quote, freshName, runQuote)
+import PlutusCore.MkPlc (mkIterApp, mkIterAppNoAnn)
 import Test.Tasty (TestTree, testGroup)
+import Transform.Lib
+  ( T
+  , app
+  , builtin
+  , case_
+  , con
+  , constr
+  , delay
+  , err
+  , force
+  , ite
+  , lam
+  , name
+  , sopFalse
+  , sopTrue
+  , text
+  , var
+  )
 import Transform.Simplify.Lib (goldenVsCse, goldenVsOptimized)
 import UntypedPlutusCore
   ( CseWhichSubterms (..)
@@ -21,157 +33,85 @@ import UntypedPlutusCore
 import UntypedPlutusCore.MkUPlc (mkIterLamAbs)
 
 basic :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-basic = Force () $ Delay () $ mkConstant @Integer () 1
+basic = force $ delay $ con 1
 
 nested :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-nested = Force () $ Force () $ Delay () $ Delay () $ mkConstant @Integer () 1
+nested = force $ force $ delay $ delay $ con 1
 
 extraDelays :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-extraDelays = Force () $ Delay () $ Delay () $ mkConstant @Integer () 1
+extraDelays = force $ delay $ delay $ con 1
 
 interveningLambda :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-interveningLambda = runQuote $ do
-  n <- freshName "a"
-  let lam = LamAbs () n $ Delay () $ Apply () (Var () n) (Var () n)
-      arg = mkConstant @Integer () 1
-  pure $ Force () $ Apply () lam arg
+interveningLambda = force (lam "a" (delay (var "a" `app` var "a")) `app` con 1)
 
 caseOfCase1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase1 = runQuote $ do
-  b <- freshName "b"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Constr () 0 []
-      false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase1 = case_ (ite (var "b") sopTrue sopFalse) [con 1, con 2]
 
 {-| This should not simplify, because one of the branches of `ifThenElse` is not a `Constr`.
 Unless both branches are known constructors, the case-of-case transformation
 may increase the program size. -}
 caseOfCase2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase2 = runQuote $ do
-  b <- freshName "b"
-  t <- freshName "t"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Var () t
-      false = Constr () 1 []
-      alts = V.fromList [mkConstant @Integer () 1, mkConstant @Integer () 2]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase2 = case_ (ite (var "b") (var "t") sopFalse) [con 1, con 2]
 
 {-| Similar to `caseOfCase1`, but the type of the @true@ and @false@ branches is
 @[Integer]@ rather than Bool (note that @Constr 0@ has two parameters, @x@ and @xs@). -}
 caseOfCase3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-caseOfCase3 = runQuote $ do
-  b <- freshName "b"
-  x <- freshName "x"
-  xs <- freshName "xs"
-  f <- freshName "f"
-  let ite = Force () (Builtin () PLC.IfThenElse)
-      true = Constr () 0 [Var () x, Var () xs]
-      false = Constr () 1 []
-      altTrue = Var () f
-      altFalse = mkConstant @Integer () 2
-      alts = V.fromList [altTrue, altFalse]
-  pure $ Case () (mkIterApp ite [((), Var () b), ((), true), ((), false)]) alts
+caseOfCase3 = case_ (ite (var "b") trueBranch sopFalse) [var "f", con 2]
+  where
+    trueBranch = constr 0 [var "x", var "xs"]
 
 -- | The `Delay` should be floated into the lambda.
 floatDelay1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-floatDelay1 = runQuote $ do
-  a <- freshName "a"
-  let body =
-        Apply
-          ()
-          (Apply () (Builtin () PLC.AddInteger) (Force () (Var () a)))
-          (Force () (Var () a))
-      lam = LamAbs () a body
-  pure $ Apply () lam (Delay () (mkConstant @Integer () 1))
+floatDelay1 = lam "a" (force (var "a") `plus` force (var "a")) `app` delay (con 1)
 
 {-| The `Delay` should not be floated into the lambda, because the argument (1 + 2)
 is not work-free. -}
 floatDelay2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-floatDelay2 = runQuote $ do
-  a <- freshName "a"
-  let body =
-        Apply
-          ()
-          (Apply () (Builtin () PLC.AddInteger) (Force () (Var () a)))
-          (Force () (Var () a))
-      lam = LamAbs () a body
-      arg =
-        Apply
-          ()
-          (Apply () (Builtin () PLC.AddInteger) (mkConstant @Integer () 1))
-          (mkConstant @Integer () 2)
-  pure $ Apply () lam (Delay () arg)
+floatDelay2 =
+  lam "a" (force (var "a") `plus` force (var "a"))
+    `app` delay (con 1 `plus` con 2)
 
 {-| The `Delay` should not be floated into the lambda in the first simplifier iteration,
 because one of the occurrences of `a` is not under `Force`. It should be floated into
 the lambda in the second simplifier iteration, after `b` is inlined. -}
 floatDelay3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-floatDelay3 = runQuote $ do
-  a <- freshName "a"
-  b <- freshName "b"
-  let secondArg = Force () (Apply () (LamAbs () b (Var () b)) (Var () a))
-      body = Apply () (Apply () (Builtin () PLC.AddInteger) (Force () (Var () a))) secondArg
-      lam = LamAbs () a body
-  pure $ Apply () lam (Delay () (mkConstant @Integer () 1))
+floatDelay3 =
+  lam "a" (force (var "a") `plus` force (lam "b" (var "b") `app` var "a"))
+    `app` delay (con 1)
 
 {-| The 'Delay' should not be floated into the lambda because the argument to the 'Delay' is
 not pure. -}
 floatDelay4 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-floatDelay4 = runQuote $ do
-  a <- freshName "a"
-  let body =
-        Case
-          ()
-          (Constr () 0 [])
-          $ V.fromList
-            [ mkConstant @Integer () 1
-            , Force () (Var () a)
-            ]
-      lam = LamAbs () a body
-  pure $ Apply () lam (Delay () (Constr () 0 [Error ()]))
+floatDelay4 = lam "a" body `app` delay (constr 0 [err])
+  where
+    body = case_ (constr 0 []) [con 1, force (var "a")]
 
 basicInline :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-basicInline = runQuote $ do
-  n <- freshName "a"
-  pure $ Apply () (LamAbs () n (Var () n)) (mkConstant @Integer () 1)
+basicInline = lam "a" (var "a") `app` con 1
 
 {-| A helper function to create a term which tests whether the inliner
-behaves as expected for a given pure or impure term. It receives
-a 'Quote' that produces a term together with a list of free variables.
-The free variables are bound at the top level of the final term in order
-to ensure that the produced final term is well-scoped. -}
+behaves as expected for a given pure or impure term. It receives a term
+together with a list of its free variables. The free variables are bound
+at the top level of the final term in order to ensure that the produced
+final term is well-scoped. -}
 mkInlinePurityTest
-  :: Quote ([Name], Term Name PLC.DefaultUni PLC.DefaultFun ())
+  :: ([Name], Term Name PLC.DefaultUni PLC.DefaultFun ())
   -> Term Name PLC.DefaultUni PLC.DefaultFun ()
-mkInlinePurityTest termToInline = runQuote $ do
-  a <- freshName "a"
-  b <- freshName "b"
-  -- In `[(\a . \b . a) termToInline]`, `termToInline` will be inlined
-  -- if and only if it is pure.
-  (freeVars, term) <- termToInline
-  let withTopLevelBindings =
-        mkIterLamAbs
-          (UVarDecl () <$> freeVars)
-  pure $
-    withTopLevelBindings $
-      Apply () (LamAbs () a $ LamAbs () b $ Var () a) term
+mkInlinePurityTest (freeVars, term) =
+  -- In `[(\a . \b . a) term]`, `term` will be inlined if and only if it is pure.
+  mkIterLamAbs (UVarDecl () <$> freeVars) $
+    lam "a" (lam "b" (var "a")) `app` term
 
 -- | A single @Var@ is pure.
 inlinePure1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlinePure1 = mkInlinePurityTest $ do
-  a <- freshName "a"
-  pure ([a], Var () a)
+inlinePure1 = mkInlinePurityTest ([name "a"], var "a")
 
 {-| @force (delay a)@ is pure.
 
 Note that this relies on @forceDelayCancel@ to cancel the @force@ and the @delay@,
 otherwise the inliner would treat the term as impure. -}
 inlinePure2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlinePure2 = mkInlinePurityTest $ do
-  a <- freshName "a"
-  pure ([a], Force () $ Delay () $ Var () a)
+inlinePure2 = mkInlinePurityTest ([name "a"], force $ delay (var "a"))
 
 {-| @[(\x -> \y -> [x x]) (con integer 1)]@ is pure.
 
@@ -179,70 +119,41 @@ Note that the @(con integer 1)@ won't get inlined: it isn't pre-inlined because
 @x@ occurs twice, and it isn't post-inlined because @costIsAcceptable Constant{} = False@.
 However, the entire term will be inlined since it is pure. -}
 inlinePure3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlinePure3 = mkInlinePurityTest $ do
-  x <- freshName "x"
-  y <- freshName "y"
-  let t =
-        Apply
-          ()
-          (LamAbs () x $ LamAbs () y $ Apply () (Var () x) (Var () x))
-          (mkConstant @Integer () 1)
-      vars = []
-  pure (vars, t)
+inlinePure3 =
+  mkInlinePurityTest
+    ([], app (lam "x" $ lam "y" $ var "x" `app` var "x") (con 1))
 
 {-| @force ([(\x -> delay (\y -> [x x])) (delay ([error (con integer 1)]))])@ is pure,
 but it is very tricky to see so. It requires us to match up a force and a
 delay through several steps of intervening computation. -}
 inlinePure4 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlinePure4 = mkInlinePurityTest $ do
-  x <- freshName "x"
-  y <- freshName "y"
-  let term =
-        Force () $
-          Apply
-            ()
-            (LamAbs () x $ Delay () $ LamAbs () y $ Apply () (Var () x) (Var () x))
-            (Delay () $ Apply () (Error ()) $ mkConstant @Integer () 1)
-  pure ([], term)
+inlinePure4 =
+  mkInlinePurityTest
+    ( []
+    , force $
+        lam "x" (delay (lam "y" (var "x" `app` var "x")))
+          `app` delay (err `app` con 1)
+    )
 
 -- | @error@ is impure.
 inlineImpure1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlineImpure1 = mkInlinePurityTest $ pure ([], Error ())
+inlineImpure1 = mkInlinePurityTest ([], err)
 
 -- | @force (delay error)@ is impure.
 inlineImpure2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlineImpure2 = mkInlinePurityTest $ pure ([], Force () . Delay () $ Error ())
+inlineImpure2 = mkInlinePurityTest ([], force (delay err))
 
 {-| @force (force (force (delay (delay (delay (error))))))@ is impure, since it
 is the same as @error@. -}
 inlineImpure3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
 inlineImpure3 =
-  mkInlinePurityTest $
-    pure
-      ( []
-      , Force ()
-          . Force ()
-          . Force ()
-          . Delay ()
-          . Delay ()
-          . Delay ()
-          $ Error ()
-      )
+  mkInlinePurityTest ([], force . force . force . delay . delay $ delay err)
 
 {-| @force (force (force (delay (delay a))))@ is impure, since @a@ may expand
 to an impure term such as @error@. -}
 inlineImpure4 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-inlineImpure4 = mkInlinePurityTest $ do
-  a <- freshName "a"
-  let term =
-        Force ()
-          . Force ()
-          . Force ()
-          . Delay ()
-          . Delay ()
-          . Var ()
-          $ a
-  pure ([a], term)
+inlineImpure4 =
+  mkInlinePurityTest ([name "a"], force . force . force . delay $ delay (var "a"))
 
 {-| @(\a -> f (a 0 1) (a 2)) (\x y -> g x y)@
 
@@ -252,49 +163,33 @@ the size or the cost.
 The second occurrence of `a` should be unconditionally inlined in the second simplifier
 iteration, but in this test we are only running one iteration. -}
 callsiteInline :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-callsiteInline = runQuote $ do
-  a <- freshName "a"
-  f <- freshName "f"
-  g <- freshName "g"
-  x <- freshName "x"
-  y <- freshName "y"
-  let fun =
-        LamAbs () a $
-          mkIterAppNoAnn
-            (Var () f)
-            [ mkIterAppNoAnn (Var () a) [mkConstant @Integer () 0, mkConstant @Integer () 1]
-            , mkIterAppNoAnn (Var () a) [mkConstant @Integer () 2]
-            ]
-      arg = LamAbs () x . LamAbs () y $ mkIterAppNoAnn (Var () g) [Var () y, Var () x]
-      termWithBoundTopLevel = LamAbs () f $ LamAbs () g $ Apply () fun arg
-  pure termWithBoundTopLevel
+callsiteInline = lam "f" $ lam "g" $ app fun arg
+  where
+    fun =
+      lam "a" $
+        mkIterAppNoAnn
+          (var "f")
+          [ mkIterAppNoAnn (var "a") [con 0, con 1]
+          , mkIterAppNoAnn (var "a") [con 2]
+          ]
+    arg =
+      lam "x" . lam "y" $
+        mkIterAppNoAnn (var "g") [var "y", var "x"]
 
 multiApp :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-multiApp = runQuote $ do
-  a <- freshName "a"
-  b <- freshName "b"
-  c <- freshName "c"
-  let lam = LamAbs () a $ LamAbs () b $ LamAbs () c $ mkIterAppNoAnn (Var () c) [Var () a, Var () b]
-      app =
-        mkIterAppNoAnn
-          lam
-          [ mkConstant @Integer () 1
-          , mkConstant @Integer () 2
-          , mkConstant @Integer () 3
-          ]
-  pure app
+multiApp = mkIterAppNoAnn applyLam [con 1, con 2, con 3]
+  where
+    applyLam =
+      lam "a" $
+        lam "b" $
+          lam "c" $
+            mkIterAppNoAnn (var "c") [var "a", var "b"]
 
 forceDelayNoApps :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelayNoApps = runQuote $ do
-  let one = mkConstant @Integer () 1
-      term = Force () $ Delay () $ Force () $ Delay () $ Force () $ Delay () one
-  pure term
+forceDelayNoApps = force $ delay $ force $ delay $ force $ delay $ con 1
 
 forceDelayNoAppsLayered :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelayNoAppsLayered = runQuote $ do
-  let one = mkConstant @Integer () 1
-      term = Force () $ Force () $ Force () $ Delay () $ Delay () $ Delay () one
-  pure term
+forceDelayNoAppsLayered = force $ force $ force $ delay $ delay $ delay $ con 1
 
 {-| The UPLC term in this test should come from the following TPLC term after erasing its types:
 
@@ -304,63 +199,31 @@ forceDelayNoAppsLayered = runQuote $ do
 This case is simple in the sense that each type abstraction
 is followed by a single term abstraction. -}
 forceDelaySimple :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelaySimple = runQuote $ do
-  x <- freshName "x"
-  y <- freshName "y"
-  z <- freshName "z"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      three = mkConstant @Integer () 3
-      t = Delay () (LamAbs () x (Delay () (LamAbs () y (Delay () (LamAbs () z (Var () z))))))
-      app = Apply () (Force () (Apply () (Force () (Apply () (Force () t) one)) two)) three
-  pure app
+forceDelaySimple = force (force (force t `app` con 1) `app` con 2) `app` con 3
+  where
+    t = delay (lam "x" (delay (lam "y" (delay (lam "z" (var "z"))))))
 
 {-| A test for the case when there are multiple applications between the 'Force' at the top
 and the 'Delay' at the top of the term inside the abstractions/applications. -}
 forceDelayMultiApply :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelayMultiApply = runQuote $ do
-  x1 <- freshName "x1"
-  x2 <- freshName "x2"
-  x3 <- freshName "x3"
-  f <- freshName "f"
-  funcVar <- freshName "funcVar"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      three = mkConstant @Integer () 3
-      term =
-        LamAbs () funcVar $
-          Force () $
-            mkIterAppNoAnn
-              ( LamAbs () x1 $
-                  LamAbs () x2 $
-                    LamAbs () x3 $
-                      LamAbs () f $
-                        Delay () $
-                          mkIterAppNoAnn (Var () f) [Var () x1, Var () x2, Var () x3]
-              )
-              [one, two, three, Var () funcVar]
-  pure term
+forceDelayMultiApply =
+  lam "funcVar" $
+    force $
+      mkIterAppNoAnn
+        ( lam "x1" $
+            lam "x2" $
+              lam "x3" $
+                lam "f" $
+                  delay $
+                    mkIterAppNoAnn (var "f") [var "x1", var "x2", var "x3"]
+        )
+        [con 1, con 2, con 3, var "funcVar"]
 
 {-| A test for the case when there are multiple type abstractions over a single term
 abstraction/application. -}
 forceDelayMultiForce :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelayMultiForce = runQuote $ do
-  x <- freshName "x"
-  let one = mkConstant @Integer () 1
-      term =
-        Force () $
-          Force () $
-            Force () $
-              Apply
-                ()
-                ( LamAbs () x $
-                    Delay () $
-                      Delay () $
-                        Delay () $
-                          Var () x
-                )
-                one
-  pure term
+forceDelayMultiForce =
+  force $ force $ force $ app (lam "x" $ delay $ delay $ delay (var "x")) (con 1)
 
 {-| The UPLC term in this test should come from the following TPLC term after erasing its types:
 
@@ -374,252 +237,149 @@ forceDelayMultiForce = runQuote $ do
 
 Note this term has multiple interleaved type and term instantiations/applications. -}
 forceDelayComplex :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceDelayComplex = runQuote $ do
-  x <- freshName "x"
-  y1 <- freshName "y1"
-  y2 <- freshName "y2"
-  y3 <- freshName "y3"
-  z1 <- freshName "z1"
-  z2 <- freshName "z2"
-  f <- freshName "f"
-  funcVar <- freshName "funcVar"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      three = mkConstant @Integer () 3
-      foo = mkConstant @Text () "foo"
-      bar = mkConstant @Text () "bar"
-      term =
-        Delay () $
-          Delay () $
-            LamAbs () x $
-              Delay () $
-                Delay () $
-                  Delay () $
-                    LamAbs () y1 $
-                      LamAbs () y2 $
-                        LamAbs () y3 $
-                          Delay () $
-                            LamAbs () z1 $
-                              LamAbs () z2 $
-                                Delay () $
-                                  LamAbs () f $
-                                    mkIterAppNoAnn
-                                      (Var () f)
-                                      [ Var () x
-                                      , Var () y1
-                                      , Var () y2
-                                      , Var () y3
-                                      , Var () z1
-                                      , Var () z2
-                                      ]
-      app =
-        LamAbs () funcVar $
-          Apply
-            ()
-            ( Force () $
-                mkIterAppNoAnn
-                  ( Force () $
-                      mkIterAppNoAnn
-                        ( Force () $
-                            Force () $
-                              Force () $
-                                Apply
-                                  ()
-                                  (Force () $ Force () term)
-                                  one
-                        )
-                        [two, foo, bar]
-                  )
-                  [three, three]
-            )
-            (Var () funcVar)
-  pure app
+forceDelayComplex = whole
+  where
+    term =
+      delay
+        . delay
+        . lam "x"
+        . delay
+        . delay
+        . delay
+        . lam "y1"
+        . lam "y2"
+        . lam "y3"
+        . delay
+        . lam "z1"
+        . lam "z2"
+        . delay
+        . lam "f"
+        $ mkIterAppNoAnn
+          (var "f")
+          [ var "x"
+          , var "y1"
+          , var "y2"
+          , var "y3"
+          , var "z1"
+          , var "z2"
+          ]
+    whole =
+      lam "funcVar" $
+        app
+          ( force $
+              mkIterAppNoAnn
+                ( force $
+                    mkIterAppNoAnn
+                      (force (force (force (force (force term) `app` con 1))))
+                      [ con 2
+                      , text "foo"
+                      , text "bar"
+                      ]
+                )
+                [ con 3
+                , con 3
+                ]
+          )
+          (var "funcVar")
 
 forceCaseDelayNoApps1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayNoApps1 = runQuote $ do
-  scrut <- freshName "scrut"
-  let one = mkConstant @Integer () 1
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case () (Var () scrut) (V.fromList [Delay () one])
-  pure term
+forceCaseDelayNoApps1 =
+  lam "scrut" $ force $ case_ (var "scrut") [delay (con 1)]
 
 forceCaseDelayWithApps1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayWithApps1 = runQuote $ do
-  scrut <- freshName "scrut"
-  x <- freshName "x"
-  let one = mkConstant @Integer () 1
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case
-              ()
-              (Var () scrut)
-              (V.fromList [LamAbs () x $ Delay () one])
-  pure term
+forceCaseDelayWithApps1 =
+  lam "scrut" $ force $ case_ (var "scrut") [lam "x" $ delay (con 1)]
 
 forceCaseDelayNoApps2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayNoApps2 = runQuote $ do
-  scrut <- freshName "scrut"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case
-              ()
-              (Var () scrut)
-              (V.fromList [Delay () one, Delay () two])
-  pure term
+forceCaseDelayNoApps2 =
+  lam "scrut" $ force $ case_ (var "scrut") [delay (con 1), delay (con 2)]
 
 forceCaseDelayWithApps2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayWithApps2 = runQuote $ do
-  scrut <- freshName "scrut"
-  x <- freshName "x"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case
-              ()
-              (Var () scrut)
-              (V.fromList [LamAbs () x $ Delay () one, Delay () two])
-  pure term
+forceCaseDelayWithApps2 =
+  lam "scrut" $
+    force $
+      case_ (var "scrut") [lam "x" $ delay (con 1), delay (con 2)]
 
 forceCaseDelayNoApps2Fail :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayNoApps2Fail = runQuote $ do
-  scrut <- freshName "scrut"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case
-              ()
-              (Var () scrut)
-              (V.fromList [Delay () one, two])
-  pure term
+forceCaseDelayNoApps2Fail =
+  lam "scrut" $ force $ case_ (var "scrut") [delay (con 1), con 2]
 
 forceCaseDelayWithApps2Fail :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-forceCaseDelayWithApps2Fail = runQuote $ do
-  scrut <- freshName "scrut"
-  x <- freshName "x"
-  y <- freshName "y"
-  let one = mkConstant @Integer () 1
-      two = mkConstant @Integer () 2
-      term =
-        LamAbs () scrut $
-          Force () $
-            Case
-              ()
-              (Var () scrut)
-              ( V.fromList
-                  [ LamAbs () x $ LamAbs () y $ Delay () one
-                  , LamAbs () x two
-                  ]
-              )
-  pure term
+forceCaseDelayWithApps2Fail =
+  lam "scrut" $
+    force $
+      case_
+        (var "scrut")
+        [ lam "x" (lam "y" (delay (con 1)))
+        , lam "x" (con 2)
+        ]
 
 -- case ((\x -> constr 0 []) 1) [42]
 letFloatOutCase1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-letFloatOutCase1 =
-  let arg = mkConstant @Integer () 1
-      body = Constr () 0 []
-      branch = mkConstant @Integer () 42
-   in Case () (Apply () (LamAbs () xName body) arg) (V.fromList [branch])
-  where
-    xName = runQuote $ freshName "x"
+letFloatOutCase1 = case_ (lam "x" sopTrue `app` con 1) [con 42]
 
 -- \a -> case ((\x -> constr 0 [x, x]) a) addInteger
 letFloatOutCase2 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-letFloatOutCase2 = runQuote $ do
-  a <- freshName "a"
-  x <- freshName "x"
-  let body = Constr () 0 [Var () x, Var () x]
-      binding = Apply () (LamAbs () x body) (Var () a)
-  pure $ LamAbs () a $ Case () binding (V.fromList [Builtin () PLC.AddInteger])
+letFloatOutCase2 = lam "a" $ case_ binding [builtin PLC.AddInteger]
+  where
+    body = constr 0 [var "x", var "x"]
+    binding = lam "x" body `app` var "a"
 
 -- \a -> force ((\x -> delay x) a)
 letFloatOutForce :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-letFloatOutForce = runQuote $ do
-  a <- freshName "a"
-  x <- freshName "x"
-  let lam = LamAbs () x (Delay () (Var () x))
-      binding = Apply () lam (Var () a)
-  pure $ LamAbs () a (Force () binding)
+letFloatOutForce = lam "a" (force binding)
+  where
+    delayLam = lam "x" (delay (var "x"))
+    binding = delayLam `app` var "a"
 
 -- | This is the first example in Note [CSE].
 cse1 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-cse1 = runQuote $ do
-  x <- freshName "x"
-  y <- freshName "y"
-  let plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-      body = plus onePlusTwoPlusX caseExpr
-      con = mkConstant @Integer ()
-      twoPlusX = plus (con 2) (Var () x)
-      onePlusTwoPlusX = plus (con 1) twoPlusX
-      threePlusX = plus (con 3) (Var () x)
-      fourPlusX = plus (con 4) (Var () x)
-      branch1 = plus onePlusTwoPlusX threePlusX
-      branch2 = plus twoPlusX threePlusX
-      branch3 = fourPlusX
-      caseExpr = Case () (Var () y) (V.fromList [branch1, branch2, branch3])
-  pure $ LamAbs () x (LamAbs () y body)
+cse1 = lam "x" (lam "y" (plus onePlusTwoPlusX caseExpr))
+  where
+    twoPlusX = plus (con 2) (var "x")
+    onePlusTwoPlusX = plus (con 1) twoPlusX
+    threePlusX = plus (con 3) (var "x")
+    fourPlusX = plus (con 4) (var "x")
+    branch1 = plus onePlusTwoPlusX threePlusX
+    branch2 = plus twoPlusX threePlusX
+    branch3 = fourPlusX
+    caseExpr = case_ (var "y") [branch1, branch2, branch3]
 
 -- | This is the second example in Note [CSE].
 cse2 :: Term Name DefaultUni DefaultFun ()
-cse2 = Force () (Force () body)
+cse2 = force (force body)
   where
-    plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-    con = mkConstant @Integer ()
-    body = mkIterApp (Builtin () PLC.IfThenElse) [((), cond), ((), true), ((), false)]
-    cond = Apply () (Apply () (Builtin () PLC.LessThanInteger) (con 0)) (con 0)
-    true = Delay () (plus (plus (con 1) (con 2)) (plus (con 1) (con 2)))
-    false = Delay () (plus (con 1) (con 2))
+    body = mkIterApp (builtin PLC.IfThenElse) [((), cond), ((), trueBranch), ((), falseBranch)]
+    cond = builtin PLC.LessThanInteger `app` con 0 `app` con 0
+    trueBranch = delay (plus (plus (con 1) (con 2)) (plus (con 1) (con 2)))
+    falseBranch = delay (plus (con 1) (con 2))
 
 -- | This is the third example in Note [CSE].
 cse3 :: Term Name PLC.DefaultUni PLC.DefaultFun ()
-cse3 = runQuote $ do
-  x <- freshName "x"
-  y <- freshName "y"
-  z <- freshName "z"
-  f <- freshName "f"
-  let plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-      con = mkConstant @Integer ()
-      arg1 =
-        mkIterApp
-          (LamAbs () y (plus (con 1) (plus (Var () y) (Var () y))))
-          [((), plus (con 0) (Var () x))]
-      arg2 =
-        mkIterApp
-          (LamAbs () z (plus (con 2) (plus (Var () z) (Var () z))))
-          [((), plus (con 0) (Var () x))]
-  pure $ LamAbs () f $ LamAbs () x (mkIterApp (Var () f) [((), arg1), ((), arg2)])
+cse3 = lam "f" $ lam "x" $ var "f" `app` arg1 `app` arg2
+  where
+    arg1 =
+      lam "y" (plus (con 1) (plus (var "y") (var "y")))
+        `app` plus (con 0) (var "x")
+    arg2 =
+      lam "z" (plus (con 2) (plus (var "z") (var "z")))
+        `app` plus (con 0) (var "x")
 
 --  ((1+2) + (3+4) + ...)
 --  +
 --  ((1+2) + (3+4) + ...)
 cseExpensive :: Term Name DefaultUni DefaultFun ()
-cseExpensive = plus arg arg'
+cseExpensive = mkArg [0 .. 200] `plus` mkArg [0 .. 200]
   where
-    plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-    con = mkConstant @Integer ()
-    mkArg = foldl1 plus . fmap (\i -> plus (con (2 * i)) (con (2 * i + 1)))
-    arg = mkArg [0 .. 200]
-    arg' = mkArg [0 .. 200]
+    mkArg = foldl1 plus . map (\i -> plus (con (2 * i)) (con (2 * i + 1)))
 
 -- tree where nodes are + and leaves are constants
 csePlusTree :: Term Name DefaultUni DefaultFun ()
 csePlusTree = go 5
   where
-    go :: Int -> Term Name DefaultUni DefaultFun ()
+    go :: Int -> T
     go 0 = con 1
     go n = plus (go (n - 1)) (go (n - 1))
-
-    plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-    con = mkConstant @Integer ()
 
 -- (1 + (1 + ... + 0))
 -- optimised to
@@ -627,12 +387,9 @@ csePlusTree = go 5
 cseRepeatPlus :: Term Name DefaultUni DefaultFun ()
 cseRepeatPlus = go 5
   where
-    go :: Int -> Term Name DefaultUni DefaultFun ()
+    go :: Int -> T
     go 0 = con 0
     go n = plus (con 1) (go (n - 1))
-
-    plus a b = mkIterApp (Builtin () PLC.AddInteger) [((), a), ((), b)]
-    con = mkConstant @Integer ()
 
 testSimplifyInputs :: [(String, Term Name PLC.DefaultUni PLC.DefaultFun ())]
 testSimplifyInputs =
@@ -694,3 +451,9 @@ test_simplify =
     $ fmap (uncurry goldenVsOptimized) testSimplifyInputs
       <> fmap (uncurry (goldenVsCse ExcludeWorkFree)) testCseInputs
       <> fmap (uncurry (goldenVsCse AllSubterms)) testCseInputsWorkFree
+
+--------------------------------------------------------------------------------
+-- Local helpers ---------------------------------------------------------------
+
+plus :: T -> T -> T
+plus i j = builtin PLC.AddInteger `app` i `app` j


### PR DESCRIPTION
Preparatory refactor before changing CSE tests in a follow-up PR.


`Transform.Inline.Spec` already had a section of UPLC term-construction helpers (`var`, `lam`, `app`, `delay`, `case_`, `builtin`, `addInteger`). 

- [x] Lift them into a shared `Transform.Lib` module reusable across other test specs in the same testlib.
- [x] Make Simplifier Spec use these helpers.