### PR TITLE
Certifier: count optimization sites for FloatOut

### DIFF
--- a/plutus-metatheory/plutus-metatheory.cabal
+++ b/plutus-metatheory/plutus-metatheory.cabal
@@ -374,6 +374,8 @@ library
     MAlonzo.Code.Untyped.Relation.Binary
     MAlonzo.Code.Untyped.Relation.Binary.Core
     MAlonzo.Code.Untyped.Relation.Binary.Modular
+    MAlonzo.Code.Untyped.Relation.Binary.Modular.Patterns
+    MAlonzo.Code.Untyped.Relation.Binary.Modular.Structures
     MAlonzo.Code.Untyped.Relation.Binary.Properties
     MAlonzo.Code.Untyped.Relation.Binary.Structures
     MAlonzo.Code.Untyped.RenamingSubstitution

--- a/plutus-metatheory/src/CertifierReport.lagda.md
+++ b/plutus-metatheory/src/CertifierReport.lagda.md
@@ -12,7 +12,8 @@ open import VerifiedCompilation.Certificate
 open import VerifiedCompilation.UntypedTranslation
 open import VerifiedCompilation.UInline
 open import VerifiedCompilation.UCaseReduce as CR
-open import Untyped.Relation.Binary.Modular hiding (_+_)
+import VerifiedCompilation.FloatOut as FloatOut
+open import Untyped.Relation.Binary.Modular
 open import Untyped.Relation.Binary.Core renaming (Pointwise to PW)
 open import Untyped
 open import Untyped.RenamingSubstitution using (Sub)
@@ -118,32 +119,6 @@ numSitesInline (case r rs) = numSitesInline r + numSitesInlineᵖʷ rs
 numSitesInlineᵖʷ Pointwise.[] = 0
 numSitesInlineᵖʷ (x Pointwise.∷ xs) = numSitesInline x + numSitesInlineᵖʷ xs
 
-numSitesCaseReduce :
-  ∀ {X} {M N : X ⊢}
-  → M CR.~ N
-  → ℕ
-numSitesCaseReduce* :
-  ∀ {X} {Ms Ns : List (X ⊢)}
-  → PW _~_ Ms Ns
-  → ℕ
-
-numSitesCaseReduce (cr-reduction _)                = 1
-numSitesCaseReduce (cr-trans p q)                  = numSitesCaseReduce p + numSitesCaseReduce q
-numSitesCaseReduce (cr-sym p)                      = numSitesCaseReduce p
-numSitesCaseReduce (cr-refl)                       = 0
-numSitesCaseReduce (cr-compat (compat-varF n))     = 0
-numSitesCaseReduce (cr-compat (compat-lambdaF p))  = numSitesCaseReduce p
-numSitesCaseReduce (cr-compat (compat-applyF p q)) = numSitesCaseReduce p + numSitesCaseReduce q
-numSitesCaseReduce (cr-compat (compat-forceF p))   = numSitesCaseReduce p
-numSitesCaseReduce (cr-compat (compat-delayF p))   = numSitesCaseReduce p
-numSitesCaseReduce (cr-compat (compat-conF))       = 0
-numSitesCaseReduce (cr-compat (compat-constrF ps)) = numSitesCaseReduce* ps
-numSitesCaseReduce (cr-compat (compat-caseF p qs)) = numSitesCaseReduce p + numSitesCaseReduce* qs
-numSitesCaseReduce (cr-compat (compat-builtinF))   = 0
-numSitesCaseReduce (cr-compat (compat-errorF))     = 0
-
-numSitesCaseReduce* [] = 0
-numSitesCaseReduce* (x ∷ xs) = numSitesCaseReduce x + numSitesCaseReduce* xs
 
 numSites : {M N : 0 ⊢} (tag : CertifiedOptTag) → RelationOf (inj₂ tag) M N → ℕ
 numSites forceDelayT p = numSites′ p
@@ -153,7 +128,7 @@ numSites inlineT p = numSitesInline p
 numSites forceCaseDelayT p = numSites′ p
 numSites applyToCaseT p = numSites′ p
 numSites {M = M} caseReduceT p = numSitesCaseReduce (CR.sound {M = M} p)
-numSites letFloatOutT p = 0
+numSites letFloatOutT p = FloatOut.numSites p
 
 showSites : {M N : 0 ⊢} → (tag : OptTag) → RelationOf tag M N → String
 showSites (inj₁ _) _ = ""

--- a/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Certifier.hs
@@ -104,7 +104,7 @@ d_runCertifierMain_10 v0 v1
                           MAlonzo.Code.Utils.C__'44'__450
                           (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                           (coe
-                             MAlonzo.Code.CertifierReport.d_makeReport_334 (coe v2) (coe v1)))
+                             MAlonzo.Code.CertifierReport.d_makeReport_290 (coe v2) (coe v1)))
                 MAlonzo.Code.VerifiedCompilation.C_abort_10 v4
                   -> coe
                        MAlonzo.Code.Agda.Builtin.Maybe.C_just_16
@@ -112,7 +112,7 @@ d_runCertifierMain_10 v0 v1
                           MAlonzo.Code.Utils.C__'44'__450
                           (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
                           (coe
-                             MAlonzo.Code.CertifierReport.d_makeReport_334 (coe v2) (coe v1)))
+                             MAlonzo.Code.CertifierReport.d_makeReport_290 (coe v2) (coe v1)))
                 _ -> MAlonzo.RTE.mazUnreachableError
          MAlonzo.Code.Utils.C_inj'8322'_14 v3
            -> coe
@@ -123,5 +123,5 @@ d_runCertifierMain_10 v0 v1
                       MAlonzo.Code.Utils.C__'44'__450
                       (coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10)
                       (coe
-                         MAlonzo.Code.CertifierReport.d_makeReport_334 (coe v2) (coe v1))))
+                         MAlonzo.Code.CertifierReport.d_makeReport_290 (coe v2) (coe v1))))
          _ -> MAlonzo.RTE.mazUnreachableError)

--- a/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/CertifierReport.hs
@@ -24,11 +24,10 @@ import qualified MAlonzo.Code.Data.List.Relation.Binary.Pointwise.Base
 import qualified MAlonzo.Code.Data.Nat.Show
 import qualified MAlonzo.Code.Data.String.Base
 import qualified MAlonzo.Code.Untyped
-import qualified MAlonzo.Code.Untyped.Relation.Binary.Core
-import qualified MAlonzo.Code.Untyped.Relation.Binary.Modular
 import qualified MAlonzo.Code.Untyped.RenamingSubstitution
 import qualified MAlonzo.Code.Utils
 import qualified MAlonzo.Code.VerifiedCompilation
+import qualified MAlonzo.Code.VerifiedCompilation.FloatOut
 import qualified MAlonzo.Code.VerifiedCompilation.Trace
 import qualified MAlonzo.Code.VerifiedCompilation.UCaseReduce
 import qualified MAlonzo.Code.VerifiedCompilation.UInline
@@ -562,254 +561,13 @@ d_numSitesInline_140 v0 v1 v2 v3 v4 v5 v6 v7
       MAlonzo.Code.VerifiedCompilation.UInline.C_error_292
         -> coe (0 :: Integer)
       _ -> MAlonzo.RTE.mazUnreachableError
--- CertifierReport.numSitesCaseReduce
-d_numSitesCaseReduce_178 ::
-  Integer ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50 -> Integer
-d_numSitesCaseReduce_178 v0 v1 v2 v3
-  = case coe v3 of
-      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_fix_60 v7
-        -> case coe v7 of
-             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v11
-               -> coe (1 :: Integer)
-             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v11
-               -> case coe v11 of
-                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v15
-                      -> case coe v15 of
-                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
-                             -> coe seq (coe v19) (coe (0 :: Integer))
-                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
-                             -> case coe v19 of
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
-                                    -> case coe v23 of
-                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_ƛF_132 v27
-                                           -> case coe v1 of
-                                                MAlonzo.Code.Untyped.C_ƛ_20 v28
-                                                  -> case coe v2 of
-                                                       MAlonzo.Code.Untyped.C_ƛ_20 v29
-                                                         -> coe
-                                                              d_numSitesCaseReduce_178
-                                                              (coe
-                                                                 addInt (coe (1 :: Integer))
-                                                                 (coe v0))
-                                                              (coe v28) (coe v29) (coe v27)
-                                                       _ -> MAlonzo.RTE.mazUnreachableError
-                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v23
-                                    -> case coe v23 of
-                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v27
-                                           -> case coe v27 of
-                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C__'183'F__150 v33 v34
-                                                  -> case coe v1 of
-                                                       MAlonzo.Code.Untyped.C__'183'__22 v35 v36
-                                                         -> case coe v2 of
-                                                              MAlonzo.Code.Untyped.C__'183'__22 v37 v38
-                                                                -> coe
-                                                                     addInt
-                                                                     (coe
-                                                                        d_numSitesCaseReduce_178
-                                                                        (coe v0) (coe v35) (coe v37)
-                                                                        (coe v33))
-                                                                     (coe
-                                                                        d_numSitesCaseReduce_178
-                                                                        (coe v0) (coe v36) (coe v38)
-                                                                        (coe v34))
-                                                              _ -> MAlonzo.RTE.mazUnreachableError
-                                                       _ -> MAlonzo.RTE.mazUnreachableError
-                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v27
-                                           -> case coe v27 of
-                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v31
-                                                  -> case coe v31 of
-                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_forceF_164 v35
-                                                         -> case coe v1 of
-                                                              MAlonzo.Code.Untyped.C_force_24 v36
-                                                                -> case coe v2 of
-                                                                     MAlonzo.Code.Untyped.C_force_24 v37
-                                                                       -> coe
-                                                                            d_numSitesCaseReduce_178
-                                                                            (coe v0) (coe v36)
-                                                                            (coe v37) (coe v35)
-                                                                     _ -> MAlonzo.RTE.mazUnreachableError
-                                                              _ -> MAlonzo.RTE.mazUnreachableError
-                                                       _ -> MAlonzo.RTE.mazUnreachableError
-                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v31
-                                                  -> case coe v31 of
-                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v35
-                                                         -> case coe v35 of
-                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_delayF_178 v39
-                                                                -> case coe v1 of
-                                                                     MAlonzo.Code.Untyped.C_delay_26 v40
-                                                                       -> case coe v2 of
-                                                                            MAlonzo.Code.Untyped.C_delay_26 v41
-                                                                              -> coe
-                                                                                   d_numSitesCaseReduce_178
-                                                                                   (coe v0)
-                                                                                   (coe v40)
-                                                                                   (coe v41)
-                                                                                   (coe v39)
-                                                                            _ -> MAlonzo.RTE.mazUnreachableError
-                                                                     _ -> MAlonzo.RTE.mazUnreachableError
-                                                              _ -> MAlonzo.RTE.mazUnreachableError
-                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v35
-                                                         -> case coe v35 of
-                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v39
-                                                                -> coe
-                                                                     seq (coe v39)
-                                                                     (coe (0 :: Integer))
-                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v39
-                                                                -> case coe v39 of
-                                                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v43
-                                                                       -> case coe v43 of
-                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_constrF_206 v48
-                                                                              -> case coe v1 of
-                                                                                   MAlonzo.Code.Untyped.C_constr_34 v49 v50
-                                                                                     -> case coe
-                                                                                               v2 of
-                                                                                          MAlonzo.Code.Untyped.C_constr_34 v51 v52
-                                                                                            -> coe
-                                                                                                 d_numSitesCaseReduce'42'_186
-                                                                                                 (coe
-                                                                                                    v0)
-                                                                                                 (coe
-                                                                                                    v50)
-                                                                                                 (coe
-                                                                                                    v52)
-                                                                                                 (coe
-                                                                                                    v48)
-                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
-                                                                            _ -> MAlonzo.RTE.mazUnreachableError
-                                                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v43
-                                                                       -> case coe v43 of
-                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v47
-                                                                              -> case coe v47 of
-                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_caseF_224 v53 v54
-                                                                                     -> case coe
-                                                                                               v1 of
-                                                                                          MAlonzo.Code.Untyped.C_case_40 v55 v56
-                                                                                            -> case coe
-                                                                                                      v2 of
-                                                                                                 MAlonzo.Code.Untyped.C_case_40 v57 v58
-                                                                                                   -> coe
-                                                                                                        addInt
-                                                                                                        (coe
-                                                                                                           d_numSitesCaseReduce'42'_186
-                                                                                                           (coe
-                                                                                                              v0)
-                                                                                                           (coe
-                                                                                                              v56)
-                                                                                                           (coe
-                                                                                                              v58)
-                                                                                                           (coe
-                                                                                                              v54))
-                                                                                                        (coe
-                                                                                                           d_numSitesCaseReduce_178
-                                                                                                           (coe
-                                                                                                              v0)
-                                                                                                           (coe
-                                                                                                              v55)
-                                                                                                           (coe
-                                                                                                              v57)
-                                                                                                           (coe
-                                                                                                              v53))
-                                                                                                 _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
-                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v47
-                                                                              -> case coe v47 of
-                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v51
-                                                                                     -> coe
-                                                                                          seq
-                                                                                          (coe v51)
-                                                                                          (coe
-                                                                                             (0 ::
-                                                                                                Integer))
-                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v51
-                                                                                     -> case coe
-                                                                                               v51 of
-                                                                                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v55
-                                                                                            -> coe
-                                                                                                 seq
-                                                                                                 (coe
-                                                                                                    v55)
-                                                                                                 (coe
-                                                                                                    (0 ::
-                                                                                                       Integer))
-                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
-                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
-                                                                            _ -> MAlonzo.RTE.mazUnreachableError
-                                                                     _ -> MAlonzo.RTE.mazUnreachableError
-                                                              _ -> MAlonzo.RTE.mazUnreachableError
-                                                       _ -> MAlonzo.RTE.mazUnreachableError
-                                                _ -> MAlonzo.RTE.mazUnreachableError
-                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                  _ -> MAlonzo.RTE.mazUnreachableError
-                           _ -> MAlonzo.RTE.mazUnreachableError
-                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v15
-                      -> case coe v15 of
-                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
-                             -> case coe v19 of
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_transF_80 v22 v24 v25
-                                    -> coe
-                                         addInt
-                                         (coe
-                                            d_numSitesCaseReduce_178 (coe v0) (coe v1) (coe v22)
-                                            (coe v24))
-                                         (coe
-                                            d_numSitesCaseReduce_178 (coe v0) (coe v22) (coe v2)
-                                            (coe v25))
-                                  _ -> MAlonzo.RTE.mazUnreachableError
-                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
-                             -> case coe v19 of
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
-                                    -> case coe v23 of
-                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_symF_94 v27
-                                           -> coe
-                                                d_numSitesCaseReduce_178 (coe v0) (coe v2) (coe v1)
-                                                (coe v27)
-                                         _ -> MAlonzo.RTE.mazUnreachableError
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v23
-                                    -> coe seq (coe v23) (coe (0 :: Integer))
-                                  _ -> MAlonzo.RTE.mazUnreachableError
-                           _ -> MAlonzo.RTE.mazUnreachableError
-                    _ -> MAlonzo.RTE.mazUnreachableError
-             _ -> MAlonzo.RTE.mazUnreachableError
-      _ -> MAlonzo.RTE.mazUnreachableError
--- CertifierReport.numSitesCaseReduce*
-d_numSitesCaseReduce'42'_186 ::
-  Integer ->
-  [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  [MAlonzo.Code.Untyped.T__'8866'_14] ->
-  MAlonzo.Code.Untyped.Relation.Binary.Core.T_Pointwise_20 -> Integer
-d_numSitesCaseReduce'42'_186 v0 v1 v2 v3
-  = case coe v3 of
-      MAlonzo.Code.Untyped.Relation.Binary.Core.C_'91''93'_26
-        -> coe (0 :: Integer)
-      MAlonzo.Code.Untyped.Relation.Binary.Core.C__'8759'__36 v8 v9
-        -> case coe v1 of
-             (:) v10 v11
-               -> case coe v2 of
-                    (:) v12 v13
-                      -> coe
-                           addInt
-                           (coe
-                              d_numSitesCaseReduce'42'_186 (coe v0) (coe v11) (coe v13) (coe v9))
-                           (coe
-                              d_numSitesCaseReduce_178 (coe v0) (coe v10) (coe v12) (coe v8))
-                    _ -> MAlonzo.RTE.mazUnreachableError
-             _ -> MAlonzo.RTE.mazUnreachableError
-      _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.numSites
-d_numSites_222 ::
+d_numSites_178 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny -> Integer
-d_numSites_222 v0 v1 v2 v3
+d_numSites_178 v0 v1 v2 v3
   = case coe v2 of
       MAlonzo.Code.VerifiedCompilation.Trace.C_floatDelayT_14
         -> coe du_numSites'8242'_26 v0 v1 v3
@@ -830,22 +588,25 @@ d_numSites_222 v0 v1 v2 v3
         -> coe du_numSites'8242'_26 v0 v1 v3
       MAlonzo.Code.VerifiedCompilation.Trace.C_caseReduceT_26
         -> coe
-             d_numSitesCaseReduce_178 (coe (0 :: Integer)) (coe v0) (coe v1)
+             MAlonzo.Code.VerifiedCompilation.UCaseReduce.d_numSitesCaseReduce_578
+             (coe (0 :: Integer)) (coe v0) (coe v1)
              (coe
                 MAlonzo.Code.VerifiedCompilation.UCaseReduce.du_sound_568
                 (coe (0 :: Integer)) (coe v0))
       MAlonzo.Code.VerifiedCompilation.Trace.C_letFloatOutT_28
-        -> coe (0 :: Integer)
+        -> coe
+             MAlonzo.Code.VerifiedCompilation.FloatOut.d_numSites_330
+             (coe (0 :: Integer)) (coe v0) (coe v1) (coe v3)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showSites
-d_showSites_248 ::
+d_showSites_204 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.Trace.T_UncertifiedOptTag_4
     MAlonzo.Code.VerifiedCompilation.Trace.T_CertifiedOptTag_12 ->
   AgdaAny -> MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showSites_248 v0 v1 v2 v3
+d_showSites_204 v0 v1 v2 v3
   = case coe v2 of
       MAlonzo.Code.Utils.C_inj'8321'_12 v4 -> coe ("" :: Data.Text.Text)
       MAlonzo.Code.Utils.C_inj'8322'_14 v4
@@ -856,62 +617,62 @@ d_showSites_248 v0 v1 v2 v3
                 ("Optimization sites: " :: Data.Text.Text)
                 (coe
                    MAlonzo.Code.Data.Nat.Show.d_show_56
-                   (d_numSites_222 (coe v0) (coe v1) (coe v4) (coe v3))))
+                   (d_numSites_178 (coe v0) (coe v1) (coe v4) (coe v3))))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.termSize
-d_termSize_256 ::
+d_termSize_212 ::
   Integer -> MAlonzo.Code.Untyped.T__'8866'_14 -> Integer
