### PR TITLE
Imrpoved costing for `equalsByteString` and `equalsString`

### DIFF
--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
@@ -16,6 +16,16 @@ import Hedgehog qualified as H
 integerLength :: BS.ByteString -> Integer
 integerLength = fromIntegral . BS.length
 
+-- Arguments for off-diagonal pairs when we expect the time to be constant.
+-- Benchmark the function over and 8x8 grid with no two sizes equal.  We can
+-- inspect the results visualyl to make sure that the time is (approximately)
+-- constant.
+smallerByteStrings8x8 :: H.Seed -> H.Seed -> ([BS.ByteString], [BS.ByteString])
+smallerByteStrings8x8 seed1 seed2 =
+  ( makeSizedByteStrings seed1 $ fmap (20 *) [1 .. 8]
+  , makeSizedByteStrings seed2 $ fmap (\n -> 20 * n + 5) [1 .. 8]
+  )
+
 -- Arguments for single-argument benchmarks: 150 entries.
 -- Note that the length is eight times the size.
 smallerByteStrings150 :: H.Seed -> [BS.ByteString]
@@ -53,12 +63,11 @@ benchSameTwoByteStrings name =
  different name (`EqualsByteString2` or something similar), but that would
  require some quite large changes.
 -}
-benchDifferentByteStringsElementwise :: DefaultFun -> Benchmark
-benchDifferentByteStringsElementwise name =
-  createTwoTermBuiltinBenchElementwise name [] $ zip inputs1 inputs2
+benchDifferentSizedByteStrings :: DefaultFun -> Benchmark
+benchDifferentSizedByteStrings name =
+  createTwoTermBuiltinBench name [] inputs1 inputs2
   where
-    inputs1 = smallerByteStrings150 seedA
-    inputs2 = fmap (BS.cons 0x0F) (smallerByteStrings150 seedB)
+    (inputs1, inputs2) = smallerByteStrings8x8 seedA seedB
 
 -- This is constant, even for large inputs
 benchIndexByteString :: StdGen -> Benchmark
@@ -121,7 +130,7 @@ makeBenchmarks gen =
   , benchIndexByteString gen
   , benchSliceByteString
   ]
-    <> [benchDifferentByteStringsElementwise EqualsByteString]
+    <> [benchDifferentSizedByteStrings EqualsByteString]
     <> ( benchSameTwoByteStrings
            <$> [EqualsByteString, LessThanEqualsByteString, LessThanByteString]
        )

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
@@ -45,15 +45,20 @@ benchSameTwoByteStrings name =
   where
     inputs = smallerByteStrings150 seedA
 
--- Here we benchmark different pairs of bytestrings elementwise.  This is used
--- to get times for off-diagonal comparisons, which we expect to be roughly
--- constant since the equality test returns quickly in that case.
+{- Here we benchmark different pairs of bytestrings elementwise.  This is used to
+ get times for off-diagonal comparisons, which we expect to be roughly constant
+ since the equality test returns quickly in that case.  We want the inputs to be
+ of different sizes so that we can recognise the corresponding data in the R
+ code; an alternative (perhaps better) would be to save the results under a
+ different name (`EqualsByteString2` or something similar), but that would
+ require some quite large changes.
+-}
 benchDifferentByteStringsElementwise :: DefaultFun -> Benchmark
 benchDifferentByteStringsElementwise name =
   createTwoTermBuiltinBenchElementwise name [] $ zip inputs1 inputs2
   where
     inputs1 = smallerByteStrings150 seedA
-    inputs2 = smallerByteStrings150 seedB
+    inputs2 = fmap (BS.cons 0x0F) (smallerByteStrings150 seedB)
 
 -- This is constant, even for large inputs
 benchIndexByteString :: StdGen -> Benchmark

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/ByteStrings.hs
@@ -22,8 +22,8 @@ integerLength = fromIntegral . BS.length
 -- constant.
 smallerByteStrings8x8 :: H.Seed -> H.Seed -> ([BS.ByteString], [BS.ByteString])
 smallerByteStrings8x8 seed1 seed2 =
