### PR TITLE
Metatheory: define semantic versions of value and purity

### DIFF
--- a/plutus-metatheory/src/MAlonzo/Code/Untyped/Purity.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Untyped/Purity.hs
@@ -422,3 +422,31 @@ d_allPure'63'_78 v0 v1
                                  (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
                 _ -> MAlonzo.RTE.mazUnreachableError)
       _ -> MAlonzo.RTE.mazUnreachableError
+-- Untyped.Purity.pure₀
+d_pure'8320'_470 :: MAlonzo.Code.Untyped.T__'8866'_14 -> ()
+d_pure'8320'_470 = erased
+-- Untyped.Purity.pure
+d_pure_478 :: Integer -> MAlonzo.Code.Untyped.T__'8866'_14 -> ()
+d_pure_478 = erased
+-- Untyped.Purity.pure₀-pure
+d_pure'8320''45'pure_486
+  = error
+      "MAlonzo Runtime Error: postulate evaluated: Untyped.Purity.pure\8320-pure"
+-- Untyped.Purity.value-pure
+d_value'45'pure_490 ::
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.Reduction.T_Value_180 ->
+  MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
+d_value'45'pure_490 v0 v1
+  = coe
+      d_pure'8320''45'pure_486 v0
+      (coe
+         MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 (coe v0)
+         (coe
+            MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
+            (coe MAlonzo.Code.Untyped.Reduction.C_refl_464)
+            (coe MAlonzo.Code.Untyped.Reduction.du_V'45'v_592 (coe v1))))
+-- Untyped.Purity.Pure-pure
+d_Pure'45'pure_498
+  = error
+      "MAlonzo Runtime Error: postulate evaluated: Untyped.Purity.Pure-pure"

--- a/plutus-metatheory/src/MAlonzo/Code/Untyped/Reduction.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Untyped/Reduction.hs
@@ -20,9 +20,11 @@ import qualified Data.Text
 import qualified MAlonzo.Code.Agda.Builtin.Equality
 import qualified MAlonzo.Code.Agda.Builtin.List
 import qualified MAlonzo.Code.Agda.Builtin.Maybe
+import qualified MAlonzo.Code.Agda.Builtin.Sigma
 import qualified MAlonzo.Code.Builtin
 import qualified MAlonzo.Code.Builtin.Signature
 import qualified MAlonzo.Code.Data.Fin.Base
+import qualified MAlonzo.Code.Data.Irrelevant
 import qualified MAlonzo.Code.Data.List.Base
 import qualified MAlonzo.Code.Data.List.NonEmpty.Base
 import qualified MAlonzo.Code.Data.List.Relation.Unary.All
@@ -128,26 +130,25 @@ d_nat'45'threshold_158 ::
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12
 d_nat'45'threshold_158 = erased
 -- Untyped.Reduction.Value
-d_Value_182 a0 a1 = ()
-data T_Value_182
-  = C_delay_188 | C_ƛ_192 | C_con_196 | C_builtin_200 |
-    C_unsat'8320'_208 Integer Integer T_Value_182 |
-    C_unsat'8320''8331''8321'_214 Integer T_Value_182 |
-    C_unsat'8321'_222 Integer T_Value_182 T_Value_182 |
-    C_constr_228 MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
+d_Value_180 a0 = ()
+data T_Value_180
+  = C_delay_184 | C_ƛ_188 | C_con_192 | C_builtin_196 |
+    C_unsat'8320'_204 Integer Integer T_Value_180 |
+    C_unsat'8320''8331''8321'_210 Integer T_Value_180 |
+    C_unsat'8321'_218 Integer T_Value_180 T_Value_180 |
+    C_constr_224 MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
 -- Untyped.Reduction.value-constr-recurse
-d_value'45'constr'45'recurse_234 ::
-  Integer ->
+d_value'45'constr'45'recurse_230 ::
   Integer ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  T_Value_182 -> MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
-d_value'45'constr'45'recurse_234 ~v0 ~v1 ~v2 v3
-  = du_value'45'constr'45'recurse_234 v3
-du_value'45'constr'45'recurse_234 ::
-  T_Value_182 -> MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
-du_value'45'constr'45'recurse_234 v0
+  T_Value_180 -> MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
+d_value'45'constr'45'recurse_230 ~v0 ~v1 v2
+  = du_value'45'constr'45'recurse_230 v2
+du_value'45'constr'45'recurse_230 ::
+  T_Value_180 -> MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
+du_value'45'constr'45'recurse_230 v0
   = case coe v0 of
-      C_constr_228 v3
+      C_constr_224 v3
         -> case coe v3 of
              MAlonzo.Code.Data.List.Relation.Unary.All.C_'91''93'_50 -> coe v3
              MAlonzo.Code.Data.List.Relation.Unary.All.C__'8759'__60 v6 v7
@@ -156,130 +157,184 @@ du_value'45'constr'45'recurse_234 v0
              _ -> MAlonzo.RTE.mazUnreachableError
       _ -> MAlonzo.RTE.mazUnreachableError
 -- Untyped.Reduction.iterApp
-d_iterApp_242 ::
+d_iterApp_238 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   MAlonzo.Code.Untyped.T__'8866'_14
-d_iterApp_242 ~v0 v1 v2 = du_iterApp_242 v1 v2
-du_iterApp_242 ::
+d_iterApp_238 ~v0 v1 v2 = du_iterApp_238 v1 v2
+du_iterApp_238 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   MAlonzo.Code.Untyped.T__'8866'_14
-du_iterApp_242 v0 v1
+du_iterApp_238 v0 v1
   = case coe v1 of
       [] -> coe v0
       (:) v2 v3
         -> coe
-             du_iterApp_242
+             du_iterApp_238
              (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v0) (coe v2)) (coe v3)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- Untyped.Reduction.reduceBuiltin
-d_reduceBuiltin_252
+d_reduceBuiltin_248
   = error
       "MAlonzo Runtime Error: postulate evaluated: Untyped.Reduction.reduceBuiltin"
 -- Untyped.Reduction._⟶_
-d__'10230'__256 a0 a1 a2 = ()
-data T__'10230'__256
-  = C_ξ'8321'_266 T__'10230'__256 |
-    C_ξ'8322'_274 T_Value_182 T__'10230'__256 |
-    C_ξ'8323'_280 T__'10230'__256 | C_β_286 T_Value_182 |
-    C_force'45'delay_290 | C_error'8321'_294 | C_error'8322'_298 |
-    C_force'45'error_300 | C_sat'45'app'45'builtin_306 |
-    C_sat'45'force'45'builtin_310 |
-    C_case'45'constr_320 MAlonzo.Code.Untyped.T__'8866'_14 |
-    C_broken'45'const_328 | C_constr'45'step_338 T__'10230'__256 |
-    C_constr'45'sub'45'step_348 T__'10230'__256 |
-    C_constr'45'error_354 |
-    C_constr'45'sub'45'error_362 T__'10230'__256 | C_force'45'ƛ_366 |
-    C_force'45'con_370 | C_force'45'constr_376 |
-    C_force'45'interleave'45'error_382 Integer |
-    C_app'45'interleave'45'error_392 Integer Integer |
-    C_app'45'con_398 | C_app'45'delay_404 | C_app'45'constr_412 |
-    C_case'45'error_416 | C_case'45'ƛ_422 | C_case'45'delay_428 |
-    C_case'45'con_434 | C_case'45'builtin_440 |
-    C_case'45'unsat'8320'_450 Integer Integer |
-    C_case'45'unsat'8321'_458 Integer |
-    C_case'45'reduce_466 T__'10230'__256
+d__'10230'__250 a0 a1 = ()
+data T__'10230'__250
+  = C_ξ'8321'_258 T__'10230'__250 |
+    C_ξ'8322'_266 T_Value_180 T__'10230'__250 |
+    C_ξ'8323'_272 T__'10230'__250 | C_β_278 T_Value_180 |
+    C_force'45'delay_282 | C_error'8321'_286 | C_error'8322'_290 |
+    C_force'45'error_292 | C_sat'45'app'45'builtin_298 |
+    C_sat'45'force'45'builtin_302 |
+    C_case'45'constr_312 MAlonzo.Code.Untyped.T__'8866'_14 |
+    C_broken'45'const_320 | C_constr'45'step_330 T__'10230'__250 |
+    C_constr'45'sub'45'step_340 T__'10230'__250 |
+    C_constr'45'error_346 |
+    C_constr'45'sub'45'error_354 T__'10230'__250 | C_force'45'ƛ_358 |
+    C_force'45'con_362 | C_force'45'constr_368 |
+    C_force'45'interleave'45'error_374 Integer |
+    C_app'45'interleave'45'error_384 Integer Integer |
+    C_app'45'con_390 | C_app'45'delay_396 | C_app'45'constr_404 |
+    C_case'45'error_408 | C_case'45'ƛ_414 | C_case'45'delay_420 |
+    C_case'45'con_426 | C_case'45'builtin_432 |
+    C_case'45'unsat'8320'_442 Integer Integer |
+    C_case'45'unsat'8321'_450 Integer |
+    C_case'45'reduce_458 T__'10230'__250
 -- Untyped.Reduction._⟶*_
-d__'10230''42'__470 a0 a1 a2 = ()
-data T__'10230''42'__470
-  = C_refl_476 |
-    C_trans_484 MAlonzo.Code.Untyped.T__'8866'_14 T__'10230'__256
-                T__'10230''42'__470
+d__'10230''42'__460 a0 a1 = ()
+data T__'10230''42'__460
+  = C_refl_464 |
+    C_trans_472 MAlonzo.Code.Untyped.T__'8866'_14 T__'10230'__250
+                T__'10230''42'__460
 -- Untyped.Reduction.tran-⟶*
-d_tran'45''10230''42'_494 ::
-  Integer ->
+d_tran'45''10230''42'_480 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  T__'10230''42'__470 -> T__'10230''42'__470 -> T__'10230''42'__470
-d_tran'45''10230''42'_494 ~v0 ~v1 ~v2 ~v3 v4 v5
-  = du_tran'45''10230''42'_494 v4 v5
-du_tran'45''10230''42'_494 ::
-  T__'10230''42'__470 -> T__'10230''42'__470 -> T__'10230''42'__470
-du_tran'45''10230''42'_494 v0 v1
+  T__'10230''42'__460 -> T__'10230''42'__460 -> T__'10230''42'__460
+d_tran'45''10230''42'_480 ~v0 ~v1 ~v2 v3 v4
+  = du_tran'45''10230''42'_480 v3 v4
+du_tran'45''10230''42'_480 ::
+  T__'10230''42'__460 -> T__'10230''42'__460 -> T__'10230''42'__460
+du_tran'45''10230''42'_480 v0 v1
   = case coe v0 of
-      C_refl_476 -> coe v1
-      C_trans_484 v3 v5 v6
+      C_refl_464 -> coe v1
+      C_trans_472 v3 v5 v6
         -> case coe v1 of
-             C_refl_476 -> coe C_trans_484 v3 v5 v6
-             C_trans_484 v8 v10 v11
+             C_refl_464 -> coe C_trans_472 v3 v5 v6
+             C_trans_472 v8 v10 v11
                -> coe
-                    C_trans_484 v3 v5
+                    C_trans_472 v3 v5
                     (coe
-                       du_tran'45''10230''42'_494 (coe v6) (coe C_trans_484 v8 v10 v11))
+                       du_tran'45''10230''42'_480 (coe v6) (coe C_trans_472 v8 v10 v11))
              _ -> MAlonzo.RTE.mazUnreachableError
       _ -> MAlonzo.RTE.mazUnreachableError
+-- Untyped.Reduction.irred
+d_irred_496 :: MAlonzo.Code.Untyped.T__'8866'_14 -> ()
+d_irred_496 = erased
+-- Untyped.Reduction.value
+d_value_502 :: MAlonzo.Code.Untyped.T__'8866'_14 -> ()
+d_value_502 = erased
+-- Untyped.Reduction.irred-constr
+d_irred'45'constr_510 ::
+  Integer ->
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T__'10230'__250 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
+d_irred'45'constr_510 = erased
+-- Untyped.Reduction.unsaturated
+d_unsaturated_562 a0 = ()
+data T_unsaturated_562
+  = C_arg'45'arg_570 Integer T_Value_180 T_Value_180 |
+    C_force'45'force'45'args_578 Integer Integer T_Value_180 |
+    C_force'45'args_584 Integer T_Value_180
+-- Untyped.Reduction.irred-unsaturated
+d_irred'45'unsaturated_588
+  = error
+      "MAlonzo Runtime Error: postulate evaluated: Untyped.Reduction.irred-unsaturated"
+-- Untyped.Reduction.V-v
+d_V'45'v_592 ::
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  T_Value_180 -> MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
+d_V'45'v_592 ~v0 v1 = du_V'45'v_592 v1
+du_V'45'v_592 ::
+  T_Value_180 -> MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
+du_V'45'v_592 v0
+  = coe
+      seq (coe v0)
+      (coe MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 erased erased)
+-- Untyped.Reduction.V-v*
+d_V'45'v'42'_596 ::
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44 ->
+  MAlonzo.Code.Data.List.Relation.Unary.All.T_All_44
+d_V'45'v'42'_596 v0 v1
+  = case coe v1 of
+      MAlonzo.Code.Data.List.Relation.Unary.All.C_'91''93'_50 -> coe v1
+      MAlonzo.Code.Data.List.Relation.Unary.All.C__'8759'__60 v4 v5
+        -> case coe v0 of
+             (:) v6 v7
+               -> coe
+                    MAlonzo.Code.Data.List.Relation.Unary.All.C__'8759'__60
+                    (coe du_V'45'v_592 (coe v4)) (d_V'45'v'42'_596 (coe v7) (coe v5))
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Untyped.Reduction.value-Value
+d_value'45'Value_620
+  = error
+      "MAlonzo Runtime Error: postulate evaluated: Untyped.Reduction.value-Value"
 -- Untyped.Reduction.Progress
-d_Progress_514 a0 a1 = ()
-data T_Progress_514
-  = C_step_522 MAlonzo.Code.Untyped.T__'8866'_14 T__'10230'__256 |
-    C_done_526 T_Value_182 | C_fail_528
+d_Progress_624 a0 = ()
+data T_Progress_624
+  = C_step_630 MAlonzo.Code.Untyped.T__'8866'_14 T__'10230'__250 |
+    C_done_634 T_Value_180 | C_fail_636
 -- Untyped.Reduction.progress
-d_progress_532 ::
-  MAlonzo.Code.Untyped.T__'8866'_14 -> T_Progress_514
-d_progress_532 v0
+d_progress_640 ::
+  MAlonzo.Code.Untyped.T__'8866'_14 -> T_Progress_624
+d_progress_640 v0
   = case coe v0 of
-      MAlonzo.Code.Untyped.C_ƛ_20 v1 -> coe C_done_526 (coe C_ƛ_192)
+      MAlonzo.Code.Untyped.C_ƛ_20 v1 -> coe C_done_634 (coe C_ƛ_188)
       MAlonzo.Code.Untyped.C__'183'__22 v1 v2
