### PR TITLE
Export `inclusiveLowerBound` / `inclusiveUpperBound` from `Interval` modules

### DIFF
--- a/plutus-ledger-api/changelog.d/20260518_export_inclusive_bounds.md
+++ b/plutus-ledger-api/changelog.d/20260518_export_inclusive_bounds.md
@@ -1,0 +1,9 @@
+### Added
+
+- Exported `inclusiveLowerBound` and `inclusiveUpperBound` from
+  `PlutusLedgerApi.V1.Interval`, `PlutusLedgerApi.V1.Data.Interval`,
+  and all re-exporting modules (`PlutusLedgerApi.V1`/`V2`/`V3` and the
+  `PlutusLedgerApi.Data.V1`/`V2`/`V3` counterparts). These helpers
+  normalise `LowerBound`/`UpperBound` values into an equivalent
+  inclusive `Extended a`, removing the need for validator authors to
+  re-implement the same closure handling locally.

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V1.hs
@@ -146,6 +146,8 @@ module PlutusLedgerApi.Data.V1
   , upperBound
   , strictLowerBound
   , strictUpperBound
+  , inclusiveLowerBound
+  , inclusiveUpperBound
 
     -- *** Newtypes and hash types
   , ScriptHash (..)

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V2.hs
@@ -155,6 +155,8 @@ module PlutusLedgerApi.Data.V2
   , V1.upperBound
   , V1.strictLowerBound
   , V1.strictUpperBound
+  , V1.inclusiveLowerBound
+  , V1.inclusiveUpperBound
 
     -- *** Association maps
   , Map

--- a/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/Data/V3.hs
@@ -225,6 +225,8 @@ module PlutusLedgerApi.Data.V3
   , V2.upperBound
   , V2.strictLowerBound
   , V2.strictUpperBound
+  , V2.inclusiveLowerBound
+  , V2.inclusiveUpperBound
 
     -- *** Ratio
   , Ratio.Rational

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1.hs
@@ -162,6 +162,8 @@ module PlutusLedgerApi.V1
   , Interval.upperBound
   , Interval.strictLowerBound
   , Interval.strictUpperBound
+  , Interval.inclusiveLowerBound
+  , Interval.inclusiveUpperBound
   , Interval.member
   , Interval.interval
   , Interval.hull

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Interval.hs
@@ -51,6 +51,8 @@ module PlutusLedgerApi.V1.Data.Interval
   , upperBound
   , strictLowerBound
   , strictUpperBound
+  , inclusiveLowerBound
+  , inclusiveUpperBound
   , mapInterval
   ) where
 

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Interval.hs
@@ -37,6 +37,8 @@ module PlutusLedgerApi.V1.Interval
   , upperBound
   , strictLowerBound
   , strictUpperBound
+  , inclusiveLowerBound
+  , inclusiveUpperBound
   ) where
 
 import Control.DeepSeq (NFData)

--- a/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V2.hs
@@ -99,6 +99,8 @@ module PlutusLedgerApi.V2
   , V1.upperBound
   , V1.strictLowerBound
   , V1.strictUpperBound
+  , V1.inclusiveLowerBound
+  , V1.inclusiveUpperBound
 
     -- *** Association maps
   , Map

--- a/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V3.hs
@@ -119,6 +119,8 @@ module PlutusLedgerApi.V3
   , V2.upperBound
   , V2.strictLowerBound
   , V2.strictUpperBound
+  , V2.inclusiveLowerBound
+  , V2.inclusiveUpperBound
 
     -- *** Ratio
   , Ratio.Rational


### PR DESCRIPTION
Closes #7737.

`PlutusLedgerApi.V1.Interval` and `PlutusLedgerApi.V1.Data.Interval` already define two helpers that turn a `LowerBound` / `UpperBound` into an equivalent inclusive `Extended a`:

```haskell
inclusiveLowerBound :: Enum a => LowerBound a -> Extended a
inclusiveUpperBound :: Enum a => UpperBound a -> Extended a
```

They are used internally by the `Eq` / `Ord` instances and by `isEmpty`, but they are not in the export lists. The symmetric constructors `lowerBound`, `upperBound`, `strictLowerBound`, `strictUpperBound` are exported, so validator authors who want the same closure handling end up open-coding it, typically when deriving a "current time" from `txInfoValidRange`'s lower bound.
