### PR TITLE
Propagate annotation in mkTyVar and UPLC's mkVar

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/MkPlc.hs
@@ -143,11 +143,10 @@ The @ann@ is propagated from the 'VarDecl' to the 'Var'. -}
 mkVar :: TermLike term tyname name uni fun => VarDecl tyname name uni ann -> term ann
 mkVar v = var (_varDeclAnn v) (_varDeclName v)
 
--- TODO: also propagate @ann@ for 'mkTyVar', and UPLC's 'mkVar'.
-
--- | Make a 'TyVar' referencing the given 'TyVarDecl'.
-mkTyVar :: ann -> TyVarDecl tyname ann -> Type tyname uni ann
-mkTyVar ann = TyVar ann . _tyVarDeclName
+{-| Make a 'TyVar' referencing the given 'TyVarDecl'.
+The @ann@ is propagated from the 'TyVarDecl' to the 'TyVar'. -}
+mkTyVar :: TyVarDecl tyname ann -> Type tyname uni ann
+mkTyVar tvd = TyVar (_tyVarDeclAnn tvd) (_tyVarDeclName tvd)
 
 -- | A definition. Pretty much just a pair with more descriptive names.
 data Def var val = Def

--- a/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/plutus-core/plutus-core/stdlib/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -124,7 +124,7 @@ prodN arity = runQuote $ do
     pure $ TyVarDecl () tn $ Type ()
 
   resultType <- liftQuote $ freshTyName "r"
-  let caseType = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
+  let caseType = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
   pure $
     -- \T_1 .. T_n
     mkIterTyLam tyVars $
@@ -151,10 +151,10 @@ prodNConstructor arity = runQuote $ do
 
   args <- for [0 .. (arity - 1)] $ \i -> do
     n <- liftQuote $ freshName $ "arg_" <> showText i
-    pure $ VarDecl () n $ mkTyVar () $ tyVars !! i
+    pure $ VarDecl () n $ mkTyVar $ tyVars !! i
 
   caseArg <- liftQuote $ freshName "case"
-  let caseTy = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
+  let caseTy = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
   pure $
     -- /\T_1 .. T_n
     mkIterTyAbs tyVars $
@@ -181,12 +181,12 @@ prodNAccessor arity index = runQuote $ do
     tn <- liftQuote $ freshTyName $ "t_" <> showText i
     pure $ TyVarDecl () tn $ Type ()
 
-  let tupleTy = mkIterTyAppNoAnn (prodN arity) (fmap (mkTyVar ()) tyVars)
-      selectedTy = mkTyVar () $ tyVars !! index
+  let tupleTy = mkIterTyAppNoAnn (prodN arity) (fmap mkTyVar tyVars)
+      selectedTy = mkTyVar $ tyVars !! index
 
   args <- for [0 .. (arity - 1)] $ \i -> do
     n <- liftQuote $ freshName $ "arg_" <> showText i
-    pure $ VarDecl () n $ mkTyVar () $ tyVars !! i
+    pure $ VarDecl () n $ mkTyVar $ tyVars !! i
   let selectedArg = mkVar $ args !! index
 
   tupleArg <- liftQuote $ freshName "tuple"

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Datatype.hs
@@ -386,7 +386,7 @@ mkDatatypeType opts r d@(Datatype ann tn tvs _ _) = do
 
 -- | The type of a datatype-value is of the form `[TyCon tyarg1 tyarg2 ... tyargn]`
 mkDatatypeValueType :: a -> Datatype TyName Name uni a -> Type TyName uni a
-mkDatatypeValueType ann (Datatype _ tn tvs _ _) = PIR.mkIterTyApp (PIR.mkTyVar ann tn) $ (ann,) . PIR.mkTyVar ann <$> tvs
+mkDatatypeValueType ann (Datatype _ tn tvs _ _) = PIR.mkIterTyApp (PIR.mkTyVar tn) $ (ann,) . PIR.mkTyVar <$> tvs
 
 -- Constructors
 
@@ -484,7 +484,7 @@ mkConstructor opts dty d@(Datatype ann _ tvs _ constrs) index = do
           PIR.mkIterLamAbs argsAndTypes $
             -- See Note [Recursive datatypes]
             -- wrap
-            wrap ann dty (fmap (PIR.mkTyVar ann) tvs) constrBody
+            wrap ann dty (fmap PIR.mkTyVar tvs) constrBody
   pure $ fmap (\a -> DatatypeComponent Constructor a) constr
 
 -- Destructors
@@ -515,7 +515,7 @@ mkDestructor opts dty d@(Datatype ann _ tvs _ constrs) = do
   -- This term appears *outside* the scope of the abstraction for the datatype, so we need to put in the Scott-encoded type here
   -- see Note [Abstract data types]
   -- dty t_1 .. t_n
-  let appliedReal = PIR.mkIterTyApp (getType dty) (fmap ((ann,) . PIR.mkTyVar ann) tvs)
+  let appliedReal = PIR.mkIterTyApp (getType dty) (fmap ((ann,) . PIR.mkTyVar) tvs)
 
   xn <- safeFreshName "x"
 