-        -> let v3 = d_progress_532 (coe v1) in
+        -> let v3 = d_progress_640 (coe v1) in
            coe
              (case coe v3 of
-                C_step_522 v5 v6
+                C_step_630 v5 v6
                   -> coe
-                       C_step_522
+                       C_step_630
                        (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v5) (coe v2))
-                       (coe C_ξ'8321'_266 v6)
-                C_done_526 v5
-                  -> let v6 = d_progress_532 (coe v2) in
+                       (coe C_ξ'8321'_258 v6)
+                C_done_634 v5
+                  -> let v6 = d_progress_640 (coe v2) in
                      coe
                        (case coe v6 of
-                          C_step_522 v8 v9
+                          C_step_630 v8 v9
                             -> coe
-                                 C_step_522
+                                 C_step_630
                                  (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v1) (coe v8))
-                                 (coe C_ξ'8322'_274 v5 v9)
-                          C_done_526 v8
+                                 (coe C_ξ'8322'_266 v5 v9)
+                          C_done_634 v8
                             -> case coe v5 of
-                                 C_delay_188
+                                 C_delay_184
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_app'45'delay_404)
-                                 C_ƛ_192
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_app'45'delay_396)
+                                 C_ƛ_188
                                    -> case coe v1 of
                                         MAlonzo.Code.Untyped.C_ƛ_20 v10
                                           -> coe
-                                               C_step_522
+                                               C_step_630
                                                (MAlonzo.Code.Untyped.RenamingSubstitution.d__'91'_'93'_478
                                                   (coe (0 :: Integer)) (coe v10) (coe v2))
-                                               (coe C_β_286 v8)
+                                               (coe C_β_278 v8)
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_con_196
+                                 C_con_192
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_app'45'con_398)
-                                 C_builtin_200
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_app'45'con_390)
+                                 C_builtin_196
                                    -> case coe v1 of
                                         MAlonzo.Code.Untyped.C_builtin_44 v10
                                           -> let v11
@@ -318,20 +373,20 @@ d_progress_532 v0
                                                   (case coe v12 of
                                                      0 -> case coe v11 of
                                                             1 -> coe
-                                                                   C_step_522
+                                                                   C_step_630
                                                                    (coe
-                                                                      d_reduceBuiltin_252
+                                                                      d_reduceBuiltin_248
                                                                       (0 :: Integer) v0)
-                                                                   (coe C_sat'45'app'45'builtin_306)
+                                                                   (coe C_sat'45'app'45'builtin_298)
                                                             _ -> let v13
                                                                        = subInt
                                                                            (coe v11)
                                                                            (coe (2 :: Integer)) in
                                                                  coe
                                                                    (coe
-                                                                      C_done_526
+                                                                      C_done_634
                                                                       (coe
-                                                                         C_unsat'8321'_222 v13 v5
+                                                                         C_unsat'8321'_218 v13 v5
                                                                          v8))
                                                      _ -> let v13
                                                                 = subInt
@@ -339,17 +394,17 @@ d_progress_532 v0
                                                                     (coe (1 :: Integer)) in
                                                           coe
                                                             (coe
-                                                               C_step_522
+                                                               C_step_630
                                                                (coe MAlonzo.Code.Untyped.C_error_46)
                                                                (coe
-                                                                  C_app'45'interleave'45'error_392
+                                                                  C_app'45'interleave'45'error_384
                                                                   v13 v11))))
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_unsat'8320'_208 v10 v11 v13
+                                 C_unsat'8320'_204 v10 v11 v13
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_app'45'interleave'45'error_392 v10 v11)
-                                 C_unsat'8320''8331''8321'_214 v10 v12
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_app'45'interleave'45'error_384 v10 v11)
+                                 C_unsat'8320''8331''8321'_210 v10 v12
                                    -> case coe v1 of
                                         MAlonzo.Code.Untyped.C_force_24 v13
                                           -> let v14 = coe du_sat_36 (coe v13) in
@@ -365,25 +420,25 @@ d_progress_532 v0
                                                            -> case coe v15 of
                                                                 0 -> case coe v16 of
                                                                        0 -> coe
-                                                                              C_step_522
+                                                                              C_step_630
                                                                               (coe
                                                                                  MAlonzo.Code.Untyped.C__'183'__22
                                                                                  (coe
-                                                                                    d_reduceBuiltin_252
+                                                                                    d_reduceBuiltin_248
                                                                                     (0 :: Integer)
                                                                                     v1)
                                                                                  (coe v2))
                                                                               (coe
-                                                                                 C_ξ'8321'_266
+                                                                                 C_ξ'8321'_258
                                                                                  (coe
-                                                                                    C_sat'45'force'45'builtin_310))
+                                                                                    C_sat'45'force'45'builtin_302))
                                                                        1 -> coe
-                                                                              C_step_522
+                                                                              C_step_630
                                                                               (coe
-                                                                                 d_reduceBuiltin_252
+                                                                                 d_reduceBuiltin_248
                                                                                  (0 :: Integer) v0)
                                                                               (coe
-                                                                                 C_sat'45'app'45'builtin_306)
+                                                                                 C_sat'45'app'45'builtin_298)
                                                                        _ -> let v17
                                                                                   = subInt
                                                                                       (coe v16)
@@ -392,9 +447,9 @@ d_progress_532 v0
                                                                                             Integer)) in
                                                                             coe
                                                                               (coe
-                                                                                 C_done_526
+                                                                                 C_done_634
                                                                                  (coe
-                                                                                    C_unsat'8321'_222
+                                                                                    C_unsat'8321'_218
                                                                                     v17 v5 v8))
                                                                 _ -> let v17
                                                                            = subInt
@@ -403,11 +458,11 @@ d_progress_532 v0
                                                                                   (1 :: Integer)) in
                                                                      coe
                                                                        (coe
-                                                                          C_step_522
+                                                                          C_step_630
                                                                           (coe
                                                                              MAlonzo.Code.Untyped.C_error_46)
                                                                           (coe
-                                                                             C_app'45'interleave'45'error_392
+                                                                             C_app'45'interleave'45'error_384
                                                                              v17 v16))
                                                          _ -> MAlonzo.RTE.mazUnreachableError
                                                   C_want_8 v15 v16
@@ -428,28 +483,28 @@ d_progress_532 v0
                                                                      -> case coe v18 of
                                                                           0 -> case coe v19 of
                                                                                  0 -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C__'183'__22
                                                                                            (coe
-                                                                                              d_reduceBuiltin_252
+                                                                                              d_reduceBuiltin_248
                                                                                               (0 ::
                                                                                                  Integer)
                                                                                               v1)
                                                                                            (coe v2))
                                                                                         (coe
-                                                                                           C_ξ'8321'_266
+                                                                                           C_ξ'8321'_258
                                                                                            (coe
-                                                                                              C_sat'45'force'45'builtin_310))
+                                                                                              C_sat'45'force'45'builtin_302))
                                                                                  1 -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
-                                                                                           d_reduceBuiltin_252
+                                                                                           d_reduceBuiltin_248
                                                                                            (0 ::
                                                                                               Integer)
                                                                                            v0)
                                                                                         (coe
-                                                                                           C_sat'45'app'45'builtin_306)
+                                                                                           C_sat'45'app'45'builtin_298)
                                                                                  _ -> let v20
                                                                                             = subInt
                                                                                                 (coe
@@ -459,9 +514,9 @@ d_progress_532 v0
                                                                                                       Integer)) in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_done_526
+                                                                                           C_done_634
                                                                                            (coe
-                                                                                              C_unsat'8321'_222
+                                                                                              C_unsat'8321'_218
                                                                                               v20 v5
                                                                                               v8))
                                                                           _ -> let v20
@@ -472,33 +527,33 @@ d_progress_532 v0
                                                                                                Integer)) in
                                                                                coe
                                                                                  (coe
-                                                                                    C_step_522
+                                                                                    C_step_630
                                                                                     (coe
                                                                                        MAlonzo.Code.Untyped.C_error_46)
                                                                                     (coe
-                                                                                       C_app'45'interleave'45'error_392
+                                                                                       C_app'45'interleave'45'error_384
                                                                                        v20 v19))
                                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                                          1 -> case coe v16 of
                                                                 0 -> coe
-                                                                       C_step_522
+                                                                       C_step_630
                                                                        (coe
                                                                           MAlonzo.Code.Untyped.C__'183'__22
                                                                           (coe
-                                                                             d_reduceBuiltin_252
+                                                                             d_reduceBuiltin_248
                                                                              (0 :: Integer) v1)
                                                                           (coe v2))
                                                                        (coe
-                                                                          C_ξ'8321'_266
+                                                                          C_ξ'8321'_258
                                                                           (coe
-                                                                             C_sat'45'force'45'builtin_310))
+                                                                             C_sat'45'force'45'builtin_302))
                                                                 1 -> coe
-                                                                       C_step_522
+                                                                       C_step_630
                                                                        (coe
-                                                                          d_reduceBuiltin_252
+                                                                          d_reduceBuiltin_248
                                                                           (0 :: Integer) v0)
                                                                        (coe
-                                                                          C_sat'45'app'45'builtin_306)
+                                                                          C_sat'45'app'45'builtin_298)
                                                                 _ -> let v17
                                                                            = subInt
                                                                                (coe v16)
@@ -506,9 +561,9 @@ d_progress_532 v0
                                                                                   (2 :: Integer)) in
                                                                      coe
                                                                        (coe
-                                                                          C_done_526
+                                                                          C_done_634
                                                                           (coe
-                                                                             C_unsat'8321'_222 v17
+                                                                             C_unsat'8321'_218 v17
                                                                              v5 v8))
                                                          _ -> let v17
                                                                     = subInt
@@ -516,15 +571,15 @@ d_progress_532 v0
                                                                         (coe (2 :: Integer)) in
                                                               coe
                                                                 (coe
-                                                                   C_step_522
+                                                                   C_step_630
                                                                    (coe
                                                                       MAlonzo.Code.Untyped.C_error_46)
                                                                    (coe
-                                                                      C_app'45'interleave'45'error_392
+                                                                      C_app'45'interleave'45'error_384
                                                                       v17 v16))
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_unsat'8321'_222 v11 v13 v14
+                                 C_unsat'8321'_218 v11 v13 v14
                                    -> case coe v1 of
                                         MAlonzo.Code.Untyped.C__'183'__22 v15 v16
                                           -> let v17 = coe du_sat_36 (coe v15) in
@@ -540,25 +595,25 @@ d_progress_532 v0
                                                            -> case coe v18 of
                                                                 0 -> case coe v19 of
                                                                        0 -> coe
-                                                                              C_step_522
+                                                                              C_step_630
                                                                               (coe
                                                                                  MAlonzo.Code.Untyped.C__'183'__22
                                                                                  (coe
-                                                                                    d_reduceBuiltin_252
+                                                                                    d_reduceBuiltin_248
                                                                                     (0 :: Integer)
                                                                                     v1)
                                                                                  (coe v2))
                                                                               (coe
-                                                                                 C_ξ'8321'_266
+                                                                                 C_ξ'8321'_258
                                                                                  (coe
-                                                                                    C_sat'45'app'45'builtin_306))
+                                                                                    C_sat'45'app'45'builtin_298))
                                                                        1 -> coe
-                                                                              C_step_522
+                                                                              C_step_630
                                                                               (coe
-                                                                                 d_reduceBuiltin_252
+                                                                                 d_reduceBuiltin_248
                                                                                  (0 :: Integer) v0)
                                                                               (coe
-                                                                                 C_sat'45'app'45'builtin_306)
+                                                                                 C_sat'45'app'45'builtin_298)
                                                                        _ -> let v20
                                                                                   = subInt
                                                                                       (coe v19)
@@ -567,9 +622,9 @@ d_progress_532 v0
                                                                                             Integer)) in
                                                                             coe
                                                                               (coe
-                                                                                 C_done_526
+                                                                                 C_done_634
                                                                                  (coe
-                                                                                    C_unsat'8321'_222
+                                                                                    C_unsat'8321'_218
                                                                                     v20 v5 v8))
                                                                 _ -> let v20
                                                                            = subInt
@@ -578,11 +633,11 @@ d_progress_532 v0
                                                                                   (1 :: Integer)) in
                                                                      coe
                                                                        (coe
-                                                                          C_step_522
+                                                                          C_step_630
                                                                           (coe
                                                                              MAlonzo.Code.Untyped.C_error_46)
                                                                           (coe
-                                                                             C_app'45'interleave'45'error_392
+                                                                             C_app'45'interleave'45'error_384
                                                                              v20 v19))
                                                          _ -> MAlonzo.RTE.mazUnreachableError
                                                   C_want_8 v18 v19
@@ -595,37 +650,37 @@ d_progress_532 v0
                                                                           (case coe v20 of
                                                                              0 -> case coe v21 of
                                                                                     0 -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C__'183'__22
                                                                                               (coe
-                                                                                                 d_reduceBuiltin_252
+                                                                                                 d_reduceBuiltin_248
                                                                                                  (0 ::
                                                                                                     Integer)
                                                                                                  v1)
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_ξ'8321'_266
+                                                                                              C_ξ'8321'_258
                                                                                               (coe
-                                                                                                 C_sat'45'app'45'builtin_306))
+                                                                                                 C_sat'45'app'45'builtin_298))
                                                                                     1 -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
-                                                                                              d_reduceBuiltin_252
+                                                                                              d_reduceBuiltin_248
                                                                                               (1 ::
                                                                                                  Integer)
                                                                                               v0)
                                                                                            (coe
-                                                                                              C_sat'45'app'45'builtin_306)
+                                                                                              C_sat'45'app'45'builtin_298)
                                                                                     _ -> let v22
                                                                                                = -2 ::
                                                                                                    Integer in
                                                                                          coe
                                                                                            (coe
-                                                                                              C_done_526
+                                                                                              C_done_634
                                                                                               (coe
-                                                                                                 C_unsat'8321'_222
+                                                                                                 C_unsat'8321'_218
                                                                                                  v22
                                                                                                  v5
                                                                                                  v8))
@@ -634,11 +689,11 @@ d_progress_532 v0
                                                                                             Integer in
                                                                                   coe
                                                                                     (coe
-                                                                                       C_step_522
+                                                                                       C_step_630
                                                                                        (coe
                                                                                           MAlonzo.Code.Untyped.C_error_46)
                                                                                        (coe
-                                                                                          C_app'45'interleave'45'error_392
+                                                                                          C_app'45'interleave'45'error_384
                                                                                           v22
                                                                                           v21))))
                                                                 _ -> let v20
