### PR TITLE
Optimal non-builtin valueOf in plutus-ledger-api Data.Value

### DIFF
--- a/plutus-ledger-api/changelog.d/20260527_123507_yuriy.lazaryev_issue_2242_optimal_valueof.md
+++ b/plutus-ledger-api/changelog.d/20260527_123507_yuriy.lazaryev_issue_2242_optimal_valueof.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `PlutusLedgerApi.V1.Data.Value.valueOf` rewritten to walk the underlying `BuiltinList` directly via `unsafeDataAsMap` / `unsafeDataAsB` / `unsafeDataAsI` and short-circuit on the first match. The previous implementation went through `Map.lookup`, which materialised a `Maybe` only to deconstruct it immediately. Semantics are unchanged.

--- a/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
+++ b/plutus-ledger-api/src/PlutusLedgerApi/V1/Data/Value.hs
@@ -336,11 +336,18 @@ instance MeetSemiLattice Value where
 {-| Get the quantity of the given currency in the 'Value'.
 Assumes that the underlying map doesn't contain duplicate keys. -}
 valueOf :: Value -> CurrencySymbol -> TokenName -> Integer
-valueOf value cur tn =
-  withCurrencySymbol cur value 0 \tokens ->
-    case Map.lookup tn tokens of
-      Nothing -> 0
-      Just v -> v
+valueOf (Value mp) (CurrencySymbol curBs) (TokenName tnBs) =
+  goOuter (Map.toBuiltinList mp)
+  where
+    goOuter = B.caseList' 0 \hd ->
+      if B.equalsByteString curBs (BI.unsafeDataAsB (BI.fst hd))
+        then \_ -> goInner (BI.unsafeDataAsMap (BI.snd hd))
+        else goOuter
+
+    goInner = B.caseList' 0 \hd ->
+      if B.equalsByteString tnBs (BI.unsafeDataAsB (BI.fst hd))
+        then \_ -> BI.unsafeDataAsI (BI.snd hd)
+        else goInner
 {-# INLINEABLE valueOf #-}
 
 {-| Apply a continuation function to the token quantities of the given currency

--- a/plutus-tx-plugin/test-ledger-api/Spec.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec.hs
@@ -27,6 +27,7 @@ tests =
     , Spec.Data.Budget.tests
     , Spec.Data.ScriptContext.tests
     , Spec.Data.Value.test_EqValue
+    , Spec.Data.Value.test_valueOf
     , Spec.Data.MintValue.V3.tests
     , Spec.Envelope.tests
     , Spec.ReturnUnit.V1.tests

--- a/plutus-tx-plugin/test-ledger-api/Spec/Data/Value.hs
+++ b/plutus-tx-plugin/test-ledger-api/Spec/Data/Value.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -12,9 +13,13 @@ import Prelude qualified as Haskell
 
 import PlutusLedgerApi.V1.Data.Value
 
+import Plinth.Plugin (plinthc)
 import PlutusTx.Base
+import PlutusTx.Builtins qualified as B
+import PlutusTx.Builtins.Internal qualified as BI
 import PlutusTx.Code (CompiledCode, getPlc, unsafeApplyCode)
 import PlutusTx.Data.AssocMap qualified as AssocMap
+import PlutusTx.IsData qualified as Tx
 import PlutusTx.Lift
 import PlutusTx.List qualified as List
 import PlutusTx.Maybe
@@ -22,6 +27,7 @@ import PlutusTx.Numeric
 import PlutusTx.Prelude hiding (integerToByteString)
 import PlutusTx.Show (toDigits)
 import PlutusTx.TH (compile)
+import PlutusTx.Test.Run.Code (evalResult, evaluateCompiledCode)
 import PlutusTx.Traversable qualified as Tx
 
 import PlutusCore.Builtin qualified as PLC
@@ -31,12 +37,16 @@ import UntypedPlutusCore qualified as PLC
 import UntypedPlutusCore.Evaluation.Machine.Cek qualified as PLC
 
 import Control.Exception qualified as Haskell
+import Data.ByteString qualified as BS
 import Data.Functor qualified as Haskell
 import Data.List qualified as Haskell
 import Data.Map qualified as Map
+import PlutusLedgerApi.Test.V1.Data.Value qualified as ListToValue
 import Prettyprinter qualified as Pretty
+import Test.QuickCheck (Arbitrary (arbitrary), forAll, (===))
 import Test.Tasty
 import Test.Tasty.Extras
+import Test.Tasty.QuickCheck (testProperty)
 
 scalingFactor :: Integer
 scalingFactor = 4
@@ -258,3 +268,53 @@ test_EqValue =
     $ [ test_EqCurrencyList "Short" currencyListOptions
       , test_EqCurrencyList "Long" currencyLongListOptions
       ]
+
+-- | Compiled non-builtin 'valueOf', evaluated on CEK by the property test.
+compiledValueOf :: CompiledCode (Value -> CurrencySymbol -> TokenName -> Integer)
+compiledValueOf = plinthc valueOf
+
+{-| Compiled builtin lookup: @\\bd cs tn -> lookupCoin cs tn (unsafeDataAsValue bd)@.
+Used as the independent oracle in the differential property test for 'valueOf'. -}
+compiledBuiltinLookup
+  :: CompiledCode (BI.BuiltinData -> BI.BuiltinByteString -> BI.BuiltinByteString -> Integer)
+compiledBuiltinLookup =
+  plinthc (\bd c t -> B.lookupCoin c t (B.unsafeDataAsValue bd))
+
+{-| Check that the non-builtin 'valueOf' agrees with the builtin lookup path
+('unsafeDataAsValue' + 'lookupCoin') when both are evaluated on the CEK machine. -}
+test_valueOf :: TestTree
+test_valueOf =
+  testProperty "non-builtin valueOf matches builtin lookupCoin on CEK" \rawValue ->
+    let value =
+          ListToValue.listsToValue
+            . Haskell.sortOn fst
+            . Haskell.filter (Haskell.not . Haskell.null . snd)
+            . Haskell.map
+              ( Haskell.fmap
+                  ( Haskell.sortOn fst
+                      . Haskell.filter ((Haskell./= 0) . snd)
+                  )
+              )
+            $ ListToValue.valueToLists rawValue
+        genBytes = Haskell.fmap BS.pack arbitrary
+        genKeyPair =
+          Haskell.liftA2
+            (\bs1 bs2 -> (currencySymbol bs1, tokenName bs2))
+            genBytes
+            genBytes
+     in forAll genKeyPair \(cs, tn) ->
+          let nonBuiltin =
+                evalResult
+                  . evaluateCompiledCode
+                  $ compiledValueOf
+                  `unsafeApplyCode` liftCodeDef value
+                  `unsafeApplyCode` liftCodeDef cs
+                  `unsafeApplyCode` liftCodeDef tn
+              builtin =
+                evalResult
+                  . evaluateCompiledCode
+                  $ compiledBuiltinLookup
+                  `unsafeApplyCode` liftCodeDef (Tx.toBuiltinData value)
+                  `unsafeApplyCode` liftCodeDef (unCurrencySymbol cs)
+                  `unsafeApplyCode` liftCodeDef (unTokenName tn)
+           in nonBuiltin === builtin


### PR DESCRIPTION
## Summary

`PlutusLedgerApi.V1.Data.Value.valueOf` now walks the outer and inner `BuiltinList`s directly: `unsafeDataAsMap` for the maps, `unsafeDataAsB` for the keys, `unsafeDataAsI` for the result, `equalsByteString` to compare. The loop returns `0` from the nil-case, so there is no `Maybe` constructed and immediately scrutinised. Same semantics, no public API change.

Closes [plutus-private#2242](https://github.com/IntersectMBO/plutus-private/issues/2242).

## Evidence

The lookup matrix and the `unsafeDataAsValue` baseline are on a separate, never-merge PR ([#7798](https://github.com/IntersectMBO/plutus/pull/7798)) so the 96 golden files do not sit in this PR's CI surface. Those goldens regenerate on any upstream plugin or cost-model shift, which makes them noise for a regression gate.

Old vs new `valueOf`, CPU in thousands, GHC 9.6, plutus-ledger-api 1.65.0.0. Old = `master` (`Map.lookup` + `withCurrencySymbol` continuation). New = this PR.

Shape legend: **S1** = ada only (1 token); **S3** = ada plus 2 single-token policies (3 tokens); **S8** = ada plus 7 single-token policies (8 tokens); **S100** = ada plus 10 policies of 10 tokens each (101 tokens). Lookup position is the row index of the matching `(currency, token)` inside the outer/inner maps: **ada** = first, **middle** = around the centre, **last** = final entry, **miss** = absent key (full scan).

| shape | lookup at | old CPU | new CPU | speedup |
|-------|-----------|---------|---------|---------|
| S1    | ada       |   5 423 |   3 772 | 1.44× |
| S1    | miss      |   3 180 |   2 500 | 1.27× |
| S3    | ada       |   5 423 |   3 772 | 1.44× |
| S3    | middle    |   7 905 |   5 010 | 1.58× |
| S3    | last      |  10 065 |   6 247 | 1.61× |
| S3    | miss      |   7 500 |   4 974 | 1.51× |
| S8    | ada       |   5 423 |   3 772 | 1.44× |
| S8    | middle    |  14 385 |   8 721 | 1.65× |
| S8    | last      |  20 865 |  12 432 | 1.68× |
| S8    | miss      |  18 301 |  11 159 | 1.64× |
| S100  | ada       |   5 423 |   3 772 | 1.44× |
| S100  | middle    |  25 186 |  15 162 | 1.66× |
| S100  | last      |  46 787 |  27 852 | 1.68× |
| S100  | miss      |  24 781 |  14 870 | 1.67× |

First-position lookups (`ada`) are constant in both versions because both short-circuit on the first key match; the new path is 1.44× faster on the constant cost. Linear scans (`middle`, `last`, `miss`) get a 1.6–1.7× speedup that holds across shapes, because the per-step cost dropped from `Map.lookup`-with-dictionary-conversion to a single `equalsByteString` plus three raw `unsafeDataAs*` builtins. Memory dropped roughly in proportion.

For comparison against the builtin path (`unsafeDataAsValue` + `lookupCoin`), see [#7798](https://github.com/IntersectMBO/plutus/pull/7798); the headline is that the new `valueOf` beats the builtin path on first-position lookups for large values (S100 ada: 3.77 M vs 22.11 M, ~5.9× cheaper).