-d_termSize_256 v0 v1
+d_termSize_212 v0 v1
   = case coe v1 of
       MAlonzo.Code.Untyped.C_'96'_18 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_ƛ_20 v2
         -> coe
              addInt (coe (1 :: Integer))
              (coe
-                d_termSize_256 (coe addInt (coe (1 :: Integer)) (coe v0)) (coe v2))
+                d_termSize_212 (coe addInt (coe (1 :: Integer)) (coe v0)) (coe v2))
       MAlonzo.Code.Untyped.C__'183'__22 v2 v3
         -> coe
              addInt
              (coe
-                addInt (coe (1 :: Integer)) (coe d_termSize_256 (coe v0) (coe v2)))
-             (coe d_termSize_256 (coe v0) (coe v3))
+                addInt (coe (1 :: Integer)) (coe d_termSize_212 (coe v0) (coe v2)))
+             (coe d_termSize_212 (coe v0) (coe v3))
       MAlonzo.Code.Untyped.C_force_24 v2
         -> coe
-             addInt (coe (1 :: Integer)) (coe d_termSize_256 (coe v0) (coe v2))
+             addInt (coe (1 :: Integer)) (coe d_termSize_212 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_delay_26 v2
         -> coe
-             addInt (coe (1 :: Integer)) (coe d_termSize_256 (coe v0) (coe v2))
+             addInt (coe (1 :: Integer)) (coe d_termSize_212 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_con_28 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_constr_34 v2 v3
         -> coe
              addInt (coe (1 :: Integer))
-             (coe d_termSize'7510''695'_260 (coe v0) (coe v3))
+             (coe d_termSize'7510''695'_216 (coe v0) (coe v3))
       MAlonzo.Code.Untyped.C_case_40 v2 v3
         -> coe
              addInt
              (coe
                 addInt (coe (1 :: Integer))
-                (coe d_termSize'7510''695'_260 (coe v0) (coe v3)))
-             (coe d_termSize_256 (coe v0) (coe v2))
+                (coe d_termSize'7510''695'_216 (coe v0) (coe v3)))
+             (coe d_termSize_212 (coe v0) (coe v2))
       MAlonzo.Code.Untyped.C_builtin_44 v2 -> coe (1 :: Integer)
       MAlonzo.Code.Untyped.C_error_46 -> coe (1 :: Integer)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.termSizeᵖʷ
-d_termSize'7510''695'_260 ::
+d_termSize'7510''695'_216 ::
   Integer -> [MAlonzo.Code.Untyped.T__'8866'_14] -> Integer
-d_termSize'7510''695'_260 v0 v1
+d_termSize'7510''695'_216 v0 v1
   = case coe v1 of
       [] -> coe (0 :: Integer)
       (:) v2 v3
         -> coe
-             addInt (coe d_termSize'7510''695'_260 (coe v0) (coe v3))
-             (coe d_termSize_256 (coe v0) (coe v2))
+             addInt (coe d_termSize'7510''695'_216 (coe v0) (coe v3))
+             (coe d_termSize_212 (coe v0) (coe v2))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showEvalResult
-d_showEvalResult_282 ::
+d_showEvalResult_238 ::
   MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showEvalResult_282 v0
+d_showEvalResult_238 v0
   = case coe v0 of
       MAlonzo.Code.VerifiedCompilation.Trace.C_success_124 v1 v2
         -> coe
@@ -944,10 +705,10 @@ d_showEvalResult_282 v0
                             (coe MAlonzo.Code.Data.Nat.Show.d_show_56 v3))))))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.showCostPair
-d_showCostPair_294 ::
+d_showCostPair_250 ::
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_showCostPair_294 v0
+d_showCostPair_250 v0
   = let v1 = "" :: Data.Text.Text in
     coe
       (case coe v0 of
@@ -956,7 +717,7 @@ d_showCostPair_294 v0
                 (:) v4 v5
                   -> coe
                        MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                       (d_showEvalResult_282 (coe v2))
+                       (d_showEvalResult_238 (coe v2))
                        (coe
                           MAlonzo.Code.Data.String.Base.d__'43''43'__20
                           (" (before)" :: Data.Text.Text)
@@ -964,20 +725,20 @@ d_showCostPair_294 v0
                              MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_nl_6
                              (coe
                                 MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                (d_showEvalResult_282 (coe v4)) (" (after)" :: Data.Text.Text))))
+                                (d_showEvalResult_238 (coe v4)) (" (after)" :: Data.Text.Text))))
                 _ -> coe v1
          _ -> coe v1)
 -- CertifierReport.tail
-d_tail_302 :: () -> [AgdaAny] -> [AgdaAny]
-d_tail_302 ~v0 v1 = du_tail_302 v1
-du_tail_302 :: [AgdaAny] -> [AgdaAny]
-du_tail_302 v0
+d_tail_258 :: () -> [AgdaAny] -> [AgdaAny]
+d_tail_258 ~v0 v1 = du_tail_258 v1
+du_tail_258 :: [AgdaAny] -> [AgdaAny]
+du_tail_258 v0
   = case coe v0 of
       [] -> coe v0
       (:) v1 v2 -> coe v2
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportPasses
-d_reportPasses_312 ::
+d_reportPasses_268 ::
   Integer ->
   MAlonzo.Code.VerifiedCompilation.Trace.T_NonEmptySep_90
     (MAlonzo.Code.Utils.T__'215'__436
@@ -989,7 +750,7 @@ d_reportPasses_312 ::
   AgdaAny ->
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_reportPasses_312 v0 v1 v2 v3
+d_reportPasses_268 v0 v1 v2 v3
   = case coe v1 of
       MAlonzo.Code.VerifiedCompilation.Trace.C_cons_96 v4 v5 v6
         -> case coe v5 of
@@ -1020,7 +781,7 @@ d_reportPasses_312 v0 v1 v2 v3
                                                 MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                 (coe
                                                    MAlonzo.Code.Data.Nat.Show.d_show_56
-                                                   (d_termSize_256 (coe (0 :: Integer)) (coe v4)))
+                                                   (d_termSize_212 (coe (0 :: Integer)) (coe v4)))
                                                 (coe
                                                    MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                    (" (before)" :: Data.Text.Text)
@@ -1038,7 +799,7 @@ d_reportPasses_312 v0 v1 v2 v3
                                                             MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                             (coe
                                                                MAlonzo.Code.Data.Nat.Show.d_show_56
-                                                               (d_termSize_256
+                                                               (d_termSize_212
                                                                   (coe (0 :: Integer))
                                                                   (coe
                                                                      MAlonzo.Code.VerifiedCompilation.Trace.d_head_112
@@ -1051,13 +812,13 @@ d_reportPasses_312 v0 v1 v2 v3
                                                                   d_nl_6
                                                                   (coe
                                                                      MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                     (d_showCostPair_294 (coe v3))
+                                                                     (d_showCostPair_250 (coe v3))
                                                                      (coe
                                                                         MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                                         d_nl_6
                                                                         (coe
                                                                            MAlonzo.Code.Data.String.Base.d__'43''43'__20
-                                                                           (d_showSites_248
+                                                                           (d_showSites_204
                                                                               (coe v4)
                                                                               (coe
                                                                                  MAlonzo.Code.VerifiedCompilation.Trace.d_head_112
@@ -1066,7 +827,7 @@ d_reportPasses_312 v0 v1 v2 v3
                                                                            (coe
                                                                               MAlonzo.Code.Data.String.Base.d__'43''43'__20
                                                                               d_nl_6
-                                                                              (d_reportPasses_312
+                                                                              (d_reportPasses_268
                                                                                  (coe
                                                                                     addInt
                                                                                     (coe
@@ -1075,7 +836,7 @@ d_reportPasses_312 v0 v1 v2 v3
                                                                                     (coe v0))
                                                                                  (coe v6) (coe v10)
                                                                                  (coe
-                                                                                    du_tail_302
+                                                                                    du_tail_258
                                                                                     (coe
                                                                                        v3))))))))))))))))))))
                     _ -> MAlonzo.RTE.mazUnreachableError
