### PR TITLE
Certifier: deduplicate ASTs in agda certificate

### DIFF
--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -97,6 +97,7 @@ library
   exposed-modules: Paths_plutus_metatheory
   exposed-modules:
     Certifier
+    Data.List.NonEmptySep
     FFI.AgdaUnparse
     FFI.CostInfo
     FFI.OptimizerTrace

--- a/plutus-metatheory/src/Certifier.hs
+++ b/plutus-metatheory/src/Certifier.hs
@@ -18,21 +18,23 @@ import Data.Foldable
 import Data.List.Extra (replace)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe)
+import Data.List.NonEmptySep as NES
 import Data.Text qualified as Text
 import Data.Text.IO qualified as T
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeBaseName, (</>))
+import Text.Printf (printf)
 
 import FFI.AgdaUnparse (AgdaUnparse (..), renderAgdaUnparse)
 import FFI.CostInfo
-import FFI.OptimizerTrace (Trace, mkFfiOptimizerTrace, toEvalResult)
+import FFI.OptimizerTrace
 import FFI.Untyped (UTerm)
 import MAlonzo.Code.Certifier (runCertifierMain)
 import PlutusLedgerApi.Common
 import Prettyprinter (pretty)
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
+import UntypedPlutusCore.Transform.Certify.Hints (Hints)
 import UntypedPlutusCore.Transform.Optimizer
 
 type CertName = String
@@ -109,213 +111,153 @@ mkCertifier simplTrace certName certOutput costs = do
       pure passed
     Nothing -> throwError InvalidCompilerOutput
 
-type EquivClass = Int
-
-data TermWithId = TermWithId
-  { termId :: Int
-  , term :: UTerm
-  }
-
-data Ast = Ast
-  { equivClass :: EquivClass
-  , astTermWithId :: TermWithId
-  }
-
-getTermId :: Ast -> Int
-getTermId Ast {astTermWithId = TermWithId {termId}} = termId
-
 data Certificate = Certificate
   { certName :: String
-  , certTrace :: Trace Ast
-  , certReprAsts :: [Ast]
+  , certTrace :: Trace UTerm
   }
 
 mkCertificate :: String -> Trace UTerm -> Certificate
 mkCertificate certName rawTrace =
-  let traceWithIds = addIds rawTrace
-      allTermWithIds = extractTermWithIds traceWithIds
-      groupedAsts = findEquivClasses allTermWithIds
-      allAsts = groupedAsts >>= NE.toList
-      certTrace = mkAstTrace allAsts traceWithIds
-      certReprAsts = getRepresentatives groupedAsts
+  let trace' = dedup rawTrace
    in Certificate
         { certName
-        , certTrace
-        , certReprAsts
+        , certTrace = trace'
         }
   where
