### PR TITLE
ci: harden workflows against script injection + fix draft-PR filtering

### DIFF
--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -43,6 +43,7 @@ jobs:
               const newFiles = (process.env.ADDED_FILES || "").trim().split(' ');
               // We check that added_files is the singleton array containing the empty string.
               // This is likely an output-format quirk of step-security/changed-files.
+              if (newFiles.length === 1 && newFiles[0] === "") {
                 return [];
               } else {
                 return newFiles;

--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -30,14 +30,17 @@ jobs:
       - name: Enforce Label
         uses: actions/github-script@v7.1.0
         if: github.event.pull_request.draft == false
+        env:
+          ADDED_FILES: ${{ steps.changed-files.outputs.added_files }}
+          HAS_NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'No Changelog Required') }}
         with:
-          script: | 
+          script: |
             function shouldCheckChangelog() {
-              return !${{ contains(github.event.pull_request.labels.*.name, 'No Changelog Required') }};
+              return process.env.HAS_NO_CHANGELOG_LABEL !== "true";
             }
 
             function getNewChangelogFiles() {
-              const newFiles = '${{ steps.changed-files.outputs.added_files }}'.trim().split(' ');
+              const newFiles = (process.env.ADDED_FILES || "").trim().split(' ');
               // We check that added_files is the singleton array containing the empty string.
               // This is probably a bug in tj-actions/changed-files
               if (newFiles.length === 1 && newFiles[0] === "") {

--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -42,8 +42,7 @@ jobs:
             function getNewChangelogFiles() {
               const newFiles = (process.env.ADDED_FILES || "").trim().split(' ');
               // We check that added_files is the singleton array containing the empty string.
-              // This is probably a bug in tj-actions/changed-files
-              if (newFiles.length === 1 && newFiles[0] === "") {
+              // This is likely an output-format quirk of step-security/changed-files.
                 return [];
               } else {
                 return newFiles;

--- a/.github/workflows/compare-golden-budgets.yaml
+++ b/.github/workflows/compare-golden-budgets.yaml
@@ -22,7 +22,9 @@ jobs:
         run: chmod +x scripts/eval-percent-diff.sh
 
       - name: Run the bash script and capture output
-        run: ./scripts/eval-percent-diff.sh -t ${{ github.event.pull_request.base.sha }} 2>&1 | tee output.log
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./scripts/eval-percent-diff.sh -t "$BASE_SHA" 2>&1 | tee output.log
 
       - name: Comment script output on PR
         uses: actions/github-script@v7

--- a/.github/workflows/docusaurus-site.yml
+++ b/.github/workflows/docusaurus-site.yml
@@ -45,11 +45,12 @@ jobs:
           target-folder: docs
           single-commit: true
 
-      - name: Build Preview Site 
+      - name: Build Preview Site
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
         working-directory: doc/docusaurus
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}" 
           # These match the URL expected by rossjrw/pr-preview-action@v1.6.2:
           export DOCUSAURUS_URL="https://plutus.cardano.intersectmbo.org"
           export DOCUSAURUS_BASE_URL="/pr-preview/docs/pr-${PR_NUMBER}"

--- a/.github/workflows/haddock-site.yml
+++ b/.github/workflows/haddock-site.yml
@@ -100,11 +100,6 @@ jobs:
         env:
           SCRIPT_REF: ${{ inputs.script_ref || github.ref_name }}
         run: |
-          # Validate the ref before handing it to git. It must look like a normal
-          # branch/tag/sha and must not be parseable as a command-line option
-          # (no leading '-'), to prevent git argument injection on the self-hosted
-          # runner. Defence in depth: --end-of-options stops option parsing, and
-          # 'checkout <tree-ish> -- <path>' keeps the path from being misread.
           if ! printf '%s' "$SCRIPT_REF" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9._/-]*$'; then
             echo "::error::Invalid script_ref '$SCRIPT_REF' (must match ^[A-Za-z0-9_][A-Za-z0-9._/-]*\$)"
             exit 1

--- a/.github/workflows/haddock-site.yml
+++ b/.github/workflows/haddock-site.yml
@@ -100,8 +100,17 @@ jobs:
         env:
           SCRIPT_REF: ${{ inputs.script_ref || github.ref_name }}
         run: |
-          git fetch origin "$SCRIPT_REF"
-          git checkout "origin/$SCRIPT_REF" ./scripts/combined-haddock.sh
+          # Validate the ref before handing it to git. It must look like a normal
+          # branch/tag/sha and must not be parseable as a command-line option
+          # (no leading '-'), to prevent git argument injection on the self-hosted
+          # runner. Defence in depth: --end-of-options stops option parsing, and
+          # 'checkout <tree-ish> -- <path>' keeps the path from being misread.
+          if ! printf '%s' "$SCRIPT_REF" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9._/-]*$'; then
+            echo "::error::Invalid script_ref '$SCRIPT_REF' (must match ^[A-Za-z0-9_][A-Za-z0-9._/-]*\$)"
+            exit 1
+          fi
+          git fetch origin --end-of-options "$SCRIPT_REF"
+          git checkout "origin/$SCRIPT_REF" -- ./scripts/combined-haddock.sh
             
       - name: Build Site
         run: | 

--- a/.github/workflows/haddock-site.yml
+++ b/.github/workflows/haddock-site.yml
@@ -97,9 +97,11 @@ jobs:
           ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Checkout Haddock Script
-        run: | 
-          git fetch origin ${{ inputs.script_ref || github.ref_name }}
-          git checkout origin/${{ inputs.script_ref || github.ref_name }} ./scripts/combined-haddock.sh
+        env:
+          SCRIPT_REF: ${{ inputs.script_ref || github.ref_name }}
+        run: |
+          git fetch origin "$SCRIPT_REF"
+          git checkout "origin/$SCRIPT_REF" ./scripts/combined-haddock.sh
             
       - name: Build Site
         run: | 

--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -95,11 +95,6 @@ jobs:
             const isCheckRunEvent = eventName === "check_run";
 
 
-            // The check_run / workflow_run payloads only carry a *minimal* pull
-            // request object (url, id, number, head, base) with no `draft` field,
-            // so we must fetch the PR to learn whether it is a draft. Fork PRs are
-            // not included in these arrays at all (the array is empty), in which
-            // case we treat it as non-draft and let the notification through.
             async function isDraftPullRequest() {
               const event = isWorkflowRunEvent ? context.payload.workflow_run
                           : isCheckRunEvent ? context.payload.check_run

--- a/.github/workflows/slack-message-broker.yml
+++ b/.github/workflows/slack-message-broker.yml
@@ -1,4 +1,4 @@
-# This workflow sends a message to the plutus-ci channel whenever a status check fails, 
+# This workflow sends a message to the plutus-ci channel whenever a status check fails,
 # and tried to notify the author of the commit that caused the failure.
 #
 # This workflow triggers whenever a workflow run or a check run is completed.
@@ -9,12 +9,12 @@ on:
   check_run:
     types: [completed]
   workflow_run:
-    workflows: 
+    workflows:
       - "🔗 Broken Links"
       - "👷 Cabal Build All"
       - "🗽 Cardano Constitution Tests"
       - "💰 Cost Model Benchmark"
-      - "🦕 Docusaurus Site" 
+      - "🦕 Docusaurus Site"
       - "📜 Haddock Site"
       - "🩺 Longitudinal Benchmark"
       - "🔮 Metatheory Site"
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   Send:
@@ -34,15 +35,26 @@ jobs:
       - name: Prepare Slack Message
         uses: actions/github-script@v7.1.0
         id: prepare-slack-message
-
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          WORKFLOW_NAME: ${{ github.event.workflow.name }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_RUN_STATUS: ${{ github.event.workflow_run.status }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          CHECK_RUN_NAME: ${{ github.event.check_run.name }}
+          CHECK_RUN_STATUS: ${{ github.event.check_run.status }}
+          CHECK_RUN_CONCLUSION: ${{ github.event.check_run.conclusion }}
+          CHECK_RUN_URL: ${{ github.event.check_run.html_url }}
         with:
-          script: | 
-            console.log(${{ toJson(github.event) }});
+          script: |
+            console.log(JSON.stringify(context.payload));
 
 
             function getSlackMembersToBeNotified() {
-              const senderLogin = "${{ github.event.sender.login }}";
-              const workflowName = "${{ github.event.workflow.name }}";
+              const senderLogin = process.env.SENDER_LOGIN;
+              const workflowName = process.env.WORKFLOW_NAME;
 
               const slackMemberIds = {
                 "zeme-wana": ["U03HGDNDRKR"],
@@ -77,40 +89,58 @@ jobs:
               }
             }
 
-                              
-            const isWorkflowRunEvent = "${{ github.event_name }}" == "workflow_run";
-            const isCheckRunEvent = "${{ github.event_name }}" == "check_run";
 
-            
-            function isDraftPullRequest() {
-              const workflowRunPrIsNull = "${{ github.event.workflow_run.pull_requests == null }}" === "true";
-              const isDraftPrWorkflowRun = "${{ github.event.workflow_run.pull_requests[0][0].draft }}" === "true";
+            const eventName = process.env.EVENT_NAME;
+            const isWorkflowRunEvent = eventName === "workflow_run";
+            const isCheckRunEvent = eventName === "check_run";
 
-              const checkRunPrIsNull = "${{ github.event.check_run.pull_requests == null }}" === "true";
-              const isDraftPrCheckRun = "${{ github.event.check_run.pull_requests[0][0].draft }}" === "true";
+
+            // The check_run / workflow_run payloads only carry a *minimal* pull
+            // request object (url, id, number, head, base) with no `draft` field,
+            // so we must fetch the PR to learn whether it is a draft. Fork PRs are
+            // not included in these arrays at all (the array is empty), in which
+            // case we treat it as non-draft and let the notification through.
+            async function isDraftPullRequest() {
+              const event = isWorkflowRunEvent ? context.payload.workflow_run
+                          : isCheckRunEvent ? context.payload.check_run
+                          : null;
+              const pr = event && event.pull_requests && event.pull_requests[0];
 
               console.log(`isWorkflowRunEvent:  ${isWorkflowRunEvent}`);
               console.log(`isCheckRunEvent:  ${isCheckRunEvent}`);
-              console.log(`workflowRunPrIsNull:  ${workflowRunPrIsNull}`);
-              console.log(`checkRunPrIsNull:  ${checkRunPrIsNull}`);
-              console.log(`isDraftPrWorkflowRun:  ${isDraftPrWorkflowRun}`);
-              console.log(`isDraftPrCheckRun:  ${isDraftPrCheckRun}`);
 
-              return isDraftPrWorkflowRun || isDraftPrCheckRun;
+              if (!pr) {
+                console.log("No associated pull request; treating as non-draft.");
+                return false;
+              }
+
+              try {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                console.log(`PR #${pr.number} draft:  ${data.draft}`);
+                return data.draft === true;
+              } catch (error) {
+                // Fail open: if we cannot determine draft status, send the message.
+                console.log(`Could not fetch PR #${pr.number}:  ${error}`);
+                return false;
+              }
             }
 
             const slackMembers = getSlackMembersToBeNotified();
-            const isDraftPR = isDraftPullRequest();
+            const isDraftPR = await isDraftPullRequest();
 
             let message;
             let shouldSendMessage;
-            
-         
+
+
             function handleWorkflowRunEvent() {
-              const name = "${{ github.event.workflow_run.name }}";
-              const url = "${{ github.event.workflow_run.html_url }}";
-              const status = "${{ github.event.workflow_run.status }}";
-              const conclusion = "${{ github.event.workflow_run.conclusion }}";
+              const name = process.env.WORKFLOW_RUN_NAME;
+              const url = process.env.WORKFLOW_RUN_URL;
+              const status = process.env.WORKFLOW_RUN_STATUS;
+              const conclusion = process.env.WORKFLOW_RUN_CONCLUSION;
               const failureConclusions = [ "failure", "null", "action_required", "neutral", "timed_out" ];
 
               if (failureConclusions.includes(conclusion)) {
@@ -124,10 +154,10 @@ jobs:
 
 
             function handleCheckRunEvent() {
-              const name = "${{ github.event.check_run.name }}";
-              const status = "${{ github.event.check_run.status }}";
-              const conclusion = "${{ github.event.check_run.conclusion }}";
-              const url = "${{ github.event.check_run.html_url }}";
+              const name = process.env.CHECK_RUN_NAME;
+              const status = process.env.CHECK_RUN_STATUS;
+              const conclusion = process.env.CHECK_RUN_CONCLUSION;
+              const url = process.env.CHECK_RUN_URL;
 
               const checkRunWatchlist = [
                 "ci/hydra-build:aarch64-darwin.required",
@@ -135,7 +165,7 @@ jobs:
                 "ci/eval"
               ];
 
-              if (conclusion == "failure" && checkRunWatchlist.includes(name)) {
+              if (conclusion === "failure" && checkRunWatchlist.includes(name)) {
                 message = `❌ ${name} \`${conclusion}\` <${url}|View Logs> ${slackMembers}`;
                 shouldSendMessage = true;
               } else {
@@ -145,20 +175,23 @@ jobs:
             }
 
 
-            if (!isDraftPR && isWorkflowRunEvent) { 
+            if (isDraftPR) {
+              message = `Draft PR, skipping notification: ${eventName}`;
+              shouldSendMessage = false;
+            } else if (isWorkflowRunEvent) {
               handleWorkflowRunEvent();
-            } else if (!isDraftPR && isCheckRunEvent) { 
+            } else if (isCheckRunEvent) {
               handleCheckRunEvent();
             } else {
-              message = `Unknown event or draft PR: ${{ github.event_name }}`;
+              message = `Unknown event: ${eventName}`;
               shouldSendMessage = true;
             }
 
             console.log(`message:  ${message}`);
             console.log(`shouldSendMessage:  ${shouldSendMessage}`);
 
-            core.setOutput("message", message); 
-            core.setOutput("shouldSendMessage", shouldSendMessage); 
+            core.setOutput("message", message);
+            core.setOutput("shouldSendMessage", shouldSendMessage);
 
 
       - name: Notify Slack


### PR DESCRIPTION
Several workflows interpolated untrusted `${{ github.event.* }}` values (and step outputs) directly into `github-script` bodies and shell `run:` blocks.  The fix is to pass these values through `env:` and read them as inert data: `process.env.X` in JS, quoted `"$X"` in shell.