@@ -1084,10 +845,10 @@ d_reportPasses_312 v0 v1 v2 v3
         -> coe ("" :: Data.Text.Text)
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.reportFailure
-d_reportFailure_328 ::
+d_reportFailure_284 ::
   MAlonzo.Code.VerifiedCompilation.T_Error_2 ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_reportFailure_328 v0
+d_reportFailure_284 v0
   = case coe v0 of
       MAlonzo.Code.VerifiedCompilation.C_emptyDump_4
         -> coe
@@ -1131,24 +892,24 @@ d_reportFailure_328 v0
                       ("  \10060 FAILED" :: Data.Text.Text) d_hl_8)))
       _ -> MAlonzo.RTE.mazUnreachableError
 -- CertifierReport.makeReport
-d_makeReport_334 ::
+d_makeReport_290 ::
   MAlonzo.Code.Utils.T_Either_6
     MAlonzo.Code.VerifiedCompilation.T_Error_2
     MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14 ->
   [MAlonzo.Code.VerifiedCompilation.Trace.T_EvalResult_122] ->
   MAlonzo.Code.Agda.Builtin.String.T_String_6
-d_makeReport_334 v0 v1
+d_makeReport_290 v0 v1
   = coe
       MAlonzo.Code.Data.String.Base.d__'43''43'__20
       ("UPLC OPTIMIZATION: CERTIFIER REPORT" :: Data.Text.Text)
       (coe
          MAlonzo.Code.Data.String.Base.d__'43''43'__20 d_nl_6
          (coe
-            MAlonzo.Code.Utils.du_either_22 (coe v0) (coe d_reportFailure_328)
+            MAlonzo.Code.Utils.du_either_22 (coe v0) (coe d_reportFailure_284)
             (coe
                (\ v2 ->
                   case coe v2 of
                     MAlonzo.Code.Agda.Builtin.Sigma.C__'44'__32 v3 v4
                       -> coe
-                           d_reportPasses_312 (coe (1 :: Integer)) (coe v3) (coe v4) (coe v1)
+                           d_reportPasses_268 (coe (1 :: Integer)) (coe v3) (coe v4) (coe v1)
                     _ -> MAlonzo.RTE.mazUnreachableError))))

--- a/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular.hs
@@ -31,15 +31,14 @@ import qualified MAlonzo.Code.Relation.Nullary.Reflects
 import qualified MAlonzo.Code.Untyped
 import qualified MAlonzo.Code.Untyped.Equality
 import qualified MAlonzo.Code.Untyped.Relation.Binary.Core
-import qualified MAlonzo.Code.Untyped.Relation.Binary.Structures
 import qualified MAlonzo.Code.VerifiedCompilation.UntypedViews
 
 -- Untyped.Relation.Binary.Modular.RelationT
 d_RelationT_8 :: ()
 d_RelationT_8 = erased
--- Untyped.Relation.Binary.Modular._+_
-d__'43'__16 a0 a1 a2 a3 a4 a5 = ()
-data T__'43'__16 = C_inl_30 AgdaAny | C_inr_38 AgdaAny
+-- Untyped.Relation.Binary.Modular._⊕_
+d__'8853'__16 a0 a1 a2 a3 a4 a5 = ()
+data T__'8853'__16 = C_inl_30 AgdaAny | C_inr_38 AgdaAny
 -- Untyped.Relation.Binary.Modular.Empty
 d_Empty_40 ::
   (Integer ->
@@ -116,155 +115,8 @@ d_CompatTerm_248 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 -> ()
 d_CompatTerm_248 = erased
--- Untyped.Relation.Binary.Modular.CompatTerm-TermCompatible
-d_CompatTerm'45'TermCompatible_330 ::
-  (Integer ->
-   MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
-  (Integer ->
-   MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.Untyped.T__'8866'_14 -> T__'43'__16 -> AgdaAny) ->
-  MAlonzo.Code.Untyped.Relation.Binary.Structures.T_TermCompatible_30
-d_CompatTerm'45'TermCompatible_330 ~v0 v1
-  = du_CompatTerm'45'TermCompatible_330 v1
-du_CompatTerm'45'TermCompatible_330 ::
-  (Integer ->
-   MAlonzo.Code.Untyped.T__'8866'_14 ->
-   MAlonzo.Code.Untyped.T__'8866'_14 -> T__'43'__16 -> AgdaAny) ->
-  MAlonzo.Code.Untyped.Relation.Binary.Structures.T_TermCompatible_30
-du_CompatTerm'45'TermCompatible_330 v0
-  = coe
-      MAlonzo.Code.Untyped.Relation.Binary.Structures.C_constructor_150
-      (coe
-         (\ v1 v2 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_'96'_18 (coe v2))
-              (coe MAlonzo.Code.Untyped.C_'96'_18 (coe v2))
-              (coe C_inl_30 (coe C_'96'F__118))))
-      (coe
-         (\ v1 v2 v3 v4 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_ƛ_20 (coe v2))
-              (coe MAlonzo.Code.Untyped.C_ƛ_20 (coe v3))
-              (coe C_inr_38 (coe C_inl_30 (coe C_ƛF_132 v4)))))
-      (coe
-         (\ v1 v2 v3 v4 v5 v6 v7 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v2) (coe v4))
-              (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v3) (coe v5))
-              (coe
-                 C_inr_38
-                 (coe C_inr_38 (coe C_inl_30 (coe C__'183'F__150 v6 v7))))))
-      (coe
-         (\ v1 v2 v3 v4 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_force_24 (coe v2))
-              (coe MAlonzo.Code.Untyped.C_force_24 (coe v3))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38 (coe C_inr_38 (coe C_inl_30 (coe C_forceF_164 v4)))))))
-      (coe
-         (\ v1 v2 v3 v4 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_delay_26 (coe v2))
-              (coe MAlonzo.Code.Untyped.C_delay_26 (coe v3))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38 (coe C_inr_38 (coe C_inl_30 (coe C_delayF_178 v4))))))))
-      (coe
-         (\ v1 v2 v3 v4 v5 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_constr_34 (coe v2) (coe v3))
-              (coe MAlonzo.Code.Untyped.C_constr_34 (coe v2) (coe v4))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38
-                       (coe
-                          C_inr_38
-                          (coe
-                             C_inr_38
-                             (coe C_inr_38 (coe C_inl_30 (coe C_constrF_206 v5))))))))))
-      (coe
-         (\ v1 v2 v3 v4 v5 v6 v7 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_case_40 (coe v2) (coe v4))
-              (coe MAlonzo.Code.Untyped.C_case_40 (coe v3) (coe v5))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38
-                       (coe
-                          C_inr_38
-                          (coe
-                             C_inr_38
-                             (coe
-                                C_inr_38
-                                (coe C_inr_38 (coe C_inl_30 (coe C_caseF_224 v6 v7)))))))))))
-      (coe
-         (\ v1 v2 ->
-            coe
-              v0 v2 (coe MAlonzo.Code.Untyped.C_con_28 (coe v1))
-              (coe MAlonzo.Code.Untyped.C_con_28 (coe v1))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38
-                       (coe C_inr_38 (coe C_inr_38 (coe C_inl_30 (coe C_conF_190)))))))))
-      (coe
-         (\ v1 v2 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_builtin_44 (coe v2))
-              (coe MAlonzo.Code.Untyped.C_builtin_44 (coe v2))
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38
-                       (coe
-                          C_inr_38
-                          (coe
-                             C_inr_38
-                             (coe
-                                C_inr_38
-                                (coe
-                                   C_inr_38
-                                   (coe C_inr_38 (coe C_inl_30 (coe C_builtinF_236))))))))))))
-      (coe
-         (\ v1 ->
-            coe
-              v0 v1 (coe MAlonzo.Code.Untyped.C_error_46)
-              (coe MAlonzo.Code.Untyped.C_error_46)
-              (coe
-                 C_inr_38
-                 (coe
-                    C_inr_38
-                    (coe
-                       C_inr_38
-                       (coe
-                          C_inr_38
-                          (coe
-                             C_inr_38
-                             (coe
-                                C_inr_38
-                                (coe
-                                   C_inr_38
-                                   (coe
-                                      C_inr_38
-                                      (coe C_inr_38 (coe C_inl_30 (coe C_errorF_246)))))))))))))
 -- Untyped.Relation.Binary.Modular.DecidableT
-d_DecidableT_350 ::
+d_DecidableT_250 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -272,9 +124,9 @@ d_DecidableT_350 ::
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
   ()
-d_DecidableT_350 = erased
--- Untyped.Relation.Binary.Modular._+-dec_
-d__'43''45'dec__360 ::
+d_DecidableT_250 = erased
+-- Untyped.Relation.Binary.Modular._⊕-dec_
+d__'8853''45'dec__260 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -320,9 +172,9 @@ d__'43''45'dec__360 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d__'43''45'dec__360 ~v0 ~v1 v2 v3 v4 v5 v6 v7 v8
-  = du__'43''45'dec__360 v2 v3 v4 v5 v6 v7 v8
-du__'43''45'dec__360 ::
+d__'8853''45'dec__260 ~v0 ~v1 v2 v3 v4 v5 v6 v7 v8
+  = du__'8853''45'dec__260 v2 v3 v4 v5 v6 v7 v8
+du__'8853''45'dec__260 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -356,7 +208,7 @@ du__'43''45'dec__360 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du__'43''45'dec__360 v0 v1 v2 v3 v4 v5 v6
+du__'8853''45'dec__260 v0 v1 v2 v3 v4 v5 v6
   = let v7 = coe v0 v2 v3 v4 v5 v6 in
     coe
       (case coe v7 of
@@ -397,7 +249,7 @@ du__'43''45'dec__360 v0 v1 v2 v3 v4 v5 v6
                              _ -> MAlonzo.RTE.mazUnreachableError))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.empty?
-d_empty'63'_438 ::
+d_empty'63'_338 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -409,16 +261,16 @@ d_empty'63'_438 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_empty'63'_438 ~v0 ~v1 ~v2 ~v3 ~v4 = du_empty'63'_438
-du_empty'63'_438 ::
+d_empty'63'_338 ~v0 ~v1 ~v2 ~v3 ~v4 = du_empty'63'_338
+du_empty'63'_338 ::
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_empty'63'_438
+du_empty'63'_338
   = coe
       MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32
       (coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8)
       (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26)
 -- Untyped.Relation.Binary.Modular.Fix-dec
-d_Fix'45'dec_448 ::
+d_Fix'45'dec_348 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -440,8 +292,8 @@ d_Fix'45'dec_448 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_Fix'45'dec_448 ~v0 v1 v2 v3 v4 = du_Fix'45'dec_448 v1 v2 v3 v4
-du_Fix'45'dec_448 ::
+d_Fix'45'dec_348 ~v0 v1 v2 v3 v4 = du_Fix'45'dec_348 v1 v2 v3 v4
+du_Fix'45'dec_348 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -457,9 +309,9 @@ du_Fix'45'dec_448 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_Fix'45'dec_448 v0 v1 v2 v3
+du_Fix'45'dec_348 v0 v1 v2 v3
   = let v4