--- a/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Compiler/Definitions.hs
@@ -309,30 +309,29 @@ lookupOrDefineTerm name mdef = do
       defineTerm name def deps
       pure $ mkVar (PLC.defVar def)
 
-lookupType :: MonadDefs key uni fun ann m => ann -> key -> m (Maybe (Type TyName uni ann))
-lookupType x name = do
+lookupType :: MonadDefs key uni fun ann m => key -> m (Maybe (Type TyName uni ann))
+lookupType name = do
   DefState {_typeDefs = tys, _datatypeDefs = dtys, _aliases = as} <- liftDef $ DefT get
   pure $ case Map.lookup name tys of
     Just (def, _) ->
-      Just $ if Set.member name as then PLC.defVal def else mkTyVar x $ PLC.defVar def
+      Just $ if Set.member name as then PLC.defVal def else mkTyVar $ PLC.defVar def
     Nothing -> case Map.lookup name dtys of
-      Just (def, _) -> Just $ mkTyVar x $ PLC.defVar def
+      Just (def, _) -> Just $ mkTyVar $ PLC.defVar def
       Nothing -> Nothing
 
 lookupOrDefineType
   :: MonadDefs key uni fun ann m
-  => ann
-  -> key
+  => key
   -> m (TypeDef TyName uni ann, Set.Set key)
   -> m (Type TyName uni ann)
-lookupOrDefineType x name mdef = do
-  mTy <- lookupType x name
+lookupOrDefineType name mdef = do
+  mTy <- lookupType name
   case mTy of
     Just ty -> pure ty
     Nothing -> do
       (def, deps) <- mdef
       defineType name def deps
-      pure $ mkTyVar x $ PLC.defVar def
+      pure $ mkTyVar $ PLC.defVar def
 
 lookupConstructors
   :: MonadDefs key uni fun ann m

--- a/plutus-core/plutus-ir/src/PlutusIR/Contexts.hs
+++ b/plutus-core/plutus-ir/src/PlutusIR/Contexts.hs
@@ -167,7 +167,7 @@ splitNormalDatatypeMatch vinfo matcherName args
       splitAppContext (length tyvars) args
   , Just tvs <- extractTyArgs vars =
       let
-        scrutTy = mkIterTyApp (mkTyVar () (void tyname)) $ ((),) . void <$> tvs
+        scrutTy = mkIterTyApp (mkTyVar (void tyname)) $ ((),) . void <$> tvs
         sm = SplitMatchContext vars (scrut, scrutTy, scrutAnn) (resTy, resTyAnn) branches
        in
         Just sm

--- a/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
+++ b/plutus-core/untyped-plutus-core/src/UntypedPlutusCore/MkUPlc.hs
@@ -7,9 +7,10 @@ import UntypedPlutusCore.Core.Type
 -- | A term definition as a variable.
 type UTermDef name uni fun ann = Def (UVarDecl name ann) (Term name uni fun ann)
 
--- | Make a 'Var' referencing the given 'VarDecl'.
-mkVar :: ann -> UVarDecl name ann -> Term name uni fun ann
-mkVar ann = Var ann . _uvarDeclName
+{-| Make a 'Var' referencing the given 'UVarDecl'.
+The @ann@ is propagated from the 'UVarDecl' to the 'Var'. -}
+mkVar :: UVarDecl name ann -> Term name uni fun ann
+mkVar uvd = Var (_uvarDeclAnn uvd) (_uvarDeclName uvd)
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Builtins.hs
@@ -852,7 +852,7 @@ lookupBuiltinTerm name = do
 lookupBuiltinType :: Compiling uni fun m ann => TH.Name -> m (PIRType uni)
 lookupBuiltinType name = do
   ghcName <- lookupGhcName name
-  maybeType <- PIR.lookupType annMayInline (LexName ghcName)
+  maybeType <- PIR.lookupType (LexName ghcName)
   case maybeType of
     Just t -> pure t
     Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)

--- a/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/PlutusTx/Compiler/Type.hs
@@ -195,7 +195,7 @@ compileTyCon tc
         "Recursive newtypes, use data:" GHC.<+> GHC.ppr tcName
       -- See Note [Dependency tracking]
       modifyCurDeps (\d -> Set.insert lexName d)
-      maybeDef <- PIR.lookupType annMayInline lexName
+      maybeDef <- PIR.lookupType lexName
       case maybeDef of
         Just ty -> pure ty
         -- See Note [Dependency tracking]
@@ -206,7 +206,7 @@ compileTyCon tc
               -- See Note [Coercions and newtypes]
               -- See Note [Occurrences of recursive names]
               -- We do this for dependency tracking, we won't use it due to the blackholing
-              PIR.defineType lexName (PIR.Def tvd (PIR.mkTyVar annMayInline tvd)) mempty
+              PIR.defineType lexName (PIR.Def tvd (PIR.mkTyVar tvd)) mempty
               -- Type variables are in scope for the rhs of the alias
               alias <-
                 mkIterTyLamScoped (GHC.tyConTyVars tc) $
@@ -238,7 +238,7 @@ compileTyCon tc
                 let datatype = PIR.Datatype annMayInline tvd tvs matchName constructors
 
                 PIR.modifyDatatypeDef @_ @uni lexName (const $ PIR.Def tvd datatype)