@@ -652,29 +707,29 @@ d_progress_532 v0
                                                                           (case coe v21 of
                                                                              0 -> case coe v19 of
                                                                                     1 -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C__'183'__22
                                                                                               (coe
-                                                                                                 d_reduceBuiltin_252
+                                                                                                 d_reduceBuiltin_248
                                                                                                  (0 ::
                                                                                                     Integer)
                                                                                                  v1)
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_ξ'8321'_266
+                                                                                              C_ξ'8321'_258
                                                                                               (coe
-                                                                                                 C_sat'45'app'45'builtin_306))
+                                                                                                 C_sat'45'app'45'builtin_298))
                                                                                     2 -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
-                                                                                              d_reduceBuiltin_252
+                                                                                              d_reduceBuiltin_248
                                                                                               (0 ::
                                                                                                  Integer)
                                                                                               v0)
                                                                                            (coe
-                                                                                              C_sat'45'app'45'builtin_306)
+                                                                                              C_sat'45'app'45'builtin_298)
                                                                                     _ -> let v22
                                                                                                = subInt
                                                                                                    (coe
@@ -684,9 +739,9 @@ d_progress_532 v0
                                                                                                          Integer)) in
                                                                                          coe
                                                                                            (coe
-                                                                                              C_done_526
+                                                                                              C_done_634
                                                                                               (coe
-                                                                                                 C_unsat'8321'_222
+                                                                                                 C_unsat'8321'_218
                                                                                                  v22
                                                                                                  v5
                                                                                                  v8))
@@ -695,11 +750,11 @@ d_progress_532 v0
                                                                                             Integer in
                                                                                   coe
                                                                                     (coe
-                                                                                       C_step_522
+                                                                                       C_step_630
                                                                                        (coe
                                                                                           MAlonzo.Code.Untyped.C_error_46)
                                                                                        (coe
-                                                                                          C_app'45'interleave'45'error_392
+                                                                                          C_app'45'interleave'45'error_384
                                                                                           v22
                                                                                           v20))))
                                                          _ -> let v20
@@ -716,28 +771,28 @@ d_progress_532 v0
                                                                      -> case coe v21 of
                                                                           0 -> case coe v22 of
                                                                                  0 -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C__'183'__22
                                                                                            (coe
-                                                                                              d_reduceBuiltin_252
+                                                                                              d_reduceBuiltin_248
                                                                                               (0 ::
                                                                                                  Integer)
                                                                                               v1)
                                                                                            (coe v2))
                                                                                         (coe
-                                                                                           C_ξ'8321'_266
+                                                                                           C_ξ'8321'_258
                                                                                            (coe
-                                                                                              C_sat'45'app'45'builtin_306))
+                                                                                              C_sat'45'app'45'builtin_298))
                                                                                  1 -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
-                                                                                           d_reduceBuiltin_252
+                                                                                           d_reduceBuiltin_248
                                                                                            (0 ::
                                                                                               Integer)
                                                                                            v0)
                                                                                         (coe
-                                                                                           C_sat'45'app'45'builtin_306)
+                                                                                           C_sat'45'app'45'builtin_298)
                                                                                  _ -> let v23
                                                                                             = subInt
                                                                                                 (coe
@@ -747,9 +802,9 @@ d_progress_532 v0
                                                                                                       Integer)) in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_done_526
+                                                                                           C_done_634
                                                                                            (coe
-                                                                                              C_unsat'8321'_222
+                                                                                              C_unsat'8321'_218
                                                                                               v23 v5
                                                                                               v8))
                                                                           _ -> let v23
@@ -760,39 +815,39 @@ d_progress_532 v0
                                                                                                Integer)) in
                                                                                coe
                                                                                  (coe
-                                                                                    C_step_522
+                                                                                    C_step_630
                                                                                     (coe
                                                                                        MAlonzo.Code.Untyped.C_error_46)
                                                                                     (coe
-                                                                                       C_app'45'interleave'45'error_392
+                                                                                       C_app'45'interleave'45'error_384
                                                                                        v23 v22))
                                                                    _ -> MAlonzo.RTE.mazUnreachableError)
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_constr_228 v11
+                                 C_constr_224 v11
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_app'45'constr_412)
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_app'45'constr_404)
                                  _ -> MAlonzo.RTE.mazUnreachableError
-                          C_fail_528
+                          C_fail_636
                             -> coe
-                                 C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                 (coe C_error'8322'_298)
+                                 C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                 (coe C_error'8322'_290)
                           _ -> MAlonzo.RTE.mazUnreachableError)
-                C_fail_528
+                C_fail_636
                   -> coe
-                       C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                       (coe C_error'8321'_294)
+                       C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                       (coe C_error'8321'_286)
                 _ -> MAlonzo.RTE.mazUnreachableError)
       MAlonzo.Code.Untyped.C_force_24 v1
-        -> let v2 = d_progress_532 (coe v1) in
+        -> let v2 = d_progress_640 (coe v1) in
            coe
              (case coe v2 of
-                C_step_522 v4 v5
+                C_step_630 v4 v5
                   -> coe
-                       C_step_522 (coe MAlonzo.Code.Untyped.C_force_24 (coe v4))
-                       (coe C_ξ'8323'_280 v5)
-                C_done_526 v4
+                       C_step_630 (coe MAlonzo.Code.Untyped.C_force_24 (coe v4))
+                       (coe C_ξ'8323'_272 v5)
+                C_done_634 v4
                   -> let v5 = coe du_sat_36 (coe v1) in
                      coe
                        (case coe v5 of
@@ -800,8 +855,8 @@ d_progress_532 v0
                             -> case coe v1 of
                                  MAlonzo.Code.Untyped.C_ƛ_20 v6
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_force'45'ƛ_366)
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_force'45'ƛ_358)
                                  MAlonzo.Code.Untyped.C__'183'__22 v6 v7
                                    -> coe
                                         seq (coe v4)
@@ -815,73 +870,73 @@ d_progress_532 v0
                                            MAlonzo.Code.Relation.Nullary.Negation.Core.du_contradiction_44
                                            erased)
                                  MAlonzo.Code.Untyped.C_delay_26 v6
-                                   -> coe C_step_522 v6 (coe C_force'45'delay_290)
+                                   -> coe C_step_630 v6 (coe C_force'45'delay_282)
                                  MAlonzo.Code.Untyped.C_con_28 v6
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_force'45'con_370)
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_force'45'con_362)
                                  MAlonzo.Code.Untyped.C_constr_34 v6 v7
                                    -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_force'45'constr_376)
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_force'45'constr_368)
                                  MAlonzo.Code.Untyped.C_error_46
-                                   -> coe C_step_522 v1 (coe C_force'45'error_300)
+                                   -> coe C_step_630 v1 (coe C_force'45'error_292)
                                  _ -> MAlonzo.RTE.mazUnreachableError
                           C_want_8 v6 v7
                             -> case coe v6 of
                                  0 -> coe
-                                        C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                        (coe C_force'45'interleave'45'error_382 v7)
+                                        C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                        (coe C_force'45'interleave'45'error_374 v7)
                                  1 -> case coe v7 of
                                         0 -> coe
-                                               C_step_522
-                                               (coe d_reduceBuiltin_252 (0 :: Integer) v0)
-                                               (coe C_sat'45'force'45'builtin_310)
+                                               C_step_630
+                                               (coe d_reduceBuiltin_248 (0 :: Integer) v0)
+                                               (coe C_sat'45'force'45'builtin_302)
                                         _ -> let v8 = subInt (coe v7) (coe (1 :: Integer)) in
                                              coe
                                                (coe
-                                                  C_done_526
-                                                  (coe C_unsat'8320''8331''8321'_214 v8 v4))
+                                                  C_done_634
+                                                  (coe C_unsat'8320''8331''8321'_210 v8 v4))
                                  _ -> let v8 = subInt (coe v6) (coe (2 :: Integer)) in
-                                      coe (coe C_done_526 (coe C_unsat'8320'_208 v8 v7 v4))
+                                      coe (coe C_done_634 (coe C_unsat'8320'_204 v8 v7 v4))
                           _ -> MAlonzo.RTE.mazUnreachableError)
-                C_fail_528
+                C_fail_636
                   -> coe
-                       C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                       (coe C_force'45'error_300)
+                       C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                       (coe C_force'45'error_292)
                 _ -> MAlonzo.RTE.mazUnreachableError)
       MAlonzo.Code.Untyped.C_delay_26 v1
-        -> coe C_done_526 (coe C_delay_188)
-      MAlonzo.Code.Untyped.C_con_28 v1 -> coe C_done_526 (coe C_con_196)
+        -> coe C_done_634 (coe C_delay_184)
+      MAlonzo.Code.Untyped.C_con_28 v1 -> coe C_done_634 (coe C_con_192)
       MAlonzo.Code.Untyped.C_constr_34 v1 v2
         -> case coe v2 of
              []
                -> coe
-                    C_done_526
+                    C_done_634
                     (coe
-                       C_constr_228
+                       C_constr_224
                        (coe MAlonzo.Code.Data.List.Relation.Unary.All.C_'91''93'_50))
              (:) v3 v4
-               -> let v5 = d_progress_532 (coe v3) in
+               -> let v5 = d_progress_640 (coe v3) in
                   coe
                     (case coe v5 of
-                       C_step_522 v7 v8
+                       C_step_630 v7 v8
                          -> coe
-                              C_step_522
+                              C_step_630
                               (coe
                                  MAlonzo.Code.Untyped.C_constr_34 (coe v1)
                                  (coe
                                     MAlonzo.Code.Agda.Builtin.List.C__'8759'__22 (coe v7) (coe v4)))
-                              (coe C_constr'45'step_338 v8)
-                       C_done_526 v7
+                              (coe C_constr'45'step_330 v8)
+                       C_done_634 v7
                          -> let v8
-                                  = d_progress_532
+                                  = d_progress_640
                                       (coe MAlonzo.Code.Untyped.C_constr_34 (coe v1) (coe v4)) in
                             coe
                               (case coe v8 of
-                                 C_step_522 v10 v11
+                                 C_step_630 v10 v11
                                    -> case coe v11 of
-                                        C_constr'45'step_338 v16
+                                        C_constr'45'step_330 v16
                                           -> case coe v4 of
                                                (:) v17 v18
                                                  -> case coe v10 of
@@ -889,7 +944,7 @@ d_progress_532 v0
                                                         -> case coe v20 of
                                                              (:) v21 v22
                                                                -> coe
-                                                                    C_step_522
+                                                                    C_step_630
                                                                     (coe
                                                                        MAlonzo.Code.Untyped.C_constr_34
                                                                        (coe v1)
@@ -900,13 +955,13 @@ d_progress_532 v0
                                                                              MAlonzo.Code.Agda.Builtin.List.C__'8759'__22
                                                                              (coe v21) (coe v18))))
                                                                     (coe
-                                                                       C_constr'45'sub'45'step_348
+                                                                       C_constr'45'sub'45'step_340
                                                                        (coe
-                                                                          C_constr'45'step_338 v16))
+                                                                          C_constr'45'step_330 v16))
                                                              _ -> MAlonzo.RTE.mazUnreachableError
                                                       _ -> MAlonzo.RTE.mazUnreachableError
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_constr'45'sub'45'step_348 v16
+                                        C_constr'45'sub'45'step_340 v16
                                           -> case coe v4 of
                                                (:) v17 v18
                                                  -> case coe v10 of
@@ -914,7 +969,7 @@ d_progress_532 v0
                                                         -> case coe v20 of
                                                              (:) v21 v22
                                                                -> coe
-                                                                    C_step_522
+                                                                    C_step_630
                                                                     (coe
                                                                        MAlonzo.Code.Untyped.C_constr_34
                                                                        (coe v1)
@@ -925,92 +980,92 @@ d_progress_532 v0
                                                                              MAlonzo.Code.Agda.Builtin.List.C__'8759'__22
                                                                              (coe v17) (coe v22))))
                                                                     (coe
-                                                                       C_constr'45'sub'45'step_348
+                                                                       C_constr'45'sub'45'step_340
                                                                        (coe
-                                                                          C_constr'45'sub'45'step_348
+                                                                          C_constr'45'sub'45'step_340
                                                                           v16))
                                                              _ -> MAlonzo.RTE.mazUnreachableError
                                                       _ -> MAlonzo.RTE.mazUnreachableError
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_constr'45'error_354
+                                        C_constr'45'error_346
                                           -> coe
-                                               C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
+                                               C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
                                                (coe
-                                                  C_constr'45'sub'45'error_362
-                                                  (coe C_constr'45'error_354))
-                                        C_constr'45'sub'45'error_362 v15
+                                                  C_constr'45'sub'45'error_354
+                                                  (coe C_constr'45'error_346))
+                                        C_constr'45'sub'45'error_354 v15
                                           -> coe
-                                               C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
+                                               C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
                                                (coe
-                                                  C_constr'45'sub'45'error_362
-                                                  (coe C_constr'45'sub'45'error_362 v15))
+                                                  C_constr'45'sub'45'error_354
+                                                  (coe C_constr'45'sub'45'error_354 v15))
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_done_526 v10
+                                 C_done_634 v10
                                    -> coe
-                                        C_done_526
+                                        C_done_634
                                         (coe
-                                           C_constr_228
+                                           C_constr_224
                                            (coe
                                               MAlonzo.Code.Data.List.Relation.Unary.All.C__'8759'__60
-                                              v7 (coe du_value'45'constr'45'recurse_234 (coe v10))))
+                                              v7 (coe du_value'45'constr'45'recurse_230 (coe v10))))
                                  _ -> MAlonzo.RTE.mazUnreachableError)
-                       C_fail_528
+                       C_fail_636
                          -> coe
-                              C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                              (coe C_constr'45'error_354)
+                              C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                              (coe C_constr'45'error_346)
                        _ -> MAlonzo.RTE.mazUnreachableError)
              _ -> MAlonzo.RTE.mazUnreachableError
       MAlonzo.Code.Untyped.C_case_40 v1 v2
         -> case coe v1 of
              MAlonzo.Code.Untyped.C_ƛ_20 v3
                -> coe
-                    C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                    (coe C_case'45'ƛ_422)
+                    C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                    (coe C_case'45'ƛ_414)
              MAlonzo.Code.Untyped.C__'183'__22 v3 v4