-          = coe v0 erased (coe du_Fix'45'dec_448 (coe v0)) v1 v2 v3 in
+          = coe v0 erased (coe du_Fix'45'dec_348 (coe v0)) v1 v2 v3 in
     coe
       (case coe v4 of
          MAlonzo.Code.Relation.Nullary.Decidable.Core.C__because__32 v5 v6
@@ -481,7 +333,7 @@ du_Fix'45'dec_448 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular..extendedlambda1
-d_'46'extendedlambda1_476 ::
+d_'46'extendedlambda1_376 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -504,9 +356,9 @@ d_'46'extendedlambda1_476 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   (AgdaAny -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20) ->
   T_Fix_50 -> MAlonzo.Code.Data.Irrelevant.T_Irrelevant_20
-d_'46'extendedlambda1_476 = erased
+d_'46'extendedlambda1_376 = erased
 -- Untyped.Relation.Binary.Modular.compatVar?
-d_compatVar'63'_480 ::
+d_compatVar'63'_380 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -518,12 +370,12 @@ d_compatVar'63'_480 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatVar'63'_480 ~v0 ~v1 ~v2 v3 v4 = du_compatVar'63'_480 v3 v4
-du_compatVar'63'_480 ::
+d_compatVar'63'_380 ~v0 ~v1 ~v2 v3 v4 = du_compatVar'63'_380 v3 v4
+du_compatVar'63'_380 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatVar'63'_480 v0 v1
+du_compatVar'63'_380 v0 v1
   = let v2
           = \ v2 ->
               coe MAlonzo.Code.VerifiedCompilation.UntypedViews.du_'8943'_2404 in
@@ -901,7 +753,7 @@ du_compatVar'63'_480 v0 v1
                    (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatApply?
-d_compatApply'63'_534 ::
+d_compatApply'63'_434 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -913,9 +765,9 @@ d_compatApply'63'_534 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatApply'63'_534 ~v0 v1 v2 v3 v4
-  = du_compatApply'63'_534 v1 v2 v3 v4
-du_compatApply'63'_534 ::
+d_compatApply'63'_434 ~v0 v1 v2 v3 v4
+  = du_compatApply'63'_434 v1 v2 v3 v4
+du_compatApply'63'_434 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -924,7 +776,7 @@ du_compatApply'63'_534 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatApply'63'_534 v0 v1 v2 v3
+du_compatApply'63'_434 v0 v1 v2 v3
   = let v4
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1022,7 +874,7 @@ du_compatApply'63'_534 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatLam?
-d_compatLam'63'_614 ::
+d_compatLam'63'_514 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -1034,9 +886,9 @@ d_compatLam'63'_614 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatLam'63'_614 ~v0 v1 v2 v3 v4
-  = du_compatLam'63'_614 v1 v2 v3 v4
-du_compatLam'63'_614 ::
+d_compatLam'63'_514 ~v0 v1 v2 v3 v4
+  = du_compatLam'63'_514 v1 v2 v3 v4
+du_compatLam'63'_514 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -1045,7 +897,7 @@ du_compatLam'63'_614 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatLam'63'_614 v0 v1 v2 v3
+du_compatLam'63'_514 v0 v1 v2 v3
   = let v4
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1127,7 +979,7 @@ du_compatLam'63'_614 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatForce?
-d_compatForce'63'_678 ::
+d_compatForce'63'_578 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -1139,9 +991,9 @@ d_compatForce'63'_678 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatForce'63'_678 ~v0 v1 v2 v3 v4
-  = du_compatForce'63'_678 v1 v2 v3 v4
-du_compatForce'63'_678 ::
+d_compatForce'63'_578 ~v0 v1 v2 v3 v4
+  = du_compatForce'63'_578 v1 v2 v3 v4
+du_compatForce'63'_578 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -1150,7 +1002,7 @@ du_compatForce'63'_678 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatForce'63'_678 v0 v1 v2 v3
+du_compatForce'63'_578 v0 v1 v2 v3
   = let v4
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1225,7 +1077,7 @@ du_compatForce'63'_678 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatDelay?
-d_compatDelay'63'_742 ::
+d_compatDelay'63'_642 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -1237,9 +1089,9 @@ d_compatDelay'63'_742 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatDelay'63'_742 ~v0 v1 v2 v3 v4
-  = du_compatDelay'63'_742 v1 v2 v3 v4
-du_compatDelay'63'_742 ::
+d_compatDelay'63'_642 ~v0 v1 v2 v3 v4
+  = du_compatDelay'63'_642 v1 v2 v3 v4
+du_compatDelay'63'_642 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -1248,7 +1100,7 @@ du_compatDelay'63'_742 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatDelay'63'_742 v0 v1 v2 v3
+du_compatDelay'63'_642 v0 v1 v2 v3
   = let v4
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -1323,7 +1175,7 @@ du_compatDelay'63'_742 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatConstr?
-d_compatConstr'63'_806 ::
+d_compatConstr'63'_706 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -1335,9 +1187,9 @@ d_compatConstr'63'_806 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatConstr'63'_806 ~v0 v1 v2 v3 v4
-  = du_compatConstr'63'_806 v1 v2 v3 v4
-du_compatConstr'63'_806 ::
+d_compatConstr'63'_706 ~v0 v1 v2 v3 v4
+  = du_compatConstr'63'_706 v1 v2 v3 v4
+du_compatConstr'63'_706 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -1346,7 +1198,7 @@ du_compatConstr'63'_806 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatConstr'63'_806 v0 v1 v2 v3
+du_compatConstr'63'_706 v0 v1 v2 v3
   = let v4
           = \ v4 ->
               coe MAlonzo.Code.VerifiedCompilation.UntypedViews.du_'8943'_2404 in
@@ -1910,7 +1762,7 @@ du_compatConstr'63'_806 v0 v1 v2 v3
                       (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
             _ -> MAlonzo.RTE.mazUnreachableError))
 -- Untyped.Relation.Binary.Modular.compatCase?
-d_compatCase'63'_904 ::
+d_compatCase'63'_804 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -1922,9 +1774,9 @@ d_compatCase'63'_904 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatCase'63'_904 ~v0 v1 v2 v3 v4
-  = du_compatCase'63'_904 v1 v2 v3 v4
-du_compatCase'63'_904 ::
+d_compatCase'63'_804 ~v0 v1 v2 v3 v4
+  = du_compatCase'63'_804 v1 v2 v3 v4
+du_compatCase'63'_804 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -1933,7 +1785,7 @@ du_compatCase'63'_904 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatCase'63'_904 v0 v1 v2 v3
+du_compatCase'63'_804 v0 v1 v2 v3
   = let v4
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -2035,7 +1887,7 @@ du_compatCase'63'_904 v0 v1 v2 v3
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatCon?
-d_compatCon'63'_984 ::
+d_compatCon'63'_884 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -2047,12 +1899,12 @@ d_compatCon'63'_984 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatCon'63'_984 ~v0 ~v1 ~v2 v3 v4 = du_compatCon'63'_984 v3 v4
-du_compatCon'63'_984 ::
+d_compatCon'63'_884 ~v0 ~v1 ~v2 v3 v4 = du_compatCon'63'_884 v3 v4
+du_compatCon'63'_884 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatCon'63'_984 v0 v1
+du_compatCon'63'_884 v0 v1
   = let v2
           = \ v2 ->
               coe MAlonzo.Code.VerifiedCompilation.UntypedViews.du_'8943'_2404 in
@@ -2428,7 +2280,7 @@ du_compatCon'63'_984 v0 v1
                    (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatBuiltin?
-d_compatBuiltin'63'_1038 ::
+d_compatBuiltin'63'_938 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -2440,13 +2292,13 @@ d_compatBuiltin'63'_1038 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatBuiltin'63'_1038 ~v0 ~v1 ~v2 v3 v4
-  = du_compatBuiltin'63'_1038 v3 v4
-du_compatBuiltin'63'_1038 ::
+d_compatBuiltin'63'_938 ~v0 ~v1 ~v2 v3 v4
+  = du_compatBuiltin'63'_938 v3 v4
+du_compatBuiltin'63'_938 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatBuiltin'63'_1038 v0 v1
+du_compatBuiltin'63'_938 v0 v1
   = let v2
           = \ v2 ->
               coe MAlonzo.Code.VerifiedCompilation.UntypedViews.du_'8943'_2404 in
@@ -2822,7 +2674,7 @@ du_compatBuiltin'63'_1038 v0 v1
                    (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatError?
-d_compatError'63'_1092 ::
+d_compatError'63'_992 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -2834,13 +2686,13 @@ d_compatError'63'_1092 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatError'63'_1092 ~v0 ~v1 ~v2 v3 v4
-  = du_compatError'63'_1092 v3 v4
-du_compatError'63'_1092 ::
+d_compatError'63'_992 ~v0 ~v1 ~v2 v3 v4
+  = du_compatError'63'_992 v3 v4
+du_compatError'63'_992 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatError'63'_1092 v0 v1
+du_compatError'63'_992 v0 v1
   = let v2
           = coe
               MAlonzo.Code.Relation.Nullary.Decidable.Core.du__'215''45'dec__84
@@ -2878,7 +2730,7 @@ du_compatError'63'_1092 v0 v1
                           (coe MAlonzo.Code.Relation.Nullary.Reflects.C_of'8319'_26))
          _ -> MAlonzo.RTE.mazUnreachableError)
 -- Untyped.Relation.Binary.Modular.compatTerm?
-d_compatTerm'63'_1120 ::
+d_compatTerm'63'_1020 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -2890,8 +2742,8 @@ d_compatTerm'63'_1120 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-d_compatTerm'63'_1120 ~v0 = du_compatTerm'63'_1120
-du_compatTerm'63'_1120 ::
+d_compatTerm'63'_1020 ~v0 = du_compatTerm'63'_1020
+du_compatTerm'63'_1020 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2900,41 +2752,41 @@ du_compatTerm'63'_1120 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
-du_compatTerm'63'_1120
+du_compatTerm'63'_1020
   = coe
-      du__'43''45'dec__360
-      (\ v0 v1 v2 v3 v4 -> coe du_compatVar'63'_480 v3 v4)
+      du__'8853''45'dec__260
+      (\ v0 v1 v2 v3 v4 -> coe du_compatVar'63'_380 v3 v4)
       (coe
-         du__'43''45'dec__360
-         (\ v0 v1 v2 v3 v4 -> coe du_compatLam'63'_614 v1 v2 v3 v4)
+         du__'8853''45'dec__260
+         (\ v0 v1 v2 v3 v4 -> coe du_compatLam'63'_514 v1 v2 v3 v4)
          (coe
-            du__'43''45'dec__360
-            (\ v0 v1 v2 v3 v4 -> coe du_compatApply'63'_534 v1 v2 v3 v4)
+            du__'8853''45'dec__260
+            (\ v0 v1 v2 v3 v4 -> coe du_compatApply'63'_434 v1 v2 v3 v4)
             (coe
-               du__'43''45'dec__360
-               (\ v0 v1 v2 v3 v4 -> coe du_compatForce'63'_678 v1 v2 v3 v4)
+               du__'8853''45'dec__260
+               (\ v0 v1 v2 v3 v4 -> coe du_compatForce'63'_578 v1 v2 v3 v4)
                (coe
-                  du__'43''45'dec__360
-                  (\ v0 v1 v2 v3 v4 -> coe du_compatDelay'63'_742 v1 v2 v3 v4)
+                  du__'8853''45'dec__260
+                  (\ v0 v1 v2 v3 v4 -> coe du_compatDelay'63'_642 v1 v2 v3 v4)
                   (coe
-                     du__'43''45'dec__360
-                     (\ v0 v1 v2 v3 v4 -> coe du_compatCon'63'_984 v3 v4)
+                     du__'8853''45'dec__260
+                     (\ v0 v1 v2 v3 v4 -> coe du_compatCon'63'_884 v3 v4)
                      (coe
-                        du__'43''45'dec__360
-                        (\ v0 v1 v2 v3 v4 -> coe du_compatConstr'63'_806 v1 v2 v3 v4)
+                        du__'8853''45'dec__260
+                        (\ v0 v1 v2 v3 v4 -> coe du_compatConstr'63'_706 v1 v2 v3 v4)
                         (coe
-                           du__'43''45'dec__360
-                           (\ v0 v1 v2 v3 v4 -> coe du_compatCase'63'_904 v1 v2 v3 v4)
+                           du__'8853''45'dec__260
+                           (\ v0 v1 v2 v3 v4 -> coe du_compatCase'63'_804 v1 v2 v3 v4)
                            (coe
-                              du__'43''45'dec__360
-                              (\ v0 v1 v2 v3 v4 -> coe du_compatBuiltin'63'_1038 v3 v4)
+                              du__'8853''45'dec__260
+                              (\ v0 v1 v2 v3 v4 -> coe du_compatBuiltin'63'_938 v3 v4)
                               (coe
-                                 du__'43''45'dec__360
-                                 (\ v0 v1 v2 v3 v4 -> coe du_compatError'63'_1092 v3 v4)
-                                 (\ v0 v1 v2 v3 v4 -> coe du_empty'63'_438))))))))))
+                                 du__'8853''45'dec__260
+                                 (\ v0 v1 v2 v3 v4 -> coe du_compatError'63'_992 v3 v4)
+                                 (\ v0 v1 v2 v3 v4 -> coe du_empty'63'_338))))))))))
       erased
 -- Untyped.Relation.Binary.Modular._<|>_
