### PR TITLE
INLINE `decodeListOf`

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Data.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Data.hs
@@ -273,6 +273,7 @@ decodeListOf decoder =
   CBOR.decodeListLenOrIndef >>= \case
     Nothing -> decodeSequenceLenIndef (flip (:)) [] reverse decoder
     Just n -> decodeSequenceLenN (flip (:)) [] reverse n decoder
+{-# INLINE decodeListOf #-}
 
 decodeMap :: Decoder s Data
 decodeMap =


### PR DESCRIPTION
Add `{-# INLINE decodeListOf #-}` to the small helper in [`decodeListOf `](plutus-core/plutus-core/src/PlutusCore/Data.hs) that drives every list-of-`Data` CBOR decode. This function is on the per-script-execution hot path and inlining it will yield performance improvements.