-               -> let v5 = d_progress_532 (coe v3) in
+               -> let v5 = d_progress_640 (coe v3) in
                   coe
                     (case coe v5 of
-                       C_step_522 v7 v8
+                       C_step_630 v7 v8
                          -> let v9
                                   = coe MAlonzo.Code.Untyped.C__'183'__22 (coe v7) (coe v4) in
                             coe
-                              (let v10 = coe C_ξ'8321'_266 v8 in
+                              (let v10 = coe C_ξ'8321'_258 v8 in
                                coe
                                  (coe
-                                    C_step_522
+                                    C_step_630
                                     (coe MAlonzo.Code.Untyped.C_case_40 (coe v9) (coe v2))
-                                    (coe C_case'45'reduce_466 v10)))
-                       C_done_526 v7
-                         -> let v8 = d_progress_532 (coe v4) in
+                                    (coe C_case'45'reduce_458 v10)))
+                       C_done_634 v7
+                         -> let v8 = d_progress_640 (coe v4) in
                             coe
                               (case coe v8 of
-                                 C_step_522 v10 v11
+                                 C_step_630 v10 v11
                                    -> let v12
                                             = coe
                                                 MAlonzo.Code.Untyped.C__'183'__22 (coe v3)
                                                 (coe v10) in
                                       coe
-                                        (let v13 = coe C_ξ'8322'_274 v7 v11 in
+                                        (let v13 = coe C_ξ'8322'_266 v7 v11 in
                                          coe
                                            (coe
-                                              C_step_522
+                                              C_step_630
                                               (coe
                                                  MAlonzo.Code.Untyped.C_case_40 (coe v12) (coe v2))
-                                              (coe C_case'45'reduce_466 v13)))
-                                 C_done_526 v10
+                                              (coe C_case'45'reduce_458 v13)))
+                                 C_done_634 v10
                                    -> case coe v7 of
-                                        C_delay_188
+                                        C_delay_184
                                           -> let v12 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v13 = coe C_app'45'delay_404 in
+                                               (let v13 = coe C_app'45'delay_396 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v12)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v13)))
-                                        C_ƛ_192
+                                                     (coe C_case'45'reduce_458 v13)))
+                                        C_ƛ_188
                                           -> case coe v3 of
                                                MAlonzo.Code.Untyped.C_ƛ_20 v12
                                                  -> let v13
@@ -1018,27 +1073,27 @@ d_progress_532 v0
                                                               (coe (0 :: Integer)) (coe v12)
                                                               (coe v4) in
                                                     coe
-                                                      (let v14 = coe C_β_286 v10 in
+                                                      (let v14 = coe C_β_278 v10 in
                                                        coe
                                                          (coe
-                                                            C_step_522
+                                                            C_step_630
                                                             (coe
                                                                MAlonzo.Code.Untyped.C_case_40
                                                                (coe v13) (coe v2))
-                                                            (coe C_case'45'reduce_466 v14)))
+                                                            (coe C_case'45'reduce_458 v14)))
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_con_196
+                                        C_con_192
                                           -> let v12 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v13 = coe C_app'45'con_398 in
+                                               (let v13 = coe C_app'45'con_390 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v12)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v13)))
-                                        C_builtin_200
+                                                     (coe C_case'45'reduce_458 v13)))
+                                        C_builtin_196
                                           -> case coe v3 of
                                                MAlonzo.Code.Untyped.C_builtin_44 v12
                                                  -> let v13
@@ -1078,22 +1133,22 @@ d_progress_532 v0
                                                             0 -> case coe v13 of
                                                                    1 -> let v15
                                                                               = coe
-                                                                                  d_reduceBuiltin_252
+                                                                                  d_reduceBuiltin_248
                                                                                   (0 :: Integer)
                                                                                   v1 in
                                                                         coe
                                                                           (let v16
                                                                                  = coe
-                                                                                     C_sat'45'app'45'builtin_306 in
+                                                                                     C_sat'45'app'45'builtin_298 in
                                                                            coe
                                                                              (coe
-                                                                                C_step_522
+                                                                                C_step_630
                                                                                 (coe
                                                                                    MAlonzo.Code.Untyped.C_case_40
                                                                                    (coe v15)
                                                                                    (coe v2))
                                                                                 (coe
-                                                                                   C_case'45'reduce_466
+                                                                                   C_case'45'reduce_458
                                                                                    v16)))
                                                                    _ -> let v15
                                                                               = subInt
@@ -1103,11 +1158,11 @@ d_progress_532 v0
                                                                                         Integer)) in
                                                                         coe
                                                                           (coe
-                                                                             C_step_522
+                                                                             C_step_630
                                                                              (coe
                                                                                 MAlonzo.Code.Untyped.C_error_46)
                                                                              (coe
-                                                                                C_case'45'unsat'8321'_458
+                                                                                C_case'45'unsat'8321'_450
                                                                                 v15))
                                                             _ -> let v15
                                                                        = subInt
@@ -1120,33 +1175,33 @@ d_progress_532 v0
                                                                     coe
                                                                       (let v17
                                                                              = coe
-                                                                                 C_app'45'interleave'45'error_392
+                                                                                 C_app'45'interleave'45'error_384
                                                                                  v15 v13 in
                                                                        coe
                                                                          (coe
-                                                                            C_step_522
+                                                                            C_step_630
                                                                             (coe
                                                                                MAlonzo.Code.Untyped.C_case_40
                                                                                (coe v16) (coe v2))
                                                                             (coe
-                                                                               C_case'45'reduce_466
+                                                                               C_case'45'reduce_458
                                                                                v17))))))
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_unsat'8320'_208 v12 v13 v15
+                                        C_unsat'8320'_204 v12 v13 v15
                                           -> let v16 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
                                                (let v17
                                                       = coe
-                                                          C_app'45'interleave'45'error_392 v12
+                                                          C_app'45'interleave'45'error_384 v12
                                                           v13 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v16)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v17)))
-                                        C_unsat'8320''8331''8321'_214 v12 v14
+                                                     (coe C_case'45'reduce_458 v17)))
+                                        C_unsat'8320''8331''8321'_210 v12 v14
                                           -> case coe v3 of
                                                MAlonzo.Code.Untyped.C_force_24 v15
                                                  -> let v16 = coe du_sat_36 (coe v15) in
@@ -1161,25 +1216,25 @@ d_progress_532 v0
                                                                                erased in
                                                                      coe
                                                                        (case coe v17 of
-                                                                          C_step_522 v19 v20
+                                                                          C_step_630 v19 v20
                                                                             -> coe
-                                                                                 C_step_522
+                                                                                 C_step_630
                                                                                  (coe
                                                                                     MAlonzo.Code.Untyped.C_case_40
                                                                                     (coe v19)
                                                                                     (coe v2))
                                                                                  (coe
-                                                                                    C_case'45'reduce_466
+                                                                                    C_case'45'reduce_458
                                                                                     v20)
-                                                                          C_done_526 v19
+                                                                          C_done_634 v19
                                                                             -> case coe v19 of
-                                                                                 C_unsat'8321'_222 v22 v24 v25
+                                                                                 C_unsat'8321'_218 v22 v24 v25
                                                                                    -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C_error_46)
                                                                                         (coe
-                                                                                           C_case'45'unsat'8321'_458
+                                                                                           C_case'45'unsat'8321'_450
                                                                                            v22)
                                                                                  _ -> MAlonzo.RTE.mazUnreachableError
                                                                           _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1190,7 +1245,7 @@ d_progress_532 v0
                                                                                          = coe
                                                                                              MAlonzo.Code.Untyped.C__'183'__22
                                                                                              (coe
-                                                                                                d_reduceBuiltin_252
+                                                                                                d_reduceBuiltin_248
                                                                                                 (0 ::
                                                                                                    Integer)
                                                                                                 v3)
@@ -1199,12 +1254,12 @@ d_progress_532 v0
                                                                                    coe
                                                                                      (let v20
                                                                                             = coe
-                                                                                                C_ξ'8321'_266
+                                                                                                C_ξ'8321'_258
                                                                                                 (coe
-                                                                                                   C_sat'45'force'45'builtin_310) in
+                                                                                                   C_sat'45'force'45'builtin_302) in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1212,21 +1267,21 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v20)))
                                                                               1 -> let v19
                                                                                          = coe
-                                                                                             d_reduceBuiltin_252
+                                                                                             d_reduceBuiltin_248
                                                                                              (0 ::
                                                                                                 Integer)
                                                                                              v1 in
                                                                                    coe
                                                                                      (let v20
                                                                                             = coe
-                                                                                                C_sat'45'app'45'builtin_306 in
+                                                                                                C_sat'45'app'45'builtin_298 in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1234,7 +1289,7 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v20)))
                                                                               _ -> let v19
                                                                                          = subInt
@@ -1245,11 +1300,11 @@ d_progress_532 v0
                                                                                                    Integer)) in
                                                                                    coe
                                                                                      (coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C_error_46)
                                                                                         (coe
-                                                                                           C_case'45'unsat'8321'_458
+                                                                                           C_case'45'unsat'8321'_450
                                                                                            v19))
                                                                        _ -> let v19
                                                                                   = subInt
@@ -1264,18 +1319,18 @@ d_progress_532 v0
                                                                                coe
                                                                                  (let v21
                                                                                         = coe
-                                                                                            C_app'45'interleave'45'error_392
+                                                                                            C_app'45'interleave'45'error_384
                                                                                             v19
                                                                                             v18 in
                                                                                   coe
                                                                                     (coe
-                                                                                       C_step_522
+                                                                                       C_step_630
                                                                                        (coe
                                                                                           MAlonzo.Code.Untyped.C_case_40
                                                                                           (coe v20)
                                                                                           (coe v2))
                                                                                        (coe
-                                                                                          C_case'45'reduce_466
+                                                                                          C_case'45'reduce_458
                                                                                           v21))))
                                                                 _ -> MAlonzo.RTE.mazUnreachableError
                                                          C_want_8 v17 v18
@@ -1295,9 +1350,9 @@ d_progress_532 v0
                                                                                          erased in
                                                                                coe
                                                                                  (case coe v20 of
-                                                                                    C_step_522 v22 v23
+                                                                                    C_step_630 v22 v23
                                                                                       -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1305,18 +1360,18 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v23)
-                                                                                    C_done_526 v22
+                                                                                    C_done_634 v22
                                                                                       -> case coe
                                                                                                 v22 of
-                                                                                           C_unsat'8321'_222 v25 v27 v28
+                                                                                           C_unsat'8321'_218 v25 v27 v28
                                                                                              -> coe
-                                                                                                  C_step_522
+                                                                                                  C_step_630
                                                                                                   (coe
                                                                                                      MAlonzo.Code.Untyped.C_error_46)
                                                                                                   (coe
-                                                                                                     C_case'45'unsat'8321'_458
+                                                                                                     C_case'45'unsat'8321'_450
                                                                                                      v25)
                                                                                            _ -> MAlonzo.RTE.mazUnreachableError
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1328,7 +1383,7 @@ d_progress_532 v0
                                                                                                    = coe
                                                                                                        MAlonzo.Code.Untyped.C__'183'__22
                                                                                                        (coe
-                                                                                                          d_reduceBuiltin_252
+                                                                                                          d_reduceBuiltin_248
                                                                                                           (0 ::
                                                                                                              Integer)
                                                                                                           v3)
@@ -1337,12 +1392,12 @@ d_progress_532 v0
                                                                                              coe
                                                                                                (let v23
                                                                                                       = coe
-                                                                                                          C_ξ'8321'_266
+                                                                                                          C_ξ'8321'_258
                                                                                                           (coe
-                                                                                                             C_sat'45'force'45'builtin_310) in
+                                                                                                             C_sat'45'force'45'builtin_302) in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_case_40
                                                                                                         (coe
@@ -1350,21 +1405,21 @@ d_progress_532 v0
                                                                                                         (coe
                                                                                                            v2))
                                                                                                      (coe
-                                                                                                        C_case'45'reduce_466
+                                                                                                        C_case'45'reduce_458
                                                                                                         v23)))
                                                                                         1 -> let v22
                                                                                                    = coe
-                                                                                                       d_reduceBuiltin_252
+                                                                                                       d_reduceBuiltin_248
                                                                                                        (0 ::
                                                                                                           Integer)
                                                                                                        v1 in
                                                                                              coe
                                                                                                (let v23
                                                                                                       = coe
-                                                                                                          C_sat'45'app'45'builtin_306 in
+                                                                                                          C_sat'45'app'45'builtin_298 in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_case_40
                                                                                                         (coe
@@ -1372,7 +1427,7 @@ d_progress_532 v0
                                                                                                         (coe
                                                                                                            v2))
                                                                                                      (coe
-                                                                                                        C_case'45'reduce_466
+                                                                                                        C_case'45'reduce_458
                                                                                                         v23)))
                                                                                         _ -> let v22
                                                                                                    = subInt
@@ -1383,11 +1438,11 @@ d_progress_532 v0
                                                                                                              Integer)) in
                                                                                              coe
                                                                                                (coe
-                                                                                                  C_step_522
+                                                                                                  C_step_630
                                                                                                   (coe
                                                                                                      MAlonzo.Code.Untyped.C_error_46)
                                                                                                   (coe
-                                                                                                     C_case'45'unsat'8321'_458
+                                                                                                     C_case'45'unsat'8321'_450
                                                                                                      v22))
                                                                                  _ -> let v22
                                                                                             = subInt
@@ -1403,12 +1458,12 @@ d_progress_532 v0
                                                                                          coe
                                                                                            (let v24
                                                                                                   = coe
-                                                                                                      C_app'45'interleave'45'error_392
+                                                                                                      C_app'45'interleave'45'error_384
                                                                                                       v22
                                                                                                       v21 in
                                                                                             coe
                                                                                               (coe
-                                                                                                 C_step_522
+                                                                                                 C_step_630
                                                                                                  (coe
                                                                                                     MAlonzo.Code.Untyped.C_case_40
                                                                                                     (coe
@@ -1416,7 +1471,7 @@ d_progress_532 v0
                                                                                                     (coe
                                                                                                        v2))
                                                                                                  (coe
-                                                                                                    C_case'45'reduce_466
+                                                                                                    C_case'45'reduce_458
                                                                                                     v24))))
                                                                           _ -> MAlonzo.RTE.mazUnreachableError)
                                                                 1 -> case coe v18 of
@@ -1424,7 +1479,7 @@ d_progress_532 v0
                                                                                   = coe
                                                                                       MAlonzo.Code.Untyped.C__'183'__22
                                                                                       (coe
-                                                                                         d_reduceBuiltin_252
+                                                                                         d_reduceBuiltin_248
                                                                                          (0 ::
                                                                                             Integer)
                                                                                          v3)
@@ -1432,37 +1487,37 @@ d_progress_532 v0
                                                                             coe
                                                                               (let v20
                                                                                      = coe
-                                                                                         C_ξ'8321'_266
+                                                                                         C_ξ'8321'_258
                                                                                          (coe
-                                                                                            C_sat'45'force'45'builtin_310) in
+                                                                                            C_sat'45'force'45'builtin_302) in
                                                                                coe
                                                                                  (coe
-                                                                                    C_step_522
+                                                                                    C_step_630
                                                                                     (coe
                                                                                        MAlonzo.Code.Untyped.C_case_40
                                                                                        (coe v19)
                                                                                        (coe v2))
                                                                                     (coe
-                                                                                       C_case'45'reduce_466
+                                                                                       C_case'45'reduce_458
                                                                                        v20)))
                                                                        1 -> let v19
                                                                                   = coe