-    addIds
-      :: Trace UTerm
-      -> Trace TermWithId
-    addIds = go 0
-      where
-        go
-          :: Int
-          -> Trace UTerm
-          -> Trace TermWithId
-        go _ [] = []
-        go id' ((stage, (hints, (before, after))) : rest) =
-          let beforeWithId = TermWithId id' before
-              afterWithId = TermWithId (id' + 1) after
-           in (stage, (hints, (beforeWithId, afterWithId))) : go (id' + 2) rest
+    dedup :: Trace UTerm -> Trace UTerm
+    dedup (Singleton x) = Singleton x
+    dedup (Cons x sep xs)
+      -- If subsequent ASTs are equal, drop the pass
+      | x == NES.head xs = dedup xs
+      | otherwise = Cons x sep (dedup xs)
 
-    extractTermWithIds
-      :: Trace TermWithId
-      -> [TermWithId]
-    extractTermWithIds = concatMap (\(_, (_, (before, after))) -> [before, after])
+{-| Module name with string components, e.g.
+  "Data" :| ["List", "NonEmpty"] -}
+type ModuleName = NonEmpty String
 
-    findEquivClasses :: [TermWithId] -> [NonEmpty Ast]
-    findEquivClasses =
-      go 0 . NE.groupBy (\x y -> term x == term y)
-      where
-        go :: EquivClass -> [NonEmpty TermWithId] -> [NonEmpty Ast]
-        go _ [] = []
-        go cl (ts : rest) =
-          let asts = fmap (\t -> Ast {astTermWithId = t, equivClass = cl}) ts
-           in asts : go (cl + 1) rest
+moduleIdent :: ModuleName -> String
+moduleIdent = fold . NE.intersperse "."
 
-    getRepresentatives :: [NonEmpty Ast] -> [Ast]
-    getRepresentatives = fmap NE.head
+moduleFileName :: ModuleName -> FilePath
+moduleFileName m = foldr (</>) "" m ++ ".agda"
 
-    errorMessage :: String
-    errorMessage =
-      "Internal error: could not find AST.\
-      \ This is an issue in the certifier, please open a bug report at\
-      \ https://github.com/IntersectMBO/plutus/issues"
+-- | Drops the last component of the module to obtain its directory
+moduleDir :: ModuleName -> String
+moduleDir m = foldr (</>) "" (NE.init m)
 
-    mkAstTrace
-      :: [Ast]
-      -> Trace TermWithId
-      -> Trace Ast
-    mkAstTrace _ [] = []
-    mkAstTrace allAsts ((stage, (hints, (rawBefore, rawAfter))) : rest) =
-      let processedBefore =
-            fromMaybe (error errorMessage) $
-              find (\ast -> getTermId ast == termId rawBefore) allAsts
-          processedAfter =
-            fromMaybe (error errorMessage) $
-              find (\ast -> getTermId ast == termId rawAfter) allAsts
-       in (stage, (hints, (processedBefore, processedAfter))) : mkAstTrace allAsts rest
+{-| Module name in agda, for a given equivalence class. Each list element is a module segment that is to be
+separated by "." (agda identifier) or by "/" (files) -}
+mkAstModuleName :: Int -> ModuleName
+mkAstModuleName n =
+  ("Pass" <> printf "%03d" n) :| ["AST"]
 
-mkAstModuleName :: Ast -> String
-mkAstModuleName Ast {equivClass} =
-  "Ast" <> show equivClass
+mkAgdaAstFile :: Int -> UTerm -> Maybe Hints -> (ModuleName, String)
+mkAgdaAstFile n pre mHints =
+  ( modName
+  , unlines $
+      [ "module " <> moduleIdent modName <> " where"
+      , ""
+      , "open import Data.Unit"
+      , "open import Data.Nat"
+      , "open import Data.Integer"
+      , "open import Data.Maybe"
+      , "open import Data.Bool.Base using (Bool; false; true)"
+      , "open import Data.List using (List; _∷_; [])"
+      , ""
+      , "open import RawU"
+      , "open import Builtin"
+      , "open import Utils"
+      , ""
+      , "open import Untyped using (_⊢)"
+      , "open import VerifiedCompilation using (checkScope)"
+      , "open import VerifiedCompilation.Trace"
+      , ""
+      , "raw : Untyped"
+      , "raw = " <> renderAgdaUnparse pre
+      , ""
+      , "ast : 0 ⊢"
+      , "ast = to-witness-T (checkScope raw) tt"
+      ]
+        ++ case mHints of
+          Just hints ->
+            [ ""
+            , "hints : Hints"
+            , "hints = " <> renderAgdaUnparse hints
+            ]
+          Nothing -> []
+  )
+  where
+    modName = mkAstModuleName n
 
-mkAgdaAstFile :: Ast -> (FilePath, String)
-mkAgdaAstFile ast =
-  let agdaAst = renderAgdaUnparse (term . astTermWithId $ ast)
-      agdaId = equivClass ast
-      agdaModuleName = mkAstModuleName ast
-      agdaIdStr = "ast" <> show agdaId
-      agdaAstTy = agdaIdStr <> " : Untyped"
-      agdaAstDef = agdaIdStr <> " = " <> agdaAst
-      agdaAstFile = agdaModuleName <> ".agda"
-   in (agdaAstFile, mkAstModule agdaModuleName agdaAstTy agdaAstDef)
-
-mkAstModule :: String -> String -> String -> String
-mkAstModule agdaIdStr agdaAstTy agdaAstDef =
-  "module "
-    <> agdaIdStr
-    <> " where\
-       \\n\
-       \\nopen import VerifiedCompilation\
-       \\nopen import VerifiedCompilation.Certificate\
-       \\nopen import VerifiedCompilation.Trace\
-       \\nopen import RawU\
-       \\nopen import Builtin\
-       \\nopen import Data.Unit\
-       \\nopen import Data.Nat\
-       \\nopen import Data.Integer\
-       \\nopen import Utils\
-       \\nimport Agda.Builtin.Bool\
-       \\nimport Relation.Nullary\
-       \\nimport VerifiedCompilation.UntypedTranslation\
-       \\nopen import Agda.Builtin.Maybe\
-       \\nopen import Data.Empty using (⊥)\
-       \\nopen import Data.Bool.Base using (Bool; false; true)\
-       \\nopen import Agda.Builtin.Equality using (_≡_; refl)\
-       \\n\
-       \\n"
-    <> agdaAstTy
-    <> "\n\
-       \\n"
-    <> agdaAstDef
-    <> "\n"
-
-mkAgdaOpenImport :: String -> String
-mkAgdaOpenImport agdaModuleName =
-  "open import " <> agdaModuleName
+mkAgdaImport :: Bool -> ModuleName -> String
+mkAgdaImport open moduleName =
+  openModifier open ("import " <> moduleIdent moduleName)
+  where
+    openModifier True str = "open " <> str
+    openModifier False str = str
 
 newtype AgdaVar = AgdaVar String
 
 instance AgdaUnparse AgdaVar where
   agdaUnparse (AgdaVar var) = pretty var
 
-mkCertificateFile :: Certificate -> (FilePath, String)
-mkCertificateFile Certificate {certName, certTrace, certReprAsts} =
-  let imports = fmap (mkAgdaOpenImport . mkAstModuleName) certReprAsts
-      agdaTrace =
-        renderAgdaUnparse $
-          ( \(st, (hints, (ast1, ast2))) ->
-              ( st
-              ,
-                ( hints
-                ,
-                  ( AgdaVar $ "ast" <> (show . equivClass) ast1
-                  , AgdaVar $ "ast" <> (show . equivClass) ast2
-                  )
-                )
-              )
-          )
-            <$> certTrace
-      certFile = certName <> ".agda"
-   in (certFile, mkCertificateModule certName agdaTrace imports)
+mkCertificateFile :: Certificate -> String
+mkCertificateFile Certificate {certName, certTrace} =
+  unlines $
+    [ "module " <> certName <> " where"
+    , ""
+    , "open import VerifiedCompilation.Trace"
+    , "open import Untyped using (_⊢)"
+    , "open import Utils hiding (List; _>>=_)"
+    , "open import VerifiedCompilation"
+    , "open import Data.Unit"
+    , ""
+    ]
+      ++ map (mkAgdaImport False) astImports
+      ++ [ ""
+         , "trace : Trace (0 ⊢)"
+         , "trace ="
+         ]
+      ++ map ("  " ++) (printTrace traceExpr)
+      ++ [ ""
+         , "certificate : Certificate trace"
+         , "certificate = cert trace (certify trace) tt"
+         , ""
+         ]
+  where
+    astImports :: [ModuleName]
+    astImports = map mkAstModuleName [0 .. length certTrace - 1]
 
-mkCertificateModule :: String -> String -> [String] -> String
-mkCertificateModule certModule agdaTrace imports =
-  "module "
-    <> certModule
-    <> " where\
-       \\n\
-       \\nopen import Certifier\
-       \\nopen import VerifiedCompilation\
-       \\nopen import VerifiedCompilation.Certificate hiding (_>>=_)\
-       \\nopen import VerifiedCompilation.Trace\
-       \\nopen import Untyped\
-       \\nopen import RawU\
-       \\nopen import Builtin\
-       \\nopen import Data.Unit\
-       \\nopen import Data.Nat\
-       \\nopen import Data.Integer\
-       \\nopen import Data.Maybe\
-       \\nopen import Data.List\
-       \\nopen import Utils hiding (List; _>>=_)\
-       \\nimport Agda.Builtin.Bool\
-       \\nimport Relation.Nullary\
-       \\nimport VerifiedCompilation.UntypedTranslation\
-       \\nopen import Agda.Builtin.List using (_∷_; [])\
-       \\nopen import Agda.Builtin.Maybe\
-       \\nopen import Data.Empty using (⊥)\
-       \\nopen import Data.Bool.Base using (Bool; false; true)\
-       \\nopen import Agda.Builtin.Equality using (_≡_; refl)\
-       \\n"
-    <> unlines imports
-    <> "\n"
-    <> "\n\
-       \\nasts : List (OptTag × Hints × Untyped × Untyped)\
-       \\nasts = "
-    <> agdaTrace
-    <> "\n\
-       \\nasts_trace : Trace (0 ⊢)\
-       \\nasts_trace = to-witness-T (toTrace asts >>= checkScopeᵗ) tt\
-       \\n\
-       \\ncertificate : Certificate asts_trace\
-       \\ncertificate = cert asts_trace (certify asts_trace) tt\
-       \\n"
+    -- replace hints and asts by agda variables that point to the right module
+    traceExpr :: NonEmptySep (OptStage, AgdaVar) AgdaVar
+    traceExpr = go 0 certTrace
+      where
+        go n (Singleton _) = Singleton (moduleVar n "ast")
+        go n (Cons _ (stage, _) xs) =
+          Cons
+            (moduleVar n "ast")
+            (stage, moduleVar n "hints")
+            (go (n + 1) xs)
+
+    moduleVar :: Int -> String -> AgdaVar
+    moduleVar n x =
+      AgdaVar $
+        moduleIdent (mkAstModuleName n)
+          <> "."
+          <> x
+
+-- Ad-hoc pretty printing so it can be printed over multiple lines
+printTrace :: NonEmptySep (OptStage, AgdaVar) AgdaVar -> [String]
+printTrace (Singleton x) = ["singleton" ++ " " ++ renderAgdaUnparse x]
+printTrace (Cons x (stage, y) xs) =
+  [ renderAgdaUnparse x
+  , "  ∷[ " ++ renderAgdaUnparse stage ++ " , " ++ renderAgdaUnparse y ++ " ]"
+  ]
+    ++ printTrace xs
 
 data AgdaCertificateProject = AgdaCertificateProject
   { mainModule :: (FilePath, String)
-  , astModules :: [(FilePath, String)]
+  , astModules :: [(ModuleName, String)]
   , agdalib :: (FilePath, String)
   }
 
@@ -337,9 +279,17 @@ mkAgdaCertificateProject
 mkAgdaCertificateProject cert =
   let name = certName cert
       mainModule = mkCertificateFile cert
-      astModules = fmap mkAgdaAstFile (certReprAsts cert)
+      astModules = astModuleFiles 0 (certTrace cert)
       agdalib = mkAgdaLib name
-   in AgdaCertificateProject {mainModule, astModules, agdalib}
+   in AgdaCertificateProject
+        { mainModule = (certName cert <> ".agda", mainModule)
+        , astModules
+        , agdalib
+        }
+  where
+    astModuleFiles :: Int -> Trace UTerm -> [(ModuleName, String)]
+    astModuleFiles n (Singleton x) = [mkAgdaAstFile n x Nothing]
+    astModuleFiles n (Cons x (_, h) xs) = mkAgdaAstFile n x (Just h) : astModuleFiles (n + 1) xs
 
 writeCertificateProject
   :: CertDir
@@ -358,12 +308,14 @@ writeCertificateProject
           certName = takeBaseName mainModulePath
       createDirectoryIfMissing True certDir
       createDirectoryIfMissing True (certDir </> "src")
+      for_ astModules $ \(modName, _) -> do
+        createDirectoryIfMissing True (certDir </> "src" </> moduleDir modName)
       writeFile (certDir </> "src" </> mainModulePath) mainModuleContents
       writeFile (certDir </> agdalibPath) agdalibContents
       let readmeTemplate = $(embedStringFile "file-embed/certificate-README.md")
       writeFile (certDir </> "README.md") (replace "{{NAME}}" certName readmeTemplate)
       traverse_
-        ( \(path, contents) ->
-            writeFile (certDir </> "src" </> path) contents
+        ( \(modName, contents) ->
+            writeFile (certDir </> "src" </> moduleFileName modName) contents
         )
         astModules

--- a/plutus-metatheory/src/Certifier.lagda.md
+++ b/plutus-metatheory/src/Certifier.lagda.md
@@ -20,15 +20,14 @@ open import VerifiedCompilation.Trace
 open import VerifiedCompilation.Certificate hiding (_>>=_)
 open import CertifierReport using (makeReport)
 
-runCertifier : Dump → Either Error (Σ (Trace (0 ⊢)) Certificate)
-runCertifier dump = do
-  trace ← try (toTrace dump) emptyDump
+runCertifier : Trace Untyped → Either Error (Σ (Trace (0 ⊢)) Certificate)
+runCertifier trace = do
   trace' ← try (checkScopeᵗ trace) illScoped
   cert ← certify trace'
   return (trace' , cert)
 
 -- FIXME: Instead of `Maybe Bool`, we should use something like `Error` on the Haskell side
-runCertifierMain : Dump → L.List EvalResult → Maybe (Bool × String)
+runCertifierMain : Trace Untyped → L.List EvalResult → Maybe (Bool × String)
 runCertifierMain dump costs =
   let r = runCertifier dump
   in case r of λ where

--- a/plutus-metatheory/src/CertifierReport.lagda.md
+++ b/plutus-metatheory/src/CertifierReport.lagda.md
@@ -205,8 +205,8 @@ reportPasses :
   (r : Certificate t)
   → List EvalResult
   → String
-reportPasses _ (done _) _ _ = ""
-reportPasses n (step tag _ x trace) (p , proofs) costs =
+reportPasses _ (singleton _) _ _ = ""
+reportPasses n (cons x (tag , _) trace) (p , proofs) costs =
   hl ++
   "Pass " ++ showℕ n ++ ": " ++ showTag tag ++
   hl ++

--- a/plutus-metatheory/src/Data/List/NonEmptySep.hs
+++ b/plutus-metatheory/src/Data/List/NonEmptySep.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Data.List.NonEmptySep
+  ( NonEmptySep (..)
+  , head
+  , fromList
+  ) where
+
+import Control.DeepSeq
+import GHC.Generics
+import Prelude hiding (head)
+
+-- | A non-empty list of `a`, separated by values of type `sep`
+data NonEmptySep sep a
+  = Cons a sep (NonEmptySep sep a)
+  | Singleton a
+  deriving (Show, Generic)
+  deriving anyclass (NFData)
+
+instance Functor (NonEmptySep sep) where
+  fmap f (Singleton x) = Singleton (f x)
+  fmap f (Cons x y xs) = Cons (f x) y (fmap f xs)
+
+instance Foldable (NonEmptySep sep) where
+  foldr f e (Singleton a) = f a e
+  foldr f e (Cons x _ xs) = f x (foldr f e xs)
+
+fromList :: ([(a, sep)], a) -> NonEmptySep sep a
+fromList ([], x) = Singleton x
+fromList ((x, y) : ys, z) = Cons x y (fromList (ys, z))
+
+head :: NonEmptySep sep a -> a
+head (Singleton x) = x
+head (Cons x _ _) = x

--- a/plutus-metatheory/src/FFI/AgdaUnparse.hs
+++ b/plutus-metatheory/src/FFI/AgdaUnparse.hs
@@ -5,6 +5,7 @@
 module FFI.AgdaUnparse where
 
 import Data.ByteString (ByteString)
+import Data.List.NonEmptySep
 import Data.Proxy
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -34,6 +35,15 @@ class AgdaUnparse a where
 -- | Render an 'AgdaUnparse' value to a 'String'.
 renderAgdaUnparse :: AgdaUnparse a => a -> String
 renderAgdaUnparse = renderString . layoutPretty (LayoutOptions Unbounded) . agdaUnparse
+
+instance (AgdaUnparse a, AgdaUnparse b) => AgdaUnparse (NonEmptySep a b) where
+  agdaUnparse (Singleton x) = parens ("singleton" <+> agdaUnparse x)
+  agdaUnparse (Cons x y xs) =
+    parens $
+      "cons"
+        <+> agdaUnparse x
+        <+> agdaUnparse y
+        <+> agdaUnparse xs
 
 instance AgdaUnparse AgdaFFI.UTerm where
   agdaUnparse =
@@ -71,7 +81,7 @@ instance AgdaUnparse UncertifiedOptStage where
 instance AgdaUnparse Hints.Hints where
   agdaUnparse = \case
     Hints.NoHints -> "none"
-    Hints.Inline x -> "inline" <+> parens (agdaUnparse x)
+    Hints.Inline x -> parens ("inline" <+> agdaUnparse x)
 
 instance AgdaUnparse Hints.Inline where
   agdaUnparse = \case

--- a/plutus-metatheory/src/FFI/OptimizerTrace.hs
+++ b/plutus-metatheory/src/FFI/OptimizerTrace.hs
@@ -1,8 +1,7 @@
 {-# OPTIONS_GHC -Wall #-}
 
 module FFI.OptimizerTrace
-  ( TraceElem
-  , Trace
+  ( Trace
   , mkFfiOptimizerTrace
   , toEvalResult
   ) where
@@ -13,28 +12,44 @@ import PlutusCore.Evaluation.Machine.ExBudget
 import PlutusCore.Evaluation.Machine.ExMemory
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek
-import UntypedPlutusCore.Transform.Certify.Hints qualified as Certify
+import UntypedPlutusCore.Transform.Certify.Hints (Hints)
 import UntypedPlutusCore.Transform.Optimizer
+import Prelude hiding (head)
 
 import Data.Coerce
 import Data.Functor
+import Data.List.NonEmptySep
 import Data.SatInt
 import Data.Text qualified as T
 
-type TraceElem a = (OptStage, (Certify.Hints, (a, a)))
-type Trace a = [TraceElem a]
+-- A certifier trace is a non-empty list of asts of type `a`, separated by the
+-- optimizer pass that ran and the hints that were emitted
+type Trace a = NonEmptySep (OptStage, Hints) a
 
 mkFfiOptimizerTrace
   :: OptimizerTrace UPLC.Name UPLC.DefaultUni UPLC.DefaultFun a
   -> Trace FFI.UTerm
-mkFfiOptimizerTrace (OptimizerTrace simplTrace) = reverse $ toFfiAst <$> simplTrace
+mkFfiOptimizerTrace (OptimizerTrace simplNonEmptySep) = go (reverse simplNonEmptySep)
   where
-    toFfiAst (Optimization before stage hints after) =
+    go
+      :: [Optimization UPLC.Name UPLC.DefaultUni UPLC.DefaultFun a]
+      -> Trace FFI.UTerm
+    go [] = error "Empty trace"
+    go [Optimization before stage hints after] =
       case (UPLC.deBruijnTerm before, UPLC.deBruijnTerm after) of
         (Right before', Right after') ->
-          (stage, (hints, (FFI.conv (void before'), FFI.conv (void after'))))
+          Cons
+            (FFI.conv (void before'))
+            (stage, hints)
+            (Singleton (FFI.conv (void after')))
         (Left (err :: UPLC.FreeVariableError), _) -> error $ show err
         (_, Left (err :: UPLC.FreeVariableError)) -> error $ show err
+    -- ignore _after, it should be equal to subsequent before
+    go (Optimization before stage hints _after : xs) =
+      case UPLC.deBruijnTerm before of
+        Right before' ->
+          Cons (FFI.conv (void before')) (stage, hints) (go xs)
+        Left (err :: UPLC.FreeVariableError) -> error $ show err
 
 toEvalResult
   :: Maybe (CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)

--- a/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
@@ -30,15 +30,13 @@ import qualified MAlonzo.Code.VerifiedCompilation.Trace
 
 -- Certifier.runCertifier
 d_runCertifier_2 ::
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.RawU.T_Untyped_208 ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.T_Error_2
     MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
@@ -47,64 +45,49 @@ d_runCertifier_2 v0
       MAlonzo.Code.Utils.du_eitherBind_54
       (coe
          MAlonzo.Code.Utils.du_try_102
-         (coe MAlonzo.Code.VerifiedCompilation.Trace.d_toTrace_106 (coe v0))
-         (coe MAlonzo.Code.VerifiedCompilation.C_emptyDump_4))
+         (coe
+            MAlonzo.Code.VerifiedCompilation.d_checkScope'7511'_102 (coe v0))
+         (coe MAlonzo.Code.VerifiedCompilation.C_illScoped_6))
       (coe
          (\ v1 ->
             coe
               MAlonzo.Code.Utils.du_eitherBind_54
-              (coe
-                 MAlonzo.Code.Utils.du_try_102
-                 (coe
-                    MAlonzo.Code.VerifiedCompilation.d_checkScope'7511'_102 (coe v1))
-                 (coe MAlonzo.Code.VerifiedCompilation.C_illScoped_6))
+              (coe MAlonzo.Code.VerifiedCompilation.d_certify_46 (coe v1))
               (coe
                  (\ v2 ->
                     coe
-                      MAlonzo.Code.Utils.du_eitherBind_54
-                      (coe MAlonzo.Code.VerifiedCompilation.d_certify_46 (coe v2))
+                      MAlonzo.Code.Utils.C_inj'8322'_14
                       (coe
-                         (\ v3 ->
-                            coe
-                              MAlonzo.Code.Utils.C_inj'8322'_14
-                              (coe
-                                 MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 (coe v2)
-                                 (coe v3))))))))
+                         MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 (coe v1) (coe v2))))))
 -- Certifier.runCertifierMain
 runCertifierMain ::
-  MAlonzo.Code.Agda.Builtin.List.T_List_10
-    ()
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
     (MAlonzo.Code.Utils.T__'215'__436
        (MAlonzo.Code.Utils.T_Either_6
           MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
           MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
-       (MAlonzo.Code.Utils.T__'215'__436
-          MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80
-          (MAlonzo.Code.Utils.T__'215'__436
-             MAlonzo.Code.RawU.T_Untyped_208
-             MAlonzo.Code.RawU.T_Untyped_208))) ->
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.RawU.T_Untyped_208 ->
   MAlonzo.Code.Agda.Builtin.List.T_List_10
-    () MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142 ->
+    () MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122 ->
   MAlonzo.Code.Agda.Builtin.Maybe.T_Maybe_10
     ()
     (MAlonzo.Code.Utils.T__'215'__436
        Bool MAlonzo.Code.Agda.Builtin.String.T_String_6)
-runCertifierMain = coe d_runCertifierMain_12
-d_runCertifierMain_12 ::
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
-        MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142] ->
+runCertifierMain = coe d_runCertifierMain_10
+d_runCertifierMain_10 ::
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.RawU.T_Untyped_208 ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   Maybe
     (MAlonzo.Code.Utils.T__'215'__436
        Bool MAlonzo.Code.Agda.Builtin.String.T_String_6)
-d_runCertifierMain_12 v0 v1
+d_runCertifierMain_10 v0 v1
   = let v2 = d_runCertifier_2 (coe v0) in
     coe
       (case coe v2 of

--- a/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
@@ -909,11 +909,11 @@ d_termSize'7510''695'_260 v0 v1
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showEvalResult
 d_showEvalResult_282 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showEvalResult_282 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_success_144 v1 v2
+      MAlonzo.Code.VerifiedCompilation.Trace.C_success_124 v1 v2
         -> coe
              MAlonzo.Code.Data.String.Base.d__'43''43'__20
              (d_'8649'__2 (coe ("Execution Cost: CPU = " :: Data.Text.Text)))
@@ -924,7 +924,7 @@ d_showEvalResult_282 v0
                    MAlonzo.Code.Data.String.Base.d__'43''43'__20
                    (", MEM = " :: Data.Text.Text)
                    (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v2)))
-      MAlonzo.Code.VerifiedCompilation.Trace.C_failure_146 v1 v2 v3
+      MAlonzo.Code.VerifiedCompilation.Trace.C_failure_126 v1 v2 v3
         -> coe
              MAlonzo.Code.Data.String.Base.d__'43''43'__20
              (d_'8649'__2 (coe ("Evaluation FAILED: " :: Data.Text.Text)))
@@ -945,7 +945,7 @@ d_showEvalResult_282 v0
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showCostPair
 d_showCostPair_294 ::
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_showCostPair_294 v0
   = let v1 = "" :: Data.Text.Text in
@@ -979,92 +979,108 @@ du_tail_302 v0
 -- CertifierReport.reportPasses
 d_reportPasses_312 ::
   Integer ->
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.Untyped.T__'8866'_14 ->
   AgdaAny ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_reportPasses_312 v0 v1 v2 v3
   = case coe v1 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_92 v4 v5 v6 v7
-        -> case coe v2 of
-             MAlonzo.Code.Utils.C__'44'__450 v8 v9
-               -> coe
-                    MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_hl_8
-                    (coe
-                       MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                       ("Pass " :: Data.Text.Text)
-                       (coe
-                          MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                          (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v0)
-                          (coe
-                             MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                             (": " :: Data.Text.Text)
-                             (coe
-                                MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                (d_showTag_14 (coe v4))
-                                (coe
-                                   MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_hl_8
-                                   (coe
-                                      MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                      (d_'8649'__2 (coe ("Program Size: " :: Data.Text.Text)))
-                                      (coe
-                                         MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                         (coe
-                                            MAlonzo.Code.Data.Nat.Show.d_show_56
-                                            (d_termSize_256 (coe (0 :: Integer)) (coe v6)))
-                                         (coe
-                                            MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                            (" (before)" :: Data.Text.Text)
-                                            (coe
-                                               MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_nl_6
-                                               (coe
-                                                  MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                  (d_'8649'__2
-                                                     (coe ("Program Size: " :: Data.Text.Text)))
-                                                  (coe
-                                                     MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                     (coe
-                                                        MAlonzo.Code.Data.Nat.Show.d_show_56
-                                                        (d_termSize_256
-                                                           (coe (0 :: Integer))
-                                                           (coe
-                                                              MAlonzo.Code.VerifiedCompilation.Trace.d_head_98
-                                                              (coe v7))))
-                                                     (coe
-                                                        MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                        (" (after)" :: Data.Text.Text)
-                                                        (coe
-                                                           MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                           d_nl_6
-                                                           (coe
-                                                              MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                              (d_showCostPair_294 (coe v3))
-                                                              (coe
-                                                                 MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                 d_nl_6
-                                                                 (coe
-                                                                    MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                    (d_showSites_248
-                                                                       (coe v6)
-                                                                       (coe
-                                                                          MAlonzo.Code.VerifiedCompilation.Trace.d_head_98
-                                                                          (coe v7))
-                                                                       (coe v4) (coe v8))
-                                                                    (coe
-                                                                       MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                       d_nl_6
-                                                                       (d_reportPasses_312
-                                                                          (coe
-                                                                             addInt
-                                                                             (coe (1 :: Integer))
-                                                                             (coe v0))
-                                                                          (coe v7) (coe v9)
-                                                                          (coe
-                                                                             du_tail_302
-                                                                             (coe
-                                                                                v3))))))))))))))))))))
+      MAlonzo.Code.VerifiedCompilation.Trace.C_cons_96 v4 v5 v6
+        -> case coe v5 of
+             MAlonzo.Code.Utils.C__'44'__450 v7 v8
+               -> case coe v2 of
+                    MAlonzo.Code.Utils.C__'44'__450 v9 v10
+                      -> coe
+                           MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_hl_8
+                           (coe
+                              MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                              ("Pass " :: Data.Text.Text)
+                              (coe
+                                 MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                 (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v0)
+                                 (coe
+                                    MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                    (": " :: Data.Text.Text)
+                                    (coe
+                                       MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                       (d_showTag_14 (coe v7))
+                                       (coe
+                                          MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_hl_8
+                                          (coe
+                                             MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                             (d_'8649'__2
+                                                (coe ("Program Size: " :: Data.Text.Text)))
+                                             (coe
+                                                MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                (coe
+                                                   MAlonzo.Code.Data.Nat.Show.d_show_56
+                                                   (d_termSize_256 (coe (0 :: Integer)) (coe v4)))
+                                                (coe
+                                                   MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                   (" (before)" :: Data.Text.Text)
+                                                   (coe
+                                                      MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                      d_nl_6
+                                                      (coe
+                                                         MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                         (d_'8649'__2
+                                                            (coe
+                                                               ("Program Size: "
+                                                                ::
+                                                                Data.Text.Text)))
+                                                         (coe
+                                                            MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                            (coe
+                                                               MAlonzo.Code.Data.Nat.Show.d_show_56
+                                                               (d_termSize_256
+                                                                  (coe (0 :: Integer))
+                                                                  (coe
+                                                                     MAlonzo.Code.VerifiedCompilation.Trace.d_head_112
+                                                                     (coe v6))))
+                                                            (coe
+                                                               MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                               (" (after)" :: Data.Text.Text)
+                                                               (coe
+                                                                  MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                                  d_nl_6
+                                                                  (coe
+                                                                     MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                                     (d_showCostPair_294 (coe v3))
+                                                                     (coe
+                                                                        MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                                        d_nl_6
+                                                                        (coe
+                                                                           MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                                           (d_showSites_248
+                                                                              (coe v4)
+                                                                              (coe
+                                                                                 MAlonzo.Code.VerifiedCompilation.Trace.d_head_112
+                                                                                 (coe v6))
+                                                                              (coe v7) (coe v9))
+                                                                           (coe
+                                                                              MAlonzo.Code.Data.String.Base.d__'43''43'__20
+                                                                              d_nl_6
+                                                                              (d_reportPasses_312
+                                                                                 (coe
+                                                                                    addInt
+                                                                                    (coe
+                                                                                       (1 ::
+                                                                                          Integer))
+                                                                                    (coe v0))
+                                                                                 (coe v6) (coe v10)
+                                                                                 (coe
+                                                                                    du_tail_302
+                                                                                    (coe
+                                                                                       v3))))))))))))))))))))
+                    _ -> MAlonzo.RTE.mazUnreachableError
              _ -> MAlonzo.RTE.mazUnreachableError
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_94 v4
+      MAlonzo.Code.VerifiedCompilation.Trace.C_singleton_98 v4
         -> coe ("" :: Data.Text.Text)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportFailure
@@ -1119,7 +1135,7 @@ d_makeReport_334 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.T_Error_2
     MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
-  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_142] ->
+  [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
 d_makeReport_334 v0 v1
   = coe

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation.hs
@@ -143,43 +143,66 @@ d_certifyPass_26 v0 v1
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.Certificate
 d_Certificate_34 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88 -> ()
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.Untyped.T__'8866'_14 ->
+  ()
 d_Certificate_34 = erased
 -- VerifiedCompilation.certify
 d_certify_46 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Utils.T_Either_6 T_Error_2 AgdaAny
 d_certify_46 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_92 v1 v2 v3 v4
-        -> let v5
-                 = coe
-                     d_certifyPass_26 v1 v2 v3
-                     (MAlonzo.Code.VerifiedCompilation.Trace.d_head_98 (coe v4)) in
-           coe
-             (case coe v5 of
-                MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_18 v6
-                  -> coe
-                       MAlonzo.Code.Utils.du_eitherBind_54 (coe d_certify_46 (coe v4))
-                       (coe
-                          (\ v7 ->
-                             coe
-                               MAlonzo.Code.Utils.C_inj'8322'_14
-                               (coe MAlonzo.Code.Utils.C__'44'__450 (coe v6) (coe v7))))
-                MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_26 v9 v10 v11
-                  -> coe
-                       MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_counterExample_8 (coe v9))
-                MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_32 v8 v9 v10
-                  -> coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_abort_10 (coe v8))
-                _ -> MAlonzo.RTE.mazUnreachableError)
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_94 v1
+      MAlonzo.Code.VerifiedCompilation.Trace.C_cons_96 v1 v2 v3
+        -> case coe v2 of
+             MAlonzo.Code.Utils.C__'44'__450 v4 v5
+               -> let v6
+                        = coe
+                            d_certifyPass_26 v4 v5 v1
+                            (MAlonzo.Code.VerifiedCompilation.Trace.d_head_112 (coe v3)) in
+                  coe
+                    (case coe v6 of
+                       MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_18 v7
+                         -> coe
+                              MAlonzo.Code.Utils.du_eitherBind_54 (coe d_certify_46 (coe v3))
+                              (coe
+                                 (\ v8 ->
+                                    coe
+                                      MAlonzo.Code.Utils.C_inj'8322'_14
+                                      (coe MAlonzo.Code.Utils.C__'44'__450 (coe v7) (coe v8))))
+                       MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_26 v10 v11 v12
+                         -> coe
+                              MAlonzo.Code.Utils.C_inj'8321'_12
+                              (coe C_counterExample_8 (coe v10))
+                       MAlonzo.Code.VerifiedCompilation.Certificate.C_abort_32 v9 v10 v11
+                         -> coe MAlonzo.Code.Utils.C_inj'8321'_12 (coe C_abort_10 (coe v9))
+                       _ -> MAlonzo.RTE.mazUnreachableError)
+             _ -> MAlonzo.RTE.mazUnreachableError
+      MAlonzo.Code.VerifiedCompilation.Trace.C_singleton_98 v1
         -> coe
              MAlonzo.Code.Utils.C_inj'8322'_14
              (coe MAlonzo.Code.Agda.Builtin.Unit.C_tt_8)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.cert
 d_cert_96 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88 ->
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Utils.T_Either_6 T_Error_2 AgdaAny ->
   AgdaAny -> AgdaAny
 d_cert_96 ~v0 v1 v2 = du_cert_96 v1 v2
@@ -200,27 +223,42 @@ d_checkScope_100 v0
       (coe MAlonzo.Code.Untyped.d_scopeCheckU0_288 (coe v0))
 -- VerifiedCompilation.checkScopeᵗ
 d_checkScope'7511'_102 ::
-  MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88 ->
-  Maybe MAlonzo.Code.VerifiedCompilation.Trace.T_Trace_88
+  MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+    (MAlonzo.Code.Utils.T__'215'__436
+       (MAlonzo.Code.Utils.T_Either_6
+          MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+          MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+       MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+    MAlonzo.Code.RawU.T_Untyped_208 ->
+  Maybe
+    (MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
+       (MAlonzo.Code.Utils.T__'215'__436
+          (MAlonzo.Code.Utils.T_Either_6
+             MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
+             MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12)
+          MAlonzo.Code.VerifiedCompilation.Trace.T_Hints_80)
+       MAlonzo.Code.Untyped.T__'8866'_14)
 d_checkScope'7511'_102 v0
   = case coe v0 of
-      MAlonzo.Code.VerifiedCompilation.Trace.C_step_92 v1 v2 v3 v4
+      MAlonzo.Code.VerifiedCompilation.Trace.C_cons_96 v1 v2 v3
         -> coe
-             MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
-             (coe d_checkScope_100 (coe v3))
+             seq (coe v2)
              (coe
-                (\ v5 ->
-                   coe
-                     MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
-                     (coe d_checkScope'7511'_102 (coe v4))
-                     (coe
-                        (\ v6 ->
-                           coe
-                             MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
-                             (coe
-                                MAlonzo.Code.VerifiedCompilation.Trace.C_step_92 (coe v1) (coe v2)
-                                (coe v5) (coe v6))))))
-      MAlonzo.Code.VerifiedCompilation.Trace.C_done_94 v1
+                MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
+                (coe d_checkScope_100 (coe v1))
+                (coe
+                   (\ v4 ->
+                      coe
+                        MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
+                        (coe d_checkScope'7511'_102 (coe v3))
+                        (coe
+                           (\ v5 ->
+                              coe
+                                MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
+                                (coe
+                                   MAlonzo.Code.VerifiedCompilation.Trace.C_cons_96 (coe v4)
+                                   (coe v2) (coe v5)))))))
+      MAlonzo.Code.VerifiedCompilation.Trace.C_singleton_98 v1
         -> coe
              MAlonzo.Code.Data.Maybe.Base.du__'62''62''61'__72
              (coe d_checkScope_100 (coe v1))
@@ -228,5 +266,6 @@ d_checkScope'7511'_102 v0
                 (\ v2 ->
                    coe
                      MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
-                     (coe MAlonzo.Code.VerifiedCompilation.Trace.C_done_94 (coe v2))))
+                     (coe
+                        MAlonzo.Code.VerifiedCompilation.Trace.C_singleton_98 (coe v2))))
       _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/Trace.hs
@@ -18,13 +18,12 @@ import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
 import qualified MAlonzo.RTE
 import qualified Data.Text
 import qualified MAlonzo.Code.Agda.Builtin.List
-import qualified MAlonzo.Code.Agda.Builtin.Maybe
 import qualified MAlonzo.Code.Agda.Builtin.String
-import qualified MAlonzo.Code.RawU
 import qualified MAlonzo.Code.Utils
 
 import UntypedPlutusCore.Transform.Certify.Trace
 import qualified UntypedPlutusCore.Transform.Certify.Hints as Hints
+import qualified Data.List.NonEmptySep as NES
 import FFI.CostInfo
 -- VerifiedCompilation.Trace.UncertifiedOptTag
 d_UncertifiedOptTag_4 = ()
@@ -224,148 +223,47 @@ cover_Hints_80 x
   = case x of
       Hints.Inline _ -> ()
       Hints.NoHints -> ()
--- VerifiedCompilation.Trace.Trace
-d_Trace_88 a0 = ()
-data T_Trace_88
-  = C_step_92 (MAlonzo.Code.Utils.T_Either_6
-                 T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-              T_Hints_80 AgdaAny T_Trace_88 |
-    C_done_94 AgdaAny
+-- VerifiedCompilation.Trace.NonEmptySep
+d_NonEmptySep_90 a0 a1 = ()
+type T_NonEmptySep_90 a0 a1 = NES.NonEmptySep a0 a1
+pattern C_cons_96 a0 a1 a2 = NES.Cons a0 a1 a2
+pattern C_singleton_98 a0 = NES.Singleton a0
+check_cons_96 ::
+  forall xS.
+    forall xA.
+      xA -> xS -> T_NonEmptySep_90 xS xA -> T_NonEmptySep_90 xS xA
+check_cons_96 = NES.Cons
+check_singleton_98 ::
+  forall xS. forall xA. xA -> T_NonEmptySep_90 xS xA
+check_singleton_98 = NES.Singleton
+cover_NonEmptySep_90 :: NES.NonEmptySep a1 a2 -> ()
+cover_NonEmptySep_90 x
+  = case x of
+      NES.Cons _ _ _ -> ()
+      NES.Singleton _ -> ()
 -- VerifiedCompilation.Trace.head
-d_head_98 :: T_Trace_88 -> AgdaAny
-d_head_98 v0
+d_head_112 :: T_NonEmptySep_90 AgdaAny AgdaAny -> AgdaAny
+d_head_112 v0
   = case coe v0 of
-      C_step_92 v1 v2 v3 v4 -> coe v3
-      C_done_94 v1 -> coe v1
+      C_cons_96 v1 v2 v3 -> coe v1
+      C_singleton_98 v1 -> coe v1
       _ -> MAlonzo.RTE.mazUnreachableError
--- VerifiedCompilation.Trace.Dump
-d_Dump_104 :: ()
-d_Dump_104 = erased
--- VerifiedCompilation.Trace.toTrace
-d_toTrace_106 ::
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
-  Maybe T_Trace_88
-d_toTrace_106 v0
-  = case coe v0 of
-      [] -> coe MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
-      (:) v1 v2
-        -> coe
-             MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
-             (coe du_go_116 (coe v1) (coe v2))
-      _ -> MAlonzo.RTE.mazUnreachableError
--- VerifiedCompilation.Trace._.go
-d_go_116 ::
-  MAlonzo.Code.Utils.T__'215'__436
-    (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-    (MAlonzo.Code.Utils.T__'215'__436
-       T_Hints_80
-       (MAlonzo.Code.Utils.T__'215'__436
-          MAlonzo.Code.RawU.T_Untyped_208
-          MAlonzo.Code.RawU.T_Untyped_208)) ->
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
-  MAlonzo.Code.Utils.T__'215'__436
-    (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-    (MAlonzo.Code.Utils.T__'215'__436
-       T_Hints_80
-       (MAlonzo.Code.Utils.T__'215'__436
-          MAlonzo.Code.RawU.T_Untyped_208
-          MAlonzo.Code.RawU.T_Untyped_208)) ->
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
-  T_Trace_88
-d_go_116 ~v0 ~v1 v2 v3 = du_go_116 v2 v3
-du_go_116 ::
-  MAlonzo.Code.Utils.T__'215'__436
-    (MAlonzo.Code.Utils.T_Either_6
-       T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-    (MAlonzo.Code.Utils.T__'215'__436
-       T_Hints_80
-       (MAlonzo.Code.Utils.T__'215'__436
-          MAlonzo.Code.RawU.T_Untyped_208
-          MAlonzo.Code.RawU.T_Untyped_208)) ->
-  [MAlonzo.Code.Utils.T__'215'__436
-     (MAlonzo.Code.Utils.T_Either_6
-        T_UncertifiedOptTag_4 T_CertifiedOptTag_12)
-     (MAlonzo.Code.Utils.T__'215'__436
-        T_Hints_80
-        (MAlonzo.Code.Utils.T__'215'__436
-           MAlonzo.Code.RawU.T_Untyped_208
-           MAlonzo.Code.RawU.T_Untyped_208))] ->
-  T_Trace_88
-du_go_116 v0 v1
-  = case coe v0 of
-      MAlonzo.Code.Utils.C__'44'__450 v2 v3
-        -> case coe v3 of
-             MAlonzo.Code.Utils.C__'44'__450 v4 v5
-               -> case coe v5 of
-                    MAlonzo.Code.Utils.C__'44'__450 v6 v7
-                      -> case coe v1 of
-                           []
-                             -> coe
-                                  C_step_92 (coe v2) (coe v4) (coe v6) (coe C_done_94 (coe v7))
-                           (:) v8 v9
-                             -> case coe v8 of
-                                  MAlonzo.Code.Utils.C__'44'__450 v10 v11
-                                    -> case coe v11 of
-                                         MAlonzo.Code.Utils.C__'44'__450 v12 v13
-                                           -> case coe v13 of
-                                                MAlonzo.Code.Utils.C__'44'__450 v14 v15
-                                                  -> coe
-                                                       C_step_92 (coe v2) (coe v4) (coe v6)
-                                                       (coe
-                                                          du_go_116
-                                                          (coe
-                                                             MAlonzo.Code.Utils.C__'44'__450
-                                                             (coe v10)
-                                                             (coe
-                                                                MAlonzo.Code.Utils.C__'44'__450
-                                                                (coe v12)
-                                                                (coe
-                                                                   MAlonzo.Code.Utils.C__'44'__450
-                                                                   (coe v7) (coe v15))))
-                                                          (coe v9))
-                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                  _ -> MAlonzo.RTE.mazUnreachableError
-                           _ -> MAlonzo.RTE.mazUnreachableError
-                    _ -> MAlonzo.RTE.mazUnreachableError
-             _ -> MAlonzo.RTE.mazUnreachableError
-      _ -> MAlonzo.RTE.mazUnreachableError
+-- VerifiedCompilation.Trace.Trace
+d_Trace_118 :: () -> ()
+d_Trace_118 = erased
 -- VerifiedCompilation.Trace.EvalResult
-d_EvalResult_142 = ()
-type T_EvalResult_142 = EvalResult
-pattern C_success_144 a0 a1 = EvalSuccess a0 a1
-pattern C_failure_146 a0 a1 a2 = EvalFailure a0 a1 a2
-check_success_144 :: Integer -> Integer -> T_EvalResult_142
-check_success_144 = EvalSuccess
-check_failure_146 ::
+d_EvalResult_122 = ()
+type T_EvalResult_122 = EvalResult
+pattern C_success_124 a0 a1 = EvalSuccess a0 a1
+pattern C_failure_126 a0 a1 a2 = EvalFailure a0 a1 a2
+check_success_124 :: Integer -> Integer -> T_EvalResult_122
+check_success_124 = EvalSuccess
+check_failure_126 ::
   MAlonzo.Code.Agda.Builtin.String.T_String_6 ->
-  Integer -> Integer -> T_EvalResult_142
-check_failure_146 = EvalFailure
-cover_EvalResult_142 :: EvalResult -> ()
-cover_EvalResult_142 x
+  Integer -> Integer -> T_EvalResult_122
+check_failure_126 = EvalFailure
+cover_EvalResult_122 :: EvalResult -> ()
+cover_EvalResult_122 x
   = case x of
       EvalSuccess _ _ -> ()
       EvalFailure _ _ _ -> ()

--- a/plutus-metatheory/src/VerifiedCompilation.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation.lagda.md
@@ -118,12 +118,12 @@ corresponding certifiers of each pass.
 
 ```
 Certificate : Trace (0 ⊢) → Set
-Certificate (done _) = ⊤
-Certificate (step pass hints t ts) = RelationOf pass t (head ts) × Certificate ts
+Certificate (singleton _) = ⊤
+Certificate (cons t (pass , hints) ts) = RelationOf pass t (head ts) × Certificate ts
 
 certify : (trace : Trace (0 ⊢)) → Either Error (Certificate trace)
-certify (done _) = inj₂ tt
-certify (step pass hints x xs) with certifyPass pass hints x (head xs)
+certify (singleton _) = inj₂ tt
+certify (cons x (pass , hints) xs) with certifyPass pass hints x (head xs)
 ... | ce _ tag _ _ = inj₁ (counterExample tag)
 ... | abort tag _ _ = inj₁ (abort tag)
 ... | proof p =
@@ -150,11 +150,11 @@ checkScope = eitherToMaybe ∘ scopeCheckU0
 
 -- Scope-check all terms in a trace
 checkScopeᵗ : Trace Untyped → Maybe (Trace (0 ⊢))
-checkScopeᵗ (done x) = do
+checkScopeᵗ (singleton x) = do
   x' ← checkScope x
-  return (done x')
-checkScopeᵗ (step pass hints t ts) = do
+  return (singleton x')
+checkScopeᵗ (cons t (pass , hints) ts) = do
   t' ← checkScope t
   ts' ← checkScopeᵗ ts
-  return (step pass hints t' ts')
+  return (cons t' (pass , hints) ts')
 ```

--- a/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/Trace.lagda.md
@@ -123,49 +123,34 @@ data Hints : Set where
 
 ## Compiler traces
 
+A `NonEmptySep S A` is a non-empty list of values of type `A`, separated by
+values of type `S`. 
+```
+
+data NonEmptySep (S A : Set) : Set where
+  cons : A → S → NonEmptySep S A → NonEmptySep S A
+  singleton : A → NonEmptySep S A
+
+{-# FOREIGN GHC import qualified Data.List.NonEmptySep as NES #-}
+{-# COMPILE GHC NonEmptySep = data NES.NonEmptySep (NES.Cons | NES.Singleton) #-}
+
+pattern _∷[_]_ x y xs = cons x y xs
+infixr 5 _∷[_]_
+
+-- Get the first term in the trace
+head : ∀{S A} → NonEmptySep S A → A
+head (singleton x) = x
+head (cons x _ _) = x
+```
+
 A `Trace A` is a sequence of optimisation transformations applied to terms of
-type `A`. Each transition is labeled with a `OptTag` that contains
+AST type `A`. Each transition is labeled with a `OptTag` and `Hints` that have
 information about which pass was performed.
 
 ```
-
-data Trace (A : Set) : Set where
-  -- One step in the pipeline, with its pass and input term
-  step : OptTag → Hints → A → Trace A → Trace A
-  -- Final AST in the trace
-  done : A → Trace A
-
--- Get the first term in the trace
-head : ∀{A} → Trace A → A
-head (done x) = x
-head (step _ _ x _) = x
-
-```
-
-`Dump` is the structure that is currently dumped on the Haskell side. We can convert it in a `Trace` using `toTrace`
-
-```
-
-
--- The current trace structure dumped from Haskell
-Dump : Set
-Dump = List (OptTag × Hints × Untyped × Untyped)
-
---
--- Since there is duplication in the dump, i.e. it is of the form
---
---     [(_ , x , y) ; (_ , y , z) ; (_ , z , w) ...]
---
--- This conversion entirely ignores the duplicated terms.
--- FIXME: just dump the Trace structure directly from
--- Haskell, this function won't be necessary
-toTrace : Dump → Maybe (Trace Untyped)
-toTrace [] = nothing
-toTrace (x ∷ xs) = just (go x xs)
-  where
-    go : OptTag × Hints × Untyped × Untyped → Dump → Trace Untyped
-    go (pass , hints , x , y) [] = step pass hints x (done y)
-    go (pass , hints , x , y) ((pass' , hints' , _ , z) ∷ xs) = step pass hints x (go (pass' , hints' , y , z) xs)
+-- An optimizer trace, parametrized by the AST type
+Trace : Set → Set
+Trace A = NonEmptySep (OptTag × Hints) A
 ```
 
 `EvalResult` is used to report script execution costs, before and after an optimisation (or optimisations).


### PR DESCRIPTION
Fixes https://github.com/IntersectMBO/plutus-private/issues/2162

Agda certificates can be slow to type-check for large programs. The current compilation trace records all passes, even if the pass did not change the AST. This means that agda is running unnecessary decision procedures during type checking.

For example, the marlowe semantics validator has a trace of 133 passes, while there are only 33 of those that change something about the AST. This PR deduplicates the trace so that only real transformations are certified.

Also
- Adds `Data.List.NonEmptySep` for representing the certifier trace properly on both Haskell/Agda side
- Move hints to their corresponding AST modules
- Print the top-level trace in a readable way