### PR TITLE
Make default builtins 32-bit-correct (wasm32): bounds-check index/length narrowing

### DIFF
--- a/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Bitwise.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UnboxedTuples #-}
+
+#include "MachDeps.h"
 
 {-| Implementations for CIP-121, CIP-122 and CIP-123. Grouped because they all operate on
 'ByteString's, and require similar functionality. -}
@@ -57,7 +60,9 @@ import GHC.Exts
   , intToInt8#
   , isTrue#
   , neWord8#
+#if WORD_SIZE_IN_BITS == 64
   , quotInt#
+#endif
   , quotRemInt#
   , sizeofByteArray#
   , word2Int#
@@ -170,7 +175,16 @@ unsafeIntegerToByteString requestedByteOrder requestedLength input = case input 
           -- can then figure out the number of unused bytes (all-zero)
           -- by taking the quotient of the leading zero count by 8.
           let counted# = clz# (int2Word# i#)
+#if WORD_SIZE_IN_BITS == 64
               minLength = 8 - I# (quotInt# (word2Int# counted#) 8#)
+#else
+              -- `clz#` counts leading zeroes of the platform word, so the
+              -- unused byte count must be derived from the actual word size
+              -- rather than a hardcoded 8 bytes.
+              wordSizeInBits = Bits.finiteBitSize (0 :: Int)
+              bitLength = wordSizeInBits - I# (word2Int# counted#)
+              minLength = (bitLength + 7) `quot` 8
+#endif
            in if
                 | requestedLength == 0 -> Right (mkSmall minLength i#)
                 | requestedLength < minLength -> Left NotEnoughDigits
@@ -509,6 +523,7 @@ complementByteString bs = unsafeDupablePerformIO . BS.useAsCStringLen bs $ \(src
 {-# INLINEABLE complementByteString #-}
 
 -- | Bit read at index, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122)
+#if WORD_SIZE_IN_BITS == 64
 readBit :: ByteString -> Int -> BuiltinResult Bool
 readBit bs ix
   | ix < 0 = do
@@ -527,6 +542,30 @@ readBit bs ix
     len :: Int
     len = BS.length bs
 {-# INLINEABLE readBit #-}
+#else
+-- On 32-bit platforms the bit index must be bounds-checked in 'Integer'
+-- space before narrowing to the platform 'Int', which would otherwise wrap.
+readBit :: ByteString -> Integer -> BuiltinResult Bool
+readBit bs ix
+  | ix < 0 = do
+      emit "readBit: index out of bounds"
+      emit $ "Index: " <> (pack . show $ ix)
+      builtinResultFailure
+  | ix >= toInteger len * 8 = do
+      emit "readBit: index out of bounds"
+      emit $ "Index: " <> (pack . show $ ix)
+      builtinResultFailure
+  | otherwise = do
+      let (bigIxInteger, littleIxInteger) = ix `quotRem` 8
+      let bigIx = fromInteger bigIxInteger
+      let littleIx = fromInteger littleIxInteger
+      let flipIx = len - bigIx - 1
+      pure $ Bits.testBit (BS.index bs flipIx) littleIx
+  where
+    len :: Int
+    len = BS.length bs
+{-# INLINEABLE readBit #-}
+#endif
 
 -- | Bulk bit write, as per [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122)
 writeBits :: ByteString -> [Integer] -> Bool -> BuiltinResult ByteString

--- a/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
+++ b/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+#include "MachDeps.h"
+
 module PlutusCore.Default.Builtins where
 
 import PlutusPrelude
@@ -1065,6 +1067,36 @@ throw an "operational" evaluation error). Please respect the distinction when ad
 functions.
 -}
 
+#if WORD_SIZE_IN_BITS != 64
+-- On 32-bit platforms indices and lengths must be bounds-checked in
+-- 'Integer' space before narrowing to the platform 'Int', which would
+-- otherwise wrap. On 64-bit platforms the original denotations are
+-- compiled unchanged.
+boundedByteStringLength :: Integer -> Int
+boundedByteStringLength n
+  | n <= 0 = 0
+  | n > toInteger (maxBound :: Int) = maxBound
+  | otherwise = fromInteger n
+{-# INLINE boundedByteStringLength #-}
+
+sliceByteStringInteger :: Integer -> Integer -> BS.ByteString -> BS.ByteString
+sliceByteStringInteger start n xs
+  | n <= 0 = mempty
+  | start >= inputLength = mempty
+  | start <= 0 = BS.take takeLength xs
+  | otherwise = BS.take takeLength . BS.drop (fromInteger start) $ xs
+  where
+    inputLength = toInteger $ BS.length xs
+    takeLength = boundedByteStringLength n
+{-# INLINE sliceByteStringInteger #-}
+
+indexByteStringInteger :: BS.ByteString -> Integer -> BuiltinResult Word8
+indexByteStringInteger xs n
+  | n < 0 || n >= toInteger (BS.length xs) = fail "Index out of bounds"
+  | otherwise = pure . BS.index xs $ fromInteger n
+{-# INLINE indexByteStringInteger #-}
+#endif
+
 instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
   type CostingPart uni DefaultFun = BuiltinCostModel
 
@@ -1299,6 +1331,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
           DefaultFunSemanticsVariantD -> consByteStringMeaning_V1
           DefaultFunSemanticsVariantE -> consByteStringMeaning_V2
   toBuiltinMeaning semvar SliceByteString
+#if WORD_SIZE_IN_BITS == 64
     | ensurable semvar =
         let sliceByteStringD :: Int -> Int -> CByteString -> BS.ByteString
             sliceByteStringD start n (CByteString xs) = BS.take n (BS.drop start xs)
@@ -1313,6 +1346,22 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
          in makeBuiltinMeaning
               sliceByteStringD
               (runCostingFunThreeArguments . paramSliceByteString)
+#else
+    | ensurable semvar =
+        let sliceByteStringD :: Integer -> Integer -> CByteString -> BS.ByteString
+            sliceByteStringD start n (CByteString xs) = sliceByteStringInteger start n xs
+            {-# INLINE sliceByteStringD #-}
+         in makeBuiltinMeaning
+              sliceByteStringD
+              (runCostingFunThreeArguments . paramSliceByteString)
+    | otherwise =
+        let sliceByteStringD :: Integer -> Integer -> BS.ByteString -> BS.ByteString
+            sliceByteStringD = sliceByteStringInteger
+            {-# INLINE sliceByteStringD #-}
+         in makeBuiltinMeaning
+              sliceByteStringD
+              (runCostingFunThreeArguments . paramSliceByteString)
+#endif
   toBuiltinMeaning _semvar LengthOfByteString =
     let lengthOfByteStringD :: BS.ByteString -> BuiltinResult Int
         lengthOfByteStringD = pure . BS.length
@@ -1321,6 +1370,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
           lengthOfByteStringD
           (runCostingFunOneArgument . paramLengthOfByteString)
   toBuiltinMeaning semvar IndexByteString
+#if WORD_SIZE_IN_BITS == 64
     | ensurable semvar =
         let indexByteStringD :: CByteString -> Int -> BuiltinResult Word8
             indexByteStringD (CByteString xs) n =
@@ -1340,6 +1390,26 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
          in makeBuiltinMeaning
               indexByteStringD
               (runCostingFunTwoArguments . paramIndexByteString)
+#else
+    | ensurable semvar =
+        let indexByteStringD :: CByteString -> Integer -> BuiltinResult Word8
+            indexByteStringD (CByteString xs) n =
+              -- See Note [Structural vs operational errors within builtins].
+              -- The arguments are going to be printed in the "cause" part of the error
+              -- message, so we don't need to repeat them here.
+              indexByteStringInteger xs n
+            {-# INLINE indexByteStringD #-}
+         in makeBuiltinMeaning
+              indexByteStringD
+              (runCostingFunTwoArguments . paramIndexByteString)
+    | otherwise =
+        let indexByteStringD :: BS.ByteString -> Integer -> BuiltinResult Word8
+            indexByteStringD = indexByteStringInteger
+            {-# INLINE indexByteStringD #-}
+         in makeBuiltinMeaning
+              indexByteStringD
+              (runCostingFunTwoArguments . paramIndexByteString)
+#endif
   toBuiltinMeaning semvar EqualsByteString
     | ensurable semvar =
         let equalsByteStringD :: CByteString -> CByteString -> Bool
@@ -2174,6 +2244,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
   -- Bitwise operations
 
   toBuiltinMeaning semvar ReadBit
+#if WORD_SIZE_IN_BITS == 64
     | ensurable semvar =
         let readBitD :: CByteString -> Int -> BuiltinResult Bool
             readBitD (CByteString xs) = Bitwise.readBit xs
@@ -2188,6 +2259,22 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
          in makeBuiltinMeaning
               readBitD
               (runCostingFunTwoArguments . paramReadBit)
+#else
+    | ensurable semvar =
+        let readBitD :: CByteString -> Integer -> BuiltinResult Bool
+            readBitD (CByteString xs) = Bitwise.readBit xs
+            {-# INLINE readBitD #-}
+         in makeBuiltinMeaning
+              readBitD
+              (runCostingFunTwoArguments . paramReadBit)
+    | otherwise =
+        let readBitD :: BS.ByteString -> Integer -> BuiltinResult Bool
+            readBitD = Bitwise.readBit
+            {-# INLINE readBitD #-}
+         in makeBuiltinMeaning
+              readBitD
+              (runCostingFunTwoArguments . paramReadBit)
+#endif
   toBuiltinMeaning semvar WriteBits
     | ensurable semvar =
         let writeBitsD
@@ -2385,6 +2472,7 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
         {-# INLINE listToArrayDenotation #-}
      in makeBuiltinMeaning listToArrayDenotation (runCostingFunOneArgument . paramListToArray)
   toBuiltinMeaning _semvar IndexArray =
+#if WORD_SIZE_IN_BITS == 64
     let indexArrayDenotation :: SomeConstant uni (Vector a) -> Int -> BuiltinResult (Opaque val a)
         indexArrayDenotation (SomeConstant (Some (ValueOf uni vec))) n =
           case uni of
@@ -2392,6 +2480,14 @@ instance uni ~ DefaultUni => ToBuiltinMeaning uni DefaultFun where
               case vec Vector.!? n of
                 Nothing -> fail "Array index out of bounds"
                 Just el -> pure $ fromValueOf arg el
+#else
+    let indexArrayDenotation :: SomeConstant uni (Vector a) -> Integer -> BuiltinResult (Opaque val a)
+        indexArrayDenotation (SomeConstant (Some (ValueOf uni vec))) n =
+          case uni of
+            DefaultUniArray arg
+              | n < 0 || n >= toInteger (Vector.length vec) -> fail "Array index out of bounds"
+              | otherwise -> pure . fromValueOf arg $ vec Vector.! fromInteger n
+#endif
             _ ->
               -- See Note [Structural vs operational errors within builtins].
               -- The arguments are going to be printed in the "cause" part of the error

--- a/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
+++ b/plutus-core/untyped-plutus-core/testlib/Evaluation/Builtins/Definition.hs
@@ -426,6 +426,12 @@ test_BuiltinArray =
             term = mkIterAppNoAnn (tyInst () (builtin () IndexArray) integer) [arrayOfInts, index]
         typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
           @?= Right (EvaluationSuccess expectedValue)
+    , testCase "indexArray-large-word32-index" do
+        let arrayOfInts = mkConstant @(Vector Integer) @DefaultUni () (Vector.fromList [1 .. 10])
+        let index = mkConstant @Integer @DefaultUni () (2 ^ (32 :: Integer) + 1)
+            term = mkIterAppNoAnn (tyInst () (builtin () IndexArray) integer) [arrayOfInts, index]
+        typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting term
+          @?= Right EvaluationFailure
     ]
 
 test_BuiltinPair :: TestTree
@@ -671,6 +677,20 @@ fails fileName fun typeArgs termArgs = do
                     , map pretty logs
                     ]
 
+evaluatesToFailure
+  :: String
+  -> DefaultFun
+  -> [Type TyName DefaultUni ()]
+  -> [Term TyName Name DefaultUni DefaultFun ()]
+  -> TestNested
+evaluatesToFailure testName fun typeArgs termArgs =
+  embed . testCase testName $
+    Right EvaluationFailure
+      @=? typecheckEvaluateCekNoEmit
+        def
+        defaultBuiltinCostModelForTesting
+        (mkIterAppNoAnn (mkIterInstNoAnn (builtin () fun) typeArgs) termArgs)
+
 -- | Test all integer related builtins
 test_Integer :: TestNested
 test_Integer = testNestedM "Integer" $ do
@@ -793,6 +813,24 @@ test_String = testNestedM "String" $ do
     SliceByteString
     []
     [cons @Integer 6, cons @Integer 5, cons @ByteString "hello world"]
+  let aboveInt32 = 2 ^ (31 :: Integer) + 1
+      aboveWord32 = 2 ^ (32 :: Integer) + 1
+      sampleBytes = pack [0x42, 0x99]
+  evals @ByteString
+    sampleBytes
+    SliceByteString
+    []
+    [cons @Integer 0, cons @Integer aboveWord32, cons @ByteString sampleBytes]
+  evals @ByteString
+    mempty
+    SliceByteString
+    []
+    [cons @Integer aboveInt32, cons @Integer 1, cons @ByteString sampleBytes]
+  evals @ByteString
+    mempty
+    SliceByteString
+    []
+    [cons @Integer aboveWord32, cons @Integer 1, cons @ByteString sampleBytes]
 
   evals @Integer 11 LengthOfByteString [] [cons @ByteString "hello world"]
   evals @Integer 0 LengthOfByteString [] [cons @ByteString ""]
@@ -805,11 +843,21 @@ test_String = testNestedM "String" $ do
     IndexByteString
     []
     [cons @ByteString "hello world", cons @Integer 12]
+  evaluatesToFailure
+    "indexByteString-large-word32-index"
+    IndexByteString
+    []
+    [cons @ByteString sampleBytes, cons @Integer aboveWord32]
   fails
     "indexByteString-out-of-bounds-empty"
     IndexByteString
     []
     [cons @ByteString "", cons @Integer 0]
+  evaluatesToFailure
+    "readBit-large-word32-index"
+    ReadBit
+    []
+    [cons @ByteString (pack [0x02]), cons @Integer aboveWord32]
 
 test_MatchList :: MatchOption -> TestNested
 test_MatchList optMatch = testNestedM "MatchList" $ do
@@ -1867,6 +1915,16 @@ test_Conversion =
             . mapTestLimitAtLeast 50 (`div` 20)
             $ property Conversion.i2bProperty7
         , testGroup "CIP-121 examples" Conversion.i2bCipExamples
+        , testCase "small positive integer minimal bytes" do
+            let expected = cons @ByteString (pack [0x01])
+                mkTerm endianness =
+                  mkIterAppNoAnn
+                    (builtin () IntegerToByteString)
+                    [cons @Bool endianness, cons @Integer 0, cons @Integer 1]
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting (mkTerm True)
+              @?= Right (EvaluationSuccess expected)
+            typecheckEvaluateCekNoEmit def defaultBuiltinCostModelForTesting (mkTerm False)
+              @?= Right (EvaluationSuccess expected)
         , testGroup "Tests for integerToByteString size limit" Conversion.i2bLimitTests
         ]
     , testGroup

--- a/plutus-tx/src/PlutusTx/Builtins/Internal.hs
+++ b/plutus-tx/src/PlutusTx/Builtins/Internal.hs
@@ -1,9 +1,12 @@
 -- editorconfig-checker-disable-file
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
+
+#include "MachDeps.h"
 -- This ensures that we don't put *anything* about these functions into the interface
 -- file, otherwise GHC can be clever about the ones that are always error, even though
 -- they're OPAQUE!
@@ -250,9 +253,35 @@ consByteString n (BuiltinByteString b) = BuiltinByteString $ BS.cons (fromIntegr
 {-| Slices the given bytestring and never fails. The first integer marks the beginning index and the
   second marks the end. Indices are expected to be 0-indexed, and when the first integer is greater
   than the second, it returns an empty bytestring. -}
+#if WORD_SIZE_IN_BITS == 64
 sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
 sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ BS.take (fromIntegral n) (BS.drop (fromIntegral start) b)
 {-# OPAQUE sliceByteString #-}
+#else
+-- On 32-bit platforms indices and lengths must be bounds-checked in 'Integer'
+-- space before narrowing to the platform 'Int', which would otherwise wrap.
+sliceByteString :: BuiltinInteger -> BuiltinInteger -> BuiltinByteString -> BuiltinByteString
+sliceByteString start n (BuiltinByteString b) = BuiltinByteString $ sliceByteStringInteger start n b
+{-# OPAQUE sliceByteString #-}
+
+boundedByteStringLength :: Integer -> Int
+boundedByteStringLength n
+  | n <= 0 = 0
+  | n > toInteger (maxBound :: Int) = maxBound
+  | otherwise = fromInteger n
+{-# OPAQUE boundedByteStringLength #-}
+
+sliceByteStringInteger :: Integer -> Integer -> BS.ByteString -> BS.ByteString
+sliceByteStringInteger start n b
+  | n <= 0 = BS.empty
+  | start >= inputLength = BS.empty
+  | start <= 0 = BS.take takeLength b
+  | otherwise = BS.take takeLength . BS.drop (fromInteger start) $ b
+  where
+    inputLength = toInteger $ BS.length b
+    takeLength = boundedByteStringLength n
+{-# OPAQUE sliceByteStringInteger #-}
+#endif
 
 -- | Returns the length of the provided bytestring.
 lengthOfByteString :: BuiltinByteString -> BuiltinInteger
@@ -262,7 +291,13 @@ lengthOfByteString (BuiltinByteString b) = toInteger $ BS.length b
 {-| Returns the n-th byte from the bytestring. Fails if the given index is not in the range @[0..j)@,
   where @j@ is the length of the bytestring. -}
 indexByteString :: BuiltinByteString -> BuiltinInteger -> BuiltinInteger
+#if WORD_SIZE_IN_BITS == 64
 indexByteString (BuiltinByteString b) i = toInteger $ BS.index b (fromInteger i)
+#else
+indexByteString (BuiltinByteString b) i
+  | i < 0 || i >= toInteger (BS.length b) = Haskell.error "indexByteString: index out of bounds"
+  | otherwise = toInteger . BS.index b $ fromInteger i
+#endif
 {-# OPAQUE indexByteString #-}
 
 -- | An empty bytestring.
@@ -672,7 +707,13 @@ listToArray (BuiltinList l) = BuiltinArray (Vector.fromList l)
 {-| Returns the n-th element from the array. Fails if the given index is not in the range @[0..j)@,
   where @j@ is the length of the array. -}
 indexArray :: BuiltinArray a -> BuiltinInteger -> a
+#if WORD_SIZE_IN_BITS == 64
 indexArray (BuiltinArray v) i = v Vector.! fromInteger i
+#else
+indexArray (BuiltinArray v) i
+  | i < 0 || i >= toInteger (Vector.length v) = Haskell.error "indexArray: index out of bounds"
+  | otherwise = v Vector.! fromInteger i
+#endif
 {-# OPAQUE indexArray #-}
 
 {-
@@ -1006,7 +1047,11 @@ readBit
   -> BuiltinInteger
   -> Bool
 readBit (BuiltinByteString bs) i =
+#if WORD_SIZE_IN_BITS == 64
   case Bitwise.readBit bs (fromIntegral i) of
+#else
+  case Bitwise.readBit bs i of
+#endif
     BuiltinFailure logs err ->
       traceAll (logs <> pure (display err)) $
         Haskell.error "readBit errored."
@@ -1136,7 +1181,13 @@ scaleValue c (BuiltinValue val) =
 {-# OPAQUE scaleValue #-}
 
 caseInteger :: Integer -> [a] -> a
+#if WORD_SIZE_IN_BITS == 64
 caseInteger i b = b !! fromIntegral i
+#else
+caseInteger i b
+  | i < 0 || i >= toInteger (length b) = Haskell.error "caseInteger: index out of bounds"
+  | otherwise = b !! fromInteger i
+#endif
 {-# OPAQUE caseInteger #-}
 
 {-| Case matching on a builtin pair. Continuation is needed here to make


### PR DESCRIPTION
Fixes #7808.

Several default builtins narrow an `Integer` index/length to the platform `Int` **before** bounds-checking. On 64-bit targets the narrowing is lossless; on 32-bit targets (notably wasm32, GHC's wasm backend) it wraps, so the same script and arguments can evaluate differently than on a 64-bit node. Affected: `sliceByteString`, `indexByteString`, `readBit`, `indexArray`, `integerToByteString` (hardcoded 8-byte word), and the corresponding PlutusTx wrappers.

### Approach

All changes are gated behind `WORD_SIZE_IN_BITS` (the codebase's existing idiom, cf. `PlutusCore.Default.Universe` and `PlutusCore.Flat.*`):

- **64-bit targets compile the original source unchanged.** No semantics, costing, codegen or golden change on any platform a block producer runs on; there is nothing to re-benchmark.
- On 32-bit targets, indices and lengths are bounds-checked in `Integer` space before narrowing, restoring the 64-bit observable behaviour.

The test cases added to `Evaluation.Builtins.Definition` are unconditional: they pass on 64-bit before and after this change, and fail on an unpatched 32-bit build.

### Verification

- `plutus-core-test`, `untyped-plutus-core-test` and `plutus-tx-test` pass on this branch (x86_64-linux, ghc96) with **no golden changes**.
- The same fix applied to a release base passes the **full `plutus-core-test` suite (2697 tests, `--hedgehog-tests 1000`) cross-compiled to wasm32-wasi and run under wasmtime**, i.e. with `WORD_SIZE_IN_BITS == 32`: https://github.com/lambdasistemi/plutus/tree/wasm32-fixes. The same tree also passes all 37 nix flake-check test suites on x86_64-linux.

Follow-up branches exist that (a) enable building and running the test suites on wasm32 and (b) add a nightly wasm32 CI job; happy to open them as separate PRs if there is interest.