-                                                                                      d_reduceBuiltin_252
+                                                                                      d_reduceBuiltin_248
                                                                                       (0 :: Integer)
                                                                                       v1 in
                                                                             coe
                                                                               (let v20
                                                                                      = coe
-                                                                                         C_sat'45'app'45'builtin_306 in
+                                                                                         C_sat'45'app'45'builtin_298 in
                                                                                coe
                                                                                  (coe
-                                                                                    C_step_522
+                                                                                    C_step_630
                                                                                     (coe
                                                                                        MAlonzo.Code.Untyped.C_case_40
                                                                                        (coe v19)
                                                                                        (coe v2))
                                                                                     (coe
-                                                                                       C_case'45'reduce_466
+                                                                                       C_case'45'reduce_458
                                                                                        v20)))
                                                                        _ -> let v19
                                                                                   = subInt
@@ -1472,11 +1527,11 @@ d_progress_532 v0
                                                                                             Integer)) in
                                                                             coe
                                                                               (coe
-                                                                                 C_step_522
+                                                                                 C_step_630
                                                                                  (coe
                                                                                     MAlonzo.Code.Untyped.C_error_46)
                                                                                  (coe
-                                                                                    C_case'45'unsat'8321'_458
+                                                                                    C_case'45'unsat'8321'_450
                                                                                     v19))
                                                                 _ -> let v19
                                                                            = subInt
@@ -1490,21 +1545,21 @@ d_progress_532 v0
                                                                         coe
                                                                           (let v21
                                                                                  = coe
-                                                                                     C_app'45'interleave'45'error_392
+                                                                                     C_app'45'interleave'45'error_384
                                                                                      v19 v18 in
                                                                            coe
                                                                              (coe
-                                                                                C_step_522
+                                                                                C_step_630
                                                                                 (coe
                                                                                    MAlonzo.Code.Untyped.C_case_40
                                                                                    (coe v20)
                                                                                    (coe v2))
                                                                                 (coe
-                                                                                   C_case'45'reduce_466
+                                                                                   C_case'45'reduce_458
                                                                                    v21))))
                                                          _ -> MAlonzo.RTE.mazUnreachableError)
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_unsat'8321'_222 v13 v15 v16
+                                        C_unsat'8321'_218 v13 v15 v16
                                           -> case coe v3 of
                                                MAlonzo.Code.Untyped.C__'183'__22 v17 v18
                                                  -> let v19 = coe du_sat_36 (coe v17) in
@@ -1519,25 +1574,25 @@ d_progress_532 v0
                                                                                erased in
                                                                      coe
                                                                        (case coe v20 of
-                                                                          C_step_522 v22 v23
+                                                                          C_step_630 v22 v23
                                                                             -> coe
-                                                                                 C_step_522
+                                                                                 C_step_630
                                                                                  (coe
                                                                                     MAlonzo.Code.Untyped.C_case_40
                                                                                     (coe v22)
                                                                                     (coe v2))
                                                                                  (coe
-                                                                                    C_case'45'reduce_466
+                                                                                    C_case'45'reduce_458
                                                                                     v23)
-                                                                          C_done_526 v22
+                                                                          C_done_634 v22
                                                                             -> case coe v22 of
-                                                                                 C_unsat'8321'_222 v25 v27 v28
+                                                                                 C_unsat'8321'_218 v25 v27 v28
                                                                                    -> coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C_error_46)
                                                                                         (coe
-                                                                                           C_case'45'unsat'8321'_458
+                                                                                           C_case'45'unsat'8321'_450
                                                                                            v25)
                                                                                  _ -> MAlonzo.RTE.mazUnreachableError
                                                                           _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1548,7 +1603,7 @@ d_progress_532 v0
                                                                                          = coe
                                                                                              MAlonzo.Code.Untyped.C__'183'__22
                                                                                              (coe
-                                                                                                d_reduceBuiltin_252
+                                                                                                d_reduceBuiltin_248
                                                                                                 (0 ::
                                                                                                    Integer)
                                                                                                 v3)
@@ -1557,12 +1612,12 @@ d_progress_532 v0
                                                                                    coe
                                                                                      (let v23
                                                                                             = coe
-                                                                                                C_ξ'8321'_266
+                                                                                                C_ξ'8321'_258
                                                                                                 (coe
-                                                                                                   C_sat'45'app'45'builtin_306) in
+                                                                                                   C_sat'45'app'45'builtin_298) in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1570,21 +1625,21 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v23)))
                                                                               1 -> let v22
                                                                                          = coe
-                                                                                             d_reduceBuiltin_252
+                                                                                             d_reduceBuiltin_248
                                                                                              (0 ::
                                                                                                 Integer)
                                                                                              v1 in
                                                                                    coe
                                                                                      (let v23
                                                                                             = coe
-                                                                                                C_sat'45'app'45'builtin_306 in
+                                                                                                C_sat'45'app'45'builtin_298 in
                                                                                       coe
                                                                                         (coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1592,7 +1647,7 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v23)))
                                                                               _ -> let v22
                                                                                          = subInt
@@ -1603,11 +1658,11 @@ d_progress_532 v0
                                                                                                    Integer)) in
                                                                                    coe
                                                                                      (coe
-                                                                                        C_step_522
+                                                                                        C_step_630
                                                                                         (coe
                                                                                            MAlonzo.Code.Untyped.C_error_46)
                                                                                         (coe
-                                                                                           C_case'45'unsat'8321'_458
+                                                                                           C_case'45'unsat'8321'_450
                                                                                            v22))
                                                                        _ -> let v22
                                                                                   = subInt
@@ -1622,18 +1677,18 @@ d_progress_532 v0
                                                                                coe
                                                                                  (let v24
                                                                                         = coe
-                                                                                            C_app'45'interleave'45'error_392
+                                                                                            C_app'45'interleave'45'error_384
                                                                                             v22
                                                                                             v21 in
                                                                                   coe
                                                                                     (coe
-                                                                                       C_step_522
+                                                                                       C_step_630
                                                                                        (coe
                                                                                           MAlonzo.Code.Untyped.C_case_40
                                                                                           (coe v23)
                                                                                           (coe v2))
                                                                                        (coe
-                                                                                          C_case'45'reduce_466
+                                                                                          C_case'45'reduce_458
                                                                                           v24))))
                                                                 _ -> MAlonzo.RTE.mazUnreachableError
                                                          C_want_8 v20 v21
@@ -1653,7 +1708,7 @@ d_progress_532 v0
                                                                                                       = coe
                                                                                                           MAlonzo.Code.Untyped.C__'183'__22
                                                                                                           (coe
-                                                                                                             d_reduceBuiltin_252
+                                                                                                             d_reduceBuiltin_248
                                                                                                              (0 ::
                                                                                                                 Integer)
                                                                                                              v3)
@@ -1662,12 +1717,12 @@ d_progress_532 v0
                                                                                                 coe
                                                                                                   (let v25
                                                                                                          = coe
-                                                                                                             C_ξ'8321'_266
+                                                                                                             C_ξ'8321'_258
                                                                                                              (coe
-                                                                                                                C_sat'45'app'45'builtin_306) in
+                                                                                                                C_sat'45'app'45'builtin_298) in
                                                                                                    coe
                                                                                                      (coe
-                                                                                                        C_step_522
+                                                                                                        C_step_630
                                                                                                         (coe
                                                                                                            MAlonzo.Code.Untyped.C_case_40
                                                                                                            (coe
@@ -1675,21 +1730,21 @@ d_progress_532 v0
                                                                                                            (coe
                                                                                                               v2))
                                                                                                         (coe
-                                                                                                           C_case'45'reduce_466
+                                                                                                           C_case'45'reduce_458
                                                                                                            v25)))
                                                                                            1 -> let v24
                                                                                                       = coe
-                                                                                                          d_reduceBuiltin_252
+                                                                                                          d_reduceBuiltin_248
                                                                                                           (1 ::
                                                                                                              Integer)
                                                                                                           v1 in
                                                                                                 coe
                                                                                                   (let v25
                                                                                                          = coe
-                                                                                                             C_sat'45'app'45'builtin_306 in
+                                                                                                             C_sat'45'app'45'builtin_298 in
                                                                                                    coe
                                                                                                      (coe
-                                                                                                        C_step_522
+                                                                                                        C_step_630
                                                                                                         (coe
                                                                                                            MAlonzo.Code.Untyped.C_case_40
                                                                                                            (coe
@@ -1697,18 +1752,18 @@ d_progress_532 v0
                                                                                                            (coe
                                                                                                               v2))
                                                                                                         (coe
-                                                                                                           C_case'45'reduce_466
+                                                                                                           C_case'45'reduce_458
                                                                                                            v25)))
                                                                                            _ -> let v24
                                                                                                       = -2 ::
                                                                                                           Integer in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_error_46)
                                                                                                      (coe
-                                                                                                        C_case'45'unsat'8321'_458
+                                                                                                        C_case'45'unsat'8321'_450
                                                                                                         v24))
                                                                                     _ -> let v24
                                                                                                = -1 ::
@@ -1720,12 +1775,12 @@ d_progress_532 v0
                                                                                             coe
                                                                                               (let v26
                                                                                                      = coe
-                                                                                                         C_app'45'interleave'45'error_392
+                                                                                                         C_app'45'interleave'45'error_384
                                                                                                          v24
                                                                                                          v23 in
                                                                                                coe
                                                                                                  (coe
-                                                                                                    C_step_522
+                                                                                                    C_step_630
                                                                                                     (coe
                                                                                                        MAlonzo.Code.Untyped.C_case_40
                                                                                                        (coe
@@ -1733,7 +1788,7 @@ d_progress_532 v0
                                                                                                        (coe
                                                                                                           v2))
                                                                                                     (coe
-                                                                                                       C_case'45'reduce_466
+                                                                                                       C_case'45'reduce_458
                                                                                                        v26))))))
                                                                        _ -> let v22
                                                                                   = subInt
@@ -1753,7 +1808,7 @@ d_progress_532 v0
                                                                                                       = coe
                                                                                                           MAlonzo.Code.Untyped.C__'183'__22
                                                                                                           (coe
-                                                                                                             d_reduceBuiltin_252
+                                                                                                             d_reduceBuiltin_248
                                                                                                              (0 ::
                                                                                                                 Integer)
                                                                                                              v3)
@@ -1762,12 +1817,12 @@ d_progress_532 v0
                                                                                                 coe
                                                                                                   (let v25
                                                                                                          = coe
-                                                                                                             C_ξ'8321'_266
+                                                                                                             C_ξ'8321'_258
                                                                                                              (coe
-                                                                                                                C_sat'45'app'45'builtin_306) in
+                                                                                                                C_sat'45'app'45'builtin_298) in
                                                                                                    coe
                                                                                                      (coe
-                                                                                                        C_step_522
+                                                                                                        C_step_630
                                                                                                         (coe
                                                                                                            MAlonzo.Code.Untyped.C_case_40
                                                                                                            (coe
@@ -1775,21 +1830,21 @@ d_progress_532 v0
                                                                                                            (coe
                                                                                                               v2))
                                                                                                         (coe
-                                                                                                           C_case'45'reduce_466
+                                                                                                           C_case'45'reduce_458
                                                                                                            v25)))
                                                                                            2 -> let v24
                                                                                                       = coe
-                                                                                                          d_reduceBuiltin_252
+                                                                                                          d_reduceBuiltin_248
                                                                                                           (0 ::
                                                                                                              Integer)
                                                                                                           v1 in
                                                                                                 coe
                                                                                                   (let v25
                                                                                                          = coe
-                                                                                                             C_sat'45'app'45'builtin_306 in
+                                                                                                             C_sat'45'app'45'builtin_298 in
                                                                                                    coe
                                                                                                      (coe
-                                                                                                        C_step_522
+                                                                                                        C_step_630
                                                                                                         (coe
                                                                                                            MAlonzo.Code.Untyped.C_case_40
                                                                                                            (coe
@@ -1797,7 +1852,7 @@ d_progress_532 v0
                                                                                                            (coe
                                                                                                               v2))
                                                                                                         (coe
-                                                                                                           C_case'45'reduce_466
+                                                                                                           C_case'45'reduce_458
                                                                                                            v25)))
                                                                                            _ -> let v24
                                                                                                       = subInt
@@ -1808,11 +1863,11 @@ d_progress_532 v0
                                                                                                                 Integer)) in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_error_46)
                                                                                                      (coe
-                                                                                                        C_case'45'unsat'8321'_458
+                                                                                                        C_case'45'unsat'8321'_450
                                                                                                         v24))
                                                                                     _ -> let v24
                                                                                                = -1 ::
@@ -1824,12 +1879,12 @@ d_progress_532 v0
                                                                                             coe
                                                                                               (let v26
                                                                                                      = coe
-                                                                                                         C_app'45'interleave'45'error_392
+                                                                                                         C_app'45'interleave'45'error_384
                                                                                                          v24
                                                                                                          v22 in
                                                                                                coe
                                                                                                  (coe
-                                                                                                    C_step_522
+                                                                                                    C_step_630
                                                                                                     (coe
                                                                                                        MAlonzo.Code.Untyped.C_case_40
                                                                                                        (coe
@@ -1837,7 +1892,7 @@ d_progress_532 v0
                                                                                                        (coe
                                                                                                           v2))
                                                                                                     (coe
-                                                                                                       C_case'45'reduce_466
+                                                                                                       C_case'45'reduce_458
                                                                                                        v26))))))
                                                                 _ -> let v22
                                                                            = coe
@@ -1852,9 +1907,9 @@ d_progress_532 v0
                                                                                          erased in
                                                                                coe
                                                                                  (case coe v23 of
-                                                                                    C_step_522 v25 v26
+                                                                                    C_step_630 v25 v26
                                                                                       -> coe
-                                                                                           C_step_522
+                                                                                           C_step_630
                                                                                            (coe
                                                                                               MAlonzo.Code.Untyped.C_case_40
                                                                                               (coe
@@ -1862,18 +1917,18 @@ d_progress_532 v0
                                                                                               (coe
                                                                                                  v2))
                                                                                            (coe
-                                                                                              C_case'45'reduce_466
+                                                                                              C_case'45'reduce_458
                                                                                               v26)
-                                                                                    C_done_526 v25
+                                                                                    C_done_634 v25
                                                                                       -> case coe
                                                                                                 v25 of
-                                                                                           C_unsat'8321'_222 v28 v30 v31
+                                                                                           C_unsat'8321'_218 v28 v30 v31
                                                                                              -> coe
-                                                                                                  C_step_522
+                                                                                                  C_step_630
                                                                                                   (coe
                                                                                                      MAlonzo.Code.Untyped.C_error_46)
                                                                                                   (coe
-                                                                                                     C_case'45'unsat'8321'_458
+                                                                                                     C_case'45'unsat'8321'_450
                                                                                                      v28)
                                                                                            _ -> MAlonzo.RTE.mazUnreachableError
                                                                                     _ -> MAlonzo.RTE.mazUnreachableError)
@@ -1885,7 +1940,7 @@ d_progress_532 v0
                                                                                                    = coe
                                                                                                        MAlonzo.Code.Untyped.C__'183'__22
                                                                                                        (coe
-                                                                                                          d_reduceBuiltin_252
+                                                                                                          d_reduceBuiltin_248
                                                                                                           (0 ::
                                                                                                              Integer)
                                                                                                           v3)
@@ -1894,12 +1949,12 @@ d_progress_532 v0
                                                                                              coe
                                                                                                (let v26
                                                                                                       = coe
-                                                                                                          C_ξ'8321'_266
+                                                                                                          C_ξ'8321'_258
                                                                                                           (coe
-                                                                                                             C_sat'45'app'45'builtin_306) in
+                                                                                                             C_sat'45'app'45'builtin_298) in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_case_40
                                                                                                         (coe
@@ -1907,21 +1962,21 @@ d_progress_532 v0
                                                                                                         (coe
                                                                                                            v2))
                                                                                                      (coe
-                                                                                                        C_case'45'reduce_466
+                                                                                                        C_case'45'reduce_458
                                                                                                         v26)))
                                                                                         1 -> let v25
                                                                                                    = coe