-d__'60''124''62'__1128 ::
+d__'60''124''62'__1028 ::
   ((Integer ->
     MAlonzo.Code.Untyped.T__'8866'_14 ->
     MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
@@ -2959,9 +2811,9 @@ d__'60''124''62'__1128 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   Maybe MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
-d__'60''124''62'__1128 ~v0 ~v1 ~v2 v3 v4 v5 v6
-  = du__'60''124''62'__1128 v3 v4 v5 v6
-du__'60''124''62'__1128 ::
+d__'60''124''62'__1028 ~v0 ~v1 ~v2 v3 v4 v5 v6
+  = du__'60''124''62'__1028 v3 v4 v5 v6
+du__'60''124''62'__1028 ::
   (Integer ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
    Maybe MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14) ->
@@ -2971,7 +2823,7 @@ du__'60''124''62'__1128 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   Maybe MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
-du__'60''124''62'__1128 v0 v1 v2 v3
+du__'60''124''62'__1028 v0 v1 v2 v3
   = let v4 = coe v0 v2 v3 in
     coe
       (case coe v4 of

--- a/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular/Patterns.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular/Patterns.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Untyped.Relation.Binary.Modular.Patterns where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+

--- a/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular/Structures.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/Untyped/Relation/Binary/Modular/Structures.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Untyped.Relation.Binary.Modular.Structures where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+import qualified MAlonzo.Code.Untyped
+import qualified MAlonzo.Code.Untyped.Relation.Binary.Modular
+import qualified MAlonzo.Code.Untyped.Relation.Binary.Structures
+
+-- Untyped.Relation.Binary.Modular.Structures.CompatTerm-TermCompatible
+d_CompatTerm'45'TermCompatible_12 ::
+  (Integer ->
+   MAlonzo.Code.Untyped.T__'8866'_14 ->
+   MAlonzo.Code.Untyped.T__'8866'_14 -> ()) ->
+  (Integer ->
+   MAlonzo.Code.Untyped.T__'8866'_14 ->
+   MAlonzo.Code.Untyped.T__'8866'_14 ->
+   MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16 ->
+   AgdaAny) ->
+  MAlonzo.Code.Untyped.Relation.Binary.Structures.T_TermCompatible_30
+d_CompatTerm'45'TermCompatible_12 ~v0 v1
+  = du_CompatTerm'45'TermCompatible_12 v1
+du_CompatTerm'45'TermCompatible_12 ::
+  (Integer ->
+   MAlonzo.Code.Untyped.T__'8866'_14 ->
+   MAlonzo.Code.Untyped.T__'8866'_14 ->
+   MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16 ->
+   AgdaAny) ->
+  MAlonzo.Code.Untyped.Relation.Binary.Structures.T_TermCompatible_30
+du_CompatTerm'45'TermCompatible_12 v0
+  = coe
+      MAlonzo.Code.Untyped.Relation.Binary.Structures.C_constructor_150
+      (coe
+         (\ v1 v2 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_'96'_18 (coe v2))
+              (coe MAlonzo.Code.Untyped.C_'96'_18 (coe v2))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                 (coe MAlonzo.Code.Untyped.Relation.Binary.Modular.C_'96'F__118))))
+      (coe
+         (\ v1 v2 v3 v4 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_ƛ_20 (coe v2))
+              (coe MAlonzo.Code.Untyped.C_ƛ_20 (coe v3))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                    (coe MAlonzo.Code.Untyped.Relation.Binary.Modular.C_ƛF_132 v4)))))
+      (coe
+         (\ v1 v2 v3 v4 v5 v6 v7 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v2) (coe v4))
+              (coe MAlonzo.Code.Untyped.C__'183'__22 (coe v3) (coe v5))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C__'183'F__150 v6
+                          v7))))))
+      (coe
+         (\ v1 v2 v3 v4 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_force_24 (coe v2))
+              (coe MAlonzo.Code.Untyped.C_force_24 (coe v3))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_forceF_164 v4)))))))
+      (coe
+         (\ v1 v2 v3 v4 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_delay_26 (coe v2))
+              (coe MAlonzo.Code.Untyped.C_delay_26 (coe v3))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_delayF_178
+                                v4))))))))
+      (coe
+         (\ v1 v2 v3 v4 v5 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_constr_34 (coe v2) (coe v3))
+              (coe MAlonzo.Code.Untyped.C_constr_34 (coe v2) (coe v4))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                (coe
+                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                                   (coe
+                                      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_constrF_206
+                                      v5))))))))))
+      (coe
+         (\ v1 v2 v3 v4 v5 v6 v7 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_case_40 (coe v2) (coe v4))
+              (coe MAlonzo.Code.Untyped.C_case_40 (coe v3) (coe v5))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                (coe
+                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                   (coe
+                                      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                                      (coe
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_caseF_224 v6
+                                         v7)))))))))))
+      (coe
+         (\ v1 v2 ->
+            coe
+              v0 v2 (coe MAlonzo.Code.Untyped.C_con_28 (coe v1))
+              (coe MAlonzo.Code.Untyped.C_con_28 (coe v1))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                                (coe
+                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_conF_190)))))))))
+      (coe
+         (\ v1 v2 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_builtin_44 (coe v2))
+              (coe MAlonzo.Code.Untyped.C_builtin_44 (coe v2))
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                (coe
+                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                   (coe
+                                      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                      (coe
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                                         (coe
+                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_builtinF_236))))))))))))
+      (coe
+         (\ v1 ->
+            coe
+              v0 v1 (coe MAlonzo.Code.Untyped.C_error_46)
+              (coe MAlonzo.Code.Untyped.C_error_46)
+              (coe
+                 MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                 (coe
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                    (coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                       (coe
+                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                          (coe
+                             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                             (coe
+                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                (coe
+                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                   (coe
+                                      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                      (coe
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38
+                                         (coe
+                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30
+                                            (coe
+                                               MAlonzo.Code.Untyped.Relation.Binary.Modular.C_errorF_246)))))))))))))

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/FloatOut.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/FloatOut.hs
@@ -516,19 +516,24 @@ d_dec_304 ::
   MAlonzo.Code.Relation.Nullary.Decidable.Core.T_Dec_20
 d_dec_304 v0
   = coe
-      MAlonzo.Code.Untyped.Relation.Binary.Modular.du_Fix'45'dec_448
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.du_Fix'45'dec_348
       (coe
-         MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'43''45'dec__360
+         MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'8853''45'dec__260
          (\ v1 ->
             coe
-              MAlonzo.Code.Untyped.Relation.Binary.Modular.du_compatTerm'63'_1120)
+              MAlonzo.Code.Untyped.Relation.Binary.Modular.du_compatTerm'63'_1020)
          (coe
-            MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'43''45'dec__360
+            MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'8853''45'dec__260
             (\ v1 v2 v3 v4 v5 -> coe du_apply'45'dec_62 v2 v3 v4 v5)
             (coe
-               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'43''45'dec__360
+               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'8853''45'dec__260
                (\ v1 v2 v3 v4 v5 -> coe du_case'45'dec_148 v2 v3 v4 v5)
-               (\ v1 v2 v3 v4 v5 -> coe du_force'45'dec_234 v2 v3 v4 v5))))
+               (coe
+                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'8853''45'dec__260
+                  (\ v1 v2 v3 v4 v5 -> coe du_force'45'dec_234 v2 v3 v4 v5)
+                  (\ v1 v2 v3 v4 v5 ->
+                     coe
+                       MAlonzo.Code.Untyped.Relation.Binary.Modular.du_empty'63'_338)))))
       (coe v0)
 -- VerifiedCompilation.FloatOut.decide
 d_decide_312 ::
@@ -553,3 +558,303 @@ d_decide_312 v0 v1 v2
                           MAlonzo.Code.VerifiedCompilation.Certificate.C_ce_52
                           MAlonzo.Code.VerifiedCompilation.Trace.d_LetFloatOutT_44 v1 v2)
          _ -> MAlonzo.RTE.mazUnreachableError)
+-- VerifiedCompilation.FloatOut.numSites
+d_numSites_330 ::
+  Integer ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50 -> Integer
+d_numSites_330 v0 v1 v2 v3
+  = case coe v3 of
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_fix_60 v7
+        -> case coe v7 of
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v11
+               -> coe
+                    d_numSites'45'compat_346 (coe v0) (coe v1) (coe v2) (coe v11)
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v11
+               -> case coe v11 of
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v15
+                      -> case coe v15 of
+                           C_float'45'apply_22 v22 v23
+                             -> case coe v1 of
+                                  MAlonzo.Code.Untyped.C__'183'__22 v24 v25
+                                    -> case coe v2 of
+                                         MAlonzo.Code.Untyped.C__'183'__22 v26 v27
+                                           -> case coe v26 of
+                                                MAlonzo.Code.Untyped.C_ƛ_20 v28
+                                                  -> case coe v28 of
+                                                       MAlonzo.Code.Untyped.C__'183'__22 v29 v30
+                                                         -> coe
+                                                              addInt
+                                                              (coe
+                                                                 addInt (coe (1 :: Integer))
+                                                                 (coe
+                                                                    d_numSites_330
+                                                                    (coe
+                                                                       addInt (coe (1 :: Integer))
+                                                                       (coe v0))
+                                                                    (coe
+                                                                       MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                                                       (coe v0) (coe v25))
+                                                                    (coe v30) (coe v23)))
+                                                              (coe
+                                                                 d_numSites_330 (coe v0) (coe v24)
+                                                                 (coe
+                                                                    MAlonzo.Code.Untyped.C__'183'__22
+                                                                    (coe
+                                                                       MAlonzo.Code.Untyped.C_ƛ_20
+                                                                       (coe v29))
+                                                                    (coe v27))
+                                                                 (coe v22))
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v15
+                      -> case coe v15 of
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
+                             -> case coe v19 of
+                                  C_float'45'case_42 v26 v27
+                                    -> case coe v1 of
+                                         MAlonzo.Code.Untyped.C_case_40 v28 v29
+                                           -> case coe v2 of
+                                                MAlonzo.Code.Untyped.C__'183'__22 v30 v31
+                                                  -> case coe v30 of
+                                                       MAlonzo.Code.Untyped.C_ƛ_20 v32
+                                                         -> case coe v32 of
+                                                              MAlonzo.Code.Untyped.C_case_40 v33 v34
+                                                                -> coe
+                                                                     addInt
+                                                                     (coe
+                                                                        addInt (coe (1 :: Integer))
+                                                                        (coe
+                                                                           d_numSites'42'_338
+                                                                           (coe
+                                                                              addInt
+                                                                              (coe (1 :: Integer))
+                                                                              (coe v0))
+                                                                           (coe
+                                                                              MAlonzo.Code.Data.List.Base.du_map_22
+                                                                              (coe
+                                                                                 MAlonzo.Code.Untyped.RenamingSubstitution.d_weaken_88
+                                                                                 (coe v0))
+                                                                              (coe v29))
+                                                                           (coe v34) (coe v27)))
+                                                                     (coe
+                                                                        d_numSites_330 (coe v0)
+                                                                        (coe v28)
+                                                                        (coe
+                                                                           MAlonzo.Code.Untyped.C__'183'__22
+                                                                           (coe
+                                                                              MAlonzo.Code.Untyped.C_ƛ_20
+                                                                              (coe v33))
+                                                                           (coe v31))
+                                                                        (coe v26))
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
+                                    -> case coe v23 of
+                                         C_float'45'force_58 v28
+                                           -> case coe v1 of
+                                                MAlonzo.Code.Untyped.C_force_24 v29
+                                                  -> case coe v2 of
+                                                       MAlonzo.Code.Untyped.C__'183'__22 v30 v31
+                                                         -> case coe v30 of
+                                                              MAlonzo.Code.Untyped.C_ƛ_20 v32
+                                                                -> case coe v32 of
+                                                                     MAlonzo.Code.Untyped.C_force_24 v33
+                                                                       -> coe
+                                                                            addInt
+                                                                            (coe (1 :: Integer))
+                                                                            (coe
+                                                                               d_numSites_330
+                                                                               (coe v0) (coe v29)
+                                                                               (coe
+                                                                                  MAlonzo.Code.Untyped.C__'183'__22
+                                                                                  (coe
+                                                                                     MAlonzo.Code.Untyped.C_ƛ_20
+                                                                                     (coe v33))
+                                                                                  (coe v31))
+                                                                               (coe v28))
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- VerifiedCompilation.FloatOut.numSites*
+d_numSites'42'_338 ::
+  Integer ->
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  MAlonzo.Code.Untyped.Relation.Binary.Core.T_Pointwise_20 -> Integer
+d_numSites'42'_338 v0 v1 v2 v3
+  = case coe v3 of
+      MAlonzo.Code.Untyped.Relation.Binary.Core.C_'91''93'_26
+        -> coe (0 :: Integer)
+      MAlonzo.Code.Untyped.Relation.Binary.Core.C__'8759'__36 v8 v9
+        -> case coe v1 of
+             (:) v10 v11
+               -> case coe v2 of
+                    (:) v12 v13
+                      -> coe
+                           addInt
+                           (coe d_numSites'42'_338 (coe v0) (coe v11) (coe v13) (coe v9))
+                           (coe d_numSites_330 (coe v0) (coe v10) (coe v12) (coe v8))
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- VerifiedCompilation.FloatOut.numSites-compat
+d_numSites'45'compat_346 ::
+  Integer ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16 ->
+  Integer
+d_numSites'45'compat_346 v0 v1 v2 v3
+  = case coe v3 of
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v7
+        -> coe seq (coe v7) (coe (0 :: Integer))
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v7
+        -> case coe v7 of
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v11
+               -> case coe v11 of
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_ƛF_132 v15
+                      -> case coe v1 of
+                           MAlonzo.Code.Untyped.C_ƛ_20 v16
+                             -> case coe v2 of
+                                  MAlonzo.Code.Untyped.C_ƛ_20 v17
+                                    -> coe
+                                         d_numSites_330 (coe addInt (coe (1 :: Integer)) (coe v0))
+                                         (coe v16) (coe v17) (coe v15)
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v11
+               -> case coe v11 of
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v15
+                      -> case coe v15 of
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C__'183'F__150 v21 v22
+                             -> case coe v1 of
+                                  MAlonzo.Code.Untyped.C__'183'__22 v23 v24
+                                    -> case coe v2 of
+                                         MAlonzo.Code.Untyped.C__'183'__22 v25 v26
+                                           -> coe
+                                                addInt
+                                                (coe
+                                                   d_numSites_330 (coe v0) (coe v23) (coe v25)
+                                                   (coe v21))
+                                                (coe
+                                                   d_numSites_330 (coe v0) (coe v24) (coe v26)
+                                                   (coe v22))
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v15
+                      -> case coe v15 of
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_forceF_164 v23
+                                    -> case coe v1 of
+                                         MAlonzo.Code.Untyped.C_force_24 v24
+                                           -> case coe v2 of
+                                                MAlonzo.Code.Untyped.C_force_24 v25
+                                                  -> coe
+                                                       d_numSites_330 (coe v0) (coe v24) (coe v25)
+                                                       (coe v23)
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
+                                    -> case coe v23 of
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_delayF_178 v27
+                                           -> case coe v1 of
+                                                MAlonzo.Code.Untyped.C_delay_26 v28
+                                                  -> case coe v2 of
+                                                       MAlonzo.Code.Untyped.C_delay_26 v29
+                                                         -> coe
+                                                              d_numSites_330 (coe v0) (coe v28)
+                                                              (coe v29) (coe v27)
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v23
+                                    -> case coe v23 of
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v27
+                                           -> coe seq (coe v27) (coe (0 :: Integer))
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v27
+                                           -> case coe v27 of
+                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v31
+                                                  -> case coe v31 of
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_constrF_206 v36
+                                                         -> case coe v1 of
+                                                              MAlonzo.Code.Untyped.C_constr_34 v37 v38
+                                                                -> case coe v2 of
+                                                                     MAlonzo.Code.Untyped.C_constr_34 v39 v40
+                                                                       -> coe
+                                                                            d_numSites'42'_338
+                                                                            (coe v0) (coe v38)
+                                                                            (coe v40) (coe v36)
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v31
+                                                  -> case coe v31 of
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v35
+                                                         -> case coe v35 of
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_caseF_224 v41 v42
+                                                                -> case coe v1 of
+                                                                     MAlonzo.Code.Untyped.C_case_40 v43 v44
+                                                                       -> case coe v2 of
+                                                                            MAlonzo.Code.Untyped.C_case_40 v45 v46
+                                                                              -> coe
+                                                                                   addInt
+                                                                                   (coe
+                                                                                      d_numSites'42'_338
+                                                                                      (coe v0)
+                                                                                      (coe v44)
+                                                                                      (coe v46)
+                                                                                      (coe v42))
+                                                                                   (coe
+                                                                                      d_numSites_330
+                                                                                      (coe v0)
+                                                                                      (coe v43)
+                                                                                      (coe v45)
+                                                                                      (coe v41))
+                                                                            _ -> MAlonzo.RTE.mazUnreachableError
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v35
+                                                         -> case coe v35 of
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v39
+                                                                -> coe
+                                                                     seq (coe v39)
+                                                                     (coe (0 :: Integer))
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v39
+                                                                -> case coe v39 of
+                                                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v43
+                                                                       -> coe
+                                                                            seq (coe v43)
+                                                                            (coe (0 :: Integer))
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError

--- a/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
+++ b/plutus-metatheory/src/MAlonzo/Code/VerifiedCompilation/UCaseReduce.hs
@@ -35,6 +35,7 @@ import qualified MAlonzo.Code.Untyped.Equality
 import qualified MAlonzo.Code.Untyped.Reduction
 import qualified MAlonzo.Code.Untyped.Relation.Binary.Core
 import qualified MAlonzo.Code.Untyped.Relation.Binary.Modular
+import qualified MAlonzo.Code.Untyped.Relation.Binary.Modular.Structures
 import qualified MAlonzo.Code.Untyped.Relation.Binary.Properties
 import qualified MAlonzo.Code.Untyped.Relation.Binary.Structures
 import qualified MAlonzo.Code.Untyped.Transform
@@ -136,7 +137,7 @@ d_cr'45'TermCompat_208 ::
   MAlonzo.Code.Untyped.Relation.Binary.Structures.T_TermCompatible_30
 d_cr'45'TermCompat_208
   = coe
-      MAlonzo.Code.Untyped.Relation.Binary.Modular.du_CompatTerm'45'TermCompatible_330
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.Structures.du_CompatTerm'45'TermCompatible_12
       (coe
          (\ v0 v1 v2 v3 ->
             coe
@@ -1833,28 +1834,28 @@ d_reduce_504 ::
   Maybe MAlonzo.Code.Agda.Builtin.Sigma.T_Σ_14
 d_reduce_504 v0
   = coe
-      MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
       (coe (\ v1 -> coe du_red'45'constr_258))
       (coe
-         MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+         MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
          (coe (\ v1 -> coe du_red'45'unit_304))
          (coe
-            MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+            MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
             (coe (\ v1 -> coe du_red'45'false'8321'_324))
             (coe
-               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                (coe (\ v1 -> coe du_red'45'bool_342))
                (coe
-                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                   (coe (\ v1 -> coe du_red'45'integer_364))
                   (coe
-                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                      (coe (\ v1 -> coe du_red'45'cons'8321'_404))
                      (coe
-                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                         (coe (\ v1 -> coe du_red'45'cons'8322'_430))
                         (coe
-                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                            (coe (\ v1 -> coe du_red'45'nil_456))
                            (coe (\ v1 -> coe du_red'45'pair_478)))))))))
       (coe v0)
@@ -1923,25 +1924,25 @@ d_decide_526 v0 v1 v2
                   coe
                     (let v4
                            = coe
-                               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                (coe (\ v4 -> coe du_red'45'unit_304))
                                (coe
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                   (coe (\ v4 -> coe du_red'45'false'8321'_324))
                                   (coe
-                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                      (coe (\ v4 -> coe du_red'45'bool_342))
                                      (coe
-                                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                         (coe (\ v4 -> coe du_red'45'integer_364))
                                         (coe
-                                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                            (coe (\ v4 -> coe du_red'45'cons'8321'_404))
                                            (coe
-                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                               (coe (\ v4 -> coe du_red'45'cons'8322'_430))
                                               (coe
-                                                 MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                                 MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                                  (coe (\ v4 -> coe du_red'45'nil_456))
                                                  (coe (\ v4 -> coe du_red'45'pair_478)))))))) in
                      coe
@@ -2529,11 +2530,11 @@ d_red'8838'cr_556 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
-  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'43'__16 ->
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16 ->
   MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50
 d_red'8838'cr_556 ~v0 ~v1 ~v2 ~v3 ~v4 v5 = du_red'8838'cr_556 v5
 du_red'8838'cr_556 ::
-  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'43'__16 ->
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16 ->
   MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50
 du_red'8838'cr_556 v0
   = coe
@@ -2547,14 +2548,14 @@ d_reduce'45'refine_558 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
-  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'43'__16
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16
 d_reduce'45'refine_558 ~v0 ~v1 v2 = du_reduce'45'refine_558 v2
 du_reduce'45'refine_558 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
-  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'43'__16
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T__'8853'__16
 du_reduce'45'refine_558 v0 v1 v2 v3
   = coe
       MAlonzo.Code.Untyped.Relation.Binary.Properties.du_refine'63''45'refines_234
@@ -2606,20 +2607,261 @@ du_sound_568 v0 v1
                   (d_case'45'reduce_508 (coe v0) (coe v1))
                   (d_case'45'reduce'45'refines_550 (coe v0) (coe v1))
                   (coe du_cr'45'refl''_200)))))
+-- VerifiedCompilation.UCaseReduce.numSitesCaseReduce
+d_numSitesCaseReduce_578 ::
+  Integer ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.T__'8866'_14 ->
+  MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50 -> Integer
+d_numSitesCaseReduce_578 v0 v1 v2 v3
+  = case coe v3 of
+      MAlonzo.Code.Untyped.Relation.Binary.Modular.C_fix_60 v7
+        -> case coe v7 of
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v11
+               -> coe (1 :: Integer)
+             MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v11
+               -> case coe v11 of
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v15
+                      -> case coe v15 of
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
+                             -> coe seq (coe v19) (coe (0 :: Integer))
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
+                                    -> case coe v23 of
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_ƛF_132 v27
+                                           -> case coe v1 of
+                                                MAlonzo.Code.Untyped.C_ƛ_20 v28
+                                                  -> case coe v2 of
+                                                       MAlonzo.Code.Untyped.C_ƛ_20 v29
+                                                         -> coe
+                                                              d_numSitesCaseReduce_578
+                                                              (coe
+                                                                 addInt (coe (1 :: Integer))
+                                                                 (coe v0))
+                                                              (coe v28) (coe v29) (coe v27)
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v23
+                                    -> case coe v23 of
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v27
+                                           -> case coe v27 of
+                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C__'183'F__150 v33 v34
+                                                  -> case coe v1 of
+                                                       MAlonzo.Code.Untyped.C__'183'__22 v35 v36
+                                                         -> case coe v2 of
+                                                              MAlonzo.Code.Untyped.C__'183'__22 v37 v38
+                                                                -> coe
+                                                                     addInt
+                                                                     (coe
+                                                                        d_numSitesCaseReduce_578
+                                                                        (coe v0) (coe v35) (coe v37)
+                                                                        (coe v33))
+                                                                     (coe
+                                                                        d_numSitesCaseReduce_578
+                                                                        (coe v0) (coe v36) (coe v38)
+                                                                        (coe v34))
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v27
+                                           -> case coe v27 of
+                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v31
+                                                  -> case coe v31 of
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_forceF_164 v35
+                                                         -> case coe v1 of
+                                                              MAlonzo.Code.Untyped.C_force_24 v36
+                                                                -> case coe v2 of
+                                                                     MAlonzo.Code.Untyped.C_force_24 v37
+                                                                       -> coe
+                                                                            d_numSitesCaseReduce_578
+                                                                            (coe v0) (coe v36)
+                                                                            (coe v37) (coe v35)
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v31
+                                                  -> case coe v31 of
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v35
+                                                         -> case coe v35 of
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_delayF_178 v39
+                                                                -> case coe v1 of
+                                                                     MAlonzo.Code.Untyped.C_delay_26 v40
+                                                                       -> case coe v2 of
+                                                                            MAlonzo.Code.Untyped.C_delay_26 v41
+                                                                              -> coe
+                                                                                   d_numSitesCaseReduce_578
+                                                                                   (coe v0)
+                                                                                   (coe v40)
+                                                                                   (coe v41)
+                                                                                   (coe v39)
+                                                                            _ -> MAlonzo.RTE.mazUnreachableError
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v35
+                                                         -> case coe v35 of
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v39
+                                                                -> coe
+                                                                     seq (coe v39)
+                                                                     (coe (0 :: Integer))
+                                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v39
+                                                                -> case coe v39 of
+                                                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v43
+                                                                       -> case coe v43 of
+                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_constrF_206 v48
+                                                                              -> case coe v1 of
+                                                                                   MAlonzo.Code.Untyped.C_constr_34 v49 v50
+                                                                                     -> case coe
+                                                                                               v2 of
+                                                                                          MAlonzo.Code.Untyped.C_constr_34 v51 v52
+                                                                                            -> coe
+                                                                                                 d_numSitesCaseReduce'42'_586
+                                                                                                 (coe
+                                                                                                    v0)
+                                                                                                 (coe
+                                                                                                    v50)
+                                                                                                 (coe
+                                                                                                    v52)
+                                                                                                 (coe
+                                                                                                    v48)
+                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
+                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
+                                                                            _ -> MAlonzo.RTE.mazUnreachableError
+                                                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v43
+                                                                       -> case coe v43 of
+                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v47
+                                                                              -> case coe v47 of
+                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_caseF_224 v53 v54
+                                                                                     -> case coe
+                                                                                               v1 of
+                                                                                          MAlonzo.Code.Untyped.C_case_40 v55 v56
+                                                                                            -> case coe
+                                                                                                      v2 of
+                                                                                                 MAlonzo.Code.Untyped.C_case_40 v57 v58
+                                                                                                   -> coe
+                                                                                                        addInt
+                                                                                                        (coe
+                                                                                                           d_numSitesCaseReduce'42'_586
+                                                                                                           (coe
+                                                                                                              v0)
+                                                                                                           (coe
+                                                                                                              v56)
+                                                                                                           (coe
+                                                                                                              v58)
+                                                                                                           (coe
+                                                                                                              v54))
+                                                                                                        (coe
+                                                                                                           d_numSitesCaseReduce_578
+                                                                                                           (coe
+                                                                                                              v0)
+                                                                                                           (coe
+                                                                                                              v55)
+                                                                                                           (coe
+                                                                                                              v57)
+                                                                                                           (coe
+                                                                                                              v53))
+                                                                                                 _ -> MAlonzo.RTE.mazUnreachableError
+                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
+                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
+                                                                            MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v47
+                                                                              -> case coe v47 of
+                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v51
+                                                                                     -> coe
+                                                                                          seq
+                                                                                          (coe v51)
+                                                                                          (coe
+                                                                                             (0 ::
+                                                                                                Integer))
+                                                                                   MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v51
+                                                                                     -> case coe
+                                                                                               v51 of
+                                                                                          MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v55
+                                                                                            -> coe
+                                                                                                 seq
+                                                                                                 (coe
+                                                                                                    v55)
+                                                                                                 (coe
+                                                                                                    (0 ::
+                                                                                                       Integer))
+                                                                                          _ -> MAlonzo.RTE.mazUnreachableError
+                                                                                   _ -> MAlonzo.RTE.mazUnreachableError
+                                                                            _ -> MAlonzo.RTE.mazUnreachableError
+                                                                     _ -> MAlonzo.RTE.mazUnreachableError
+                                                              _ -> MAlonzo.RTE.mazUnreachableError
+                                                       _ -> MAlonzo.RTE.mazUnreachableError
+                                                _ -> MAlonzo.RTE.mazUnreachableError
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v15
+                      -> case coe v15 of
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_transF_80 v22 v24 v25
+                                    -> coe
+                                         addInt
+                                         (coe
+                                            d_numSitesCaseReduce_578 (coe v0) (coe v1) (coe v22)
+                                            (coe v24))
+                                         (coe
+                                            d_numSitesCaseReduce_578 (coe v0) (coe v22) (coe v2)
+                                            (coe v25))
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v19
+                             -> case coe v19 of
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inl_30 v23
+                                    -> case coe v23 of
+                                         MAlonzo.Code.Untyped.Relation.Binary.Modular.C_symF_94 v27
+                                           -> coe
+                                                d_numSitesCaseReduce_578 (coe v0) (coe v2) (coe v1)
+                                                (coe v27)
+                                         _ -> MAlonzo.RTE.mazUnreachableError
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.C_inr_38 v23
+                                    -> coe seq (coe v23) (coe (0 :: Integer))
+                                  _ -> MAlonzo.RTE.mazUnreachableError
+                           _ -> MAlonzo.RTE.mazUnreachableError
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- VerifiedCompilation.UCaseReduce.numSitesCaseReduce*
+d_numSitesCaseReduce'42'_586 ::
+  Integer ->
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  [MAlonzo.Code.Untyped.T__'8866'_14] ->
+  MAlonzo.Code.Untyped.Relation.Binary.Core.T_Pointwise_20 -> Integer
+d_numSitesCaseReduce'42'_586 v0 v1 v2 v3
+  = case coe v3 of
+      MAlonzo.Code.Untyped.Relation.Binary.Core.C_'91''93'_26
+        -> coe (0 :: Integer)
+      MAlonzo.Code.Untyped.Relation.Binary.Core.C__'8759'__36 v8 v9
+        -> case coe v1 of
+             (:) v10 v11
+               -> case coe v2 of
+                    (:) v12 v13
+                      -> coe
+                           addInt
+                           (coe
+                              d_numSitesCaseReduce'42'_586 (coe v0) (coe v11) (coe v13) (coe v9))
+                           (coe
+                              d_numSitesCaseReduce_578 (coe v0) (coe v10) (coe v12) (coe v8))
+                    _ -> MAlonzo.RTE.mazUnreachableError
+             _ -> MAlonzo.RTE.mazUnreachableError
+      _ -> MAlonzo.RTE.mazUnreachableError
 -- VerifiedCompilation.UCaseReduce._≈_
