### PR TITLE
Move evaluateCekLikeInProd to plutus-ledger-api

### DIFF
--- a/plutus-benchmark/common/PlutusBenchmark/Common.hs
+++ b/plutus-benchmark/common/PlutusBenchmark/Common.hs
@@ -32,6 +32,7 @@ import Paths_plutus_benchmark as Export
 import PlutusBenchmark.ProtocolParameters as PP
 
 import PlutusLedgerApi.Common qualified as LedgerApi
+import PlutusLedgerApi.Test.Scripts (evaluateCekLikeInProd)
 
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin qualified as PLC
@@ -51,7 +52,6 @@ import PlutusTx.Test.Util.Compiled
   )
 import UntypedPlutusCore qualified as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek as Cek
-import UntypedPlutusCore.Evaluation.Machine.Cek qualified as UPLC
 
 import Control.DeepSeq (force)
 import Criterion.Main
@@ -120,21 +120,6 @@ mkEvalCtx ll semvar =
 -- Plutus language version and the ost recent semantic variant.
 mkMostRecentEvalCtx :: LedgerApi.EvaluationContext
 mkMostRecentEvalCtx = mkEvalCtx maxBound maxBound
-
--- | Evaluate a term as it would be evaluated using the on-chain evaluator.
-evaluateCekLikeInProd
-  :: LedgerApi.EvaluationContext
-  -> UPLC.Term PLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
-  -> Either
-       (UPLC.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
-       (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
-evaluateCekLikeInProd evalCtx term =
-  let
-    -- The validation benchmarks were all created from PlutusV1 scripts
-    pv = LedgerApi.ledgerLanguageIntroducedIn LedgerApi.PlutusV1
-   in
-    Cek.cekResultToEither . Cek._cekReportResult $
-      LedgerApi.evaluateTerm UPLC.restrictingEnormous pv LedgerApi.Quiet evalCtx term
 
 {-| Evaluate a term and either throw if evaluation fails or discard the result and return '()'.
 Useful for benchmarking. -}

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -91,15 +91,16 @@ library plutus-benchmark-common
 
   other-modules:   Paths_plutus_benchmark
   build-depends:
-    , base                         >=4.9   && <5
+    , base                                         >=4.9   && <5
     , bytestring
     , criterion
     , deepseq
     , directory
     , filepath
-    , plutus-core                  ^>=1.65
+    , plutus-core                                  ^>=1.65
     , plutus-core:flat
-    , plutus-ledger-api            ^>=1.65
+    , plutus-ledger-api                            ^>=1.65
+    , plutus-ledger-api:plutus-ledger-api-testlib
     , plutus-tx:plutus-tx-testlib
     , tasty
     , tasty-golden

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
@@ -1,16 +1,19 @@
 module PlutusLedgerApi.Test.Scripts
   ( uplcToScriptForEvaluation
   , compiledCodeToScriptForEvaluation
+  , evaluateCekLikeInProd
 
     -- * Example scripts
   , unitRedeemer
   , unitDatum
   ) where
 
+import PlutusCore qualified as PLC
 import PlutusLedgerApi.Common
 import PlutusLedgerApi.V1.Scripts
 import PlutusTx.Code (CompiledCode)
 import UntypedPlutusCore qualified as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek qualified as Cek
 
 uplcToScriptForEvaluation
   :: PlutusLedgerLanguage
@@ -35,3 +38,18 @@ unitDatum = Datum $ toBuiltinData ()
 -- | @()@ as a redeemer.
 unitRedeemer :: Redeemer
 unitRedeemer = Redeemer $ toBuiltinData ()
+
+{-| Evaluate a term as it would be evaluated using the on-chain evaluator.
+Always use this for benchmarking UPLC scripts. -}
+evaluateCekLikeInProd
+  :: EvaluationContext
+  -> UPLC.Term PLC.NamedDeBruijn PLC.DefaultUni PLC.DefaultFun ()
+  -> Either
+       (Cek.CekEvaluationException UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun)
+       (UPLC.Term UPLC.NamedDeBruijn UPLC.DefaultUni UPLC.DefaultFun ())
+evaluateCekLikeInProd evalCtx term =
+  let
+    pv = ledgerLanguageIntroducedIn PlutusV1
+   in
+    Cek.cekResultToEither . Cek._cekReportResult $
+      evaluateTerm Cek.restrictingEnormous pv Quiet evalCtx term

--- a/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
+++ b/plutus-ledger-api/testlib/PlutusLedgerApi/Test/Scripts.hs
@@ -53,3 +53,4 @@ evaluateCekLikeInProd evalCtx term =
    in
     Cek.cekResultToEither . Cek._cekReportResult $
       evaluateTerm Cek.restrictingEnormous pv Quiet evalCtx term
+{-# INLINE evaluateCekLikeInProd #-}


### PR DESCRIPTION
I want to move `evaluateCekLikeInProd`  from `plutus-benchmark` to `plutus-ledger-api` so that I can use it without depending on `plutus-benchmark`.  Let's check that it doesn't affect the benchmark results first though. 