-                                                                                                       d_reduceBuiltin_252
+                                                                                                       d_reduceBuiltin_248
                                                                                                        (0 ::
                                                                                                           Integer)
                                                                                                        v1 in
                                                                                              coe
                                                                                                (let v26
                                                                                                       = coe
-                                                                                                          C_sat'45'app'45'builtin_306 in
+                                                                                                          C_sat'45'app'45'builtin_298 in
                                                                                                 coe
                                                                                                   (coe
-                                                                                                     C_step_522
+                                                                                                     C_step_630
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Untyped.C_case_40
                                                                                                         (coe
@@ -1929,7 +1984,7 @@ d_progress_532 v0
                                                                                                         (coe
                                                                                                            v2))
                                                                                                      (coe
-                                                                                                        C_case'45'reduce_466
+                                                                                                        C_case'45'reduce_458
                                                                                                         v26)))
                                                                                         _ -> let v25
                                                                                                    = subInt
@@ -1940,11 +1995,11 @@ d_progress_532 v0
                                                                                                              Integer)) in
                                                                                              coe
                                                                                                (coe
-                                                                                                  C_step_522
+                                                                                                  C_step_630
                                                                                                   (coe
                                                                                                      MAlonzo.Code.Untyped.C_error_46)
                                                                                                   (coe
-                                                                                                     C_case'45'unsat'8321'_458
+                                                                                                     C_case'45'unsat'8321'_450
                                                                                                      v25))
                                                                                  _ -> let v25
                                                                                             = subInt
@@ -1960,12 +2015,12 @@ d_progress_532 v0
                                                                                          coe
                                                                                            (let v27
                                                                                                   = coe
-                                                                                                      C_app'45'interleave'45'error_392
+                                                                                                      C_app'45'interleave'45'error_384
                                                                                                       v25
                                                                                                       v24 in
                                                                                             coe
                                                                                               (coe
-                                                                                                 C_step_522
+                                                                                                 C_step_630
                                                                                                  (coe
                                                                                                     MAlonzo.Code.Untyped.C_case_40
                                                                                                     (coe
@@ -1973,57 +2028,57 @@ d_progress_532 v0
                                                                                                     (coe
                                                                                                        v2))
                                                                                                  (coe
-                                                                                                    C_case'45'reduce_466
+                                                                                                    C_case'45'reduce_458
                                                                                                     v27))))
                                                                           _ -> MAlonzo.RTE.mazUnreachableError)
                                                          _ -> MAlonzo.RTE.mazUnreachableError)
                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                        C_constr_228 v13
+                                        C_constr_224 v13
                                           -> let v14 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v15 = coe C_app'45'constr_412 in
+                                               (let v15 = coe C_app'45'constr_404 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v14)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v15)))
+                                                     (coe C_case'45'reduce_458 v15)))
                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                 C_fail_528
+                                 C_fail_636
                                    -> let v9 = coe MAlonzo.Code.Untyped.C_error_46 in
                                       coe
-                                        (let v10 = coe C_error'8322'_298 in
+                                        (let v10 = coe C_error'8322'_290 in
                                          coe
                                            (coe
-                                              C_step_522
+                                              C_step_630
                                               (coe MAlonzo.Code.Untyped.C_case_40 (coe v9) (coe v2))
-                                              (coe C_case'45'reduce_466 v10)))
+                                              (coe C_case'45'reduce_458 v10)))
                                  _ -> MAlonzo.RTE.mazUnreachableError)
-                       C_fail_528
+                       C_fail_636
                          -> let v6 = coe MAlonzo.Code.Untyped.C_error_46 in
                             coe
-                              (let v7 = coe C_error'8321'_294 in
+                              (let v7 = coe C_error'8321'_286 in
                                coe
                                  (coe
-                                    C_step_522
+                                    C_step_630
                                     (coe MAlonzo.Code.Untyped.C_case_40 (coe v6) (coe v2))
-                                    (coe C_case'45'reduce_466 v7)))
+                                    (coe C_case'45'reduce_458 v7)))
                        _ -> MAlonzo.RTE.mazUnreachableError)
              MAlonzo.Code.Untyped.C_force_24 v3
-               -> let v4 = d_progress_532 (coe v3) in
+               -> let v4 = d_progress_640 (coe v3) in
                   coe
                     (case coe v4 of
-                       C_step_522 v6 v7
+                       C_step_630 v6 v7
                          -> let v8 = coe MAlonzo.Code.Untyped.C_force_24 (coe v6) in
                             coe
-                              (let v9 = coe C_ξ'8323'_280 v7 in
+                              (let v9 = coe C_ξ'8323'_272 v7 in
                                coe
                                  (coe
-                                    C_step_522
+                                    C_step_630
                                     (coe MAlonzo.Code.Untyped.C_case_40 (coe v8) (coe v2))
-                                    (coe C_case'45'reduce_466 v9)))
-                       C_done_526 v6
+                                    (coe C_case'45'reduce_458 v9)))
+                       C_done_634 v6
                          -> let v7 = coe du_sat_36 (coe v3) in
                             coe
                               (case coe v7 of
@@ -2032,14 +2087,14 @@ d_progress_532 v0
                                         MAlonzo.Code.Untyped.C_ƛ_20 v8
                                           -> let v9 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v10 = coe C_force'45'ƛ_366 in
+                                               (let v10 = coe C_force'45'ƛ_358 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v9)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v10)))
+                                                     (coe C_case'45'reduce_458 v10)))
                                         MAlonzo.Code.Untyped.C__'183'__22 v8 v9
                                           -> let v10
                                                    = seq
@@ -2049,29 +2104,29 @@ d_progress_532 v0
                                                           erased) in
                                              coe
                                                (case coe v10 of
-                                                  C_step_522 v12 v13
+                                                  C_step_630 v12 v13
                                                     -> coe
-                                                         C_step_522
+                                                         C_step_630
                                                          (coe
                                                             MAlonzo.Code.Untyped.C_case_40 (coe v12)
                                                             (coe v2))
-                                                         (coe C_case'45'reduce_466 v13)
-                                                  C_done_526 v12
+                                                         (coe C_case'45'reduce_458 v13)
+                                                  C_done_634 v12
                                                     -> case coe v12 of
-                                                         C_unsat'8320'_208 v14 v15 v17
+                                                         C_unsat'8320'_204 v14 v15 v17
                                                            -> coe
-                                                                C_step_522
+                                                                C_step_630
                                                                 (coe
                                                                    MAlonzo.Code.Untyped.C_error_46)
                                                                 (coe
-                                                                   C_case'45'unsat'8320'_450 v14
+                                                                   C_case'45'unsat'8320'_442 v14
                                                                    v15)
-                                                         C_unsat'8320''8331''8321'_214 v14 v16
+                                                         C_unsat'8320''8331''8321'_210 v14 v16
                                                            -> coe
-                                                                C_step_522
+                                                                C_step_630
                                                                 (coe
                                                                    MAlonzo.Code.Untyped.C_error_46)
-                                                                (coe C_case'45'unsat'8321'_458 v14)
+                                                                (coe C_case'45'unsat'8321'_450 v14)
                                                          _ -> MAlonzo.RTE.mazUnreachableError
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         MAlonzo.Code.Untyped.C_force_24 v8
@@ -2083,131 +2138,131 @@ d_progress_532 v0
                                                           erased) in
                                              coe
                                                (case coe v9 of
-                                                  C_step_522 v11 v12
+                                                  C_step_630 v11 v12
                                                     -> coe
-                                                         C_step_522
+                                                         C_step_630
                                                          (coe
                                                             MAlonzo.Code.Untyped.C_case_40 (coe v11)
                                                             (coe v2))
-                                                         (coe C_case'45'reduce_466 v12)
-                                                  C_done_526 v11
+                                                         (coe C_case'45'reduce_458 v12)
+                                                  C_done_634 v11
                                                     -> case coe v11 of
-                                                         C_unsat'8320'_208 v13 v14 v16
+                                                         C_unsat'8320'_204 v13 v14 v16
                                                            -> coe
-                                                                C_step_522
+                                                                C_step_630
                                                                 (coe
                                                                    MAlonzo.Code.Untyped.C_error_46)
                                                                 (coe
-                                                                   C_case'45'unsat'8320'_450 v13
+                                                                   C_case'45'unsat'8320'_442 v13
                                                                    v14)
-                                                         C_unsat'8320''8331''8321'_214 v13 v15
+                                                         C_unsat'8320''8331''8321'_210 v13 v15
                                                            -> coe
-                                                                C_step_522
+                                                                C_step_630
                                                                 (coe
                                                                    MAlonzo.Code.Untyped.C_error_46)
-                                                                (coe C_case'45'unsat'8321'_458 v13)
+                                                                (coe C_case'45'unsat'8321'_450 v13)
                                                          _ -> MAlonzo.RTE.mazUnreachableError
                                                   _ -> MAlonzo.RTE.mazUnreachableError)
                                         MAlonzo.Code.Untyped.C_delay_26 v8
-                                          -> let v9 = coe C_force'45'delay_290 in
+                                          -> let v9 = coe C_force'45'delay_282 in
                                              coe
                                                (coe
-                                                  C_step_522
+                                                  C_step_630
                                                   (coe
                                                      MAlonzo.Code.Untyped.C_case_40 (coe v8)
                                                      (coe v2))
-                                                  (coe C_case'45'reduce_466 v9))
+                                                  (coe C_case'45'reduce_458 v9))
                                         MAlonzo.Code.Untyped.C_con_28 v8
                                           -> let v9 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v10 = coe C_force'45'con_370 in
+                                               (let v10 = coe C_force'45'con_362 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v9)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v10)))
+                                                     (coe C_case'45'reduce_458 v10)))
                                         MAlonzo.Code.Untyped.C_constr_34 v8 v9
                                           -> let v10 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
-                                               (let v11 = coe C_force'45'constr_376 in
+                                               (let v11 = coe C_force'45'constr_368 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v10)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v11)))
+                                                     (coe C_case'45'reduce_458 v11)))
                                         MAlonzo.Code.Untyped.C_error_46
-                                          -> let v8 = coe C_force'45'error_300 in
+                                          -> let v8 = coe C_force'45'error_292 in
                                              coe
                                                (coe
-                                                  C_step_522
+                                                  C_step_630
                                                   (coe
                                                      MAlonzo.Code.Untyped.C_case_40 (coe v3)
                                                      (coe v2))
-                                                  (coe C_case'45'reduce_466 v8))
+                                                  (coe C_case'45'reduce_458 v8))
                                         _ -> MAlonzo.RTE.mazUnreachableError
                                  C_want_8 v8 v9
                                    -> case coe v8 of
                                         0 -> let v10 = coe MAlonzo.Code.Untyped.C_error_46 in
                                              coe
                                                (let v11
-                                                      = coe C_force'45'interleave'45'error_382 v9 in
+                                                      = coe C_force'45'interleave'45'error_374 v9 in
                                                 coe
                                                   (coe
-                                                     C_step_522
+                                                     C_step_630
                                                      (coe
                                                         MAlonzo.Code.Untyped.C_case_40 (coe v10)
                                                         (coe v2))
-                                                     (coe C_case'45'reduce_466 v11)))
+                                                     (coe C_case'45'reduce_458 v11)))
                                         1 -> case coe v9 of
                                                0 -> let v10
                                                           = coe
-                                                              d_reduceBuiltin_252 (0 :: Integer)
+                                                              d_reduceBuiltin_248 (0 :: Integer)
                                                               v1 in
                                                     coe
                                                       (let v11
-                                                             = coe C_sat'45'force'45'builtin_310 in
+                                                             = coe C_sat'45'force'45'builtin_302 in
                                                        coe
                                                          (coe
-                                                            C_step_522
+                                                            C_step_630
                                                             (coe
                                                                MAlonzo.Code.Untyped.C_case_40
                                                                (coe v10) (coe v2))
-                                                            (coe C_case'45'reduce_466 v11)))
+                                                            (coe C_case'45'reduce_458 v11)))
                                                _ -> let v10
                                                           = subInt (coe v9) (coe (1 :: Integer)) in
                                                     coe
                                                       (coe
-                                                         C_step_522
+                                                         C_step_630
                                                          (coe MAlonzo.Code.Untyped.C_error_46)
-                                                         (coe C_case'45'unsat'8321'_458 v10))
+                                                         (coe C_case'45'unsat'8321'_450 v10))
                                         _ -> let v10 = subInt (coe v8) (coe (2 :: Integer)) in
                                              coe
                                                (coe
-                                                  C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                                                  (coe C_case'45'unsat'8320'_450 v10 v9))
+                                                  C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                                                  (coe C_case'45'unsat'8320'_442 v10 v9))
                                  _ -> MAlonzo.RTE.mazUnreachableError)
-                       C_fail_528
+                       C_fail_636
                          -> let v5 = coe MAlonzo.Code.Untyped.C_error_46 in
                             coe
-                              (let v6 = coe C_force'45'error_300 in
+                              (let v6 = coe C_force'45'error_292 in
                                coe
                                  (coe
-                                    C_step_522
+                                    C_step_630
                                     (coe MAlonzo.Code.Untyped.C_case_40 (coe v5) (coe v2))
-                                    (coe C_case'45'reduce_466 v6)))
+                                    (coe C_case'45'reduce_458 v6)))
                        _ -> MAlonzo.RTE.mazUnreachableError)
              MAlonzo.Code.Untyped.C_delay_26 v3
                -> coe
-                    C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                    (coe C_case'45'delay_428)
+                    C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                    (coe C_case'45'delay_420)
              MAlonzo.Code.Untyped.C_con_28 v3
                -> coe
-                    C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                    (coe C_case'45'con_434)
+                    C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                    (coe C_case'45'con_426)
              MAlonzo.Code.Untyped.C_constr_34 v3 v4
                -> let v5
                         = coe