-d__'8776'__572 ::
+d__'8776'__616 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 -> ()
-d__'8776'__572 = erased
+d__'8776'__616 = erased
 -- VerifiedCompilation.UCaseReduce._≈*_
-d__'8776''42'__578 ::
+d__'8776''42'__622 ::
   Integer ->
   [MAlonzo.Code.Untyped.T__'8866'_14] ->
   [MAlonzo.Code.Untyped.T__'8866'_14] -> ()
-d__'8776''42'__578 = erased
+d__'8776''42'__622 = erased
 -- VerifiedCompilation.UCaseReduce.Decide.sound-both
-d_sound'45'both_596 ::
+d_sound'45'both_640 ::
   Integer ->
   (MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2630,14 +2872,14 @@ d_sound'45'both_596 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Agda.Builtin.Equality.T__'8801'__12 ->
   MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50
-d_sound'45'both_596 ~v0 ~v1 v2 v3 v4 ~v5
-  = du_sound'45'both_596 v2 v3 v4
-du_sound'45'both_596 ::
+d_sound'45'both_640 ~v0 ~v1 v2 v3 v4 ~v5
+  = du_sound'45'both_640 v2 v3 v4
+du_sound'45'both_640 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.Relation.Binary.Modular.T_Fix_50
-du_sound'45'both_596 v0 v1 v2
+du_sound'45'both_640 v0 v1 v2
   = coe
       MAlonzo.Code.Untyped.Relation.Binary.Modular.C_fix_60
       (coe
@@ -2676,7 +2918,7 @@ du_sound'45'both_596 v0 v1 v2
                                                    (d_case'45'reduce'45'refines_550
                                                       (coe v0) (coe v2)))))))))))))))))
 -- VerifiedCompilation.UCaseReduce.Decide.decide-~