-              pure $ PIR.mkTyVar annMayInline tvd
+              pure $ PIR.mkTyVar tvd
 
 {- Note [Case expressions and laziness]
 PLC is strict, but users *do* expect that, e.g. they can write an if expression and have it be

--- a/plutus-tx/src/PlutusTx/Lift/Class.hs
+++ b/plutus-tx/src/PlutusTx/Lift/Class.hs
@@ -119,7 +119,7 @@ instance Typeable uni (->) where
     b <- PLC.liftQuote $ PLC.freshTyName "b"
     let tvda = TyVarDecl () a (Type ())
         tvdb = TyVarDecl () b (Type ())
-    pure $ mkIterTyLam [tvda, tvdb] $ TyFun () (mkTyVar () tvda) (mkTyVar () tvdb)
+    pure $ mkIterTyLam [tvda, tvdb] $ TyFun () (mkTyVar tvda) (mkTyVar tvdb)
 
 -- Primitives
 

--- a/plutus-tx/src/PlutusTx/Lift/TH.hs
+++ b/plutus-tx/src/PlutusTx/Lift/TH.hs
@@ -183,7 +183,7 @@ data Dep = TypeableDep TH.Type | LiftDep TH.Type deriving stock (Show, Eq, Ord)
 type Deps = Set.Set Dep
 
 withTyVars :: MonadReader (LocalVars uni) m => [(TH.Name, TyVarDecl TyName ())] -> m a -> m a
-withTyVars mappings = local (\scope -> foldl' (\acc (n, tvd) -> Map.insert n (mkTyVar () tvd) acc) scope mappings)
+withTyVars mappings = local (\scope -> foldl' (\acc (n, tvd) -> Map.insert n (mkTyVar tvd) acc) scope mappings)
 
 thWithTyVars :: MonadReader THLocalVars m => [TH.Name] -> m a -> m a
 thWithTyVars names = local (\scope -> foldr Set.insert scope names)
@@ -317,7 +317,7 @@ compileTypeableType ty name = do
     let trep' :: forall fun. RTCompileScope PLC.DefaultUni fun (Type TyName PLC.DefaultUni ())
         trep' = Trans.lift $ unCompileType ($$(TH.liftCode trep))
      in CompileTypeScope $ do
-          maybeType <- lookupType () name
+          maybeType <- lookupType name
           case maybeType of
             Just t -> pure t
             -- this will need some additional constraints in scope
@@ -360,7 +360,7 @@ compileTypeRep dt@TH.DatatypeInfo {TH.datatypeName = tyName, TH.datatypeVars = t
             argTy' = unCompileTypeScope $$(TH.liftCode argTy)
             act :: forall fun. RTCompileScope PLC.DefaultUni fun (Type TyName PLC.DefaultUni ())
             act = do
-              maybeDefined <- lookupType () tyName
+              maybeDefined <- lookupType tyName
               case maybeDefined of
                 Just ty -> pure ty
                 Nothing -> do
@@ -384,14 +384,14 @@ compileTypeRep dt@TH.DatatypeInfo {TH.datatypeName = tyName, TH.datatypeVars = t
             constrExprs' = $$(TH.liftCode $ tyListE constrExprs)
             act :: forall fun. RTCompileScope PLC.DefaultUni fun (Type TyName PLC.DefaultUni ())
             act = do
-              maybeDefined <- lookupType () tyName
+              maybeDefined <- lookupType tyName
               case maybeDefined of
                 Just ty -> pure ty
                 Nothing -> do
                   (_, dtvd) <- mkTyVarDecl tyName typeKind
                   tvds <- traverse (uncurry mkTyVarDecl) tvNamesAndKinds
 
-                  let resultType = mkIterTyAppNoAnn (mkTyVar () dtvd) (fmap (mkTyVar () . snd) tvds)
+                  let resultType = mkIterTyAppNoAnn (mkTyVar dtvd) (fmap (mkTyVar . snd) tvds)
                   matchName <- safeFreshName (T.pack "match_" <> showName tyName)
 
                   -- See Note [Occurrences of recursive names]
@@ -409,7 +409,7 @@ compileTypeRep dt@TH.DatatypeInfo {TH.datatypeName = tyName, TH.datatypeVars = t
                     let datatype = Datatype () dtvd (fmap snd tvds) matchName constrs
 
                     defineDatatype tyName (PLC.Def dtvd datatype) deps
-                  pure $ mkTyVar () dtvd
+                  pure $ mkTyVar dtvd
            in
             CompileType $ runReaderT act mempty
           ||]


### PR DESCRIPTION
## Summary

Resolves the TODO:

```haskell
-- TODO: also propagate @ann@ for 'mkTyVar', and UPLC's 'mkVar'.
```

`PlutusCore.MkPlc.mkVar` already propagates the annotation from the
`VarDecl`. This change brings `mkTyVar` and `UntypedPlutusCore.MkUPlc.mkVar`
in line so the three helpers behave consistently, removing a footgun where
callers could pass an annotation that diverges from the one stored in the
declaration.