@@ -2216,62 +2271,62 @@ d_progress_532 v0
                     (case coe v5 of
                        MAlonzo.Code.Agda.Builtin.Maybe.C_just_16 v6
                          -> coe
-                              C_step_522 (coe du_iterApp_242 (coe v6) (coe v4))
-                              (coe C_case'45'constr_320 v6)
+                              C_step_630 (coe du_iterApp_238 (coe v6) (coe v4))
+                              (coe C_case'45'constr_312 v6)
                        MAlonzo.Code.Agda.Builtin.Maybe.C_nothing_18
                          -> coe
-                              C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                              (coe C_broken'45'const_328)
+                              C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                              (coe C_broken'45'const_320)
                        _ -> MAlonzo.RTE.mazUnreachableError)
              MAlonzo.Code.Untyped.C_case_40 v3 v4
-               -> let v5 = d_progress_532 (coe v1) in
+               -> let v5 = d_progress_640 (coe v1) in
                   coe
                     (case coe v5 of
-                       C_step_522 v7 v8
+                       C_step_630 v7 v8
                          -> coe
-                              C_step_522 (coe MAlonzo.Code.Untyped.C_case_40 (coe v7) (coe v2))
-                              (coe C_case'45'reduce_466 v8)
+                              C_step_630 (coe MAlonzo.Code.Untyped.C_case_40 (coe v7) (coe v2))
+                              (coe C_case'45'reduce_458 v8)
                        _ -> MAlonzo.RTE.mazUnreachableError)
              MAlonzo.Code.Untyped.C_builtin_44 v3
                -> coe
-                    C_step_522 (coe MAlonzo.Code.Untyped.C_error_46)
-                    (coe C_case'45'builtin_440)
+                    C_step_630 (coe MAlonzo.Code.Untyped.C_error_46)
+                    (coe C_case'45'builtin_432)
              MAlonzo.Code.Untyped.C_error_46
-               -> coe C_step_522 v1 (coe C_case'45'error_416)
+               -> coe C_step_630 v1 (coe C_case'45'error_408)
              _ -> MAlonzo.RTE.mazUnreachableError
       MAlonzo.Code.Untyped.C_builtin_44 v1
-        -> coe C_done_526 (coe C_builtin_200)
-      MAlonzo.Code.Untyped.C_error_46 -> coe C_fail_528
+        -> coe C_done_634 (coe C_builtin_196)
+      MAlonzo.Code.Untyped.C_error_46 -> coe C_fail_636
       _ -> MAlonzo.RTE.mazUnreachableError
 -- Untyped.Reduction._≅_
-d__'8773'__1202 a0 a1 a2 = ()
-data T__'8773'__1202
-  = C_reduce_1212 MAlonzo.Code.Untyped.T__'8866'_14
-                  T__'10230''42'__470 T__'10230''42'__470
+d__'8773'__1308 a0 a1 = ()
+data T__'8773'__1308
+  = C_reduce_1316 MAlonzo.Code.Untyped.T__'8866'_14
+                  T__'10230''42'__460 T__'10230''42'__460
 -- Untyped.Reduction.refl-≅
-d_refl'45''8773'_1218 ::
-  MAlonzo.Code.Untyped.T__'8866'_14 -> T__'8773'__1202
-d_refl'45''8773'_1218 v0
-  = coe C_reduce_1212 v0 (coe C_refl_476) (coe C_refl_476)
+d_refl'45''8773'_1320 ::
+  MAlonzo.Code.Untyped.T__'8866'_14 -> T__'8773'__1308
+d_refl'45''8773'_1320 v0
+  = coe C_reduce_1316 v0 (coe C_refl_464) (coe C_refl_464)
 -- Untyped.Reduction.integer
-d_integer_1220 :: MAlonzo.Code.Builtin.Signature.T__'8866''9839'_4
-d_integer_1220
+d_integer_1322 :: MAlonzo.Code.Builtin.Signature.T__'8866''9839'_4
+d_integer_1322
   = coe
       MAlonzo.Code.RawU.du_tag2TyTag_232
       (coe MAlonzo.Code.RawU.C_integer_30)
 -- Untyped.Reduction.con-integer
-d_con'45'integer_1224 ::
+d_con'45'integer_1326 ::
   Integer -> Integer -> MAlonzo.Code.Untyped.T__'8866'_14
-d_con'45'integer_1224 ~v0 v1 = du_con'45'integer_1224 v1
-du_con'45'integer_1224 ::
+d_con'45'integer_1326 ~v0 v1 = du_con'45'integer_1326 v1
+du_con'45'integer_1326 ::
   Integer -> MAlonzo.Code.Untyped.T__'8866'_14
-du_con'45'integer_1224 v0
+du_con'45'integer_1326 v0
   = coe
       MAlonzo.Code.Untyped.C_con_28
-      (coe MAlonzo.Code.RawU.C_tmCon_206 (coe d_integer_1220) (coe v0))
+      (coe MAlonzo.Code.RawU.C_tmCon_206 (coe d_integer_1322) (coe v0))
 -- Untyped.Reduction.ex1
-d_ex1_1236 :: MAlonzo.Code.Untyped.T__'8866'_14
-d_ex1_1236
+d_ex1_1338 :: MAlonzo.Code.Untyped.T__'8866'_14
+d_ex1_1338
   = coe
       MAlonzo.Code.Untyped.C__'183'__22
       (coe
@@ -2299,11 +2354,11 @@ d_ex1_1236
                   (coe
                      MAlonzo.Code.Data.Fin.Base.C_suc_16
                      (coe MAlonzo.Code.Data.Fin.Base.C_zero_12)))))
-         (coe du_con'45'integer_1224 (coe (2 :: Integer))))
-      (coe du_con'45'integer_1224 (coe (3 :: Integer)))
+         (coe du_con'45'integer_1326 (coe (2 :: Integer))))
+      (coe du_con'45'integer_1326 (coe (3 :: Integer)))
 -- Untyped.Reduction.ex2
-d_ex2_1238 :: MAlonzo.Code.Untyped.T__'8866'_14
-d_ex2_1238
+d_ex2_1340 :: MAlonzo.Code.Untyped.T__'8866'_14
+d_ex2_1340
   = coe
       MAlonzo.Code.Untyped.C__'183'__22
       (coe
@@ -2331,5 +2386,5 @@ d_ex2_1238
                   (coe
                      MAlonzo.Code.Untyped.C_'96'_18
                      (coe MAlonzo.Code.Data.Fin.Base.C_zero_12)))))