-d_decide'45''126'_604 ::
+d_decide'45''126'_648 ::
   Integer ->
   (MAlonzo.Code.Untyped.T__'8866'_14 ->
    MAlonzo.Code.Untyped.T__'8866'_14 ->
@@ -2685,14 +2927,14 @@ d_decide'45''126'_604 ::
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
-d_decide'45''126'_604 v0 ~v1 v2 v3
-  = du_decide'45''126'_604 v0 v2 v3
-du_decide'45''126'_604 ::
+d_decide'45''126'_648 v0 ~v1 v2 v3
+  = du_decide'45''126'_648 v0 v2 v3
+du_decide'45''126'_648 ::
   Integer ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.Untyped.T__'8866'_14 ->
   MAlonzo.Code.VerifiedCompilation.Certificate.T_ProofOrCE_38
-du_decide'45''126'_604 v0 v1 v2
+du_decide'45''126'_648 v0 v1 v2
   = let v3
           = MAlonzo.Code.Untyped.Equality.d_decEq'45''8866'_56
               (coe v0)
@@ -2718,25 +2960,25 @@ du_decide'45''126'_604 v0 v1 v2
                   coe
                     (let v4
                            = coe
-                               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                               MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                (coe (\ v4 -> coe du_red'45'unit_304))
                                (coe
-                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                  MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                   (coe (\ v4 -> coe du_red'45'false'8321'_324))
                                   (coe
-                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                     MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                      (coe (\ v4 -> coe du_red'45'bool_342))
                                      (coe
-                                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                        MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                         (coe (\ v4 -> coe du_red'45'integer_364))
                                         (coe
-                                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                           MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                            (coe (\ v4 -> coe du_red'45'cons'8321'_404))
                                            (coe
-                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                              MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                               (coe (\ v4 -> coe du_red'45'cons'8322'_430))
                                               (coe
-                                                 MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1128
+                                                 MAlonzo.Code.Untyped.Relation.Binary.Modular.du__'60''124''62'__1028
                                                  (coe (\ v4 -> coe du_red'45'nil_456))
                                                  (coe (\ v4 -> coe du_red'45'pair_478)))))))) in
                      coe
@@ -3287,7 +3529,7 @@ du_decide'45''126'_604 v0 v1 v2
                        seq (coe v5)
                        (coe
                           MAlonzo.Code.VerifiedCompilation.Certificate.C_proof_44
-                          (coe du_sound'45'both_596 (coe v0) (coe v1) (coe v2)))
+                          (coe du_sound'45'both_640 (coe v0) (coe v1) (coe v2)))
                 else coe
                        seq (coe v5)
                        (coe

--- a/plutus-metatheory/src/Untyped/Relation/Binary/Modular.lagda.md
+++ b/plutus-metatheory/src/Untyped/Relation/Binary/Modular.lagda.md
@@ -56,11 +56,11 @@ RelationT = @++ Relation → Relation
 ## Basic combinators for relation transformers
 
 ```
-infixr 5 _+_
+infixr 5 _⊕_
 
-data _+_ (F G : RelationT) (@++ R : Relation) : Relation where
-  inl : ∀ {X} {M N : X ⊢} → F R M N → (F + G) R M N
-  inr : ∀ {X} {M N : X ⊢} → G R M N → (F + G) R M N
+data _⊕_ (F G : RelationT) (@++ R : Relation) : Relation where
+  inl : ∀ {X} {M N : X ⊢} → F R M N → (F ⊕ G) R M N
+  inr : ∀ {X} {M N : X ⊢} → G R M N → (F ⊕ G) R M N
 
 Empty : RelationT
 Empty R M N = ⊥
@@ -174,59 +174,10 @@ Term-compatibility can be constructed by using compatibility rules of all constr
 ```
 CompatTerm : RelationT
 CompatTerm
-  = CompatVar + CompatLambda + CompatApply + CompatForce + CompatDelay
-  + CompatCon + CompatConstr + CompatCase + CompatBuiltin + CompatError + Empty
+  = CompatVar ⊕ CompatLambda ⊕ CompatApply ⊕ CompatForce ⊕ CompatDelay
+  ⊕ CompatCon ⊕ CompatConstr ⊕ CompatCase ⊕ CompatBuiltin ⊕ CompatError ⊕ Empty
 ```
 
-## Pattern synonyms
-
-Convenient synonyms for constructing/matching cases of `CompatTerm`
-
-```
--- TODO: solve this with metaprogramming or typeclasses
-pattern p0 p = inl p
-pattern p1 p = inr (p0 p)
-pattern p2 p = inr (p1 p)
-pattern p3 p = inr (p2 p)
-pattern p4 p = inr (p3 p)
-pattern p5 p = inr (p4 p)
-pattern p6 p = inr (p5 p)
-pattern p7 p = inr (p6 p)
-pattern p8 p = inr (p7 p)
-pattern p9 p = inr (p8 p)
-
-pattern compat-varF n     = p0 (`F n)
-pattern compat-lambdaF p  = p1 (ƛF p)
-pattern compat-applyF p q = p2 (p ·F q)
-pattern compat-forceF p   = p3 (forceF p)
-pattern compat-delayF p   = p4 (delayF p)
-pattern compat-conF       = p5 conF
-pattern compat-constrF p  = p6 (constrF p)
-pattern compat-caseF p q  = p7 (caseF p q)
-pattern compat-builtinF   = p8 builtinF
-pattern compat-errorF     = p9 errorF
-```
-
-
-## Structures
-
-If a relation has the `CompatTerm` rules, then it forms a `TermCompatible` structure.
-
-```
-CompatTerm-TermCompatible : ∀ {R : Relation} → CompatTerm R ⊆ R → TermCompatible R
-CompatTerm-TermCompatible inj = record
-  { compat-var     = inj (compat-varF _)
-  ; compat-ƛ       = λ RM → inj (compat-lambdaF RM)
-  ; compat-·       = λ RM RN → inj (compat-applyF RM RN)
-  ; compat-force   = λ RM → inj (compat-forceF RM)
-  ; compat-delay   = λ RM → inj (compat-delayF RM)
-  ; compat-constr  = λ RMS → inj (compat-constrF RMS)
-  ; compat-case    = λ RM RMS → inj (compat-caseF RM RMS)
-  ; compat-con     = inj compat-conF
-  ; compat-builtin = inj compat-builtinF
-  ; compat-error   = inj compat-errorF
-  }
-```
 
 
 ## Decision procedures
@@ -245,13 +196,13 @@ DecidableT F =
 ## Decision procedures for combinators
 
 ```
-infixr 5 _+-dec_
-_+-dec_ :
+infixr 5 _⊕-dec_
+_⊕-dec_ :
   ∀ {F G : RelationT}
   → DecidableT F
   → DecidableT G
-  → DecidableT (F + G)
-_+-dec_ F? G? R? M M'
+  → DecidableT (F ⊕ G)
+_⊕-dec_ F? G? R? M M'
   with F? R? M M'
 ... | yes P = yes (inl P)
 ... | no ¬P
@@ -377,16 +328,16 @@ compatError? R? M M'
 compatTerm? : DecidableT CompatTerm
 compatTerm?
   =     compatVar?
-  +-dec compatLam?
-  +-dec compatApply?
-  +-dec compatForce?
-  +-dec compatDelay?
-  +-dec compatCon?
-  +-dec compatConstr?
-  +-dec compatCase?
-  +-dec compatBuiltin?
-  +-dec compatError?
-  +-dec empty?
+  ⊕-dec compatLam?
+  ⊕-dec compatApply?
+  ⊕-dec compatForce?
+  ⊕-dec compatDelay?
+  ⊕-dec compatCon?
+  ⊕-dec compatConstr?
+  ⊕-dec compatCase?
+  ⊕-dec compatBuiltin?
+  ⊕-dec compatError?
+  ⊕-dec empty?
 ```
 
 
@@ -400,7 +351,7 @@ _<|>_ :
   ∀ {F G : RelationT} {R : Relation}
   → Refinement? (F R)
   → Refinement? (G R)
-  → Refinement? ((F + G) R)
+  → Refinement? ((F ⊕ G) R)
 (f <|> g) M
   with f M
 ... | just (N , RMN) = just (N , inl RMN)
@@ -477,24 +428,24 @@ the compatibility rules for force and delay)
 ```
   RemoveFD : Relation
   RemoveFD = Fix
-    ( ForceApply + DelayLambda
-    + CompatVar + CompatLambda + CompatApply
-    + CompatCon + CompatConstr + CompatCase
-    + CompatBuiltin + CompatError
+    ( ForceApply ⊕ DelayLambda
+    ⊕ CompatVar ⊕ CompatLambda ⊕ CompatApply
+    ⊕ CompatCon ⊕ CompatConstr ⊕ CompatCase
+    ⊕ CompatBuiltin ⊕ CompatError
     )
 
   dec-RemoveFD : DecidableRel RemoveFD
   dec-RemoveFD = Fix-dec
     (     dec-ForceApply
-    +-dec dec-DelayLambda
-    +-dec compatVar?
-    +-dec compatLam?
-    +-dec compatApply?
-    +-dec compatCon?
-    +-dec compatConstr?
-    +-dec compatCase?
-    +-dec compatBuiltin?
-    +-dec compatError?
+    ⊕-dec dec-DelayLambda
+    ⊕-dec compatVar?
+    ⊕-dec compatLam?
+    ⊕-dec compatApply?
+    ⊕-dec compatCon?
+    ⊕-dec compatConstr?
+    ⊕-dec compatCase?
+    ⊕-dec compatBuiltin?
+    ⊕-dec compatError?
     )
 ```
 

--- a/plutus-metatheory/src/Untyped/Relation/Binary/Modular/Patterns.lagda.md
+++ b/plutus-metatheory/src/Untyped/Relation/Binary/Modular/Patterns.lagda.md
@@ -1,0 +1,38 @@
+---
+title: Untyped.Relation.Binary.Modular.Patterns
+layout: page
+---
+
+Convenient pattern synonyms for matching on modular relation constructors.
+
+```
+module Untyped.Relation.Binary.Modular.Patterns where
+
+open import Untyped.Relation.Binary.Modular
+```
+
+## Pattern synonyms
+
+```
+pattern inj₀ p = inl p
+pattern inj₁ p = inr (inj₀ p)
+pattern inj₂ p = inr (inj₁ p)
+pattern inj₃ p = inr (inj₂ p)
+pattern inj₄ p = inr (inj₃ p)
+pattern inj₅ p = inr (inj₄ p)
+pattern inj₆ p = inr (inj₅ p)
+pattern inj₇ p = inr (inj₆ p)
+pattern inj₈ p = inr (inj₇ p)
+pattern inj₉ p = inr (inj₈ p)
+
+pattern compat-varF n     = inj₀ (`F n)
+pattern compat-lambdaF p  = inj₁ (ƛF p)
+pattern compat-applyF p q = inj₂ (p ·F q)
+pattern compat-forceF p   = inj₃ (forceF p)
+pattern compat-delayF p   = inj₄ (delayF p)
+pattern compat-conF       = inj₅ conF
+pattern compat-constrF p  = inj₆ (constrF p)
+pattern compat-caseF p q  = inj₇ (caseF p q)
+pattern compat-builtinF   = inj₈ builtinF
+pattern compat-errorF     = inj₉ errorF
+```

--- a/plutus-metatheory/src/Untyped/Relation/Binary/Modular/Structures.lagda.md
+++ b/plutus-metatheory/src/Untyped/Relation/Binary/Modular/Structures.lagda.md
@@ -1,0 +1,32 @@
+---
+title: Untyped.Relation.Binary.Modular.Patterns
+layout: page
+---
+
+```
+module Untyped.Relation.Binary.Modular.Structures where
+
+open import Untyped.Relation.Binary
+open import Untyped.Relation.Binary.Modular
+open import Untyped.Relation.Binary.Modular.Patterns
+```
+
+## Structures
+
+If a relation has the `CompatTerm` rules, then it forms a `TermCompatible` structure.
+
+```
+CompatTerm-TermCompatible : ∀ {R : Relation} → CompatTerm R ⊆ R → TermCompatible R
+CompatTerm-TermCompatible inj = record
+  { compat-var     = inj (compat-varF _)
+  ; compat-ƛ       = λ RM → inj (compat-lambdaF RM)
+  ; compat-·       = λ RM RN → inj (compat-applyF RM RN)
+  ; compat-force   = λ RM → inj (compat-forceF RM)
+  ; compat-delay   = λ RM → inj (compat-delayF RM)
+  ; compat-constr  = λ RMS → inj (compat-constrF RMS)
+  ; compat-case    = λ RM RMS → inj (compat-caseF RM RMS)
+  ; compat-con     = inj compat-conF
+  ; compat-builtin = inj compat-builtinF
+  ; compat-error   = inj compat-errorF
+  }
+```

--- a/plutus-metatheory/src/VerifiedCompilation/FloatOut.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/FloatOut.lagda.md
@@ -8,9 +8,9 @@ layout: page
 module VerifiedCompilation.FloatOut where
 
 open import Function using (case_of_)
-open import Data.Nat using (suc; zero)
+open import Data.Nat using (suc; zero; ℕ; _+_)
 open import Data.List using (List; map)
-open import Data.Product using (_,_)
+open import Data.Product using (_,_; ∃)
 open import Relation.Nullary using (Dec; yes; no; does; _×-dec_)
 
 open import Untyped
@@ -18,6 +18,7 @@ open import VerifiedCompilation.UntypedViews
 open import Untyped.RenamingSubstitution using (weaken)
 open import Untyped.Relation.Binary
 open import Untyped.Relation.Binary.Modular
+open import Untyped.Relation.Binary.Modular.Patterns
 
 open import VerifiedCompilation.Certificate using (ProofOrCE; ce; proof; LetFloatOutT; Proof?; abort)
 ```
@@ -55,7 +56,7 @@ Closed under term-compatibility.
 ```
 infix 5 FloatOut
 FloatOut : Relation
-FloatOut = Fix (CompatTerm + FloatApply + FloatCase + FloatForce)
+FloatOut = Fix (CompatTerm ⊕ FloatApply ⊕ FloatCase ⊕ FloatForce ⊕ Empty)
 ```
 
 ## Decision procedure
@@ -100,7 +101,7 @@ to more often see a compatibility case:
 
 ```
 dec : DecidableRel FloatOut
-dec = Fix-dec (compatTerm? +-dec apply-dec +-dec case-dec +-dec force-dec)
+dec = Fix-dec (compatTerm? ⊕-dec apply-dec ⊕-dec case-dec ⊕-dec force-dec ⊕-dec empty?)
 ```
 
 Wrapper for `ProofOrCE`:
@@ -111,6 +112,33 @@ decide M M' = case dec M M' of λ where
   (no ¬P) → ce ¬P LetFloatOutT M M'
   -- note: using a with-abstraction here instead of case_of_ causes agda to hang
   -- possibly due to infinite unfolding of dec?
+```
+
+## Counting optimization sites
+
+```
+numSites : ∀ {X} {M N : X ⊢} → FloatOut M N → ℕ
+numSites* : ∀ {X} {Ms Ns : List (X ⊢)} → Pointwise FloatOut Ms Ns → ℕ
+numSites-compat : ∀ {X} {M N : X ⊢} → CompatTerm FloatOut M N → ℕ
+
+numSites (fix (inj₀ P)) = numSites-compat P
+numSites (fix (inj₁ (float-apply RM RN))) = 1 + numSites RM + numSites RN
+numSites (fix (inj₂ (float-case RM RMs))) = 1 + numSites RM + numSites* RMs
+numSites (fix (inj₃ (float-force RM))) = 1 + numSites RM
+
+numSites* [] = 0
+numSites* (RM ∷ RMs) = numSites RM + numSites* RMs
+
+numSites-compat compat-conF = 0
+numSites-compat compat-builtinF = 0
+numSites-compat compat-errorF = 0
+numSites-compat (compat-varF _) = 0
+numSites-compat (compat-lambdaF P) = numSites P
+numSites-compat (compat-applyF P Q) = numSites P + numSites Q
+numSites-compat (compat-forceF P) = numSites P
+numSites-compat (compat-delayF P) = numSites P
+numSites-compat (compat-constrF Ps) = numSites* Ps
+numSites-compat (compat-caseF P Ps) = numSites P + numSites* Ps
 ```
 
 ## Example tests

--- a/plutus-metatheory/src/VerifiedCompilation/UCaseReduce.lagda.md
+++ b/plutus-metatheory/src/VerifiedCompilation/UCaseReduce.lagda.md
@@ -38,7 +38,7 @@ open import Data.Maybe
 open import Data.List using (List; _∷_; []; [_])
 open import Data.Product
 open import Data.Unit using (tt)
-open import Data.Nat using (ℕ; zero; suc)
+open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Data.Fin using (Fin)
 open import Data.Integer using (ℤ ; +_; -[1+_])
@@ -54,6 +54,8 @@ open import Untyped.Equality
 open import Untyped.Reduction using (iterApp)
 open import Untyped.Relation.Binary
 open import Untyped.Relation.Binary.Modular
+open import Untyped.Relation.Binary.Modular.Patterns
+open import Untyped.Relation.Binary.Modular.Structures
 open import Untyped.Transform
 open Untyped.Transform.Refines?
 open import Untyped.CEK using (lookup?)
@@ -151,14 +153,14 @@ Combining the reduction rules:
 Reduction : RelationT
 Reduction
   = CaseConstr
-  + CaseUnit
-  + CaseFalse₁
-  + CaseBool
-  + CaseInteger
-  + CaseCons₁
-  + CaseCons₂
-  + CaseNil
-  + CasePair
+  ⊕ CaseUnit
+  ⊕ CaseFalse₁
+  ⊕ CaseBool
+  ⊕ CaseInteger
+  ⊕ CaseCons₁
+  ⊕ CaseCons₂
+  ⊕ CaseNil
+  ⊕ CasePair
 ```
 
 The equivalence is closed under the reduction rules and compatibility
@@ -166,7 +168,7 @@ rules
 
 ```
 _~_ : Relation
-_~_ = Fix (Reduction + CompatTerm + Transitivity + Symmetry + Reflexivity)
+_~_ = Fix (Reduction ⊕ CompatTerm ⊕ Transitivity ⊕ Symmetry ⊕ Reflexivity)
 ```
 
 Pattern synonyms for constructors:
@@ -399,6 +401,37 @@ sound eq =
   cr-trans
     case-reduce-refines
     (cr-refl' eq)
+```
+
+## Counting optimization sites
+
+```
+numSitesCaseReduce :
+  ∀ {X} {M N : X ⊢}
+  → M ~ N
+  → ℕ
+numSitesCaseReduce* :
+  ∀ {X} {Ms Ns : List (X ⊢)}
+  → Pointwise _~_ Ms Ns
+  → ℕ
+
+numSitesCaseReduce (cr-reduction _)                = 1
+numSitesCaseReduce (cr-trans p q)                  = numSitesCaseReduce p + numSitesCaseReduce q
+numSitesCaseReduce (cr-sym p)                      = numSitesCaseReduce p
+numSitesCaseReduce (cr-refl)                       = 0
+numSitesCaseReduce (cr-compat (compat-varF n))     = 0
+numSitesCaseReduce (cr-compat (compat-lambdaF p))  = numSitesCaseReduce p
+numSitesCaseReduce (cr-compat (compat-applyF p q)) = numSitesCaseReduce p + numSitesCaseReduce q
+numSitesCaseReduce (cr-compat (compat-forceF p))   = numSitesCaseReduce p
+numSitesCaseReduce (cr-compat (compat-delayF p))   = numSitesCaseReduce p
+numSitesCaseReduce (cr-compat (compat-conF))       = 0
+numSitesCaseReduce (cr-compat (compat-constrF ps)) = numSitesCaseReduce* ps
+numSitesCaseReduce (cr-compat (compat-caseF p qs)) = numSitesCaseReduce p + numSitesCaseReduce* qs
+numSitesCaseReduce (cr-compat (compat-builtinF))   = 0
+numSitesCaseReduce (cr-compat (compat-errorF))     = 0
+
+numSitesCaseReduce* [] = 0
+numSitesCaseReduce* (x ∷ xs) = numSitesCaseReduce x + numSitesCaseReduce* xs
 ```
 
 ### Deciding `_~_`

--- a/plutus-metatheory/test/certifier-report/golden/n-queens.golden.report
+++ b/plutus-metatheory/test/certifier-report/golden/n-queens.golden.report
@@ -25,7 +25,7 @@ Pass 3: Float bindings outwards  ✅
   Program Size: 3504 (after)
   Execution Cost: CPU = 283210581782, MEM = 1720009055 (before)
   Execution Cost: CPU = 283210581782, MEM = 1720009055 (after)
-  Optimization sites: 0
+  Optimization sites: 2
 
 ──────────────────────────────────────────────────────
 Pass 4: Force-Delay Cancellation  ✅
@@ -97,7 +97,7 @@ Pass 11: Float bindings outwards  ✅
   Program Size: 3170 (after)
   Execution Cost: CPU = 264858581782, MEM = 1605309055 (before)
   Execution Cost: CPU = 264858581782, MEM = 1605309055 (after)
-  Optimization sites: 0
+  Optimization sites: 38
 
 ──────────────────────────────────────────────────────
 Pass 12: Force-Delay Cancellation  ✅
@@ -169,7 +169,7 @@ Pass 19: Float bindings outwards  ✅
   Program Size: 2527 (after)
   Execution Cost: CPU = 217316549782, MEM = 1308171355 (before)
   Execution Cost: CPU = 217316549782, MEM = 1308171355 (after)
-  Optimization sites: 0
+  Optimization sites: 31
 
 ──────────────────────────────────────────────────────
 Pass 20: Force-Delay Cancellation  ✅
@@ -313,7 +313,7 @@ Pass 35: Float bindings outwards  ✅
   Program Size: 1846 (after)
   Execution Cost: CPU = 118993781782, MEM = 693654055 (before)
   Execution Cost: CPU = 118993781782, MEM = 693654055 (after)
-  Optimization sites: 0
+  Optimization sites: 4
 
 ──────────────────────────────────────────────────────
 Pass 36: Force-Delay Cancellation  ✅
@@ -898,7 +898,7 @@ Pass 100: Float bindings outwards  ✅
   Program Size: 1773 (after)
   Execution Cost: CPU = 117353877782, MEM = 683404655 (before)
   Execution Cost: CPU = 117353877782, MEM = 683404655 (after)
-  Optimization sites: 0
+  Optimization sites: 1
 
 ──────────────────────────────────────────────────────
 Pass 101: Force-Delay Cancellation  ✅


### PR DESCRIPTION
Counts the number of optimization sites for the float-out pass in the certifier. Also refactors a few things related to modular relations:

- rename + to ⊕ to avoid clashes with Data.Nat.+
- move numSitesCaseReduce to the UCaseReduce module
- rename  pattern synonyms for modular relations to `injₙ` rather than `pn`, and move into their own module. As a consequence also factor out a Untyped.Relation.Binary.Modular.Structures module, avoiding circular imports.