-  ( makeSizedByteStrings seed1 $ fmap (20 *) [1 .. 8]
-  , makeSizedByteStrings seed2 $ fmap (\n -> 20 * n + 5) [1 .. 8]
+  ( makeSizedByteStrings seed1 $ fmap (200 *) [1 .. 8]
+  , makeSizedByteStrings seed2 $ fmap (\n -> 200 * n + 100) [1 .. 8]
   )
 
 -- Arguments for single-argument benchmarks: 150 entries.

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
@@ -143,6 +143,15 @@ benchTwoTextStrings name =
       s2 = makeSizedTextStrings seedB twoArgumentSizes
    in createTwoTermBuiltinBench name [] s1 s2
 
+-- Benchmark times for a function applied to arguments of different sizes over
+-- an 8x8 grid.  This is used for benchmarking EqualsString off the diagonal.
+benchDifferentSizedTextStrings :: DefaultFun -> Benchmark
+benchDifferentSizedTextStrings name =
+  createTwoTermBuiltinBench name [] inputs1 inputs2
+  where
+    inputs1 = makeSizedTextStrings seedA $ fmap (600 *) [1 .. 8]
+    inputs2 = makeSizedTextStrings seedB $ fmap (\n -> 600 * n + 100) [1 .. 8]
+
 -- Benchmark times for a function applied to equal arguments.  This is used for
 -- benchmarking EqualsString on the diagonal.  Copy the string here, because
 -- otherwise it'll be exactly the same and the equality will short-circuit.
@@ -157,5 +166,6 @@ makeBenchmarks _gen =
   [ benchOneTextString EncodeUtf8
   , benchOneUtf8ByteString DecodeUtf8
   , benchTwoTextStrings AppendString
+  , benchDifferentSizedTextStrings EqualsString
   , benchSameTwoTextStrings EqualsString
   ]

--- a/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
+++ b/plutus-core/cost-model/budgeting-bench/Benchmarks/Strings.hs
@@ -149,8 +149,8 @@ benchDifferentSizedTextStrings :: DefaultFun -> Benchmark
 benchDifferentSizedTextStrings name =
   createTwoTermBuiltinBench name [] inputs1 inputs2
   where
-    inputs1 = makeSizedTextStrings seedA $ fmap (600 *) [1 .. 8]
-    inputs2 = makeSizedTextStrings seedB $ fmap (\n -> 600 * n + 100) [1 .. 8]
+    inputs1 = makeSizedTextStrings seedA $ fmap (1200 *) [1 .. 8]
+    inputs2 = makeSizedTextStrings seedB $ fmap (\n -> 1200 * n + 600) [1 .. 8]
 
 -- Benchmark times for a function applied to equal arguments.  This is used for
 -- benchmarking EqualsString on the diagonal.  Copy the string here, because

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -444,6 +444,23 @@ modelFun <- function(path) {
         return (mk.result(m, "linear_in_u"))
    }
 
+   linearOnDiagonal <- function (fname) {
+        filtered <- filter(data, name == fname)
+        data.on.diagonal <- filter(filtered, x_mem == y_mem)
+        if (nrow(data.on.diagonal) == 0) {
+            stop ("No on-diagonal data found for ", fname)
+        }
+        m <- lm(t ~ x_mem, discard.overhead (data.on.diagonal))
+
+        data.off.diagonal <- filter(filtered, x_mem != y_mem)
+        if (nrow(data.off.diagonal) == 0) {
+            stop ("No off-diagonal data found for ", fname)
+        }
+        constant <- mean(discard.overhead(data.off.diagonal)$t)
+
+        mk.result(m, "linear_on_diagonal", constant=constant)
+    }
+
     ##### Integers #####
 
     addIntegerModel <- {
@@ -563,25 +580,9 @@ modelFun <- function(path) {
     indexByteStringModel    <- constantModel ("IndexByteString")     ## Constant-time array access
 
     ## NOTE: We could also use const_off_diagonal here, but we have to keep
-    ## linear _on_diagonal for backward compatibility for the time being.
+    ## linear_on_diagonal for backward compatibility for the time being.
     ## See Note [Backward compatibility for costing functions].
-    equalsByteStringModel <- {
-        fname <- "EqualsByteString"
-        filtered <- filter(data, name == fname)
-        data.on.diagonal <- filter(filtered, x_mem == y_mem)
-        if (nrow(data.on.diagonal) == 0) {
-            stop ("No on-diagonal data found for ", fname)
-        }
-        m <- lm(t ~ x_mem, discard.overhead (data.on.diagonal))
-
-        data.off.diagonal <- filter(filtered, x_mem != y_mem)
-        if (nrow(data.off.diagonal) == 0) {
-            stop ("No off-diagonal data found for ", fname)
-        }
-        constant <- mean(discard.overhead(data.off.diagonal)$t)
-
-        mk.result(m, "linear_on_diagonal", constant=constant)
-    }
+    equalsByteStringModel <- linearOnDiagonal ("EqualsByteString")
 
     lessThanByteStringModel <- {
         fname <- "LessThanByteString"
@@ -633,23 +634,9 @@ modelFun <- function(path) {
     }
 
     ## NOTE: We could also use const_off_diagonal here, but we have to keep
-    ## linear _on_diagonal for backward compatibility for the time being.
+    ## linear_on_diagonal for backward compatibility for the time being.
     ## See Note [Backward compatibility for costing functions].
-    equalsStringModel <- {
-        fname <- "EqualsString"
-        filtered <- data %>%
-            filter.and.check.nonempty(fname) %>%
-            filter(x_mem == y_mem) %>%
-            discard.overhead ()
-        m <- lm(t ~ x_mem, filtered)
-
-        constant <- min(filtered$t)
-        ## FIXME.  The `constant` value above is the off-diagonal cost, which
-        ## we don't collect benchmarking data for.  We might want to collect
-        ## some data and infer it.
-
-        mk.result(m, "linear_on_diagonal", constant=constant)
-    }
+    equalsStringModel <- linearOnDiagonal ("EqualsString")
 
     decodeUtf8Model <- linearInX ("DecodeUtf8")
     encodeUtf8Model <- linearInX ("EncodeUtf8")

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -567,17 +567,18 @@ modelFun <- function(path) {
     ## See Note [Backward compatibility for costing functions].
     equalsByteStringModel <- {
         fname <- "EqualsByteString"
-        data.on.diagonal <- data %>%
-            filter.and.check.nonempty(fname) %>%
-            filter(x_mem == y_mem) %>%
-            discard.overhead ()
-        m <- lm(t ~ x_mem, data.on.diagonal)
+        filtered <- filter(data, name == fname)
+        data.on.diagonal <- filter(filtered, x_mem == y_mem)
+        if (nrow(data.on.diagonal) == 0) {
+            stop ("No on-diagonal data found for ", fname)
+        }
+        m <- lm(t ~ x_mem, discard.overhead (data.on.diagonal))
 
-        data.off.diagonal <- data %>%
-            filter.and.check.nonempty(fname) %>%
-            filter(x_mem != y_mem) %>%
-            discard.overhead ()
-        constant <- mean(data.off.diagonal$t)
+        data.off.diagonal <- filter(filtered, x_mem != y_mem)
+        if (nrow(data.off.diagonal) == 0) {
+            stop ("No off-diagonal data found for ", fname)
+        }
+        constant <- mean(discard.overhead(data.off.diagonal)$t)
 
         mk.result(m, "linear_on_diagonal", constant=constant)
     }

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -593,7 +593,8 @@ modelFun <- function(path) {
         mk.result(m, "min_size")
     }
 
-    lessThanEqualsByteStringModel <- lessThanByteStringModel  ## Check this!
+    lessThanEqualsByteStringModel <- lessThanByteStringModel
+    ## Experiments show that the behaivour of these functions is identical.
 
 
     ###### Hashing functions #####

--- a/plutus-core/cost-model/data/models.R
+++ b/plutus-core/cost-model/data/models.R
@@ -567,15 +567,17 @@ modelFun <- function(path) {
     ## See Note [Backward compatibility for costing functions].
     equalsByteStringModel <- {
         fname <- "EqualsByteString"
-        filtered <- data %>%
+        data.on.diagonal <- data %>%
             filter.and.check.nonempty(fname) %>%
             filter(x_mem == y_mem) %>%
             discard.overhead ()
-        m <- lm(t ~ x_mem, filtered)
+        m <- lm(t ~ x_mem, data.on.diagonal)
 
-        constant <- min(filtered$t)
-        ## FIXME.  The `constant` value above is the off-diagonal cost, which we
-        ## don't collect benchmarking data for.  Collect some data and infer it.
+        data.off.diagonal <- data %>%
+            filter.and.check.nonempty(fname) %>%
+            filter(x_mem != y_mem) %>%
+            discard.overhead ()
+        constant <- mean(data.off.diagonal$t)
 
         mk.result(m, "linear_on_diagonal", constant=constant)
     }


### PR DESCRIPTION
This fixes the FIXME comments in the costing function inference code [here](https://github.com/IntersectMBO/plutus/blob/892718785f533def3da309a7e7e09b4ecd709d69/plutus-core/cost-model/data/models.R#L577) and [here](https://github.com/IntersectMBO/plutus/blob/892718785f533def3da309a7e7e09b4ecd709d69/plutus-core/cost-model/data/models.R#L644).

The costing functions for `equalsByteString` and `equalsString` are linear on the diagonal (ie, when we're comparing two inputs of the same size) and constant off the diagonal (when the inputs have different sizes, in which case they can't possibly be equal).  Previously we just ran benchmarks for inputs which were actually equal (which is the worst case) and took the off-diagonal cost to be equal to the minimum of the on-diagonal cost.  That was a little inelegant, so this PR adds some benchmark inputs that really are of different sizes, and the R code uses the results for those to determine the off-diagonal cost.  Graphs of a test run of the benchmarks are shown below and show that our assumption of constant costs away from the diagonal is reasonable..  The off-diagonal costs determined from the new benchmarks aren't significantly different from the old ones, so I haven't changed the cost models.

Benchmark results for `equalsByteString`:
<img width="527" height="468" alt="equalsByteString" src="https://github.com/user-attachments/assets/e0fbe32f-1730-43e1-b724-f4aa8cf6d1e4" />

Benchmark results for `equalsString`:
<img width="544" height="478" alt="equalsString" src="https://github.com/user-attachments/assets/38678685-e450-45bb-9b35-d8b3d847fe36" />