-         (coe du_con'45'integer_1224 (coe (3 :: Integer))))
-      (coe du_con'45'integer_1224 (coe (2 :: Integer)))
+         (coe du_con'45'integer_1326 (coe (3 :: Integer))))
+      (coe du_con'45'integer_1326 (coe (2 :: Integer)))

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UApplyToCase.hs
@@ -136,7 +136,7 @@ d_a2c'63'_32 v0 v1 v2
                                                                                                       v0
                                                                                                       v1
                                                                                                       (coe
-                                                                                                         MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                         MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                          (coe
                                                                                                             v27)
                                                                                                          (coe
@@ -209,7 +209,7 @@ d_a2c'63'_32 v0 v1 v2
                                                                                                                         v0
                                                                                                                         v1
                                                                                                                         (coe
-                                                                                                                           MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                                           MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                                            (coe
                                                                                                                               v32)
                                                                                                                            (coe

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
@@ -221,7 +221,7 @@ du_red'45'constr_258 v0
                                                                                    (coe
                                                                                       MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                       (coe
-                                                                                         MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                         MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                          (coe v18)
                                                                                          (coe v16))
                                                                                       (coe
@@ -277,7 +277,7 @@ du_red'45'constr_258 v0
                                                                                                      (coe
                                                                                                         MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                                         (coe
-                                                                                                           MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                           MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                            (coe
                                                                                                               v23)
                                                                                                            (coe
@@ -2197,7 +2197,7 @@ d_decide_526 v0 v1 v2
                                                                                                                             (coe
                                                                                                                                MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                                                                (coe
-                                                                                                                                  MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                                                  MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                                                   (coe
                                                                                                                                      v26)
                                                                                                                                   (coe
@@ -2315,7 +2315,7 @@ d_decide_526 v0 v1 v2
                                                                                                                                               (coe
                                                                                                                                                  MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                                                                                  (coe
-                                                                                                                                                    MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                                                                    MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                                                                     (coe
                                                                                                                                                        v31)
                                                                                                                                                     (coe
@@ -2992,7 +2992,7 @@ du_decide'45''126'_604 v0 v1 v2
                                                                                                                             (coe
                                                                                                                                MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                                                                (coe
-                                                                                                                                  MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                                                  MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                                                   (coe
                                                                                                                                      v26)
                                                                                                                                   (coe
@@ -3110,7 +3110,7 @@ du_decide'45''126'_604 v0 v1 v2
                                                                                                                                               (coe
                                                                                                                                                  MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32
                                                                                                                                                  (coe
-                                                                                                                                                    MAlonzo.Code.Untyped.Reduction.du_iterApp_242
+                                                                                                                                                    MAlonzo.Code.Untyped.Reduction.du_iterApp_238
                                                                                                                                                     (coe
                                                                                                                                                        v31)
                                                                                                                                                     (coe

--- a/plutus-metatheory/src/Untyped/Purity.lagda.md
+++ b/plutus-metatheory/src/Untyped/Purity.lagda.md
@@ -15,7 +15,7 @@ open import Untyped using (_⊢; case; builtin; _·_; force; `; ƛ; delay; con; 
 open import Relation.Nullary using (Dec; yes; no; ¬_; _×-dec_)
 open import Builtin using (Builtin; arity; arity₀)
 open import RawU using (TmCon)
-open import Data.Product using (_,_; _×_)
+open import Data.Product using (_,_; _×_ ; ∃)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Nat using (ℕ; zero; suc; _>_; _>?_)
 open import Data.List using (List; _∷_; [])
@@ -29,7 +29,7 @@ open import Data.Empty using (⊥)
 open import Function.Base using (case_of_)
 open import Untyped.CEK using (lookup?)
 open import VerifiedCompilation.UntypedViews using (isDelay?; isTerm?; isLambda?; isdelay; isterm; islambda)
-open import Untyped.Reduction using (iterApp; Arity; want; no-builtin; sat)
+open import Untyped.Reduction using (iterApp; Arity; want; no-builtin; sat; _⟶*_; value)
 ```
 ## Saturation
 
@@ -141,4 +141,55 @@ isPure? (constr i xs) with allPure? xs
 isPure? (case scrut ts) =  no λ ()
 isPure? (builtin b) = yes builtin
 isPure? error = no λ ()
+```
+
+## Semantics of purity
+
+Note: this is currently based on the reduction semantics in `Untyped.Reduction`,
+which may change in the future (e.g. in favour of directly working against CEK
+semantics, or an updated `Untyped.Reduction`). We reuse `Env` from the CEK
+module but otherwise not CEK semantics is used at the moment.
+
+```
+open import Untyped.RenamingSubstitution using (Sub; sub)
+open import Untyped.Reduction using (_⟶*_; refl; Value; value; V-v)
+open import Untyped.CEK using (env2sub)
+```
+
+A closed term is semantically pure when it eventually reduces to a value.
+
+```
+pure₀ : 0 ⊢ → Set
+pure₀ M = ∃ λ N → (M ⟶* N) × value N
+```
+
+An open term is semantically pure when closing it with a value substitution
+results in a closed pure term:
+
+```
+pure : ∀{X} → X ⊢ → Set
+pure M = ∃ λ ρ → pure₀ (sub (env2sub ρ) M)
+```
+
+TODO, substituting the empty environment is the identity:
+
+```
+postulate
+  pure₀-pure : ∀ {M} → pure₀ M → pure M
+```
+
+Every value is trivially pure:
+
+```
+value-pure : ∀ {M : 0 ⊢} → Value M → pure M
+value-pure v = pure₀-pure (_ , refl , (V-v v))
+```
+
+## Soundness of `Pure`
+
+TODO:
+
+```
+postulate
+  Pure-pure : ∀ {X} {M : X ⊢} → Pure M → pure M
 ```

--- a/plutus-metatheory/src/Untyped/Reduction.lagda.md
+++ b/plutus-metatheory/src/Untyped/Reduction.lagda.md
@@ -11,7 +11,7 @@ module Untyped.Reduction where
 
 ```
 open import Untyped using (_⊢; case; builtin; _·_; force; `; ƛ; delay; con; constr; error)
-open import Untyped.RenamingSubstitution using (_[_])
+open import Untyped.RenamingSubstitution using (_[_]; Sub; sub)
 open import Data.Maybe using (Maybe; just; nothing)
 open import RawU using (TmCon)
 open import Builtin using (Builtin; equals; decBuiltin; arity; arity₀)
@@ -23,8 +23,8 @@ open import Data.Fin using (Fin; zero; suc)
 open import Data.Nat using (ℕ; zero; suc; _<_; _≟_; _<?_; _≤_)
 open import Data.Nat.Properties using (suc-injective)
 open import Data.List using (List; []; _∷_)
-open import Untyped.CEK using (BUILTIN'; lookup?)
-open import Data.List.Relation.Unary.All using (All)
+open import Untyped.CEK using (BUILTIN'; lookup?; Env; env2sub)
+open import Data.List.Relation.Unary.All using (All; map; _∷_; [])
 import Relation.Binary.PropositionalEquality as Eq using (subst; trans; sym)
 open import Relation.Nullary using (yes;no)
 ```
@@ -84,9 +84,9 @@ nat-threshold {suc a} {suc b} (Data.Nat.s≤s a<b) (Data.Nat.s≤s b≤sa) = con
 variable
   X Y : ℕ
 
-data Value {X : ℕ} : X ⊢ → Set where
-  delay : {a : X ⊢} → Value (delay a)
-  ƛ : {a : (suc X) ⊢ } → Value (ƛ a)
+data Value : 0 ⊢ → Set where
+  delay : {a : 0 ⊢} → Value (delay a)
+  ƛ : {a : (suc 0) ⊢ } → Value (ƛ a)
   con : {n : TmCon} → Value (con n)
   builtin : {b : Builtin} → Value (builtin b)
 
@@ -94,7 +94,7 @@ data Value {X : ℕ} : X ⊢ → Set where
   -- after it has been force'd or had something applied
   -- hence, unsat-builtin₀ and unsat-builtin₁ have
   -- (suc (suc _)) requirements.
-  unsat₀ : {t : X ⊢} {a₀ a₁ : ℕ}
+  unsat₀ : {t : 0 ⊢} {a₀ a₁ : ℕ}
             → sat t ≡ want (suc (suc a₀)) a₁
             → Value t
             → Value (force t)
@@ -102,20 +102,20 @@ data Value {X : ℕ} : X ⊢ → Set where
   -- unsat-builtin₀₋₁ handles the case where
   -- we consume the last type argument but
   -- still have some unsaturated term args.
-  unsat₀₋₁ : {t : X ⊢} {a₁ : ℕ}
+  unsat₀₋₁ : {t : 0 ⊢} {a₁ : ℕ}
             → sat t ≡ want (suc zero) (suc a₁)
             → Value t
             → Value (force t)
 
-  unsat₁ : {t t₁ : X ⊢} {a₁ : ℕ}
+  unsat₁ : {t t₁ : 0 ⊢} {a₁ : ℕ}
             → sat t ≡ want zero (suc (suc a₁))
             → Value t
             → Value t₁
             → Value (t · t₁)
 
-  constr : {vs : List (X ⊢)} {n : ℕ} → All Value vs → Value (constr n vs)
+  constr : {vs : List (0 ⊢)} {n : ℕ} → All Value vs → Value (constr n vs)
 
-value-constr-recurse : {i : ℕ} {vs : List (X ⊢)} → Value (constr i vs) → All Value vs
+value-constr-recurse : {i : ℕ} {vs : List (0 ⊢)} → Value (constr i vs) → All Value vs
 value-constr-recurse (constr All.[]) = All.[]
 value-constr-recurse (constr (px All.∷ x)) = px All.∷ x
 
@@ -133,84 +133,180 @@ postulate
   reduceBuiltin : X ⊢ → X ⊢
 
 infix 5 _⟶_
-data _⟶_ {X : ℕ} : X ⊢ → X ⊢ → Set where
-  ξ₁ : {a a' b : X ⊢} → a ⟶ a' → a · b ⟶ a' · b
+data _⟶_ : 0 ⊢ → 0 ⊢ → Set where
+  ξ₁ : {a a' b : 0 ⊢} → a ⟶ a' → a · b ⟶ a' · b
   -- Value is required in ξ₂ to make this deterministically resolve the left side first
-  ξ₂ : {a b b' : X ⊢} → Value a → b ⟶ b' → a · b ⟶ a · b'
-  ξ₃ : {a a' : X ⊢} → a ⟶ a' → force a ⟶ force a'
-  β : {a : (suc X) ⊢}{b : X ⊢} → Value b → ƛ a · b ⟶ a [ b ]
-  force-delay : {a : X ⊢} → force (delay a) ⟶ a
+  ξ₂ : {a b b' : 0 ⊢} → Value a → b ⟶ b' → a · b ⟶ a · b'
+  ξ₃ : {a a' : 0 ⊢} → a ⟶ a' → force a ⟶ force a'
+  β : {a : (suc 0) ⊢}{b : 0 ⊢} → Value b → ƛ a · b ⟶ a [ b ]
+  force-delay : {a : 0 ⊢} → force (delay a) ⟶ a
 
-  error₁ : {a : X ⊢} → (error · a) ⟶ error
-  error₂ : {a : X ⊢} → (a · error) ⟶ error
+  error₁ : {a : 0 ⊢} → (error · a) ⟶ error
+  error₂ : {a : 0 ⊢} → (a · error) ⟶ error
   force-error : force error ⟶ error
 
   -- Builtins that are saturated will reduce
-  sat-app-builtin : {t₁ t₂ : X ⊢}
+  sat-app-builtin : {t₁ t₂ : 0 ⊢}
               → sat (t₁ · t₂) ≡ want zero zero
               → (t₁ · t₂) ⟶ reduceBuiltin (t₁ · t₂)
-  sat-force-builtin : {t : X ⊢}
+  sat-force-builtin : {t : 0 ⊢}
               → sat (force t) ≡ want zero zero
               → (force t) ⟶ reduceBuiltin (force t)
 
-  case-constr : {i : ℕ} {t : X ⊢} {vs ts : List (X ⊢)}
+  case-constr : {i : ℕ} {t : 0 ⊢} {vs ts : List (0 ⊢)}
               → lookup? i ts ≡ just t
               → case (constr i vs) ts ⟶ iterApp t vs
-  broken-const : {i : ℕ} {vs ts : List (X ⊢)}
+  broken-const : {i : ℕ} {vs ts : List (0 ⊢)}
               → lookup? i ts ≡ nothing
               → case (constr i vs) ts ⟶ error
-  constr-step : {i : ℕ} {v v' : X ⊢} {vs : List (X ⊢)}
+  constr-step : {i : ℕ} {v v' : 0 ⊢} {vs : List (0 ⊢)}
               → v ⟶ v'
               → constr i (v ∷ vs) ⟶ constr i (v' ∷ vs)
-  constr-sub-step : {i : ℕ} {v : X ⊢} {vs vs' : List (X ⊢)}
+  constr-sub-step : {i : ℕ} {v : 0 ⊢} {vs vs' : List (0 ⊢)}
               → constr i vs ⟶ constr i vs'
               → constr i (v ∷ vs) ⟶ constr i (v ∷ vs')
-  constr-error : {i : ℕ} {vs : List (X ⊢)}
+  constr-error : {i : ℕ} {vs : List (0 ⊢)}
               → constr i (error ∷ vs) ⟶ error
-  constr-sub-error : {i : ℕ} {v : X ⊢} {vs : List (X ⊢)}
+  constr-sub-error : {i : ℕ} {v : 0 ⊢} {vs : List (0 ⊢)}
     → constr i vs ⟶ error
     → constr i (v ∷ vs) ⟶ error
 
   -- Many of the things that you can force that aren't delay
-  force-ƛ : {a : suc X ⊢} → force (ƛ a) ⟶ error
+  force-ƛ : {a : suc 0 ⊢} → force (ƛ a) ⟶ error
   force-con : {c : TmCon} → force (con c) ⟶ error
-  force-constr : {i : ℕ} {vs : List (X ⊢)} → force (constr i vs) ⟶ error
+  force-constr : {i : ℕ} {vs : List (0 ⊢)} → force (constr i vs) ⟶ error
 
   -- Currently, this assumes type arguments have to come first
-  force-interleave-error : {a₁ : ℕ} {t : X ⊢}
+  force-interleave-error : {a₁ : ℕ} {t : 0 ⊢}
                → sat t ≡ want zero a₁
                → force t ⟶ error
-  app-interleave-error : {a₀ a₁ : ℕ} {t t₁ : X ⊢}
+  app-interleave-error : {a₀ a₁ : ℕ} {t t₁ : 0 ⊢}
                → sat t ≡ want (suc a₀) a₁
                → (t · t₁) ⟶ error
 
   -- Many of the things that you can apply to that aren't ƛ
-  app-con : {b : X ⊢} {c : TmCon} → (con c) · b ⟶ error
-  app-delay : {a b : X ⊢} → (delay a) · b ⟶ error
-  app-constr : {b : X ⊢} {i : ℕ} {vs : List (X ⊢)} → (constr i vs) · b ⟶ error
+  app-con : {b : 0 ⊢} {c : TmCon} → (con c) · b ⟶ error
+  app-delay : {a b : 0 ⊢} → (delay a) · b ⟶ error
+  app-constr : {b : 0 ⊢} {i : ℕ} {vs : List (0 ⊢)} → (constr i vs) · b ⟶ error
 
   -- Many of the things that you can case that aren't constr
-  case-error : {ts : List (X ⊢)} → case error ts ⟶ error
-  case-ƛ : {t : suc X ⊢} {ts : List (X ⊢)} → case (ƛ t) ts ⟶ error
-  case-delay : {t : X ⊢} {ts : List (X ⊢)} → case (delay t) ts ⟶ error
-  case-con : {c : TmCon} {ts : List (X ⊢)} → case (con c) ts ⟶ error
-  case-builtin : {b : Builtin} {ts : List (X ⊢)} → case (builtin b) ts ⟶ error
-  case-unsat₀ : {t : X ⊢} {ts : List (X ⊢)} {a₀ a₁ : ℕ} → sat t ≡ want (suc a₀) a₁ → case t ts ⟶ error
-  case-unsat₁ : {t : X ⊢} {ts : List (X ⊢)} {a₁ : ℕ} → sat t ≡ want zero (suc a₁) → case t ts ⟶ error
-  case-reduce :  {t t' : X ⊢} {ts : List (X ⊢)}
+  case-error : {ts : List (0 ⊢)} → case error ts ⟶ error
+  case-ƛ : {t : suc 0 ⊢} {ts : List (0 ⊢)} → case (ƛ t) ts ⟶ error
+  case-delay : {t : 0 ⊢} {ts : List (0 ⊢)} → case (delay t) ts ⟶ error
+  case-con : {c : TmCon} {ts : List (0 ⊢)} → case (con c) ts ⟶ error
+  case-builtin : {b : Builtin} {ts : List (0 ⊢)} → case (builtin b) ts ⟶ error
+  case-unsat₀ : {t : 0 ⊢} {ts : List (0 ⊢)} {a₀ a₁ : ℕ} → sat t ≡ want (suc a₀) a₁ → case t ts ⟶ error
+  case-unsat₁ : {t : 0 ⊢} {ts : List (0 ⊢)} {a₁ : ℕ} → sat t ≡ want zero (suc a₁) → case t ts ⟶ error
+  case-reduce :  {t t' : 0 ⊢} {ts : List (0 ⊢)}
               → t ⟶ t'
               → case t ts ⟶ case t' ts
 
 
 infix 5 _⟶*_
-data _⟶*_ {X : ℕ} : X ⊢ → X ⊢ → Set where
-  refl : {M : X ⊢} → M ⟶* M
-  trans : { M P N : X ⊢} → M ⟶ P → P ⟶* N → M ⟶* N
+data _⟶*_ : 0 ⊢ → 0 ⊢ → Set where
+  refl : {M : 0 ⊢} → M ⟶* M
+  trans : { M P N : 0 ⊢} → M ⟶ P → P ⟶* N → M ⟶* N
 
-tran-⟶* : ∀ {X : ℕ}{a b c : X ⊢} → a ⟶* b → b ⟶* c → a ⟶* c
+tran-⟶* : ∀ {a b c : 0 ⊢} → a ⟶* b → b ⟶* c → a ⟶* c
 tran-⟶* refl b→c = b→c
 tran-⟶* (trans x a→b) refl = trans x a→b
 tran-⟶* (trans x a→b) (trans x₁ b→c) = trans x (tran-⟶* a→b (trans x₁ b→c))
+```
+
+## Semantics of values
+
+Irreducible terms cannot take a step:
+
+```
+irred : 0 ⊢ → Set
+irred M = ∀{N} → ¬ (M ⟶ N)
+```
+
+Defining `irred` like this, rather than `irred M = ¬ ∃ (λ N → M ⟶ N)` leverages
+implicit parameters and makes proofs a bit shorter.
+
+```
+value : 0 ⊢ → Set
+value M = irred M × ¬ M ≡ error
+```
+
+A short lemma about constructors:
+
+```
+irred-constr :
+  ∀ {i} {Ms : List (0 ⊢)}
+  → All value Ms
+  → irred (constr i Ms)
+irred-constr ((irred-M , ¬err) ∷ vs) step with step
+... | constr-step step₁ = irred-M step₁
+... | constr-sub-step step₁ = irred-constr vs step₁
+... | constr-error = ¬err refl
+... | constr-sub-error step₁ = irred-constr vs step₁
+```
+
+Unproven lemma about unsaturated built-ins. This will probably change once we have
+a better definitions unsaturated built-ins.
+
+First we capture the current definition of unsaturated terms, which is a bit
+awkward (it uses `Value` for the sub-expression that can only be an unsaturated
+built-in) and incomplete (it disallows interleaving forces and applications):
+
+```
+data unsaturated : (0 ⊢) → Set where
+  arg-arg :
+    ∀ {M N y}
+    → sat M ≡ want 0 (suc (suc y))
+    → Value M
+    → Value N
+    → unsaturated (M · N)
+
+  force-force-args :
+    ∀ {M x y}
+    → sat M ≡ want (suc (suc x)) y
+    → Value M
+    → unsaturated (force M)
+
+  force-args :
+    ∀ {M y}
+    → sat M ≡ want 1 (suc y)
+    → Value M
+    → unsaturated (force M)
+```
+
+Then we assume that any such unsaturated built-in is irreducible.
+
+```
+postulate
+  irred-unsaturated :
+    ∀ {M}
+    → unsaturated M
+    → irred M
+```
+
+Any syntactic value is also semantically a value:
+
+```
+V-v : ∀ {M : 0 ⊢} → Value M → value M
+V-v* : ∀ {Ms : List (0 ⊢)} → All Value Ms → All value Ms
+V-v delay            = (λ ()) , λ ()
+V-v ƛ                = (λ ()) , λ ()
+V-v con              = (λ ()) , λ ()
+V-v (constr vs)      = irred-constr (V-v* vs) , λ ()
+
+V-v builtin          = (λ ()) , λ ()
+V-v (unsat₀ wants val-M)    = irred-unsaturated (force-force-args wants val-M) , λ ()
+V-v (unsat₀₋₁ wants val-M)  = irred-unsaturated (force-args wants val-M) , λ ()
+V-v (unsat₁ wants val-M val-N) = irred-unsaturated (arg-arg wants val-M val-N) , λ ()
+
+V-v* [] = []
+V-v* (px ∷ xs) = V-v px ∷ V-v* xs
+```
+
+The other direction should hold too
+
+```
+postulate
+  value-Value : ∀ {M : 0 ⊢} → value M → Value M
 
 {-
 value-¬⟶ : ∀ {X : ℕ}{M : X ⊢} → Value M → ¬ (∃[ N ] ( M ⟶ N ))
@@ -235,12 +331,12 @@ value-¬⟶ {M = M} error = λ ()
 ## Progress
 ```
 
-data Progress {X : ℕ} : (a : X ⊢) → Set where
-  step : {a b : X ⊢}
+data Progress : (a : 0 ⊢) → Set where
+  step : {a b : 0 ⊢}
         → a ⟶ b
         → Progress a
 
-  done : {a : X ⊢}
+  done : {a : 0 ⊢}
         → Value a
         → Progress a
 
@@ -334,10 +430,10 @@ progress error = fail
 ## "Reduction" Equivalence
 ```
 infix 5 _≅_
-data _≅_ {X : ℕ} : X ⊢ → X ⊢ → Set where
-  reduce : {a b c : X ⊢} → a ⟶* c → b ⟶* c → a ≅ b
+data _≅_ : 0 ⊢ → 0 ⊢ → Set where
+  reduce : {a b c : 0 ⊢} → a ⟶* c → b ⟶* c → a ≅ b
 
-refl-≅ : ∀{X : ℕ}{a : X ⊢} → a ≅ a
+refl-≅ : ∀{a : 0 ⊢} → a ≅ a
 refl-≅ = reduce refl refl
 
 --tran-≅ : ∀{X : ℕ}{a b c : X ⊢} → a ≅ b → b ≅ c → a ≅ c


### PR DESCRIPTION
Adds semantic definitions of values and purity, based on the current UPLC reduction semantics. Also changes `Reduction.lagda.md` semantics to be closer to the pdf spec, in the sense that it is only defined for closed terms.

Semantic versions of `Value` and `Pure` are needed for proving certain translation relations sound. Proving that `Pure` (syntactic) implies `pure` (semantic) will be next.